### PR TITLE
feat(clientes): add commercial operations backend

### DIFF
--- a/crm/api/package.json
+++ b/crm/api/package.json
@@ -25,6 +25,7 @@
     "migrate-commercial-contact-rollout": "node scripts/migrate-atendimento-commercial-contact-rollout.mjs",
     "migrate-commercial-action-ledger": "node scripts/migrate-atendimento-commercial-action-ledger.mjs",
     "migrate-commercial-data-quality": "node scripts/migrate-atendimento-commercial-data-quality.mjs",
+    "migrate-commercial-operations": "node scripts/migrate-atendimento-commercial-operations.mjs",
     "migrate-clinical-approval": "node scripts/migrate-clinical-approval.mjs",
     "migrate-identity-clusters": "node scripts/migrate-atendimento-identity-clusters.mjs",
     "migrate-atendimento-staging": "node scripts/migrate-atendimento-staging.mjs",

--- a/crm/api/scripts/migrate-atendimento-commercial-operations.mjs
+++ b/crm/api/scripts/migrate-atendimento-commercial-operations.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import { createPgPool } from '../server/harmonia/store/pg.js'
+import {
+    applyCommercialOperationsMigration,
+    commercialOperationsMigrationPlan,
+    rollbackCommercialOperationsMigration,
+} from '../server/atendimento/commercialOperationsMigration.js'
+import {
+    assertAtendimentoMigrationDestination,
+    ATENDIMENTO_MIGRATION_TARGETS,
+    isStrictAtendimentoMigrationDestination,
+} from '../server/atendimento/migrationDestination.js'
+
+function commandError(code) {
+    const error = new Error(code)
+    error.code = code
+    return error
+}
+
+function parseTarget(args) {
+    const values = args.filter((arg) => arg.startsWith('--target='))
+    if (values.length > 1) throw commandError('COMMERCIAL_OPERATIONS_TARGET_INVALID')
+    const value = values[0] ? values[0].slice('--target='.length) : ATENDIMENTO_MIGRATION_TARGETS.LOCAL
+    if (value === ATENDIMENTO_MIGRATION_TARGETS.LOCAL || value === ATENDIMENTO_MIGRATION_TARGETS.STAGING) return value
+    throw commandError('COMMERCIAL_OPERATIONS_TARGET_INVALID')
+}
+
+let pool = null
+
+try {
+    const args = process.argv.slice(2)
+    const target = parseTarget(args)
+    const actions = args.filter((arg) => ['--dry-run', '--apply', '--rollback'].includes(arg))
+    if (actions.length !== 1 || args.length !== actions.length + args.filter((arg) => arg.startsWith('--target=')).length) {
+        throw commandError('COMMERCIAL_OPERATIONS_MIGRATION_ACTION_INVALID')
+    }
+    const action = actions[0].slice(2)
+    const databaseUrl = String(process.env.DATABASE_URL || '').trim()
+    if (!databaseUrl || !isStrictAtendimentoMigrationDestination(databaseUrl, target)) {
+        throw commandError('COMMERCIAL_OPERATIONS_DESTINATION_UNSAFE')
+    }
+    pool = createPgPool(databaseUrl)
+    if (!pool) throw commandError('COMMERCIAL_OPERATIONS_POOL_REQUIRED')
+
+    if (action === 'dry-run') {
+        const client = await pool.connect()
+        try {
+            await client.query('begin')
+            const identity = await assertAtendimentoMigrationDestination(client, databaseUrl, target)
+            const registry = await client.query(`select to_regclass('crm_atendimento.schema_migrations') as registry`)
+            await client.query('rollback')
+            process.stdout.write(`${JSON.stringify({ ok: true, action, target, identity, registryPresent: Boolean(registry.rows[0]?.registry), plan: commercialOperationsMigrationPlan() })}\n`)
+        } catch (error) {
+            try { await client.query('rollback') } catch { /* preserve guarded failure */ }
+            throw error
+        } finally {
+            client.release()
+        }
+    } else {
+        const result = action === 'apply'
+            ? await applyCommercialOperationsMigration({ pool, databaseUrl, target })
+            : await rollbackCommercialOperationsMigration({ pool, databaseUrl, target })
+        process.stdout.write(`${JSON.stringify({ ok: true, action, target, result, commercialContactWritesEnabled: false, messagingEnabled: false })}\n`)
+    }
+} catch (error) {
+    const code = /^[A-Z][A-Z0-9_]{1,100}$/.test(String(error?.code || ''))
+        ? error.code
+        : 'COMMERCIAL_OPERATIONS_MIGRATION_FAILED'
+    process.stderr.write(`${JSON.stringify({ ok: false, code })}\n`)
+    process.exitCode = 1
+} finally {
+    if (pool) await pool.end()
+}

--- a/crm/api/server/atendimento/__tests__/commercialOperations.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialOperations.test.js
@@ -34,6 +34,7 @@ test('freezes a campaign cohort with opaque filters and deterministic control as
     assert.equal(campaign.identityIds.length, 2)
     assert.equal(stableControlGroup({ campaignSeed: 'campaign:opaque', identityId: identityA, percentage: 20 }), stableControlGroup({ campaignSeed: 'campaign:opaque', identityId: identityA, percentage: 20 }))
     assert.equal(campaignMemberState({ eligible: false, sourceStale: true }), 'review')
+    assert.equal(campaignMemberState({ eligible: false, controlGroup: true }), 'blocked')
     assert.throws(() => normalizeCampaignPayload({ ...campaign, filters: { owner: 'customer@example.com' } }), /COMMERCIAL_CAMPAIGN_FILTER_INVALID/)
 })
 

--- a/crm/api/server/atendimento/__tests__/commercialOperations.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialOperations.test.js
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+    COMMERCIAL_OUTCOME_CODES,
+    actionQueueFlags,
+    aggregateCommercialActionMetrics,
+    campaignMemberState,
+    computeAverageStageDurations,
+    normalizeCampaignPayload,
+    normalizeOperationMutation,
+    projectCommercialTimelineEvent,
+    stableControlGroup,
+} from '../commercialOperations.js'
+
+const identityA = '11111111-1111-4111-8111-111111111111'
+const identityB = '22222222-2222-4222-8222-222222222222'
+
+test('normalizes only structured operational outcomes and rejects PII-like idempotency keys', () => {
+    assert.equal(COMMERCIAL_OUTCOME_CODES.includes('sale'), true)
+    assert.deepEqual(normalizeOperationMutation({ idempotencyKey: 'action:opaque-key-1', reason: 'Atualização segura', outcomeCode: 'sale' }, { requireReason: true }), {
+        idempotencyKey: 'action:opaque-key-1', expectedRevision: null, reason: 'Atualização segura', outcomeCode: 'sale',
+    })
+    assert.throws(() => normalizeOperationMutation({ idempotencyKey: 'operator@example.com' }), /INVALID_COMMERCIAL_IDEMPOTENCY_KEY/)
+    assert.throws(() => normalizeOperationMutation({ idempotencyKey: 'action:1', reason: '5511999999999' }, { requireReason: true }), /COMMERCIAL_OPERATION_REASON_INVALID/)
+})
+
+test('freezes a campaign cohort with opaque filters and deterministic control assignment', () => {
+    const campaign = normalizeCampaignPayload({
+        name: 'Retorno seguro', segmentKey: 'return', segmentVersion: 'v1', unit: 'centro', owner: 'gestor.crm', reason: 'Coorte de teste segura',
+        filters: { status: ['open'], actionFlag: 'overdue' }, identityIds: [identityA, identityB], cutoffAt: '2026-08-07T12:00:00.000Z',
+        assignmentWindowStart: '2026-08-08T00:00:00.000Z', assignmentWindowEnd: '2026-08-15T00:00:00.000Z', controlGroupPercent: 20,
+    })
+    assert.equal(campaign.identityIds.length, 2)
+    assert.equal(stableControlGroup({ campaignSeed: 'campaign:opaque', identityId: identityA, percentage: 20 }), stableControlGroup({ campaignSeed: 'campaign:opaque', identityId: identityA, percentage: 20 }))
+    assert.equal(campaignMemberState({ eligible: false, sourceStale: true }), 'review')
+    assert.throws(() => normalizeCampaignPayload({ ...campaign, filters: { owner: 'customer@example.com' } }), /COMMERCIAL_CAMPAIGN_FILTER_INVALID/)
+})
+
+test('classifies queues and computes team metrics without contact data', () => {
+    const flags = actionQueueFlags({ status: 'contacted', dueDate: '2026-08-06', owner: 'gestor.crm' }, {
+        today: '2026-08-07', actorIds: ['gestor.crm'], eligibility: { status: 'eligible', expiresAt: '2026-08-10T00:00:00.000Z' }, sourceStale: true,
+    })
+    assert.deepEqual(flags, ['assigned_to_me', 'overdue', 'awaiting_response', 'no_return', 'permission_expiring', 'source_stale'])
+    const metrics = aggregateCommercialActionMetrics([
+        { status: 'contacted', owner: 'gestor.crm', dueDate: '2026-08-06' },
+        { status: 'won_sale', owner: 'gestor.crm', outcomeCode: 'sale' },
+    ], { today: '2026-08-07' })
+    assert.equal(metrics.totals.total, 2)
+    assert.equal(metrics.totals.sale, 1)
+    assert.equal(metrics.byOwner[0].owner, 'gestor.crm')
+})
+
+test('calculates stage durations and projects an allowlisted Customer 360 shape', () => {
+    assert.deepEqual(computeAverageStageDurations([
+        { actionId: 'a', status: 'open', occurredAt: '2026-08-01T00:00:00.000Z' },
+        { actionId: 'a', status: 'responded', occurredAt: '2026-08-01T12:00:00.000Z' },
+    ]), { open: { hours: 12, samples: 1 } })
+    const event = projectCommercialTimelineEvent({
+        event_id: 'event:1', event_type: 'campaign', created_at: '2026-08-01T00:00:00.000Z', source_label: 'CRM', unit_slug: 'centro',
+        actor_label: 'customer@example.com', trace_id: '33333333-3333-4333-8333-333333333333', status: 'draft', context: { phone: '5511999999999' },
+    })
+    assert.equal(event.actor, null)
+    assert.deepEqual(Object.keys(event).sort(), ['actor', 'campaignId', 'consentReview', 'correlationId', 'id', 'occurredAt', 'offerId', 'source', 'status', 'type', 'unit'])
+})

--- a/crm/api/server/atendimento/__tests__/commercialOperationsMigration.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialOperationsMigration.test.js
@@ -28,6 +28,7 @@ test('commercial operations migration is additive, append-only and denies messag
     assert.match(sql, /before truncate/)
     assert.doesNotMatch(grants, /grant\s+(?:all privileges|delete|truncate)/)
     assert.match(grants, /revoke update, delete, truncate, references, trigger on table crm_atendimento\.commercial_campaign_events/)
+    assert.match(grants, /grant select on table crm_atendimento\.schema_migrations to skincos_staging_crm_app/)
     assert.match(grants, /grant select, insert on table crm_atendimento\.commercial_operation_mutations/)
     assert.match(grants, /grant select, insert on table crm_atendimento\.commercial_campaign_events/)
 })

--- a/crm/api/server/atendimento/__tests__/commercialOperationsMigration.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialOperationsMigration.test.js
@@ -14,7 +14,7 @@ test('commercial operations migration is additive, append-only and denies messag
     const grants = __testables.runtimeGrantStatements('staging').join('\n').toLowerCase()
 
     assert.equal(plan.id, COMMERCIAL_OPERATIONS_MIGRATION_ID)
-    assert.deepEqual(plan.appendOnlyTables, ['commercial_operation_mutations', 'commercial_campaign_events'])
+    assert.deepEqual(plan.appendOnlyTables, ['commercial_action_events', 'commercial_operation_mutations', 'commercial_campaign_events'])
     assert.match(plan.messagePolicy, /never dispatch a message/i)
     assert.match(plan.piiPolicy, /no phone, email, message payload/i)
     assert.doesNotMatch(sql, /drop\s+trigger/)
@@ -32,8 +32,11 @@ test('commercial operations migration is additive, append-only and denies messag
     assert.match(grants, /grant select, insert on table crm_atendimento\.commercial_campaign_events/)
 })
 
-test('commercial operations trigger readiness verifies both immutable ledgers', () => {
+test('commercial operations trigger readiness verifies inherited and new immutable ledgers', () => {
     const readiness = __testables.triggerReadinessStatement()
+    assert.match(readiness, /commercial_action_events_immutable/)
+    assert.match(readiness, /commercial_action_events_no_truncate/)
+    assert.match(readiness, /prevent_commercial_ledger_mutation/)
     assert.match(readiness, /commercial_operation_mutations_v2_immutable/)
     assert.match(readiness, /commercial_operation_mutations_v2_no_truncate/)
     assert.match(readiness, /commercial_campaign_events_v2_immutable/)

--- a/crm/api/server/atendimento/__tests__/commercialOperationsMigration.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialOperationsMigration.test.js
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+    COMMERCIAL_OPERATIONS_MIGRATION_ID,
+    __testables,
+    applyCommercialOperationsMigration,
+    commercialOperationsMigrationPlan,
+} from '../commercialOperationsMigration.js'
+
+test('commercial operations migration is additive, append-only and denies message capability', () => {
+    const plan = commercialOperationsMigrationPlan()
+    const sql = __testables.STATEMENTS.join('\n').toLowerCase()
+    const grants = __testables.runtimeGrantStatements('staging').join('\n').toLowerCase()
+
+    assert.equal(plan.id, COMMERCIAL_OPERATIONS_MIGRATION_ID)
+    assert.deepEqual(plan.appendOnlyTables, ['commercial_operation_mutations', 'commercial_campaign_events'])
+    assert.match(plan.messagePolicy, /never dispatch a message/i)
+    assert.match(plan.piiPolicy, /no phone, email, message payload/i)
+    assert.doesNotMatch(sql, /drop\s+trigger/)
+    assert.doesNotMatch(sql, /on delete cascade/)
+    assert.match(sql, /commercial_actions_outcome_code_v2_valid/)
+    assert.match(sql, /commercial_operation_mutations/)
+    assert.match(sql, /commercial_campaigns/)
+    assert.match(sql, /commercial_campaign_members/)
+    assert.match(sql, /commercial_campaign_events/)
+    assert.match(sql, /before update or delete/)
+    assert.match(sql, /before truncate/)
+    assert.doesNotMatch(grants, /grant\s+(?:all privileges|delete|truncate)/)
+    assert.match(grants, /revoke update, delete, truncate, references, trigger on table crm_atendimento\.commercial_campaign_events/)
+    assert.match(grants, /grant select, insert on table crm_atendimento\.commercial_operation_mutations/)
+    assert.match(grants, /grant select, insert on table crm_atendimento\.commercial_campaign_events/)
+})
+
+test('commercial operations trigger readiness verifies both immutable ledgers', () => {
+    const readiness = __testables.triggerReadinessStatement()
+    assert.match(readiness, /commercial_operation_mutations_v2_immutable/)
+    assert.match(readiness, /commercial_operation_mutations_v2_no_truncate/)
+    assert.match(readiness, /commercial_campaign_events_v2_immutable/)
+    assert.match(readiness, /commercial_campaign_events_v2_no_truncate/)
+    assert.match(readiness, /prevent_commercial_operations_evidence_mutation_v2/)
+})
+
+test('commercial operations migration refuses unsafe destinations before opening a database connection', async () => {
+    let connected = false
+    await assert.rejects(
+        () => applyCommercialOperationsMigration({
+            pool: { connect: async () => { connected = true } },
+            databaseUrl: 'postgresql://unsafe.example.invalid/skincos_crm_local',
+            target: 'production',
+        }),
+        { code: 'COMMERCIAL_OPERATIONS_DESTINATION_UNSAFE' },
+    )
+    assert.equal(connected, false)
+})

--- a/crm/api/server/atendimento/__tests__/commercialOperationsStore.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialOperationsStore.test.js
@@ -56,6 +56,15 @@ test('fails closed for a manager without an explicit unit claim and retains hard
     })
 })
 
+test('requires an opaque actor subject before deriving operational audit or idempotency identity', () => {
+    assert.equal(__testables.actorPrincipal({ subject: 'crm:gestor-1', id: 'legacy-ignored' }), 'crm:gestor-1')
+    assert.equal(__testables.actorPrincipal({ id: 'gestor.crm' }), 'gestor.crm')
+    assert.throws(
+        () => __testables.actorPrincipal({ username: 'operator@example.test', email: 'operator@example.test' }),
+        (error) => error?.code === 'ACTOR_IDENTITY_REQUIRED' && error?.statusCode === 401,
+    )
+})
+
 test('treats every required consent/block and identity source as stale until a complete validated checkpoint exists', async () => {
     assert.equal(__testables.COMMERCIAL_REQUIRED_SOURCE_IDS.includes('consent.harmonia_opt_outs'), true)
     assert.equal(__testables.COMMERCIAL_REQUIRED_SOURCE_IDS.includes('blocks.commercial_permissions'), true)
@@ -122,6 +131,7 @@ test('reports migration readiness only when relations and append-only triggers a
     assert.equal(readiness.appendOnlyReady, true)
     assert.equal(readiness.safety.automationEnabled, false)
     assert.equal(queries.length, 2)
+    assert.equal(queries.some(({ sql }) => sql.includes('from crm_atendimento.schema_migrations')), true)
 
     const incomplete = await commercialOperationsReadiness({
         async query(sql) {

--- a/crm/api/server/atendimento/__tests__/commercialOperationsStore.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialOperationsStore.test.js
@@ -1,0 +1,263 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+    COMMERCIAL_OPERATIONS_SAFETY_FLAGS,
+    __testables,
+    commercialOperationsReadiness,
+    createCommercialOperationsStore,
+} from '../commercialOperationsStore.js'
+
+const actor = Object.freeze({
+    id: 'gestor.crm',
+    role: 'GESTOR',
+    allowedUnits: ['centro'],
+    allowedUnitsDeclared: true,
+})
+
+function readyAvailability() {
+    return {
+        actions: true,
+        action_events: true,
+        mutations: true,
+        campaigns: true,
+        members: true,
+        campaign_events: true,
+        absences: true,
+        action_event_immutable: true,
+        action_event_no_truncate: true,
+        mutation_immutable: true,
+        mutation_no_truncate: true,
+        campaign_event_immutable: true,
+        campaign_event_no_truncate: true,
+        migration_registry: true,
+    }
+}
+
+test('fails closed for a manager without an explicit unit claim and retains hard-disabled flags', () => {
+    assert.deepEqual(__testables.commercialOperationsUnitScope({ id: 'gestor.crm', role: 'GESTOR' }), [])
+    assert.throws(() => __testables.requestedUnitScope({ id: 'gestor.crm', role: 'GESTOR' }, 'centro'), /COMMERCIAL_UNIT_FORBIDDEN/)
+    assert.deepEqual(COMMERCIAL_OPERATIONS_SAFETY_FLAGS, {
+        commercialContactWritesEnabled: false,
+        messagesEnabled: false,
+        automationEnabled: false,
+        consentWritesEnabled: false,
+        outboundDispatchEnabled: false,
+    })
+})
+
+test('treats every required consent/block and identity source as stale until a complete validated checkpoint exists', async () => {
+    assert.equal(__testables.COMMERCIAL_REQUIRED_SOURCE_IDS.includes('consent.harmonia_opt_outs'), true)
+    assert.equal(__testables.COMMERCIAL_REQUIRED_SOURCE_IDS.includes('blocks.commercial_permissions'), true)
+    assert.equal(__testables.COMMERCIAL_REQUIRED_SOURCE_IDS.includes('identity.global_graph'), true)
+    const calls = []
+    const healthy = await __testables.sourceStale({
+        async query(sql, values) {
+            calls.push({ sql, values })
+            return { rows: [{ checkpoint_count: __testables.COMMERCIAL_REQUIRED_SOURCE_IDS.length, stale: false }] }
+        },
+    }, { sourceCheckpoints: true })
+    assert.equal(healthy, false)
+    assert.deepEqual(calls[0].values, [__testables.COMMERCIAL_REQUIRED_SOURCE_IDS])
+    const missing = await __testables.sourceStale({
+        async query() { return { rows: [{ checkpoint_count: __testables.COMMERCIAL_REQUIRED_SOURCE_IDS.length - 1, stale: false }] } },
+    }, { sourceCheckpoints: true })
+    assert.equal(missing, true)
+})
+
+test('reports migration readiness only when relations and append-only triggers are present', async () => {
+    const queries = []
+    const db = {
+        async query(sql, values = []) {
+            queries.push({ sql, values })
+            if (sql.includes("to_regclass('crm_atendimento.commercial_actions')")) return { rows: [readyAvailability()] }
+            if (sql.includes('where id=$1 and rolled_back_at is null')) return { rows: [{ id: '20260807_commercial_operations_v2' }] }
+            throw new Error(`unexpected sql: ${sql}`)
+        },
+    }
+    const readiness = await commercialOperationsReadiness(db)
+    assert.equal(readiness.ready, true)
+    assert.equal(readiness.appendOnlyReady, true)
+    assert.equal(readiness.safety.automationEnabled, false)
+    assert.equal(queries.length, 2)
+
+    const incomplete = await commercialOperationsReadiness({
+        async query(sql) {
+            if (sql.includes("to_regclass('crm_atendimento.commercial_actions')")) return { rows: [{ ...readyAvailability(), campaign_event_no_truncate: false }] }
+            if (sql.includes('where id=$1 and rolled_back_at is null')) return { rows: [{ id: '20260807_commercial_operations_v2' }] }
+            throw new Error(`unexpected sql: ${sql}`)
+        },
+    })
+    assert.equal(incomplete.ready, false)
+    assert.equal(incomplete.appendOnlyReady, false)
+})
+
+test('serializes idempotency before reading the ledger and never passes raw reason or key to SQL', async () => {
+    const previous = process.env.ATENDIMENTO_ACTOR_HMAC_KEY
+    process.env.ATENDIMENTO_ACTOR_HMAC_KEY = 'a'.repeat(32)
+    const calls = []
+    const client = {
+        async query(sql, values = []) {
+            calls.push({ sql, values })
+            if (sql.includes('pg_advisory_xact_lock')) return { rows: [] }
+            if (sql.includes("to_regclass('crm_atendimento.commercial_actions')")) return { rows: [readyAvailability()] }
+            if (sql.includes('where id=$1 and rolled_back_at is null')) return { rows: [{ id: '20260807_commercial_operations_v2' }] }
+            if (sql.includes('from crm_atendimento.commercial_operation_mutations')) {
+                return { rows: [{ request_fingerprint: values[0] ? calls.find((call) => call.sql.includes('pg_advisory_xact_lock'))?.values[0] : '', response: { operation: 'replayed' } }] }
+            }
+            throw new Error(`unexpected sql: ${sql}`)
+        },
+    }
+    try {
+        // Obtain the exact HMAC request fingerprint through the same public
+        // normalizer, then replay it from the append-only mutation ledger.
+        const context = __testables.mutationInput(actor, 'campaign_update', {
+            idempotencyKey: 'campaign:opaque-key-123', reason: 'Ajuste operacional seguro', expectedRevision: 1,
+        }, { campaignId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', state: 'paused' })
+        client.query = async (sql, values = []) => {
+            calls.push({ sql, values })
+            if (sql.includes('pg_advisory_xact_lock')) return { rows: [] }
+            if (sql.includes("to_regclass('crm_atendimento.commercial_actions')")) return { rows: [readyAvailability()] }
+            if (sql.includes('where id=$1 and rolled_back_at is null')) return { rows: [{ id: '20260807_commercial_operations_v2' }] }
+            if (sql.includes('from crm_atendimento.commercial_operation_mutations')) return { rows: [{ request_fingerprint: context.requestFingerprint, response: { operation: 'replayed' } }] }
+            throw new Error(`unexpected sql: ${sql}`)
+        }
+        const replay = await __testables.runCommercialOperationMutation(client, {
+            actor,
+            operation: 'campaign_update',
+            payload: { idempotencyKey: 'campaign:opaque-key-123', reason: 'Ajuste operacional seguro', expectedRevision: 1 },
+            fingerprintPayload: { campaignId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', state: 'paused' },
+            execute: async () => { throw new Error('a replay must not execute mutable work') },
+        })
+        assert.equal(replay.idempotent, true)
+        assert.equal(replay.operation, 'replayed')
+        const advisory = calls.findIndex((call) => call.sql.includes('pg_advisory_xact_lock'))
+        const ledger = calls.findIndex((call) => call.sql.includes('from crm_atendimento.commercial_operation_mutations'))
+        assert.ok(advisory >= 0 && advisory < ledger)
+        const serialized = JSON.stringify(calls)
+        assert.doesNotMatch(serialized, /campaign:opaque-key-123|Ajuste operacional seguro/)
+    } finally {
+        if (previous === undefined) delete process.env.ATENDIMENTO_ACTOR_HMAC_KEY
+        else process.env.ATENDIMENTO_ACTOR_HMAC_KEY = previous
+    }
+})
+
+test('projects rebalance and Customer 360 data without raw owner or technical event identifiers', async () => {
+    const actionId = '11111111-1111-4111-8111-111111111111'
+    const plan = __testables.projectRebalancePlan([
+        { id: actionId, owner: '5511999999999', status: 'open', revision: 3, unit_slug: 'centro', absent_owner: true },
+    ], { 'gestor.crm': 4 })
+    assert.deepEqual(plan, [{ actionId, fromOwner: null, toOwner: 'gestor.crm', expectedRevision: 3, unit: 'centro' }])
+    const event = __testables.projectTimeline({
+        id: 'internal-event-id', type: 'action', occurredAt: '2026-08-07T00:00:00.000Z', source: 'CRM ação', unit: 'centro',
+        actor: 'customer@example.com', trace_id: '33333333-3333-4333-8333-333333333333', context: { phone: '5511999999999' },
+    })
+    assert.doesNotMatch(event.id, /internal-event-id/)
+    assert.equal(event.actor, null)
+    assert.equal(event.correlationId, '33333333-3333-4333-8333-333333333333')
+    assert.deepEqual(Object.keys(event).sort(), ['actor', 'campaignId', 'consentReview', 'correlationId', 'id', 'occurredAt', 'offerId', 'source', 'status', 'type', 'unit'])
+})
+
+test('exposes an injected readiness-only store without opening a mutation path', async () => {
+    const pool = {
+        async query(sql) {
+            if (sql.includes("to_regclass('crm_atendimento.commercial_actions')")) return { rows: [readyAvailability()] }
+            if (sql.includes('where id=$1 and rolled_back_at is null')) return { rows: [{ id: '20260807_commercial_operations_v2' }] }
+            throw new Error(`unexpected sql: ${sql}`)
+        },
+    }
+    const store = createCommercialOperationsStore({ pool })
+    const readiness = await store.readiness(actor)
+    assert.equal(readiness.ready, true)
+    assert.equal(readiness.safety.commercialContactWritesEnabled, false)
+})
+
+test('records an opt-out request as an outcome without writing consent or dispatching contact', async () => {
+    const previous = process.env.ATENDIMENTO_ACTOR_HMAC_KEY
+    process.env.ATENDIMENTO_ACTOR_HMAC_KEY = 'b'.repeat(32)
+    const actionId = '11111111-1111-4111-8111-111111111111'
+    const identityId = '22222222-2222-4222-8222-222222222222'
+    const calls = []
+    const client = {
+        release() {},
+        async query(sql, values = []) {
+            calls.push({ sql, values })
+            if (['begin', 'commit', 'rollback'].includes(sql)) return { rows: [] }
+            if (sql.includes('pg_advisory_xact_lock')) return { rows: [] }
+            if (sql.includes("to_regclass('crm_atendimento.commercial_actions')")) return { rows: [readyAvailability()] }
+            if (sql.includes('where id=$1 and rolled_back_at is null')) return { rows: [{ id: '20260807_commercial_operations_v2' }] }
+            if (sql.includes('from crm_atendimento.commercial_operation_mutations')) return { rows: [] }
+            if (sql.includes('where action.id=$1 for update of action')) {
+                return { rows: [{ id: actionId, identity_id: identityId, revision: 2, status: 'contacted', owner: 'gestor.crm', unit_slug: 'centro' }] }
+            }
+            if (sql.includes('update crm_atendimento.commercial_actions')) return { rows: [] }
+            if (sql.includes('insert into crm_atendimento.commercial_action_events')) return { rows: [] }
+            if (sql.includes('from crm_atendimento.commercial_campaign_members') && sql.includes('where action_id=$1 for update')) return { rows: [] }
+            if (sql.includes('has_table_privilege')) return { rows: [{
+                permissions: false, source_checkpoints: false, identity_members: false, review_decisions: false,
+                attendance_caixa_links: false, app_attendance_links: false, app_caixa_links: false,
+                lead_app_links: false, lead_caixa_links: false,
+            }] }
+            if (sql.includes('select action.id::text,action.segment_key')) return { rows: [{
+                id: actionId, segment_key: 'synthetic', action_type: 'follow_up', status: 'responded', owner: 'gestor.crm',
+                due_date: '2026-08-08', revision: 3, outcome_code: 'opt_out_requested', created_at: '2026-08-07T00:00:00.000Z',
+                updated_at: '2026-08-07T00:01:00.000Z', unit_slug: 'centro', permission_status: 'review_required',
+                permission_expires_at: null, source_stale: true, identity_in_review: true,
+            }] }
+            if (sql.includes('insert into crm_atendimento.commercial_operation_mutations')) return { rows: [] }
+            throw new Error(`unexpected sql: ${sql}`)
+        },
+    }
+    try {
+        const store = createCommercialOperationsStore({ pool: { connect: async () => client } })
+        const result = await store.recordOutcome(actionId, {
+            idempotencyKey: 'action:synthetic-outcome-1', expectedRevision: 2,
+            reason: 'Solicitação sintética de opt-out', outcomeCode: 'opt_out_requested',
+        }, actor)
+        assert.equal(result.requiresSeparateConsentWorkflow, true)
+        assert.equal(result.action.outcomeCode, 'opt_out_requested')
+        assert.equal(result.safety.messagesEnabled, false)
+        assert.equal(calls.some((call) => /(?:insert into|update)\s+crm_atendimento\.commercial_contact_permissions/i.test(call.sql)), false)
+        assert.equal(calls.some((call) => /harmonia|dispatch|webhook/i.test(call.sql)), false)
+        assert.equal(calls.find((call) => call.sql.includes('update crm_atendimento.commercial_actions')).values[2], 'opt_out_requested')
+    } finally {
+        if (previous === undefined) delete process.env.ATENDIMENTO_ACTOR_HMAC_KEY
+        else process.env.ATENDIMENTO_ACTOR_HMAC_KEY = previous
+    }
+})
+
+test('rejects a stale optimistic revision before an action reassignment can write evidence', async () => {
+    const previous = process.env.ATENDIMENTO_ACTOR_HMAC_KEY
+    process.env.ATENDIMENTO_ACTOR_HMAC_KEY = 'c'.repeat(32)
+    const actionId = '11111111-1111-4111-8111-111111111111'
+    const calls = []
+    const client = {
+        release() {},
+        async query(sql, values = []) {
+            calls.push({ sql, values })
+            if (['begin', 'commit', 'rollback'].includes(sql)) return { rows: [] }
+            if (sql.includes('pg_advisory_xact_lock')) return { rows: [] }
+            if (sql.includes("to_regclass('crm_atendimento.commercial_actions')")) return { rows: [readyAvailability()] }
+            if (sql.includes('where id=$1 and rolled_back_at is null')) return { rows: [{ id: '20260807_commercial_operations_v2' }] }
+            if (sql.includes('from crm_atendimento.commercial_operation_mutations')) return { rows: [] }
+            if (sql.includes('where action.id=$1 for update of action')) {
+                return { rows: [{ id: actionId, identity_id: '22222222-2222-4222-8222-222222222222', revision: 3, status: 'open', owner: 'gestor.crm', unit_slug: 'centro' }] }
+            }
+            throw new Error(`unexpected sql: ${sql}`)
+        },
+    }
+    try {
+        const store = createCommercialOperationsStore({ pool: { connect: async () => client } })
+        await assert.rejects(() => store.reassignAction(actionId, {
+            idempotencyKey: 'action:synthetic-reassign-1', expectedRevision: 2,
+            reason: 'Redistribuição sintética', owner: 'gestor.backup',
+        }, actor), /COMMERCIAL_ACTION_CONFLICT/)
+        assert.equal(calls.some((call) => call.sql.includes('update crm_atendimento.commercial_actions')), false)
+        assert.equal(calls.some((call) => call.sql.includes('insert into crm_atendimento.commercial_action_events')), false)
+        assert.equal(calls.some((call) => call.sql.includes('insert into crm_atendimento.commercial_operation_mutations')), false)
+        assert.equal(calls.at(-1).sql, 'rollback')
+    } finally {
+        if (previous === undefined) delete process.env.ATENDIMENTO_ACTOR_HMAC_KEY
+        else process.env.ATENDIMENTO_ACTOR_HMAC_KEY = previous
+    }
+})

--- a/crm/api/server/atendimento/__tests__/commercialOperationsStore.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialOperationsStore.test.js
@@ -34,6 +34,16 @@ function readyAvailability() {
     }
 }
 
+function experimentGuardAvailability({ ready = true } = {}) {
+    return {
+        assignments: ready,
+        experiments: ready,
+        assignments_read: ready,
+        experiments_read: ready,
+        migration_ready: ready,
+    }
+}
+
 test('fails closed for a manager without an explicit unit claim and retains hard-disabled flags', () => {
     assert.deepEqual(__testables.commercialOperationsUnitScope({ id: 'gestor.crm', role: 'GESTOR' }), [])
     assert.throws(() => __testables.requestedUnitScope({ id: 'gestor.crm', role: 'GESTOR' }, 'centro'), /COMMERCIAL_UNIT_FORBIDDEN/)
@@ -63,6 +73,38 @@ test('treats every required consent/block and identity source as stale until a c
         async query() { return { rows: [{ checkpoint_count: __testables.COMMERCIAL_REQUIRED_SOURCE_IDS.length - 1, stale: false }] } },
     }, { sourceCheckpoints: true })
     assert.equal(missing, true)
+})
+
+test('fails closed when the analytics experiment guard is absent and permits only an empty active holdout result', async () => {
+    const unitId = '33333333-3333-4333-8333-333333333333'
+    const identityId = '22222222-2222-4222-8222-222222222222'
+    await assert.rejects(() => __testables.assertNoActiveExperimentHoldout({
+        async query(sql) {
+            if (sql.includes("to_regclass('crm_atendimento.commercial_experiment_assignments')")) {
+                return { rows: [experimentGuardAvailability({ ready: false })] }
+            }
+            throw new Error(`unexpected sql: ${sql}`)
+        },
+    }, { unitId, identityIds: [identityId] }), /COMMERCIAL_EXPERIMENT_GUARD_NOT_READY/)
+
+    const calls = []
+    await __testables.assertNoActiveExperimentHoldout({
+        async query(sql, values = []) {
+            calls.push({ sql, values })
+            if (sql.includes("to_regclass('crm_atendimento.commercial_experiment_assignments')")) {
+                return { rows: [experimentGuardAvailability()] }
+            }
+            if (sql.includes('pg_advisory_xact_lock')) return { rows: [] }
+            if (sql.includes('from crm_atendimento.commercial_experiment_assignments assignment')) return { rows: [] }
+            throw new Error(`unexpected sql: ${sql}`)
+        },
+    }, { unitId, identityIds: [identityId] })
+    assert.equal(calls.some((call) => call.sql.includes('from crm_atendimento.commercial_experiment_assignments assignment')), true)
+    const holdoutQuery = calls.find((call) => call.sql.includes('from crm_atendimento.commercial_experiment_assignments assignment'))
+    assert.equal(holdoutQuery.values[2].join(','), 'control,excluded')
+    assert.match(holdoutQuery.sql, /experiment\.state='active'/)
+    assert.match(holdoutQuery.sql, /experiment\.starts_at <= now\(\)/)
+    assert.match(holdoutQuery.sql, /experiment\.ends_at > now\(\)/)
 })
 
 test('reports migration readiness only when relations and append-only triggers are present', async () => {
@@ -162,6 +204,7 @@ test('exposes an injected readiness-only store without opening a mutation path',
     const pool = {
         async query(sql) {
             if (sql.includes("to_regclass('crm_atendimento.commercial_actions')")) return { rows: [readyAvailability()] }
+            if (sql.includes("to_regclass('crm_atendimento.commercial_experiment_assignments')")) return { rows: [experimentGuardAvailability({ ready: false })] }
             if (sql.includes('where id=$1 and rolled_back_at is null')) return { rows: [{ id: '20260807_commercial_operations_v2' }] }
             throw new Error(`unexpected sql: ${sql}`)
         },
@@ -170,6 +213,7 @@ test('exposes an injected readiness-only store without opening a mutation path',
     const readiness = await store.readiness(actor)
     assert.equal(readiness.ready, true)
     assert.equal(readiness.safety.commercialContactWritesEnabled, false)
+    assert.equal(readiness.experimentCrossoverGuard.ready, false)
 })
 
 test('records an opt-out request as an outcome without writing consent or dispatching contact', async () => {
@@ -254,6 +298,90 @@ test('rejects a stale optimistic revision before an action reassignment can writ
         }, actor), /COMMERCIAL_ACTION_CONFLICT/)
         assert.equal(calls.some((call) => call.sql.includes('update crm_atendimento.commercial_actions')), false)
         assert.equal(calls.some((call) => call.sql.includes('insert into crm_atendimento.commercial_action_events')), false)
+        assert.equal(calls.some((call) => call.sql.includes('insert into crm_atendimento.commercial_operation_mutations')), false)
+        assert.equal(calls.at(-1).sql, 'rollback')
+    } finally {
+        if (previous === undefined) delete process.env.ATENDIMENTO_ACTOR_HMAC_KEY
+        else process.env.ATENDIMENTO_ACTOR_HMAC_KEY = previous
+    }
+})
+
+test('rejects campaign creation when an active experiment has the identity in control or excluded', async () => {
+    const previous = process.env.ATENDIMENTO_ACTOR_HMAC_KEY
+    process.env.ATENDIMENTO_ACTOR_HMAC_KEY = 'd'.repeat(32)
+    const identityId = '22222222-2222-4222-8222-222222222222'
+    const unitId = '33333333-3333-4333-8333-333333333333'
+    const calls = []
+    const client = {
+        release() {},
+        async query(sql, values = []) {
+            calls.push({ sql, values })
+            if (['begin', 'commit', 'rollback'].includes(sql)) return { rows: [] }
+            if (sql.includes('pg_advisory_xact_lock')) return { rows: [] }
+            if (sql.includes("to_regclass('crm_atendimento.commercial_actions')")) return { rows: [readyAvailability()] }
+            if (sql.includes("to_regclass('crm_atendimento.commercial_experiment_assignments')")) return { rows: [experimentGuardAvailability()] }
+            if (sql.includes('where id=$1 and rolled_back_at is null')) return { rows: [{ id: '20260807_commercial_operations_v2' }] }
+            if (sql.includes('from crm_atendimento.commercial_operation_mutations')) return { rows: [] }
+            if (sql.includes('select id::text,slug from crm_atendimento.units where slug=$1')) return { rows: [{ id: unitId, slug: 'centro' }] }
+            if (sql.includes('from crm_atendimento.commercial_experiment_assignments assignment')) {
+                return { rows: [{ identity_id: identityId, variant: 'control' }] }
+            }
+            throw new Error(`unexpected sql: ${sql}`)
+        },
+    }
+    try {
+        const store = createCommercialOperationsStore({ pool: { connect: async () => client } })
+        await assert.rejects(() => store.createCampaign({
+            idempotencyKey: 'campaign:synthetic-holdout-1', reason: 'Coorte sintética de experimento',
+            name: 'Retorno sintético', segmentKey: 'return', segmentVersion: 'v1', unit: 'centro', owner: 'gestor.crm',
+            filters: { status: ['open'] }, identityIds: [identityId], cutoffAt: '2026-08-07T12:00:00.000Z',
+            assignmentWindowStart: '2026-08-08T00:00:00.000Z', assignmentWindowEnd: '2026-08-15T00:00:00.000Z', controlGroupPercent: 20,
+        }, actor), /COMMERCIAL_EXPERIMENT_HOLDOUT_ACTIVE/)
+        assert.equal(calls.some((call) => call.sql.includes('insert into crm_atendimento.commercial_campaigns')), false)
+        assert.equal(calls.some((call) => call.sql.includes('insert into crm_atendimento.commercial_campaign_members')), false)
+        assert.equal(calls.some((call) => call.sql.includes('insert into crm_atendimento.commercial_operation_mutations')), false)
+        assert.equal(calls.at(-1).sql, 'rollback')
+    } finally {
+        if (previous === undefined) delete process.env.ATENDIMENTO_ACTOR_HMAC_KEY
+        else process.env.ATENDIMENTO_ACTOR_HMAC_KEY = previous
+    }
+})
+
+test('rejects action reassignment before action, campaign or ledger writes for an active experiment holdout', async () => {
+    const previous = process.env.ATENDIMENTO_ACTOR_HMAC_KEY
+    process.env.ATENDIMENTO_ACTOR_HMAC_KEY = 'e'.repeat(32)
+    const actionId = '11111111-1111-4111-8111-111111111111'
+    const identityId = '22222222-2222-4222-8222-222222222222'
+    const unitId = '33333333-3333-4333-8333-333333333333'
+    const calls = []
+    const client = {
+        release() {},
+        async query(sql, values = []) {
+            calls.push({ sql, values })
+            if (['begin', 'commit', 'rollback'].includes(sql)) return { rows: [] }
+            if (sql.includes('pg_advisory_xact_lock')) return { rows: [] }
+            if (sql.includes("to_regclass('crm_atendimento.commercial_actions')")) return { rows: [readyAvailability()] }
+            if (sql.includes("to_regclass('crm_atendimento.commercial_experiment_assignments')")) return { rows: [experimentGuardAvailability()] }
+            if (sql.includes('where id=$1 and rolled_back_at is null')) return { rows: [{ id: '20260807_commercial_operations_v2' }] }
+            if (sql.includes('from crm_atendimento.commercial_operation_mutations')) return { rows: [] }
+            if (sql.includes('where action.id=$1 for update of action')) {
+                return { rows: [{ id: actionId, identity_id: identityId, unit_id: unitId, revision: 2, status: 'open', owner: 'gestor.crm', unit_slug: 'centro' }] }
+            }
+            if (sql.includes('from crm_atendimento.commercial_experiment_assignments assignment')) {
+                return { rows: [{ identity_id: identityId, variant: 'excluded' }] }
+            }
+            throw new Error(`unexpected sql: ${sql}`)
+        },
+    }
+    try {
+        const store = createCommercialOperationsStore({ pool: { connect: async () => client } })
+        await assert.rejects(() => store.reassignAction(actionId, {
+            idempotencyKey: 'action:synthetic-holdout-1', expectedRevision: 2,
+            reason: 'Redistribuição sintética bloqueada', owner: 'gestor.backup',
+        }, actor), /COMMERCIAL_EXPERIMENT_HOLDOUT_ACTIVE/)
+        assert.equal(calls.some((call) => call.sql.includes('update crm_atendimento.commercial_actions')), false)
+        assert.equal(calls.some((call) => call.sql.includes('insert into crm_atendimento.commercial_action_events')), false)
+        assert.equal(calls.some((call) => call.sql.includes('update crm_atendimento.commercial_campaign_members')), false)
         assert.equal(calls.some((call) => call.sql.includes('insert into crm_atendimento.commercial_operation_mutations')), false)
         assert.equal(calls.at(-1).sql, 'rollback')
     } finally {

--- a/crm/api/server/atendimento/__tests__/routes.test.js
+++ b/crm/api/server/atendimento/__tests__/routes.test.js
@@ -7,7 +7,7 @@ function actorHeader(actor) {
     return Buffer.from(JSON.stringify(actor)).toString('base64url')
 }
 
-function captureAtendimentoRoutes(store) {
+function captureAtendimentoRoutes(store, options = {}) {
     const routes = new Map()
     const router = {
         use() { return router },
@@ -17,7 +17,7 @@ function captureAtendimentoRoutes(store) {
         patch(path, handler) { routes.set(`PATCH ${path}`, handler); return router },
         delete(path, handler) { routes.set(`DELETE ${path}`, handler); return router },
     }
-    createAtendimentoRouter({ store, routerFactory: () => router })
+    createAtendimentoRouter({ store, ...options, routerFactory: () => router })
     return routes
 }
 
@@ -325,4 +325,52 @@ test('keeps cluster workspace, reveal and deterministic bulk routes inside the G
     assert.equal(blocked.state.status, 403)
     assert.deepEqual(blocked.state.body, { ok: false, error: 'FORBIDDEN' })
     assert.equal(calls.length, 2)
+})
+
+test('routes Commercial Operations through its injected store with a single opaque idempotency key', async () => {
+    const calls = []
+    const operations = {
+        async readiness(actor) { calls.push(['readiness', actor.id]); return { ready: true, safety: { messagesEnabled: false } } },
+        async wallet(query, actor) { calls.push(['wallet', query, actor.id]); return { actions: [], safety: { messagesEnabled: false } } },
+        async createCampaign(payload, actor) { calls.push(['campaign', payload, actor.id]); return { campaign: { campaignId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' }, safety: { messagesEnabled: false } } },
+    }
+    const routes = captureAtendimentoRoutes({}, { commercialOperationsStore: operations })
+    const actor = { id: 'gestor-1', role: 'GESTOR', allowedModules: ['atendimento'], allowedUnits: ['novo-hamburgo'], allowedUnitsDeclared: true }
+
+    const readiness = captureResponse()
+    await routes.get('GET /commercial/operations/readiness')({ atendimentoActor: actor }, readiness)
+    assert.equal(readiness.state.status, 200)
+    assert.equal(readiness.state.body.safety.messagesEnabled, false)
+
+    const wallet = captureResponse()
+    await routes.get('GET /commercial/operations/wallet')({ atendimentoActor: actor, query: { unit: 'novo-hamburgo' } }, wallet)
+    assert.equal(wallet.state.status, 200)
+    assert.deepEqual(calls[1], ['wallet', { unit: 'novo-hamburgo' }, 'gestor-1'])
+
+    const campaign = captureResponse()
+    await routes.get('POST /commercial/operations/campaigns')({
+        atendimentoActor: actor,
+        headers: { 'idempotency-key': 'campaign:opaque-key-1' },
+        body: { idempotencyKey: 'campaign:opaque-key-1', reason: 'Coorte sintética aprovada.' },
+    }, campaign)
+    assert.equal(campaign.state.status, 200)
+    assert.equal(calls[2][1].idempotencyKey, 'campaign:opaque-key-1')
+    assert.equal(campaign.state.body.safety.messagesEnabled, false)
+
+    const beforeForbidden = calls.length
+    const forbidden = captureResponse()
+    await routes.get('POST /commercial/operations/campaigns')({
+        atendimentoActor: { ...actor, role: 'GERENTE' }, headers: {}, body: { idempotencyKey: 'campaign:opaque-key-2' },
+    }, forbidden)
+    assert.equal(forbidden.state.status, 403)
+    assert.equal(calls.length, beforeForbidden)
+
+    const mismatch = captureResponse()
+    await routes.get('POST /commercial/operations/campaigns')({
+        atendimentoActor: actor,
+        headers: { 'idempotency-key': 'campaign:opaque-key-3' },
+        body: { idempotencyKey: 'campaign:opaque-key-4' },
+    }, mismatch)
+    assert.equal(mismatch.state.status, 400)
+    assert.equal(calls.length, beforeForbidden)
 })

--- a/crm/api/server/atendimento/commercialOperations.js
+++ b/crm/api/server/atendimento/commercialOperations.js
@@ -312,8 +312,11 @@ export function computeAverageStageDurations(events = []) {
 }
 
 export function campaignMemberState({ eligible, controlGroup, identityInReview, sourceStale } = {}) {
-    if (controlGroup) return 'control'
     if (!eligible) return identityInReview || sourceStale ? 'review' : 'blocked'
+    // A holdout is reproducible only within the same eligible population.  An
+    // ineligible identity is never silently reclassified as control; it must
+    // remain blocked/review until the underlying gate becomes healthy.
+    if (controlGroup) return 'control'
     if (identityInReview || sourceStale) return 'review'
     return 'eligible'
 }

--- a/crm/api/server/atendimento/commercialOperations.js
+++ b/crm/api/server/atendimento/commercialOperations.js
@@ -1,0 +1,374 @@
+import { createHash } from 'node:crypto'
+
+// This module deliberately contains only deterministic, PII-free domain
+// contracts. Persistence, RBAC and contact eligibility are enforced by the
+// store that consumes these values; no caller can turn an outcome into a send.
+export const COMMERCIAL_OUTCOME_CODES = Object.freeze([
+    'no_response',
+    'wrong_number',
+    'requested_follow_up',
+    'not_interested',
+    'completed_elsewhere',
+    'scheduled',
+    'attended',
+    'cancelled',
+    'sale',
+    'clinical_return',
+    'opt_out_requested',
+])
+
+export const COMMERCIAL_CAMPAIGN_STATES = Object.freeze([
+    'draft', 'scheduled', 'active', 'paused', 'completed', 'cancelled',
+])
+
+export const COMMERCIAL_CAMPAIGN_MEMBER_STATES = Object.freeze([
+    'eligible', 'blocked', 'review', 'control', 'assigned', 'completed', 'cancelled',
+])
+
+export const COMMERCIAL_OPERATION_FLAGS = Object.freeze([
+    'assigned_to_me',
+    'due_today',
+    'overdue',
+    'awaiting_response',
+    'scheduled',
+    'no_return',
+    'permission_expiring',
+    'ineligible',
+    'source_stale',
+    'identity_review',
+])
+
+const ACTIVE_ACTION_STATUSES = new Set(['open', 'contacted', 'responded', 'scheduled'])
+const ID_PATTERN = /^[A-Za-z0-9._:-]{8,200}$/
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const OWNER_PATTERN = /^[A-Za-z0-9._:+\- ]{1,160}$/
+const FILTER_KEYS = new Set(['segment', 'segmentKey', 'priority', 'source', 'status', 'unit', 'stale', 'identityReview', 'permission', 'owner', 'actionFlag'])
+
+function text(value) {
+    return typeof value === 'string' ? value.trim() : String(value ?? '').trim()
+}
+
+function dateOnly(value) {
+    const normalized = text(value).slice(0, 10)
+    return /^\d{4}-\d{2}-\d{2}$/.test(normalized) ? normalized : ''
+}
+
+function dateTime(value) {
+    const date = new Date(value)
+    return Number.isNaN(date.getTime()) ? null : date
+}
+
+function safeObject(value, maximumBytes = 16_000) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+    const serialized = JSON.stringify(value)
+    return serialized.length <= maximumBytes ? value : null
+}
+
+function containsPiiLikeValue(value) {
+    const raw = text(value)
+    return /@/.test(raw) || /\d{7,}/.test(raw)
+}
+
+function stableValue(value) {
+    if (value === null || typeof value !== 'object') return value
+    if (Array.isArray(value)) return value.map(stableValue)
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stableValue(value[key])]))
+}
+
+export function commercialOperationError(code, statusCode = 400) {
+    const error = new Error(code)
+    error.code = code
+    error.statusCode = statusCode
+    return error
+}
+
+export function stableOperationFingerprint(value) {
+    return createHash('sha256').update(JSON.stringify(stableValue(value))).digest('hex')
+}
+
+export function normalizeOutcomeCode(value) {
+    const normalized = text(value).toLowerCase().replace(/[\s-]+/g, '_')
+    return COMMERCIAL_OUTCOME_CODES.includes(normalized) ? normalized : ''
+}
+
+export function normalizeOperationMutation(payload = {}, { requireIdempotency = true, requireReason = false } = {}) {
+    const candidate = payload && typeof payload === 'object' && !Array.isArray(payload) ? payload : {}
+    const idempotencyKey = text(candidate.idempotencyKey)
+    const expectedRevision = candidate.expectedRevision == null || candidate.expectedRevision === ''
+        ? null
+        : Number(candidate.expectedRevision)
+    const reason = text(candidate.reason)
+    const outcomeCode = normalizeOutcomeCode(candidate.outcomeCode)
+
+    if (requireIdempotency && !idempotencyKey) throw commercialOperationError('COMMERCIAL_IDEMPOTENCY_KEY_REQUIRED')
+    if (idempotencyKey && (!ID_PATTERN.test(idempotencyKey) || containsPiiLikeValue(idempotencyKey))) {
+        throw commercialOperationError('INVALID_COMMERCIAL_IDEMPOTENCY_KEY')
+    }
+    if (expectedRevision != null && (!Number.isInteger(expectedRevision) || expectedRevision < 1)) {
+        throw commercialOperationError('COMMERCIAL_EXPECTED_REVISION_INVALID')
+    }
+    if ((requireReason || reason) && (reason.length < 3 || reason.length > 1_000 || containsPiiLikeValue(reason))) {
+        throw commercialOperationError('COMMERCIAL_OPERATION_REASON_INVALID')
+    }
+    if (candidate.outcomeCode != null && !outcomeCode) throw commercialOperationError('INVALID_COMMERCIAL_OUTCOME')
+    return { idempotencyKey, expectedRevision, reason, outcomeCode }
+}
+
+export function normalizeCampaignFilters(value) {
+    const input = safeObject(value)
+    if (input === null) throw commercialOperationError('COMMERCIAL_CAMPAIGN_FILTER_INVALID')
+    const filters = {}
+    for (const [key, raw] of Object.entries(input)) {
+        if (!FILTER_KEYS.has(key)) throw commercialOperationError('COMMERCIAL_CAMPAIGN_FILTER_INVALID')
+        const values = Array.isArray(raw) ? raw : [raw]
+        if (values.length > 20 || values.some((entry) => {
+            const candidate = text(entry)
+            return candidate.length > 120 || containsPiiLikeValue(candidate)
+        })) {
+            throw commercialOperationError('COMMERCIAL_CAMPAIGN_FILTER_INVALID')
+        }
+        if (values.some((entry) => !['string', 'number', 'boolean'].includes(typeof entry))) {
+            throw commercialOperationError('COMMERCIAL_CAMPAIGN_FILTER_INVALID')
+        }
+        filters[key] = Array.isArray(raw) ? [...values] : raw
+    }
+    return filters
+}
+
+export function normalizeCampaignPayload(payload = {}) {
+    const input = payload && typeof payload === 'object' && !Array.isArray(payload) ? payload : {}
+    const name = text(input.name)
+    const segmentKey = text(input.segmentKey)
+    const segmentVersion = text(input.segmentVersion)
+    const unit = text(input.unit || input.unitSlug).toLowerCase()
+    const owner = text(input.owner)
+    const reason = text(input.reason)
+    const cutoffAt = dateTime(input.cutoffAt || input.cutoff_at)
+    const assignmentWindowStart = dateTime(input.assignmentWindowStart || input.assignment_window_start)
+    const assignmentWindowEnd = dateTime(input.assignmentWindowEnd || input.assignment_window_end)
+    const controlGroupPercent = Number(input.controlGroupPercent ?? input.control_group_percent ?? 0)
+    const offerId = text(input.offerId)
+    const identityIds = [...new Set((Array.isArray(input.identityIds) ? input.identityIds : []).map(text).filter(Boolean))]
+    const state = text(input.state).toLowerCase() || 'draft'
+    const filters = normalizeCampaignFilters(input.filters)
+
+    if (!name || name.length > 160 || containsPiiLikeValue(name)) throw commercialOperationError('INVALID_COMMERCIAL_CAMPAIGN_NAME')
+    if (!segmentKey || segmentKey.length > 120 || !segmentVersion || segmentVersion.length > 120) throw commercialOperationError('COMMERCIAL_CAMPAIGN_SEGMENT_REQUIRED')
+    if (!/^[a-z0-9._-]+$/i.test(segmentKey) || !/^[a-z0-9._-]+$/i.test(segmentVersion)) throw commercialOperationError('COMMERCIAL_CAMPAIGN_SEGMENT_REQUIRED')
+    if (!unit || unit.length > 120 || !/^[a-z0-9._-]+$/i.test(unit)) throw commercialOperationError('COMMERCIAL_CAMPAIGN_UNIT_REQUIRED')
+    if (!owner || !OWNER_PATTERN.test(owner) || containsPiiLikeValue(owner)) throw commercialOperationError('COMMERCIAL_CAMPAIGN_OWNER_REQUIRED')
+    if (reason.length < 3 || reason.length > 1_000 || containsPiiLikeValue(reason)) throw commercialOperationError('COMMERCIAL_CAMPAIGN_REASON_REQUIRED')
+    if (!cutoffAt || !assignmentWindowStart || !assignmentWindowEnd || assignmentWindowEnd < assignmentWindowStart) throw commercialOperationError('INVALID_COMMERCIAL_CAMPAIGN_WINDOW')
+    if (!Number.isInteger(controlGroupPercent) || controlGroupPercent < 0 || controlGroupPercent > 100) throw commercialOperationError('INVALID_COMMERCIAL_CONTROL_GROUP')
+    if (!identityIds.length || identityIds.length > 500 || identityIds.some((id) => !UUID_PATTERN.test(id))) throw commercialOperationError('COMMERCIAL_CAMPAIGN_COHORT_REQUIRED')
+    if (offerId && !UUID_PATTERN.test(offerId)) throw commercialOperationError('COMMERCIAL_CAMPAIGN_OFFER_INVALID')
+    if (!COMMERCIAL_CAMPAIGN_STATES.includes(state)) throw commercialOperationError('INVALID_COMMERCIAL_CAMPAIGN_STATE')
+
+    return {
+        name,
+        segmentKey,
+        segmentVersion,
+        unit,
+        owner,
+        reason,
+        filters,
+        identityIds,
+        cutoffAt: cutoffAt.toISOString(),
+        assignmentWindowStart: assignmentWindowStart.toISOString(),
+        assignmentWindowEnd: assignmentWindowEnd.toISOString(),
+        controlGroupPercent,
+        offerId: offerId || null,
+        state,
+    }
+}
+
+export function actionQueueFlags(action = {}, {
+    today = new Date().toISOString().slice(0, 10),
+    actorIds = [],
+    eligibility = null,
+    sourceStale = false,
+    identityInReview = false,
+} = {}) {
+    const flags = []
+    const status = text(action.status).toLowerCase()
+    const dueDate = dateOnly(action.dueDate || action.due_date)
+    const owner = text(action.owner)
+    const active = ACTIVE_ACTION_STATUSES.has(status)
+    const normalizedActors = new Set(actorIds.map(text).filter(Boolean).map((id) => id.toLowerCase()))
+    if (owner && normalizedActors.has(owner.toLowerCase())) flags.push('assigned_to_me')
+    if (active && dueDate === today) flags.push('due_today')
+    if (active && dueDate && dueDate < today) flags.push('overdue')
+    if (status === 'contacted') flags.push('awaiting_response')
+    if (status === 'scheduled') flags.push('scheduled')
+    // "Sem retorno" is deliberately a later operational condition than simply
+    // awaiting a response: the declared return/follow-up deadline must have
+    // elapsed.  We accept the legacy due date as the final fallback so existing
+    // actions remain visible, but never infer it from contact content.
+    const returnDueDate = dateOnly(action.returnDueAt || action.return_due_at || action.followUpDueAt || action.follow_up_due_at || action.dueDate || action.due_date)
+    if (active && status === 'contacted' && returnDueDate && returnDueDate < today) flags.push('no_return')
+    const expiry = dateTime(eligibility?.expiresAt || eligibility?.expires_at)
+    const now = dateTime(`${today}T00:00:00.000Z`) || new Date()
+    if (expiry && expiry >= now && expiry.getTime() <= now.getTime() + 7 * 86_400_000) flags.push('permission_expiring')
+    if (eligibility && eligibility.status !== 'eligible') flags.push('ineligible')
+    if (sourceStale) flags.push('source_stale')
+    if (identityInReview) flags.push('identity_review')
+    return flags
+}
+
+export function classifyCommercialAction(action = {}, options = {}) {
+    const queueFlags = actionQueueFlags(action, options)
+    return {
+        ...action,
+        queueFlags,
+        active: ACTIVE_ACTION_STATUSES.has(text(action.status).toLowerCase()),
+    }
+}
+
+function increment(record, key, amount = 1) {
+    record[key] = Number(record[key] || 0) + amount
+}
+
+function outcomeTotals(action, status, outcome) {
+    return {
+        completed: ['closed', 'cancelled', 'won_sale', 'returned'].includes(status) || ['attended', 'sale', 'clinical_return', 'cancelled'].includes(outcome),
+        responded: ['responded', 'scheduled', 'won_sale', 'returned'].includes(status) || ['requested_follow_up', 'scheduled', 'attended', 'cancelled', 'sale', 'clinical_return', 'opt_out_requested'].includes(outcome),
+        scheduled: status === 'scheduled' || outcome === 'scheduled',
+        attended: outcome === 'attended',
+        sale: status === 'won_sale' || outcome === 'sale',
+        returned: status === 'returned' || outcome === 'clinical_return',
+        cancelled: status === 'cancelled' || outcome === 'cancelled',
+    }
+}
+
+export function aggregateCommercialActionMetrics(actions = [], { today = new Date().toISOString().slice(0, 10) } = {}) {
+    const totals = { total: 0, active: 0, dueToday: 0, overdue: 0, completed: 0, responded: 0, scheduled: 0, attended: 0, sale: 0, returned: 0, cancelled: 0 }
+    const byStatus = {}
+    const owners = new Map()
+    for (const action of actions) {
+        const status = text(action.status).toLowerCase() || 'open'
+        const outcome = normalizeOutcomeCode(action.outcomeCode || action.outcome_code)
+        const flags = action.queueFlags || actionQueueFlags(action, { today })
+        const normalized = outcomeTotals(action, status, outcome)
+        increment(totals, 'total')
+        increment(byStatus, status)
+        if (ACTIVE_ACTION_STATUSES.has(status)) increment(totals, 'active')
+        if (flags.includes('due_today')) increment(totals, 'dueToday')
+        if (flags.includes('overdue')) increment(totals, 'overdue')
+        for (const [key, enabled] of Object.entries(normalized)) if (enabled) increment(totals, key)
+        const owner = text(action.owner) || 'unassigned'
+        const row = owners.get(owner) || { owner, total: 0, active: 0, overdue: 0, completed: 0, responded: 0, scheduled: 0, attended: 0, sale: 0, returned: 0, cancelled: 0, statuses: {} }
+        increment(row, 'total')
+        increment(row.statuses, status)
+        if (ACTIVE_ACTION_STATUSES.has(status)) increment(row, 'active')
+        if (flags.includes('overdue')) increment(row, 'overdue')
+        for (const [key, enabled] of Object.entries(normalized)) if (enabled) increment(row, key)
+        owners.set(owner, row)
+    }
+    const denominator = totals.total || 1
+    const rate = (key) => Math.round((totals[key] / denominator) * 10_000) / 100
+    return {
+        totals: {
+            ...totals,
+            completionRate: rate('completed'),
+            responseRate: rate('responded'),
+            schedulingRate: rate('scheduled'),
+            attendanceRate: rate('attended'),
+            saleRate: rate('sale'),
+            returnRate: rate('returned'),
+            cancellationRate: rate('cancelled'),
+        },
+        byStatus,
+        byOwner: [...owners.values()].sort((left, right) => right.active - left.active || left.owner.localeCompare(right.owner)),
+    }
+}
+
+export function computeAverageStageDurations(events = []) {
+    const byAction = new Map()
+    for (const event of events) {
+        const actionId = text(event.actionId || event.action_id)
+        const status = text(event.status)
+        const occurredAt = dateTime(event.occurredAt || event.createdAt || event.created_at)
+        if (!actionId || !status || !occurredAt) continue
+        const rows = byAction.get(actionId) || []
+        rows.push({ status, occurredAt })
+        byAction.set(actionId, rows)
+    }
+    const duration = new Map()
+    for (const rows of byAction.values()) {
+        rows.sort((left, right) => left.occurredAt - right.occurredAt)
+        for (let index = 0; index < rows.length - 1; index += 1) {
+            const current = rows[index]
+            const next = rows[index + 1]
+            const state = duration.get(current.status) || { totalHours: 0, samples: 0 }
+            state.totalHours += Math.max(0, (next.occurredAt.getTime() - current.occurredAt.getTime()) / 3_600_000)
+            state.samples += 1
+            duration.set(current.status, state)
+        }
+    }
+    return Object.fromEntries([...duration.entries()].map(([status, values]) => [status, {
+        hours: Math.round((values.totalHours / Math.max(1, values.samples)) * 100) / 100,
+        samples: values.samples,
+    }]))
+}
+
+export function campaignMemberState({ eligible, controlGroup, identityInReview, sourceStale } = {}) {
+    if (controlGroup) return 'control'
+    if (!eligible) return identityInReview || sourceStale ? 'review' : 'blocked'
+    if (identityInReview || sourceStale) return 'review'
+    return 'eligible'
+}
+
+export function stableControlGroup({ campaignSeed, identityId, percentage }) {
+    const percent = Number(percentage)
+    if (!UUID_PATTERN.test(text(identityId)) || !Number.isInteger(percent) || percent < 0 || percent > 100) {
+        throw commercialOperationError('INVALID_COMMERCIAL_CONTROL_GROUP')
+    }
+    if (!text(campaignSeed) || text(campaignSeed).length > 200) throw commercialOperationError('INVALID_COMMERCIAL_CAMPAIGN_SEED')
+    const bucket = Number.parseInt(stableOperationFingerprint({ campaignSeed: text(campaignSeed), identityId: text(identityId) }).slice(0, 8), 16) % 100
+    return bucket < percent
+}
+
+export function planWalletBalance(actions = [], capacities = {}) {
+    const loads = new Map()
+    const active = actions.filter((action) => ACTIVE_ACTION_STATUSES.has(text(action.status).toLowerCase()))
+    for (const action of active.filter((action) => !action.absentOwner)) {
+        const owner = text(action.owner)
+        if (owner) loads.set(owner, (loads.get(owner) || 0) + 1)
+    }
+    const targets = Object.entries(capacities)
+        .map(([owner, capacity]) => ({ owner: text(owner), capacity: Math.max(0, Number(capacity) || 0), load: loads.get(text(owner)) || 0 }))
+        .filter((entry) => entry.owner && OWNER_PATTERN.test(entry.owner))
+        .sort((left, right) => (left.load / Math.max(1, left.capacity)) - (right.load / Math.max(1, right.capacity)) || left.owner.localeCompare(right.owner))
+    const moves = []
+    for (const action of active) {
+        const current = text(action.owner)
+        const capacity = capacities[current]
+        const needsMove = !current || action.absentOwner || (capacity != null && (loads.get(current) || 0) > Number(capacity))
+        if (!needsMove) continue
+        const target = targets.find((entry) => entry.owner !== current && entry.load < entry.capacity)
+        if (!target) continue
+        moves.push({ actionId: text(action.id), fromOwner: current || null, toOwner: target.owner })
+        target.load += 1
+    }
+    return moves.filter((move) => UUID_PATTERN.test(move.actionId))
+}
+
+// Presentation is intentionally explicit. Do not spread raw evidence/context
+// into Customer 360; that is how technical identifiers and PII leak by drift.
+export function projectCommercialTimelineEvent(row = {}) {
+    const type = text(row.type || row.event_type)
+    const allowedTypes = new Set(['attendance', 'sale', 'permission', 'opt_out', 'action', 'contact', 'response', 'appointment', 'campaign', 'offer', 'identity_decision', 'quality_finding', 'correction'])
+    return {
+        id: text(row.id || row.event_id),
+        type: allowedTypes.has(type) ? type : 'correction',
+        occurredAt: dateTime(row.occurredAt || row.occurred_on || row.created_at)?.toISOString() || null,
+        source: text(row.source || row.source_label).slice(0, 80),
+        unit: text(row.unit || row.unit_slug || row.unit_name).slice(0, 120),
+        actor: containsPiiLikeValue(row.actor || row.actor_label) ? null : text(row.actor || row.actor_label).slice(0, 160) || null,
+        correlationId: UUID_PATTERN.test(text(row.correlationId || row.trace_id)) ? text(row.correlationId || row.trace_id) : null,
+        campaignId: UUID_PATTERN.test(text(row.campaignId || row.campaign_id)) ? text(row.campaignId || row.campaign_id) : null,
+        offerId: UUID_PATTERN.test(text(row.offerId || row.offer_id)) ? text(row.offerId || row.offer_id) : null,
+        consentReview: text(row.consentReview || row.consent_review).slice(0, 80) || null,
+        status: text(row.status || row.event_status).slice(0, 80) || 'confirmed',
+    }
+}

--- a/crm/api/server/atendimento/commercialOperationsMigration.js
+++ b/crm/api/server/atendimento/commercialOperationsMigration.js
@@ -58,6 +58,9 @@ function runtimeGrantStatements(target) {
         `revoke update, delete, truncate, references, trigger on table crm_atendimento.commercial_campaign_events from ${role}`,
         `revoke delete, truncate, references, trigger on table crm_atendimento.commercial_owner_absences from ${role}`,
         `grant usage on schema crm_atendimento to ${role}`,
+        // Runtime readiness and the experiment crossover guard read this
+        // registry.  The runtime role remains unable to apply migrations.
+        `grant select on table crm_atendimento.schema_migrations to ${role}`,
         `grant select, insert, update on table crm_atendimento.commercial_actions to ${role}`,
         `grant select, insert on table crm_atendimento.commercial_action_events to ${role}`,
         `grant select, insert on table crm_atendimento.commercial_operation_mutations to ${role}`,

--- a/crm/api/server/atendimento/commercialOperationsMigration.js
+++ b/crm/api/server/atendimento/commercialOperationsMigration.js
@@ -1,0 +1,333 @@
+import {
+    assertAtendimentoMigrationDestination,
+    ATENDIMENTO_MIGRATION_TARGETS,
+    isStrictAtendimentoMigrationDestination,
+} from './migrationDestination.js'
+import {
+    COMMERCIAL_CAMPAIGN_MEMBER_STATES,
+    COMMERCIAL_CAMPAIGN_STATES,
+    COMMERCIAL_OUTCOME_CODES,
+} from './commercialOperations.js'
+
+export const COMMERCIAL_OPERATIONS_MIGRATION_ID = '20260807_commercial_operations_v2'
+
+const RUNTIME_ROLES = Object.freeze({
+    [ATENDIMENTO_MIGRATION_TARGETS.LOCAL]: 'skincos',
+    [ATENDIMENTO_MIGRATION_TARGETS.STAGING]: 'skincos_staging_crm_app',
+})
+
+const PREREQUISITE_RELATIONS = Object.freeze([
+    'crm_atendimento.units',
+    'crm_atendimento.global_client_identities',
+    'crm_atendimento.commercial_actions',
+    'crm_atendimento.commercial_action_events',
+    'crm_atendimento.commercial_offers',
+])
+
+const OUTCOME_SQL = COMMERCIAL_OUTCOME_CODES.map((value) => `'${value}'`).join(', ')
+const CAMPAIGN_STATE_SQL = COMMERCIAL_CAMPAIGN_STATES.map((value) => `'${value}'`).join(', ')
+const MEMBER_STATE_SQL = COMMERCIAL_CAMPAIGN_MEMBER_STATES.map((value) => `'${value}'`).join(', ')
+
+function migrationError(code) {
+    const error = new Error(code)
+    error.code = code
+    return error
+}
+
+function createTriggerIfMissing(relation, triggerName, triggerSql) {
+    return `do $$ begin
+        if not exists (
+            select 1 from pg_trigger
+             where tgrelid = '${relation}'::regclass and tgname = '${triggerName}'
+        ) then
+            execute $trigger$${triggerSql}$trigger$;
+        end if;
+    end $$`
+}
+
+function runtimeGrantStatements(target) {
+    const role = RUNTIME_ROLES[target]
+    if (!role) throw migrationError('COMMERCIAL_OPERATIONS_RUNTIME_ROLE_UNKNOWN')
+    return [
+        `revoke create on schema crm_atendimento from ${role}`,
+        `revoke delete, truncate, references, trigger on table crm_atendimento.commercial_actions from ${role}`,
+        `revoke update, delete, truncate, references, trigger on table crm_atendimento.commercial_action_events from ${role}`,
+        `revoke update, delete, truncate, references, trigger on table crm_atendimento.commercial_operation_mutations from ${role}`,
+        `revoke delete, truncate, references, trigger on table crm_atendimento.commercial_campaigns from ${role}`,
+        `revoke delete, truncate, references, trigger on table crm_atendimento.commercial_campaign_members from ${role}`,
+        `revoke update, delete, truncate, references, trigger on table crm_atendimento.commercial_campaign_events from ${role}`,
+        `revoke delete, truncate, references, trigger on table crm_atendimento.commercial_owner_absences from ${role}`,
+        `grant usage on schema crm_atendimento to ${role}`,
+        `grant select, insert, update on table crm_atendimento.commercial_actions to ${role}`,
+        `grant select, insert on table crm_atendimento.commercial_action_events to ${role}`,
+        `grant select, insert on table crm_atendimento.commercial_operation_mutations to ${role}`,
+        `grant select, insert, update on table crm_atendimento.commercial_campaigns to ${role}`,
+        `grant select, insert, update on table crm_atendimento.commercial_campaign_members to ${role}`,
+        `grant select, insert on table crm_atendimento.commercial_campaign_events to ${role}`,
+        `grant select, insert, update on table crm_atendimento.commercial_owner_absences to ${role}`,
+        `grant usage, select on sequence crm_atendimento.commercial_campaign_events_event_order_seq to ${role}`,
+    ]
+}
+
+const STATEMENTS = Object.freeze([
+    `create extension if not exists pgcrypto`,
+    `create schema if not exists crm_atendimento`,
+    `alter table crm_atendimento.commercial_actions add column if not exists revision integer not null default 1`,
+    `alter table crm_atendimento.commercial_actions add column if not exists outcome_code text`,
+    `alter table crm_atendimento.commercial_actions add column if not exists outcome_recorded_at timestamptz`,
+    `alter table crm_atendimento.commercial_actions add column if not exists idempotency_key text`,
+    `alter table crm_atendimento.commercial_action_events add column if not exists outcome_code text`,
+    `do $$ begin
+        if not exists (select 1 from pg_constraint where conrelid = 'crm_atendimento.commercial_actions'::regclass and conname = 'commercial_actions_outcome_code_v2_valid') then
+            alter table crm_atendimento.commercial_actions add constraint commercial_actions_outcome_code_v2_valid
+                check (outcome_code is null or outcome_code in (${OUTCOME_SQL})) not valid;
+        end if;
+        if not exists (select 1 from pg_constraint where conrelid = 'crm_atendimento.commercial_action_events'::regclass and conname = 'commercial_action_events_outcome_code_v2_valid') then
+            alter table crm_atendimento.commercial_action_events add constraint commercial_action_events_outcome_code_v2_valid
+                check (outcome_code is null or outcome_code in (${OUTCOME_SQL})) not valid;
+        end if;
+    end $$`,
+    `create table if not exists crm_atendimento.commercial_operation_mutations (
+        id uuid primary key default gen_random_uuid(),
+        mutation_key text not null check (mutation_key ~ '^[A-Za-z0-9._:-]{8,240}$'),
+        operation text not null check (operation in ('action_create', 'action_update', 'action_reassign', 'campaign_create', 'campaign_update', 'absence_upsert', 'rebalance')),
+        actor_id text not null check (char_length(actor_id) between 1 and 160 and actor_id !~ '[@]'),
+        request_fingerprint text not null check (request_fingerprint ~ '^[a-f0-9]{64}$'),
+        response jsonb not null default '{}'::jsonb,
+        created_at timestamptz not null default now(),
+        unique(mutation_key, operation)
+    )`,
+    `create table if not exists crm_atendimento.commercial_campaigns (
+        id uuid primary key default gen_random_uuid(),
+        name text not null check (char_length(btrim(name)) between 1 and 160 and name !~ '[@]'),
+        revision integer not null default 1 check (revision >= 1),
+        segment_key text not null check (segment_key ~ '^[A-Za-z0-9._-]{1,120}$'),
+        segment_version text not null check (segment_version ~ '^[A-Za-z0-9._-]{1,120}$'),
+        filters_snapshot jsonb not null default '{}'::jsonb,
+        context_hash text not null check (context_hash ~ '^[a-f0-9]{64}$'),
+        cutoff_at timestamptz not null,
+        unit_id uuid not null references crm_atendimento.units(id) on delete restrict,
+        owner text not null check (char_length(btrim(owner)) between 1 and 160 and owner !~ '[@]'),
+        offer_id uuid references crm_atendimento.commercial_offers(id) on delete restrict,
+        assignment_window_start timestamptz not null,
+        assignment_window_end timestamptz not null,
+        control_group_percent integer not null default 0 check (control_group_percent between 0 and 100),
+        state text not null default 'draft' check (state in (${CAMPAIGN_STATE_SQL})),
+        author text not null check (char_length(author) between 1 and 160 and author !~ '[@]'),
+        reason text not null check (char_length(btrim(reason)) between 3 and 1000 and reason !~ '[@]'),
+        created_at timestamptz not null default now(),
+        updated_at timestamptz not null default now(),
+        check (assignment_window_end >= assignment_window_start)
+    )`,
+    `create table if not exists crm_atendimento.commercial_campaign_members (
+        id uuid primary key default gen_random_uuid(),
+        campaign_id uuid not null references crm_atendimento.commercial_campaigns(id) on delete restrict,
+        identity_id uuid not null references crm_atendimento.global_client_identities(id) on delete restrict,
+        unit_id uuid not null references crm_atendimento.units(id) on delete restrict,
+        segment_key text not null check (segment_key ~ '^[A-Za-z0-9._-]{1,120}$'),
+        segment_version text not null check (segment_version ~ '^[A-Za-z0-9._-]{1,120}$'),
+        cutoff_at timestamptz not null,
+        owner text not null check (char_length(btrim(owner)) between 1 and 160 and owner !~ '[@]'),
+        offer_id uuid references crm_atendimento.commercial_offers(id) on delete restrict,
+        control_group boolean not null default false,
+        state text not null check (state in (${MEMBER_STATE_SQL})),
+        eligibility_snapshot jsonb not null default '{}'::jsonb,
+        action_id uuid references crm_atendimento.commercial_actions(id) on delete restrict,
+        revision integer not null default 1 check (revision >= 1),
+        created_at timestamptz not null default now(),
+        updated_at timestamptz not null default now(),
+        unique(campaign_id, identity_id)
+    )`,
+    `create table if not exists crm_atendimento.commercial_campaign_events (
+        id uuid primary key default gen_random_uuid(),
+        event_order bigint generated always as identity,
+        campaign_id uuid not null references crm_atendimento.commercial_campaigns(id) on delete restrict,
+        member_id uuid references crm_atendimento.commercial_campaign_members(id) on delete restrict,
+        event_type text not null check (event_type in ('created', 'state_changed', 'member_added', 'member_assigned', 'member_outcome', 'rebalanced', 'cancelled')),
+        actor_id text not null check (char_length(actor_id) between 1 and 160 and actor_id !~ '[@]'),
+        trace_id uuid not null,
+        payload jsonb not null default '{}'::jsonb,
+        created_at timestamptz not null default now(),
+        unique(campaign_id, member_id, event_type, trace_id)
+    )`,
+    `create table if not exists crm_atendimento.commercial_owner_absences (
+        id uuid primary key default gen_random_uuid(),
+        owner text not null check (char_length(btrim(owner)) between 1 and 160 and owner !~ '[@]'),
+        unit_id uuid not null references crm_atendimento.units(id) on delete restrict,
+        absence_type text not null check (absence_type in ('vacation', 'absence', 'leave')),
+        starts_at date not null,
+        ends_at date not null,
+        substitute_owner text check (substitute_owner is null or (char_length(btrim(substitute_owner)) between 1 and 160 and substitute_owner !~ '[@]')),
+        reason text not null check (char_length(btrim(reason)) between 3 and 1000 and reason !~ '[@]'),
+        revision integer not null default 1 check (revision >= 1),
+        created_by text not null check (char_length(created_by) between 1 and 160 and created_by !~ '[@]'),
+        updated_by text not null check (char_length(updated_by) between 1 and 160 and updated_by !~ '[@]'),
+        created_at timestamptz not null default now(),
+        updated_at timestamptz not null default now(),
+        check (ends_at >= starts_at),
+        unique(owner, unit_id, starts_at, ends_at)
+    )`,
+    `create unique index if not exists commercial_actions_actor_idempotency_v2_idx
+        on crm_atendimento.commercial_actions(created_by, idempotency_key) where idempotency_key is not null`,
+    `create index if not exists commercial_actions_owner_due_v2_idx
+        on crm_atendimento.commercial_actions(owner, due_date, status)`,
+    `create index if not exists commercial_campaigns_state_v2_idx
+        on crm_atendimento.commercial_campaigns(unit_id, state, updated_at desc)`,
+    `create index if not exists commercial_campaign_members_identity_v2_idx
+        on crm_atendimento.commercial_campaign_members(identity_id, state)`,
+    `create index if not exists commercial_campaign_events_campaign_v2_idx
+        on crm_atendimento.commercial_campaign_events(campaign_id, event_order desc)`,
+    `create index if not exists commercial_owner_absences_current_v2_idx
+        on crm_atendimento.commercial_owner_absences(unit_id, owner, starts_at, ends_at)`,
+    `create or replace function crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()
+        returns trigger language plpgsql as $$ begin
+            raise exception 'commercial operations evidence is append-only';
+        end $$`,
+    createTriggerIfMissing('crm_atendimento.commercial_operation_mutations', 'commercial_operation_mutations_v2_immutable', `create trigger commercial_operation_mutations_v2_immutable before update or delete on crm_atendimento.commercial_operation_mutations for each row execute function crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()`),
+    createTriggerIfMissing('crm_atendimento.commercial_operation_mutations', 'commercial_operation_mutations_v2_no_truncate', `create trigger commercial_operation_mutations_v2_no_truncate before truncate on crm_atendimento.commercial_operation_mutations for each statement execute function crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()`),
+    createTriggerIfMissing('crm_atendimento.commercial_campaign_events', 'commercial_campaign_events_v2_immutable', `create trigger commercial_campaign_events_v2_immutable before update or delete on crm_atendimento.commercial_campaign_events for each row execute function crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()`),
+    createTriggerIfMissing('crm_atendimento.commercial_campaign_events', 'commercial_campaign_events_v2_no_truncate', `create trigger commercial_campaign_events_v2_no_truncate before truncate on crm_atendimento.commercial_campaign_events for each statement execute function crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()`),
+])
+
+function triggerReadinessStatement() {
+    const tables = ['commercial_operation_mutations', 'commercial_campaign_events']
+    const fields = tables.flatMap((table, index) => [
+        `exists(select 1 from pg_trigger where tgrelid = to_regclass('crm_atendimento.${table}') and tgname = '${table}_v2_immutable' and tgenabled = 'O' and tgfoid = to_regprocedure('crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()')) as immutable_${index}`,
+        `exists(select 1 from pg_trigger where tgrelid = to_regclass('crm_atendimento.${table}') and tgname = '${table}_v2_no_truncate' and tgenabled = 'O' and tgfoid = to_regprocedure('crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()')) as no_truncate_${index}`,
+    ])
+    return `select ${fields.join(', ')}`
+}
+
+async function ensureRegistry(client) {
+    await client.query(`create schema if not exists crm_atendimento`)
+    await client.query(`create table if not exists crm_atendimento.schema_migrations (
+        id text primary key, applied_at timestamptz not null default now(), rolled_back_at timestamptz,
+        details jsonb not null default '{}'::jsonb
+    )`)
+}
+
+async function assertPrerequisites(client) {
+    const projection = PREREQUISITE_RELATIONS.map((relation, index) => `to_regclass('${relation}') is not null as relation_${index}`).join(', ')
+    const result = await client.query(`select ${projection}`)
+    if (!Object.values(result.rows[0] || {}).every(Boolean)) throw migrationError('COMMERCIAL_OPERATIONS_PREREQUISITES_MISSING')
+}
+
+async function assertDestination(client, databaseUrl, target) {
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw migrationError('COMMERCIAL_OPERATIONS_DESTINATION_UNSAFE')
+    try {
+        return await assertAtendimentoMigrationDestination(client, databaseUrl, target)
+    } catch {
+        throw migrationError('COMMERCIAL_OPERATIONS_DESTINATION_UNSAFE')
+    }
+}
+
+async function assertAppendOnlyTriggers(client) {
+    const result = await client.query(triggerReadinessStatement())
+    if (!Object.values(result.rows[0] || {}).every(Boolean)) throw migrationError('COMMERCIAL_OPERATIONS_APPEND_ONLY_GUARD_MISSING')
+}
+
+export function commercialOperationsMigrationPlan() {
+    return {
+        id: COMMERCIAL_OPERATIONS_MIGRATION_ID,
+        adds: [
+            'commercial_actions.revision',
+            'commercial_actions.outcome_code',
+            'commercial_actions.idempotency_key',
+            'commercial_operation_mutations',
+            'commercial_campaigns',
+            'commercial_campaign_members',
+            'commercial_campaign_events',
+            'commercial_owner_absences',
+        ],
+        appendOnlyTables: ['commercial_operation_mutations', 'commercial_campaign_events'],
+        piiPolicy: 'Operational records accept only opaque ids, bounded allowlisted codes, aggregate eligibility snapshots and masked presentation contracts. They store no phone, email, message payload or raw customer evidence.',
+        messagePolicy: 'Campaign membership and outcomes never dispatch a message. commercialContactWritesEnabled remains a separate, default-false control.',
+        rollback: 'Non-destructive: campaigns, actions and append-only evidence are retained; rollback only records the migration state.',
+        runtimeAccess: 'The runtime role receives no DDL, DELETE or TRUNCATE access. Evidence and idempotency ledgers are INSERT/SELECT only.',
+    }
+}
+
+export async function applyCommercialOperationsMigration({
+    pool,
+    databaseUrl,
+    target = ATENDIMENTO_MIGRATION_TARGETS.LOCAL,
+} = {}) {
+    if (!pool) throw migrationError('COMMERCIAL_OPERATIONS_POOL_REQUIRED')
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw migrationError('COMMERCIAL_OPERATIONS_DESTINATION_UNSAFE')
+    const client = await pool.connect()
+    let transactionOpen = false
+    try {
+        await client.query('begin')
+        transactionOpen = true
+        await client.query(`set local lock_timeout = '3s'`)
+        await client.query(`set local statement_timeout = '60s'`)
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [COMMERCIAL_OPERATIONS_MIGRATION_ID])
+        const destination = await assertDestination(client, databaseUrl, target)
+        await ensureRegistry(client)
+        await assertPrerequisites(client)
+        for (const statement of STATEMENTS) await client.query(statement)
+        await assertAppendOnlyTriggers(client)
+        const grants = runtimeGrantStatements(target)
+        for (const statement of grants) await client.query(statement)
+        const report = {
+            ...commercialOperationsMigrationPlan(),
+            applied: true,
+            target,
+            database: destination.database,
+            runtimeRole: RUNTIME_ROLES[target],
+            runtimeGrants: grants,
+        }
+        await client.query(`insert into crm_atendimento.schema_migrations(id, applied_at, rolled_back_at, details)
+            values ($1, now(), null, $2::jsonb)
+            on conflict(id) do update set applied_at = excluded.applied_at, rolled_back_at = null, details = excluded.details`, [
+            COMMERCIAL_OPERATIONS_MIGRATION_ID,
+            JSON.stringify(report),
+        ])
+        await client.query('commit')
+        transactionOpen = false
+        return report
+    } catch (error) {
+        if (transactionOpen) {
+            try { await client.query('rollback') } catch { /* preserve original failure */ }
+        }
+        throw error
+    } finally {
+        client.release()
+    }
+}
+
+export async function rollbackCommercialOperationsMigration({
+    pool,
+    databaseUrl,
+    target = ATENDIMENTO_MIGRATION_TARGETS.LOCAL,
+} = {}) {
+    if (!pool) throw migrationError('COMMERCIAL_OPERATIONS_POOL_REQUIRED')
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw migrationError('COMMERCIAL_OPERATIONS_DESTINATION_UNSAFE')
+    const client = await pool.connect()
+    let transactionOpen = false
+    try {
+        await client.query('begin')
+        transactionOpen = true
+        await client.query(`set local lock_timeout = '3s'`)
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [COMMERCIAL_OPERATIONS_MIGRATION_ID])
+        await assertDestination(client, databaseUrl, target)
+        await ensureRegistry(client)
+        await client.query(`insert into crm_atendimento.schema_migrations(id, applied_at, rolled_back_at, details)
+            values ($1, now(), now(), '{"rollback":"non-destructive","evidenceRetained":true}'::jsonb)
+            on conflict(id) do update set rolled_back_at = now(), details = excluded.details`, [
+            COMMERCIAL_OPERATIONS_MIGRATION_ID,
+        ])
+        await client.query('commit')
+        transactionOpen = false
+        return { id: COMMERCIAL_OPERATIONS_MIGRATION_ID, rolledBack: true, destructive: false, evidenceRetained: true }
+    } catch (error) {
+        if (transactionOpen) {
+            try { await client.query('rollback') } catch { /* preserve original failure */ }
+        }
+        throw error
+    } finally {
+        client.release()
+    }
+}
+
+export const __testables = { STATEMENTS, runtimeGrantStatements, triggerReadinessStatement, PREREQUISITE_RELATIONS }

--- a/crm/api/server/atendimento/commercialOperationsMigration.js
+++ b/crm/api/server/atendimento/commercialOperationsMigration.js
@@ -190,10 +190,29 @@ const STATEMENTS = Object.freeze([
 ])
 
 function triggerReadinessStatement() {
-    const tables = ['commercial_operation_mutations', 'commercial_campaign_events']
-    const fields = tables.flatMap((table, index) => [
-        `exists(select 1 from pg_trigger where tgrelid = to_regclass('crm_atendimento.${table}') and tgname = '${table}_v2_immutable' and tgenabled = 'O' and tgfoid = to_regprocedure('crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()')) as immutable_${index}`,
-        `exists(select 1 from pg_trigger where tgrelid = to_regclass('crm_atendimento.${table}') and tgname = '${table}_v2_no_truncate' and tgenabled = 'O' and tgfoid = to_regprocedure('crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()')) as no_truncate_${index}`,
+    const ledgers = [
+        {
+            table: 'commercial_action_events',
+            immutable: 'commercial_action_events_immutable',
+            noTruncate: 'commercial_action_events_no_truncate',
+            functionName: 'crm_atendimento.prevent_commercial_ledger_mutation()',
+        },
+        {
+            table: 'commercial_operation_mutations',
+            immutable: 'commercial_operation_mutations_v2_immutable',
+            noTruncate: 'commercial_operation_mutations_v2_no_truncate',
+            functionName: 'crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()',
+        },
+        {
+            table: 'commercial_campaign_events',
+            immutable: 'commercial_campaign_events_v2_immutable',
+            noTruncate: 'commercial_campaign_events_v2_no_truncate',
+            functionName: 'crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()',
+        },
+    ]
+    const fields = ledgers.flatMap((ledger, index) => [
+        `exists(select 1 from pg_trigger where tgrelid = to_regclass('crm_atendimento.${ledger.table}') and tgname = '${ledger.immutable}' and tgenabled = 'O' and tgfoid = to_regprocedure('${ledger.functionName}')) as immutable_${index}`,
+        `exists(select 1 from pg_trigger where tgrelid = to_regclass('crm_atendimento.${ledger.table}') and tgname = '${ledger.noTruncate}' and tgenabled = 'O' and tgfoid = to_regprocedure('${ledger.functionName}')) as no_truncate_${index}`,
     ])
     return `select ${fields.join(', ')}`
 }
@@ -239,7 +258,7 @@ export function commercialOperationsMigrationPlan() {
             'commercial_campaign_events',
             'commercial_owner_absences',
         ],
-        appendOnlyTables: ['commercial_operation_mutations', 'commercial_campaign_events'],
+        appendOnlyTables: ['commercial_action_events', 'commercial_operation_mutations', 'commercial_campaign_events'],
         piiPolicy: 'Operational records accept only opaque ids, bounded allowlisted codes, aggregate eligibility snapshots and masked presentation contracts. They store no phone, email, message payload or raw customer evidence.',
         messagePolicy: 'Campaign membership and outcomes never dispatch a message. commercialContactWritesEnabled remains a separate, default-false control.',
         rollback: 'Non-destructive: campaigns, actions and append-only evidence are retained; rollback only records the migration state.',

--- a/crm/api/server/atendimento/commercialOperationsStore.js
+++ b/crm/api/server/atendimento/commercialOperationsStore.js
@@ -27,6 +27,12 @@ const ACTIVE_ACTION_STATUSES = Object.freeze(['open', 'contacted', 'responded', 
 const ACTION_STATUSES = Object.freeze([...ACTIVE_ACTION_STATUSES, 'won_sale', 'returned', 'closed', 'cancelled'])
 const ABSENCE_TYPES = new Set(['vacation', 'absence', 'leave'])
 const COMMERCIAL_REQUIRED_SOURCE_IDS = Object.freeze(requiredClientesSources().map((source) => source.id).sort())
+// This is intentionally a literal contract rather than an import from the
+// analytics module: Operations v2 must remain deployable before Analytics,
+// while cohort/owner-assignment mutations fail closed until that additive
+// migration is active.
+const COMMERCIAL_ANALYTICS_EXPERIMENT_MIGRATION_ID = '20260807_commercial_analytics_v2'
+const EXPERIMENT_CROSSOVER_BLOCKING_VARIANTS = Object.freeze(['control', 'excluded'])
 const OUTCOME_STATUSES = Object.freeze({
     no_response: 'contacted',
     wrong_number: 'closed',
@@ -338,6 +344,72 @@ async function sourceStale(db, dependencies) {
         from crm_atendimento.clientes_source_operation_checkpoints checkpoint
         where checkpoint.source_id=any($1::text[])`, [COMMERCIAL_REQUIRED_SOURCE_IDS])
     return count(result.rows[0]?.checkpoint_count) < COMMERCIAL_REQUIRED_SOURCE_IDS.length || bool(result.rows[0]?.stale)
+}
+
+function normalizedExperimentIdentityIds(identityIds) {
+    return [...new Set((Array.isArray(identityIds) ? identityIds : [identityIds])
+        .map((identityId) => assertUuid(identityId, 'INVALID_COMMERCIAL_EXPERIMENT_IDENTITY')))].sort()
+}
+
+async function experimentCrossoverGuardReadiness(db) {
+    // `to_regclass` and explicit SELECT grants let Operations retain a safe
+    // hook before Analytics is promoted.  Absence of either table, privilege
+    // or active migration is an unsafe/unknown experiment state, never an
+    // empty holdout set.
+    const result = await db.query(`select
+        to_regclass('crm_atendimento.commercial_experiment_assignments') is not null as assignments,
+        to_regclass('crm_atendimento.commercial_experiments') is not null as experiments,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_experiment_assignments'), 'SELECT'), false) as assignments_read,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_experiments'), 'SELECT'), false) as experiments_read,
+        exists(select 1 from crm_atendimento.schema_migrations
+            where id=$1 and rolled_back_at is null) as migration_ready`, [COMMERCIAL_ANALYTICS_EXPERIMENT_MIGRATION_ID])
+    const row = result.rows[0] || {}
+    return {
+        ready: bool(row.assignments) && bool(row.experiments) && bool(row.assignments_read) && bool(row.experiments_read) && bool(row.migration_ready),
+        assignments: bool(row.assignments),
+        experiments: bool(row.experiments),
+        assignmentsRead: bool(row.assignments_read),
+        experimentsRead: bool(row.experiments_read),
+        migrationReady: bool(row.migration_ready),
+    }
+}
+
+async function activeExperimentHoldouts(client, { unitId, identityIds }) {
+    const unit = assertUuid(unitId, 'INVALID_COMMERCIAL_EXPERIMENT_UNIT')
+    const identities = normalizedExperimentIdentityIds(identityIds)
+    if (!identities.length) return []
+    const readiness = await experimentCrossoverGuardReadiness(client)
+    if (!readiness.ready) throw operationalError('COMMERCIAL_EXPERIMENT_GUARD_NOT_READY', 409)
+
+    // Analytics must acquire this same deterministic namespace before writing
+    // assignments.  Operations holds it across the check and mutation so a
+    // second Operations request cannot turn a control/excluded identity into
+    // a silent crossover.
+    for (const identityId of identities) {
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [
+            `commercial-experiment-crossover:${unit}:${identityId}`,
+        ])
+    }
+    const result = await client.query(`select assignment.identity_id::text,assignment.variant
+        from crm_atendimento.commercial_experiment_assignments assignment
+        join crm_atendimento.commercial_experiments experiment on experiment.id=assignment.experiment_id
+        where assignment.identity_id=any($1::uuid[])
+          and assignment.unit_id=$2::uuid
+          and assignment.variant=any($3::text[])
+          and experiment.state='active'
+          and experiment.starts_at <= now()
+          and experiment.ends_at > now()
+        order by assignment.identity_id asc,assignment.variant asc
+        for key share of assignment,experiment`, [identities, unit, EXPERIMENT_CROSSOVER_BLOCKING_VARIANTS])
+    return (result.rows || []).map((row) => ({
+        identityId: assertUuid(row.identity_id, 'COMMERCIAL_EXPERIMENT_ASSIGNMENT_INVALID'),
+        variant: EXPERIMENT_CROSSOVER_BLOCKING_VARIANTS.includes(text(row.variant)) ? text(row.variant) : 'excluded',
+    }))
+}
+
+async function assertNoActiveExperimentHoldout(client, context) {
+    const holdouts = await activeExperimentHoldouts(client, context)
+    if (holdouts.length) throw operationalError('COMMERCIAL_EXPERIMENT_HOLDOUT_ACTIVE', 409)
 }
 
 function scopeWhere(scope, params, unitColumn = 'unit.slug') {
@@ -913,6 +985,13 @@ async function createCampaign(client, payload, actor) {
         fingerprintPayload: { campaign: frozenCampaignContext(campaign), contextHash },
         execute: async ({ actorRef }) => {
             const unit = await resolveCampaignUnit(client, unitSlug)
+            // Do this before the campaign/cohort write path.  A missing
+            // Analytics migration is treated as unknown eligibility and is
+            // rejected by the guard rather than allowing a silent crossover.
+            await assertNoActiveExperimentHoldout(client, {
+                unitId: unit.id,
+                identityIds: campaign.identityIds,
+            })
             await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [`commercial-operations:campaign:${unit.id}:${contextHash}`])
             const existing = await client.query(`select id::text from crm_atendimento.commercial_campaigns
                 where unit_id=$1 and context_hash=$2
@@ -1099,7 +1178,7 @@ async function actionProjection(client, actionId, actor) {
 async function actionForMutation(client, actionId, actor) {
     const id = assertUuid(actionId, 'INVALID_COMMERCIAL_ACTION')
     const result = await client.query(`select action.id::text,action.identity_id::text,action.revision,action.status,action.owner,
-            unit.slug as unit_slug
+            action.unit_id::text as unit_id,unit.slug as unit_slug
         from crm_atendimento.commercial_actions action
         join crm_atendimento.units unit on unit.id=action.unit_id
         where action.id=$1 for update of action`, [id])
@@ -1123,6 +1202,10 @@ async function reassignAction(client, actionId, payload, actor) {
                 throw operationalError('COMMERCIAL_ACTION_CONFLICT', 409)
             }
             if (owner === action.owner) throw operationalError('COMMERCIAL_ACTION_REASSIGNMENT_UNCHANGED', 400)
+            await assertNoActiveExperimentHoldout(client, {
+                unitId: action.unit_id,
+                identityIds: [action.identity_id],
+            })
             await client.query(`update crm_atendimento.commercial_actions
                 set owner=$2,revision=revision+1,updated_by=$3,updated_at=now()
                 where id=$1`, [id, owner, actorRef])
@@ -1266,7 +1349,7 @@ async function upsertAbsence(client, payload, actor) {
 async function rebalanceActions(client, scope, { lock = false } = {}) {
     const params = []
     const where = [scopeWhere(scope, params), `action.status=any($${params.push(ACTIVE_ACTION_STATUSES)}::text[])`]
-    const result = await client.query(`select action.id::text,action.identity_id::text,action.owner,action.status,action.revision,
+    const result = await client.query(`select action.id::text,action.identity_id::text,action.unit_id::text as unit_id,action.owner,action.status,action.revision,
             unit.slug as unit_slug,
             exists(select 1 from crm_atendimento.commercial_owner_absences absence
                 where absence.unit_id=action.unit_id and absence.owner=action.owner
@@ -1340,6 +1423,18 @@ async function applyRebalance(client, payload, actor) {
                 throw operationalError('COMMERCIAL_REBALANCE_CONFLICT', 409)
             }
             const byId = new Map(actions.map((action) => [text(action.id).toLowerCase(), action]))
+            const identitiesByUnit = new Map()
+            for (const move of moves) {
+                const action = byId.get(move.actionId)
+                if (!action) continue
+                const unitId = assertUuid(action.unit_id, 'INVALID_COMMERCIAL_EXPERIMENT_UNIT')
+                const identities = identitiesByUnit.get(unitId) || []
+                identities.push(action.identity_id)
+                identitiesByUnit.set(unitId, identities)
+            }
+            for (const [unitId, identityIds] of [...identitiesByUnit.entries()].sort(([left], [right]) => left.localeCompare(right))) {
+                await assertNoActiveExperimentHoldout(client, { unitId, identityIds })
+            }
             const applied = []
             for (const move of moves) {
                 const action = byId.get(move.actionId)
@@ -1520,7 +1615,15 @@ export function createCommercialOperationsStore({ pool, databaseUrl } = {}) {
         async readiness(actor) {
             requirePool(pgPool)
             assertCommercialOperationsManager(actor)
-            return commercialOperationsReadiness(pgPool)
+            const readiness = await commercialOperationsReadiness(pgPool)
+            // Analytics is an explicit write-guard dependency rather than a
+            // prerequisite for the read-only Operations surface.  Report it
+            // separately so an operator can see why cohort/assignment writes
+            // remain fail-closed before the Analytics migration is promoted.
+            const experimentCrossoverGuard = readiness.ready
+                ? await experimentCrossoverGuardReadiness(pgPool)
+                : { ready: false, assignments: false, experiments: false, assignmentsRead: false, experimentsRead: false, migrationReady: false }
+            return { ...readiness, experimentCrossoverGuard }
         },
 
         async wallet(query, actor) {
@@ -1588,11 +1691,16 @@ export function createCommercialOperationsStore({ pool, databaseUrl } = {}) {
 export const __testables = {
     ABSENCE_TYPES,
     ACTION_STATUSES,
+    COMMERCIAL_ANALYTICS_EXPERIMENT_MIGRATION_ID,
     COMMERCIAL_REQUIRED_SOURCE_IDS,
     COMMERCIAL_OPERATIONS_SAFETY_FLAGS,
+    EXPERIMENT_CROSSOVER_BLOCKING_VARIANTS,
+    activeExperimentHoldouts,
     activeActionStatuses: ACTIVE_ACTION_STATUSES,
     actionFlagSql,
+    assertNoActiveExperimentHoldout,
     commercialOperationsUnitScope,
+    experimentCrossoverGuardReadiness,
     mapWalletAction,
     mutationInput,
     normalizeCapacities,

--- a/crm/api/server/atendimento/commercialOperationsStore.js
+++ b/crm/api/server/atendimento/commercialOperationsStore.js
@@ -2,6 +2,7 @@ import { createHmac, randomUUID } from 'node:crypto'
 
 import { createPgPool, withPgTransaction } from '../harmonia/store/pg.js'
 import { requiredClientesSources } from '../clientes/sourceCatalog.js'
+import { actorSubject } from './actorSubject.js'
 import {
     COMMERCIAL_CAMPAIGN_STATES,
     COMMERCIAL_OPERATION_FLAGS,
@@ -120,7 +121,7 @@ function projectOwner(value) {
 }
 
 function actorPrincipal(actor) {
-    const value = text(actor?.id || actor?.username || actor?.email)
+    const value = actorSubject(actor)
     if (!value) throw operationalError('ACTOR_IDENTITY_REQUIRED', 401)
     return value
 }
@@ -1698,6 +1699,7 @@ export const __testables = {
     activeExperimentHoldouts,
     activeActionStatuses: ACTIVE_ACTION_STATUSES,
     actionFlagSql,
+    actorPrincipal,
     assertNoActiveExperimentHoldout,
     commercialOperationsUnitScope,
     experimentCrossoverGuardReadiness,

--- a/crm/api/server/atendimento/commercialOperationsStore.js
+++ b/crm/api/server/atendimento/commercialOperationsStore.js
@@ -1,0 +1,1608 @@
+import { createHmac, randomUUID } from 'node:crypto'
+
+import { createPgPool, withPgTransaction } from '../harmonia/store/pg.js'
+import { requiredClientesSources } from '../clientes/sourceCatalog.js'
+import {
+    COMMERCIAL_CAMPAIGN_STATES,
+    COMMERCIAL_OPERATION_FLAGS,
+    actionQueueFlags,
+    campaignMemberState,
+    commercialOperationError,
+    computeAverageStageDurations,
+    normalizeCampaignFilters,
+    normalizeCampaignPayload,
+    normalizeOutcomeCode,
+    normalizeOperationMutation,
+    planWalletBalance,
+    projectCommercialTimelineEvent,
+    stableControlGroup,
+    stableOperationFingerprint,
+} from './commercialOperations.js'
+import { COMMERCIAL_OPERATIONS_MIGRATION_ID } from './commercialOperationsMigration.js'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const UNIT_RE = /^[a-z0-9][a-z0-9._-]{0,119}$/i
+const OWNER_RE = /^[A-Za-zÀ-ÿ0-9._:+\- ]{1,160}$/
+const ACTIVE_ACTION_STATUSES = Object.freeze(['open', 'contacted', 'responded', 'scheduled'])
+const ACTION_STATUSES = Object.freeze([...ACTIVE_ACTION_STATUSES, 'won_sale', 'returned', 'closed', 'cancelled'])
+const ABSENCE_TYPES = new Set(['vacation', 'absence', 'leave'])
+const COMMERCIAL_REQUIRED_SOURCE_IDS = Object.freeze(requiredClientesSources().map((source) => source.id).sort())
+const OUTCOME_STATUSES = Object.freeze({
+    no_response: 'contacted',
+    wrong_number: 'closed',
+    requested_follow_up: 'responded',
+    not_interested: 'closed',
+    completed_elsewhere: 'closed',
+    scheduled: 'scheduled',
+    attended: 'closed',
+    cancelled: 'cancelled',
+    sale: 'won_sale',
+    clinical_return: 'returned',
+    opt_out_requested: 'responded',
+})
+const WALLET_SORTS = Object.freeze({
+    dueDate: 'action.due_date',
+    updatedAt: 'action.updated_at',
+    createdAt: 'action.created_at',
+    status: 'action.status',
+    owner: "coalesce(action.owner, '')",
+})
+
+// This is deliberately a hard boundary, not an environment-controlled flag.
+// The operation layer can create internal work and audit it, but cannot write
+// consent, schedule a send, enqueue delivery or turn a campaign into outbound
+// communication.
+export const COMMERCIAL_OPERATIONS_SAFETY_FLAGS = Object.freeze({
+    commercialContactWritesEnabled: false,
+    messagesEnabled: false,
+    automationEnabled: false,
+    consentWritesEnabled: false,
+    outboundDispatchEnabled: false,
+})
+
+function text(value) {
+    return String(value ?? '').trim()
+}
+
+function operationalError(code, statusCode = 409) {
+    const error = commercialOperationError(code, statusCode)
+    error.code = code
+    error.statusCode = statusCode
+    return error
+}
+
+function requirePool(pgPool) {
+    if (!pgPool) throw operationalError('DATABASE_URL_not_configured', 503)
+}
+
+function bool(value) {
+    return value === true
+}
+
+function count(value) {
+    const number = Number(value)
+    return Number.isFinite(number) && number >= 0 ? Math.floor(number) : 0
+}
+
+function dateOnly(value) {
+    const raw = text(value).slice(0, 10)
+    return /^\d{4}-\d{2}-\d{2}$/.test(raw) ? raw : null
+}
+
+function iso(value) {
+    const timestamp = Date.parse(value || '')
+    return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : null
+}
+
+function containsPiiLikeValue(value) {
+    const raw = text(value)
+    return /@/.test(raw) || /\d{7,}/.test(raw)
+}
+
+function safeOwner(value, { required = false } = {}) {
+    const owner = text(value)
+    if (!owner && required) throw operationalError('COMMERCIAL_OPERATION_OWNER_REQUIRED', 400)
+    if (owner && (!OWNER_RE.test(owner) || containsPiiLikeValue(owner))) {
+        throw operationalError('INVALID_COMMERCIAL_OPERATION_OWNER', 400)
+    }
+    return owner || null
+}
+
+function projectOwner(value) {
+    const owner = text(value)
+    return owner && OWNER_RE.test(owner) && !containsPiiLikeValue(owner) ? owner : null
+}
+
+function actorPrincipal(actor) {
+    const value = text(actor?.id || actor?.username || actor?.email)
+    if (!value) throw operationalError('ACTOR_IDENTITY_REQUIRED', 401)
+    return value
+}
+
+function auditSecret() {
+    const secret = text(
+        process.env.ATENDIMENTO_ACTOR_HMAC_KEY ||
+        process.env.ESCALA_ACTOR_HMAC_KEY ||
+        process.env.CRM_ESCALA_HMAC_KEY,
+    )
+    if (secret.length < 32) throw operationalError('COMMERCIAL_OPERATIONS_AUDIT_KEY_REQUIRED', 503)
+    return secret
+}
+
+function digest(purpose, value) {
+    return createHmac('sha256', auditSecret())
+        .update(`${purpose}:${stableOperationFingerprint(value)}`)
+        .digest('hex')
+}
+
+function actorReference(actor) {
+    return `actor:${digest('commercial-operations-actor', { actor: actorPrincipal(actor) })}`
+}
+
+function isGlobalCommercialActor(actor) {
+    return actor?.isGlobalAdmin === true || text(actor?.role).toUpperCase() === 'ADMIN'
+}
+
+export function commercialOperationsUnitScope(actor) {
+    if (isGlobalCommercialActor(actor)) return null
+    // A commercial actor without an explicit unit claim is never silently
+    // promoted to a cross-unit reader.  The signed-actor parser carries
+    // `allowedUnitsDeclared`, but accepting a direct store caller must remain
+    // equally fail-closed.
+    if (!Array.isArray(actor?.allowedUnits)) return []
+    return [...new Set(actor.allowedUnits.map((unit) => text(unit).toLowerCase()).filter((unit) => UNIT_RE.test(unit)))].sort()
+}
+
+export function assertCommercialOperationsManager(actor) {
+    const role = text(actor?.role).toUpperCase()
+    if (role === 'GESTOR' || role === 'ADMIN' || actor?.isGlobalAdmin === true) return
+    throw operationalError('FORBIDDEN', 403)
+}
+
+function requestedUnitScope(actor, requested) {
+    const actorScope = commercialOperationsUnitScope(actor)
+    const unit = text(requested).toLowerCase()
+    if (actorScope === null) {
+        if (unit && unit !== 'all' && !UNIT_RE.test(unit)) throw operationalError('INVALID_COMMERCIAL_UNIT', 400)
+        return { unit: unit && unit !== 'all' ? unit : null, unitSlugs: null }
+    }
+    if (!actorScope.length) throw operationalError('COMMERCIAL_UNIT_FORBIDDEN', 403)
+    if (!unit || unit === 'all') return { unit: null, unitSlugs: actorScope }
+    if (!UNIT_RE.test(unit)) throw operationalError('INVALID_COMMERCIAL_UNIT', 400)
+    if (!actorScope.includes(unit)) throw operationalError('COMMERCIAL_UNIT_FORBIDDEN', 403)
+    return { unit, unitSlugs: [unit] }
+}
+
+function assertUnitAllowed(actor, unit) {
+    const value = text(unit).toLowerCase()
+    if (!UNIT_RE.test(value)) throw operationalError('INVALID_COMMERCIAL_UNIT', 400)
+    const scope = commercialOperationsUnitScope(actor)
+    if (scope !== null && (!scope.length || !scope.includes(value))) throw operationalError('COMMERCIAL_UNIT_FORBIDDEN', 403)
+    return value
+}
+
+function assertUuid(value, code = 'INVALID_COMMERCIAL_OPERATION_ID') {
+    const id = text(value).toLowerCase()
+    if (!UUID_RE.test(id)) throw operationalError(code, 400)
+    return id
+}
+
+function normalizeLimit(value, fallback = 50, maximum = 100) {
+    const number = Number(value)
+    if (!Number.isInteger(number) || number < 1) return fallback
+    return Math.min(number, maximum)
+}
+
+function normalizeOffset(value) {
+    const number = Number(value)
+    return Number.isInteger(number) && number > 0 ? number : 0
+}
+
+function normalizeDateRange(startValue, endValue, code = 'INVALID_COMMERCIAL_OPERATION_DATE_RANGE') {
+    const startsAt = dateOnly(startValue)
+    const endsAt = dateOnly(endValue)
+    if (!startsAt || !endsAt || endsAt < startsAt) throw operationalError(code, 400)
+    return { startsAt, endsAt }
+}
+
+function normalizeCapacities(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw operationalError('COMMERCIAL_REBALANCE_CAPACITIES_REQUIRED', 400)
+    }
+    const entries = Object.entries(value)
+    if (!entries.length || entries.length > 100) throw operationalError('COMMERCIAL_REBALANCE_CAPACITIES_REQUIRED', 400)
+    const capacities = {}
+    for (const [rawOwner, rawCapacity] of entries) {
+        const owner = safeOwner(rawOwner, { required: true })
+        const capacity = Number(rawCapacity)
+        if (!Number.isInteger(capacity) || capacity < 0 || capacity > 10_000) {
+            throw operationalError('INVALID_COMMERCIAL_REBALANCE_CAPACITY', 400)
+        }
+        capacities[owner] = capacity
+    }
+    return Object.fromEntries(Object.entries(capacities).sort(([left], [right]) => left.localeCompare(right)))
+}
+
+function normalizeExpectedRevisions(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw operationalError('COMMERCIAL_REBALANCE_EXPECTED_REVISIONS_REQUIRED', 400)
+    }
+    const revisions = {}
+    for (const [rawId, rawRevision] of Object.entries(value)) {
+        const id = assertUuid(rawId, 'INVALID_COMMERCIAL_ACTION')
+        const revision = Number(rawRevision)
+        if (!Number.isInteger(revision) || revision < 1) throw operationalError('COMMERCIAL_EXPECTED_REVISION_INVALID', 400)
+        revisions[id] = revision
+    }
+    return revisions
+}
+
+function normalizeActionFlags(value) {
+    const candidates = Array.isArray(value) ? value : text(value).split(',')
+    const flags = [...new Set(candidates.map((item) => text(item)).filter(Boolean))]
+    if (flags.length > 10 || flags.some((flag) => !COMMERCIAL_OPERATION_FLAGS.includes(flag))) {
+        throw operationalError('INVALID_COMMERCIAL_OPERATION_FLAG', 400)
+    }
+    return flags
+}
+
+function operationSafety() {
+    return { ...COMMERCIAL_OPERATIONS_SAFETY_FLAGS }
+}
+
+function mapReadiness(row = {}, migrationReady = false) {
+    const tables = ['actions', 'action_events', 'mutations', 'campaigns', 'members', 'campaign_events', 'absences']
+    const triggers = [
+        'action_event_immutable', 'action_event_no_truncate',
+        'mutation_immutable', 'mutation_no_truncate', 'campaign_event_immutable', 'campaign_event_no_truncate',
+    ]
+    const relationsReady = tables.every((key) => bool(row[key]))
+    const appendOnlyReady = triggers.every((key) => bool(row[key]))
+    return {
+        ready: relationsReady && appendOnlyReady && migrationReady,
+        migrationId: COMMERCIAL_OPERATIONS_MIGRATION_ID,
+        relationsReady,
+        appendOnlyReady,
+        migrationReady,
+        safety: operationSafety(),
+    }
+}
+
+export async function commercialOperationsReadiness(db) {
+    const availability = await db.query(`select
+        to_regclass('crm_atendimento.commercial_actions') is not null as actions,
+        to_regclass('crm_atendimento.commercial_action_events') is not null as action_events,
+        to_regclass('crm_atendimento.commercial_operation_mutations') is not null as mutations,
+        to_regclass('crm_atendimento.commercial_campaigns') is not null as campaigns,
+        to_regclass('crm_atendimento.commercial_campaign_members') is not null as members,
+        to_regclass('crm_atendimento.commercial_campaign_events') is not null as campaign_events,
+        to_regclass('crm_atendimento.commercial_owner_absences') is not null as absences,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_action_events')
+            and tgname='commercial_action_events_immutable' and tgenabled='O'
+            and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_ledger_mutation()')) as action_event_immutable,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_action_events')
+            and tgname='commercial_action_events_no_truncate' and tgenabled='O'
+            and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_ledger_mutation()')) as action_event_no_truncate,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_operation_mutations')
+            and tgname='commercial_operation_mutations_v2_immutable' and tgenabled='O'
+            and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()')) as mutation_immutable,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_operation_mutations')
+            and tgname='commercial_operation_mutations_v2_no_truncate' and tgenabled='O'
+            and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()')) as mutation_no_truncate,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_campaign_events')
+            and tgname='commercial_campaign_events_v2_immutable' and tgenabled='O'
+            and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()')) as campaign_event_immutable,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_campaign_events')
+            and tgname='commercial_campaign_events_v2_no_truncate' and tgenabled='O'
+            and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()')) as campaign_event_no_truncate,
+        to_regclass('crm_atendimento.schema_migrations') is not null as migration_registry`)
+    const row = availability.rows[0] || {}
+    if (!row.migration_registry) return mapReadiness(row, false)
+    const migration = await db.query(`select id from crm_atendimento.schema_migrations
+        where id=$1 and rolled_back_at is null`, [COMMERCIAL_OPERATIONS_MIGRATION_ID])
+    return mapReadiness(row, !!migration.rows[0]?.id)
+}
+
+async function assertCommercialOperationsReady(db) {
+    const readiness = await commercialOperationsReadiness(db)
+    if (!readiness.ready) throw operationalError('COMMERCIAL_OPERATIONS_NOT_READY', 409)
+    return readiness
+}
+
+async function operationalDependencies(db) {
+    const result = await db.query(`select
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_contact_permissions'), 'SELECT'), false) as permissions,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.clientes_source_operation_checkpoints'), 'SELECT'), false) as source_checkpoints,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.global_client_identity_members'), 'SELECT'), false) as identity_members,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.client_caixa_links'), 'SELECT'), false) as attendance_caixa_links,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.app_registration_attendance_links'), 'SELECT'), false) as app_attendance_links,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.app_registration_caixa_links'), 'SELECT'), false) as app_caixa_links,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.supplemental_lead_profile_app_links'), 'SELECT'), false) as lead_app_links,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.supplemental_lead_profile_caixa_links'), 'SELECT'), false) as lead_caixa_links,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.identity_review_decisions'), 'SELECT'), false) as review_decisions`)
+    const row = result.rows[0] || {}
+    return {
+        permissions: bool(row.permissions),
+        sourceCheckpoints: bool(row.source_checkpoints),
+        identityReview: bool(row.identity_members) && bool(row.review_decisions) && bool(row.attendance_caixa_links) &&
+            bool(row.app_attendance_links) && bool(row.app_caixa_links) && bool(row.lead_app_links) && bool(row.lead_caixa_links),
+    }
+}
+
+async function sourceStale(db, dependencies) {
+    if (!dependencies.sourceCheckpoints) return true
+    const result = await db.query(`select count(*)::int as checkpoint_count,
+        bool_or(checkpoint.last_status <> 'complete' or checkpoint.validated_snapshot_complete is not true or
+            checkpoint.reconciliation_required is true or checkpoint.validated_at is null or
+            checkpoint.validated_at < now() - interval '48 hours') as stale
+        from crm_atendimento.clientes_source_operation_checkpoints checkpoint
+        where checkpoint.source_id=any($1::text[])`, [COMMERCIAL_REQUIRED_SOURCE_IDS])
+    return count(result.rows[0]?.checkpoint_count) < COMMERCIAL_REQUIRED_SOURCE_IDS.length || bool(result.rows[0]?.stale)
+}
+
+function scopeWhere(scope, params, unitColumn = 'unit.slug') {
+    if (scope.unit) {
+        params.push(scope.unit)
+        return `${unitColumn} = $${params.length}`
+    }
+    if (scope.unitSlugs) {
+        params.push(scope.unitSlugs)
+        return `${unitColumn} = any($${params.length}::text[])`
+    }
+    return `${unitColumn} is not null`
+}
+
+function permissionSql(dependencies) {
+    if (!dependencies.permissions) {
+        return {
+            join: '',
+            status: "'review_required'::text",
+            expiresAt: 'null::timestamptz',
+        }
+    }
+    return {
+        join: `left join crm_atendimento.commercial_contact_permissions permission
+            on permission.identity_id=action.identity_id and permission.channel='whatsapp'`,
+        status: `case when permission.status='granted' and (permission.expires_at is null or permission.expires_at >= now()) then 'eligible'
+            when permission.status='denied' or (permission.expires_at is not null and permission.expires_at < now()) then 'blocked'
+            else 'review_required' end`,
+        expiresAt: 'permission.expires_at',
+    }
+}
+
+function identityReviewSql(dependencies) {
+    if (!dependencies.identityReview) return 'true'
+    // The review lookup is an allowlisted existence projection: no member,
+    // candidate, context or evidence column is selected or serialized.
+    return `exists(
+        select 1 from crm_atendimento.global_client_identity_members member
+         where member.identity_id=action.identity_id and (
+            (member.source_type='attendance_client' and exists(select 1 from crm_atendimento.client_caixa_links link
+                where link.client_id=member.source_id::uuid and link.status in ('suggested','ambiguous')))
+            or (member.source_type='app_registration' and (
+                exists(select 1 from crm_atendimento.app_registration_attendance_links link
+                    where link.app_registration_id=member.source_id and link.status in ('suggested','ambiguous'))
+                or exists(select 1 from crm_atendimento.app_registration_caixa_links link
+                    where link.app_registration_id=member.source_id and link.status in ('suggested','ambiguous'))
+            ))
+            or (member.source_type='lead_profile' and (
+                exists(select 1 from crm_atendimento.supplemental_lead_profile_app_links link
+                    where link.source_profile_id=member.source_id and link.status in ('suggested','ambiguous'))
+                or exists(select 1 from crm_atendimento.supplemental_lead_profile_caixa_links link
+                    where link.source_profile_id=member.source_id and link.status in ('suggested','ambiguous'))
+            ))
+        )
+    )`
+}
+
+function actionFlagSql(flag, { permissionStatus, permissionExpiresAt, sourceIsStale, identityReview, actorOwner }, params) {
+    switch (flag) {
+        case 'assigned_to_me':
+            params.push(actorOwner)
+            return `coalesce(action.owner,'') = $${params.length}`
+        case 'due_today':
+            return `action.status = any($${params.push(ACTIVE_ACTION_STATUSES)}::text[]) and action.due_date=current_date`
+        case 'overdue':
+            return `action.status = any($${params.push(ACTIVE_ACTION_STATUSES)}::text[]) and action.due_date < current_date`
+        case 'awaiting_response': return `action.status='contacted'`
+        case 'scheduled': return `action.status='scheduled'`
+        case 'no_return': return `action.status='contacted' and action.due_date < current_date`
+        case 'permission_expiring': return `${permissionExpiresAt} >= now() and ${permissionExpiresAt} <= now() + interval '7 days'`
+        case 'ineligible': return `${permissionStatus} <> 'eligible'`
+        case 'source_stale':
+            params.push(sourceIsStale)
+            return `$${params.length}::boolean`
+        case 'identity_review': return identityReview
+        default: throw operationalError('INVALID_COMMERCIAL_OPERATION_FLAG', 400)
+    }
+}
+
+function mapWalletAction(row, actor) {
+    const permission = { status: text(row.permission_status) || 'review_required', expiresAt: iso(row.permission_expires_at) }
+    const queueFlags = actionQueueFlags({
+        status: row.status,
+        dueDate: row.due_date,
+        owner: row.owner,
+    }, {
+        actorIds: [actorPrincipal(actor)],
+        eligibility: permission,
+        sourceStale: bool(row.source_stale),
+        identityInReview: bool(row.identity_in_review),
+    })
+    return {
+        actionId: text(row.id),
+        unit: text(row.unit_slug) || null,
+        segmentKey: text(row.segment_key),
+        actionType: text(row.action_type),
+        status: text(row.status),
+        owner: projectOwner(row.owner),
+        dueDate: dateOnly(row.due_date),
+        revision: count(row.revision) || 1,
+        outcomeCode: text(row.outcome_code) || null,
+        permission,
+        sourceStale: bool(row.source_stale),
+        identityInReview: bool(row.identity_in_review),
+        queueFlags,
+        createdAt: iso(row.created_at),
+        updatedAt: iso(row.updated_at),
+    }
+}
+
+async function queryWallet(pgPool, query, actor) {
+    const dependencies = await operationalDependencies(pgPool)
+    const [globalSourceStale, scope] = await Promise.all([
+        sourceStale(pgPool, dependencies),
+        Promise.resolve(requestedUnitScope(actor, query?.unit)),
+    ])
+    const flags = normalizeActionFlags(query?.actionFlag || query?.actionFlags)
+    const status = text(query?.status).toLowerCase()
+    const owner = query?.owner == null || query?.owner === '' ? '' : safeOwner(query.owner)
+    const sort = Object.prototype.hasOwnProperty.call(WALLET_SORTS, text(query?.sort)) ? text(query.sort) : 'dueDate'
+    const direction = text(query?.direction).toLowerCase() === 'asc' ? 'asc' :
+        (text(query?.direction).toLowerCase() === 'desc' ? 'desc' : (sort === 'dueDate' ? 'asc' : 'desc'))
+    const limit = normalizeLimit(query?.limit)
+    const offset = normalizeOffset(query?.offset)
+    if (status && !ACTION_STATUSES.includes(status)) throw operationalError('INVALID_COMMERCIAL_ACTION_STATUS', 400)
+    const permission = permissionSql(dependencies)
+    const identityReview = identityReviewSql(dependencies)
+    const params = []
+    const where = [scopeWhere(scope, params)]
+    if (status) {
+        params.push(status)
+        where.push(`action.status=$${params.length}`)
+    }
+    if (owner) {
+        params.push(owner)
+        where.push(`action.owner=$${params.length}`)
+    }
+    for (const flag of flags) {
+        where.push(actionFlagSql(flag, {
+            permissionStatus: permission.status,
+            permissionExpiresAt: permission.expiresAt,
+            sourceIsStale: globalSourceStale,
+            identityReview,
+            actorOwner: actorPrincipal(actor),
+        }, params))
+    }
+    params.push(globalSourceStale, limit, offset)
+    const rows = await pgPool.query(`select action.id::text, action.segment_key, action.action_type, action.status, action.owner,
+            action.due_date, action.revision, action.outcome_code, action.created_at, action.updated_at,
+            unit.slug as unit_slug, ${permission.status} as permission_status, ${permission.expiresAt} as permission_expires_at,
+            $${params.length - 2}::boolean as source_stale, ${identityReview} as identity_in_review,
+            count(*) over()::int as total_count
+        from crm_atendimento.commercial_actions action
+        join crm_atendimento.units unit on unit.id=action.unit_id
+        ${permission.join}
+        where ${where.join(' and ')}
+        order by ${WALLET_SORTS[sort]} ${direction} nulls last, action.updated_at desc, action.id asc
+        limit $${params.length - 1} offset $${params.length}`, params)
+    const actions = (rows.rows || []).map((row) => mapWalletAction(row, actor))
+    return {
+        total: count(rows.rows?.[0]?.total_count),
+        limit,
+        offset,
+        sort,
+        direction,
+        filters: { unit: scope.unit || null, status: status || null, owner: owner || null, actionFlags: flags },
+        actions,
+        pagination: { hasPrevious: offset > 0, hasNext: offset + actions.length < count(rows.rows?.[0]?.total_count) },
+        safety: operationSafety(),
+    }
+}
+
+function mapOwnerMetric(row) {
+    return {
+        owner: projectOwner(row.owner) || 'unassigned',
+        total: count(row.total),
+        active: count(row.active),
+        overdue: count(row.overdue),
+        completed: count(row.completed),
+        responded: count(row.responded),
+        scheduled: count(row.scheduled),
+        attended: count(row.attended),
+        sale: count(row.sale),
+        returned: count(row.returned),
+        cancelled: count(row.cancelled),
+    }
+}
+
+async function queryStageDurations(pgPool, scope) {
+    const params = []
+    const where = scopeWhere(scope, params)
+    const result = await pgPool.query(`select event.action_id::text,event.status,event.created_at
+        from crm_atendimento.commercial_action_events event
+        join crm_atendimento.commercial_actions action on action.id=event.action_id
+        join crm_atendimento.units unit on unit.id=action.unit_id
+        where ${where}
+        order by event.action_id,event.event_order asc
+        limit 10000`, params)
+    return computeAverageStageDurations((result.rows || []).map((row) => ({
+        actionId: row.action_id,
+        status: row.status,
+        createdAt: row.created_at,
+    })))
+}
+
+async function queryTeam(pgPool, query, actor) {
+    const scope = requestedUnitScope(actor, query?.unit)
+    const params = []
+    const where = scopeWhere(scope, params)
+    const [owners, statuses, absences, stageDurations] = await Promise.all([
+        pgPool.query(`select coalesce(action.owner,'') as owner,
+                count(*)::int as total,
+                count(*) filter (where action.status=any($${params.push(ACTIVE_ACTION_STATUSES)}::text[]))::int as active,
+                count(*) filter (where action.status=any($${params.push(ACTIVE_ACTION_STATUSES)}::text[]) and action.due_date < current_date)::int as overdue,
+                count(*) filter (where action.status in ('closed','cancelled','won_sale','returned') or action.outcome_code in ('attended','sale','clinical_return','cancelled'))::int as completed,
+                count(*) filter (where action.status in ('responded','scheduled','won_sale','returned') or action.outcome_code in ('requested_follow_up','scheduled','attended','cancelled','sale','clinical_return','opt_out_requested'))::int as responded,
+                count(*) filter (where action.status='scheduled' or action.outcome_code='scheduled')::int as scheduled,
+                count(*) filter (where action.outcome_code='attended')::int as attended,
+                count(*) filter (where action.status='won_sale' or action.outcome_code='sale')::int as sale,
+                count(*) filter (where action.status='returned' or action.outcome_code='clinical_return')::int as returned,
+                count(*) filter (where action.status='cancelled' or action.outcome_code='cancelled')::int as cancelled
+            from crm_atendimento.commercial_actions action
+            join crm_atendimento.units unit on unit.id=action.unit_id
+            where ${where}
+            group by coalesce(action.owner,'') order by active desc, owner asc`, params),
+        pgPool.query(`select action.status, count(*)::int as count
+            from crm_atendimento.commercial_actions action
+            join crm_atendimento.units unit on unit.id=action.unit_id
+            where ${where} group by action.status`, params.slice(0, -2)),
+        pgPool.query(`select absence.id::text, absence.owner, unit.slug as unit, absence.absence_type,
+                absence.starts_at, absence.ends_at, absence.substitute_owner, absence.revision
+            from crm_atendimento.commercial_owner_absences absence
+            join crm_atendimento.units unit on unit.id=absence.unit_id
+            where ${scopeWhere(scope, [])}
+              and absence.ends_at >= current_date
+             order by absence.starts_at asc`, scope.unit ? [scope.unit] : scope.unitSlugs ? [scope.unitSlugs] : []),
+        queryStageDurations(pgPool, scope),
+    ])
+    const byOwner = (owners.rows || []).map(mapOwnerMetric)
+    const totals = byOwner.reduce((result, row) => Object.fromEntries(Object.keys(row).filter((key) => key !== 'owner').map((key) => [key, count(result[key]) + count(row[key])])), {})
+    const total = count(totals.total)
+    const rate = (key) => total ? Math.round((count(totals[key]) / total) * 10_000) / 100 : 0
+    return {
+        totals: {
+            ...totals,
+            completionRate: rate('completed'), responseRate: rate('responded'), schedulingRate: rate('scheduled'),
+            attendanceRate: rate('attended'), saleRate: rate('sale'), returnRate: rate('returned'), cancellationRate: rate('cancelled'),
+        },
+        byOwner,
+        byStatus: Object.fromEntries((statuses.rows || []).map((row) => [text(row.status), count(row.count)])),
+        stageDurations,
+        absences: (absences.rows || []).map((row) => ({
+            absenceId: text(row.id), owner: projectOwner(row.owner) || 'unassigned', unit: text(row.unit),
+            type: text(row.absence_type), startsAt: dateOnly(row.starts_at), endsAt: dateOnly(row.ends_at),
+            substituteOwner: projectOwner(row.substitute_owner), revision: count(row.revision) || 1,
+        })),
+        safety: operationSafety(),
+    }
+}
+
+function identityReviewFor(identityColumn, dependencies) {
+    return identityReviewSql(dependencies).replaceAll('action.identity_id', identityColumn)
+}
+
+function mapCampaign(row = {}) {
+    let filters = {}
+    try { filters = normalizeCampaignFilters(row.filters_snapshot || {}) } catch { /* corrupt legacy snapshot stays hidden */ }
+    return {
+        campaignId: text(row.id),
+        name: text(row.name),
+        revision: count(row.revision) || 1,
+        segmentKey: text(row.segment_key),
+        segmentVersion: text(row.segment_version),
+        filters,
+        contextHash: /^[a-f0-9]{64}$/i.test(text(row.context_hash)) ? text(row.context_hash).toLowerCase() : null,
+        cutoffAt: iso(row.cutoff_at),
+        unit: text(row.unit_slug),
+        owner: projectOwner(row.owner) || 'unassigned',
+        offerId: UUID_RE.test(text(row.offer_id)) ? text(row.offer_id).toLowerCase() : null,
+        assignmentWindowStart: iso(row.assignment_window_start),
+        assignmentWindowEnd: iso(row.assignment_window_end),
+        controlGroupPercent: count(row.control_group_percent),
+        state: COMMERCIAL_CAMPAIGN_STATES.includes(text(row.state)) ? text(row.state) : 'draft',
+        author: projectOwner(row.author) || null,
+        createdAt: iso(row.created_at),
+        updatedAt: iso(row.updated_at),
+        members: {
+            total: count(row.member_total),
+            eligible: count(row.member_eligible),
+            blocked: count(row.member_blocked),
+            review: count(row.member_review),
+            control: count(row.member_control),
+            assigned: count(row.member_assigned),
+            completed: count(row.member_completed),
+            cancelled: count(row.member_cancelled),
+        },
+    }
+}
+
+function mapCampaignEvent(row = {}) {
+    return {
+        eventOrder: count(row.event_order),
+        type: text(row.event_type),
+        occurredAt: iso(row.created_at),
+        actor: projectOwner(row.actor_id),
+        correlationId: UUID_RE.test(text(row.trace_id)) ? text(row.trace_id).toLowerCase() : null,
+        memberState: ['eligible', 'blocked', 'review', 'control', 'assigned', 'completed', 'cancelled'].includes(text(row.member_state))
+            ? text(row.member_state) : null,
+        outcomeCode: text(row.outcome_code) || null,
+    }
+}
+
+function frozenCampaignContext(campaign) {
+    return {
+        name: campaign.name,
+        segmentKey: campaign.segmentKey,
+        segmentVersion: campaign.segmentVersion,
+        filters: campaign.filters,
+        identityIds: [...campaign.identityIds].sort(),
+        cutoffAt: campaign.cutoffAt,
+        unit: campaign.unit,
+        owner: campaign.owner,
+        offerId: campaign.offerId,
+        assignmentWindowStart: campaign.assignmentWindowStart,
+        assignmentWindowEnd: campaign.assignmentWindowEnd,
+        controlGroupPercent: campaign.controlGroupPercent,
+        state: campaign.state,
+    }
+}
+
+async function campaignCohortDependencies(db) {
+    const result = await db.query(`select
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.global_client_identities'), 'SELECT'), false) as identities,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.global_client_identity_members'), 'SELECT'), false) as members,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.attendance_client_links'), 'SELECT'), false) as attendance_links,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.attendances'), 'SELECT'), false) as attendances,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_caixa.sales'), 'SELECT'), false) as sales,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.app_client_registrations'), 'SELECT'), false) as app_registrations,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.supplemental_lead_profiles'), 'SELECT'), false) as lead_profiles`)
+    const row = result.rows[0] || {}
+    return Object.values(row).every(bool)
+}
+
+async function resolveCampaignUnit(client, unitSlug) {
+    const result = await client.query(`select id::text,slug from crm_atendimento.units where slug=$1`, [unitSlug])
+    const unit = result.rows[0]
+    if (!unit?.id) throw operationalError('COMMERCIAL_UNIT_NOT_FOUND', 404)
+    return unit
+}
+
+async function readCampaignCohort(client, { identityIds, unitSlug, dependencies, globalSourceStale }) {
+    if (!dependencies) throw operationalError('COMMERCIAL_CAMPAIGN_COHORT_SOURCE_UNAVAILABLE', 409)
+    const permissions = await operationalDependencies(client)
+    const permission = permissionSql(permissions)
+    const review = identityReviewFor('identity.id', permissions)
+    const result = await client.query(`select identity.id::text as identity_id,
+            ${permission.status} as permission_status,
+            ${review} as identity_in_review,
+            exists(
+                select 1 from crm_atendimento.global_client_identity_members member
+                 where member.identity_id=identity.id and (
+                    (member.source_type='attendance_client' and member.source_id ~ '^[0-9a-fA-F-]{36}$' and exists(
+                        select 1 from crm_atendimento.attendance_client_links link
+                        join crm_atendimento.attendances attendance on attendance.id=link.attendance_id and attendance.deleted_at is null
+                        join crm_atendimento.units attendance_unit on attendance_unit.id=attendance.unit_id
+                        where link.client_id=member.source_id::uuid and attendance_unit.slug=$2
+                    ))
+                    or (member.source_type='caixa_customer' and member.source_id ~ '^[0-9a-fA-F-]{36}$' and exists(
+                        select 1 from crm_caixa.sales sale
+                        join crm_atendimento.units sale_unit on sale_unit.id=sale.unit_id
+                        where sale.customer_id=member.source_id::uuid and sale_unit.slug=$2
+                    ))
+                    or (member.source_type='app_registration' and exists(
+                        select 1 from crm_atendimento.app_client_registrations registration
+                        join lateral jsonb_array_elements_text(coalesce(registration.unit_slugs, '[]'::jsonb)) scope(slug) on true
+                        where registration.source_client_id=member.source_id and scope.slug=$2
+                    ))
+                    or (member.source_type='lead_profile' and exists(
+                        select 1 from crm_atendimento.supplemental_lead_profiles lead
+                        join lateral jsonb_array_elements_text(coalesce(lead.unit_slugs, '[]'::jsonb)) scope(slug) on true
+                        where lead.source_profile_id=member.source_id and scope.slug=$2
+                    ))
+                 )
+            ) as unit_match
+        from crm_atendimento.global_client_identities identity
+        ${permission.join.replaceAll('action.identity_id', 'identity.id')}
+        where identity.id=any($1::uuid[])`, [identityIds, unitSlug])
+    const found = new Map((result.rows || []).map((row) => [text(row.identity_id).toLowerCase(), row]))
+    if (found.size !== identityIds.length || identityIds.some((identityId) => !bool(found.get(identityId)?.unit_match))) {
+        throw operationalError('COMMERCIAL_CAMPAIGN_IDENTITY_UNIT_FORBIDDEN', 403)
+    }
+    return identityIds.map((identityId) => {
+        const row = found.get(identityId)
+        const permissionStatus = text(row.permission_status) || 'review_required'
+        const identityInReview = bool(row.identity_in_review)
+        const eligible = permissionStatus === 'eligible'
+        return {
+            identityId,
+            permissionStatus,
+            sourceStale: globalSourceStale,
+            identityInReview,
+            eligible,
+        }
+    })
+}
+
+function mutationInput(actor, operation, payload, fingerprintPayload, { requireReason = true } = {}) {
+    const mutation = normalizeOperationMutation(payload, { requireIdempotency: true, requireReason })
+    const actorRef = actorReference(actor)
+    const mutationKey = `co:${digest('commercial-operation-idempotency', {
+        actorRef, operation, idempotencyKey: mutation.idempotencyKey,
+    })}`
+    const requestFingerprint = digest('commercial-operation-request', {
+        actorRef,
+        operation,
+        payload: fingerprintPayload,
+    })
+    return { mutation, actorRef, mutationKey, requestFingerprint }
+}
+
+async function runCommercialOperationMutation(client, {
+    actor,
+    operation,
+    payload,
+    fingerprintPayload,
+    requireReason = true,
+    execute,
+}) {
+    const context = mutationInput(actor, operation, payload, fingerprintPayload, { requireReason })
+    // Serialize every idempotency namespace before examining the operation
+    // ledger or mutable rows. This makes a replay safe even when an earlier
+    // successful mutation has changed its optimistic revision.
+    await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [context.mutationKey])
+    // Readiness is checked only after the idempotency lock.  A retry therefore
+    // cannot observe a partially applied migration or race another request
+    // while deciding whether the ledger already contains its result.
+    await assertCommercialOperationsReady(client)
+    const existing = await client.query(`select request_fingerprint,response
+        from crm_atendimento.commercial_operation_mutations
+        where mutation_key=$1 and operation=$2 for update`, [context.mutationKey, operation])
+    if (existing.rows[0]) {
+        if (text(existing.rows[0].request_fingerprint) !== context.requestFingerprint) {
+            throw operationalError('COMMERCIAL_IDEMPOTENCY_CONFLICT', 409)
+        }
+        return { ...(existing.rows[0].response || {}), idempotent: true, safety: operationSafety() }
+    }
+    const response = await execute(context)
+    await client.query(`insert into crm_atendimento.commercial_operation_mutations(
+            mutation_key,operation,actor_id,request_fingerprint,response)
+        values($1,$2,$3,$4,$5::jsonb)`, [
+        context.mutationKey,
+        operation,
+        context.actorRef,
+        context.requestFingerprint,
+        JSON.stringify(response || {}),
+    ])
+    return { ...(response || {}), idempotent: false, safety: operationSafety() }
+}
+
+async function recordCampaignEvent(client, { campaignId, memberId = null, eventType, actorRef, traceId, payload = {} }) {
+    await client.query(`insert into crm_atendimento.commercial_campaign_events(
+            campaign_id,member_id,event_type,actor_id,trace_id,payload)
+        values($1,$2,$3,$4,$5,$6::jsonb)`, [
+        campaignId, memberId, eventType, actorRef, traceId, JSON.stringify(payload),
+    ])
+}
+
+async function recordActionEvent(client, {
+    actionId,
+    identityId,
+    previousStatus,
+    status,
+    outcomeCode = null,
+    actorRef,
+    traceId,
+    details = {},
+}) {
+    // `details` is an explicit operational allowlist.  Do not pass an action
+    // payload, note, customer object, identity context or source evidence here:
+    // the action ledger is append-only and must therefore be safe to retain.
+    const safeDetails = {
+        operation: text(details.operation),
+        ownerChanged: details.ownerChanged === true,
+        rebalance: details.rebalance === true,
+        reasonDigest: /^[a-f0-9]{64}$/i.test(text(details.reasonDigest)) ? text(details.reasonDigest) : null,
+    }
+    await client.query(`insert into crm_atendimento.commercial_action_events(
+            action_id,identity_id,event_type,previous_status,status,trace_id,recorded_by,
+            contact_eligibility_status,contact_eligibility_reason,details,outcome_code)
+        values($1,$2,'updated',$3,$4,$5,$6,$7,$8,$9::jsonb,$10)`, [
+        actionId,
+        identityId,
+        previousStatus,
+        status,
+        traceId,
+        actorRef,
+        null,
+        null,
+        JSON.stringify(safeDetails),
+        outcomeCode,
+    ])
+}
+
+function memberStateForAction(status, outcomeCode, currentState) {
+    if (['control', 'blocked', 'review', 'completed', 'cancelled'].includes(text(currentState))) return text(currentState)
+    if (text(status) === 'cancelled' || outcomeCode === 'cancelled') return 'cancelled'
+    if (['won_sale', 'returned', 'closed'].includes(text(status)) || ['attended', 'sale', 'clinical_return'].includes(outcomeCode)) return 'completed'
+    return 'assigned'
+}
+
+async function synchronizeCampaignMembershipForAction(client, {
+    actionId,
+    owner = null,
+    status,
+    outcomeCode = null,
+    actorRef,
+    reasonDigest,
+}) {
+    const memberships = await client.query(`select id::text,campaign_id::text,state
+        from crm_atendimento.commercial_campaign_members
+        where action_id=$1 for update`, [actionId])
+    for (const member of memberships.rows || []) {
+        const nextState = memberStateForAction(status, outcomeCode, member.state)
+        await client.query(`update crm_atendimento.commercial_campaign_members
+            set owner=coalesce($2,owner),state=$3,revision=revision+1,updated_at=now()
+            where id=$1`, [member.id, owner, nextState])
+        await recordCampaignEvent(client, {
+            campaignId: member.campaign_id,
+            memberId: member.id,
+            eventType: outcomeCode ? 'member_outcome' : 'member_assigned',
+            actorRef,
+            traceId: randomUUID(),
+            payload: outcomeCode
+                ? { state: nextState, outcomeCode, reasonDigest }
+                : { state: nextState, ownerChanged: owner !== null, reasonDigest },
+        })
+    }
+}
+
+async function campaignProjection(client, campaignId, actor) {
+    const scope = requestedUnitScope(actor)
+    const params = [campaignId]
+    const where = ["campaign.id=$1", scopeWhere(scope, params)]
+    const result = await client.query(`select campaign.id::text,campaign.name,campaign.revision,campaign.segment_key,campaign.segment_version,
+            campaign.filters_snapshot,campaign.context_hash,campaign.cutoff_at,unit.slug as unit_slug,campaign.owner,campaign.offer_id::text,
+            campaign.assignment_window_start,campaign.assignment_window_end,campaign.control_group_percent,campaign.state,campaign.author,
+            campaign.created_at,campaign.updated_at,
+            count(member.id)::int as member_total,
+            count(member.id) filter(where member.state='eligible')::int as member_eligible,
+            count(member.id) filter(where member.state='blocked')::int as member_blocked,
+            count(member.id) filter(where member.state='review')::int as member_review,
+            count(member.id) filter(where member.state='control')::int as member_control,
+            count(member.id) filter(where member.state='assigned')::int as member_assigned,
+            count(member.id) filter(where member.state='completed')::int as member_completed,
+            count(member.id) filter(where member.state='cancelled')::int as member_cancelled
+        from crm_atendimento.commercial_campaigns campaign
+        join crm_atendimento.units unit on unit.id=campaign.unit_id
+        left join crm_atendimento.commercial_campaign_members member on member.campaign_id=campaign.id
+        where ${where.join(' and ')}
+        group by campaign.id,unit.slug`, params)
+    if (!result.rows[0]) throw operationalError('COMMERCIAL_CAMPAIGN_NOT_FOUND', 404)
+    return mapCampaign(result.rows[0])
+}
+
+async function createCampaign(client, payload, actor) {
+    const campaign = normalizeCampaignPayload(payload)
+    const unitSlug = assertUnitAllowed(actor, campaign.unit)
+    const contextHash = stableOperationFingerprint(frozenCampaignContext(campaign))
+    return runCommercialOperationMutation(client, {
+        actor,
+        operation: 'campaign_create',
+        payload,
+        fingerprintPayload: { campaign: frozenCampaignContext(campaign), contextHash },
+        execute: async ({ actorRef }) => {
+            const unit = await resolveCampaignUnit(client, unitSlug)
+            await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [`commercial-operations:campaign:${unit.id}:${contextHash}`])
+            const existing = await client.query(`select id::text from crm_atendimento.commercial_campaigns
+                where unit_id=$1 and context_hash=$2
+                order by created_at asc,id asc limit 1 for update`, [unit.id, contextHash])
+            if (existing.rows[0]?.id) {
+                const persisted = await campaignProjection(client, existing.rows[0].id, actor)
+                return { campaign: persisted, cohort: { ...persisted.members }, deduplicated: true }
+            }
+            const dependencies = await campaignCohortDependencies(client)
+            const stale = await sourceStale(client, await operationalDependencies(client))
+            if (campaign.offerId) {
+                const offer = await client.query(`select id from crm_atendimento.commercial_offers where id=$1`, [campaign.offerId])
+                if (!offer.rows[0]?.id) throw operationalError('COMMERCIAL_CAMPAIGN_OFFER_NOT_FOUND', 404)
+            }
+            const cohort = await readCampaignCohort(client, {
+                identityIds: [...campaign.identityIds].sort(), unitSlug, dependencies, globalSourceStale: stale,
+            })
+            const created = await client.query(`insert into crm_atendimento.commercial_campaigns(
+                    name,segment_key,segment_version,filters_snapshot,context_hash,cutoff_at,unit_id,owner,offer_id,
+                    assignment_window_start,assignment_window_end,control_group_percent,state,author,reason)
+                values($1,$2,$3,$4::jsonb,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+                returning id::text`, [
+                campaign.name, campaign.segmentKey, campaign.segmentVersion, JSON.stringify(campaign.filters), contextHash,
+                campaign.cutoffAt, unit.id, campaign.owner, campaign.offerId, campaign.assignmentWindowStart,
+                campaign.assignmentWindowEnd, campaign.controlGroupPercent, campaign.state, actorRef, `digest:${digest('campaign-reason', { reason: campaign.reason })}`,
+            ])
+            const campaignId = created.rows[0]?.id
+            if (!campaignId) throw operationalError('COMMERCIAL_CAMPAIGN_CREATE_FAILED', 500)
+            const traceId = randomUUID()
+            await recordCampaignEvent(client, {
+                campaignId, eventType: 'created', actorRef, traceId,
+                payload: { contextHash, cohortCount: cohort.length, controlGroupPercent: campaign.controlGroupPercent },
+            })
+            const stateCounts = { eligible: 0, blocked: 0, review: 0, control: 0, assigned: 0, completed: 0, cancelled: 0 }
+            for (const member of cohort) {
+                const controlGroup = member.eligible && !member.sourceStale && !member.identityInReview && stableControlGroup({
+                    campaignSeed: contextHash, identityId: member.identityId, percentage: campaign.controlGroupPercent,
+                })
+                const state = campaignMemberState({
+                    eligible: member.eligible, controlGroup, identityInReview: member.identityInReview, sourceStale: member.sourceStale,
+                })
+                stateCounts[state] += 1
+                const eligibilitySnapshot = {
+                    permissionStatus: member.permissionStatus,
+                    sourceStale: member.sourceStale,
+                    identityInReview: member.identityInReview,
+                    evaluatedAt: new Date().toISOString(),
+                }
+                const inserted = await client.query(`insert into crm_atendimento.commercial_campaign_members(
+                        campaign_id,identity_id,unit_id,segment_key,segment_version,cutoff_at,owner,offer_id,control_group,state,eligibility_snapshot)
+                    values($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::jsonb) returning id::text`, [
+                    campaignId, member.identityId, unit.id, campaign.segmentKey, campaign.segmentVersion, campaign.cutoffAt,
+                    campaign.owner, campaign.offerId, controlGroup, state, JSON.stringify(eligibilitySnapshot),
+                ])
+                await recordCampaignEvent(client, {
+                    campaignId, memberId: inserted.rows[0]?.id || null, eventType: 'member_added', actorRef, traceId: randomUUID(),
+                    payload: { state, controlGroup },
+                })
+            }
+            return {
+                campaign: await campaignProjection(client, campaignId, actor),
+                cohort: { total: cohort.length, ...stateCounts },
+            }
+        },
+    })
+}
+
+async function listCampaigns(pgPool, query, actor) {
+    const scope = requestedUnitScope(actor, query?.unit)
+    const state = text(query?.state).toLowerCase()
+    if (state && !COMMERCIAL_CAMPAIGN_STATES.includes(state)) throw operationalError('INVALID_COMMERCIAL_CAMPAIGN_STATE', 400)
+    const limit = normalizeLimit(query?.limit)
+    const offset = normalizeOffset(query?.offset)
+    const params = []
+    const where = [scopeWhere(scope, params)]
+    if (state) { params.push(state); where.push(`campaign.state=$${params.length}`) }
+    params.push(limit, offset)
+    const result = await pgPool.query(`select campaign.id::text,campaign.name,campaign.revision,campaign.segment_key,campaign.segment_version,
+            campaign.filters_snapshot,campaign.context_hash,campaign.cutoff_at,unit.slug as unit_slug,campaign.owner,campaign.offer_id::text,
+            campaign.assignment_window_start,campaign.assignment_window_end,campaign.control_group_percent,campaign.state,campaign.author,
+            campaign.created_at,campaign.updated_at,
+            count(member.id)::int as member_total,
+            count(member.id) filter(where member.state='eligible')::int as member_eligible,
+            count(member.id) filter(where member.state='blocked')::int as member_blocked,
+            count(member.id) filter(where member.state='review')::int as member_review,
+            count(member.id) filter(where member.state='control')::int as member_control,
+            count(member.id) filter(where member.state='assigned')::int as member_assigned,
+            count(member.id) filter(where member.state='completed')::int as member_completed,
+            count(member.id) filter(where member.state='cancelled')::int as member_cancelled,
+            count(*) over()::int as total_count
+        from crm_atendimento.commercial_campaigns campaign
+        join crm_atendimento.units unit on unit.id=campaign.unit_id
+        left join crm_atendimento.commercial_campaign_members member on member.campaign_id=campaign.id
+        where ${where.join(' and ')}
+        group by campaign.id,unit.slug
+        order by campaign.updated_at desc,campaign.id asc
+        limit $${params.length - 1} offset $${params.length}`, params)
+    const campaigns = (result.rows || []).map(mapCampaign)
+    return {
+        total: count(result.rows?.[0]?.total_count), limit, offset, campaigns,
+        pagination: { hasPrevious: offset > 0, hasNext: offset + campaigns.length < count(result.rows?.[0]?.total_count) },
+        safety: operationSafety(),
+    }
+}
+
+async function campaignDetail(pgPool, campaignId, query, actor) {
+    const id = assertUuid(campaignId, 'INVALID_COMMERCIAL_CAMPAIGN')
+    if (query?.unit) assertUnitAllowed(actor, query.unit)
+    const campaign = await campaignProjection(pgPool, id, actor)
+    const events = await pgPool.query(`select event_order,event_type,actor_id,trace_id,created_at,
+            case when payload->>'state' in ('eligible','blocked','review','control','assigned','completed','cancelled') then payload->>'state' else null end as member_state,
+            case when payload->>'outcomeCode' ~ '^[a-z_]{2,80}$' then payload->>'outcomeCode' else null end as outcome_code
+        from crm_atendimento.commercial_campaign_events
+        where campaign_id=$1 order by event_order desc limit $2`, [id, normalizeLimit(query?.eventLimit, 50, 100)])
+    return { campaign, events: (events.rows || []).map(mapCampaignEvent), safety: operationSafety() }
+}
+
+async function updateCampaign(client, campaignId, payload, actor) {
+    const id = assertUuid(campaignId, 'INVALID_COMMERCIAL_CAMPAIGN')
+    const stateProvided = Object.prototype.hasOwnProperty.call(payload || {}, 'state')
+    const state = stateProvided ? text(payload.state).toLowerCase() : null
+    if (Object.prototype.hasOwnProperty.call(payload || {}, 'owner') ||
+        Object.prototype.hasOwnProperty.call(payload || {}, 'filters') ||
+        Object.prototype.hasOwnProperty.call(payload || {}, 'segmentKey') ||
+        Object.prototype.hasOwnProperty.call(payload || {}, 'segmentVersion') ||
+        Object.prototype.hasOwnProperty.call(payload || {}, 'identityIds') ||
+        Object.prototype.hasOwnProperty.call(payload || {}, 'offerId') ||
+        Object.prototype.hasOwnProperty.call(payload || {}, 'unit')) {
+        throw operationalError('COMMERCIAL_CAMPAIGN_FROZEN_CONTEXT', 409)
+    }
+    if (!stateProvided) throw operationalError('COMMERCIAL_CAMPAIGN_CHANGE_REQUIRED', 400)
+    if (stateProvided && !COMMERCIAL_CAMPAIGN_STATES.includes(state)) throw operationalError('INVALID_COMMERCIAL_CAMPAIGN_STATE', 400)
+    return runCommercialOperationMutation(client, {
+        actor,
+        operation: 'campaign_update',
+        payload,
+        fingerprintPayload: { campaignId: id, state, expectedRevision: payload?.expectedRevision, reason: text(payload?.reason) },
+        execute: async ({ mutation, actorRef }) => {
+            const current = await client.query(`select campaign.id::text,campaign.revision,campaign.state,unit.slug as unit_slug
+                from crm_atendimento.commercial_campaigns campaign
+                join crm_atendimento.units unit on unit.id=campaign.unit_id
+                where campaign.id=$1 for update of campaign`, [id])
+            const row = current.rows[0]
+            if (!row?.id) throw operationalError('COMMERCIAL_CAMPAIGN_NOT_FOUND', 404)
+            assertUnitAllowed(actor, row.unit_slug)
+            if (mutation.expectedRevision == null || count(row.revision) !== mutation.expectedRevision) {
+                throw operationalError('COMMERCIAL_CAMPAIGN_CONFLICT', 409)
+            }
+            if (state === row.state) throw operationalError('COMMERCIAL_CAMPAIGN_CHANGE_REQUIRED', 400)
+            await client.query(`update crm_atendimento.commercial_campaigns
+                set state=$2,revision=revision+1,updated_at=now()
+                where id=$1`, [id, state])
+            await recordCampaignEvent(client, {
+                campaignId: id, eventType: 'state_changed', actorRef, traceId: randomUUID(),
+                payload: { previousState: row.state, state,
+                    reasonDigest: digest('campaign-update-reason', { reason: mutation.reason }) },
+            })
+            return { campaign: await campaignProjection(client, id, actor) }
+        },
+    })
+}
+
+async function actionProjection(client, actionId, actor) {
+    const scope = requestedUnitScope(actor)
+    const dependencies = await operationalDependencies(client)
+    const [globalSourceStale] = await Promise.all([sourceStale(client, dependencies)])
+    const permission = permissionSql(dependencies)
+    const identityReview = identityReviewSql(dependencies)
+    const params = [actionId]
+    const where = ['action.id=$1', scopeWhere(scope, params)]
+    params.push(globalSourceStale)
+    const result = await client.query(`select action.id::text,action.segment_key,action.action_type,action.status,action.owner,
+            action.due_date,action.revision,action.outcome_code,action.created_at,action.updated_at,
+            unit.slug as unit_slug,${permission.status} as permission_status,${permission.expiresAt} as permission_expires_at,
+            $${params.length}::boolean as source_stale,${identityReview} as identity_in_review
+        from crm_atendimento.commercial_actions action
+        join crm_atendimento.units unit on unit.id=action.unit_id
+        ${permission.join}
+        where ${where.join(' and ')}`, params)
+    if (!result.rows[0]) throw operationalError('COMMERCIAL_ACTION_NOT_FOUND', 404)
+    return mapWalletAction(result.rows[0], actor)
+}
+
+async function actionForMutation(client, actionId, actor) {
+    const id = assertUuid(actionId, 'INVALID_COMMERCIAL_ACTION')
+    const result = await client.query(`select action.id::text,action.identity_id::text,action.revision,action.status,action.owner,
+            unit.slug as unit_slug
+        from crm_atendimento.commercial_actions action
+        join crm_atendimento.units unit on unit.id=action.unit_id
+        where action.id=$1 for update of action`, [id])
+    const action = result.rows[0]
+    if (!action?.id) throw operationalError('COMMERCIAL_ACTION_NOT_FOUND', 404)
+    assertUnitAllowed(actor, action.unit_slug)
+    return action
+}
+
+async function reassignAction(client, actionId, payload, actor) {
+    const id = assertUuid(actionId, 'INVALID_COMMERCIAL_ACTION')
+    const owner = safeOwner(payload?.owner, { required: true })
+    return runCommercialOperationMutation(client, {
+        actor,
+        operation: 'action_reassign',
+        payload,
+        fingerprintPayload: { actionId: id, owner, expectedRevision: payload?.expectedRevision, reason: text(payload?.reason) },
+        execute: async ({ mutation, actorRef }) => {
+            const action = await actionForMutation(client, id, actor)
+            if (mutation.expectedRevision == null || count(action.revision) !== mutation.expectedRevision) {
+                throw operationalError('COMMERCIAL_ACTION_CONFLICT', 409)
+            }
+            if (owner === action.owner) throw operationalError('COMMERCIAL_ACTION_REASSIGNMENT_UNCHANGED', 400)
+            await client.query(`update crm_atendimento.commercial_actions
+                set owner=$2,revision=revision+1,updated_by=$3,updated_at=now()
+                where id=$1`, [id, owner, actorRef])
+            const reasonDigest = digest('action-reassign-reason', { reason: mutation.reason })
+            await recordActionEvent(client, {
+                actionId: id, identityId: action.identity_id, previousStatus: action.status, status: action.status,
+                actorRef, traceId: randomUUID(),
+                details: { operation: 'reassign', ownerChanged: true, reasonDigest },
+            })
+            await synchronizeCampaignMembershipForAction(client, {
+                actionId: id, owner, status: action.status, actorRef, reasonDigest,
+            })
+            return { action: await actionProjection(client, id, actor) }
+        },
+    })
+}
+
+async function recordActionOutcome(client, actionId, payload, actor) {
+    const id = assertUuid(actionId, 'INVALID_COMMERCIAL_ACTION')
+    const outcomeCode = normalizeOutcomeCode(payload?.outcomeCode)
+    if (!outcomeCode) throw operationalError('INVALID_COMMERCIAL_OUTCOME', 400)
+    const nextStatus = OUTCOME_STATUSES[outcomeCode]
+    return runCommercialOperationMutation(client, {
+        actor,
+        // The migration deliberately keeps structured outcomes under the
+        // existing audited action-update operation; it does not create a send
+        // operation or consent mutation.
+        operation: 'action_update',
+        payload,
+        fingerprintPayload: { actionId: id, outcomeCode, expectedRevision: payload?.expectedRevision, reason: text(payload?.reason) },
+        execute: async ({ mutation, actorRef }) => {
+            const action = await actionForMutation(client, id, actor)
+            if (mutation.expectedRevision == null || count(action.revision) !== mutation.expectedRevision) {
+                throw operationalError('COMMERCIAL_ACTION_CONFLICT', 409)
+            }
+            await client.query(`update crm_atendimento.commercial_actions
+                set status=$2,outcome_code=$3,outcome_recorded_at=now(),
+                    completed_at=case when $2 in ('won_sale','returned','closed','cancelled') then now() else completed_at end,
+                    revision=revision+1,updated_by=$4,updated_at=now()
+                where id=$1`, [id, nextStatus, outcomeCode, actorRef])
+            const reasonDigest = digest('action-outcome-reason', { reason: mutation.reason })
+            await recordActionEvent(client, {
+                actionId: id, identityId: action.identity_id, previousStatus: action.status, status: nextStatus,
+                outcomeCode, actorRef, traceId: randomUUID(),
+                details: { operation: 'outcome', reasonDigest },
+            })
+            await synchronizeCampaignMembershipForAction(client, {
+                actionId: id, status: nextStatus, outcomeCode, actorRef, reasonDigest,
+            })
+            return {
+                action: await actionProjection(client, id, actor),
+                // This is an operational signal only. A distinct consent flow
+                // must review the request; this module never records it.
+                requiresSeparateConsentWorkflow: outcomeCode === 'opt_out_requested',
+            }
+        },
+    })
+}
+
+function normalizeAbsencePayload(payload) {
+    const unit = text(payload?.unit).toLowerCase()
+    const owner = safeOwner(payload?.owner, { required: true })
+    const absenceType = text(payload?.absenceType || payload?.type).toLowerCase()
+    const substituteOwner = payload?.substituteOwner == null || payload?.substituteOwner === ''
+        ? null : safeOwner(payload.substituteOwner, { required: true })
+    const absenceId = payload?.absenceId ? assertUuid(payload.absenceId, 'INVALID_COMMERCIAL_ABSENCE') : null
+    if (!UNIT_RE.test(unit)) throw operationalError('INVALID_COMMERCIAL_UNIT', 400)
+    if (!ABSENCE_TYPES.has(absenceType)) throw operationalError('INVALID_COMMERCIAL_ABSENCE_TYPE', 400)
+    const range = normalizeDateRange(payload?.startsAt, payload?.endsAt, 'INVALID_COMMERCIAL_ABSENCE_RANGE')
+    return { absenceId, unit, owner, absenceType, substituteOwner, ...range }
+}
+
+function mapAbsence(row = {}) {
+    return {
+        absenceId: text(row.id),
+        unit: text(row.unit_slug || row.unit),
+        owner: projectOwner(row.owner) || 'unassigned',
+        type: text(row.absence_type),
+        startsAt: dateOnly(row.starts_at),
+        endsAt: dateOnly(row.ends_at),
+        substituteOwner: projectOwner(row.substitute_owner),
+        revision: count(row.revision) || 1,
+        createdAt: iso(row.created_at),
+        updatedAt: iso(row.updated_at),
+    }
+}
+
+async function upsertAbsence(client, payload, actor) {
+    const absence = normalizeAbsencePayload(payload)
+    const unitSlug = assertUnitAllowed(actor, absence.unit)
+    return runCommercialOperationMutation(client, {
+        actor,
+        operation: 'absence_upsert',
+        payload,
+        fingerprintPayload: { ...absence, expectedRevision: payload?.expectedRevision, reason: text(payload?.reason) },
+        execute: async ({ mutation, actorRef }) => {
+            const unit = await resolveCampaignUnit(client, unitSlug)
+            const current = await client.query(`select absence.id::text,absence.owner,absence.absence_type,absence.starts_at,absence.ends_at,
+                    absence.substitute_owner,absence.revision,unit.slug as unit_slug,absence.created_at,absence.updated_at
+                from crm_atendimento.commercial_owner_absences absence
+                join crm_atendimento.units unit on unit.id=absence.unit_id
+                where ${absence.absenceId ? 'absence.id=$1' : 'absence.owner=$1 and absence.unit_id=$2 and absence.starts_at=$3 and absence.ends_at=$4'}
+                for update of absence`, absence.absenceId
+                ? [absence.absenceId]
+                : [absence.owner, unit.id, absence.startsAt, absence.endsAt])
+            const row = current.rows[0]
+            if (row) {
+                assertUnitAllowed(actor, row.unit_slug)
+                if (text(row.unit_slug).toLowerCase() !== unitSlug) {
+                    throw operationalError('COMMERCIAL_ABSENCE_UNIT_CONFLICT', 409)
+                }
+                if (mutation.expectedRevision == null || count(row.revision) !== mutation.expectedRevision) {
+                    throw operationalError('COMMERCIAL_ABSENCE_CONFLICT', 409)
+                }
+                await client.query(`update crm_atendimento.commercial_owner_absences
+                    set owner=$2,absence_type=$3,starts_at=$4,ends_at=$5,substitute_owner=$6,
+                        reason=$7,revision=revision+1,updated_by=$8,updated_at=now()
+                    where id=$1`, [
+                    row.id, absence.owner, absence.absenceType, absence.startsAt, absence.endsAt, absence.substituteOwner,
+                    `digest:${digest('absence-reason', { reason: mutation.reason })}`, actorRef,
+                ])
+                const updated = await client.query(`select absence.id::text,absence.owner,absence.absence_type,absence.starts_at,absence.ends_at,
+                        absence.substitute_owner,absence.revision,unit.slug as unit_slug,absence.created_at,absence.updated_at
+                    from crm_atendimento.commercial_owner_absences absence
+                    join crm_atendimento.units unit on unit.id=absence.unit_id where absence.id=$1`, [row.id])
+                return { absence: mapAbsence(updated.rows[0]) }
+            }
+            if (mutation.expectedRevision != null) throw operationalError('COMMERCIAL_ABSENCE_NOT_FOUND', 404)
+            const inserted = await client.query(`insert into crm_atendimento.commercial_owner_absences(
+                    owner,unit_id,absence_type,starts_at,ends_at,substitute_owner,reason,created_by,updated_by)
+                values($1,$2,$3,$4,$5,$6,$7,$8,$8)
+                returning id::text,owner,absence_type,starts_at,ends_at,substitute_owner,revision,created_at,updated_at`, [
+                absence.owner, unit.id, absence.absenceType, absence.startsAt, absence.endsAt, absence.substituteOwner,
+                `digest:${digest('absence-reason', { reason: mutation.reason })}`, actorRef,
+            ])
+            return { absence: mapAbsence({ ...inserted.rows[0], unit_slug: unitSlug }) }
+        },
+    })
+}
+
+async function rebalanceActions(client, scope, { lock = false } = {}) {
+    const params = []
+    const where = [scopeWhere(scope, params), `action.status=any($${params.push(ACTIVE_ACTION_STATUSES)}::text[])`]
+    const result = await client.query(`select action.id::text,action.identity_id::text,action.owner,action.status,action.revision,
+            unit.slug as unit_slug,
+            exists(select 1 from crm_atendimento.commercial_owner_absences absence
+                where absence.unit_id=action.unit_id and absence.owner=action.owner
+                  and current_date between absence.starts_at and absence.ends_at) as absent_owner
+        from crm_atendimento.commercial_actions action
+        join crm_atendimento.units unit on unit.id=action.unit_id
+        where ${where.join(' and ')}
+        order by action.due_date asc nulls last,action.id asc${lock ? ' for update of action' : ''}`, params)
+    return (result.rows || []).map((row) => ({ ...row, absentOwner: bool(row.absent_owner) }))
+}
+
+function projectRebalancePlan(actions, capacities) {
+    const normalizedActions = actions.map((action) => ({
+        ...action,
+        absentOwner: action.absentOwner === true || action.absent_owner === true,
+    }))
+    const moves = planWalletBalance(normalizedActions, capacities)
+    const byId = new Map(actions.map((action) => [text(action.id).toLowerCase(), action]))
+    return moves.map((move) => {
+        const action = byId.get(text(move.actionId).toLowerCase())
+        return {
+            actionId: text(move.actionId).toLowerCase(),
+            fromOwner: projectOwner(move.fromOwner),
+            toOwner: projectOwner(move.toOwner),
+            expectedRevision: count(action?.revision) || 1,
+            unit: text(action?.unit_slug) || null,
+        }
+    }).filter((move) => UUID_RE.test(move.actionId) && move.toOwner)
+}
+
+async function previewRebalance(pgPool, payload, actor) {
+    const capacities = normalizeCapacities(payload?.capacities)
+    const scope = requestedUnitScope(actor, payload?.unit)
+    const actions = await rebalanceActions(pgPool, scope)
+    const moves = projectRebalancePlan(actions, capacities)
+    return {
+        unit: scope.unit || null,
+        capacities,
+        totalEligibleActions: actions.length,
+        moves,
+        safety: operationSafety(),
+    }
+}
+
+async function applyRebalance(client, payload, actor) {
+    const capacities = normalizeCapacities(payload?.capacities)
+    const expectedRevisions = normalizeExpectedRevisions(payload?.expectedRevisions)
+    const scope = requestedUnitScope(actor, payload?.unit)
+    return runCommercialOperationMutation(client, {
+        actor,
+        operation: 'rebalance',
+        payload,
+        fingerprintPayload: {
+            unit: scope.unit || scope.unitSlugs || 'all', capacities, expectedRevisions,
+            reason: text(payload?.reason),
+        },
+        execute: async ({ mutation, actorRef }) => {
+            // A scope-specific lock establishes a single plan writer.  The
+            // action rows are then locked before their revisions are compared.
+            await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [
+                `commercial-operations:rebalance:${scope.unit || (scope.unitSlugs || ['all']).join(',')}`,
+            ])
+            const actions = await rebalanceActions(client, scope, { lock: true })
+            const moves = projectRebalancePlan(actions, capacities)
+            const plannedIds = new Set(moves.map((move) => move.actionId))
+            const expectedIds = Object.keys(expectedRevisions)
+            if (plannedIds.size !== expectedIds.length || expectedIds.some((id) => !plannedIds.has(id))) {
+                throw operationalError('COMMERCIAL_REBALANCE_PLAN_CONFLICT', 409)
+            }
+            if (moves.some((move) => expectedRevisions[move.actionId] !== move.expectedRevision)) {
+                throw operationalError('COMMERCIAL_REBALANCE_CONFLICT', 409)
+            }
+            const byId = new Map(actions.map((action) => [text(action.id).toLowerCase(), action]))
+            const applied = []
+            for (const move of moves) {
+                const action = byId.get(move.actionId)
+                if (!action || count(action.revision) !== move.expectedRevision) {
+                    throw operationalError('COMMERCIAL_REBALANCE_CONFLICT', 409)
+                }
+                await client.query(`update crm_atendimento.commercial_actions
+                    set owner=$2,revision=revision+1,updated_by=$3,updated_at=now()
+                    where id=$1`, [move.actionId, move.toOwner, actorRef])
+                await recordActionEvent(client, {
+                    actionId: move.actionId,
+                    identityId: action.identity_id,
+                    previousStatus: action.status,
+                    status: action.status,
+                    actorRef,
+                    traceId: randomUUID(),
+                    details: { operation: 'rebalance', ownerChanged: true, rebalance: true,
+                        reasonDigest: digest('rebalance-reason', { reason: mutation.reason }) },
+                })
+                const memberships = await client.query(`update crm_atendimento.commercial_campaign_members
+                    set owner=$2,revision=revision+1,updated_at=now()
+                    where action_id=$1
+                    returning id::text,campaign_id::text`, [move.actionId, move.toOwner])
+                for (const member of memberships.rows || []) {
+                    await recordCampaignEvent(client, {
+                        campaignId: member.campaign_id,
+                        memberId: member.id,
+                        eventType: 'rebalanced',
+                        actorRef,
+                        traceId: randomUUID(),
+                        payload: { fromOwner: move.fromOwner, toOwner: move.toOwner },
+                    })
+                }
+                applied.push({ ...move, revision: move.expectedRevision + 1 })
+            }
+            return { moves: applied, moved: applied.length }
+        },
+    })
+}
+
+function opaqueTimelineId(source, id) {
+    const prefix = /^[a-z_]{2,40}$/i.test(text(source)) ? text(source).toLowerCase() : 'event'
+    return `${prefix}:${stableOperationFingerprint({ prefix, id: text(id) }).slice(0, 24)}`
+}
+
+function timelineActionType(row) {
+    const outcome = normalizeOutcomeCode(row.outcome_code)
+    if (outcome === 'opt_out_requested') return 'opt_out'
+    if (text(row.status) === 'contacted' || outcome === 'no_response' || outcome === 'wrong_number') return 'contact'
+    if (text(row.status) === 'responded' || outcome === 'requested_follow_up') return 'response'
+    if (text(row.status) === 'scheduled' || outcome === 'scheduled') return 'appointment'
+    return 'action'
+}
+
+function projectTimeline(row) {
+    const event = projectCommercialTimelineEvent(row)
+    return { ...event, id: opaqueTimelineId(event.source || event.type, row.id || row.event_id) }
+}
+
+async function assertCustomer360Scope(pgPool, identityId, query, actor) {
+    const scope = requestedUnitScope(actor, query?.unit)
+    // Customer 360 must always be anchored to one unit.  Even a global actor
+    // cannot accidentally request an unbounded identity timeline.
+    if (!scope.unit) throw operationalError('COMMERCIAL_CUSTOMER_360_UNIT_REQUIRED', 400)
+    const dependencies = await campaignCohortDependencies(pgPool)
+    const permissions = await operationalDependencies(pgPool)
+    const stale = await sourceStale(pgPool, permissions)
+    await readCampaignCohort(pgPool, {
+        identityIds: [identityId],
+        unitSlug: scope.unit,
+        dependencies,
+        globalSourceStale: stale,
+    })
+    return { unit: scope.unit, dependencies: permissions, sourceStale: stale }
+}
+
+async function customer360(pgPool, identityId, query, actor) {
+    const id = assertUuid(identityId, 'INVALID_COMMERCIAL_IDENTITY')
+    const { unit, dependencies, sourceStale } = await assertCustomer360Scope(pgPool, id, query, actor)
+    const limit = normalizeLimit(query?.limit, 100, 200)
+    const eventLimit = Math.max(20, Math.min(100, limit))
+    const [actions, campaigns, permissions, attendance, sales, decisions] = await Promise.all([
+        pgPool.query(`select event.id::text,event.status,event.outcome_code,event.trace_id,event.recorded_by as actor,
+                event.created_at,unit.slug as unit_slug
+            from crm_atendimento.commercial_action_events event
+            join crm_atendimento.commercial_actions action on action.id=event.action_id
+            join crm_atendimento.units unit on unit.id=action.unit_id
+            where event.identity_id=$1 and unit.slug=$2
+            order by event.event_order desc limit $3`, [id, unit, eventLimit]),
+        pgPool.query(`select event.id::text,event.event_type,event.trace_id,event.actor_id as actor,event.created_at,
+                unit.slug as unit_slug,campaign.id::text as campaign_id,campaign.offer_id::text as offer_id
+            from crm_atendimento.commercial_campaign_members member
+            join crm_atendimento.commercial_campaigns campaign on campaign.id=member.campaign_id
+            join crm_atendimento.units unit on unit.id=campaign.unit_id
+            join crm_atendimento.commercial_campaign_events event on event.campaign_id=campaign.id and (event.member_id=member.id or event.member_id is null)
+            where member.identity_id=$1 and unit.slug=$2
+            order by event.event_order desc limit $3`, [id, unit, eventLimit]),
+        dependencies.permissions
+            ? pgPool.query(`select event.id::text,event.status,event.trace_id,event.recorded_by as actor,event.created_at
+                from crm_atendimento.commercial_contact_permission_events event
+                where event.identity_id=$1
+                order by event.created_at desc limit $2`, [id, eventLimit])
+            : Promise.resolve({ rows: [] }),
+        pgPool.query(`select attendance.id::text,attendance.service_date as occurred_at,unit.slug as unit_slug
+            from crm_atendimento.global_client_identity_members member
+            join crm_atendimento.attendance_client_links link on link.client_id=member.source_id::uuid
+            join crm_atendimento.attendances attendance on attendance.id=link.attendance_id and attendance.deleted_at is null
+            join crm_atendimento.units unit on unit.id=attendance.unit_id
+            where member.identity_id=$1 and member.source_type='attendance_client' and member.source_id ~ '^[0-9a-fA-F-]{36}$' and unit.slug=$2
+            order by attendance.service_date desc limit $3`, [id, unit, eventLimit]),
+        pgPool.query(`select sale.id::text,sale.occurred_on as occurred_at,unit.slug as unit_slug
+            from crm_atendimento.global_client_identity_members member
+            join crm_caixa.sales sale on sale.customer_id=member.source_id::uuid
+            join crm_atendimento.units unit on unit.id=sale.unit_id
+            where member.identity_id=$1 and member.source_type='caixa_customer' and member.source_id ~ '^[0-9a-fA-F-]{36}$' and unit.slug=$2
+            order by sale.occurred_on desc limit $3`, [id, unit, eventLimit]),
+        dependencies.identityReview
+            ? pgPool.query(`select decision.id::text,decision.decision as status,decision.created_at
+                from crm_atendimento.identity_review_decisions decision
+                where exists(select 1 from crm_atendimento.global_client_identity_members member
+                    where member.identity_id=$1 and (member.source_id=decision.source_id or member.source_id=decision.target_id))
+                order by decision.event_order desc limit $2`, [id, eventLimit])
+            : Promise.resolve({ rows: [] }),
+    ])
+    const events = [
+        ...(actions.rows || []).map((row) => projectTimeline({
+            id: row.id, type: timelineActionType(row), occurredAt: row.created_at, source: 'CRM ação', unit: row.unit_slug,
+            actor: row.actor, correlationId: row.trace_id, status: row.status,
+        })),
+        ...(campaigns.rows || []).map((row) => projectTimeline({
+            id: row.id, type: 'campaign', occurredAt: row.created_at, source: 'CRM campanha', unit: row.unit_slug,
+            actor: row.actor, correlationId: row.trace_id, campaignId: row.campaign_id, offerId: row.offer_id,
+            status: row.event_type,
+        })),
+        ...(permissions.rows || []).map((row) => projectTimeline({
+            id: row.id, type: 'permission', occurredAt: row.created_at, source: 'Governança de permissão', unit,
+            actor: row.actor, correlationId: row.trace_id, consentReview: row.status, status: row.status,
+        })),
+        ...(attendance.rows || []).map((row) => projectTimeline({
+            id: row.id, type: 'attendance', occurredAt: row.occurred_at, source: 'Atendimento', unit: row.unit_slug, status: 'confirmed',
+        })),
+        ...(sales.rows || []).map((row) => projectTimeline({
+            id: row.id, type: 'sale', occurredAt: row.occurred_at, source: 'Caixa', unit: row.unit_slug, status: 'confirmed',
+        })),
+        ...(decisions.rows || []).map((row) => projectTimeline({
+            id: row.id, type: 'identity_decision', occurredAt: row.created_at, source: 'Revisão de identidade', unit, status: row.status,
+        })),
+    ]
+    if (sourceStale) {
+        events.push(projectTimeline({
+            id: `source-freshness:${unit}`, type: 'quality_finding', occurredAt: new Date().toISOString(),
+            source: 'Clientes fontes', unit, status: 'source_stale',
+        }))
+    }
+    events.sort((left, right) => String(right.occurredAt || '').localeCompare(String(left.occurredAt || '')) || left.id.localeCompare(right.id))
+    return {
+        unit,
+        events: events.slice(0, limit),
+        partial: !dependencies.permissions || !dependencies.identityReview,
+        safety: operationSafety(),
+    }
+}
+
+export function createCommercialOperationsStore({ pool, databaseUrl } = {}) {
+    const pgPool = pool || createPgPool(databaseUrl || process.env.DATABASE_URL)
+
+    const assertReadAccess = async (actor) => {
+        requirePool(pgPool)
+        assertCommercialOperationsManager(actor)
+        await assertCommercialOperationsReady(pgPool)
+    }
+    const assertMutationAccess = (actor) => {
+        requirePool(pgPool)
+        assertCommercialOperationsManager(actor)
+    }
+
+    return {
+        async readiness(actor) {
+            requirePool(pgPool)
+            assertCommercialOperationsManager(actor)
+            return commercialOperationsReadiness(pgPool)
+        },
+
+        async wallet(query, actor) {
+            await assertReadAccess(actor)
+            return queryWallet(pgPool, query, actor)
+        },
+
+        async team(query, actor) {
+            await assertReadAccess(actor)
+            return queryTeam(pgPool, query, actor)
+        },
+
+        async campaigns(query, actor) {
+            await assertReadAccess(actor)
+            return listCampaigns(pgPool, query, actor)
+        },
+
+        async campaign(campaignId, query, actor) {
+            await assertReadAccess(actor)
+            return campaignDetail(pgPool, campaignId, query, actor)
+        },
+
+        async customer360(identityId, query, actor) {
+            await assertReadAccess(actor)
+            return customer360(pgPool, identityId, query, actor)
+        },
+
+        async previewRebalance(payload, actor) {
+            await assertReadAccess(actor)
+            return previewRebalance(pgPool, payload, actor)
+        },
+
+        async createCampaign(payload, actor) {
+            assertMutationAccess(actor)
+            return withPgTransaction(pgPool, (client) => createCampaign(client, payload, actor))
+        },
+
+        async updateCampaign(campaignId, payload, actor) {
+            assertMutationAccess(actor)
+            return withPgTransaction(pgPool, (client) => updateCampaign(client, campaignId, payload, actor))
+        },
+
+        async reassignAction(actionId, payload, actor) {
+            assertMutationAccess(actor)
+            return withPgTransaction(pgPool, (client) => reassignAction(client, actionId, payload, actor))
+        },
+
+        async recordOutcome(actionId, payload, actor) {
+            assertMutationAccess(actor)
+            return withPgTransaction(pgPool, (client) => recordActionOutcome(client, actionId, payload, actor))
+        },
+
+        async upsertAbsence(payload, actor) {
+            assertMutationAccess(actor)
+            return withPgTransaction(pgPool, (client) => upsertAbsence(client, payload, actor))
+        },
+
+        async applyRebalance(payload, actor) {
+            assertMutationAccess(actor)
+            return withPgTransaction(pgPool, (client) => applyRebalance(client, payload, actor))
+        },
+    }
+}
+
+export const __testables = {
+    ABSENCE_TYPES,
+    ACTION_STATUSES,
+    COMMERCIAL_REQUIRED_SOURCE_IDS,
+    COMMERCIAL_OPERATIONS_SAFETY_FLAGS,
+    activeActionStatuses: ACTIVE_ACTION_STATUSES,
+    actionFlagSql,
+    commercialOperationsUnitScope,
+    mapWalletAction,
+    mutationInput,
+    normalizeCapacities,
+    normalizeExpectedRevisions,
+    opaqueTimelineId,
+    operationSafety,
+    projectRebalancePlan,
+    projectTimeline,
+    requestedUnitScope,
+    runCommercialOperationMutation,
+    sourceStale,
+    timelineActionType,
+}

--- a/crm/api/server/atendimento/routes.js
+++ b/crm/api/server/atendimento/routes.js
@@ -2,6 +2,7 @@ import { createHmac, timingSafeEqual } from 'crypto'
 import express from 'express'
 import { createAtendimentoStore, canAccessAtendimento } from './store.js'
 import { createCommercialDataQualityStore } from './commercialDataQualityStore.js'
+import { createCommercialOperationsStore } from './commercialOperationsStore.js'
 import { createClientesSourceOperationsStore } from '../clientes/sourceOperationsStore.js'
 import { importAtendimentoFromGoogleSheet, importGerenciaFromGoogleSheet, readGerenciaChartIds } from './importer.js'
 import { atendimentoModuleUnavailable, readAtendimentoModuleControl } from './moduleControl.js'
@@ -192,6 +193,16 @@ function requestsClinicalCadenceApproval(payload) {
     return String(payload?.status || '').trim().toLowerCase() === 'approved'
 }
 
+function commercialOperationPayload(req) {
+    const body = req?.body && typeof req.body === 'object' && !Array.isArray(req.body) ? req.body : {}
+    const bodyKey = String(body.idempotencyKey || '').trim()
+    const headerKey = String(req?.headers?.['idempotency-key'] || '').trim()
+    if (bodyKey && headerKey && bodyKey !== headerKey) {
+        throw sourceOperationsError('COMMERCIAL_IDEMPOTENCY_KEY_MISMATCH', 400)
+    }
+    return { ...body, idempotencyKey: headerKey || bodyKey }
+}
+
 function isLocalRequest(req) {
     // Host is caller-controlled. Only the peer address may authorize the
     // unsigned local-development actor or the local mirror diagnostics.
@@ -265,6 +276,16 @@ export function createAtendimentoRouter(options = {}) {
         pool: options.commercialDataQualityPool,
         databaseUrl: options.databaseUrl,
     })
+    let commercialOperationsStore = options.commercialOperationsStore || null
+    const getCommercialOperationsStore = () => {
+        if (!commercialOperationsStore) {
+            commercialOperationsStore = createCommercialOperationsStore({
+                pool: options.commercialOperationsPool,
+                databaseUrl: options.databaseUrl,
+            })
+        }
+        return commercialOperationsStore
+    }
     let commercialSourceOperationsStore = options.commercialSourceOperationsStore || null
     const getCommercialSourceOperationsStore = () => {
         if (!commercialSourceOperationsStore) {
@@ -614,6 +635,143 @@ export function createAtendimentoRouter(options = {}) {
             // Missing schema, a pool failure or an unavailable dependency must
             // not disclose database details to the console.
             return json(res, 503, { ok: false, error: 'COMMERCIAL_SOURCE_OPERATIONS_UNAVAILABLE' })
+        }
+    })
+
+    // Commercial Operations v2 is intentionally separate from the legacy
+    // action store.  Its read models are PII-minimized, and every mutation
+    // below is an internal ledger/work-queue operation only: there is no send,
+    // consent write, campaign dispatch or automated contact route here.
+    expressRouter.get('/commercial/operations/readiness', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            const readiness = await getCommercialOperationsStore().readiness(req.atendimentoActor)
+            return json(res, readiness.ready ? 200 : 503, { ok: readiness.ready, ...readiness })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/operations/wallet', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialOperationsStore().wallet(req.query || {}, req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/operations/team', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialOperationsStore().team(req.query || {}, req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/operations/campaigns', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialOperationsStore().campaigns(req.query || {}, req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/operations/campaigns/:campaignId', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, {
+                ok: true,
+                ...(await getCommercialOperationsStore().campaign(String(req.params.campaignId || ''), req.query || {}, req.atendimentoActor)),
+            })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/operations/customer-360/:identityId', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, {
+                ok: true,
+                ...(await getCommercialOperationsStore().customer360(String(req.params.identityId || ''), req.query || {}, req.atendimentoActor)),
+            })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/operations/campaigns', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialOperationsStore().createCampaign(commercialOperationPayload(req), req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.patch('/commercial/operations/campaigns/:campaignId', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, {
+                ok: true,
+                ...(await getCommercialOperationsStore().updateCampaign(String(req.params.campaignId || ''), commercialOperationPayload(req), req.atendimentoActor)),
+            })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/operations/actions/:actionId/reassign', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, {
+                ok: true,
+                ...(await getCommercialOperationsStore().reassignAction(String(req.params.actionId || ''), commercialOperationPayload(req), req.atendimentoActor)),
+            })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/operations/actions/:actionId/outcome', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, {
+                ok: true,
+                ...(await getCommercialOperationsStore().recordOutcome(String(req.params.actionId || ''), commercialOperationPayload(req), req.atendimentoActor)),
+            })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/operations/absences', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialOperationsStore().upsertAbsence(commercialOperationPayload(req), req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/operations/rebalance/preview', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialOperationsStore().previewRebalance(req.body || {}, req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/operations/rebalance/apply', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialOperationsStore().applyRebalance(commercialOperationPayload(req), req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
         }
     })
 

--- a/docs/runbooks/clientes-commercial-operations-v2.md
+++ b/docs/runbooks/clientes-commercial-operations-v2.md
@@ -1,0 +1,143 @@
+# Clientes — Operações Comerciais v2
+
+Este runbook descreve o backend de operação comercial interna. Ele não
+autoriza promoção, escrita de consentimento, envio de mensagens, automação de
+campanha ou alteração de regras clínicas. A tranche mantém todos estes
+controles desligados por contrato, independentemente de variável de ambiente:
+
+```json
+{
+  "commercialContactWritesEnabled": false,
+  "messagesEnabled": false,
+  "automationEnabled": false,
+  "consentWritesEnabled": false,
+  "outboundDispatchEnabled": false
+}
+```
+
+Nenhuma rota v2 chama Harmonia, provider de WhatsApp, shell, fila de entrega,
+cadência clínica ou o gravador de permissões. `opt_out_requested` é somente um
+outcome estruturado e devolve `requiresSeparateConsentWorkflow=true`; a
+gravação de consentimento continua em seu fluxo próprio e fail-closed.
+
+## Superfícies e autorização
+
+As rotas ficam em `/commercial/operations/*` e usam o store injetável
+`crm/api/server/atendimento/commercialOperationsStore.js`, separado do store
+legado. Todas exigem a política já existente de Clientes (`GESTOR`) e o store
+repete a checagem de papel. Um gestor sem `allowedUnits` declarado recebe 403;
+ele nunca ganha leitura global por omissão. ADMIN global continua sujeito à
+assinatura de ator da API.
+
+| Rota | Uso | Dados retornados |
+| --- | --- | --- |
+| `GET /readiness` | Estado da migration e dos ledgers | Sem PII; flags hard-disabled. |
+| `GET /wallet` | Carteira paginada e filtros operacionais | IDs de ação, unidade, status, flags e datas; sem identidade, nome, telefone, e-mail ou notas. |
+| `GET /team` | Carga, SLA, outcomes agregados, ausências e duração média de estágios | Agregados por responsável; sem cliente. |
+| `GET /campaigns` e `/:campaignId` | Coortes congeladas e eventos | Snapshot allowlisted, contagens e referências opacas; sem membros individuais. |
+| `GET /customer-360/:identityId?unit=<slug>` | Timeline unit-bound | Projeção allowlisted, IDs de evento opacos e sem context/evidence bruto. |
+| `POST/PATCH` de operações | Campanha, outcome, reatribuição, ausência e rebalanceamento | Apenas trabalho interno auditado; nunca contato externo. |
+
+Customer 360 exige unidade explícita inclusive para administrador global. A
+identidade precisa ter prova atual de vínculo com a unidade antes da timeline;
+sem prova, o retorno é negado. Eventos globais são reduzidos à revisão de
+consentimento/decisão autorizada, nunca à evidência bruta da fonte.
+
+## Readiness de migration
+
+A operação só fica pronta quando a migration
+`20260807_commercial_operations_v2` está ativa e as relações abaixo estão
+presentes:
+
+- `commercial_actions` e seu ledger append-only `commercial_action_events`;
+- `commercial_operation_mutations` e `commercial_campaign_events`, ambos com
+  bloqueio de `UPDATE`, `DELETE` e `TRUNCATE`;
+- `commercial_campaigns`, `commercial_campaign_members` e
+  `commercial_owner_absences`.
+
+O readiness verifica os gatilhos herdados do ledger de ações e os gatilhos v2
+dos ledgers de mutation/campaign. Falha de schema, role, trigger ou migration
+mantém leitura e escrita v2 indisponíveis; não há fallback para tabelas
+parcialmente migradas.
+
+Aplique somente por entrypoint allowlisted e destino estrito já existente:
+
+```text
+npm --prefix crm/api run migrate-commercial-operations -- --dry-run
+npm --prefix crm/api run migrate-commercial-operations -- --apply
+npm --prefix crm/api run migrate-commercial-operations -- --rollback
+```
+
+O executor aceita somente o destino local aprovado. Para staging, a migration
+precisa entrar no release target-bound de Atendimento com backup e evidência
+de destino. Não passe `DATABASE_URL`, segredo, path, URL, shell, SSH, `eval`
+ou comando em variáveis/argumentos. Não existe caminho de produção nesta
+tranche.
+
+O rollback é não destrutivo: registra a migration como revertida e preserva
+ações, campanhas, memberships e evidências append-only. Para voltar o código,
+use o SHA anterior após confirmar que o readiness v2 deixa de ser anunciado;
+nunca apague um ledger para “desfazer” uma operação.
+
+## Concorrência, versão e auditoria
+
+Cada mutação requer:
+
+1. `Idempotency-Key` opaca (ou o mesmo `idempotencyKey` no corpo), nunca PII;
+2. justificativa sem PII;
+3. `expectedRevision` na alteração de ação, campanha, ausência ou plano de
+   rebalanceamento.
+
+O backend obtém primeiro um advisory lock HMAC da chave de idempotência, só
+então verifica readiness e consulta o ledger. Repetição com o mesmo payload
+reproduz a resposta; reutilização da chave com outro fingerprint retorna 409.
+As linhas mutáveis são travadas com `FOR UPDATE`; rebalanceamento acrescenta um
+lock por escopo de unidade e reconstrói o plano dentro da transação. O ledger
+guarda ator HMAC, fingerprint e resposta minimizada, sem chave bruta ou razão
+em texto.
+
+Campanhas congelam filtros, segmento/versão, corte, coorte, unidade,
+responsável, oferta, janela e control group. O control group é determinístico
+por hash do contexto e só pode conter membros elegíveis; nenhum membro em
+revisão, stale ou bloqueado é promovido a holdout. Mudanças de contexto são
+recusadas; somente o ciclo de vida da campanha muda com versão otimista. Uma
+coorte semanticamente idêntica é deduplicada sob lock de unidade/contexto.
+
+## Fontes e freshness
+
+Elegibilidade e Customer 360 leem somente checkpoints de fonte já validados.
+As fontes obrigatórias vêm do catálogo versionado de Clientes, incluindo
+Atendimento, cadastro, vendas, opt-outs Harmonia, bloqueios de permissão e o
+grafo de identidade. Cada uma precisa de último estado `complete`, snapshot
+completo comprovado, nenhuma reconciliação pendente e validação de até 48 h.
+Ausência, parcial, inválida, dead ou stale torna a condição `sourceStale=true`;
+nunca há promoção por falta de dado. Fontes opcionais continuam visíveis na
+operação de fontes, mas não transformam ausência em exclusão de cliente.
+
+## Verificação antes de revisão
+
+Em um worktree com dependências já disponíveis, execute os testes focais:
+
+```text
+node --test --test-concurrency=1 \
+  server/atendimento/__tests__/commercialOperations.test.js \
+  server/atendimento/__tests__/commercialOperationsMigration.test.js \
+  server/atendimento/__tests__/commercialOperationsStore.test.js \
+  server/atendimento/__tests__/routes.test.js
+```
+
+Também confirme:
+
+- `git diff --check` sem saída;
+- nenhum endpoint v2 contém provider, `Harmonia`, dispatch, webhook, shell ou
+  gravação de `commercial_contact_permissions`;
+- readiness saudável e readiness falho quando um trigger/registro de migration
+  faltar;
+- repetição, conflito de fingerprint, escopo de unidade vazio, revisão
+  otimista e rebalanceamento concorrente por fixtures sintéticas;
+- o retorno de carteira, equipe, campanha e timeline não contém telefone,
+  e-mail, nome de cliente, nota, `context` ou `evidence` bruto.
+
+CI deve executar a suíte completa da API com a árvore de dependências do
+release. Este runbook não substitui smoke autenticado de staging nem autoriza
+produção.

--- a/docs/runbooks/clientes-commercial-operations-v2.md
+++ b/docs/runbooks/clientes-commercial-operations-v2.md
@@ -31,7 +31,7 @@ assinatura de ator da API.
 
 | Rota | Uso | Dados retornados |
 | --- | --- | --- |
-| `GET /readiness` | Estado da migration e dos ledgers | Sem PII; flags hard-disabled. |
+| `GET /readiness` | Estado da migration, dos ledgers e do guard de crossover | Sem PII; flags hard-disabled e dependência de Analytics explícita. |
 | `GET /wallet` | Carteira paginada e filtros operacionais | IDs de ação, unidade, status, flags e datas; sem identidade, nome, telefone, e-mail ou notas. |
 | `GET /team` | Carga, SLA, outcomes agregados, ausências e duração média de estágios | Agregados por responsável; sem cliente. |
 | `GET /campaigns` e `/:campaignId` | Coortes congeladas e eventos | Snapshot allowlisted, contagens e referências opacas; sem membros individuais. |
@@ -103,6 +103,33 @@ revisão, stale ou bloqueado é promovido a holdout. Mudanças de contexto são
 recusadas; somente o ciclo de vida da campanha muda com versão otimista. Uma
 coorte semanticamente idêntica é deduplicada sob lock de unidade/contexto.
 
+## Holdout e prevenção de crossover
+
+Antes de criar uma campanha ou reatribuir/rebalancear uma ação, o backend
+consulta o contrato de Analytics
+`20260807_commercial_analytics_v2`. Para a mesma unidade, uma assignment
+`control` ou `excluded` de experimento em estado `active`, com janela contendo
+o instante atual, retorna `409 COMMERCIAL_EXPERIMENT_HOLDOUT_ACTIVE` antes de
+qualquer escrita de ação, campanha, membership, evento ou ledger. A v2 não
+tem rota de criação de ação; qualquer rota futura que a adicione deve chamar o
+mesmo guard antes do `INSERT`.
+
+O guard exige `commercial_experiment_assignments`,
+`commercial_experiments`, permissões `SELECT` e o registro ativo da migration.
+Enquanto Analytics não estiver integrado/aplicado, ou se qualquer um desses
+elementos estiver indisponível, a operação falha fechada com
+`409 COMMERCIAL_EXPERIMENT_GUARD_NOT_READY`; ausência de tabela nunca é
+interpretada como coorte vazia. Operations não cria, altera ou remove
+assignments de experimento.
+
+O namespace de lock compartilhado é
+`commercial-experiment-crossover:<unit-id>:<identity-id>`, em ordem
+determinística. A implementação de Analytics deve adquirir o mesmo lock antes
+de persistir assignments para fechar a corrida entre uma atribuição de
+experimento e uma operação comercial. Essa integração é uma dependência da
+promotion da escrita interna; até lá, o fail-closed impede o uso dessas
+mutações. Nenhum desses fluxos habilita contato, envio ou automação.
+
 ## Fontes e freshness
 
 Elegibilidade e Customer 360 leem somente checkpoints de fonte já validados.
@@ -135,6 +162,8 @@ Também confirme:
   faltar;
 - repetição, conflito de fingerprint, escopo de unidade vazio, revisão
   otimista e rebalanceamento concorrente por fixtures sintéticas;
+- campanha/reassign bloqueados por `control`/`excluded` ativo, e bloqueio
+  fail-closed quando a migration/role/tabela de Analytics não estiver pronta;
 - o retorno de carteira, equipe, campanha e timeline não contém telefone,
   e-mail, nome de cliente, nota, `context` ou `evidence` bruto.
 


### PR DESCRIPTION
# Summary

Implementa o backend isolado de Operações Comerciais v2 para Clientes, sem acoplar o novo domínio ao `store.js` legado.

- carteira e gestão de equipe somente leitura, minimizadas de PII e fechadas por unidade/RBAC;
- campanhas/coortes versionadas, snapshot congelado e grupo de controle determinístico;
- outcomes estruturados, ausência, reatribuição e rebalanceamento com locks, versões otimistas e idempotência serializada antes de leituras mutáveis;
- Customer 360 projetado por allowlist, sem contexto/evidência genéricos ou IDs técnicos expostos;
- readiness de migration que verifica tabelas, registros e gatilhos append-only, além de freshness obrigatório das fontes;
- guarda de crossover: campanhas, reatribuições e rebalanceamentos bloqueiam `control`/`excluded` ativos por unidade; tabela, role ou migration de Analytics ausente retornam fail-closed;
- flags explícitas e imutáveis para manter envio, automação, escrita comercial e escrita de consentimento desativados;
- runbook operacional e testes focados de store, migration e rotas.

## Type of change

- [x] Feature
- [x] Fix
- [ ] Refactor
- [x] Docs
- [ ] Performance
- [x] Security
- [ ] Breaking change

## Checklist

- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [x] Docs updated (README, API refs, diagrams)
- [x] Security review (CodeQL, gitleaks)
- [ ] Performance impact measured

## Links

- Issue: Clientes — Operações Comerciais v2
- Design/ADR: domínio isolado em `commercialOperationsStore.js`
- Migration steps: migration aditiva `20260807_commercial_operations_v2`; não aplicada nesta PR.
- Dependency: `20260807_commercial_analytics_v2` deve fornecer `commercial_experiment_assignments` e adquirir o namespace de lock documentado antes de gravar assignments.

## Screenshots / Evidence

Validação local focal: 31/31 testes passaram em `commercialOperations*.test.js` e `routes.test.js`; `node --check` e `git diff --check` verdes. O worktree não possui dependências próprias, por isso os testes usaram exclusivamente dependências já existentes de outro worktree por um loader transitório de teste; CI deve executar o build/typecheck/e2e em ambiente limpo.

Cobertura de segurança inclui ausência de migration/tabela/role de Analytics, holdout `control` na criação de campanha e `excluded` na reatribuição, comprovando que não ocorre escrita de ação, campanha, membership, evento ou ledger nos caminhos bloqueados.

Não foram executados migration, deploy, escrita de banco, envio de mensagens ou escrita de consentimento.