### PR TITLE
feat(clientes): persist governed analytics series

### DIFF
--- a/crm/api/package.json
+++ b/crm/api/package.json
@@ -26,6 +26,7 @@
     "migrate-commercial-action-ledger": "node scripts/migrate-atendimento-commercial-action-ledger.mjs",
     "migrate-commercial-data-quality": "node scripts/migrate-atendimento-commercial-data-quality.mjs",
     "migrate-commercial-operations": "node scripts/migrate-atendimento-commercial-operations.mjs",
+    "migrate-commercial-analytics": "node scripts/migrate-atendimento-commercial-analytics.mjs",
     "migrate-clinical-approval": "node scripts/migrate-clinical-approval.mjs",
     "migrate-atendimento-staging": "node scripts/migrate-atendimento-staging.mjs",
     "refresh-commercial-data-quality": "node scripts/refresh-commercial-data-quality.mjs",

--- a/crm/api/package.json
+++ b/crm/api/package.json
@@ -25,6 +25,7 @@
     "migrate-commercial-contact-rollout": "node scripts/migrate-atendimento-commercial-contact-rollout.mjs",
     "migrate-commercial-action-ledger": "node scripts/migrate-atendimento-commercial-action-ledger.mjs",
     "migrate-commercial-data-quality": "node scripts/migrate-atendimento-commercial-data-quality.mjs",
+    "migrate-commercial-operations": "node scripts/migrate-atendimento-commercial-operations.mjs",
     "migrate-clinical-approval": "node scripts/migrate-clinical-approval.mjs",
     "migrate-atendimento-staging": "node scripts/migrate-atendimento-staging.mjs",
     "refresh-commercial-data-quality": "node scripts/refresh-commercial-data-quality.mjs",

--- a/crm/api/scripts/migrate-atendimento-commercial-analytics.mjs
+++ b/crm/api/scripts/migrate-atendimento-commercial-analytics.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import { createPgPool } from '../server/harmonia/store/pg.js'
+import {
+    applyCommercialAnalyticsMigration,
+    commercialAnalyticsMigrationPlan,
+    rollbackCommercialAnalyticsMigration,
+} from '../server/atendimento/commercialAnalyticsMigration.js'
+import {
+    assertAtendimentoMigrationDestination,
+    ATENDIMENTO_MIGRATION_TARGETS,
+    isStrictAtendimentoMigrationDestination,
+} from '../server/atendimento/migrationDestination.js'
+
+function errorWithCode(code) { const error = new Error(code); error.code = code; return error }
+
+function parseArguments(args) {
+    const targets = args.filter((arg) => arg.startsWith('--target='))
+    const actions = args.filter((arg) => ['--dry-run', '--apply', '--rollback'].includes(arg))
+    if (targets.length > 1 || actions.length !== 1 || args.length !== targets.length + actions.length) throw errorWithCode('COMMERCIAL_ANALYTICS_MIGRATION_ACTION_INVALID')
+    const targetValue = targets[0] ? targets[0].slice('--target='.length) : ATENDIMENTO_MIGRATION_TARGETS.LOCAL
+    if (![ATENDIMENTO_MIGRATION_TARGETS.LOCAL, ATENDIMENTO_MIGRATION_TARGETS.STAGING].includes(targetValue)) throw errorWithCode('COMMERCIAL_ANALYTICS_TARGET_INVALID')
+    return { target: targetValue, action: actions[0].slice(2) }
+}
+
+let pool = null
+try {
+    const { target, action } = parseArguments(process.argv.slice(2))
+    const databaseUrl = String(process.env.DATABASE_URL || '').trim()
+    if (!databaseUrl || !isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw errorWithCode('COMMERCIAL_ANALYTICS_DESTINATION_UNSAFE')
+    pool = createPgPool(databaseUrl)
+    if (!pool) throw errorWithCode('COMMERCIAL_ANALYTICS_POOL_REQUIRED')
+    if (action === 'dry-run') {
+        const client = await pool.connect()
+        try {
+            await client.query('begin')
+            const identity = await assertAtendimentoMigrationDestination(client, databaseUrl, target)
+            const registry = await client.query(`select to_regclass('crm_atendimento.schema_migrations') as registry`)
+            await client.query('rollback')
+            process.stdout.write(`${JSON.stringify({ ok: true, action, target, identity, registryPresent: Boolean(registry.rows[0]?.registry), plan: commercialAnalyticsMigrationPlan() })}\n`)
+        } catch (error) {
+            try { await client.query('rollback') } catch { /* preserve guarded failure */ }
+            throw error
+        } finally { client.release() }
+    } else {
+        const result = action === 'apply'
+            ? await applyCommercialAnalyticsMigration({ pool, databaseUrl, target })
+            : await rollbackCommercialAnalyticsMigration({ pool, databaseUrl, target })
+        process.stdout.write(`${JSON.stringify({ ok: true, action, target, result, commercialContactWritesEnabled: false, messagingEnabled: false })}\n`)
+    }
+} catch (error) {
+    const code = /^[A-Z][A-Z0-9_]{1,100}$/.test(String(error?.code || '')) ? error.code : 'COMMERCIAL_ANALYTICS_MIGRATION_FAILED'
+    process.stderr.write(`${JSON.stringify({ ok: false, code })}\n`)
+    process.exitCode = 1
+} finally {
+    if (pool) await pool.end()
+}

--- a/crm/api/scripts/migrate-atendimento-commercial-operations.mjs
+++ b/crm/api/scripts/migrate-atendimento-commercial-operations.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import { createPgPool } from '../server/harmonia/store/pg.js'
+import {
+    applyCommercialOperationsMigration,
+    commercialOperationsMigrationPlan,
+    rollbackCommercialOperationsMigration,
+} from '../server/atendimento/commercialOperationsMigration.js'
+import {
+    assertAtendimentoMigrationDestination,
+    ATENDIMENTO_MIGRATION_TARGETS,
+    isStrictAtendimentoMigrationDestination,
+} from '../server/atendimento/migrationDestination.js'
+
+function commandError(code) {
+    const error = new Error(code)
+    error.code = code
+    return error
+}
+
+function parseTarget(args) {
+    const values = args.filter((arg) => arg.startsWith('--target='))
+    if (values.length > 1) throw commandError('COMMERCIAL_OPERATIONS_TARGET_INVALID')
+    const value = values[0] ? values[0].slice('--target='.length) : ATENDIMENTO_MIGRATION_TARGETS.LOCAL
+    if (value === ATENDIMENTO_MIGRATION_TARGETS.LOCAL || value === ATENDIMENTO_MIGRATION_TARGETS.STAGING) return value
+    throw commandError('COMMERCIAL_OPERATIONS_TARGET_INVALID')
+}
+
+let pool = null
+
+try {
+    const args = process.argv.slice(2)
+    const target = parseTarget(args)
+    const actions = args.filter((arg) => ['--dry-run', '--apply', '--rollback'].includes(arg))
+    if (actions.length !== 1 || args.length !== actions.length + args.filter((arg) => arg.startsWith('--target=')).length) {
+        throw commandError('COMMERCIAL_OPERATIONS_MIGRATION_ACTION_INVALID')
+    }
+    const action = actions[0].slice(2)
+    const databaseUrl = String(process.env.DATABASE_URL || '').trim()
+    if (!databaseUrl || !isStrictAtendimentoMigrationDestination(databaseUrl, target)) {
+        throw commandError('COMMERCIAL_OPERATIONS_DESTINATION_UNSAFE')
+    }
+    pool = createPgPool(databaseUrl)
+    if (!pool) throw commandError('COMMERCIAL_OPERATIONS_POOL_REQUIRED')
+
+    if (action === 'dry-run') {
+        const client = await pool.connect()
+        try {
+            await client.query('begin')
+            const identity = await assertAtendimentoMigrationDestination(client, databaseUrl, target)
+            const registry = await client.query(`select to_regclass('crm_atendimento.schema_migrations') as registry`)
+            await client.query('rollback')
+            process.stdout.write(`${JSON.stringify({ ok: true, action, target, identity, registryPresent: Boolean(registry.rows[0]?.registry), plan: commercialOperationsMigrationPlan() })}\n`)
+        } catch (error) {
+            try { await client.query('rollback') } catch { /* preserve guarded failure */ }
+            throw error
+        } finally {
+            client.release()
+        }
+    } else {
+        const result = action === 'apply'
+            ? await applyCommercialOperationsMigration({ pool, databaseUrl, target })
+            : await rollbackCommercialOperationsMigration({ pool, databaseUrl, target })
+        process.stdout.write(`${JSON.stringify({ ok: true, action, target, result, commercialContactWritesEnabled: false, messagingEnabled: false })}\n`)
+    }
+} catch (error) {
+    const code = /^[A-Z][A-Z0-9_]{1,100}$/.test(String(error?.code || ''))
+        ? error.code
+        : 'COMMERCIAL_OPERATIONS_MIGRATION_FAILED'
+    process.stderr.write(`${JSON.stringify({ ok: false, code })}\n`)
+    process.exitCode = 1
+} finally {
+    if (pool) await pool.end()
+}

--- a/crm/api/server/atendimento/__tests__/commercialAnalytics.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialAnalytics.test.js
@@ -93,5 +93,8 @@ test('segment definitions are explicit and membership snapshots expose only aggr
     const drift = buildSegmentDrift([first, second])
     assert.equal(drift.available, true)
     assert.equal(drift.population.current, 1)
+    const corrected = { ...second, memberCount: 2, createdAt: '2026-08-08T12:00:00.000Z' }
+    const earlier = { ...second, memberCount: 1, createdAt: '2026-08-08T08:00:00.000Z' }
+    assert.equal(buildSegmentDrift([first, corrected, earlier]).population.current, 2)
     assert.throws(() => normalizeSegmentDefinition({ key: 'return-risk', version: 'v1', criteria: { email: 'customer@example.com' } }), commercialAnalyticsError('COMMERCIAL_SEGMENT_DEFINITION_INVALID'))
 })

--- a/crm/api/server/atendimento/__tests__/commercialAnalytics.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialAnalytics.test.js
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+    buildCommercialFunnel,
+    buildExperimentAssignments,
+    buildExperimentResult,
+    buildQualityTimeSeries,
+    buildSegmentDrift,
+    buildSegmentMembershipSnapshot,
+    commercialAnalyticsError,
+    deterministicExperimentVariant,
+    isWithinAttributionWindow,
+    normalizeAnalyticsFilters,
+    normalizeAttributionWindows,
+    normalizeSegmentDefinition,
+    sanitizeAnalyticsPayload,
+} from '../commercialAnalytics.js'
+
+const identityA = '11111111-1111-4111-8111-111111111111'
+const identityB = '22222222-2222-4222-8222-222222222222'
+
+test('analytics filters, windows and payloads remain bounded and PII-free', () => {
+    assert.deepEqual(normalizeAttributionWindows({ version: 'v2', responseDays: 5 }).responseDays, 5)
+    assert.throws(() => normalizeAttributionWindows({ responseDays: 731 }), { code: 'COMMERCIAL_ATTRIBUTION_WINDOW_INVALID' })
+    assert.deepEqual(normalizeAnalyticsFilters({ from: '2026-08-01', to: '2026-08-31', dimensions: 'unit,campaign', attributionState: 'observed' }).dimensions, ['unit', 'campaign'])
+    assert.throws(() => normalizeAnalyticsFilters({ unit: 'customer@example.com' }), { code: 'INVALID_ANALYTICS_FILTER' })
+    assert.deepEqual(sanitizeAnalyticsPayload({ name: 'Ana', phoneRaw: '+5511999999999', metrics: { coverage_identity: 0.8 }, label: 'safe' }), { metrics: { coverage_identity: 0.8 }, label: 'safe' })
+    assert.equal(isWithinAttributionWindow('2026-08-01', '2026-08-10', 'responded', { responseDays: 7 }), false)
+})
+
+test('quality analytics derives history, aging, SLA and coverage from aggregate records', () => {
+    const result = buildQualityTimeSeries({
+        asOf: '2026-08-10T00:00:00.000Z',
+        findings: [{ findingKey: 'freshness.leads', status: 'open', observedCount: 3, owner: 'gestor.crm', firstDetectedAt: '2026-08-08T00:00:00.000Z', slaDueAt: '2026-08-09T00:00:00.000Z' }],
+        findingEvents: [
+            { findingKey: 'freshness.leads', eventType: 'detected', status: 'open', observedCount: 3, createdAt: '2026-08-08T00:00:00.000Z' },
+            { findingKey: 'freshness.leads', eventType: 'reopened', status: 'open', observedCount: 3, createdAt: '2026-08-09T00:00:00.000Z' },
+            { findingKey: 'freshness.leads', eventType: 'updated', status: 'acknowledged', observedCount: 3, createdAt: '2026-08-09T02:00:00.000Z' },
+        ],
+        metricSnapshots: [{ sourceKey: 'freshness.leads', recordedAt: '2026-08-10T00:00:00.000Z', metrics: { coverage_identity: 0.8, coverage_consent: 0.7 } }],
+    })
+    // Two ledger dates plus the current observation make the history
+    // continuous even if a source has not emitted a finding event today.
+    assert.equal(result.byFinding['freshness.leads'].length, 3)
+    assert.equal(result.overdueSla, 1)
+    assert.equal(result.ownerCoverage, 1)
+    assert.equal(result.coverage.coverage_identity, 0.8)
+    assert.equal(result.freshness.length, 1)
+    assert.equal(result.reopenRate, 0.5)
+})
+
+test('funnel separates observed, attributed and treatment-incremental conversions', () => {
+    const result = buildCommercialFunnel({
+        eligibleIdentities: [{ identityId: identityA }, { identityId: identityB }],
+        campaignMembers: [{ identityId: identityA, unitSlug: 'centro' }],
+        assignments: [{ identityId: identityA, variant: 'treatment' }, { identityId: identityB, variant: 'control' }],
+        actions: [{ id: 'action-a', identityId: identityA, unitSlug: 'centro', status: 'contacted', contactedAt: '2026-08-01T00:00:00.000Z', createdAt: '2026-08-01T00:00:00.000Z' }],
+        events: [
+            { identityId: identityA, type: 'responded', unitSlug: 'centro', occurredAt: '2026-08-05T00:00:00.000Z' },
+            { identityId: identityA, type: 'purchased', unitSlug: 'centro', occurredAt: '2026-10-15T00:00:00.000Z' },
+        ],
+        windows: { responseDays: 7, saleDays: 60 },
+    })
+    assert.deepEqual(result.stages.eligible, { observed: 2, attributed: 2, incremental: 1 })
+    assert.deepEqual(result.stages.responded, { observed: 1, attributed: 1, incremental: 1 })
+    assert.deepEqual(result.stages.purchased, { observed: 1, attributed: 0, incremental: 0 })
+})
+
+test('experiments persist deterministic assignments, prevent crossover and warn on insufficient samples', () => {
+    const variant = deterministicExperimentVariant(identityA, 'return-risk', 'aug-2026', 20)
+    assert.equal(variant, deterministicExperimentVariant(identityA, 'return-risk', 'aug-2026', 20))
+    const assignments = buildExperimentAssignments([{ identityId: identityA, unitSlug: 'centro' }], {
+        experimentKey: 'return-risk', seed: 'aug-2026', controlPercent: 20,
+        existingAssignments: [{ identityId: identityA, unitSlug: 'centro', variant: 'control', eligible: true }],
+    })
+    assert.equal(assignments[0].variant, 'control')
+    assert.equal(assignments[0].preserved, true)
+    assert.throws(() => buildExperimentAssignments([{ identityId: identityA, unitSlug: 'barra' }], {
+        experimentKey: 'return-risk', seed: 'aug-2026', existingAssignments: [{ identityId: identityA, unitSlug: 'centro', variant: 'control' }],
+    }), { code: 'COMMERCIAL_EXPERIMENT_SCOPE_CONFLICT' })
+    const result = buildExperimentResult(assignments, [{ identityId: identityA, type: 'responded' }])
+    assert.equal(result.warning, 'INSUFFICIENT_SAMPLE')
+})
+
+test('segment definitions are explicit and membership snapshots expose only aggregates and hash', () => {
+    const definition = normalizeSegmentDefinition({ key: 'return-risk', version: 'v1', criteria: { daysSinceVisit: { gte: 90 } }, thresholds: { risk: 0.7 }, author: 'gestor.crm' })
+    const first = buildSegmentMembershipSnapshot(definition, [{ identityId: identityA, bucket: 'high' }, { identityId: identityB, bucket: 'medium' }], { snapshotAt: '2026-08-01', unitSlug: 'centro' })
+    const second = buildSegmentMembershipSnapshot(definition, [{ identityId: identityA, bucket: 'high' }], { snapshotAt: '2026-08-08', unitSlug: 'centro' })
+    assert.equal(first.memberCount, 2)
+    assert.match(first.membershipHash, /^[a-f0-9]{64}$/)
+    assert.equal(Object.hasOwn(first, 'members'), false)
+    const drift = buildSegmentDrift([first, second])
+    assert.equal(drift.available, true)
+    assert.equal(drift.population.current, 1)
+    assert.throws(() => normalizeSegmentDefinition({ key: 'return-risk', version: 'v1', criteria: { email: 'customer@example.com' } }), commercialAnalyticsError('COMMERCIAL_SEGMENT_DEFINITION_INVALID'))
+})

--- a/crm/api/server/atendimento/__tests__/commercialAnalyticsMigration.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialAnalyticsMigration.test.js
@@ -20,6 +20,7 @@ test('analytics migration is additive, PII-minimizing and cannot authorize messa
     assert.doesNotMatch(sql, /on delete cascade/)
     assert.match(sql, /commercial_attribution_windows/)
     assert.match(sql, /commercial_segment_membership_snapshots/)
+    assert.match(sql, /version_key text not null/)
     assert.match(sql, /commercial_analytics_metric_snapshots/)
     assert.match(sql, /event_key text not null unique/)
     assert.match(sql, /commercial_analytics_mutations/)
@@ -29,6 +30,9 @@ test('analytics migration is additive, PII-minimizing and cannot authorize messa
     assert.doesNotMatch(grants, /grant\s+(?:all privileges|delete|truncate)/)
     assert.match(grants, /grant select, insert on table crm_atendimento\.commercial_analytics_events/)
     assert.match(grants, /grant select, insert on table crm_atendimento\.commercial_analytics_mutations/)
+    assert.match(grants, /grant select on table crm_atendimento\.schema_migrations/)
+    assert.match(sql, /unique nulls not distinct\(segment_version_id, unit_id, snapshot_date, membership_hash\)/)
+    assert.match(sql, /unique nulls not distinct\(source_key, finding_key, unit_id, bucket_date, metrics_hash\)/)
 })
 
 test('analytics migration readiness checks every immutable evidence relation', () => {

--- a/crm/api/server/atendimento/__tests__/commercialAnalyticsMigration.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialAnalyticsMigration.test.js
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+    COMMERCIAL_ANALYTICS_MIGRATION_ID,
+    __testables,
+    applyCommercialAnalyticsMigration,
+    commercialAnalyticsMigrationPlan,
+} from '../commercialAnalyticsMigration.js'
+
+test('analytics migration is additive, PII-minimizing and cannot authorize messaging', () => {
+    const plan = commercialAnalyticsMigrationPlan()
+    const sql = __testables.STATEMENTS.join('\n').toLowerCase()
+    const grants = __testables.runtimeGrantStatements('staging').join('\n').toLowerCase()
+    assert.equal(plan.id, COMMERCIAL_ANALYTICS_MIGRATION_ID)
+    assert.match(plan.piiPolicy, /no name, phone, email, message body/i)
+    assert.match(plan.messagingPolicy, /do not schedule, dispatch or retry messages/i)
+    assert.equal(plan.appendOnlyTables.includes('commercial_experiment_assignments'), true)
+    assert.doesNotMatch(sql, /drop\s+trigger/)
+    assert.doesNotMatch(sql, /on delete cascade/)
+    assert.match(sql, /commercial_attribution_windows/)
+    assert.match(sql, /commercial_segment_membership_snapshots/)
+    assert.match(sql, /commercial_analytics_metric_snapshots/)
+    assert.match(sql, /commercial_experiment_assignments/)
+    assert.match(sql, /before update or delete/)
+    assert.match(sql, /before truncate/)
+    assert.doesNotMatch(grants, /grant\s+(?:all privileges|delete|truncate)/)
+    assert.match(grants, /grant select, insert on table crm_atendimento\.commercial_analytics_events/)
+})
+
+test('analytics migration readiness checks every immutable evidence relation', () => {
+    const readiness = __testables.triggerReadinessStatement()
+    for (const table of __testables.EVIDENCE_TABLES) {
+        assert.match(readiness, new RegExp(table))
+    }
+    assert.match(readiness, /prevent_commercial_analytics_evidence_mutation_v2/)
+})
+
+test('analytics migration refuses unsafe destinations without connecting', async () => {
+    let connected = false
+    await assert.rejects(
+        () => applyCommercialAnalyticsMigration({
+            pool: { connect: async () => { connected = true } },
+            databaseUrl: 'postgresql://unsafe.example.invalid/skincos_crm_local',
+            target: 'production',
+        }),
+        { code: 'COMMERCIAL_ANALYTICS_DESTINATION_UNSAFE' },
+    )
+    assert.equal(connected, false)
+})

--- a/crm/api/server/atendimento/__tests__/commercialAnalyticsMigration.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialAnalyticsMigration.test.js
@@ -21,11 +21,14 @@ test('analytics migration is additive, PII-minimizing and cannot authorize messa
     assert.match(sql, /commercial_attribution_windows/)
     assert.match(sql, /commercial_segment_membership_snapshots/)
     assert.match(sql, /commercial_analytics_metric_snapshots/)
+    assert.match(sql, /event_key text not null unique/)
+    assert.match(sql, /commercial_analytics_mutations/)
     assert.match(sql, /commercial_experiment_assignments/)
     assert.match(sql, /before update or delete/)
     assert.match(sql, /before truncate/)
     assert.doesNotMatch(grants, /grant\s+(?:all privileges|delete|truncate)/)
     assert.match(grants, /grant select, insert on table crm_atendimento\.commercial_analytics_events/)
+    assert.match(grants, /grant select, insert on table crm_atendimento\.commercial_analytics_mutations/)
 })
 
 test('analytics migration readiness checks every immutable evidence relation', () => {

--- a/crm/api/server/atendimento/__tests__/commercialAnalyticsStore.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialAnalyticsStore.test.js
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createCommercialAnalyticsStore, __testables } from '../commercialAnalyticsStore.js'
+
+function compact(sql) { return String(sql).replace(/\s+/g, ' ').trim().toLowerCase() }
+
+function createReadyPool() {
+    const mutations = new Map()
+    const metricRows = []
+    let metricInserts = 0
+    const pool = {
+        async connect() { return client },
+        async query(sql, params) { return query(sql, params) },
+        state: { mutations, metricRows, get metricInserts() { return metricInserts } },
+    }
+    const client = { query, release() {} }
+    async function query(sql, params = []) {
+        const statement = compact(sql)
+        if (statement.startsWith('select to_regclass')) {
+            return { rows: [{ registry: 'crm_atendimento.schema_migrations', windows: 'windows', definitions: 'definitions', versions: 'versions', metrics: 'metrics', events: 'events', mutations: 'mutations', experiments: 'experiments', assignments: 'assignments' }] }
+        }
+        if (statement.includes('from crm_atendimento.schema_migrations')) return { rows: [{ id: '20260807_commercial_analytics_v2' }] }
+        if (['begin', 'commit', 'rollback'].includes(statement) || statement.startsWith('set local') || statement.includes('pg_advisory_xact_lock')) return { rows: [] }
+        if (statement.startsWith('select id::text,slug from crm_atendimento.units')) return { rows: [{ id: '10000000-0000-4000-8000-000000000001', slug: params[0] }] }
+        if (statement.includes('from crm_atendimento.commercial_analytics_mutations')) {
+            const key = params.slice(0, 3).join(':')
+            const value = mutations.get(key)
+            return { rows: value ? [value] : [] }
+        }
+        if (statement.includes('insert into crm_atendimento.commercial_analytics_metric_snapshots')) {
+            metricInserts += 1
+            const row = {
+                source_key: params[0], finding_key: params[1], unit_id: params[2], bucket_date: params[3],
+                metrics: JSON.parse(params[4]), created_at: '2026-08-07T00:00:00.000Z',
+            }
+            metricRows.push(row)
+            return { rows: [row] }
+        }
+        if (statement.includes('insert into crm_atendimento.commercial_analytics_mutations')) {
+            const key = params.slice(0, 3).join(':')
+            mutations.set(key, { request_fingerprint: params[3], response: JSON.parse(params[4]) })
+            return { rows: [] }
+        }
+        throw new Error(`unexpected SQL: ${statement}`)
+    }
+    return pool
+}
+
+test('analytics store keeps metric snapshots system-only, unit-scoped and idempotent', async () => {
+    const pool = createReadyPool()
+    const store = createCommercialAnalyticsStore({ pool, mutationHmacKey: 'a'.repeat(48), clock: () => new Date('2026-08-07T10:00:00.000Z') })
+    const actor = { id: 'system:clientes-source-refresh', role: 'SYSTEM', system: true }
+    const payload = {
+        sourceKey: 'freshness.crm-source', unit: 'centro', bucketDate: '2026-08-07',
+        metrics: { coverage_identity: 0.99, records_read: 120 }, idempotencyKey: 'source-refresh-20260807',
+    }
+    const first = await store.recordMetricSnapshot(payload, actor)
+    const second = await store.recordMetricSnapshot(payload, actor)
+    assert.deepEqual(second, first)
+    assert.equal(pool.state.metricInserts, 1)
+    assert.equal(pool.state.metricRows[0].unit_id, '10000000-0000-4000-8000-000000000001')
+    assert.equal(JSON.stringify(first).includes('@'), false)
+    await assert.rejects(
+        () => store.recordMetricSnapshot(payload, { id: 'manager-1', role: 'GESTOR' }),
+        { code: 'ANALYTICS_SYSTEM_WRITER_REQUIRED' },
+    )
+})
+
+test('analytics store rejects PII-shaped metric and snapshot input before persistence', () => {
+    assert.throws(
+        () => __testables.normalizeSafeObject({ coverage_identity: 1, email: 'cliente@example.com' }, 'ANALYTICS_METRIC_PAYLOAD_INVALID'),
+        { code: 'ANALYTICS_METRIC_PAYLOAD_INVALID' },
+    )
+    assert.throws(
+        () => __testables.normalizeSafeObject({ coverage_identity: 1, operator_label: 'Ana' }, 'ANALYTICS_METRIC_PAYLOAD_INVALID'),
+        { code: 'ANALYTICS_METRIC_PAYLOAD_INVALID' },
+    )
+    assert.throws(
+        () => __testables.normalizeSnapshotMembers([{ identityId: '10000000-0000-4000-8000-000000000001', phone: '+55 51 99999-9999' }]),
+        { code: 'ANALYTICS_SNAPSHOT_MEMBERS_INVALID' },
+    )
+    assert.throws(
+        () => __testables.opaqueActorId({ email: 'manager@example.com' }),
+        { code: 'ANALYTICS_ACTOR_ID_REQUIRED' },
+    )
+})

--- a/crm/api/server/atendimento/__tests__/commercialAnalyticsStore.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialAnalyticsStore.test.js
@@ -85,3 +85,23 @@ test('analytics store rejects PII-shaped metric and snapshot input before persis
         { code: 'ANALYTICS_ACTOR_ID_REQUIRED' },
     )
 })
+
+test('serializes experiment assignments with the Operations crossover namespace', async () => {
+    const locks = []
+    const client = { async query(sql, params) { locks.push({ sql: compact(sql), key: params?.[0] }); return { rows: [] } } }
+    const unitId = '10000000-0000-4000-8000-000000000001'
+    const firstIdentity = '10000000-0000-4000-8000-000000000010'
+    const secondIdentity = '10000000-0000-4000-8000-000000000020'
+
+    await __testables.lockExperimentCrossoverAssignments(client, unitId, [
+        { identityId: secondIdentity },
+        { identityId: firstIdentity },
+        { identityId: secondIdentity },
+    ])
+
+    assert.deepEqual(locks.map((item) => item.key), [
+        `commercial-experiment-crossover:${unitId}:${firstIdentity}`,
+        `commercial-experiment-crossover:${unitId}:${secondIdentity}`,
+    ])
+    assert.equal(locks.every((item) => item.sql.includes('pg_advisory_xact_lock')), true)
+})

--- a/crm/api/server/atendimento/__tests__/commercialOperations.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialOperations.test.js
@@ -34,6 +34,7 @@ test('freezes a campaign cohort with opaque filters and deterministic control as
     assert.equal(campaign.identityIds.length, 2)
     assert.equal(stableControlGroup({ campaignSeed: 'campaign:opaque', identityId: identityA, percentage: 20 }), stableControlGroup({ campaignSeed: 'campaign:opaque', identityId: identityA, percentage: 20 }))
     assert.equal(campaignMemberState({ eligible: false, sourceStale: true }), 'review')
+    assert.equal(campaignMemberState({ eligible: false, controlGroup: true }), 'blocked')
     assert.throws(() => normalizeCampaignPayload({ ...campaign, filters: { owner: 'customer@example.com' } }), /COMMERCIAL_CAMPAIGN_FILTER_INVALID/)
 })
 

--- a/crm/api/server/atendimento/__tests__/commercialOperations.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialOperations.test.js
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+    COMMERCIAL_OUTCOME_CODES,
+    actionQueueFlags,
+    aggregateCommercialActionMetrics,
+    campaignMemberState,
+    computeAverageStageDurations,
+    normalizeCampaignPayload,
+    normalizeOperationMutation,
+    projectCommercialTimelineEvent,
+    stableControlGroup,
+} from '../commercialOperations.js'
+
+const identityA = '11111111-1111-4111-8111-111111111111'
+const identityB = '22222222-2222-4222-8222-222222222222'
+
+test('normalizes only structured operational outcomes and rejects PII-like idempotency keys', () => {
+    assert.equal(COMMERCIAL_OUTCOME_CODES.includes('sale'), true)
+    assert.deepEqual(normalizeOperationMutation({ idempotencyKey: 'action:opaque-key-1', reason: 'Atualização segura', outcomeCode: 'sale' }, { requireReason: true }), {
+        idempotencyKey: 'action:opaque-key-1', expectedRevision: null, reason: 'Atualização segura', outcomeCode: 'sale',
+    })
+    assert.throws(() => normalizeOperationMutation({ idempotencyKey: 'operator@example.com' }), /INVALID_COMMERCIAL_IDEMPOTENCY_KEY/)
+    assert.throws(() => normalizeOperationMutation({ idempotencyKey: 'action:1', reason: '5511999999999' }, { requireReason: true }), /COMMERCIAL_OPERATION_REASON_INVALID/)
+})
+
+test('freezes a campaign cohort with opaque filters and deterministic control assignment', () => {
+    const campaign = normalizeCampaignPayload({
+        name: 'Retorno seguro', segmentKey: 'return', segmentVersion: 'v1', unit: 'centro', owner: 'gestor.crm', reason: 'Coorte de teste segura',
+        filters: { status: ['open'], actionFlag: 'overdue' }, identityIds: [identityA, identityB], cutoffAt: '2026-08-07T12:00:00.000Z',
+        assignmentWindowStart: '2026-08-08T00:00:00.000Z', assignmentWindowEnd: '2026-08-15T00:00:00.000Z', controlGroupPercent: 20,
+    })
+    assert.equal(campaign.identityIds.length, 2)
+    assert.equal(stableControlGroup({ campaignSeed: 'campaign:opaque', identityId: identityA, percentage: 20 }), stableControlGroup({ campaignSeed: 'campaign:opaque', identityId: identityA, percentage: 20 }))
+    assert.equal(campaignMemberState({ eligible: false, sourceStale: true }), 'review')
+    assert.throws(() => normalizeCampaignPayload({ ...campaign, filters: { owner: 'customer@example.com' } }), /COMMERCIAL_CAMPAIGN_FILTER_INVALID/)
+})
+
+test('classifies queues and computes team metrics without contact data', () => {
+    const flags = actionQueueFlags({ status: 'contacted', dueDate: '2026-08-06', owner: 'gestor.crm' }, {
+        today: '2026-08-07', actorIds: ['gestor.crm'], eligibility: { status: 'eligible', expiresAt: '2026-08-10T00:00:00.000Z' }, sourceStale: true,
+    })
+    assert.deepEqual(flags, ['assigned_to_me', 'overdue', 'awaiting_response', 'no_return', 'permission_expiring', 'source_stale'])
+    const metrics = aggregateCommercialActionMetrics([
+        { status: 'contacted', owner: 'gestor.crm', dueDate: '2026-08-06' },
+        { status: 'won_sale', owner: 'gestor.crm', outcomeCode: 'sale' },
+    ], { today: '2026-08-07' })
+    assert.equal(metrics.totals.total, 2)
+    assert.equal(metrics.totals.sale, 1)
+    assert.equal(metrics.byOwner[0].owner, 'gestor.crm')
+})
+
+test('calculates stage durations and projects an allowlisted Customer 360 shape', () => {
+    assert.deepEqual(computeAverageStageDurations([
+        { actionId: 'a', status: 'open', occurredAt: '2026-08-01T00:00:00.000Z' },
+        { actionId: 'a', status: 'responded', occurredAt: '2026-08-01T12:00:00.000Z' },
+    ]), { open: { hours: 12, samples: 1 } })
+    const event = projectCommercialTimelineEvent({
+        event_id: 'event:1', event_type: 'campaign', created_at: '2026-08-01T00:00:00.000Z', source_label: 'CRM', unit_slug: 'centro',
+        actor_label: 'customer@example.com', trace_id: '33333333-3333-4333-8333-333333333333', status: 'draft', context: { phone: '5511999999999' },
+    })
+    assert.equal(event.actor, null)
+    assert.deepEqual(Object.keys(event).sort(), ['actor', 'campaignId', 'consentReview', 'correlationId', 'id', 'occurredAt', 'offerId', 'source', 'status', 'type', 'unit'])
+})

--- a/crm/api/server/atendimento/__tests__/commercialOperationsMigration.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialOperationsMigration.test.js
@@ -14,7 +14,7 @@ test('commercial operations migration is additive, append-only and denies messag
     const grants = __testables.runtimeGrantStatements('staging').join('\n').toLowerCase()
 
     assert.equal(plan.id, COMMERCIAL_OPERATIONS_MIGRATION_ID)
-    assert.deepEqual(plan.appendOnlyTables, ['commercial_operation_mutations', 'commercial_campaign_events'])
+    assert.deepEqual(plan.appendOnlyTables, ['commercial_action_events', 'commercial_operation_mutations', 'commercial_campaign_events'])
     assert.match(plan.messagePolicy, /never dispatch a message/i)
     assert.match(plan.piiPolicy, /no phone, email, message payload/i)
     assert.doesNotMatch(sql, /drop\s+trigger/)
@@ -32,8 +32,11 @@ test('commercial operations migration is additive, append-only and denies messag
     assert.match(grants, /grant select, insert on table crm_atendimento\.commercial_campaign_events/)
 })
 
-test('commercial operations trigger readiness verifies both immutable ledgers', () => {
+test('commercial operations trigger readiness verifies inherited and new immutable ledgers', () => {
     const readiness = __testables.triggerReadinessStatement()
+    assert.match(readiness, /commercial_action_events_immutable/)
+    assert.match(readiness, /commercial_action_events_no_truncate/)
+    assert.match(readiness, /prevent_commercial_ledger_mutation/)
     assert.match(readiness, /commercial_operation_mutations_v2_immutable/)
     assert.match(readiness, /commercial_operation_mutations_v2_no_truncate/)
     assert.match(readiness, /commercial_campaign_events_v2_immutable/)

--- a/crm/api/server/atendimento/__tests__/commercialOperationsMigration.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialOperationsMigration.test.js
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+    COMMERCIAL_OPERATIONS_MIGRATION_ID,
+    __testables,
+    applyCommercialOperationsMigration,
+    commercialOperationsMigrationPlan,
+} from '../commercialOperationsMigration.js'
+
+test('commercial operations migration is additive, append-only and denies message capability', () => {
+    const plan = commercialOperationsMigrationPlan()
+    const sql = __testables.STATEMENTS.join('\n').toLowerCase()
+    const grants = __testables.runtimeGrantStatements('staging').join('\n').toLowerCase()
+
+    assert.equal(plan.id, COMMERCIAL_OPERATIONS_MIGRATION_ID)
+    assert.deepEqual(plan.appendOnlyTables, ['commercial_operation_mutations', 'commercial_campaign_events'])
+    assert.match(plan.messagePolicy, /never dispatch a message/i)
+    assert.match(plan.piiPolicy, /no phone, email, message payload/i)
+    assert.doesNotMatch(sql, /drop\s+trigger/)
+    assert.doesNotMatch(sql, /on delete cascade/)
+    assert.match(sql, /commercial_actions_outcome_code_v2_valid/)
+    assert.match(sql, /commercial_operation_mutations/)
+    assert.match(sql, /commercial_campaigns/)
+    assert.match(sql, /commercial_campaign_members/)
+    assert.match(sql, /commercial_campaign_events/)
+    assert.match(sql, /before update or delete/)
+    assert.match(sql, /before truncate/)
+    assert.doesNotMatch(grants, /grant\s+(?:all privileges|delete|truncate)/)
+    assert.match(grants, /revoke update, delete, truncate, references, trigger on table crm_atendimento\.commercial_campaign_events/)
+    assert.match(grants, /grant select, insert on table crm_atendimento\.commercial_operation_mutations/)
+    assert.match(grants, /grant select, insert on table crm_atendimento\.commercial_campaign_events/)
+})
+
+test('commercial operations trigger readiness verifies both immutable ledgers', () => {
+    const readiness = __testables.triggerReadinessStatement()
+    assert.match(readiness, /commercial_operation_mutations_v2_immutable/)
+    assert.match(readiness, /commercial_operation_mutations_v2_no_truncate/)
+    assert.match(readiness, /commercial_campaign_events_v2_immutable/)
+    assert.match(readiness, /commercial_campaign_events_v2_no_truncate/)
+    assert.match(readiness, /prevent_commercial_operations_evidence_mutation_v2/)
+})
+
+test('commercial operations migration refuses unsafe destinations before opening a database connection', async () => {
+    let connected = false
+    await assert.rejects(
+        () => applyCommercialOperationsMigration({
+            pool: { connect: async () => { connected = true } },
+            databaseUrl: 'postgresql://unsafe.example.invalid/skincos_crm_local',
+            target: 'production',
+        }),
+        { code: 'COMMERCIAL_OPERATIONS_DESTINATION_UNSAFE' },
+    )
+    assert.equal(connected, false)
+})

--- a/crm/api/server/atendimento/__tests__/commercialOperationsStore.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialOperationsStore.test.js
@@ -1,0 +1,263 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+    COMMERCIAL_OPERATIONS_SAFETY_FLAGS,
+    __testables,
+    commercialOperationsReadiness,
+    createCommercialOperationsStore,
+} from '../commercialOperationsStore.js'
+
+const actor = Object.freeze({
+    id: 'gestor.crm',
+    role: 'GESTOR',
+    allowedUnits: ['centro'],
+    allowedUnitsDeclared: true,
+})
+
+function readyAvailability() {
+    return {
+        actions: true,
+        action_events: true,
+        mutations: true,
+        campaigns: true,
+        members: true,
+        campaign_events: true,
+        absences: true,
+        action_event_immutable: true,
+        action_event_no_truncate: true,
+        mutation_immutable: true,
+        mutation_no_truncate: true,
+        campaign_event_immutable: true,
+        campaign_event_no_truncate: true,
+        migration_registry: true,
+    }
+}
+
+test('fails closed for a manager without an explicit unit claim and retains hard-disabled flags', () => {
+    assert.deepEqual(__testables.commercialOperationsUnitScope({ id: 'gestor.crm', role: 'GESTOR' }), [])
+    assert.throws(() => __testables.requestedUnitScope({ id: 'gestor.crm', role: 'GESTOR' }, 'centro'), /COMMERCIAL_UNIT_FORBIDDEN/)
+    assert.deepEqual(COMMERCIAL_OPERATIONS_SAFETY_FLAGS, {
+        commercialContactWritesEnabled: false,
+        messagesEnabled: false,
+        automationEnabled: false,
+        consentWritesEnabled: false,
+        outboundDispatchEnabled: false,
+    })
+})
+
+test('treats every required consent/block and identity source as stale until a complete validated checkpoint exists', async () => {
+    assert.equal(__testables.COMMERCIAL_REQUIRED_SOURCE_IDS.includes('consent.harmonia_opt_outs'), true)
+    assert.equal(__testables.COMMERCIAL_REQUIRED_SOURCE_IDS.includes('blocks.commercial_permissions'), true)
+    assert.equal(__testables.COMMERCIAL_REQUIRED_SOURCE_IDS.includes('identity.global_graph'), true)
+    const calls = []
+    const healthy = await __testables.sourceStale({
+        async query(sql, values) {
+            calls.push({ sql, values })
+            return { rows: [{ checkpoint_count: __testables.COMMERCIAL_REQUIRED_SOURCE_IDS.length, stale: false }] }
+        },
+    }, { sourceCheckpoints: true })
+    assert.equal(healthy, false)
+    assert.deepEqual(calls[0].values, [__testables.COMMERCIAL_REQUIRED_SOURCE_IDS])
+    const missing = await __testables.sourceStale({
+        async query() { return { rows: [{ checkpoint_count: __testables.COMMERCIAL_REQUIRED_SOURCE_IDS.length - 1, stale: false }] } },
+    }, { sourceCheckpoints: true })
+    assert.equal(missing, true)
+})
+
+test('reports migration readiness only when relations and append-only triggers are present', async () => {
+    const queries = []
+    const db = {
+        async query(sql, values = []) {
+            queries.push({ sql, values })
+            if (sql.includes("to_regclass('crm_atendimento.commercial_actions')")) return { rows: [readyAvailability()] }
+            if (sql.includes('where id=$1 and rolled_back_at is null')) return { rows: [{ id: '20260807_commercial_operations_v2' }] }
+            throw new Error(`unexpected sql: ${sql}`)
+        },
+    }
+    const readiness = await commercialOperationsReadiness(db)
+    assert.equal(readiness.ready, true)
+    assert.equal(readiness.appendOnlyReady, true)
+    assert.equal(readiness.safety.automationEnabled, false)
+    assert.equal(queries.length, 2)
+
+    const incomplete = await commercialOperationsReadiness({
+        async query(sql) {
+            if (sql.includes("to_regclass('crm_atendimento.commercial_actions')")) return { rows: [{ ...readyAvailability(), campaign_event_no_truncate: false }] }
+            if (sql.includes('where id=$1 and rolled_back_at is null')) return { rows: [{ id: '20260807_commercial_operations_v2' }] }
+            throw new Error(`unexpected sql: ${sql}`)
+        },
+    })
+    assert.equal(incomplete.ready, false)
+    assert.equal(incomplete.appendOnlyReady, false)
+})
+
+test('serializes idempotency before reading the ledger and never passes raw reason or key to SQL', async () => {
+    const previous = process.env.ATENDIMENTO_ACTOR_HMAC_KEY
+    process.env.ATENDIMENTO_ACTOR_HMAC_KEY = 'a'.repeat(32)
+    const calls = []
+    const client = {
+        async query(sql, values = []) {
+            calls.push({ sql, values })
+            if (sql.includes('pg_advisory_xact_lock')) return { rows: [] }
+            if (sql.includes("to_regclass('crm_atendimento.commercial_actions')")) return { rows: [readyAvailability()] }
+            if (sql.includes('where id=$1 and rolled_back_at is null')) return { rows: [{ id: '20260807_commercial_operations_v2' }] }
+            if (sql.includes('from crm_atendimento.commercial_operation_mutations')) {
+                return { rows: [{ request_fingerprint: values[0] ? calls.find((call) => call.sql.includes('pg_advisory_xact_lock'))?.values[0] : '', response: { operation: 'replayed' } }] }
+            }
+            throw new Error(`unexpected sql: ${sql}`)
+        },
+    }
+    try {
+        // Obtain the exact HMAC request fingerprint through the same public
+        // normalizer, then replay it from the append-only mutation ledger.
+        const context = __testables.mutationInput(actor, 'campaign_update', {
+            idempotencyKey: 'campaign:opaque-key-123', reason: 'Ajuste operacional seguro', expectedRevision: 1,
+        }, { campaignId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', state: 'paused' })
+        client.query = async (sql, values = []) => {
+            calls.push({ sql, values })
+            if (sql.includes('pg_advisory_xact_lock')) return { rows: [] }
+            if (sql.includes("to_regclass('crm_atendimento.commercial_actions')")) return { rows: [readyAvailability()] }
+            if (sql.includes('where id=$1 and rolled_back_at is null')) return { rows: [{ id: '20260807_commercial_operations_v2' }] }
+            if (sql.includes('from crm_atendimento.commercial_operation_mutations')) return { rows: [{ request_fingerprint: context.requestFingerprint, response: { operation: 'replayed' } }] }
+            throw new Error(`unexpected sql: ${sql}`)
+        }
+        const replay = await __testables.runCommercialOperationMutation(client, {
+            actor,
+            operation: 'campaign_update',
+            payload: { idempotencyKey: 'campaign:opaque-key-123', reason: 'Ajuste operacional seguro', expectedRevision: 1 },
+            fingerprintPayload: { campaignId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', state: 'paused' },
+            execute: async () => { throw new Error('a replay must not execute mutable work') },
+        })
+        assert.equal(replay.idempotent, true)
+        assert.equal(replay.operation, 'replayed')
+        const advisory = calls.findIndex((call) => call.sql.includes('pg_advisory_xact_lock'))
+        const ledger = calls.findIndex((call) => call.sql.includes('from crm_atendimento.commercial_operation_mutations'))
+        assert.ok(advisory >= 0 && advisory < ledger)
+        const serialized = JSON.stringify(calls)
+        assert.doesNotMatch(serialized, /campaign:opaque-key-123|Ajuste operacional seguro/)
+    } finally {
+        if (previous === undefined) delete process.env.ATENDIMENTO_ACTOR_HMAC_KEY
+        else process.env.ATENDIMENTO_ACTOR_HMAC_KEY = previous
+    }
+})
+
+test('projects rebalance and Customer 360 data without raw owner or technical event identifiers', async () => {
+    const actionId = '11111111-1111-4111-8111-111111111111'
+    const plan = __testables.projectRebalancePlan([
+        { id: actionId, owner: '5511999999999', status: 'open', revision: 3, unit_slug: 'centro', absent_owner: true },
+    ], { 'gestor.crm': 4 })
+    assert.deepEqual(plan, [{ actionId, fromOwner: null, toOwner: 'gestor.crm', expectedRevision: 3, unit: 'centro' }])
+    const event = __testables.projectTimeline({
+        id: 'internal-event-id', type: 'action', occurredAt: '2026-08-07T00:00:00.000Z', source: 'CRM ação', unit: 'centro',
+        actor: 'customer@example.com', trace_id: '33333333-3333-4333-8333-333333333333', context: { phone: '5511999999999' },
+    })
+    assert.doesNotMatch(event.id, /internal-event-id/)
+    assert.equal(event.actor, null)
+    assert.equal(event.correlationId, '33333333-3333-4333-8333-333333333333')
+    assert.deepEqual(Object.keys(event).sort(), ['actor', 'campaignId', 'consentReview', 'correlationId', 'id', 'occurredAt', 'offerId', 'source', 'status', 'type', 'unit'])
+})
+
+test('exposes an injected readiness-only store without opening a mutation path', async () => {
+    const pool = {
+        async query(sql) {
+            if (sql.includes("to_regclass('crm_atendimento.commercial_actions')")) return { rows: [readyAvailability()] }
+            if (sql.includes('where id=$1 and rolled_back_at is null')) return { rows: [{ id: '20260807_commercial_operations_v2' }] }
+            throw new Error(`unexpected sql: ${sql}`)
+        },
+    }
+    const store = createCommercialOperationsStore({ pool })
+    const readiness = await store.readiness(actor)
+    assert.equal(readiness.ready, true)
+    assert.equal(readiness.safety.commercialContactWritesEnabled, false)
+})
+
+test('records an opt-out request as an outcome without writing consent or dispatching contact', async () => {
+    const previous = process.env.ATENDIMENTO_ACTOR_HMAC_KEY
+    process.env.ATENDIMENTO_ACTOR_HMAC_KEY = 'b'.repeat(32)
+    const actionId = '11111111-1111-4111-8111-111111111111'
+    const identityId = '22222222-2222-4222-8222-222222222222'
+    const calls = []
+    const client = {
+        release() {},
+        async query(sql, values = []) {
+            calls.push({ sql, values })
+            if (['begin', 'commit', 'rollback'].includes(sql)) return { rows: [] }
+            if (sql.includes('pg_advisory_xact_lock')) return { rows: [] }
+            if (sql.includes("to_regclass('crm_atendimento.commercial_actions')")) return { rows: [readyAvailability()] }
+            if (sql.includes('where id=$1 and rolled_back_at is null')) return { rows: [{ id: '20260807_commercial_operations_v2' }] }
+            if (sql.includes('from crm_atendimento.commercial_operation_mutations')) return { rows: [] }
+            if (sql.includes('where action.id=$1 for update of action')) {
+                return { rows: [{ id: actionId, identity_id: identityId, revision: 2, status: 'contacted', owner: 'gestor.crm', unit_slug: 'centro' }] }
+            }
+            if (sql.includes('update crm_atendimento.commercial_actions')) return { rows: [] }
+            if (sql.includes('insert into crm_atendimento.commercial_action_events')) return { rows: [] }
+            if (sql.includes('from crm_atendimento.commercial_campaign_members') && sql.includes('where action_id=$1 for update')) return { rows: [] }
+            if (sql.includes('has_table_privilege')) return { rows: [{
+                permissions: false, source_checkpoints: false, identity_members: false, review_decisions: false,
+                attendance_caixa_links: false, app_attendance_links: false, app_caixa_links: false,
+                lead_app_links: false, lead_caixa_links: false,
+            }] }
+            if (sql.includes('select action.id::text,action.segment_key')) return { rows: [{
+                id: actionId, segment_key: 'synthetic', action_type: 'follow_up', status: 'responded', owner: 'gestor.crm',
+                due_date: '2026-08-08', revision: 3, outcome_code: 'opt_out_requested', created_at: '2026-08-07T00:00:00.000Z',
+                updated_at: '2026-08-07T00:01:00.000Z', unit_slug: 'centro', permission_status: 'review_required',
+                permission_expires_at: null, source_stale: true, identity_in_review: true,
+            }] }
+            if (sql.includes('insert into crm_atendimento.commercial_operation_mutations')) return { rows: [] }
+            throw new Error(`unexpected sql: ${sql}`)
+        },
+    }
+    try {
+        const store = createCommercialOperationsStore({ pool: { connect: async () => client } })
+        const result = await store.recordOutcome(actionId, {
+            idempotencyKey: 'action:synthetic-outcome-1', expectedRevision: 2,
+            reason: 'Solicitação sintética de opt-out', outcomeCode: 'opt_out_requested',
+        }, actor)
+        assert.equal(result.requiresSeparateConsentWorkflow, true)
+        assert.equal(result.action.outcomeCode, 'opt_out_requested')
+        assert.equal(result.safety.messagesEnabled, false)
+        assert.equal(calls.some((call) => /(?:insert into|update)\s+crm_atendimento\.commercial_contact_permissions/i.test(call.sql)), false)
+        assert.equal(calls.some((call) => /harmonia|dispatch|webhook/i.test(call.sql)), false)
+        assert.equal(calls.find((call) => call.sql.includes('update crm_atendimento.commercial_actions')).values[2], 'opt_out_requested')
+    } finally {
+        if (previous === undefined) delete process.env.ATENDIMENTO_ACTOR_HMAC_KEY
+        else process.env.ATENDIMENTO_ACTOR_HMAC_KEY = previous
+    }
+})
+
+test('rejects a stale optimistic revision before an action reassignment can write evidence', async () => {
+    const previous = process.env.ATENDIMENTO_ACTOR_HMAC_KEY
+    process.env.ATENDIMENTO_ACTOR_HMAC_KEY = 'c'.repeat(32)
+    const actionId = '11111111-1111-4111-8111-111111111111'
+    const calls = []
+    const client = {
+        release() {},
+        async query(sql, values = []) {
+            calls.push({ sql, values })
+            if (['begin', 'commit', 'rollback'].includes(sql)) return { rows: [] }
+            if (sql.includes('pg_advisory_xact_lock')) return { rows: [] }
+            if (sql.includes("to_regclass('crm_atendimento.commercial_actions')")) return { rows: [readyAvailability()] }
+            if (sql.includes('where id=$1 and rolled_back_at is null')) return { rows: [{ id: '20260807_commercial_operations_v2' }] }
+            if (sql.includes('from crm_atendimento.commercial_operation_mutations')) return { rows: [] }
+            if (sql.includes('where action.id=$1 for update of action')) {
+                return { rows: [{ id: actionId, identity_id: '22222222-2222-4222-8222-222222222222', revision: 3, status: 'open', owner: 'gestor.crm', unit_slug: 'centro' }] }
+            }
+            throw new Error(`unexpected sql: ${sql}`)
+        },
+    }
+    try {
+        const store = createCommercialOperationsStore({ pool: { connect: async () => client } })
+        await assert.rejects(() => store.reassignAction(actionId, {
+            idempotencyKey: 'action:synthetic-reassign-1', expectedRevision: 2,
+            reason: 'Redistribuição sintética', owner: 'gestor.backup',
+        }, actor), /COMMERCIAL_ACTION_CONFLICT/)
+        assert.equal(calls.some((call) => call.sql.includes('update crm_atendimento.commercial_actions')), false)
+        assert.equal(calls.some((call) => call.sql.includes('insert into crm_atendimento.commercial_action_events')), false)
+        assert.equal(calls.some((call) => call.sql.includes('insert into crm_atendimento.commercial_operation_mutations')), false)
+        assert.equal(calls.at(-1).sql, 'rollback')
+    } finally {
+        if (previous === undefined) delete process.env.ATENDIMENTO_ACTOR_HMAC_KEY
+        else process.env.ATENDIMENTO_ACTOR_HMAC_KEY = previous
+    }
+})

--- a/crm/api/server/atendimento/__tests__/routes.test.js
+++ b/crm/api/server/atendimento/__tests__/routes.test.js
@@ -7,7 +7,7 @@ function actorHeader(actor) {
     return Buffer.from(JSON.stringify(actor)).toString('base64url')
 }
 
-function captureAtendimentoRoutes(store) {
+function captureAtendimentoRoutes(store, options = {}) {
     const routes = new Map()
     const router = {
         use() { return router },
@@ -17,7 +17,7 @@ function captureAtendimentoRoutes(store) {
         patch(path, handler) { routes.set(`PATCH ${path}`, handler); return router },
         delete(path, handler) { routes.set(`DELETE ${path}`, handler); return router },
     }
-    createAtendimentoRouter({ store, routerFactory: () => router })
+    createAtendimentoRouter({ store, ...options, routerFactory: () => router })
     return routes
 }
 
@@ -274,4 +274,52 @@ test('maps review payload and source-state conflicts to their client-safe status
     }, undo)
     assert.equal(undo.state.status, 409)
     assert.deepEqual(undo.state.body, { ok: false, error: 'IDENTITY_REVIEW_CONFLICT', hint: undefined })
+})
+
+test('routes Commercial Operations through its injected store with a single opaque idempotency key', async () => {
+    const calls = []
+    const operations = {
+        async readiness(actor) { calls.push(['readiness', actor.id]); return { ready: true, safety: { messagesEnabled: false } } },
+        async wallet(query, actor) { calls.push(['wallet', query, actor.id]); return { actions: [], safety: { messagesEnabled: false } } },
+        async createCampaign(payload, actor) { calls.push(['campaign', payload, actor.id]); return { campaign: { campaignId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' }, safety: { messagesEnabled: false } } },
+    }
+    const routes = captureAtendimentoRoutes({}, { commercialOperationsStore: operations })
+    const actor = { id: 'gestor-1', role: 'GESTOR', allowedModules: ['atendimento'], allowedUnits: ['novo-hamburgo'], allowedUnitsDeclared: true }
+
+    const readiness = captureResponse()
+    await routes.get('GET /commercial/operations/readiness')({ atendimentoActor: actor }, readiness)
+    assert.equal(readiness.state.status, 200)
+    assert.equal(readiness.state.body.safety.messagesEnabled, false)
+
+    const wallet = captureResponse()
+    await routes.get('GET /commercial/operations/wallet')({ atendimentoActor: actor, query: { unit: 'novo-hamburgo' } }, wallet)
+    assert.equal(wallet.state.status, 200)
+    assert.deepEqual(calls[1], ['wallet', { unit: 'novo-hamburgo' }, 'gestor-1'])
+
+    const campaign = captureResponse()
+    await routes.get('POST /commercial/operations/campaigns')({
+        atendimentoActor: actor,
+        headers: { 'idempotency-key': 'campaign:opaque-key-1' },
+        body: { idempotencyKey: 'campaign:opaque-key-1', reason: 'Coorte sintética aprovada.' },
+    }, campaign)
+    assert.equal(campaign.state.status, 200)
+    assert.equal(calls[2][1].idempotencyKey, 'campaign:opaque-key-1')
+    assert.equal(campaign.state.body.safety.messagesEnabled, false)
+
+    const beforeForbidden = calls.length
+    const forbidden = captureResponse()
+    await routes.get('POST /commercial/operations/campaigns')({
+        atendimentoActor: { ...actor, role: 'GERENTE' }, headers: {}, body: { idempotencyKey: 'campaign:opaque-key-2' },
+    }, forbidden)
+    assert.equal(forbidden.state.status, 403)
+    assert.equal(calls.length, beforeForbidden)
+
+    const mismatch = captureResponse()
+    await routes.get('POST /commercial/operations/campaigns')({
+        atendimentoActor: actor,
+        headers: { 'idempotency-key': 'campaign:opaque-key-3' },
+        body: { idempotencyKey: 'campaign:opaque-key-4' },
+    }, mismatch)
+    assert.equal(mismatch.state.status, 400)
+    assert.equal(calls.length, beforeForbidden)
 })

--- a/crm/api/server/atendimento/commercialAnalytics.js
+++ b/crm/api/server/atendimento/commercialAnalytics.js
@@ -370,7 +370,10 @@ export function buildSegmentMembershipSnapshot(definition, members = [], { snaps
 }
 
 export function buildSegmentDrift(snapshots = []) {
-    const ordered = [...snapshots].sort((left, right) => String(left.snapshotDate || left.snapshot_date).localeCompare(String(right.snapshotDate || right.snapshot_date)))
+    const ordered = [...snapshots].sort((left, right) => {
+        const dateOrder = String(left.snapshotDate || left.snapshot_date).localeCompare(String(right.snapshotDate || right.snapshot_date))
+        return dateOrder || String(left.createdAt || left.created_at || '').localeCompare(String(right.createdAt || right.created_at || ''))
+    })
     const current = ordered.at(-1); const previous = ordered.at(-2)
     if (!current || !previous) return { available: false, reason: 'INSUFFICIENT_SNAPSHOTS', dimensions: [] }
     const currentDistribution = current.distribution || {}; const previousDistribution = previous.distribution || {}

--- a/crm/api/server/atendimento/commercialAnalytics.js
+++ b/crm/api/server/atendimento/commercialAnalytics.js
@@ -1,0 +1,381 @@
+import { createHash } from 'node:crypto'
+
+// Analytics is intentionally deterministic and explainable.  It consumes
+// durable, unit-scoped records supplied by the store; it never scores a
+// person, exposes contact data, or turns a measurement into a send.
+export const COMMERCIAL_ANALYTICS_VERSION = 'commercial-analytics/v2'
+export const COMMERCIAL_ANALYTICS_FUNNEL_STAGES = Object.freeze([
+    'eligible', 'selected', 'action_created', 'contacted', 'delivered',
+    'responded', 'scheduled', 'attended', 'purchased', 'returned',
+])
+export const COMMERCIAL_ANALYTICS_DEFAULT_WINDOWS = Object.freeze({
+    version: 'v1', responseDays: 7, appointmentDays: 14, attendanceDays: 60,
+    saleDays: 60, returnDays: 180,
+})
+
+const PII_KEY = /(?:^|_)(?:name|phone|email|cpf|address|message|body|payload|raw|evidence)(?:$|_)/i
+const PII_VALUE = /@|\+?\d[\d\s().-]{6,}\d/
+const KEY = /^[a-z][a-z0-9._-]{0,119}$/i
+const DATE = /^\d{4}-\d{2}-\d{2}$/
+const DIMENSIONS = new Set(['unit', 'campaign', 'segment', 'owner', 'channel', 'offer', 'policyVersion'])
+const ATTRIBUTION_STATES = new Set(['observed', 'attributed', 'incremental'])
+const STAGE_SET = new Set(COMMERCIAL_ANALYTICS_FUNNEL_STAGES)
+
+function text(value) { return typeof value === 'string' ? value.trim() : String(value ?? '').trim() }
+function finite(value, fallback = 0) { const number = Number(value); return Number.isFinite(number) ? number : fallback }
+function nonNegative(value) { return Math.max(0, finite(value)) }
+function round(value, places = 4) { const scale = 10 ** places; return Math.round(value * scale) / scale }
+function identityOf(row) { return text(row?.identityId || row?.identity_id) }
+function eventType(row) { return text(row?.type || row?.eventType || row?.event_type).toLowerCase() }
+function occurredAt(row) { return row?.occurredAt || row?.occurred_at || row?.createdAt || row?.created_at || row?.date || null }
+
+function asDate(value) {
+    if (value instanceof Date && !Number.isNaN(value.getTime())) return value
+    const parsed = new Date(String(value || ''))
+    return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+function stable(value) {
+    if (Array.isArray(value)) return value.map(stable)
+    if (!value || typeof value !== 'object') return value
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stable(value[key])]))
+}
+
+function hash(value) { return createHash('sha256').update(JSON.stringify(stable(value))).digest('hex') }
+
+export function commercialAnalyticsError(code, statusCode = 400) {
+    const error = new Error(code)
+    error.code = code
+    error.statusCode = statusCode
+    return error
+}
+
+function containsPii(value) { return PII_VALUE.test(text(value)) }
+
+export function sanitizeAnalyticsPayload(value, depth = 0) {
+    if (depth > 4) return null
+    if (Array.isArray(value)) return value.slice(0, 100).map((item) => sanitizeAnalyticsPayload(item, depth + 1)).filter((item) => item !== undefined)
+    if (value && typeof value === 'object') {
+        const result = {}
+        for (const [key, item] of Object.entries(value)) {
+            if (Object.keys(result).length >= 40 || PII_KEY.test(key)) continue
+            const sanitized = sanitizeAnalyticsPayload(item, depth + 1)
+            if (sanitized !== undefined) result[key] = sanitized
+        }
+        return result
+    }
+    if (typeof value === 'string') return containsPii(value) ? undefined : value.slice(0, 500)
+    return ['number', 'boolean'].includes(typeof value) || value === null ? value : undefined
+}
+
+export function normalizeAttributionWindows(value = {}, defaults = COMMERCIAL_ANALYTICS_DEFAULT_WINDOWS) {
+    const source = value && typeof value === 'object' && !Array.isArray(value) ? value : {}
+    const normalizeDays = (key, fallback) => {
+        const parsed = Number(source[key] ?? source[key.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`)] ?? fallback)
+        if (!Number.isInteger(parsed) || parsed < 0 || parsed > 730) throw commercialAnalyticsError('COMMERCIAL_ATTRIBUTION_WINDOW_INVALID')
+        return parsed
+    }
+    const version = text(source.version || defaults.version)
+    if (!KEY.test(version)) throw commercialAnalyticsError('COMMERCIAL_ATTRIBUTION_WINDOW_VERSION_INVALID')
+    return {
+        version,
+        responseDays: normalizeDays('responseDays', defaults.responseDays),
+        appointmentDays: normalizeDays('appointmentDays', defaults.appointmentDays),
+        attendanceDays: normalizeDays('attendanceDays', defaults.attendanceDays),
+        saleDays: normalizeDays('saleDays', defaults.saleDays),
+        returnDays: normalizeDays('returnDays', defaults.returnDays),
+    }
+}
+
+export function normalizeAnalyticsFilters(query = {}) {
+    const source = query && typeof query === 'object' && !Array.isArray(query) ? query : {}
+    const date = (key) => {
+        const value = text(source[key])
+        if (!value) return null
+        if (!DATE.test(value)) throw commercialAnalyticsError(`INVALID_ANALYTICS_${key.toUpperCase()}`)
+        return value
+    }
+    const list = (key) => {
+        const raw = Array.isArray(source[key]) ? source[key] : text(source[key]).split(',')
+        const values = [...new Set(raw.map(text).filter(Boolean))]
+        if (values.length > 50 || values.some((value) => !KEY.test(value) || containsPii(value))) throw commercialAnalyticsError('INVALID_ANALYTICS_FILTER')
+        return values
+    }
+    const from = date('from') || date('periodStart')
+    const to = date('to') || date('periodEnd')
+    if (from && to && from > to) throw commercialAnalyticsError('INVALID_ANALYTICS_PERIOD')
+    const dimensions = list('dimensions')
+    if (dimensions.some((dimension) => !DIMENSIONS.has(dimension))) throw commercialAnalyticsError('INVALID_ANALYTICS_DIMENSION')
+    const value = (key) => {
+        const candidate = text(source[key])
+        if (candidate && (!KEY.test(candidate) || containsPii(candidate))) throw commercialAnalyticsError('INVALID_ANALYTICS_FILTER')
+        return candidate || null
+    }
+    const attributionState = text(source.attributionState || 'attributed')
+    if (!ATTRIBUTION_STATES.has(attributionState)) throw commercialAnalyticsError('INVALID_ANALYTICS_ATTRIBUTION_STATE')
+    const granularity = text(source.granularity || 'day')
+    if (!['day', 'week', 'month'].includes(granularity)) throw commercialAnalyticsError('INVALID_ANALYTICS_GRANULARITY')
+    const limit = Number(source.limit || 90)
+    if (!Number.isInteger(limit) || limit < 1 || limit > 365) throw commercialAnalyticsError('INVALID_ANALYTICS_LIMIT')
+    return { from, to, unit: value('unit'), units: list('units'), campaign: value('campaign'), segment: value('segment'), owner: value('owner'), channel: value('channel'), offer: value('offer'), policyVersion: value('policyVersion'), findingKey: value('findingKey'), sourceKey: value('sourceKey'), dimensions, attributionState, granularity, limit }
+}
+
+function bucket(value, granularity) {
+    const parsed = asDate(value)
+    if (!parsed) return null
+    const day = parsed.toISOString().slice(0, 10)
+    if (granularity === 'day') return day
+    if (granularity === 'month') return `${day.slice(0, 7)}-01`
+    const weekStart = new Date(`${day}T00:00:00.000Z`)
+    weekStart.setUTCDate(weekStart.getUTCDate() - ((weekStart.getUTCDay() + 6) % 7))
+    return weekStart.toISOString().slice(0, 10)
+}
+
+function average(values) {
+    const accepted = values.filter((value) => Number.isFinite(value))
+    return accepted.length ? round(accepted.reduce((sum, value) => sum + value, 0) / accepted.length, 2) : null
+}
+
+function hoursBetween(left, right) {
+    const start = asDate(left); const end = asDate(right)
+    return !start || !end || end < start ? null : round((end.getTime() - start.getTime()) / 3_600_000, 2)
+}
+
+export function buildQualityTimeSeries({ findings = [], findingEvents = [], metricSnapshots = [], asOf = new Date(), granularity = 'day' } = {}) {
+    const now = asDate(asOf) || new Date()
+    const byFinding = new Map()
+    const eventsByFinding = new Map()
+    for (const event of [...findingEvents].sort((left, right) => String(occurredAt(left)).localeCompare(String(occurredAt(right))))) {
+        const key = text(event.findingKey || event.finding_key)
+        const date = bucket(occurredAt(event), granularity)
+        if (!key || !date) continue
+        const series = byFinding.get(key) || new Map()
+        const current = series.get(date) || { date, observedCount: 0, events: 0, status: 'open' }
+        current.observedCount = Math.round(nonNegative(event.observedCount ?? event.observed_count ?? current.observedCount))
+        current.events += 1
+        current.status = text(event.status || current.status) || 'open'
+        series.set(date, current)
+        byFinding.set(key, series)
+        const history = eventsByFinding.get(key) || []
+        history.push(event)
+        eventsByFinding.set(key, history)
+    }
+    const activeAging = []
+    const timings = []
+    let reopened = 0; let detected = 0; let assigned = 0; let overdueSla = 0
+    for (const finding of findings) {
+        const key = text(finding.findingKey || finding.finding_key)
+        if (!key) continue
+        const count = Math.round(nonNegative(finding.observedCount ?? finding.observed_count))
+        const status = text(finding.status || 'open')
+        const date = bucket(finding.lastEvaluatedAt || finding.last_evaluated_at || now, granularity)
+        const series = byFinding.get(key) || new Map()
+        if (date && !series.has(date)) series.set(date, { date, observedCount: count, events: 0, status })
+        byFinding.set(key, series)
+        if (text(finding.owner)) assigned += 1
+        const due = asDate(finding.slaDueAt || finding.sla_due_at)
+        if (count > 0 && due && due < now && !['resolved', 'closed', 'cleared'].includes(status)) overdueSla += 1
+        const history = eventsByFinding.get(key) || []
+        const first = history.find((event) => ['detected', 'reopened'].includes(eventType(event))) || null
+        const acknowledged = history.find((event) => ['acknowledged', 'in_progress'].includes(text(event.status))) || null
+        const started = history.find((event) => text(event.status) === 'in_progress') || null
+        const resolved = history.find((event) => ['resolved', 'cleared'].includes(eventType(event)) || ['resolved', 'closed'].includes(text(event.status))) || null
+        const detectedAt = occurredAt(first) || finding.firstDetectedAt || finding.first_detected_at
+        timings.push({ findingKey: key, timeToRecognitionHours: hoursBetween(detectedAt, occurredAt(acknowledged) || finding.acknowledgedAt || finding.acknowledged_at), timeToStartHours: hoursBetween(detectedAt, occurredAt(started)), timeToResolutionHours: hoursBetween(detectedAt, occurredAt(resolved) || finding.resolvedAt || finding.resolved_at) })
+        const ageHours = hoursBetween(detectedAt, now)
+        if (count > 0) activeAging.push({ findingKey: key, ageHours: ageHours ?? 0, observedCount: count, status })
+        reopened += history.filter((event) => eventType(event) === 'reopened').length
+        detected += history.filter((event) => ['detected', 'reopened'].includes(eventType(event))).length
+    }
+    const latestMetrics = new Map()
+    for (const row of metricSnapshots) {
+        const key = `${text(row.sourceKey || row.source_key)}:${text(row.findingKey || row.finding_key)}:${text(row.unitSlug || row.unit_slug)}`
+        const current = latestMetrics.get(key)
+        if (!current || String(occurredAt(row)).localeCompare(String(occurredAt(current))) > 0) latestMetrics.set(key, sanitizeAnalyticsPayload(row))
+    }
+    const metrics = [...latestMetrics.values()]
+    const coverage = Object.fromEntries(metrics.flatMap((row) => Object.entries(row.metrics || {})).filter(([key, value]) => /^coverage[._]/i.test(key) && Number.isFinite(Number(value))).map(([key, value]) => [key, round(Number(value), 4)]))
+    return {
+        version: COMMERCIAL_ANALYTICS_VERSION,
+        granularity,
+        byFinding: Object.fromEntries([...byFinding.entries()].map(([key, values]) => [key, [...values.values()].sort((left, right) => left.date.localeCompare(right.date))])),
+        backlogAging: activeAging.sort((left, right) => right.ageHours - left.ageHours),
+        timing: { timeToRecognitionHours: average(timings.map((row) => row.timeToRecognitionHours)), timeToStartHours: average(timings.map((row) => row.timeToStartHours)), timeToResolutionHours: average(timings.map((row) => row.timeToResolutionHours)) },
+        reopenRate: detected ? round(reopened / detected) : 0,
+        ownerCoverage: findings.length ? round(assigned / findings.length) : null,
+        overdueSla,
+        coverage,
+        freshness: metrics.filter((row) => text(row.sourceKey || row.source_key).startsWith('freshness.')),
+        lastValidExecution: metrics.filter((row) => text(row.sourceKey || row.source_key) === 'source.last_valid_execution'),
+    }
+}
+
+function dimensionMatches(row, filters) {
+    const exact = (value, expected) => !expected || text(value) === text(expected)
+    return exact(row.unitSlug || row.unit_slug, filters.unit)
+        && exact(row.campaignKey || row.campaign_key || row.campaignId || row.campaign_id, filters.campaign)
+        && exact(row.segmentKey || row.segment_key, filters.segment)
+        && exact(row.owner, filters.owner)
+        && exact(row.channel || row.contactChannel || row.contact_channel, filters.channel)
+        && exact(row.offerKey || row.offer_key || row.offerId || row.offer_id, filters.offer)
+        && exact(row.policyVersion || row.policy_version, filters.policyVersion)
+}
+
+function windowDays(stage, windows) {
+    if (stage === 'responded') return windows.responseDays
+    if (stage === 'scheduled') return windows.appointmentDays
+    if (stage === 'attended') return windows.attendanceDays
+    if (stage === 'purchased') return windows.saleDays
+    if (stage === 'returned') return windows.returnDays
+    return null
+}
+
+export function isWithinAttributionWindow(anchor, eventAt, stage, windows = COMMERCIAL_ANALYTICS_DEFAULT_WINDOWS) {
+    const start = asDate(anchor); const end = asDate(eventAt)
+    const days = windowDays(stage, normalizeAttributionWindows(windows))
+    if (!start || !end || end < start) return false
+    return days === null || end.getTime() <= start.getTime() + days * 86_400_000
+}
+
+function addStage(stages, stage, identity, state) {
+    if (!STAGE_SET.has(stage) || !identity || !ATTRIBUTION_STATES.has(state)) return
+    stages[stage][state].add(identity)
+}
+
+export function buildCommercialFunnel({ eligibleIdentities = [], campaignMembers = [], actions = [], events = [], attendances = [], sales = [], assignments = [], windows = COMMERCIAL_ANALYTICS_DEFAULT_WINDOWS, filters = {} } = {}) {
+    const normalizedWindows = normalizeAttributionWindows(windows)
+    const stages = Object.fromEntries(COMMERCIAL_ANALYTICS_FUNNEL_STAGES.map((stage) => [stage, { observed: new Set(), attributed: new Set(), incremental: new Set() }]))
+    const eligible = new Set(eligibleIdentities.map(identityOf).filter(Boolean))
+    const treatment = new Set(assignments.filter((row) => text(row.variant) === 'treatment').map(identityOf))
+    for (const identity of eligible) { addStage(stages, 'eligible', identity, 'observed'); addStage(stages, 'eligible', identity, 'attributed'); if (treatment.has(identity)) addStage(stages, 'eligible', identity, 'incremental') }
+    const candidates = [...campaignMembers, ...actions].filter((row) => dimensionMatches(row, filters))
+    const actionByIdentity = new Map()
+    for (const row of actions.filter((item) => dimensionMatches(item, filters))) {
+        const identity = identityOf(row); if (!identity) continue
+        const rows = actionByIdentity.get(identity) || []; rows.push(row); actionByIdentity.set(identity, rows)
+        const anchor = row.contactedAt || row.contacted_at || row.createdAt || row.created_at
+        for (const state of ['observed', 'attributed']) addStage(stages, 'action_created', identity, state)
+        if (treatment.has(identity)) addStage(stages, 'action_created', identity, 'incremental')
+        if (row.contactedAt || row.contacted_at || ['contacted', 'responded', 'scheduled', 'won_sale', 'returned'].includes(text(row.status))) {
+            for (const state of ['observed', 'attributed']) addStage(stages, 'contacted', identity, state)
+            if (treatment.has(identity)) addStage(stages, 'contacted', identity, 'incremental')
+        }
+        const statusStage = ({ responded: 'responded', scheduled: 'scheduled', won_sale: 'purchased', returned: 'returned' })[text(row.status)]
+        if (statusStage) {
+            addStage(stages, statusStage, identity, 'observed')
+            if (isWithinAttributionWindow(anchor, row.updatedAt || row.updated_at, statusStage, normalizedWindows)) {
+                addStage(stages, statusStage, identity, 'attributed'); if (treatment.has(identity)) addStage(stages, statusStage, identity, 'incremental')
+            }
+        }
+    }
+    for (const row of candidates) {
+        const identity = identityOf(row); if (!identity) continue
+        addStage(stages, 'selected', identity, 'observed'); addStage(stages, 'selected', identity, 'attributed'); if (treatment.has(identity)) addStage(stages, 'selected', identity, 'incremental')
+    }
+    const allEvents = [...events, ...attendances.map((row) => ({ ...row, type: 'attended' })), ...sales.map((row) => ({ ...row, type: 'purchased' }))]
+    for (const event of allEvents.filter((row) => dimensionMatches(row, filters))) {
+        const identity = identityOf(event); const stage = eventType(event)
+        if (!identity || !STAGE_SET.has(stage)) continue
+        addStage(stages, stage, identity, 'observed')
+        const anchors = actionByIdentity.get(identity) || []
+        if (anchors.some((action) => isWithinAttributionWindow(action.contactedAt || action.contacted_at || action.createdAt || action.created_at, occurredAt(event), stage, normalizedWindows))) {
+            addStage(stages, stage, identity, 'attributed'); if (treatment.has(identity)) addStage(stages, stage, identity, 'incremental')
+        }
+    }
+    return {
+        version: COMMERCIAL_ANALYTICS_VERSION,
+        windows: normalizedWindows,
+        stages: Object.fromEntries(COMMERCIAL_ANALYTICS_FUNNEL_STAGES.map((stage) => [stage, Object.fromEntries(ATTRIBUTION_STATES.values().map((state) => [state, stages[stage][state].size]))])),
+        availability: { eligible: eligible.size, selectedRows: candidates.length, actionRows: actions.length, eventRows: allEvents.length, treatmentAssignments: treatment.size },
+    }
+}
+
+export function deterministicExperimentVariant(identityId, experimentKey, seed, controlPercent = 10) {
+    const identity = text(identityId); const key = text(experimentKey); const runSeed = text(seed); const percent = Number(controlPercent)
+    if (!identity || !KEY.test(key) || !KEY.test(runSeed) || !Number.isInteger(percent) || percent < 1 || percent > 99) throw commercialAnalyticsError('COMMERCIAL_EXPERIMENT_ASSIGNMENT_INVALID')
+    const bucketValue = Number.parseInt(hash({ identity, key, runSeed }).slice(0, 8), 16) % 10_000
+    return bucketValue < percent * 100 ? 'control' : 'treatment'
+}
+
+export function buildExperimentAssignments(identities = [], { experimentKey, seed, controlPercent = 10, existingAssignments = [] } = {}) {
+    const existing = new Map(existingAssignments.map((row) => [identityOf(row), row]).filter(([identity]) => identity))
+    const seen = new Set()
+    return identities.map((row) => {
+        const identityId = identityOf(row)
+        if (!identityId || seen.has(identityId)) return null
+        seen.add(identityId)
+        const previous = existing.get(identityId)
+        const eligible = row.eligible !== false
+        if (previous) {
+            if (text(previous.unitSlug || previous.unit_slug) !== text(row.unitSlug || row.unit_slug)) throw commercialAnalyticsError('COMMERCIAL_EXPERIMENT_SCOPE_CONFLICT', 409)
+            return { identityId, unitSlug: text(row.unitSlug || row.unit_slug) || null, variant: text(previous.variant), eligible: previous.eligible !== false, preserved: true, exclusionReason: previous.exclusionReason || previous.exclusion_reason || null }
+        }
+        return { identityId, unitSlug: text(row.unitSlug || row.unit_slug) || null, variant: eligible ? deterministicExperimentVariant(identityId, experimentKey, seed, controlPercent) : 'excluded', eligible, preserved: false, exclusionReason: eligible ? null : text(row.exclusionReason || row.exclusion_reason || 'criteria_not_met') }
+    }).filter(Boolean)
+}
+
+function confidenceIntervalDifference(controlRate, controlSample, treatmentRate, treatmentSample) {
+    if (controlSample < 30 || treatmentSample < 30) return null
+    const error = 1.96 * Math.sqrt((controlRate * (1 - controlRate)) / controlSample + (treatmentRate * (1 - treatmentRate)) / treatmentSample)
+    const difference = treatmentRate - controlRate
+    return [round(difference - error), round(difference + error)]
+}
+
+export function buildExperimentResult(assignments = [], outcomes = []) {
+    const outcomesByIdentity = new Map()
+    for (const row of outcomes) {
+        const identity = identityOf(row); if (!identity) continue
+        const current = outcomesByIdentity.get(identity) || { converted: false, revenue: 0 }
+        current.converted ||= row.converted === true || ['responded', 'scheduled', 'attended', 'purchased', 'returned'].includes(eventType(row))
+        current.revenue += nonNegative(row.revenue ?? row.amount)
+        outcomesByIdentity.set(identity, current)
+    }
+    const groups = { control: [], treatment: [] }
+    for (const assignment of assignments) {
+        const variant = text(assignment.variant); if (!groups[variant] || assignment.eligible === false) continue
+        groups[variant].push(outcomesByIdentity.get(identityOf(assignment)) || { converted: false, revenue: 0 })
+    }
+    const summarize = (rows) => {
+        const conversions = rows.filter((row) => row.converted).length
+        const revenue = rows.reduce((sum, row) => sum + row.revenue, 0)
+        return { sample: rows.length, conversions, conversionRate: rows.length ? round(conversions / rows.length) : null, revenue: round(revenue, 2), revenuePerMember: rows.length ? round(revenue / rows.length, 2) : null }
+    }
+    const control = summarize(groups.control); const treatment = summarize(groups.treatment)
+    const sufficientSample = control.sample >= 30 && treatment.sample >= 30
+    const lift = control.conversionRate && treatment.conversionRate != null ? round((treatment.conversionRate - control.conversionRate) / control.conversionRate) : null
+    const incrementalRevenue = control.revenuePerMember != null && treatment.sample ? round(treatment.revenue - control.revenuePerMember * treatment.sample, 2) : null
+    return { control, treatment, lift, incrementalRevenue, confidenceInterval95: control.conversionRate != null && treatment.conversionRate != null ? confidenceIntervalDifference(control.conversionRate, control.sample, treatment.conversionRate, treatment.sample) : null, sufficientSample, warning: sufficientSample ? null : 'INSUFFICIENT_SAMPLE' }
+}
+
+export function normalizeSegmentDefinition(input = {}) {
+    const source = input && typeof input === 'object' && !Array.isArray(input) ? input : {}
+    const key = text(source.key || source.segmentKey); const version = text(source.version || source.segmentVersion)
+    const criteria = sanitizeAnalyticsPayload(source.criteria)
+    const thresholds = sanitizeAnalyticsPayload(source.thresholds || {})
+    const percentiles = sanitizeAnalyticsPayload(source.percentiles || {})
+    if (!KEY.test(key) || !KEY.test(version) || !criteria || Object.keys(criteria).length === 0) throw commercialAnalyticsError('COMMERCIAL_SEGMENT_DEFINITION_INVALID')
+    return { key, version, criteria, thresholds, percentiles, effectiveFrom: text(source.effectiveFrom || source.effective_from) || null, author: containsPii(source.author) ? null : text(source.author).slice(0, 160) || null }
+}
+
+export function buildSegmentMembershipSnapshot(definition, members = [], { snapshotAt = new Date(), unitSlug = null } = {}) {
+    const normalized = normalizeSegmentDefinition(definition)
+    const unique = [...new Set(members.map(identityOf).filter(Boolean))].sort()
+    const distribution = {}
+    for (const row of members) {
+        const key = text(row.bucket || row.segmentBucket || row.segment_bucket || 'unclassified')
+        if (key && KEY.test(key)) distribution[key] = (distribution[key] || 0) + 1
+    }
+    const snapshotDate = bucket(snapshotAt, 'day')
+    return { segmentKey: normalized.key, segmentVersion: normalized.version, snapshotDate, unitSlug: text(unitSlug) || null, memberCount: unique.length, membershipHash: hash({ segmentKey: normalized.key, segmentVersion: normalized.version, snapshotDate, unitSlug: text(unitSlug) || null, members: unique }), distribution, definition: normalized }
+}
+
+export function buildSegmentDrift(snapshots = []) {
+    const ordered = [...snapshots].sort((left, right) => String(left.snapshotDate || left.snapshot_date).localeCompare(String(right.snapshotDate || right.snapshot_date)))
+    const current = ordered.at(-1); const previous = ordered.at(-2)
+    if (!current || !previous) return { available: false, reason: 'INSUFFICIENT_SNAPSHOTS', dimensions: [] }
+    const currentDistribution = current.distribution || {}; const previousDistribution = previous.distribution || {}
+    const keys = [...new Set([...Object.keys(currentDistribution), ...Object.keys(previousDistribution)])].sort()
+    return { available: true, currentDate: current.snapshotDate || current.snapshot_date, previousDate: previous.snapshotDate || previous.snapshot_date, population: { current: Math.round(nonNegative(current.memberCount ?? current.member_count)), previous: Math.round(nonNegative(previous.memberCount ?? previous.member_count)) }, dimensions: keys.map((key) => { const before = nonNegative(previousDistribution[key]); const after = nonNegative(currentDistribution[key]); return { key, current: after, previous: before, delta: round(after - before), relativeDelta: before ? round((after - before) / before) : null } }) }
+}
+
+export const __testables = { asDate, bucket, dimensionMatches, hoursBetween, hash }

--- a/crm/api/server/atendimento/commercialAnalyticsMigration.js
+++ b/crm/api/server/atendimento/commercialAnalyticsMigration.js
@@ -1,0 +1,273 @@
+import {
+    assertAtendimentoMigrationDestination,
+    ATENDIMENTO_MIGRATION_TARGETS,
+    isStrictAtendimentoMigrationDestination,
+} from './migrationDestination.js'
+
+export const COMMERCIAL_ANALYTICS_MIGRATION_ID = '20260807_commercial_analytics_v2'
+
+const RUNTIME_ROLES = Object.freeze({
+    [ATENDIMENTO_MIGRATION_TARGETS.LOCAL]: 'skincos',
+    [ATENDIMENTO_MIGRATION_TARGETS.STAGING]: 'skincos_staging_crm_app',
+})
+
+const PREREQUISITES = Object.freeze([
+    'crm_atendimento.units',
+    'crm_atendimento.global_client_identities',
+    'crm_atendimento.commercial_actions',
+    'crm_atendimento.commercial_campaigns',
+    'crm_atendimento.commercial_campaign_members',
+    'crm_atendimento.commercial_data_quality_findings',
+    'crm_atendimento.commercial_data_quality_finding_events',
+])
+
+function migrationError(code) { const error = new Error(code); error.code = code; return error }
+
+function createTriggerIfMissing(relation, triggerName, triggerSql) {
+    return `do $$ begin
+        if not exists (select 1 from pg_trigger where tgrelid = '${relation}'::regclass and tgname = '${triggerName}') then
+            execute $trigger$${triggerSql}$trigger$;
+        end if;
+    end $$`
+}
+
+function runtimeGrantStatements(target) {
+    const role = RUNTIME_ROLES[target]
+    if (!role) throw migrationError('COMMERCIAL_ANALYTICS_RUNTIME_ROLE_UNKNOWN')
+    const appendOnly = [
+        'commercial_attribution_windows', 'commercial_segment_versions',
+        'commercial_segment_membership_snapshots', 'commercial_segment_memberships',
+        'commercial_analytics_metric_snapshots', 'commercial_analytics_events',
+        'commercial_experiment_assignments',
+    ]
+    const mutable = ['commercial_segment_definitions', 'commercial_experiments']
+    return [
+        `revoke create on schema crm_atendimento from ${role}`,
+        ...appendOnly.map((table) => `revoke update, delete, truncate, references, trigger on table crm_atendimento.${table} from ${role}`),
+        ...mutable.map((table) => `revoke delete, truncate, references, trigger on table crm_atendimento.${table} from ${role}`),
+        `grant usage on schema crm_atendimento to ${role}`,
+        ...appendOnly.map((table) => `grant select, insert on table crm_atendimento.${table} to ${role}`),
+        ...mutable.map((table) => `grant select, insert, update on table crm_atendimento.${table} to ${role}`),
+    ]
+}
+
+const STATEMENTS = Object.freeze([
+    `create extension if not exists pgcrypto`,
+    `create schema if not exists crm_atendimento`,
+    `alter table crm_atendimento.commercial_campaigns add column if not exists attribution_window_version text`,
+    `create table if not exists crm_atendimento.commercial_attribution_windows (
+        id uuid primary key default gen_random_uuid(),
+        version text not null unique check (version ~ '^[A-Za-z0-9._-]{1,120}$'),
+        response_days integer not null check (response_days between 0 and 730),
+        appointment_days integer not null check (appointment_days between 0 and 730),
+        attendance_days integer not null check (attendance_days between 0 and 730),
+        sale_days integer not null check (sale_days between 0 and 730),
+        return_days integer not null check (return_days between 0 and 730),
+        effective_from timestamptz not null,
+        expires_at timestamptz,
+        author_id text not null check (char_length(author_id) between 1 and 160 and author_id !~ '[@]'),
+        reason text not null check (char_length(btrim(reason)) between 3 and 1000 and reason !~ '[@]'),
+        created_at timestamptz not null default now(),
+        check (expires_at is null or expires_at > effective_from)
+    )`,
+    `create table if not exists crm_atendimento.commercial_segment_definitions (
+        id uuid primary key default gen_random_uuid(),
+        segment_key text not null unique check (segment_key ~ '^[A-Za-z0-9._-]{1,120}$'),
+        current_revision integer not null default 1 check (current_revision >= 1),
+        current_status text not null default 'draft' check (current_status in ('draft', 'active', 'disabled')),
+        created_at timestamptz not null default now(),
+        updated_at timestamptz not null default now()
+    )`,
+    `create table if not exists crm_atendimento.commercial_segment_versions (
+        id uuid primary key default gen_random_uuid(),
+        segment_id uuid not null references crm_atendimento.commercial_segment_definitions(id) on delete restrict,
+        revision integer not null check (revision >= 1),
+        criteria jsonb not null default '{}'::jsonb,
+        thresholds jsonb not null default '{}'::jsonb,
+        percentiles jsonb not null default '{}'::jsonb,
+        effective_from timestamptz,
+        author_id text not null check (char_length(author_id) between 1 and 160 and author_id !~ '[@]'),
+        created_at timestamptz not null default now(),
+        unique(segment_id, revision)
+    )`,
+    `create table if not exists crm_atendimento.commercial_segment_membership_snapshots (
+        id uuid primary key default gen_random_uuid(),
+        segment_version_id uuid not null references crm_atendimento.commercial_segment_versions(id) on delete restrict,
+        unit_id uuid references crm_atendimento.units(id) on delete restrict,
+        snapshot_date date not null,
+        membership_hash text not null check (membership_hash ~ '^[a-f0-9]{64}$'),
+        population integer not null check (population >= 0),
+        distribution jsonb not null default '{}'::jsonb,
+        metrics jsonb not null default '{}'::jsonb,
+        created_at timestamptz not null default now(),
+        unique(segment_version_id, unit_id, snapshot_date, membership_hash)
+    )`,
+    `create table if not exists crm_atendimento.commercial_segment_memberships (
+        snapshot_id uuid not null references crm_atendimento.commercial_segment_membership_snapshots(id) on delete restrict,
+        identity_id uuid not null references crm_atendimento.global_client_identities(id) on delete restrict,
+        unit_id uuid references crm_atendimento.units(id) on delete restrict,
+        bucket_key text check (bucket_key is null or bucket_key ~ '^[A-Za-z0-9._-]{1,120}$'),
+        created_at timestamptz not null default now(),
+        primary key(snapshot_id, identity_id)
+    )`,
+    `create table if not exists crm_atendimento.commercial_analytics_metric_snapshots (
+        id uuid primary key default gen_random_uuid(),
+        source_key text not null check (source_key ~ '^[A-Za-z0-9._-]{1,120}$'),
+        finding_key text check (finding_key is null or finding_key ~ '^[A-Za-z0-9._-]{1,160}$'),
+        unit_id uuid references crm_atendimento.units(id) on delete restrict,
+        bucket_date date not null,
+        metrics jsonb not null default '{}'::jsonb,
+        metrics_hash text not null check (metrics_hash ~ '^[a-f0-9]{64}$'),
+        created_at timestamptz not null default now(),
+        unique(source_key, finding_key, unit_id, bucket_date, metrics_hash)
+    )`,
+    `create table if not exists crm_atendimento.commercial_analytics_events (
+        id uuid primary key default gen_random_uuid(),
+        identity_id uuid not null references crm_atendimento.global_client_identities(id) on delete restrict,
+        unit_id uuid references crm_atendimento.units(id) on delete restrict,
+        campaign_id uuid references crm_atendimento.commercial_campaigns(id) on delete restrict,
+        offer_id uuid references crm_atendimento.commercial_offers(id) on delete restrict,
+        event_type text not null check (event_type in ('eligible', 'selected', 'action_created', 'contacted', 'delivered', 'responded', 'scheduled', 'attended', 'purchased', 'returned')),
+        channel text check (channel is null or channel ~ '^[A-Za-z0-9._-]{1,80}$'),
+        owner_id text check (owner_id is null or (char_length(owner_id) between 1 and 160 and owner_id !~ '[@]')),
+        policy_version text check (policy_version is null or policy_version ~ '^[A-Za-z0-9._-]{1,120}$'),
+        occurred_at timestamptz not null,
+        correlation_id uuid,
+        created_at timestamptz not null default now(),
+        unique(identity_id, event_type, occurred_at, correlation_id)
+    )`,
+    `create table if not exists crm_atendimento.commercial_experiments (
+        id uuid primary key default gen_random_uuid(),
+        experiment_key text not null unique check (experiment_key ~ '^[A-Za-z0-9._-]{1,120}$'),
+        campaign_id uuid references crm_atendimento.commercial_campaigns(id) on delete restrict,
+        segment_version_id uuid not null references crm_atendimento.commercial_segment_versions(id) on delete restrict,
+        unit_id uuid not null references crm_atendimento.units(id) on delete restrict,
+        attribution_window_id uuid not null references crm_atendimento.commercial_attribution_windows(id) on delete restrict,
+        seed text not null check (seed ~ '^[A-Za-z0-9._-]{1,120}$'),
+        control_group_percent integer not null check (control_group_percent between 1 and 99),
+        state text not null default 'draft' check (state in ('draft', 'active', 'completed', 'cancelled')),
+        starts_at timestamptz not null,
+        ends_at timestamptz not null,
+        revision integer not null default 1 check (revision >= 1),
+        author_id text not null check (char_length(author_id) between 1 and 160 and author_id !~ '[@]'),
+        reason text not null check (char_length(btrim(reason)) between 3 and 1000 and reason !~ '[@]'),
+        created_at timestamptz not null default now(),
+        updated_at timestamptz not null default now(),
+        check (ends_at > starts_at)
+    )`,
+    `create table if not exists crm_atendimento.commercial_experiment_assignments (
+        experiment_id uuid not null references crm_atendimento.commercial_experiments(id) on delete restrict,
+        identity_id uuid not null references crm_atendimento.global_client_identities(id) on delete restrict,
+        unit_id uuid not null references crm_atendimento.units(id) on delete restrict,
+        variant text not null check (variant in ('control', 'treatment', 'excluded')),
+        eligible boolean not null,
+        exclusion_reason text check (exclusion_reason is null or exclusion_reason ~ '^[A-Za-z0-9._-]{1,120}$'),
+        created_at timestamptz not null default now(),
+        primary key(experiment_id, identity_id)
+    )`,
+    `create index if not exists commercial_analytics_metrics_scope_v2_idx on crm_atendimento.commercial_analytics_metric_snapshots(unit_id, bucket_date desc)`,
+    `create index if not exists commercial_analytics_events_scope_v2_idx on crm_atendimento.commercial_analytics_events(unit_id, event_type, occurred_at desc)`,
+    `create index if not exists commercial_segment_snapshot_scope_v2_idx on crm_atendimento.commercial_segment_membership_snapshots(segment_version_id, unit_id, snapshot_date desc)`,
+    `create index if not exists commercial_experiment_assignment_identity_v2_idx on crm_atendimento.commercial_experiment_assignments(identity_id, experiment_id)`,
+    `create or replace function crm_atendimento.prevent_commercial_analytics_evidence_mutation_v2()
+        returns trigger language plpgsql as $$ begin
+            raise exception 'commercial analytics evidence is append-only';
+        end $$`,
+    ...[
+        'commercial_attribution_windows', 'commercial_segment_versions',
+        'commercial_segment_membership_snapshots', 'commercial_segment_memberships',
+        'commercial_analytics_metric_snapshots', 'commercial_analytics_events',
+        'commercial_experiment_assignments',
+    ].flatMap((table) => [
+        createTriggerIfMissing(`crm_atendimento.${table}`, `${table}_v2_immutable`, `create trigger ${table}_v2_immutable before update or delete on crm_atendimento.${table} for each row execute function crm_atendimento.prevent_commercial_analytics_evidence_mutation_v2()`),
+        createTriggerIfMissing(`crm_atendimento.${table}`, `${table}_v2_no_truncate`, `create trigger ${table}_v2_no_truncate before truncate on crm_atendimento.${table} for each statement execute function crm_atendimento.prevent_commercial_analytics_evidence_mutation_v2()`),
+    ]),
+])
+
+const EVIDENCE_TABLES = Object.freeze([
+    'commercial_attribution_windows', 'commercial_segment_versions',
+    'commercial_segment_membership_snapshots', 'commercial_segment_memberships',
+    'commercial_analytics_metric_snapshots', 'commercial_analytics_events',
+    'commercial_experiment_assignments',
+])
+
+function triggerReadinessStatement() {
+    const fields = EVIDENCE_TABLES.flatMap((table, index) => [
+        `exists(select 1 from pg_trigger where tgrelid = to_regclass('crm_atendimento.${table}') and tgname = '${table}_v2_immutable' and tgenabled = 'O' and tgfoid = to_regprocedure('crm_atendimento.prevent_commercial_analytics_evidence_mutation_v2()')) as immutable_${index}`,
+        `exists(select 1 from pg_trigger where tgrelid = to_regclass('crm_atendimento.${table}') and tgname = '${table}_v2_no_truncate' and tgenabled = 'O' and tgfoid = to_regprocedure('crm_atendimento.prevent_commercial_analytics_evidence_mutation_v2()')) as no_truncate_${index}`,
+    ])
+    return `select ${fields.join(', ')}`
+}
+
+async function ensureRegistry(client) {
+    await client.query(`create schema if not exists crm_atendimento`)
+    await client.query(`create table if not exists crm_atendimento.schema_migrations (id text primary key, applied_at timestamptz not null default now(), rolled_back_at timestamptz, details jsonb not null default '{}'::jsonb)`)
+}
+
+async function assertPrerequisites(client) {
+    const fields = PREREQUISITES.map((relation, index) => `to_regclass('${relation}') is not null as relation_${index}`).join(', ')
+    const result = await client.query(`select ${fields}`)
+    if (!Object.values(result.rows[0] || {}).every(Boolean)) throw migrationError('COMMERCIAL_ANALYTICS_PREREQUISITES_MISSING')
+}
+
+async function assertDestination(client, databaseUrl, target) {
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw migrationError('COMMERCIAL_ANALYTICS_DESTINATION_UNSAFE')
+    try { return await assertAtendimentoMigrationDestination(client, databaseUrl, target) } catch { throw migrationError('COMMERCIAL_ANALYTICS_DESTINATION_UNSAFE') }
+}
+
+export function commercialAnalyticsMigrationPlan() {
+    return {
+        id: COMMERCIAL_ANALYTICS_MIGRATION_ID,
+        adds: ['commercial_attribution_windows', 'commercial_segment_definitions', 'commercial_segment_versions', 'commercial_segment_membership_snapshots', 'commercial_segment_memberships', 'commercial_analytics_metric_snapshots', 'commercial_analytics_events', 'commercial_experiments', 'commercial_experiment_assignments'],
+        appendOnlyTables: EVIDENCE_TABLES,
+        piiPolicy: 'Analytics stores only identity UUIDs for internal joins plus bounded aggregate metrics, hashes, dates, allowlisted codes and opaque actor identifiers. It stores no name, phone, email, message body, raw evidence or provider payload.',
+        messagingPolicy: 'Analytics and experiments do not schedule, dispatch or retry messages. Control assignments only block crossover during the configured window.',
+        rollback: 'Non-destructive: evidence remains retained; rollback records the migration state without deleting campaigns, members, metrics, assignments or events.',
+    }
+}
+
+export async function applyCommercialAnalyticsMigration({ pool, databaseUrl, target = ATENDIMENTO_MIGRATION_TARGETS.LOCAL } = {}) {
+    if (!pool) throw migrationError('COMMERCIAL_ANALYTICS_POOL_REQUIRED')
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw migrationError('COMMERCIAL_ANALYTICS_DESTINATION_UNSAFE')
+    const client = await pool.connect(); let transactionOpen = false
+    try {
+        await client.query('begin'); transactionOpen = true
+        await client.query(`set local lock_timeout = '3s'`)
+        await client.query(`set local statement_timeout = '60s'`)
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [COMMERCIAL_ANALYTICS_MIGRATION_ID])
+        const destination = await assertDestination(client, databaseUrl, target)
+        await ensureRegistry(client); await assertPrerequisites(client)
+        for (const statement of STATEMENTS) await client.query(statement)
+        const triggerResult = await client.query(triggerReadinessStatement())
+        if (!Object.values(triggerResult.rows[0] || {}).every(Boolean)) throw migrationError('COMMERCIAL_ANALYTICS_APPEND_ONLY_GUARD_MISSING')
+        const grants = runtimeGrantStatements(target)
+        for (const statement of grants) await client.query(statement)
+        const report = { ...commercialAnalyticsMigrationPlan(), applied: true, target, database: destination.database, runtimeRole: RUNTIME_ROLES[target] }
+        await client.query(`insert into crm_atendimento.schema_migrations(id, applied_at, rolled_back_at, details) values ($1, now(), null, $2::jsonb) on conflict(id) do update set applied_at=excluded.applied_at, rolled_back_at=null, details=excluded.details`, [COMMERCIAL_ANALYTICS_MIGRATION_ID, JSON.stringify(report)])
+        await client.query('commit'); transactionOpen = false
+        return report
+    } catch (error) {
+        if (transactionOpen) { try { await client.query('rollback') } catch { /* preserve original */ } }
+        throw error
+    } finally { client.release() }
+}
+
+export async function rollbackCommercialAnalyticsMigration({ pool, databaseUrl, target = ATENDIMENTO_MIGRATION_TARGETS.LOCAL } = {}) {
+    if (!pool) throw migrationError('COMMERCIAL_ANALYTICS_POOL_REQUIRED')
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw migrationError('COMMERCIAL_ANALYTICS_DESTINATION_UNSAFE')
+    const client = await pool.connect(); let transactionOpen = false
+    try {
+        await client.query('begin'); transactionOpen = true
+        await client.query(`set local lock_timeout = '3s'`)
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [COMMERCIAL_ANALYTICS_MIGRATION_ID])
+        await assertDestination(client, databaseUrl, target); await ensureRegistry(client)
+        await client.query(`insert into crm_atendimento.schema_migrations(id, applied_at, rolled_back_at, details) values ($1, now(), now(), '{"rollback":"non-destructive","evidenceRetained":true}'::jsonb) on conflict(id) do update set rolled_back_at=now(), details=excluded.details`, [COMMERCIAL_ANALYTICS_MIGRATION_ID])
+        await client.query('commit'); transactionOpen = false
+        return { id: COMMERCIAL_ANALYTICS_MIGRATION_ID, rolledBack: true, destructive: false, evidenceRetained: true }
+    } catch (error) {
+        if (transactionOpen) { try { await client.query('rollback') } catch { /* preserve original */ } }
+        throw error
+    } finally { client.release() }
+}
+
+export const __testables = { STATEMENTS, EVIDENCE_TABLES, PREREQUISITES, runtimeGrantStatements, triggerReadinessStatement }

--- a/crm/api/server/atendimento/commercialAnalyticsMigration.js
+++ b/crm/api/server/atendimento/commercialAnalyticsMigration.js
@@ -17,6 +17,7 @@ const PREREQUISITES = Object.freeze([
     'crm_atendimento.commercial_actions',
     'crm_atendimento.commercial_campaigns',
     'crm_atendimento.commercial_campaign_members',
+    'crm_atendimento.commercial_offers',
     'crm_atendimento.commercial_data_quality_findings',
     'crm_atendimento.commercial_data_quality_finding_events',
 ])
@@ -48,6 +49,10 @@ function runtimeGrantStatements(target) {
         `grant usage on schema crm_atendimento to ${role}`,
         ...appendOnly.map((table) => `grant select, insert on table crm_atendimento.${table} to ${role}`),
         ...mutable.map((table) => `grant select, insert, update on table crm_atendimento.${table} to ${role}`),
+        // Runtime readiness reads the migration ledger before exposing any
+        // analytics result.  Without this narrow grant a correctly migrated
+        // staging database would appear permanently unavailable to the app.
+        `grant select on table crm_atendimento.schema_migrations to ${role}`,
     ]
 }
 
@@ -82,13 +87,15 @@ const STATEMENTS = Object.freeze([
         id uuid primary key default gen_random_uuid(),
         segment_id uuid not null references crm_atendimento.commercial_segment_definitions(id) on delete restrict,
         revision integer not null check (revision >= 1),
+        version_key text not null check (version_key ~ '^[A-Za-z0-9._-]{1,120}$'),
         criteria jsonb not null default '{}'::jsonb,
         thresholds jsonb not null default '{}'::jsonb,
         percentiles jsonb not null default '{}'::jsonb,
         effective_from timestamptz,
         author_id text not null check (char_length(author_id) between 1 and 160 and author_id !~ '[@]'),
         created_at timestamptz not null default now(),
-        unique(segment_id, revision)
+        unique(segment_id, revision),
+        unique(segment_id, version_key)
     )`,
     `create table if not exists crm_atendimento.commercial_segment_membership_snapshots (
         id uuid primary key default gen_random_uuid(),
@@ -100,7 +107,7 @@ const STATEMENTS = Object.freeze([
         distribution jsonb not null default '{}'::jsonb,
         metrics jsonb not null default '{}'::jsonb,
         created_at timestamptz not null default now(),
-        unique(segment_version_id, unit_id, snapshot_date, membership_hash)
+        unique nulls not distinct(segment_version_id, unit_id, snapshot_date, membership_hash)
     )`,
     `create table if not exists crm_atendimento.commercial_segment_memberships (
         snapshot_id uuid not null references crm_atendimento.commercial_segment_membership_snapshots(id) on delete restrict,
@@ -119,7 +126,7 @@ const STATEMENTS = Object.freeze([
         metrics jsonb not null default '{}'::jsonb,
         metrics_hash text not null check (metrics_hash ~ '^[a-f0-9]{64}$'),
         created_at timestamptz not null default now(),
-        unique(source_key, finding_key, unit_id, bucket_date, metrics_hash)
+        unique nulls not distinct(source_key, finding_key, unit_id, bucket_date, metrics_hash)
     )`,
     `create table if not exists crm_atendimento.commercial_analytics_events (
         id uuid primary key default gen_random_uuid(),
@@ -132,6 +139,7 @@ const STATEMENTS = Object.freeze([
         channel text check (channel is null or channel ~ '^[A-Za-z0-9._-]{1,80}$'),
         owner_id text check (owner_id is null or (char_length(owner_id) between 1 and 160 and owner_id !~ '[@]')),
         policy_version text check (policy_version is null or policy_version ~ '^[A-Za-z0-9._-]{1,120}$'),
+        revenue_cents bigint check (revenue_cents is null or revenue_cents >= 0),
         occurred_at timestamptz not null,
         correlation_id uuid,
         created_at timestamptz not null default now(),

--- a/crm/api/server/atendimento/commercialAnalyticsMigration.js
+++ b/crm/api/server/atendimento/commercialAnalyticsMigration.js
@@ -37,7 +37,7 @@ function runtimeGrantStatements(target) {
     const appendOnly = [
         'commercial_attribution_windows', 'commercial_segment_versions',
         'commercial_segment_membership_snapshots', 'commercial_segment_memberships',
-        'commercial_analytics_metric_snapshots', 'commercial_analytics_events',
+        'commercial_analytics_metric_snapshots', 'commercial_analytics_events', 'commercial_analytics_mutations',
         'commercial_experiment_assignments',
     ]
     const mutable = ['commercial_segment_definitions', 'commercial_experiments']
@@ -123,6 +123,7 @@ const STATEMENTS = Object.freeze([
     )`,
     `create table if not exists crm_atendimento.commercial_analytics_events (
         id uuid primary key default gen_random_uuid(),
+        event_key text not null unique check (event_key ~ '^[a-f0-9]{64}$'),
         identity_id uuid not null references crm_atendimento.global_client_identities(id) on delete restrict,
         unit_id uuid references crm_atendimento.units(id) on delete restrict,
         campaign_id uuid references crm_atendimento.commercial_campaigns(id) on delete restrict,
@@ -135,6 +136,16 @@ const STATEMENTS = Object.freeze([
         correlation_id uuid,
         created_at timestamptz not null default now(),
         unique(identity_id, event_type, occurred_at, correlation_id)
+    )`,
+    `create table if not exists crm_atendimento.commercial_analytics_mutations (
+        id uuid primary key default gen_random_uuid(),
+        actor_id text not null check (char_length(actor_id) between 1 and 160 and actor_id !~ '[@]'),
+        operation text not null check (operation in ('attribution_window_create', 'segment_version_create', 'segment_snapshot_create', 'metric_snapshot_record', 'analytics_event_record', 'experiment_create', 'experiment_assign')),
+        mutation_key text not null check (mutation_key ~ '^[a-f0-9]{64}$'),
+        request_fingerprint text not null check (request_fingerprint ~ '^[a-f0-9]{64}$'),
+        response jsonb not null default '{}'::jsonb,
+        created_at timestamptz not null default now(),
+        unique(actor_id, operation, mutation_key)
     )`,
     `create table if not exists crm_atendimento.commercial_experiments (
         id uuid primary key default gen_random_uuid(),
@@ -176,7 +187,7 @@ const STATEMENTS = Object.freeze([
     ...[
         'commercial_attribution_windows', 'commercial_segment_versions',
         'commercial_segment_membership_snapshots', 'commercial_segment_memberships',
-        'commercial_analytics_metric_snapshots', 'commercial_analytics_events',
+        'commercial_analytics_metric_snapshots', 'commercial_analytics_events', 'commercial_analytics_mutations',
         'commercial_experiment_assignments',
     ].flatMap((table) => [
         createTriggerIfMissing(`crm_atendimento.${table}`, `${table}_v2_immutable`, `create trigger ${table}_v2_immutable before update or delete on crm_atendimento.${table} for each row execute function crm_atendimento.prevent_commercial_analytics_evidence_mutation_v2()`),
@@ -187,7 +198,7 @@ const STATEMENTS = Object.freeze([
 const EVIDENCE_TABLES = Object.freeze([
     'commercial_attribution_windows', 'commercial_segment_versions',
     'commercial_segment_membership_snapshots', 'commercial_segment_memberships',
-    'commercial_analytics_metric_snapshots', 'commercial_analytics_events',
+    'commercial_analytics_metric_snapshots', 'commercial_analytics_events', 'commercial_analytics_mutations',
     'commercial_experiment_assignments',
 ])
 
@@ -218,7 +229,7 @@ async function assertDestination(client, databaseUrl, target) {
 export function commercialAnalyticsMigrationPlan() {
     return {
         id: COMMERCIAL_ANALYTICS_MIGRATION_ID,
-        adds: ['commercial_attribution_windows', 'commercial_segment_definitions', 'commercial_segment_versions', 'commercial_segment_membership_snapshots', 'commercial_segment_memberships', 'commercial_analytics_metric_snapshots', 'commercial_analytics_events', 'commercial_experiments', 'commercial_experiment_assignments'],
+        adds: ['commercial_attribution_windows', 'commercial_segment_definitions', 'commercial_segment_versions', 'commercial_segment_membership_snapshots', 'commercial_segment_memberships', 'commercial_analytics_metric_snapshots', 'commercial_analytics_events', 'commercial_analytics_mutations', 'commercial_experiments', 'commercial_experiment_assignments'],
         appendOnlyTables: EVIDENCE_TABLES,
         piiPolicy: 'Analytics stores only identity UUIDs for internal joins plus bounded aggregate metrics, hashes, dates, allowlisted codes and opaque actor identifiers. It stores no name, phone, email, message body, raw evidence or provider payload.',
         messagingPolicy: 'Analytics and experiments do not schedule, dispatch or retry messages. Control assignments only block crossover during the configured window.',

--- a/crm/api/server/atendimento/commercialAnalyticsStore.js
+++ b/crm/api/server/atendimento/commercialAnalyticsStore.js
@@ -1,0 +1,890 @@
+import { createHash, createHmac, randomUUID } from 'node:crypto'
+
+import { createPgPool } from '../harmonia/store/pg.js'
+import {
+    buildCommercialFunnel,
+    buildExperimentAssignments,
+    buildExperimentResult,
+    buildQualityTimeSeries,
+    buildSegmentDrift,
+    buildSegmentMembershipSnapshot,
+    commercialAnalyticsError,
+    normalizeAnalyticsFilters,
+    normalizeAttributionWindows,
+    normalizeSegmentDefinition,
+    sanitizeAnalyticsPayload,
+} from './commercialAnalytics.js'
+import { COMMERCIAL_ANALYTICS_MIGRATION_ID } from './commercialAnalyticsMigration.js'
+
+const UNIT_KEY = /^[a-z][a-z0-9-]{1,79}$/
+const KEY = /^[A-Za-z][A-Za-z0-9._-]{0,119}$/
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const IDEMPOTENCY_KEY = /^[A-Za-z0-9._:-]{8,240}$/
+const PII_VALUE = /@|\+?\d[\d\s().-]{6,}\d/
+const DATE = /^\d{4}-\d{2}-\d{2}$/
+const EVENT_TYPES = new Set([
+    'eligible', 'selected', 'action_created', 'contacted', 'delivered',
+    'responded', 'scheduled', 'attended', 'purchased', 'returned',
+])
+const SNAPSHOT_MEMBER_KEYS = new Set(['identityId', 'identity_id', 'bucket', 'segmentBucket', 'segment_bucket'])
+
+function analyticsError(code, statusCode = 409) {
+    const error = commercialAnalyticsError(code, statusCode)
+    error.code = code
+    error.statusCode = statusCode
+    return error
+}
+
+function text(value, maximum = 240) {
+    return String(value ?? '').trim().slice(0, maximum)
+}
+
+function stable(value) {
+    if (Array.isArray(value)) return value.map(stable)
+    if (!value || typeof value !== 'object') return value
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stable(value[key])]))
+}
+
+function digest(value) {
+    return createHash('sha256').update(JSON.stringify(stable(value))).digest('hex')
+}
+
+function opaqueActorId(actor) {
+    const id = text(actor?.id || actor?.username, 160)
+    if (!id || id.includes('@') || /[\u0000-\u001f\u007f]/.test(id)) throw analyticsError('ANALYTICS_ACTOR_ID_REQUIRED', 401)
+    return id
+}
+
+function role(actor) {
+    return text(actor?.role, 40).toUpperCase()
+}
+
+function isGlobal(actor) {
+    return actor?.isGlobalAdmin === true || role(actor) === 'ADMIN'
+}
+
+function assertManager(actor) {
+    if (isGlobal(actor)) return
+    if (role(actor) !== 'GESTOR') throw analyticsError('FORBIDDEN', 403)
+}
+
+function allowedUnitSlugs(actor) {
+    return [...new Set((Array.isArray(actor?.allowedUnits) ? actor.allowedUnits : [])
+        .map((value) => text(value, 80).toLowerCase())
+        .filter((value) => UNIT_KEY.test(value)))]
+}
+
+function scopedUnits(actor, requestedUnit = null) {
+    assertManager(actor)
+    const requested = requestedUnit ? text(requestedUnit, 80).toLowerCase() : null
+    if (requested && !UNIT_KEY.test(requested)) throw analyticsError('ANALYTICS_UNIT_INVALID', 400)
+    if (isGlobal(actor)) return requested ? [requested] : null
+    const allowed = allowedUnitSlugs(actor)
+    if (!allowed.length) throw analyticsError('ANALYTICS_UNIT_SCOPE_REQUIRED', 403)
+    if (requested && !allowed.includes(requested)) throw analyticsError('FORBIDDEN_UNIT_SCOPE', 403)
+    return requested ? [requested] : allowed
+}
+
+function assertGlobal(actor) {
+    assertManager(actor)
+    if (!isGlobal(actor)) throw analyticsError('ANALYTICS_GLOBAL_SCOPE_REQUIRED', 403)
+}
+
+function normalizeReason(value) {
+    const reason = text(value, 1000)
+    if (reason.length < 3 || PII_VALUE.test(reason) || /[\u0000-\u001f\u007f]/.test(reason)) throw analyticsError('ANALYTICS_REASON_INVALID', 400)
+    return reason
+}
+
+function normalizeDateTime(value, field) {
+    const raw = text(value, 64)
+    const parsed = Date.parse(raw)
+    if (!raw || !Number.isFinite(parsed)) throw analyticsError(`ANALYTICS_${field}_INVALID`, 400)
+    return new Date(parsed).toISOString()
+}
+
+function normalizeDate(value, field) {
+    const raw = text(value, 32).slice(0, 10)
+    if (!DATE.test(raw) || Number.isNaN(Date.parse(`${raw}T00:00:00.000Z`))) {
+        throw analyticsError(`ANALYTICS_${field}_INVALID`, 400)
+    }
+    return raw
+}
+
+function normalizeUuid(value, code = 'ANALYTICS_UUID_INVALID') {
+    const id = text(value, 80).toLowerCase()
+    if (!UUID.test(id)) throw analyticsError(code, 400)
+    return id
+}
+
+function normalizeCount(value, code = 'ANALYTICS_COUNT_INVALID') {
+    const parsed = Number(value)
+    if (!Number.isInteger(parsed) || parsed < 0 || parsed > 2_147_483_647) throw analyticsError(code, 400)
+    return parsed
+}
+
+function normalizeRevenueCents(value) {
+    const parsed = Number(value)
+    if (!Number.isSafeInteger(parsed) || parsed < 0 || parsed > 9_000_000_000_000) {
+        throw analyticsError('ANALYTICS_EVENT_REVENUE_INVALID', 400)
+    }
+    return parsed
+}
+
+function normalizeKey(value, code, maximum = 120) {
+    const normalized = text(value, maximum)
+    if (!KEY.test(normalized) || PII_VALUE.test(normalized)) throw analyticsError(code, 400)
+    return normalized
+}
+
+function normalizeOptionalUuid(value, code) {
+    if (value === null || value === undefined || text(value) === '') return null
+    return normalizeUuid(value, code)
+}
+
+function normalizeOptionalOpaque(value, code, maximum = 160) {
+    const normalized = text(value, maximum)
+    if (!normalized) return null
+    if (!KEY.test(normalized) || PII_VALUE.test(normalized) || /[\u0000-\u001f\u007f]/.test(normalized)) {
+        throw analyticsError(code, 400)
+    }
+    return normalized
+}
+
+function normalizeSafeObject(value, code, { allowEmpty = false } = {}) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) throw analyticsError(code, 400)
+    const sanitized = sanitizeAnalyticsPayload(value)
+    if (!sanitized || Array.isArray(sanitized) || (!allowEmpty && Object.keys(sanitized).length === 0)) throw analyticsError(code, 400)
+    if (JSON.stringify(stable(sanitized)) !== JSON.stringify(stable(value))) throw analyticsError(code, 400)
+    const aggregate = (candidate, depth = 0) => {
+        if (depth > 4 || !candidate || typeof candidate !== 'object' || Array.isArray(candidate)) throw analyticsError(code, 400)
+        const result = {}
+        for (const [key, item] of Object.entries(candidate)) {
+            if (!KEY.test(key) || PII_VALUE.test(key)) throw analyticsError(code, 400)
+            if (item === null || typeof item === 'boolean') {
+                result[key] = item
+            } else if (typeof item === 'number' && Number.isFinite(item) && Math.abs(item) <= Number.MAX_SAFE_INTEGER) {
+                result[key] = item
+            } else if (item && typeof item === 'object' && !Array.isArray(item)) {
+                result[key] = aggregate(item, depth + 1)
+            } else {
+                // Metrics are aggregate numbers/booleans only. Textual labels
+                // would make this store an accidental PII transport.
+                throw analyticsError(code, 400)
+            }
+        }
+        return result
+    }
+    return aggregate(sanitized)
+}
+
+function normalizeSnapshotMembers(value) {
+    if (!Array.isArray(value) || value.length > 50_000) throw analyticsError('ANALYTICS_SNAPSHOT_MEMBERS_INVALID', 400)
+    const byIdentity = new Map()
+    for (const candidate of value) {
+        const record = typeof candidate === 'string' ? { identityId: candidate } : candidate
+        if (!record || typeof record !== 'object' || Array.isArray(record)) throw analyticsError('ANALYTICS_SNAPSHOT_MEMBERS_INVALID', 400)
+        if (Object.keys(record).some((key) => !SNAPSHOT_MEMBER_KEYS.has(key))) throw analyticsError('ANALYTICS_SNAPSHOT_MEMBERS_INVALID', 400)
+        const identityId = normalizeUuid(record.identityId || record.identity_id, 'ANALYTICS_SNAPSHOT_IDENTITY_INVALID')
+        const bucket = text(record.bucket || record.segmentBucket || record.segment_bucket, 120)
+        if (bucket && (!KEY.test(bucket) || PII_VALUE.test(bucket))) throw analyticsError('ANALYTICS_SNAPSHOT_BUCKET_INVALID', 400)
+        if (byIdentity.has(identityId) && byIdentity.get(identityId).bucket !== (bucket || null)) {
+            throw analyticsError('ANALYTICS_SNAPSHOT_IDENTITY_CONFLICT', 409)
+        }
+        byIdentity.set(identityId, { identityId, bucket: bucket || null })
+    }
+    return [...byIdentity.values()].sort((left, right) => left.identityId.localeCompare(right.identityId))
+}
+
+function assertSystemWriter(actor) {
+    if (actor?.system !== true || role(actor) !== 'SYSTEM') throw analyticsError('ANALYTICS_SYSTEM_WRITER_REQUIRED', 403)
+    return opaqueActorId(actor)
+}
+
+function mapWindow(row) {
+    if (!row) return null
+    return {
+        id: row.id,
+        version: row.version,
+        responseDays: Number(row.response_days),
+        appointmentDays: Number(row.appointment_days),
+        attendanceDays: Number(row.attendance_days),
+        saleDays: Number(row.sale_days),
+        returnDays: Number(row.return_days),
+        effectiveFrom: row.effective_from || null,
+        expiresAt: row.expires_at || null,
+        createdAt: row.created_at || null,
+    }
+}
+
+function mapSegment(row) {
+    if (!row) return null
+    return {
+        id: row.id,
+        key: row.segment_key,
+        revision: Number(row.revision || row.current_revision || 0),
+        version: row.version_key || `revision-${Number(row.revision || row.current_revision || 0)}`,
+        status: row.current_status || row.status || 'draft',
+        criteria: sanitizeAnalyticsPayload(row.criteria) || {},
+        thresholds: sanitizeAnalyticsPayload(row.thresholds) || {},
+        percentiles: sanitizeAnalyticsPayload(row.percentiles) || {},
+        effectiveFrom: row.effective_from || null,
+        createdAt: row.created_at || null,
+    }
+}
+
+function mapExperiment(row) {
+    if (!row) return null
+    return {
+        id: row.id,
+        key: row.experiment_key,
+        campaignId: row.campaign_id || null,
+        segmentVersionId: row.segment_version_id,
+        unit: row.unit_slug || null,
+        attributionWindowId: row.attribution_window_id,
+        controlGroupPercent: Number(row.control_group_percent),
+        state: row.state,
+        startsAt: row.starts_at || null,
+        endsAt: row.ends_at || null,
+        revision: Number(row.revision || 0),
+        createdAt: row.created_at || null,
+    }
+}
+
+function mapMetric(row) {
+    return {
+        sourceKey: row.source_key,
+        findingKey: row.finding_key || null,
+        unitSlug: row.unit_slug || null,
+        metrics: sanitizeAnalyticsPayload(row.metrics) || {},
+        occurredAt: row.bucket_date || row.created_at || null,
+    }
+}
+
+function mapEvent(row) {
+    return {
+        identityId: row.identity_id,
+        unitSlug: row.unit_slug || null,
+        campaignId: row.campaign_id || null,
+        campaignKey: row.campaign_key || null,
+        segmentKey: row.segment_key || null,
+        offerId: row.offer_id || null,
+        eventType: row.event_type,
+        channel: row.channel || null,
+        owner: row.owner_id || null,
+        policyVersion: row.policy_version || null,
+        occurredAt: row.occurred_at,
+        revenue: Number(row.revenue_cents || 0) / 100,
+    }
+}
+
+export function createCommercialAnalyticsStore({
+    pool,
+    databaseUrl,
+    mutationHmacKey = process.env.COMMERCIAL_ANALYTICS_MUTATION_HMAC_KEY,
+    clock = () => new Date(),
+} = {}) {
+    const pgPool = pool || createPgPool(databaseUrl || process.env.DATABASE_URL)
+    if (!pgPool) throw analyticsError('COMMERCIAL_ANALYTICS_POOL_REQUIRED', 503)
+    const secret = text(mutationHmacKey, 512)
+
+    async function withTransaction(callback) {
+        const client = await pgPool.connect()
+        let open = false
+        try {
+            await client.query('begin')
+            open = true
+            await client.query(`set local lock_timeout = '3s'`)
+            await client.query(`set local statement_timeout = '30s'`)
+            const result = await callback(client)
+            await client.query('commit')
+            open = false
+            return result
+        } catch (error) {
+            if (open) {
+                try { await client.query('rollback') } catch { /* preserve original error */ }
+            }
+            throw error
+        } finally {
+            client.release()
+        }
+    }
+
+    async function readiness(connection = pgPool) {
+        const availability = await connection.query(`select
+            to_regclass('crm_atendimento.schema_migrations') as registry,
+            to_regclass('crm_atendimento.commercial_attribution_windows') as windows,
+            to_regclass('crm_atendimento.commercial_segment_definitions') as definitions,
+            to_regclass('crm_atendimento.commercial_segment_versions') as versions,
+            to_regclass('crm_atendimento.commercial_analytics_metric_snapshots') as metrics,
+            to_regclass('crm_atendimento.commercial_analytics_events') as events,
+            to_regclass('crm_atendimento.commercial_analytics_mutations') as mutations,
+            to_regclass('crm_atendimento.commercial_experiments') as experiments,
+            to_regclass('crm_atendimento.commercial_experiment_assignments') as assignments`)
+        const row = availability.rows[0] || {}
+        if (!Object.values(row).every(Boolean)) return { ready: false, migrationId: COMMERCIAL_ANALYTICS_MIGRATION_ID }
+        const migration = await connection.query(`select id from crm_atendimento.schema_migrations where id=$1 and rolled_back_at is null`, [COMMERCIAL_ANALYTICS_MIGRATION_ID])
+        return { ready: !!migration.rows[0]?.id, migrationId: COMMERCIAL_ANALYTICS_MIGRATION_ID }
+    }
+
+    async function ensureReady(connection = pgPool) {
+        const status = await readiness(connection)
+        if (!status.ready) throw analyticsError('COMMERCIAL_ANALYTICS_NOT_READY', 503)
+        return status
+    }
+
+    function mutationKey(actorId, operation, idempotencyKey) {
+        if (!secret) throw analyticsError('COMMERCIAL_ANALYTICS_MUTATION_KEY_NOT_CONFIGURED', 503)
+        const value = text(idempotencyKey, 240)
+        if (!IDEMPOTENCY_KEY.test(value)) throw analyticsError('ANALYTICS_IDEMPOTENCY_KEY_INVALID', 400)
+        return createHmac('sha256', secret).update(`${actorId}:${operation}:${value}`).digest('hex')
+    }
+
+    async function runMutation(client, { actor, operation, idempotencyKey, request }, work) {
+        const actorId = opaqueActorId(actor)
+        const key = mutationKey(actorId, operation, idempotencyKey)
+        const requestFingerprint = digest(sanitizeAnalyticsPayload(request) || {})
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [`commercial-analytics:${actorId}:${operation}:${key}`])
+        const existing = await client.query(`select request_fingerprint,response from crm_atendimento.commercial_analytics_mutations
+            where actor_id=$1 and operation=$2 and mutation_key=$3 for update`, [actorId, operation, key])
+        if (existing.rows[0]) {
+            if (existing.rows[0].request_fingerprint !== requestFingerprint) throw analyticsError('ANALYTICS_IDEMPOTENCY_CONFLICT', 409)
+            return existing.rows[0].response
+        }
+        const response = sanitizeAnalyticsPayload(await work()) || {}
+        await client.query(`insert into crm_atendimento.commercial_analytics_mutations(actor_id,operation,mutation_key,request_fingerprint,response)
+            values ($1,$2,$3,$4,$5::jsonb)`, [actorId, operation, key, requestFingerprint, JSON.stringify(response)])
+        return response
+    }
+
+    async function unitRecord(client, value, { required = false } = {}) {
+        const slug = text(value, 80).toLowerCase()
+        if (!slug) {
+            if (required) throw analyticsError('ANALYTICS_UNIT_REQUIRED', 400)
+            return { id: null, slug: null }
+        }
+        if (!UNIT_KEY.test(slug)) throw analyticsError('ANALYTICS_UNIT_INVALID', 400)
+        const result = await client.query(`select id::text,slug from crm_atendimento.units where slug=$1`, [slug])
+        if (!result.rows[0]) throw analyticsError('ANALYTICS_UNIT_NOT_FOUND', 404)
+        return result.rows[0]
+    }
+
+    function systemEventKey(event) {
+        if (!secret) throw analyticsError('COMMERCIAL_ANALYTICS_MUTATION_KEY_NOT_CONFIGURED', 503)
+        return createHmac('sha256', secret)
+            .update(`commercial-analytics-event:${JSON.stringify(stable(event))}`)
+            .digest('hex')
+    }
+
+    async function recordMetricSnapshot(payload, actor) {
+        await ensureReady()
+        const actorId = assertSystemWriter(actor)
+        const sourceKey = normalizeKey(payload?.sourceKey || payload?.source_key, 'ANALYTICS_METRIC_SOURCE_INVALID')
+        const findingKey = payload?.findingKey || payload?.finding_key
+            ? normalizeKey(payload.findingKey || payload.finding_key, 'ANALYTICS_METRIC_FINDING_INVALID', 160)
+            : null
+        const bucketDate = normalizeDate(payload?.bucketDate || payload?.bucket_date || clock().toISOString(), 'METRIC_BUCKET_DATE')
+        const metrics = normalizeSafeObject(payload?.metrics, 'ANALYTICS_METRIC_PAYLOAD_INVALID', { allowEmpty: true })
+        return withTransaction(async (client) => {
+            const unit = await unitRecord(client, payload?.unit || payload?.unitSlug || payload?.unit_slug)
+            const metricsHash = digest({ sourceKey, findingKey, unit: unit.slug, bucketDate, metrics })
+            return runMutation(client, {
+                actor,
+                operation: 'metric_snapshot_record',
+                idempotencyKey: payload?.idempotencyKey,
+                request: { sourceKey, findingKey, unit: unit.slug, bucketDate, metricsHash, metrics },
+            }, async () => {
+                const inserted = await client.query(`insert into crm_atendimento.commercial_analytics_metric_snapshots(
+                        source_key,finding_key,unit_id,bucket_date,metrics,metrics_hash)
+                    values($1,$2,$3::uuid,$4::date,$5::jsonb,$6)
+                    on conflict do nothing returning source_key,finding_key,unit_id::text,bucket_date,metrics,created_at`, [
+                    sourceKey, findingKey, unit.id, bucketDate, JSON.stringify(metrics), metricsHash,
+                ])
+                const row = inserted.rows[0] || (await client.query(`select source_key,finding_key,unit_id::text,bucket_date,metrics,created_at
+                    from crm_atendimento.commercial_analytics_metric_snapshots
+                    where source_key=$1 and finding_key is not distinct from $2 and unit_id is not distinct from $3::uuid
+                        and bucket_date=$4::date and metrics_hash=$5`, [sourceKey, findingKey, unit.id, bucketDate, metricsHash])).rows[0]
+                return { metric: mapMetric({ ...row, unit_slug: unit.slug }), actor: actorId }
+            })
+        })
+    }
+
+    async function recordSegmentSnapshot(payload, actor) {
+        await ensureReady()
+        const actorId = assertSystemWriter(actor)
+        const segmentVersionId = normalizeUuid(payload?.segmentVersionId || payload?.segment_version_id, 'ANALYTICS_SEGMENT_VERSION_ID_INVALID')
+        const snapshotDate = normalizeDate(payload?.snapshotDate || payload?.snapshot_date || clock().toISOString(), 'SNAPSHOT_DATE')
+        const members = normalizeSnapshotMembers(payload?.members)
+        const metrics = payload?.metrics === undefined ? {} : normalizeSafeObject(payload.metrics, 'ANALYTICS_SNAPSHOT_METRICS_INVALID', { allowEmpty: true })
+        return withTransaction(async (client) => {
+            const unit = await unitRecord(client, payload?.unit || payload?.unitSlug || payload?.unit_slug)
+            const version = await client.query(`select version.id::text,version.revision,version.version_key,version.criteria,definition.segment_key
+                from crm_atendimento.commercial_segment_versions version
+                join crm_atendimento.commercial_segment_definitions definition on definition.id=version.segment_id
+                where version.id=$1::uuid`, [segmentVersionId])
+            const row = version.rows[0]
+            if (!row) throw analyticsError('ANALYTICS_SEGMENT_VERSION_NOT_FOUND', 404)
+            const criteria = sanitizeAnalyticsPayload(row.criteria) || {}
+            const snapshot = buildSegmentMembershipSnapshot({
+                key: row.segment_key,
+                version: row.version_key,
+                criteria: Object.keys(criteria).length ? criteria : { source: 'durable' },
+            }, members, { snapshotAt: `${snapshotDate}T00:00:00.000Z`, unitSlug: unit.slug })
+            return runMutation(client, {
+                actor,
+                operation: 'segment_snapshot_create',
+                idempotencyKey: payload?.idempotencyKey,
+                request: {
+                    segmentVersionId, unit: unit.slug, snapshotDate,
+                    membershipHash: snapshot.membershipHash, population: snapshot.memberCount,
+                    distribution: snapshot.distribution, metrics,
+                },
+            }, async () => {
+                if (members.length) {
+                    const known = await client.query(`select id::text from crm_atendimento.global_client_identities
+                        where id = any($1::uuid[])`, [members.map((member) => member.identityId)])
+                    if (known.rows.length !== members.length) throw analyticsError('ANALYTICS_SNAPSHOT_IDENTITIES_MISSING', 409)
+                }
+                const inserted = await client.query(`insert into crm_atendimento.commercial_segment_membership_snapshots(
+                        segment_version_id,unit_id,snapshot_date,membership_hash,population,distribution,metrics)
+                    values($1::uuid,$2::uuid,$3::date,$4,$5,$6::jsonb,$7::jsonb)
+                    on conflict do nothing returning id::text`, [
+                    segmentVersionId, unit.id, snapshotDate, snapshot.membershipHash, snapshot.memberCount,
+                    JSON.stringify(snapshot.distribution), JSON.stringify(metrics),
+                ])
+                const snapshotId = inserted.rows[0]?.id || (await client.query(`select id::text
+                    from crm_atendimento.commercial_segment_membership_snapshots
+                    where segment_version_id=$1::uuid and unit_id is not distinct from $2::uuid
+                        and snapshot_date=$3::date and membership_hash=$4`, [segmentVersionId, unit.id, snapshotDate, snapshot.membershipHash])).rows[0]?.id
+                if (!snapshotId) throw analyticsError('ANALYTICS_SNAPSHOT_PERSISTENCE_FAILED', 503)
+                if (inserted.rows[0]) {
+                    for (let start = 0; start < members.length; start += 500) {
+                        const batch = members.slice(start, start + 500)
+                        const values = []; const params = []
+                        for (const member of batch) {
+                            params.push(snapshotId, member.identityId, unit.id, member.bucket)
+                            const offset = params.length - 3
+                            values.push(`($${offset}::uuid,$${offset + 1}::uuid,$${offset + 2}::uuid,$${offset + 3})`)
+                        }
+                        await client.query(`insert into crm_atendimento.commercial_segment_memberships(snapshot_id,identity_id,unit_id,bucket_key)
+                            values ${values.join(',')} on conflict do nothing`, params)
+                    }
+                }
+                return {
+                    snapshot: {
+                        id: snapshotId,
+                        segmentVersionId,
+                        unit: unit.slug,
+                        snapshotDate,
+                        population: snapshot.memberCount,
+                        distribution: snapshot.distribution,
+                    },
+                    actor: actorId,
+                }
+            })
+        })
+    }
+
+    async function recordAnalyticsEvent(payload, actor) {
+        await ensureReady()
+        const actorId = assertSystemWriter(actor)
+        const identityId = normalizeUuid(payload?.identityId || payload?.identity_id, 'ANALYTICS_EVENT_IDENTITY_INVALID')
+        const unitSlug = text(payload?.unit || payload?.unitSlug || payload?.unit_slug, 80).toLowerCase()
+        const eventType = text(payload?.eventType || payload?.event_type, 80).toLowerCase()
+        if (!EVENT_TYPES.has(eventType)) throw analyticsError('ANALYTICS_EVENT_TYPE_INVALID', 400)
+        const occurredAt = normalizeDateTime(payload?.occurredAt || payload?.occurred_at || clock().toISOString(), 'EVENT_OCCURRED_AT')
+        const campaignId = normalizeOptionalUuid(payload?.campaignId || payload?.campaign_id, 'ANALYTICS_EVENT_CAMPAIGN_INVALID')
+        const offerId = normalizeOptionalUuid(payload?.offerId || payload?.offer_id, 'ANALYTICS_EVENT_OFFER_INVALID')
+        const correlationId = normalizeOptionalUuid(payload?.correlationId || payload?.correlation_id, 'ANALYTICS_EVENT_CORRELATION_INVALID')
+        const channel = normalizeOptionalOpaque(payload?.channel, 'ANALYTICS_EVENT_CHANNEL_INVALID', 80)
+        const ownerId = normalizeOptionalOpaque(payload?.ownerId || payload?.owner_id, 'ANALYTICS_EVENT_OWNER_INVALID')
+        const policyVersion = normalizeOptionalOpaque(payload?.policyVersion || payload?.policy_version, 'ANALYTICS_EVENT_POLICY_INVALID', 120)
+        const revenueCents = payload?.revenueCents === undefined && payload?.revenue_cents === undefined
+            ? null
+            : normalizeRevenueCents(payload?.revenueCents ?? payload?.revenue_cents)
+        return withTransaction(async (client) => {
+            const unit = await unitRecord(client, unitSlug, { required: true })
+            const prerequisites = await client.query(`select
+                exists(select 1 from crm_atendimento.global_client_identities where id=$1::uuid) as identity,
+                ($2::uuid is null or exists(select 1 from crm_atendimento.commercial_campaigns where id=$2::uuid and unit_id=$4::uuid)) as campaign,
+                ($3::uuid is null or exists(select 1 from crm_atendimento.commercial_offers where id=$3::uuid and unit_id=$4::uuid)) as offer`, [
+                identityId, campaignId, offerId, unit.id,
+            ])
+            if (!Object.values(prerequisites.rows[0] || {}).every(Boolean)) throw analyticsError('ANALYTICS_EVENT_PREREQUISITE_MISSING', 409)
+            const event = { identityId, unit: unit.slug, campaignId, offerId, eventType, channel, ownerId, policyVersion, revenueCents, occurredAt, correlationId }
+            const eventKey = systemEventKey(event)
+            return runMutation(client, {
+                actor,
+                operation: 'analytics_event_record',
+                idempotencyKey: payload?.idempotencyKey,
+                request: { ...event, eventKey },
+            }, async () => {
+                const inserted = await client.query(`insert into crm_atendimento.commercial_analytics_events(
+                        event_key,identity_id,unit_id,campaign_id,offer_id,event_type,channel,owner_id,policy_version,revenue_cents,occurred_at,correlation_id)
+                    values($1,$2::uuid,$3::uuid,$4::uuid,$5::uuid,$6,$7,$8,$9,$10,$11,$12::uuid)
+                    on conflict do nothing returning identity_id::text,unit_id::text,campaign_id::text,offer_id::text,event_type,channel,owner_id,policy_version,revenue_cents,occurred_at`, [
+                    eventKey, identityId, unit.id, campaignId, offerId, eventType, channel, ownerId, policyVersion, revenueCents, occurredAt, correlationId,
+                ])
+                const persisted = inserted.rows[0] || (await client.query(`select identity_id::text,unit_id::text,campaign_id::text,offer_id::text,event_type,channel,owner_id,policy_version,revenue_cents,occurred_at
+                    from crm_atendimento.commercial_analytics_events where event_key=$1`, [eventKey])).rows[0]
+                if (!persisted) throw analyticsError('ANALYTICS_EVENT_PERSISTENCE_FAILED', 503)
+                return { event: { type: persisted.event_type, unit: unit.slug, occurredAt: persisted.occurred_at }, actor: actorId }
+            })
+        })
+    }
+
+    async function visibleMetrics(filters, actor) {
+        const units = scopedUnits(actor, filters.unit)
+        const params = []
+        const where = []
+        if (units !== null) {
+            params.push(units)
+            where.push(`unit.slug = any($${params.length}::text[])`)
+        }
+        if (filters.findingKey) { params.push(filters.findingKey); where.push(`snapshot.finding_key=$${params.length}`) }
+        if (filters.sourceKey) { params.push(filters.sourceKey); where.push(`snapshot.source_key=$${params.length}`) }
+        if (filters.from) { params.push(filters.from); where.push(`snapshot.bucket_date >= $${params.length}::date`) }
+        if (filters.to) { params.push(filters.to); where.push(`snapshot.bucket_date <= $${params.length}::date`) }
+        params.push(filters.limit)
+        const result = await pgPool.query(`select snapshot.source_key,snapshot.finding_key,unit.slug as unit_slug,snapshot.metrics,
+                snapshot.bucket_date,snapshot.created_at
+            from crm_atendimento.commercial_analytics_metric_snapshots snapshot
+            left join crm_atendimento.units unit on unit.id=snapshot.unit_id
+            ${where.length ? `where ${where.join(' and ')}` : ''}
+            order by snapshot.bucket_date desc,snapshot.created_at desc limit $${params.length}`, params)
+        return result.rows.map(mapMetric)
+    }
+
+    async function quality(query, actor) {
+        await ensureReady()
+        const filters = normalizeAnalyticsFilters(query)
+        const metrics = await visibleMetrics(filters, actor)
+        if (!isGlobal(actor)) {
+            return {
+                scope: 'unit_aggregate',
+                filters,
+                ...buildQualityTimeSeries({ metricSnapshots: metrics, asOf: clock(), granularity: filters.granularity }),
+                findingsAvailable: false,
+            }
+        }
+        const [findings, events] = await Promise.all([
+            pgPool.query(`select finding_key,severity,status,owner,observed_count,sla_due_at,first_detected_at,last_observed_at,
+                    last_evaluated_at,acknowledged_at,resolved_at from crm_atendimento.commercial_data_quality_findings
+                order by finding_key`),
+            pgPool.query(`select finding.finding_key,event.event_type,event.status,event.observed_count,event.created_at
+                from crm_atendimento.commercial_data_quality_finding_events event
+                join crm_atendimento.commercial_data_quality_findings finding on finding.id=event.finding_id
+                order by event.created_at asc`),
+        ])
+        return {
+            scope: 'global_aggregate',
+            filters,
+            ...buildQualityTimeSeries({ findings: findings.rows, findingEvents: events.rows, metricSnapshots: metrics, asOf: clock(), granularity: filters.granularity }),
+            findingsAvailable: true,
+        }
+    }
+
+    async function resolvedWindows(filters) {
+        const params = []
+        const where = [`effective_from <= now()`, `(expires_at is null or expires_at > now())`]
+        if (filters?.attributionWindowVersion) { params.push(text(filters.attributionWindowVersion, 120)); where.push(`version=$${params.length}`) }
+        const result = await pgPool.query(`select * from crm_atendimento.commercial_attribution_windows
+            where ${where.join(' and ')} order by effective_from desc limit 1`, params)
+        return mapWindow(result.rows[0])
+    }
+
+    async function funnel(query, actor) {
+        await ensureReady()
+        const filters = normalizeAnalyticsFilters(query)
+        const units = scopedUnits(actor, filters.unit)
+        const params = []
+        const eventWhere = []
+        if (units !== null) { params.push(units); eventWhere.push(`unit.slug = any($${params.length}::text[])`) }
+        if (filters.from) { params.push(filters.from); eventWhere.push(`event.occurred_at >= $${params.length}::date`) }
+        if (filters.to) { params.push(filters.to); eventWhere.push(`event.occurred_at < ($${params.length}::date + interval '1 day')`) }
+        const eventSql = `select event.identity_id::text,event.event_type,event.channel,event.owner_id,event.policy_version,event.occurred_at,event.revenue_cents,
+                unit.slug as unit_slug,event.campaign_id::text,campaign.segment_key,event.offer_id::text
+            from crm_atendimento.commercial_analytics_events event
+            left join crm_atendimento.units unit on unit.id=event.unit_id
+            left join crm_atendimento.commercial_campaigns campaign on campaign.id=event.campaign_id
+            ${eventWhere.length ? `where ${eventWhere.join(' and ')}` : ''}`
+        const memberParams = units === null ? [] : [units]
+        const memberWhere = units === null ? '' : 'where unit.slug = any($1::text[])'
+        const actionParams = units === null ? [] : [units]
+        const actionWhere = units === null ? '' : 'where unit.slug = any($1::text[])'
+        const assignmentParams = units === null ? [] : [units]
+        const assignmentWhere = units === null ? '' : 'where unit.slug = any($1::text[])'
+        const [events, members, actions, assignments, window] = await Promise.all([
+            pgPool.query(eventSql, params),
+            pgPool.query(`select member.identity_id::text,unit.slug as unit_slug,member.created_at,campaign.id::text as campaign_id,
+                    campaign.segment_key,member.owner,member.offer_id::text
+                from crm_atendimento.commercial_campaign_members member
+                join crm_atendimento.units unit on unit.id=member.unit_id
+                join crm_atendimento.commercial_campaigns campaign on campaign.id=member.campaign_id ${memberWhere}`, memberParams),
+            pgPool.query(`select action.identity_id::text,action.status,action.contacted_at,action.created_at,action.updated_at,
+                    unit.slug as unit_slug,member.campaign_id::text,campaign.segment_key,member.owner,member.offer_id::text
+                from crm_atendimento.commercial_actions action
+                left join crm_atendimento.units unit on unit.id=action.unit_id
+                left join crm_atendimento.commercial_campaign_members member on member.action_id=action.id
+                left join crm_atendimento.commercial_campaigns campaign on campaign.id=member.campaign_id ${actionWhere}`, actionParams),
+            pgPool.query(`select assignment.identity_id::text,assignment.variant,assignment.eligible,unit.slug as unit_slug
+                from crm_atendimento.commercial_experiment_assignments assignment
+                join crm_atendimento.units unit on unit.id=assignment.unit_id ${assignmentWhere}`, assignmentParams),
+            resolvedWindows(query),
+        ])
+        const funnelResult = buildCommercialFunnel({
+            eligibleIdentities: events.rows.filter((row) => row.event_type === 'eligible'),
+            campaignMembers: members.rows,
+            actions: actions.rows,
+            events: events.rows.map(mapEvent),
+            assignments: assignments.rows,
+            windows: window || undefined,
+            filters,
+        })
+        return { scope: units === null ? 'global_aggregate' : 'unit_aggregate', filters, attributionWindow: window, ...funnelResult }
+    }
+
+    async function attributionWindows(query, actor) {
+        await ensureReady()
+        assertManager(actor)
+        const limit = Math.min(100, Math.max(1, Number(query?.limit || 30)))
+        const result = await pgPool.query(`select * from crm_atendimento.commercial_attribution_windows order by effective_from desc limit $1`, [limit])
+        return { windows: result.rows.map(mapWindow) }
+    }
+
+    async function createAttributionWindow(payload, actor) {
+        await ensureReady()
+        assertGlobal(actor)
+        const actorId = opaqueActorId(actor)
+        const normalized = normalizeAttributionWindows(payload)
+        const reason = normalizeReason(payload?.reason)
+        const effectiveFrom = normalizeDateTime(payload?.effectiveFrom || payload?.effective_from || clock().toISOString(), 'EFFECTIVE_FROM')
+        const expiresAt = payload?.expiresAt || payload?.expires_at ? normalizeDateTime(payload.expiresAt || payload.expires_at, 'EXPIRES_AT') : null
+        if (expiresAt && expiresAt <= effectiveFrom) throw analyticsError('ANALYTICS_WINDOW_PERIOD_INVALID', 400)
+        return withTransaction(async (client) => runMutation(client, {
+            actor, operation: 'attribution_window_create', idempotencyKey: payload?.idempotencyKey,
+            request: { version: normalized.version, ...normalized, effectiveFrom, expiresAt, reason },
+        }, async () => {
+            const inserted = await client.query(`insert into crm_atendimento.commercial_attribution_windows(
+                    version,response_days,appointment_days,attendance_days,sale_days,return_days,effective_from,expires_at,author_id,reason)
+                values($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) returning *`, [
+                normalized.version, normalized.responseDays, normalized.appointmentDays, normalized.attendanceDays,
+                normalized.saleDays, normalized.returnDays, effectiveFrom, expiresAt, actorId, reason,
+            ])
+            return { window: mapWindow(inserted.rows[0]) }
+        }))
+    }
+
+    async function segmentDefinitions(query, actor) {
+        await ensureReady()
+        assertManager(actor)
+        const limit = Math.min(100, Math.max(1, Number(query?.limit || 50)))
+        const result = await pgPool.query(`select definition.id,definition.segment_key,definition.current_revision,definition.current_status,
+                version.version_key,version.criteria,version.thresholds,version.percentiles,version.effective_from,version.created_at
+            from crm_atendimento.commercial_segment_definitions definition
+            left join crm_atendimento.commercial_segment_versions version on version.segment_id=definition.id and version.revision=definition.current_revision
+            order by definition.segment_key limit $1`, [limit])
+        return { segments: result.rows.map(mapSegment) }
+    }
+
+    async function createSegmentVersion(payload, actor) {
+        await ensureReady()
+        assertGlobal(actor)
+        const actorId = opaqueActorId(actor)
+        const normalized = normalizeSegmentDefinition(payload)
+        const expectedRevision = payload?.expectedRevision === undefined ? null : normalizeCount(payload.expectedRevision, 'ANALYTICS_SEGMENT_REVISION_INVALID')
+        return withTransaction(async (client) => runMutation(client, {
+            actor, operation: 'segment_version_create', idempotencyKey: payload?.idempotencyKey,
+            request: { ...normalized, expectedRevision },
+        }, async () => {
+            const current = await client.query(`select id,current_revision from crm_atendimento.commercial_segment_definitions where segment_key=$1 for update`, [normalized.key])
+            let segmentId; let revision
+            if (!current.rows[0]) {
+                segmentId = randomUUID(); revision = 1
+                if (expectedRevision !== null && expectedRevision !== 0) throw analyticsError('ANALYTICS_SEGMENT_VERSION_CONFLICT', 409)
+                await client.query(`insert into crm_atendimento.commercial_segment_definitions(id,segment_key,current_revision,current_status)
+                    values($1,$2,$3,'active')`, [segmentId, normalized.key, revision])
+            } else {
+                segmentId = current.rows[0].id; const currentRevision = Number(current.rows[0].current_revision)
+                if (expectedRevision !== null && expectedRevision !== currentRevision) throw analyticsError('ANALYTICS_SEGMENT_VERSION_CONFLICT', 409)
+                revision = currentRevision + 1
+                await client.query(`update crm_atendimento.commercial_segment_definitions set current_revision=$2,current_status='active',updated_at=now() where id=$1`, [segmentId, revision])
+            }
+            const duplicateVersion = await client.query(`select id from crm_atendimento.commercial_segment_versions
+                where segment_id=$1::uuid and version_key=$2 for update`, [segmentId, normalized.version])
+            if (duplicateVersion.rows[0]) throw analyticsError('ANALYTICS_SEGMENT_VERSION_KEY_CONFLICT', 409)
+            const inserted = await client.query(`insert into crm_atendimento.commercial_segment_versions(
+                    segment_id,revision,version_key,criteria,thresholds,percentiles,effective_from,author_id)
+                values($1,$2,$3,$4::jsonb,$5::jsonb,$6::jsonb,$7,$8) returning *`, [
+                segmentId, revision, normalized.version, JSON.stringify(normalized.criteria), JSON.stringify(normalized.thresholds),
+                JSON.stringify(normalized.percentiles), normalized.effectiveFrom || null, actorId,
+            ])
+            return { segment: mapSegment({ ...inserted.rows[0], segment_key: normalized.key, current_status: 'active' }) }
+        }))
+    }
+
+    async function segmentDrift(query, actor) {
+        await ensureReady()
+        assertManager(actor)
+        const segmentKey = text(query?.segmentKey || query?.segment, 120)
+        if (!KEY.test(segmentKey)) throw analyticsError('ANALYTICS_SEGMENT_KEY_INVALID', 400)
+        const units = scopedUnits(actor, query?.unit)
+        const params = [segmentKey]
+        const where = ['definition.segment_key=$1']
+        if (units !== null) { params.push(units); where.push(`unit.slug=any($${params.length}::text[])`) }
+        const result = await pgPool.query(`select snapshot.snapshot_date,snapshot.created_at,snapshot.population as member_count,snapshot.distribution,unit.slug as unit_slug
+            from crm_atendimento.commercial_segment_membership_snapshots snapshot
+            join crm_atendimento.commercial_segment_versions version on version.id=snapshot.segment_version_id
+            join crm_atendimento.commercial_segment_definitions definition on definition.id=version.segment_id
+            left join crm_atendimento.units unit on unit.id=snapshot.unit_id
+            where ${where.join(' and ')} order by snapshot.snapshot_date asc,snapshot.created_at asc`, params)
+        const byUnit = new Map()
+        for (const row of result.rows) {
+            const key = row.unit_slug || 'all'
+            const rows = byUnit.get(key) || []
+            rows.push(row)
+            byUnit.set(key, rows)
+        }
+        return { segmentKey, drift: Object.fromEntries([...byUnit.entries()].map(([unit, snapshots]) => [unit, buildSegmentDrift(snapshots)])) }
+    }
+
+    async function experiments(query, actor) {
+        await ensureReady()
+        const units = scopedUnits(actor, query?.unit)
+        const params = []
+        const where = []
+        if (units !== null) { params.push(units); where.push(`unit.slug=any($${params.length}::text[])`) }
+        const result = await pgPool.query(`select experiment.*,unit.slug as unit_slug from crm_atendimento.commercial_experiments experiment
+            join crm_atendimento.units unit on unit.id=experiment.unit_id ${where.length ? `where ${where.join(' and ')}` : ''}
+            order by experiment.created_at desc limit 100`, params)
+        return { experiments: result.rows.map(mapExperiment) }
+    }
+
+    async function createExperiment(payload, actor) {
+        await ensureReady()
+        assertManager(actor)
+        const actorId = opaqueActorId(actor)
+        const experimentKey = text(payload?.experimentKey || payload?.key, 120)
+        const seed = text(payload?.seed, 120)
+        if (!KEY.test(experimentKey) || !KEY.test(seed)) throw analyticsError('ANALYTICS_EXPERIMENT_KEY_INVALID', 400)
+        const unitSlug = text(payload?.unit, 80).toLowerCase()
+        const units = scopedUnits(actor, unitSlug)
+        if (!units?.length) throw analyticsError('ANALYTICS_UNIT_REQUIRED', 400)
+        const segmentVersionId = normalizeUuid(payload?.segmentVersionId, 'ANALYTICS_SEGMENT_VERSION_ID_INVALID')
+        const attributionWindowId = normalizeUuid(payload?.attributionWindowId, 'ANALYTICS_WINDOW_ID_INVALID')
+        const campaignId = payload?.campaignId ? normalizeUuid(payload.campaignId, 'ANALYTICS_CAMPAIGN_ID_INVALID') : null
+        const controlGroupPercent = Number(payload?.controlGroupPercent)
+        if (!Number.isInteger(controlGroupPercent) || controlGroupPercent < 1 || controlGroupPercent > 99) throw analyticsError('ANALYTICS_CONTROL_GROUP_INVALID', 400)
+        const startsAt = normalizeDateTime(payload?.startsAt, 'EXPERIMENT_START')
+        const endsAt = normalizeDateTime(payload?.endsAt, 'EXPERIMENT_END')
+        if (endsAt <= startsAt) throw analyticsError('ANALYTICS_EXPERIMENT_PERIOD_INVALID', 400)
+        const reason = normalizeReason(payload?.reason)
+        return withTransaction(async (client) => runMutation(client, {
+            actor, operation: 'experiment_create', idempotencyKey: payload?.idempotencyKey,
+            request: { experimentKey, unitSlug, segmentVersionId, attributionWindowId, campaignId, seed, controlGroupPercent, startsAt, endsAt, reason },
+        }, async () => {
+            const unit = await client.query(`select id,slug from crm_atendimento.units where slug=$1`, [unitSlug])
+            if (!unit.rows[0]) throw analyticsError('ANALYTICS_UNIT_NOT_FOUND', 404)
+            const prerequisites = await client.query(`select
+                exists(select 1 from crm_atendimento.commercial_segment_versions where id=$1::uuid) as segment,
+                exists(select 1 from crm_atendimento.commercial_attribution_windows where id=$2::uuid) as window,
+                ($3::uuid is null or exists(select 1 from crm_atendimento.commercial_campaigns where id=$3::uuid and unit_id=$4::uuid)) as campaign`, [segmentVersionId, attributionWindowId, campaignId, unit.rows[0].id])
+            if (!Object.values(prerequisites.rows[0] || {}).every(Boolean)) throw analyticsError('ANALYTICS_EXPERIMENT_PREREQUISITE_MISSING', 409)
+            const inserted = await client.query(`insert into crm_atendimento.commercial_experiments(
+                    experiment_key,campaign_id,segment_version_id,unit_id,attribution_window_id,seed,control_group_percent,state,starts_at,ends_at,author_id,reason)
+                values($1,$2,$3,$4,$5,$6,$7,'draft',$8,$9,$10,$11) returning *`, [
+                experimentKey, campaignId, segmentVersionId, unit.rows[0].id, attributionWindowId, seed,
+                controlGroupPercent, startsAt, endsAt, actorId, reason,
+            ])
+            return { experiment: mapExperiment({ ...inserted.rows[0], unit_slug: unit.rows[0].slug }) }
+        }))
+    }
+
+    async function assignExperiment(payload, actor) {
+        await ensureReady()
+        assertManager(actor)
+        const experimentId = normalizeUuid(payload?.experimentId, 'ANALYTICS_EXPERIMENT_ID_INVALID')
+        const snapshotId = normalizeUuid(payload?.snapshotId, 'ANALYTICS_SNAPSHOT_ID_INVALID')
+        return withTransaction(async (client) => {
+            const experiment = await client.query(`select experiment.*,unit.slug as unit_slug from crm_atendimento.commercial_experiments experiment
+                join crm_atendimento.units unit on unit.id=experiment.unit_id where experiment.id=$1::uuid for update`, [experimentId])
+            const row = experiment.rows[0]
+            if (!row) throw analyticsError('ANALYTICS_EXPERIMENT_NOT_FOUND', 404)
+            scopedUnits(actor, row.unit_slug)
+            return runMutation(client, {
+                actor, operation: 'experiment_assign', idempotencyKey: payload?.idempotencyKey,
+                request: { experimentId, snapshotId, unit: row.unit_slug },
+            }, async () => {
+                const members = await client.query(`select member.identity_id::text,unit.slug as unit_slug
+                    from crm_atendimento.commercial_segment_memberships member
+                    join crm_atendimento.commercial_segment_membership_snapshots snapshot on snapshot.id=member.snapshot_id
+                    join crm_atendimento.units unit on unit.id=member.unit_id
+                    where snapshot.id=$1::uuid and snapshot.segment_version_id=$2::uuid and (snapshot.unit_id is null or snapshot.unit_id=$3::uuid)`, [snapshotId, row.segment_version_id, row.unit_id])
+                if (!members.rows.length) throw analyticsError('ANALYTICS_EXPERIMENT_MEMBERSHIP_EMPTY', 409)
+                const existing = await client.query(`select identity_id::text,variant,eligible,unit_id::text from crm_atendimento.commercial_experiment_assignments where experiment_id=$1::uuid`, [experimentId])
+                const assignments = buildExperimentAssignments(members.rows, {
+                    experimentKey: row.experiment_key,
+                    seed: row.seed,
+                    controlPercent: Number(row.control_group_percent),
+                    existingAssignments: existing.rows.map((item) => ({ ...item, unit_slug: row.unit_slug })),
+                })
+                for (const assignment of assignments.filter((item) => !item.preserved)) {
+                    await client.query(`insert into crm_atendimento.commercial_experiment_assignments(experiment_id,identity_id,unit_id,variant,eligible,exclusion_reason)
+                        values($1,$2::uuid,$3::uuid,$4,$5,$6) on conflict(experiment_id,identity_id) do nothing`, [
+                        experimentId, assignment.identityId, row.unit_id, assignment.variant, assignment.eligible, assignment.exclusionReason,
+                    ])
+                }
+                const summary = assignments.reduce((accumulator, item) => {
+                    accumulator.total += 1; accumulator[item.variant] = (accumulator[item.variant] || 0) + 1; return accumulator
+                }, { total: 0, control: 0, treatment: 0, excluded: 0 })
+                return { experimentId, assignments: summary }
+            })
+        })
+    }
+
+    async function experimentResult(experimentIdValue, actor) {
+        await ensureReady()
+        const experimentId = normalizeUuid(experimentIdValue, 'ANALYTICS_EXPERIMENT_ID_INVALID')
+        const experiment = await pgPool.query(`select experiment.*,unit.slug as unit_slug from crm_atendimento.commercial_experiments experiment
+            join crm_atendimento.units unit on unit.id=experiment.unit_id where experiment.id=$1::uuid`, [experimentId])
+        const row = experiment.rows[0]
+        if (!row) throw analyticsError('ANALYTICS_EXPERIMENT_NOT_FOUND', 404)
+        scopedUnits(actor, row.unit_slug)
+        const [assignments, events] = await Promise.all([
+            pgPool.query(`select identity_id::text,variant,eligible from crm_atendimento.commercial_experiment_assignments where experiment_id=$1::uuid`, [experimentId]),
+            pgPool.query(`select event.identity_id::text,event.event_type,event.revenue_cents,event.occurred_at
+                from crm_atendimento.commercial_analytics_events event
+                where event.unit_id=$1::uuid and event.occurred_at >= $2 and event.occurred_at <= $3`, [row.unit_id, row.starts_at, row.ends_at]),
+        ])
+        return { experiment: mapExperiment(row), ...buildExperimentResult(assignments.rows, events.rows.map(mapEvent)) }
+    }
+
+    return {
+        readiness,
+        recordMetricSnapshot,
+        recordSegmentSnapshot,
+        recordAnalyticsEvent,
+        quality,
+        funnel,
+        attributionWindows,
+        createAttributionWindow,
+        segmentDefinitions,
+        createSegmentVersion,
+        segmentDrift,
+        experiments,
+        createExperiment,
+        assignExperiment,
+        experimentResult,
+    }
+}
+
+export const __testables = {
+    digest,
+    isGlobal,
+    mapEvent,
+    normalizeReason,
+    normalizeSnapshotMembers,
+    opaqueActorId,
+    normalizeSafeObject,
+    scopedUnits,
+}

--- a/crm/api/server/atendimento/commercialAnalyticsStore.js
+++ b/crm/api/server/atendimento/commercialAnalyticsStore.js
@@ -117,6 +117,22 @@ function normalizeUuid(value, code = 'ANALYTICS_UUID_INVALID') {
     return id
 }
 
+async function lockExperimentCrossoverAssignments(client, unitId, assignments) {
+    // Operations uses this same lock namespace while it verifies that an
+    // identity is not an active control/excluded member. Take every lock in
+    // deterministic order before persisting assignments so an assignment
+    // cannot race an eligible commercial mutation into a silent crossover.
+    const unit = normalizeUuid(unitId, 'ANALYTICS_EXPERIMENT_UNIT_INVALID')
+    const identityIds = [...new Set((Array.isArray(assignments) ? assignments : [])
+        .map((assignment) => normalizeUuid(assignment?.identityId, 'ANALYTICS_EXPERIMENT_IDENTITY_INVALID')))]
+        .sort()
+    for (const identityId of identityIds) {
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [
+            `commercial-experiment-crossover:${unit}:${identityId}`,
+        ])
+    }
+}
+
 function normalizeCount(value, code = 'ANALYTICS_COUNT_INVALID') {
     const parsed = Number(value)
     if (!Number.isInteger(parsed) || parsed < 0 || parsed > 2_147_483_647) throw analyticsError(code, 400)
@@ -828,6 +844,7 @@ export function createCommercialAnalyticsStore({
                     controlPercent: Number(row.control_group_percent),
                     existingAssignments: existing.rows.map((item) => ({ ...item, unit_slug: row.unit_slug })),
                 })
+                await lockExperimentCrossoverAssignments(client, row.unit_id, assignments)
                 for (const assignment of assignments.filter((item) => !item.preserved)) {
                     await client.query(`insert into crm_atendimento.commercial_experiment_assignments(experiment_id,identity_id,unit_id,variant,eligible,exclusion_reason)
                         values($1,$2::uuid,$3::uuid,$4,$5,$6) on conflict(experiment_id,identity_id) do nothing`, [
@@ -881,6 +898,7 @@ export function createCommercialAnalyticsStore({
 export const __testables = {
     digest,
     isGlobal,
+    lockExperimentCrossoverAssignments,
     mapEvent,
     normalizeReason,
     normalizeSnapshotMembers,

--- a/crm/api/server/atendimento/commercialOperations.js
+++ b/crm/api/server/atendimento/commercialOperations.js
@@ -312,8 +312,11 @@ export function computeAverageStageDurations(events = []) {
 }
 
 export function campaignMemberState({ eligible, controlGroup, identityInReview, sourceStale } = {}) {
-    if (controlGroup) return 'control'
     if (!eligible) return identityInReview || sourceStale ? 'review' : 'blocked'
+    // A holdout is reproducible only within the same eligible population.  An
+    // ineligible identity is never silently reclassified as control; it must
+    // remain blocked/review until the underlying gate becomes healthy.
+    if (controlGroup) return 'control'
     if (identityInReview || sourceStale) return 'review'
     return 'eligible'
 }

--- a/crm/api/server/atendimento/commercialOperations.js
+++ b/crm/api/server/atendimento/commercialOperations.js
@@ -1,0 +1,374 @@
+import { createHash } from 'node:crypto'
+
+// This module deliberately contains only deterministic, PII-free domain
+// contracts. Persistence, RBAC and contact eligibility are enforced by the
+// store that consumes these values; no caller can turn an outcome into a send.
+export const COMMERCIAL_OUTCOME_CODES = Object.freeze([
+    'no_response',
+    'wrong_number',
+    'requested_follow_up',
+    'not_interested',
+    'completed_elsewhere',
+    'scheduled',
+    'attended',
+    'cancelled',
+    'sale',
+    'clinical_return',
+    'opt_out_requested',
+])
+
+export const COMMERCIAL_CAMPAIGN_STATES = Object.freeze([
+    'draft', 'scheduled', 'active', 'paused', 'completed', 'cancelled',
+])
+
+export const COMMERCIAL_CAMPAIGN_MEMBER_STATES = Object.freeze([
+    'eligible', 'blocked', 'review', 'control', 'assigned', 'completed', 'cancelled',
+])
+
+export const COMMERCIAL_OPERATION_FLAGS = Object.freeze([
+    'assigned_to_me',
+    'due_today',
+    'overdue',
+    'awaiting_response',
+    'scheduled',
+    'no_return',
+    'permission_expiring',
+    'ineligible',
+    'source_stale',
+    'identity_review',
+])
+
+const ACTIVE_ACTION_STATUSES = new Set(['open', 'contacted', 'responded', 'scheduled'])
+const ID_PATTERN = /^[A-Za-z0-9._:-]{8,200}$/
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const OWNER_PATTERN = /^[A-Za-z0-9._:+\- ]{1,160}$/
+const FILTER_KEYS = new Set(['segment', 'segmentKey', 'priority', 'source', 'status', 'unit', 'stale', 'identityReview', 'permission', 'owner', 'actionFlag'])
+
+function text(value) {
+    return typeof value === 'string' ? value.trim() : String(value ?? '').trim()
+}
+
+function dateOnly(value) {
+    const normalized = text(value).slice(0, 10)
+    return /^\d{4}-\d{2}-\d{2}$/.test(normalized) ? normalized : ''
+}
+
+function dateTime(value) {
+    const date = new Date(value)
+    return Number.isNaN(date.getTime()) ? null : date
+}
+
+function safeObject(value, maximumBytes = 16_000) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+    const serialized = JSON.stringify(value)
+    return serialized.length <= maximumBytes ? value : null
+}
+
+function containsPiiLikeValue(value) {
+    const raw = text(value)
+    return /@/.test(raw) || /\d{7,}/.test(raw)
+}
+
+function stableValue(value) {
+    if (value === null || typeof value !== 'object') return value
+    if (Array.isArray(value)) return value.map(stableValue)
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stableValue(value[key])]))
+}
+
+export function commercialOperationError(code, statusCode = 400) {
+    const error = new Error(code)
+    error.code = code
+    error.statusCode = statusCode
+    return error
+}
+
+export function stableOperationFingerprint(value) {
+    return createHash('sha256').update(JSON.stringify(stableValue(value))).digest('hex')
+}
+
+export function normalizeOutcomeCode(value) {
+    const normalized = text(value).toLowerCase().replace(/[\s-]+/g, '_')
+    return COMMERCIAL_OUTCOME_CODES.includes(normalized) ? normalized : ''
+}
+
+export function normalizeOperationMutation(payload = {}, { requireIdempotency = true, requireReason = false } = {}) {
+    const candidate = payload && typeof payload === 'object' && !Array.isArray(payload) ? payload : {}
+    const idempotencyKey = text(candidate.idempotencyKey)
+    const expectedRevision = candidate.expectedRevision == null || candidate.expectedRevision === ''
+        ? null
+        : Number(candidate.expectedRevision)
+    const reason = text(candidate.reason)
+    const outcomeCode = normalizeOutcomeCode(candidate.outcomeCode)
+
+    if (requireIdempotency && !idempotencyKey) throw commercialOperationError('COMMERCIAL_IDEMPOTENCY_KEY_REQUIRED')
+    if (idempotencyKey && (!ID_PATTERN.test(idempotencyKey) || containsPiiLikeValue(idempotencyKey))) {
+        throw commercialOperationError('INVALID_COMMERCIAL_IDEMPOTENCY_KEY')
+    }
+    if (expectedRevision != null && (!Number.isInteger(expectedRevision) || expectedRevision < 1)) {
+        throw commercialOperationError('COMMERCIAL_EXPECTED_REVISION_INVALID')
+    }
+    if ((requireReason || reason) && (reason.length < 3 || reason.length > 1_000 || containsPiiLikeValue(reason))) {
+        throw commercialOperationError('COMMERCIAL_OPERATION_REASON_INVALID')
+    }
+    if (candidate.outcomeCode != null && !outcomeCode) throw commercialOperationError('INVALID_COMMERCIAL_OUTCOME')
+    return { idempotencyKey, expectedRevision, reason, outcomeCode }
+}
+
+export function normalizeCampaignFilters(value) {
+    const input = safeObject(value)
+    if (input === null) throw commercialOperationError('COMMERCIAL_CAMPAIGN_FILTER_INVALID')
+    const filters = {}
+    for (const [key, raw] of Object.entries(input)) {
+        if (!FILTER_KEYS.has(key)) throw commercialOperationError('COMMERCIAL_CAMPAIGN_FILTER_INVALID')
+        const values = Array.isArray(raw) ? raw : [raw]
+        if (values.length > 20 || values.some((entry) => {
+            const candidate = text(entry)
+            return candidate.length > 120 || containsPiiLikeValue(candidate)
+        })) {
+            throw commercialOperationError('COMMERCIAL_CAMPAIGN_FILTER_INVALID')
+        }
+        if (values.some((entry) => !['string', 'number', 'boolean'].includes(typeof entry))) {
+            throw commercialOperationError('COMMERCIAL_CAMPAIGN_FILTER_INVALID')
+        }
+        filters[key] = Array.isArray(raw) ? [...values] : raw
+    }
+    return filters
+}
+
+export function normalizeCampaignPayload(payload = {}) {
+    const input = payload && typeof payload === 'object' && !Array.isArray(payload) ? payload : {}
+    const name = text(input.name)
+    const segmentKey = text(input.segmentKey)
+    const segmentVersion = text(input.segmentVersion)
+    const unit = text(input.unit || input.unitSlug).toLowerCase()
+    const owner = text(input.owner)
+    const reason = text(input.reason)
+    const cutoffAt = dateTime(input.cutoffAt || input.cutoff_at)
+    const assignmentWindowStart = dateTime(input.assignmentWindowStart || input.assignment_window_start)
+    const assignmentWindowEnd = dateTime(input.assignmentWindowEnd || input.assignment_window_end)
+    const controlGroupPercent = Number(input.controlGroupPercent ?? input.control_group_percent ?? 0)
+    const offerId = text(input.offerId)
+    const identityIds = [...new Set((Array.isArray(input.identityIds) ? input.identityIds : []).map(text).filter(Boolean))]
+    const state = text(input.state).toLowerCase() || 'draft'
+    const filters = normalizeCampaignFilters(input.filters)
+
+    if (!name || name.length > 160 || containsPiiLikeValue(name)) throw commercialOperationError('INVALID_COMMERCIAL_CAMPAIGN_NAME')
+    if (!segmentKey || segmentKey.length > 120 || !segmentVersion || segmentVersion.length > 120) throw commercialOperationError('COMMERCIAL_CAMPAIGN_SEGMENT_REQUIRED')
+    if (!/^[a-z0-9._-]+$/i.test(segmentKey) || !/^[a-z0-9._-]+$/i.test(segmentVersion)) throw commercialOperationError('COMMERCIAL_CAMPAIGN_SEGMENT_REQUIRED')
+    if (!unit || unit.length > 120 || !/^[a-z0-9._-]+$/i.test(unit)) throw commercialOperationError('COMMERCIAL_CAMPAIGN_UNIT_REQUIRED')
+    if (!owner || !OWNER_PATTERN.test(owner) || containsPiiLikeValue(owner)) throw commercialOperationError('COMMERCIAL_CAMPAIGN_OWNER_REQUIRED')
+    if (reason.length < 3 || reason.length > 1_000 || containsPiiLikeValue(reason)) throw commercialOperationError('COMMERCIAL_CAMPAIGN_REASON_REQUIRED')
+    if (!cutoffAt || !assignmentWindowStart || !assignmentWindowEnd || assignmentWindowEnd < assignmentWindowStart) throw commercialOperationError('INVALID_COMMERCIAL_CAMPAIGN_WINDOW')
+    if (!Number.isInteger(controlGroupPercent) || controlGroupPercent < 0 || controlGroupPercent > 100) throw commercialOperationError('INVALID_COMMERCIAL_CONTROL_GROUP')
+    if (!identityIds.length || identityIds.length > 500 || identityIds.some((id) => !UUID_PATTERN.test(id))) throw commercialOperationError('COMMERCIAL_CAMPAIGN_COHORT_REQUIRED')
+    if (offerId && !UUID_PATTERN.test(offerId)) throw commercialOperationError('COMMERCIAL_CAMPAIGN_OFFER_INVALID')
+    if (!COMMERCIAL_CAMPAIGN_STATES.includes(state)) throw commercialOperationError('INVALID_COMMERCIAL_CAMPAIGN_STATE')
+
+    return {
+        name,
+        segmentKey,
+        segmentVersion,
+        unit,
+        owner,
+        reason,
+        filters,
+        identityIds,
+        cutoffAt: cutoffAt.toISOString(),
+        assignmentWindowStart: assignmentWindowStart.toISOString(),
+        assignmentWindowEnd: assignmentWindowEnd.toISOString(),
+        controlGroupPercent,
+        offerId: offerId || null,
+        state,
+    }
+}
+
+export function actionQueueFlags(action = {}, {
+    today = new Date().toISOString().slice(0, 10),
+    actorIds = [],
+    eligibility = null,
+    sourceStale = false,
+    identityInReview = false,
+} = {}) {
+    const flags = []
+    const status = text(action.status).toLowerCase()
+    const dueDate = dateOnly(action.dueDate || action.due_date)
+    const owner = text(action.owner)
+    const active = ACTIVE_ACTION_STATUSES.has(status)
+    const normalizedActors = new Set(actorIds.map(text).filter(Boolean).map((id) => id.toLowerCase()))
+    if (owner && normalizedActors.has(owner.toLowerCase())) flags.push('assigned_to_me')
+    if (active && dueDate === today) flags.push('due_today')
+    if (active && dueDate && dueDate < today) flags.push('overdue')
+    if (status === 'contacted') flags.push('awaiting_response')
+    if (status === 'scheduled') flags.push('scheduled')
+    // "Sem retorno" is deliberately a later operational condition than simply
+    // awaiting a response: the declared return/follow-up deadline must have
+    // elapsed.  We accept the legacy due date as the final fallback so existing
+    // actions remain visible, but never infer it from contact content.
+    const returnDueDate = dateOnly(action.returnDueAt || action.return_due_at || action.followUpDueAt || action.follow_up_due_at || action.dueDate || action.due_date)
+    if (active && status === 'contacted' && returnDueDate && returnDueDate < today) flags.push('no_return')
+    const expiry = dateTime(eligibility?.expiresAt || eligibility?.expires_at)
+    const now = dateTime(`${today}T00:00:00.000Z`) || new Date()
+    if (expiry && expiry >= now && expiry.getTime() <= now.getTime() + 7 * 86_400_000) flags.push('permission_expiring')
+    if (eligibility && eligibility.status !== 'eligible') flags.push('ineligible')
+    if (sourceStale) flags.push('source_stale')
+    if (identityInReview) flags.push('identity_review')
+    return flags
+}
+
+export function classifyCommercialAction(action = {}, options = {}) {
+    const queueFlags = actionQueueFlags(action, options)
+    return {
+        ...action,
+        queueFlags,
+        active: ACTIVE_ACTION_STATUSES.has(text(action.status).toLowerCase()),
+    }
+}
+
+function increment(record, key, amount = 1) {
+    record[key] = Number(record[key] || 0) + amount
+}
+
+function outcomeTotals(action, status, outcome) {
+    return {
+        completed: ['closed', 'cancelled', 'won_sale', 'returned'].includes(status) || ['attended', 'sale', 'clinical_return', 'cancelled'].includes(outcome),
+        responded: ['responded', 'scheduled', 'won_sale', 'returned'].includes(status) || ['requested_follow_up', 'scheduled', 'attended', 'cancelled', 'sale', 'clinical_return', 'opt_out_requested'].includes(outcome),
+        scheduled: status === 'scheduled' || outcome === 'scheduled',
+        attended: outcome === 'attended',
+        sale: status === 'won_sale' || outcome === 'sale',
+        returned: status === 'returned' || outcome === 'clinical_return',
+        cancelled: status === 'cancelled' || outcome === 'cancelled',
+    }
+}
+
+export function aggregateCommercialActionMetrics(actions = [], { today = new Date().toISOString().slice(0, 10) } = {}) {
+    const totals = { total: 0, active: 0, dueToday: 0, overdue: 0, completed: 0, responded: 0, scheduled: 0, attended: 0, sale: 0, returned: 0, cancelled: 0 }
+    const byStatus = {}
+    const owners = new Map()
+    for (const action of actions) {
+        const status = text(action.status).toLowerCase() || 'open'
+        const outcome = normalizeOutcomeCode(action.outcomeCode || action.outcome_code)
+        const flags = action.queueFlags || actionQueueFlags(action, { today })
+        const normalized = outcomeTotals(action, status, outcome)
+        increment(totals, 'total')
+        increment(byStatus, status)
+        if (ACTIVE_ACTION_STATUSES.has(status)) increment(totals, 'active')
+        if (flags.includes('due_today')) increment(totals, 'dueToday')
+        if (flags.includes('overdue')) increment(totals, 'overdue')
+        for (const [key, enabled] of Object.entries(normalized)) if (enabled) increment(totals, key)
+        const owner = text(action.owner) || 'unassigned'
+        const row = owners.get(owner) || { owner, total: 0, active: 0, overdue: 0, completed: 0, responded: 0, scheduled: 0, attended: 0, sale: 0, returned: 0, cancelled: 0, statuses: {} }
+        increment(row, 'total')
+        increment(row.statuses, status)
+        if (ACTIVE_ACTION_STATUSES.has(status)) increment(row, 'active')
+        if (flags.includes('overdue')) increment(row, 'overdue')
+        for (const [key, enabled] of Object.entries(normalized)) if (enabled) increment(row, key)
+        owners.set(owner, row)
+    }
+    const denominator = totals.total || 1
+    const rate = (key) => Math.round((totals[key] / denominator) * 10_000) / 100
+    return {
+        totals: {
+            ...totals,
+            completionRate: rate('completed'),
+            responseRate: rate('responded'),
+            schedulingRate: rate('scheduled'),
+            attendanceRate: rate('attended'),
+            saleRate: rate('sale'),
+            returnRate: rate('returned'),
+            cancellationRate: rate('cancelled'),
+        },
+        byStatus,
+        byOwner: [...owners.values()].sort((left, right) => right.active - left.active || left.owner.localeCompare(right.owner)),
+    }
+}
+
+export function computeAverageStageDurations(events = []) {
+    const byAction = new Map()
+    for (const event of events) {
+        const actionId = text(event.actionId || event.action_id)
+        const status = text(event.status)
+        const occurredAt = dateTime(event.occurredAt || event.createdAt || event.created_at)
+        if (!actionId || !status || !occurredAt) continue
+        const rows = byAction.get(actionId) || []
+        rows.push({ status, occurredAt })
+        byAction.set(actionId, rows)
+    }
+    const duration = new Map()
+    for (const rows of byAction.values()) {
+        rows.sort((left, right) => left.occurredAt - right.occurredAt)
+        for (let index = 0; index < rows.length - 1; index += 1) {
+            const current = rows[index]
+            const next = rows[index + 1]
+            const state = duration.get(current.status) || { totalHours: 0, samples: 0 }
+            state.totalHours += Math.max(0, (next.occurredAt.getTime() - current.occurredAt.getTime()) / 3_600_000)
+            state.samples += 1
+            duration.set(current.status, state)
+        }
+    }
+    return Object.fromEntries([...duration.entries()].map(([status, values]) => [status, {
+        hours: Math.round((values.totalHours / Math.max(1, values.samples)) * 100) / 100,
+        samples: values.samples,
+    }]))
+}
+
+export function campaignMemberState({ eligible, controlGroup, identityInReview, sourceStale } = {}) {
+    if (controlGroup) return 'control'
+    if (!eligible) return identityInReview || sourceStale ? 'review' : 'blocked'
+    if (identityInReview || sourceStale) return 'review'
+    return 'eligible'
+}
+
+export function stableControlGroup({ campaignSeed, identityId, percentage }) {
+    const percent = Number(percentage)
+    if (!UUID_PATTERN.test(text(identityId)) || !Number.isInteger(percent) || percent < 0 || percent > 100) {
+        throw commercialOperationError('INVALID_COMMERCIAL_CONTROL_GROUP')
+    }
+    if (!text(campaignSeed) || text(campaignSeed).length > 200) throw commercialOperationError('INVALID_COMMERCIAL_CAMPAIGN_SEED')
+    const bucket = Number.parseInt(stableOperationFingerprint({ campaignSeed: text(campaignSeed), identityId: text(identityId) }).slice(0, 8), 16) % 100
+    return bucket < percent
+}
+
+export function planWalletBalance(actions = [], capacities = {}) {
+    const loads = new Map()
+    const active = actions.filter((action) => ACTIVE_ACTION_STATUSES.has(text(action.status).toLowerCase()))
+    for (const action of active.filter((action) => !action.absentOwner)) {
+        const owner = text(action.owner)
+        if (owner) loads.set(owner, (loads.get(owner) || 0) + 1)
+    }
+    const targets = Object.entries(capacities)
+        .map(([owner, capacity]) => ({ owner: text(owner), capacity: Math.max(0, Number(capacity) || 0), load: loads.get(text(owner)) || 0 }))
+        .filter((entry) => entry.owner && OWNER_PATTERN.test(entry.owner))
+        .sort((left, right) => (left.load / Math.max(1, left.capacity)) - (right.load / Math.max(1, right.capacity)) || left.owner.localeCompare(right.owner))
+    const moves = []
+    for (const action of active) {
+        const current = text(action.owner)
+        const capacity = capacities[current]
+        const needsMove = !current || action.absentOwner || (capacity != null && (loads.get(current) || 0) > Number(capacity))
+        if (!needsMove) continue
+        const target = targets.find((entry) => entry.owner !== current && entry.load < entry.capacity)
+        if (!target) continue
+        moves.push({ actionId: text(action.id), fromOwner: current || null, toOwner: target.owner })
+        target.load += 1
+    }
+    return moves.filter((move) => UUID_PATTERN.test(move.actionId))
+}
+
+// Presentation is intentionally explicit. Do not spread raw evidence/context
+// into Customer 360; that is how technical identifiers and PII leak by drift.
+export function projectCommercialTimelineEvent(row = {}) {
+    const type = text(row.type || row.event_type)
+    const allowedTypes = new Set(['attendance', 'sale', 'permission', 'opt_out', 'action', 'contact', 'response', 'appointment', 'campaign', 'offer', 'identity_decision', 'quality_finding', 'correction'])
+    return {
+        id: text(row.id || row.event_id),
+        type: allowedTypes.has(type) ? type : 'correction',
+        occurredAt: dateTime(row.occurredAt || row.occurred_on || row.created_at)?.toISOString() || null,
+        source: text(row.source || row.source_label).slice(0, 80),
+        unit: text(row.unit || row.unit_slug || row.unit_name).slice(0, 120),
+        actor: containsPiiLikeValue(row.actor || row.actor_label) ? null : text(row.actor || row.actor_label).slice(0, 160) || null,
+        correlationId: UUID_PATTERN.test(text(row.correlationId || row.trace_id)) ? text(row.correlationId || row.trace_id) : null,
+        campaignId: UUID_PATTERN.test(text(row.campaignId || row.campaign_id)) ? text(row.campaignId || row.campaign_id) : null,
+        offerId: UUID_PATTERN.test(text(row.offerId || row.offer_id)) ? text(row.offerId || row.offer_id) : null,
+        consentReview: text(row.consentReview || row.consent_review).slice(0, 80) || null,
+        status: text(row.status || row.event_status).slice(0, 80) || 'confirmed',
+    }
+}

--- a/crm/api/server/atendimento/commercialOperationsMigration.js
+++ b/crm/api/server/atendimento/commercialOperationsMigration.js
@@ -1,0 +1,333 @@
+import {
+    assertAtendimentoMigrationDestination,
+    ATENDIMENTO_MIGRATION_TARGETS,
+    isStrictAtendimentoMigrationDestination,
+} from './migrationDestination.js'
+import {
+    COMMERCIAL_CAMPAIGN_MEMBER_STATES,
+    COMMERCIAL_CAMPAIGN_STATES,
+    COMMERCIAL_OUTCOME_CODES,
+} from './commercialOperations.js'
+
+export const COMMERCIAL_OPERATIONS_MIGRATION_ID = '20260807_commercial_operations_v2'
+
+const RUNTIME_ROLES = Object.freeze({
+    [ATENDIMENTO_MIGRATION_TARGETS.LOCAL]: 'skincos',
+    [ATENDIMENTO_MIGRATION_TARGETS.STAGING]: 'skincos_staging_crm_app',
+})
+
+const PREREQUISITE_RELATIONS = Object.freeze([
+    'crm_atendimento.units',
+    'crm_atendimento.global_client_identities',
+    'crm_atendimento.commercial_actions',
+    'crm_atendimento.commercial_action_events',
+    'crm_atendimento.commercial_offers',
+])
+
+const OUTCOME_SQL = COMMERCIAL_OUTCOME_CODES.map((value) => `'${value}'`).join(', ')
+const CAMPAIGN_STATE_SQL = COMMERCIAL_CAMPAIGN_STATES.map((value) => `'${value}'`).join(', ')
+const MEMBER_STATE_SQL = COMMERCIAL_CAMPAIGN_MEMBER_STATES.map((value) => `'${value}'`).join(', ')
+
+function migrationError(code) {
+    const error = new Error(code)
+    error.code = code
+    return error
+}
+
+function createTriggerIfMissing(relation, triggerName, triggerSql) {
+    return `do $$ begin
+        if not exists (
+            select 1 from pg_trigger
+             where tgrelid = '${relation}'::regclass and tgname = '${triggerName}'
+        ) then
+            execute $trigger$${triggerSql}$trigger$;
+        end if;
+    end $$`
+}
+
+function runtimeGrantStatements(target) {
+    const role = RUNTIME_ROLES[target]
+    if (!role) throw migrationError('COMMERCIAL_OPERATIONS_RUNTIME_ROLE_UNKNOWN')
+    return [
+        `revoke create on schema crm_atendimento from ${role}`,
+        `revoke delete, truncate, references, trigger on table crm_atendimento.commercial_actions from ${role}`,
+        `revoke update, delete, truncate, references, trigger on table crm_atendimento.commercial_action_events from ${role}`,
+        `revoke update, delete, truncate, references, trigger on table crm_atendimento.commercial_operation_mutations from ${role}`,
+        `revoke delete, truncate, references, trigger on table crm_atendimento.commercial_campaigns from ${role}`,
+        `revoke delete, truncate, references, trigger on table crm_atendimento.commercial_campaign_members from ${role}`,
+        `revoke update, delete, truncate, references, trigger on table crm_atendimento.commercial_campaign_events from ${role}`,
+        `revoke delete, truncate, references, trigger on table crm_atendimento.commercial_owner_absences from ${role}`,
+        `grant usage on schema crm_atendimento to ${role}`,
+        `grant select, insert, update on table crm_atendimento.commercial_actions to ${role}`,
+        `grant select, insert on table crm_atendimento.commercial_action_events to ${role}`,
+        `grant select, insert on table crm_atendimento.commercial_operation_mutations to ${role}`,
+        `grant select, insert, update on table crm_atendimento.commercial_campaigns to ${role}`,
+        `grant select, insert, update on table crm_atendimento.commercial_campaign_members to ${role}`,
+        `grant select, insert on table crm_atendimento.commercial_campaign_events to ${role}`,
+        `grant select, insert, update on table crm_atendimento.commercial_owner_absences to ${role}`,
+        `grant usage, select on sequence crm_atendimento.commercial_campaign_events_event_order_seq to ${role}`,
+    ]
+}
+
+const STATEMENTS = Object.freeze([
+    `create extension if not exists pgcrypto`,
+    `create schema if not exists crm_atendimento`,
+    `alter table crm_atendimento.commercial_actions add column if not exists revision integer not null default 1`,
+    `alter table crm_atendimento.commercial_actions add column if not exists outcome_code text`,
+    `alter table crm_atendimento.commercial_actions add column if not exists outcome_recorded_at timestamptz`,
+    `alter table crm_atendimento.commercial_actions add column if not exists idempotency_key text`,
+    `alter table crm_atendimento.commercial_action_events add column if not exists outcome_code text`,
+    `do $$ begin
+        if not exists (select 1 from pg_constraint where conrelid = 'crm_atendimento.commercial_actions'::regclass and conname = 'commercial_actions_outcome_code_v2_valid') then
+            alter table crm_atendimento.commercial_actions add constraint commercial_actions_outcome_code_v2_valid
+                check (outcome_code is null or outcome_code in (${OUTCOME_SQL})) not valid;
+        end if;
+        if not exists (select 1 from pg_constraint where conrelid = 'crm_atendimento.commercial_action_events'::regclass and conname = 'commercial_action_events_outcome_code_v2_valid') then
+            alter table crm_atendimento.commercial_action_events add constraint commercial_action_events_outcome_code_v2_valid
+                check (outcome_code is null or outcome_code in (${OUTCOME_SQL})) not valid;
+        end if;
+    end $$`,
+    `create table if not exists crm_atendimento.commercial_operation_mutations (
+        id uuid primary key default gen_random_uuid(),
+        mutation_key text not null check (mutation_key ~ '^[A-Za-z0-9._:-]{8,240}$'),
+        operation text not null check (operation in ('action_create', 'action_update', 'action_reassign', 'campaign_create', 'campaign_update', 'absence_upsert', 'rebalance')),
+        actor_id text not null check (char_length(actor_id) between 1 and 160 and actor_id !~ '[@]'),
+        request_fingerprint text not null check (request_fingerprint ~ '^[a-f0-9]{64}$'),
+        response jsonb not null default '{}'::jsonb,
+        created_at timestamptz not null default now(),
+        unique(mutation_key, operation)
+    )`,
+    `create table if not exists crm_atendimento.commercial_campaigns (
+        id uuid primary key default gen_random_uuid(),
+        name text not null check (char_length(btrim(name)) between 1 and 160 and name !~ '[@]'),
+        revision integer not null default 1 check (revision >= 1),
+        segment_key text not null check (segment_key ~ '^[A-Za-z0-9._-]{1,120}$'),
+        segment_version text not null check (segment_version ~ '^[A-Za-z0-9._-]{1,120}$'),
+        filters_snapshot jsonb not null default '{}'::jsonb,
+        context_hash text not null check (context_hash ~ '^[a-f0-9]{64}$'),
+        cutoff_at timestamptz not null,
+        unit_id uuid not null references crm_atendimento.units(id) on delete restrict,
+        owner text not null check (char_length(btrim(owner)) between 1 and 160 and owner !~ '[@]'),
+        offer_id uuid references crm_atendimento.commercial_offers(id) on delete restrict,
+        assignment_window_start timestamptz not null,
+        assignment_window_end timestamptz not null,
+        control_group_percent integer not null default 0 check (control_group_percent between 0 and 100),
+        state text not null default 'draft' check (state in (${CAMPAIGN_STATE_SQL})),
+        author text not null check (char_length(author) between 1 and 160 and author !~ '[@]'),
+        reason text not null check (char_length(btrim(reason)) between 3 and 1000 and reason !~ '[@]'),
+        created_at timestamptz not null default now(),
+        updated_at timestamptz not null default now(),
+        check (assignment_window_end >= assignment_window_start)
+    )`,
+    `create table if not exists crm_atendimento.commercial_campaign_members (
+        id uuid primary key default gen_random_uuid(),
+        campaign_id uuid not null references crm_atendimento.commercial_campaigns(id) on delete restrict,
+        identity_id uuid not null references crm_atendimento.global_client_identities(id) on delete restrict,
+        unit_id uuid not null references crm_atendimento.units(id) on delete restrict,
+        segment_key text not null check (segment_key ~ '^[A-Za-z0-9._-]{1,120}$'),
+        segment_version text not null check (segment_version ~ '^[A-Za-z0-9._-]{1,120}$'),
+        cutoff_at timestamptz not null,
+        owner text not null check (char_length(btrim(owner)) between 1 and 160 and owner !~ '[@]'),
+        offer_id uuid references crm_atendimento.commercial_offers(id) on delete restrict,
+        control_group boolean not null default false,
+        state text not null check (state in (${MEMBER_STATE_SQL})),
+        eligibility_snapshot jsonb not null default '{}'::jsonb,
+        action_id uuid references crm_atendimento.commercial_actions(id) on delete restrict,
+        revision integer not null default 1 check (revision >= 1),
+        created_at timestamptz not null default now(),
+        updated_at timestamptz not null default now(),
+        unique(campaign_id, identity_id)
+    )`,
+    `create table if not exists crm_atendimento.commercial_campaign_events (
+        id uuid primary key default gen_random_uuid(),
+        event_order bigint generated always as identity,
+        campaign_id uuid not null references crm_atendimento.commercial_campaigns(id) on delete restrict,
+        member_id uuid references crm_atendimento.commercial_campaign_members(id) on delete restrict,
+        event_type text not null check (event_type in ('created', 'state_changed', 'member_added', 'member_assigned', 'member_outcome', 'rebalanced', 'cancelled')),
+        actor_id text not null check (char_length(actor_id) between 1 and 160 and actor_id !~ '[@]'),
+        trace_id uuid not null,
+        payload jsonb not null default '{}'::jsonb,
+        created_at timestamptz not null default now(),
+        unique(campaign_id, member_id, event_type, trace_id)
+    )`,
+    `create table if not exists crm_atendimento.commercial_owner_absences (
+        id uuid primary key default gen_random_uuid(),
+        owner text not null check (char_length(btrim(owner)) between 1 and 160 and owner !~ '[@]'),
+        unit_id uuid not null references crm_atendimento.units(id) on delete restrict,
+        absence_type text not null check (absence_type in ('vacation', 'absence', 'leave')),
+        starts_at date not null,
+        ends_at date not null,
+        substitute_owner text check (substitute_owner is null or (char_length(btrim(substitute_owner)) between 1 and 160 and substitute_owner !~ '[@]')),
+        reason text not null check (char_length(btrim(reason)) between 3 and 1000 and reason !~ '[@]'),
+        revision integer not null default 1 check (revision >= 1),
+        created_by text not null check (char_length(created_by) between 1 and 160 and created_by !~ '[@]'),
+        updated_by text not null check (char_length(updated_by) between 1 and 160 and updated_by !~ '[@]'),
+        created_at timestamptz not null default now(),
+        updated_at timestamptz not null default now(),
+        check (ends_at >= starts_at),
+        unique(owner, unit_id, starts_at, ends_at)
+    )`,
+    `create unique index if not exists commercial_actions_actor_idempotency_v2_idx
+        on crm_atendimento.commercial_actions(created_by, idempotency_key) where idempotency_key is not null`,
+    `create index if not exists commercial_actions_owner_due_v2_idx
+        on crm_atendimento.commercial_actions(owner, due_date, status)`,
+    `create index if not exists commercial_campaigns_state_v2_idx
+        on crm_atendimento.commercial_campaigns(unit_id, state, updated_at desc)`,
+    `create index if not exists commercial_campaign_members_identity_v2_idx
+        on crm_atendimento.commercial_campaign_members(identity_id, state)`,
+    `create index if not exists commercial_campaign_events_campaign_v2_idx
+        on crm_atendimento.commercial_campaign_events(campaign_id, event_order desc)`,
+    `create index if not exists commercial_owner_absences_current_v2_idx
+        on crm_atendimento.commercial_owner_absences(unit_id, owner, starts_at, ends_at)`,
+    `create or replace function crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()
+        returns trigger language plpgsql as $$ begin
+            raise exception 'commercial operations evidence is append-only';
+        end $$`,
+    createTriggerIfMissing('crm_atendimento.commercial_operation_mutations', 'commercial_operation_mutations_v2_immutable', `create trigger commercial_operation_mutations_v2_immutable before update or delete on crm_atendimento.commercial_operation_mutations for each row execute function crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()`),
+    createTriggerIfMissing('crm_atendimento.commercial_operation_mutations', 'commercial_operation_mutations_v2_no_truncate', `create trigger commercial_operation_mutations_v2_no_truncate before truncate on crm_atendimento.commercial_operation_mutations for each statement execute function crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()`),
+    createTriggerIfMissing('crm_atendimento.commercial_campaign_events', 'commercial_campaign_events_v2_immutable', `create trigger commercial_campaign_events_v2_immutable before update or delete on crm_atendimento.commercial_campaign_events for each row execute function crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()`),
+    createTriggerIfMissing('crm_atendimento.commercial_campaign_events', 'commercial_campaign_events_v2_no_truncate', `create trigger commercial_campaign_events_v2_no_truncate before truncate on crm_atendimento.commercial_campaign_events for each statement execute function crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()`),
+])
+
+function triggerReadinessStatement() {
+    const tables = ['commercial_operation_mutations', 'commercial_campaign_events']
+    const fields = tables.flatMap((table, index) => [
+        `exists(select 1 from pg_trigger where tgrelid = to_regclass('crm_atendimento.${table}') and tgname = '${table}_v2_immutable' and tgenabled = 'O' and tgfoid = to_regprocedure('crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()')) as immutable_${index}`,
+        `exists(select 1 from pg_trigger where tgrelid = to_regclass('crm_atendimento.${table}') and tgname = '${table}_v2_no_truncate' and tgenabled = 'O' and tgfoid = to_regprocedure('crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()')) as no_truncate_${index}`,
+    ])
+    return `select ${fields.join(', ')}`
+}
+
+async function ensureRegistry(client) {
+    await client.query(`create schema if not exists crm_atendimento`)
+    await client.query(`create table if not exists crm_atendimento.schema_migrations (
+        id text primary key, applied_at timestamptz not null default now(), rolled_back_at timestamptz,
+        details jsonb not null default '{}'::jsonb
+    )`)
+}
+
+async function assertPrerequisites(client) {
+    const projection = PREREQUISITE_RELATIONS.map((relation, index) => `to_regclass('${relation}') is not null as relation_${index}`).join(', ')
+    const result = await client.query(`select ${projection}`)
+    if (!Object.values(result.rows[0] || {}).every(Boolean)) throw migrationError('COMMERCIAL_OPERATIONS_PREREQUISITES_MISSING')
+}
+
+async function assertDestination(client, databaseUrl, target) {
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw migrationError('COMMERCIAL_OPERATIONS_DESTINATION_UNSAFE')
+    try {
+        return await assertAtendimentoMigrationDestination(client, databaseUrl, target)
+    } catch {
+        throw migrationError('COMMERCIAL_OPERATIONS_DESTINATION_UNSAFE')
+    }
+}
+
+async function assertAppendOnlyTriggers(client) {
+    const result = await client.query(triggerReadinessStatement())
+    if (!Object.values(result.rows[0] || {}).every(Boolean)) throw migrationError('COMMERCIAL_OPERATIONS_APPEND_ONLY_GUARD_MISSING')
+}
+
+export function commercialOperationsMigrationPlan() {
+    return {
+        id: COMMERCIAL_OPERATIONS_MIGRATION_ID,
+        adds: [
+            'commercial_actions.revision',
+            'commercial_actions.outcome_code',
+            'commercial_actions.idempotency_key',
+            'commercial_operation_mutations',
+            'commercial_campaigns',
+            'commercial_campaign_members',
+            'commercial_campaign_events',
+            'commercial_owner_absences',
+        ],
+        appendOnlyTables: ['commercial_operation_mutations', 'commercial_campaign_events'],
+        piiPolicy: 'Operational records accept only opaque ids, bounded allowlisted codes, aggregate eligibility snapshots and masked presentation contracts. They store no phone, email, message payload or raw customer evidence.',
+        messagePolicy: 'Campaign membership and outcomes never dispatch a message. commercialContactWritesEnabled remains a separate, default-false control.',
+        rollback: 'Non-destructive: campaigns, actions and append-only evidence are retained; rollback only records the migration state.',
+        runtimeAccess: 'The runtime role receives no DDL, DELETE or TRUNCATE access. Evidence and idempotency ledgers are INSERT/SELECT only.',
+    }
+}
+
+export async function applyCommercialOperationsMigration({
+    pool,
+    databaseUrl,
+    target = ATENDIMENTO_MIGRATION_TARGETS.LOCAL,
+} = {}) {
+    if (!pool) throw migrationError('COMMERCIAL_OPERATIONS_POOL_REQUIRED')
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw migrationError('COMMERCIAL_OPERATIONS_DESTINATION_UNSAFE')
+    const client = await pool.connect()
+    let transactionOpen = false
+    try {
+        await client.query('begin')
+        transactionOpen = true
+        await client.query(`set local lock_timeout = '3s'`)
+        await client.query(`set local statement_timeout = '60s'`)
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [COMMERCIAL_OPERATIONS_MIGRATION_ID])
+        const destination = await assertDestination(client, databaseUrl, target)
+        await ensureRegistry(client)
+        await assertPrerequisites(client)
+        for (const statement of STATEMENTS) await client.query(statement)
+        await assertAppendOnlyTriggers(client)
+        const grants = runtimeGrantStatements(target)
+        for (const statement of grants) await client.query(statement)
+        const report = {
+            ...commercialOperationsMigrationPlan(),
+            applied: true,
+            target,
+            database: destination.database,
+            runtimeRole: RUNTIME_ROLES[target],
+            runtimeGrants: grants,
+        }
+        await client.query(`insert into crm_atendimento.schema_migrations(id, applied_at, rolled_back_at, details)
+            values ($1, now(), null, $2::jsonb)
+            on conflict(id) do update set applied_at = excluded.applied_at, rolled_back_at = null, details = excluded.details`, [
+            COMMERCIAL_OPERATIONS_MIGRATION_ID,
+            JSON.stringify(report),
+        ])
+        await client.query('commit')
+        transactionOpen = false
+        return report
+    } catch (error) {
+        if (transactionOpen) {
+            try { await client.query('rollback') } catch { /* preserve original failure */ }
+        }
+        throw error
+    } finally {
+        client.release()
+    }
+}
+
+export async function rollbackCommercialOperationsMigration({
+    pool,
+    databaseUrl,
+    target = ATENDIMENTO_MIGRATION_TARGETS.LOCAL,
+} = {}) {
+    if (!pool) throw migrationError('COMMERCIAL_OPERATIONS_POOL_REQUIRED')
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw migrationError('COMMERCIAL_OPERATIONS_DESTINATION_UNSAFE')
+    const client = await pool.connect()
+    let transactionOpen = false
+    try {
+        await client.query('begin')
+        transactionOpen = true
+        await client.query(`set local lock_timeout = '3s'`)
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [COMMERCIAL_OPERATIONS_MIGRATION_ID])
+        await assertDestination(client, databaseUrl, target)
+        await ensureRegistry(client)
+        await client.query(`insert into crm_atendimento.schema_migrations(id, applied_at, rolled_back_at, details)
+            values ($1, now(), now(), '{"rollback":"non-destructive","evidenceRetained":true}'::jsonb)
+            on conflict(id) do update set rolled_back_at = now(), details = excluded.details`, [
+            COMMERCIAL_OPERATIONS_MIGRATION_ID,
+        ])
+        await client.query('commit')
+        transactionOpen = false
+        return { id: COMMERCIAL_OPERATIONS_MIGRATION_ID, rolledBack: true, destructive: false, evidenceRetained: true }
+    } catch (error) {
+        if (transactionOpen) {
+            try { await client.query('rollback') } catch { /* preserve original failure */ }
+        }
+        throw error
+    } finally {
+        client.release()
+    }
+}
+
+export const __testables = { STATEMENTS, runtimeGrantStatements, triggerReadinessStatement, PREREQUISITE_RELATIONS }

--- a/crm/api/server/atendimento/commercialOperationsMigration.js
+++ b/crm/api/server/atendimento/commercialOperationsMigration.js
@@ -190,10 +190,29 @@ const STATEMENTS = Object.freeze([
 ])
 
 function triggerReadinessStatement() {
-    const tables = ['commercial_operation_mutations', 'commercial_campaign_events']
-    const fields = tables.flatMap((table, index) => [
-        `exists(select 1 from pg_trigger where tgrelid = to_regclass('crm_atendimento.${table}') and tgname = '${table}_v2_immutable' and tgenabled = 'O' and tgfoid = to_regprocedure('crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()')) as immutable_${index}`,
-        `exists(select 1 from pg_trigger where tgrelid = to_regclass('crm_atendimento.${table}') and tgname = '${table}_v2_no_truncate' and tgenabled = 'O' and tgfoid = to_regprocedure('crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()')) as no_truncate_${index}`,
+    const ledgers = [
+        {
+            table: 'commercial_action_events',
+            immutable: 'commercial_action_events_immutable',
+            noTruncate: 'commercial_action_events_no_truncate',
+            functionName: 'crm_atendimento.prevent_commercial_ledger_mutation()',
+        },
+        {
+            table: 'commercial_operation_mutations',
+            immutable: 'commercial_operation_mutations_v2_immutable',
+            noTruncate: 'commercial_operation_mutations_v2_no_truncate',
+            functionName: 'crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()',
+        },
+        {
+            table: 'commercial_campaign_events',
+            immutable: 'commercial_campaign_events_v2_immutable',
+            noTruncate: 'commercial_campaign_events_v2_no_truncate',
+            functionName: 'crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()',
+        },
+    ]
+    const fields = ledgers.flatMap((ledger, index) => [
+        `exists(select 1 from pg_trigger where tgrelid = to_regclass('crm_atendimento.${ledger.table}') and tgname = '${ledger.immutable}' and tgenabled = 'O' and tgfoid = to_regprocedure('${ledger.functionName}')) as immutable_${index}`,
+        `exists(select 1 from pg_trigger where tgrelid = to_regclass('crm_atendimento.${ledger.table}') and tgname = '${ledger.noTruncate}' and tgenabled = 'O' and tgfoid = to_regprocedure('${ledger.functionName}')) as no_truncate_${index}`,
     ])
     return `select ${fields.join(', ')}`
 }
@@ -239,7 +258,7 @@ export function commercialOperationsMigrationPlan() {
             'commercial_campaign_events',
             'commercial_owner_absences',
         ],
-        appendOnlyTables: ['commercial_operation_mutations', 'commercial_campaign_events'],
+        appendOnlyTables: ['commercial_action_events', 'commercial_operation_mutations', 'commercial_campaign_events'],
         piiPolicy: 'Operational records accept only opaque ids, bounded allowlisted codes, aggregate eligibility snapshots and masked presentation contracts. They store no phone, email, message payload or raw customer evidence.',
         messagePolicy: 'Campaign membership and outcomes never dispatch a message. commercialContactWritesEnabled remains a separate, default-false control.',
         rollback: 'Non-destructive: campaigns, actions and append-only evidence are retained; rollback only records the migration state.',

--- a/crm/api/server/atendimento/commercialOperationsStore.js
+++ b/crm/api/server/atendimento/commercialOperationsStore.js
@@ -1,0 +1,1608 @@
+import { createHmac, randomUUID } from 'node:crypto'
+
+import { createPgPool, withPgTransaction } from '../harmonia/store/pg.js'
+import { requiredClientesSources } from '../clientes/sourceCatalog.js'
+import {
+    COMMERCIAL_CAMPAIGN_STATES,
+    COMMERCIAL_OPERATION_FLAGS,
+    actionQueueFlags,
+    campaignMemberState,
+    commercialOperationError,
+    computeAverageStageDurations,
+    normalizeCampaignFilters,
+    normalizeCampaignPayload,
+    normalizeOutcomeCode,
+    normalizeOperationMutation,
+    planWalletBalance,
+    projectCommercialTimelineEvent,
+    stableControlGroup,
+    stableOperationFingerprint,
+} from './commercialOperations.js'
+import { COMMERCIAL_OPERATIONS_MIGRATION_ID } from './commercialOperationsMigration.js'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const UNIT_RE = /^[a-z0-9][a-z0-9._-]{0,119}$/i
+const OWNER_RE = /^[A-Za-zÀ-ÿ0-9._:+\- ]{1,160}$/
+const ACTIVE_ACTION_STATUSES = Object.freeze(['open', 'contacted', 'responded', 'scheduled'])
+const ACTION_STATUSES = Object.freeze([...ACTIVE_ACTION_STATUSES, 'won_sale', 'returned', 'closed', 'cancelled'])
+const ABSENCE_TYPES = new Set(['vacation', 'absence', 'leave'])
+const COMMERCIAL_REQUIRED_SOURCE_IDS = Object.freeze(requiredClientesSources().map((source) => source.id).sort())
+const OUTCOME_STATUSES = Object.freeze({
+    no_response: 'contacted',
+    wrong_number: 'closed',
+    requested_follow_up: 'responded',
+    not_interested: 'closed',
+    completed_elsewhere: 'closed',
+    scheduled: 'scheduled',
+    attended: 'closed',
+    cancelled: 'cancelled',
+    sale: 'won_sale',
+    clinical_return: 'returned',
+    opt_out_requested: 'responded',
+})
+const WALLET_SORTS = Object.freeze({
+    dueDate: 'action.due_date',
+    updatedAt: 'action.updated_at',
+    createdAt: 'action.created_at',
+    status: 'action.status',
+    owner: "coalesce(action.owner, '')",
+})
+
+// This is deliberately a hard boundary, not an environment-controlled flag.
+// The operation layer can create internal work and audit it, but cannot write
+// consent, schedule a send, enqueue delivery or turn a campaign into outbound
+// communication.
+export const COMMERCIAL_OPERATIONS_SAFETY_FLAGS = Object.freeze({
+    commercialContactWritesEnabled: false,
+    messagesEnabled: false,
+    automationEnabled: false,
+    consentWritesEnabled: false,
+    outboundDispatchEnabled: false,
+})
+
+function text(value) {
+    return String(value ?? '').trim()
+}
+
+function operationalError(code, statusCode = 409) {
+    const error = commercialOperationError(code, statusCode)
+    error.code = code
+    error.statusCode = statusCode
+    return error
+}
+
+function requirePool(pgPool) {
+    if (!pgPool) throw operationalError('DATABASE_URL_not_configured', 503)
+}
+
+function bool(value) {
+    return value === true
+}
+
+function count(value) {
+    const number = Number(value)
+    return Number.isFinite(number) && number >= 0 ? Math.floor(number) : 0
+}
+
+function dateOnly(value) {
+    const raw = text(value).slice(0, 10)
+    return /^\d{4}-\d{2}-\d{2}$/.test(raw) ? raw : null
+}
+
+function iso(value) {
+    const timestamp = Date.parse(value || '')
+    return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : null
+}
+
+function containsPiiLikeValue(value) {
+    const raw = text(value)
+    return /@/.test(raw) || /\d{7,}/.test(raw)
+}
+
+function safeOwner(value, { required = false } = {}) {
+    const owner = text(value)
+    if (!owner && required) throw operationalError('COMMERCIAL_OPERATION_OWNER_REQUIRED', 400)
+    if (owner && (!OWNER_RE.test(owner) || containsPiiLikeValue(owner))) {
+        throw operationalError('INVALID_COMMERCIAL_OPERATION_OWNER', 400)
+    }
+    return owner || null
+}
+
+function projectOwner(value) {
+    const owner = text(value)
+    return owner && OWNER_RE.test(owner) && !containsPiiLikeValue(owner) ? owner : null
+}
+
+function actorPrincipal(actor) {
+    const value = text(actor?.id || actor?.username || actor?.email)
+    if (!value) throw operationalError('ACTOR_IDENTITY_REQUIRED', 401)
+    return value
+}
+
+function auditSecret() {
+    const secret = text(
+        process.env.ATENDIMENTO_ACTOR_HMAC_KEY ||
+        process.env.ESCALA_ACTOR_HMAC_KEY ||
+        process.env.CRM_ESCALA_HMAC_KEY,
+    )
+    if (secret.length < 32) throw operationalError('COMMERCIAL_OPERATIONS_AUDIT_KEY_REQUIRED', 503)
+    return secret
+}
+
+function digest(purpose, value) {
+    return createHmac('sha256', auditSecret())
+        .update(`${purpose}:${stableOperationFingerprint(value)}`)
+        .digest('hex')
+}
+
+function actorReference(actor) {
+    return `actor:${digest('commercial-operations-actor', { actor: actorPrincipal(actor) })}`
+}
+
+function isGlobalCommercialActor(actor) {
+    return actor?.isGlobalAdmin === true || text(actor?.role).toUpperCase() === 'ADMIN'
+}
+
+export function commercialOperationsUnitScope(actor) {
+    if (isGlobalCommercialActor(actor)) return null
+    // A commercial actor without an explicit unit claim is never silently
+    // promoted to a cross-unit reader.  The signed-actor parser carries
+    // `allowedUnitsDeclared`, but accepting a direct store caller must remain
+    // equally fail-closed.
+    if (!Array.isArray(actor?.allowedUnits)) return []
+    return [...new Set(actor.allowedUnits.map((unit) => text(unit).toLowerCase()).filter((unit) => UNIT_RE.test(unit)))].sort()
+}
+
+export function assertCommercialOperationsManager(actor) {
+    const role = text(actor?.role).toUpperCase()
+    if (role === 'GESTOR' || role === 'ADMIN' || actor?.isGlobalAdmin === true) return
+    throw operationalError('FORBIDDEN', 403)
+}
+
+function requestedUnitScope(actor, requested) {
+    const actorScope = commercialOperationsUnitScope(actor)
+    const unit = text(requested).toLowerCase()
+    if (actorScope === null) {
+        if (unit && unit !== 'all' && !UNIT_RE.test(unit)) throw operationalError('INVALID_COMMERCIAL_UNIT', 400)
+        return { unit: unit && unit !== 'all' ? unit : null, unitSlugs: null }
+    }
+    if (!actorScope.length) throw operationalError('COMMERCIAL_UNIT_FORBIDDEN', 403)
+    if (!unit || unit === 'all') return { unit: null, unitSlugs: actorScope }
+    if (!UNIT_RE.test(unit)) throw operationalError('INVALID_COMMERCIAL_UNIT', 400)
+    if (!actorScope.includes(unit)) throw operationalError('COMMERCIAL_UNIT_FORBIDDEN', 403)
+    return { unit, unitSlugs: [unit] }
+}
+
+function assertUnitAllowed(actor, unit) {
+    const value = text(unit).toLowerCase()
+    if (!UNIT_RE.test(value)) throw operationalError('INVALID_COMMERCIAL_UNIT', 400)
+    const scope = commercialOperationsUnitScope(actor)
+    if (scope !== null && (!scope.length || !scope.includes(value))) throw operationalError('COMMERCIAL_UNIT_FORBIDDEN', 403)
+    return value
+}
+
+function assertUuid(value, code = 'INVALID_COMMERCIAL_OPERATION_ID') {
+    const id = text(value).toLowerCase()
+    if (!UUID_RE.test(id)) throw operationalError(code, 400)
+    return id
+}
+
+function normalizeLimit(value, fallback = 50, maximum = 100) {
+    const number = Number(value)
+    if (!Number.isInteger(number) || number < 1) return fallback
+    return Math.min(number, maximum)
+}
+
+function normalizeOffset(value) {
+    const number = Number(value)
+    return Number.isInteger(number) && number > 0 ? number : 0
+}
+
+function normalizeDateRange(startValue, endValue, code = 'INVALID_COMMERCIAL_OPERATION_DATE_RANGE') {
+    const startsAt = dateOnly(startValue)
+    const endsAt = dateOnly(endValue)
+    if (!startsAt || !endsAt || endsAt < startsAt) throw operationalError(code, 400)
+    return { startsAt, endsAt }
+}
+
+function normalizeCapacities(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw operationalError('COMMERCIAL_REBALANCE_CAPACITIES_REQUIRED', 400)
+    }
+    const entries = Object.entries(value)
+    if (!entries.length || entries.length > 100) throw operationalError('COMMERCIAL_REBALANCE_CAPACITIES_REQUIRED', 400)
+    const capacities = {}
+    for (const [rawOwner, rawCapacity] of entries) {
+        const owner = safeOwner(rawOwner, { required: true })
+        const capacity = Number(rawCapacity)
+        if (!Number.isInteger(capacity) || capacity < 0 || capacity > 10_000) {
+            throw operationalError('INVALID_COMMERCIAL_REBALANCE_CAPACITY', 400)
+        }
+        capacities[owner] = capacity
+    }
+    return Object.fromEntries(Object.entries(capacities).sort(([left], [right]) => left.localeCompare(right)))
+}
+
+function normalizeExpectedRevisions(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw operationalError('COMMERCIAL_REBALANCE_EXPECTED_REVISIONS_REQUIRED', 400)
+    }
+    const revisions = {}
+    for (const [rawId, rawRevision] of Object.entries(value)) {
+        const id = assertUuid(rawId, 'INVALID_COMMERCIAL_ACTION')
+        const revision = Number(rawRevision)
+        if (!Number.isInteger(revision) || revision < 1) throw operationalError('COMMERCIAL_EXPECTED_REVISION_INVALID', 400)
+        revisions[id] = revision
+    }
+    return revisions
+}
+
+function normalizeActionFlags(value) {
+    const candidates = Array.isArray(value) ? value : text(value).split(',')
+    const flags = [...new Set(candidates.map((item) => text(item)).filter(Boolean))]
+    if (flags.length > 10 || flags.some((flag) => !COMMERCIAL_OPERATION_FLAGS.includes(flag))) {
+        throw operationalError('INVALID_COMMERCIAL_OPERATION_FLAG', 400)
+    }
+    return flags
+}
+
+function operationSafety() {
+    return { ...COMMERCIAL_OPERATIONS_SAFETY_FLAGS }
+}
+
+function mapReadiness(row = {}, migrationReady = false) {
+    const tables = ['actions', 'action_events', 'mutations', 'campaigns', 'members', 'campaign_events', 'absences']
+    const triggers = [
+        'action_event_immutable', 'action_event_no_truncate',
+        'mutation_immutable', 'mutation_no_truncate', 'campaign_event_immutable', 'campaign_event_no_truncate',
+    ]
+    const relationsReady = tables.every((key) => bool(row[key]))
+    const appendOnlyReady = triggers.every((key) => bool(row[key]))
+    return {
+        ready: relationsReady && appendOnlyReady && migrationReady,
+        migrationId: COMMERCIAL_OPERATIONS_MIGRATION_ID,
+        relationsReady,
+        appendOnlyReady,
+        migrationReady,
+        safety: operationSafety(),
+    }
+}
+
+export async function commercialOperationsReadiness(db) {
+    const availability = await db.query(`select
+        to_regclass('crm_atendimento.commercial_actions') is not null as actions,
+        to_regclass('crm_atendimento.commercial_action_events') is not null as action_events,
+        to_regclass('crm_atendimento.commercial_operation_mutations') is not null as mutations,
+        to_regclass('crm_atendimento.commercial_campaigns') is not null as campaigns,
+        to_regclass('crm_atendimento.commercial_campaign_members') is not null as members,
+        to_regclass('crm_atendimento.commercial_campaign_events') is not null as campaign_events,
+        to_regclass('crm_atendimento.commercial_owner_absences') is not null as absences,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_action_events')
+            and tgname='commercial_action_events_immutable' and tgenabled='O'
+            and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_ledger_mutation()')) as action_event_immutable,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_action_events')
+            and tgname='commercial_action_events_no_truncate' and tgenabled='O'
+            and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_ledger_mutation()')) as action_event_no_truncate,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_operation_mutations')
+            and tgname='commercial_operation_mutations_v2_immutable' and tgenabled='O'
+            and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()')) as mutation_immutable,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_operation_mutations')
+            and tgname='commercial_operation_mutations_v2_no_truncate' and tgenabled='O'
+            and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()')) as mutation_no_truncate,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_campaign_events')
+            and tgname='commercial_campaign_events_v2_immutable' and tgenabled='O'
+            and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()')) as campaign_event_immutable,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_campaign_events')
+            and tgname='commercial_campaign_events_v2_no_truncate' and tgenabled='O'
+            and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_operations_evidence_mutation_v2()')) as campaign_event_no_truncate,
+        to_regclass('crm_atendimento.schema_migrations') is not null as migration_registry`)
+    const row = availability.rows[0] || {}
+    if (!row.migration_registry) return mapReadiness(row, false)
+    const migration = await db.query(`select id from crm_atendimento.schema_migrations
+        where id=$1 and rolled_back_at is null`, [COMMERCIAL_OPERATIONS_MIGRATION_ID])
+    return mapReadiness(row, !!migration.rows[0]?.id)
+}
+
+async function assertCommercialOperationsReady(db) {
+    const readiness = await commercialOperationsReadiness(db)
+    if (!readiness.ready) throw operationalError('COMMERCIAL_OPERATIONS_NOT_READY', 409)
+    return readiness
+}
+
+async function operationalDependencies(db) {
+    const result = await db.query(`select
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_contact_permissions'), 'SELECT'), false) as permissions,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.clientes_source_operation_checkpoints'), 'SELECT'), false) as source_checkpoints,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.global_client_identity_members'), 'SELECT'), false) as identity_members,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.client_caixa_links'), 'SELECT'), false) as attendance_caixa_links,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.app_registration_attendance_links'), 'SELECT'), false) as app_attendance_links,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.app_registration_caixa_links'), 'SELECT'), false) as app_caixa_links,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.supplemental_lead_profile_app_links'), 'SELECT'), false) as lead_app_links,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.supplemental_lead_profile_caixa_links'), 'SELECT'), false) as lead_caixa_links,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.identity_review_decisions'), 'SELECT'), false) as review_decisions`)
+    const row = result.rows[0] || {}
+    return {
+        permissions: bool(row.permissions),
+        sourceCheckpoints: bool(row.source_checkpoints),
+        identityReview: bool(row.identity_members) && bool(row.review_decisions) && bool(row.attendance_caixa_links) &&
+            bool(row.app_attendance_links) && bool(row.app_caixa_links) && bool(row.lead_app_links) && bool(row.lead_caixa_links),
+    }
+}
+
+async function sourceStale(db, dependencies) {
+    if (!dependencies.sourceCheckpoints) return true
+    const result = await db.query(`select count(*)::int as checkpoint_count,
+        bool_or(checkpoint.last_status <> 'complete' or checkpoint.validated_snapshot_complete is not true or
+            checkpoint.reconciliation_required is true or checkpoint.validated_at is null or
+            checkpoint.validated_at < now() - interval '48 hours') as stale
+        from crm_atendimento.clientes_source_operation_checkpoints checkpoint
+        where checkpoint.source_id=any($1::text[])`, [COMMERCIAL_REQUIRED_SOURCE_IDS])
+    return count(result.rows[0]?.checkpoint_count) < COMMERCIAL_REQUIRED_SOURCE_IDS.length || bool(result.rows[0]?.stale)
+}
+
+function scopeWhere(scope, params, unitColumn = 'unit.slug') {
+    if (scope.unit) {
+        params.push(scope.unit)
+        return `${unitColumn} = $${params.length}`
+    }
+    if (scope.unitSlugs) {
+        params.push(scope.unitSlugs)
+        return `${unitColumn} = any($${params.length}::text[])`
+    }
+    return `${unitColumn} is not null`
+}
+
+function permissionSql(dependencies) {
+    if (!dependencies.permissions) {
+        return {
+            join: '',
+            status: "'review_required'::text",
+            expiresAt: 'null::timestamptz',
+        }
+    }
+    return {
+        join: `left join crm_atendimento.commercial_contact_permissions permission
+            on permission.identity_id=action.identity_id and permission.channel='whatsapp'`,
+        status: `case when permission.status='granted' and (permission.expires_at is null or permission.expires_at >= now()) then 'eligible'
+            when permission.status='denied' or (permission.expires_at is not null and permission.expires_at < now()) then 'blocked'
+            else 'review_required' end`,
+        expiresAt: 'permission.expires_at',
+    }
+}
+
+function identityReviewSql(dependencies) {
+    if (!dependencies.identityReview) return 'true'
+    // The review lookup is an allowlisted existence projection: no member,
+    // candidate, context or evidence column is selected or serialized.
+    return `exists(
+        select 1 from crm_atendimento.global_client_identity_members member
+         where member.identity_id=action.identity_id and (
+            (member.source_type='attendance_client' and exists(select 1 from crm_atendimento.client_caixa_links link
+                where link.client_id=member.source_id::uuid and link.status in ('suggested','ambiguous')))
+            or (member.source_type='app_registration' and (
+                exists(select 1 from crm_atendimento.app_registration_attendance_links link
+                    where link.app_registration_id=member.source_id and link.status in ('suggested','ambiguous'))
+                or exists(select 1 from crm_atendimento.app_registration_caixa_links link
+                    where link.app_registration_id=member.source_id and link.status in ('suggested','ambiguous'))
+            ))
+            or (member.source_type='lead_profile' and (
+                exists(select 1 from crm_atendimento.supplemental_lead_profile_app_links link
+                    where link.source_profile_id=member.source_id and link.status in ('suggested','ambiguous'))
+                or exists(select 1 from crm_atendimento.supplemental_lead_profile_caixa_links link
+                    where link.source_profile_id=member.source_id and link.status in ('suggested','ambiguous'))
+            ))
+        )
+    )`
+}
+
+function actionFlagSql(flag, { permissionStatus, permissionExpiresAt, sourceIsStale, identityReview, actorOwner }, params) {
+    switch (flag) {
+        case 'assigned_to_me':
+            params.push(actorOwner)
+            return `coalesce(action.owner,'') = $${params.length}`
+        case 'due_today':
+            return `action.status = any($${params.push(ACTIVE_ACTION_STATUSES)}::text[]) and action.due_date=current_date`
+        case 'overdue':
+            return `action.status = any($${params.push(ACTIVE_ACTION_STATUSES)}::text[]) and action.due_date < current_date`
+        case 'awaiting_response': return `action.status='contacted'`
+        case 'scheduled': return `action.status='scheduled'`
+        case 'no_return': return `action.status='contacted' and action.due_date < current_date`
+        case 'permission_expiring': return `${permissionExpiresAt} >= now() and ${permissionExpiresAt} <= now() + interval '7 days'`
+        case 'ineligible': return `${permissionStatus} <> 'eligible'`
+        case 'source_stale':
+            params.push(sourceIsStale)
+            return `$${params.length}::boolean`
+        case 'identity_review': return identityReview
+        default: throw operationalError('INVALID_COMMERCIAL_OPERATION_FLAG', 400)
+    }
+}
+
+function mapWalletAction(row, actor) {
+    const permission = { status: text(row.permission_status) || 'review_required', expiresAt: iso(row.permission_expires_at) }
+    const queueFlags = actionQueueFlags({
+        status: row.status,
+        dueDate: row.due_date,
+        owner: row.owner,
+    }, {
+        actorIds: [actorPrincipal(actor)],
+        eligibility: permission,
+        sourceStale: bool(row.source_stale),
+        identityInReview: bool(row.identity_in_review),
+    })
+    return {
+        actionId: text(row.id),
+        unit: text(row.unit_slug) || null,
+        segmentKey: text(row.segment_key),
+        actionType: text(row.action_type),
+        status: text(row.status),
+        owner: projectOwner(row.owner),
+        dueDate: dateOnly(row.due_date),
+        revision: count(row.revision) || 1,
+        outcomeCode: text(row.outcome_code) || null,
+        permission,
+        sourceStale: bool(row.source_stale),
+        identityInReview: bool(row.identity_in_review),
+        queueFlags,
+        createdAt: iso(row.created_at),
+        updatedAt: iso(row.updated_at),
+    }
+}
+
+async function queryWallet(pgPool, query, actor) {
+    const dependencies = await operationalDependencies(pgPool)
+    const [globalSourceStale, scope] = await Promise.all([
+        sourceStale(pgPool, dependencies),
+        Promise.resolve(requestedUnitScope(actor, query?.unit)),
+    ])
+    const flags = normalizeActionFlags(query?.actionFlag || query?.actionFlags)
+    const status = text(query?.status).toLowerCase()
+    const owner = query?.owner == null || query?.owner === '' ? '' : safeOwner(query.owner)
+    const sort = Object.prototype.hasOwnProperty.call(WALLET_SORTS, text(query?.sort)) ? text(query.sort) : 'dueDate'
+    const direction = text(query?.direction).toLowerCase() === 'asc' ? 'asc' :
+        (text(query?.direction).toLowerCase() === 'desc' ? 'desc' : (sort === 'dueDate' ? 'asc' : 'desc'))
+    const limit = normalizeLimit(query?.limit)
+    const offset = normalizeOffset(query?.offset)
+    if (status && !ACTION_STATUSES.includes(status)) throw operationalError('INVALID_COMMERCIAL_ACTION_STATUS', 400)
+    const permission = permissionSql(dependencies)
+    const identityReview = identityReviewSql(dependencies)
+    const params = []
+    const where = [scopeWhere(scope, params)]
+    if (status) {
+        params.push(status)
+        where.push(`action.status=$${params.length}`)
+    }
+    if (owner) {
+        params.push(owner)
+        where.push(`action.owner=$${params.length}`)
+    }
+    for (const flag of flags) {
+        where.push(actionFlagSql(flag, {
+            permissionStatus: permission.status,
+            permissionExpiresAt: permission.expiresAt,
+            sourceIsStale: globalSourceStale,
+            identityReview,
+            actorOwner: actorPrincipal(actor),
+        }, params))
+    }
+    params.push(globalSourceStale, limit, offset)
+    const rows = await pgPool.query(`select action.id::text, action.segment_key, action.action_type, action.status, action.owner,
+            action.due_date, action.revision, action.outcome_code, action.created_at, action.updated_at,
+            unit.slug as unit_slug, ${permission.status} as permission_status, ${permission.expiresAt} as permission_expires_at,
+            $${params.length - 2}::boolean as source_stale, ${identityReview} as identity_in_review,
+            count(*) over()::int as total_count
+        from crm_atendimento.commercial_actions action
+        join crm_atendimento.units unit on unit.id=action.unit_id
+        ${permission.join}
+        where ${where.join(' and ')}
+        order by ${WALLET_SORTS[sort]} ${direction} nulls last, action.updated_at desc, action.id asc
+        limit $${params.length - 1} offset $${params.length}`, params)
+    const actions = (rows.rows || []).map((row) => mapWalletAction(row, actor))
+    return {
+        total: count(rows.rows?.[0]?.total_count),
+        limit,
+        offset,
+        sort,
+        direction,
+        filters: { unit: scope.unit || null, status: status || null, owner: owner || null, actionFlags: flags },
+        actions,
+        pagination: { hasPrevious: offset > 0, hasNext: offset + actions.length < count(rows.rows?.[0]?.total_count) },
+        safety: operationSafety(),
+    }
+}
+
+function mapOwnerMetric(row) {
+    return {
+        owner: projectOwner(row.owner) || 'unassigned',
+        total: count(row.total),
+        active: count(row.active),
+        overdue: count(row.overdue),
+        completed: count(row.completed),
+        responded: count(row.responded),
+        scheduled: count(row.scheduled),
+        attended: count(row.attended),
+        sale: count(row.sale),
+        returned: count(row.returned),
+        cancelled: count(row.cancelled),
+    }
+}
+
+async function queryStageDurations(pgPool, scope) {
+    const params = []
+    const where = scopeWhere(scope, params)
+    const result = await pgPool.query(`select event.action_id::text,event.status,event.created_at
+        from crm_atendimento.commercial_action_events event
+        join crm_atendimento.commercial_actions action on action.id=event.action_id
+        join crm_atendimento.units unit on unit.id=action.unit_id
+        where ${where}
+        order by event.action_id,event.event_order asc
+        limit 10000`, params)
+    return computeAverageStageDurations((result.rows || []).map((row) => ({
+        actionId: row.action_id,
+        status: row.status,
+        createdAt: row.created_at,
+    })))
+}
+
+async function queryTeam(pgPool, query, actor) {
+    const scope = requestedUnitScope(actor, query?.unit)
+    const params = []
+    const where = scopeWhere(scope, params)
+    const [owners, statuses, absences, stageDurations] = await Promise.all([
+        pgPool.query(`select coalesce(action.owner,'') as owner,
+                count(*)::int as total,
+                count(*) filter (where action.status=any($${params.push(ACTIVE_ACTION_STATUSES)}::text[]))::int as active,
+                count(*) filter (where action.status=any($${params.push(ACTIVE_ACTION_STATUSES)}::text[]) and action.due_date < current_date)::int as overdue,
+                count(*) filter (where action.status in ('closed','cancelled','won_sale','returned') or action.outcome_code in ('attended','sale','clinical_return','cancelled'))::int as completed,
+                count(*) filter (where action.status in ('responded','scheduled','won_sale','returned') or action.outcome_code in ('requested_follow_up','scheduled','attended','cancelled','sale','clinical_return','opt_out_requested'))::int as responded,
+                count(*) filter (where action.status='scheduled' or action.outcome_code='scheduled')::int as scheduled,
+                count(*) filter (where action.outcome_code='attended')::int as attended,
+                count(*) filter (where action.status='won_sale' or action.outcome_code='sale')::int as sale,
+                count(*) filter (where action.status='returned' or action.outcome_code='clinical_return')::int as returned,
+                count(*) filter (where action.status='cancelled' or action.outcome_code='cancelled')::int as cancelled
+            from crm_atendimento.commercial_actions action
+            join crm_atendimento.units unit on unit.id=action.unit_id
+            where ${where}
+            group by coalesce(action.owner,'') order by active desc, owner asc`, params),
+        pgPool.query(`select action.status, count(*)::int as count
+            from crm_atendimento.commercial_actions action
+            join crm_atendimento.units unit on unit.id=action.unit_id
+            where ${where} group by action.status`, params.slice(0, -2)),
+        pgPool.query(`select absence.id::text, absence.owner, unit.slug as unit, absence.absence_type,
+                absence.starts_at, absence.ends_at, absence.substitute_owner, absence.revision
+            from crm_atendimento.commercial_owner_absences absence
+            join crm_atendimento.units unit on unit.id=absence.unit_id
+            where ${scopeWhere(scope, [])}
+              and absence.ends_at >= current_date
+             order by absence.starts_at asc`, scope.unit ? [scope.unit] : scope.unitSlugs ? [scope.unitSlugs] : []),
+        queryStageDurations(pgPool, scope),
+    ])
+    const byOwner = (owners.rows || []).map(mapOwnerMetric)
+    const totals = byOwner.reduce((result, row) => Object.fromEntries(Object.keys(row).filter((key) => key !== 'owner').map((key) => [key, count(result[key]) + count(row[key])])), {})
+    const total = count(totals.total)
+    const rate = (key) => total ? Math.round((count(totals[key]) / total) * 10_000) / 100 : 0
+    return {
+        totals: {
+            ...totals,
+            completionRate: rate('completed'), responseRate: rate('responded'), schedulingRate: rate('scheduled'),
+            attendanceRate: rate('attended'), saleRate: rate('sale'), returnRate: rate('returned'), cancellationRate: rate('cancelled'),
+        },
+        byOwner,
+        byStatus: Object.fromEntries((statuses.rows || []).map((row) => [text(row.status), count(row.count)])),
+        stageDurations,
+        absences: (absences.rows || []).map((row) => ({
+            absenceId: text(row.id), owner: projectOwner(row.owner) || 'unassigned', unit: text(row.unit),
+            type: text(row.absence_type), startsAt: dateOnly(row.starts_at), endsAt: dateOnly(row.ends_at),
+            substituteOwner: projectOwner(row.substitute_owner), revision: count(row.revision) || 1,
+        })),
+        safety: operationSafety(),
+    }
+}
+
+function identityReviewFor(identityColumn, dependencies) {
+    return identityReviewSql(dependencies).replaceAll('action.identity_id', identityColumn)
+}
+
+function mapCampaign(row = {}) {
+    let filters = {}
+    try { filters = normalizeCampaignFilters(row.filters_snapshot || {}) } catch { /* corrupt legacy snapshot stays hidden */ }
+    return {
+        campaignId: text(row.id),
+        name: text(row.name),
+        revision: count(row.revision) || 1,
+        segmentKey: text(row.segment_key),
+        segmentVersion: text(row.segment_version),
+        filters,
+        contextHash: /^[a-f0-9]{64}$/i.test(text(row.context_hash)) ? text(row.context_hash).toLowerCase() : null,
+        cutoffAt: iso(row.cutoff_at),
+        unit: text(row.unit_slug),
+        owner: projectOwner(row.owner) || 'unassigned',
+        offerId: UUID_RE.test(text(row.offer_id)) ? text(row.offer_id).toLowerCase() : null,
+        assignmentWindowStart: iso(row.assignment_window_start),
+        assignmentWindowEnd: iso(row.assignment_window_end),
+        controlGroupPercent: count(row.control_group_percent),
+        state: COMMERCIAL_CAMPAIGN_STATES.includes(text(row.state)) ? text(row.state) : 'draft',
+        author: projectOwner(row.author) || null,
+        createdAt: iso(row.created_at),
+        updatedAt: iso(row.updated_at),
+        members: {
+            total: count(row.member_total),
+            eligible: count(row.member_eligible),
+            blocked: count(row.member_blocked),
+            review: count(row.member_review),
+            control: count(row.member_control),
+            assigned: count(row.member_assigned),
+            completed: count(row.member_completed),
+            cancelled: count(row.member_cancelled),
+        },
+    }
+}
+
+function mapCampaignEvent(row = {}) {
+    return {
+        eventOrder: count(row.event_order),
+        type: text(row.event_type),
+        occurredAt: iso(row.created_at),
+        actor: projectOwner(row.actor_id),
+        correlationId: UUID_RE.test(text(row.trace_id)) ? text(row.trace_id).toLowerCase() : null,
+        memberState: ['eligible', 'blocked', 'review', 'control', 'assigned', 'completed', 'cancelled'].includes(text(row.member_state))
+            ? text(row.member_state) : null,
+        outcomeCode: text(row.outcome_code) || null,
+    }
+}
+
+function frozenCampaignContext(campaign) {
+    return {
+        name: campaign.name,
+        segmentKey: campaign.segmentKey,
+        segmentVersion: campaign.segmentVersion,
+        filters: campaign.filters,
+        identityIds: [...campaign.identityIds].sort(),
+        cutoffAt: campaign.cutoffAt,
+        unit: campaign.unit,
+        owner: campaign.owner,
+        offerId: campaign.offerId,
+        assignmentWindowStart: campaign.assignmentWindowStart,
+        assignmentWindowEnd: campaign.assignmentWindowEnd,
+        controlGroupPercent: campaign.controlGroupPercent,
+        state: campaign.state,
+    }
+}
+
+async function campaignCohortDependencies(db) {
+    const result = await db.query(`select
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.global_client_identities'), 'SELECT'), false) as identities,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.global_client_identity_members'), 'SELECT'), false) as members,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.attendance_client_links'), 'SELECT'), false) as attendance_links,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.attendances'), 'SELECT'), false) as attendances,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_caixa.sales'), 'SELECT'), false) as sales,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.app_client_registrations'), 'SELECT'), false) as app_registrations,
+        coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.supplemental_lead_profiles'), 'SELECT'), false) as lead_profiles`)
+    const row = result.rows[0] || {}
+    return Object.values(row).every(bool)
+}
+
+async function resolveCampaignUnit(client, unitSlug) {
+    const result = await client.query(`select id::text,slug from crm_atendimento.units where slug=$1`, [unitSlug])
+    const unit = result.rows[0]
+    if (!unit?.id) throw operationalError('COMMERCIAL_UNIT_NOT_FOUND', 404)
+    return unit
+}
+
+async function readCampaignCohort(client, { identityIds, unitSlug, dependencies, globalSourceStale }) {
+    if (!dependencies) throw operationalError('COMMERCIAL_CAMPAIGN_COHORT_SOURCE_UNAVAILABLE', 409)
+    const permissions = await operationalDependencies(client)
+    const permission = permissionSql(permissions)
+    const review = identityReviewFor('identity.id', permissions)
+    const result = await client.query(`select identity.id::text as identity_id,
+            ${permission.status} as permission_status,
+            ${review} as identity_in_review,
+            exists(
+                select 1 from crm_atendimento.global_client_identity_members member
+                 where member.identity_id=identity.id and (
+                    (member.source_type='attendance_client' and member.source_id ~ '^[0-9a-fA-F-]{36}$' and exists(
+                        select 1 from crm_atendimento.attendance_client_links link
+                        join crm_atendimento.attendances attendance on attendance.id=link.attendance_id and attendance.deleted_at is null
+                        join crm_atendimento.units attendance_unit on attendance_unit.id=attendance.unit_id
+                        where link.client_id=member.source_id::uuid and attendance_unit.slug=$2
+                    ))
+                    or (member.source_type='caixa_customer' and member.source_id ~ '^[0-9a-fA-F-]{36}$' and exists(
+                        select 1 from crm_caixa.sales sale
+                        join crm_atendimento.units sale_unit on sale_unit.id=sale.unit_id
+                        where sale.customer_id=member.source_id::uuid and sale_unit.slug=$2
+                    ))
+                    or (member.source_type='app_registration' and exists(
+                        select 1 from crm_atendimento.app_client_registrations registration
+                        join lateral jsonb_array_elements_text(coalesce(registration.unit_slugs, '[]'::jsonb)) scope(slug) on true
+                        where registration.source_client_id=member.source_id and scope.slug=$2
+                    ))
+                    or (member.source_type='lead_profile' and exists(
+                        select 1 from crm_atendimento.supplemental_lead_profiles lead
+                        join lateral jsonb_array_elements_text(coalesce(lead.unit_slugs, '[]'::jsonb)) scope(slug) on true
+                        where lead.source_profile_id=member.source_id and scope.slug=$2
+                    ))
+                 )
+            ) as unit_match
+        from crm_atendimento.global_client_identities identity
+        ${permission.join.replaceAll('action.identity_id', 'identity.id')}
+        where identity.id=any($1::uuid[])`, [identityIds, unitSlug])
+    const found = new Map((result.rows || []).map((row) => [text(row.identity_id).toLowerCase(), row]))
+    if (found.size !== identityIds.length || identityIds.some((identityId) => !bool(found.get(identityId)?.unit_match))) {
+        throw operationalError('COMMERCIAL_CAMPAIGN_IDENTITY_UNIT_FORBIDDEN', 403)
+    }
+    return identityIds.map((identityId) => {
+        const row = found.get(identityId)
+        const permissionStatus = text(row.permission_status) || 'review_required'
+        const identityInReview = bool(row.identity_in_review)
+        const eligible = permissionStatus === 'eligible'
+        return {
+            identityId,
+            permissionStatus,
+            sourceStale: globalSourceStale,
+            identityInReview,
+            eligible,
+        }
+    })
+}
+
+function mutationInput(actor, operation, payload, fingerprintPayload, { requireReason = true } = {}) {
+    const mutation = normalizeOperationMutation(payload, { requireIdempotency: true, requireReason })
+    const actorRef = actorReference(actor)
+    const mutationKey = `co:${digest('commercial-operation-idempotency', {
+        actorRef, operation, idempotencyKey: mutation.idempotencyKey,
+    })}`
+    const requestFingerprint = digest('commercial-operation-request', {
+        actorRef,
+        operation,
+        payload: fingerprintPayload,
+    })
+    return { mutation, actorRef, mutationKey, requestFingerprint }
+}
+
+async function runCommercialOperationMutation(client, {
+    actor,
+    operation,
+    payload,
+    fingerprintPayload,
+    requireReason = true,
+    execute,
+}) {
+    const context = mutationInput(actor, operation, payload, fingerprintPayload, { requireReason })
+    // Serialize every idempotency namespace before examining the operation
+    // ledger or mutable rows. This makes a replay safe even when an earlier
+    // successful mutation has changed its optimistic revision.
+    await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [context.mutationKey])
+    // Readiness is checked only after the idempotency lock.  A retry therefore
+    // cannot observe a partially applied migration or race another request
+    // while deciding whether the ledger already contains its result.
+    await assertCommercialOperationsReady(client)
+    const existing = await client.query(`select request_fingerprint,response
+        from crm_atendimento.commercial_operation_mutations
+        where mutation_key=$1 and operation=$2 for update`, [context.mutationKey, operation])
+    if (existing.rows[0]) {
+        if (text(existing.rows[0].request_fingerprint) !== context.requestFingerprint) {
+            throw operationalError('COMMERCIAL_IDEMPOTENCY_CONFLICT', 409)
+        }
+        return { ...(existing.rows[0].response || {}), idempotent: true, safety: operationSafety() }
+    }
+    const response = await execute(context)
+    await client.query(`insert into crm_atendimento.commercial_operation_mutations(
+            mutation_key,operation,actor_id,request_fingerprint,response)
+        values($1,$2,$3,$4,$5::jsonb)`, [
+        context.mutationKey,
+        operation,
+        context.actorRef,
+        context.requestFingerprint,
+        JSON.stringify(response || {}),
+    ])
+    return { ...(response || {}), idempotent: false, safety: operationSafety() }
+}
+
+async function recordCampaignEvent(client, { campaignId, memberId = null, eventType, actorRef, traceId, payload = {} }) {
+    await client.query(`insert into crm_atendimento.commercial_campaign_events(
+            campaign_id,member_id,event_type,actor_id,trace_id,payload)
+        values($1,$2,$3,$4,$5,$6::jsonb)`, [
+        campaignId, memberId, eventType, actorRef, traceId, JSON.stringify(payload),
+    ])
+}
+
+async function recordActionEvent(client, {
+    actionId,
+    identityId,
+    previousStatus,
+    status,
+    outcomeCode = null,
+    actorRef,
+    traceId,
+    details = {},
+}) {
+    // `details` is an explicit operational allowlist.  Do not pass an action
+    // payload, note, customer object, identity context or source evidence here:
+    // the action ledger is append-only and must therefore be safe to retain.
+    const safeDetails = {
+        operation: text(details.operation),
+        ownerChanged: details.ownerChanged === true,
+        rebalance: details.rebalance === true,
+        reasonDigest: /^[a-f0-9]{64}$/i.test(text(details.reasonDigest)) ? text(details.reasonDigest) : null,
+    }
+    await client.query(`insert into crm_atendimento.commercial_action_events(
+            action_id,identity_id,event_type,previous_status,status,trace_id,recorded_by,
+            contact_eligibility_status,contact_eligibility_reason,details,outcome_code)
+        values($1,$2,'updated',$3,$4,$5,$6,$7,$8,$9::jsonb,$10)`, [
+        actionId,
+        identityId,
+        previousStatus,
+        status,
+        traceId,
+        actorRef,
+        null,
+        null,
+        JSON.stringify(safeDetails),
+        outcomeCode,
+    ])
+}
+
+function memberStateForAction(status, outcomeCode, currentState) {
+    if (['control', 'blocked', 'review', 'completed', 'cancelled'].includes(text(currentState))) return text(currentState)
+    if (text(status) === 'cancelled' || outcomeCode === 'cancelled') return 'cancelled'
+    if (['won_sale', 'returned', 'closed'].includes(text(status)) || ['attended', 'sale', 'clinical_return'].includes(outcomeCode)) return 'completed'
+    return 'assigned'
+}
+
+async function synchronizeCampaignMembershipForAction(client, {
+    actionId,
+    owner = null,
+    status,
+    outcomeCode = null,
+    actorRef,
+    reasonDigest,
+}) {
+    const memberships = await client.query(`select id::text,campaign_id::text,state
+        from crm_atendimento.commercial_campaign_members
+        where action_id=$1 for update`, [actionId])
+    for (const member of memberships.rows || []) {
+        const nextState = memberStateForAction(status, outcomeCode, member.state)
+        await client.query(`update crm_atendimento.commercial_campaign_members
+            set owner=coalesce($2,owner),state=$3,revision=revision+1,updated_at=now()
+            where id=$1`, [member.id, owner, nextState])
+        await recordCampaignEvent(client, {
+            campaignId: member.campaign_id,
+            memberId: member.id,
+            eventType: outcomeCode ? 'member_outcome' : 'member_assigned',
+            actorRef,
+            traceId: randomUUID(),
+            payload: outcomeCode
+                ? { state: nextState, outcomeCode, reasonDigest }
+                : { state: nextState, ownerChanged: owner !== null, reasonDigest },
+        })
+    }
+}
+
+async function campaignProjection(client, campaignId, actor) {
+    const scope = requestedUnitScope(actor)
+    const params = [campaignId]
+    const where = ["campaign.id=$1", scopeWhere(scope, params)]
+    const result = await client.query(`select campaign.id::text,campaign.name,campaign.revision,campaign.segment_key,campaign.segment_version,
+            campaign.filters_snapshot,campaign.context_hash,campaign.cutoff_at,unit.slug as unit_slug,campaign.owner,campaign.offer_id::text,
+            campaign.assignment_window_start,campaign.assignment_window_end,campaign.control_group_percent,campaign.state,campaign.author,
+            campaign.created_at,campaign.updated_at,
+            count(member.id)::int as member_total,
+            count(member.id) filter(where member.state='eligible')::int as member_eligible,
+            count(member.id) filter(where member.state='blocked')::int as member_blocked,
+            count(member.id) filter(where member.state='review')::int as member_review,
+            count(member.id) filter(where member.state='control')::int as member_control,
+            count(member.id) filter(where member.state='assigned')::int as member_assigned,
+            count(member.id) filter(where member.state='completed')::int as member_completed,
+            count(member.id) filter(where member.state='cancelled')::int as member_cancelled
+        from crm_atendimento.commercial_campaigns campaign
+        join crm_atendimento.units unit on unit.id=campaign.unit_id
+        left join crm_atendimento.commercial_campaign_members member on member.campaign_id=campaign.id
+        where ${where.join(' and ')}
+        group by campaign.id,unit.slug`, params)
+    if (!result.rows[0]) throw operationalError('COMMERCIAL_CAMPAIGN_NOT_FOUND', 404)
+    return mapCampaign(result.rows[0])
+}
+
+async function createCampaign(client, payload, actor) {
+    const campaign = normalizeCampaignPayload(payload)
+    const unitSlug = assertUnitAllowed(actor, campaign.unit)
+    const contextHash = stableOperationFingerprint(frozenCampaignContext(campaign))
+    return runCommercialOperationMutation(client, {
+        actor,
+        operation: 'campaign_create',
+        payload,
+        fingerprintPayload: { campaign: frozenCampaignContext(campaign), contextHash },
+        execute: async ({ actorRef }) => {
+            const unit = await resolveCampaignUnit(client, unitSlug)
+            await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [`commercial-operations:campaign:${unit.id}:${contextHash}`])
+            const existing = await client.query(`select id::text from crm_atendimento.commercial_campaigns
+                where unit_id=$1 and context_hash=$2
+                order by created_at asc,id asc limit 1 for update`, [unit.id, contextHash])
+            if (existing.rows[0]?.id) {
+                const persisted = await campaignProjection(client, existing.rows[0].id, actor)
+                return { campaign: persisted, cohort: { ...persisted.members }, deduplicated: true }
+            }
+            const dependencies = await campaignCohortDependencies(client)
+            const stale = await sourceStale(client, await operationalDependencies(client))
+            if (campaign.offerId) {
+                const offer = await client.query(`select id from crm_atendimento.commercial_offers where id=$1`, [campaign.offerId])
+                if (!offer.rows[0]?.id) throw operationalError('COMMERCIAL_CAMPAIGN_OFFER_NOT_FOUND', 404)
+            }
+            const cohort = await readCampaignCohort(client, {
+                identityIds: [...campaign.identityIds].sort(), unitSlug, dependencies, globalSourceStale: stale,
+            })
+            const created = await client.query(`insert into crm_atendimento.commercial_campaigns(
+                    name,segment_key,segment_version,filters_snapshot,context_hash,cutoff_at,unit_id,owner,offer_id,
+                    assignment_window_start,assignment_window_end,control_group_percent,state,author,reason)
+                values($1,$2,$3,$4::jsonb,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+                returning id::text`, [
+                campaign.name, campaign.segmentKey, campaign.segmentVersion, JSON.stringify(campaign.filters), contextHash,
+                campaign.cutoffAt, unit.id, campaign.owner, campaign.offerId, campaign.assignmentWindowStart,
+                campaign.assignmentWindowEnd, campaign.controlGroupPercent, campaign.state, actorRef, `digest:${digest('campaign-reason', { reason: campaign.reason })}`,
+            ])
+            const campaignId = created.rows[0]?.id
+            if (!campaignId) throw operationalError('COMMERCIAL_CAMPAIGN_CREATE_FAILED', 500)
+            const traceId = randomUUID()
+            await recordCampaignEvent(client, {
+                campaignId, eventType: 'created', actorRef, traceId,
+                payload: { contextHash, cohortCount: cohort.length, controlGroupPercent: campaign.controlGroupPercent },
+            })
+            const stateCounts = { eligible: 0, blocked: 0, review: 0, control: 0, assigned: 0, completed: 0, cancelled: 0 }
+            for (const member of cohort) {
+                const controlGroup = member.eligible && !member.sourceStale && !member.identityInReview && stableControlGroup({
+                    campaignSeed: contextHash, identityId: member.identityId, percentage: campaign.controlGroupPercent,
+                })
+                const state = campaignMemberState({
+                    eligible: member.eligible, controlGroup, identityInReview: member.identityInReview, sourceStale: member.sourceStale,
+                })
+                stateCounts[state] += 1
+                const eligibilitySnapshot = {
+                    permissionStatus: member.permissionStatus,
+                    sourceStale: member.sourceStale,
+                    identityInReview: member.identityInReview,
+                    evaluatedAt: new Date().toISOString(),
+                }
+                const inserted = await client.query(`insert into crm_atendimento.commercial_campaign_members(
+                        campaign_id,identity_id,unit_id,segment_key,segment_version,cutoff_at,owner,offer_id,control_group,state,eligibility_snapshot)
+                    values($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::jsonb) returning id::text`, [
+                    campaignId, member.identityId, unit.id, campaign.segmentKey, campaign.segmentVersion, campaign.cutoffAt,
+                    campaign.owner, campaign.offerId, controlGroup, state, JSON.stringify(eligibilitySnapshot),
+                ])
+                await recordCampaignEvent(client, {
+                    campaignId, memberId: inserted.rows[0]?.id || null, eventType: 'member_added', actorRef, traceId: randomUUID(),
+                    payload: { state, controlGroup },
+                })
+            }
+            return {
+                campaign: await campaignProjection(client, campaignId, actor),
+                cohort: { total: cohort.length, ...stateCounts },
+            }
+        },
+    })
+}
+
+async function listCampaigns(pgPool, query, actor) {
+    const scope = requestedUnitScope(actor, query?.unit)
+    const state = text(query?.state).toLowerCase()
+    if (state && !COMMERCIAL_CAMPAIGN_STATES.includes(state)) throw operationalError('INVALID_COMMERCIAL_CAMPAIGN_STATE', 400)
+    const limit = normalizeLimit(query?.limit)
+    const offset = normalizeOffset(query?.offset)
+    const params = []
+    const where = [scopeWhere(scope, params)]
+    if (state) { params.push(state); where.push(`campaign.state=$${params.length}`) }
+    params.push(limit, offset)
+    const result = await pgPool.query(`select campaign.id::text,campaign.name,campaign.revision,campaign.segment_key,campaign.segment_version,
+            campaign.filters_snapshot,campaign.context_hash,campaign.cutoff_at,unit.slug as unit_slug,campaign.owner,campaign.offer_id::text,
+            campaign.assignment_window_start,campaign.assignment_window_end,campaign.control_group_percent,campaign.state,campaign.author,
+            campaign.created_at,campaign.updated_at,
+            count(member.id)::int as member_total,
+            count(member.id) filter(where member.state='eligible')::int as member_eligible,
+            count(member.id) filter(where member.state='blocked')::int as member_blocked,
+            count(member.id) filter(where member.state='review')::int as member_review,
+            count(member.id) filter(where member.state='control')::int as member_control,
+            count(member.id) filter(where member.state='assigned')::int as member_assigned,
+            count(member.id) filter(where member.state='completed')::int as member_completed,
+            count(member.id) filter(where member.state='cancelled')::int as member_cancelled,
+            count(*) over()::int as total_count
+        from crm_atendimento.commercial_campaigns campaign
+        join crm_atendimento.units unit on unit.id=campaign.unit_id
+        left join crm_atendimento.commercial_campaign_members member on member.campaign_id=campaign.id
+        where ${where.join(' and ')}
+        group by campaign.id,unit.slug
+        order by campaign.updated_at desc,campaign.id asc
+        limit $${params.length - 1} offset $${params.length}`, params)
+    const campaigns = (result.rows || []).map(mapCampaign)
+    return {
+        total: count(result.rows?.[0]?.total_count), limit, offset, campaigns,
+        pagination: { hasPrevious: offset > 0, hasNext: offset + campaigns.length < count(result.rows?.[0]?.total_count) },
+        safety: operationSafety(),
+    }
+}
+
+async function campaignDetail(pgPool, campaignId, query, actor) {
+    const id = assertUuid(campaignId, 'INVALID_COMMERCIAL_CAMPAIGN')
+    if (query?.unit) assertUnitAllowed(actor, query.unit)
+    const campaign = await campaignProjection(pgPool, id, actor)
+    const events = await pgPool.query(`select event_order,event_type,actor_id,trace_id,created_at,
+            case when payload->>'state' in ('eligible','blocked','review','control','assigned','completed','cancelled') then payload->>'state' else null end as member_state,
+            case when payload->>'outcomeCode' ~ '^[a-z_]{2,80}$' then payload->>'outcomeCode' else null end as outcome_code
+        from crm_atendimento.commercial_campaign_events
+        where campaign_id=$1 order by event_order desc limit $2`, [id, normalizeLimit(query?.eventLimit, 50, 100)])
+    return { campaign, events: (events.rows || []).map(mapCampaignEvent), safety: operationSafety() }
+}
+
+async function updateCampaign(client, campaignId, payload, actor) {
+    const id = assertUuid(campaignId, 'INVALID_COMMERCIAL_CAMPAIGN')
+    const stateProvided = Object.prototype.hasOwnProperty.call(payload || {}, 'state')
+    const state = stateProvided ? text(payload.state).toLowerCase() : null
+    if (Object.prototype.hasOwnProperty.call(payload || {}, 'owner') ||
+        Object.prototype.hasOwnProperty.call(payload || {}, 'filters') ||
+        Object.prototype.hasOwnProperty.call(payload || {}, 'segmentKey') ||
+        Object.prototype.hasOwnProperty.call(payload || {}, 'segmentVersion') ||
+        Object.prototype.hasOwnProperty.call(payload || {}, 'identityIds') ||
+        Object.prototype.hasOwnProperty.call(payload || {}, 'offerId') ||
+        Object.prototype.hasOwnProperty.call(payload || {}, 'unit')) {
+        throw operationalError('COMMERCIAL_CAMPAIGN_FROZEN_CONTEXT', 409)
+    }
+    if (!stateProvided) throw operationalError('COMMERCIAL_CAMPAIGN_CHANGE_REQUIRED', 400)
+    if (stateProvided && !COMMERCIAL_CAMPAIGN_STATES.includes(state)) throw operationalError('INVALID_COMMERCIAL_CAMPAIGN_STATE', 400)
+    return runCommercialOperationMutation(client, {
+        actor,
+        operation: 'campaign_update',
+        payload,
+        fingerprintPayload: { campaignId: id, state, expectedRevision: payload?.expectedRevision, reason: text(payload?.reason) },
+        execute: async ({ mutation, actorRef }) => {
+            const current = await client.query(`select campaign.id::text,campaign.revision,campaign.state,unit.slug as unit_slug
+                from crm_atendimento.commercial_campaigns campaign
+                join crm_atendimento.units unit on unit.id=campaign.unit_id
+                where campaign.id=$1 for update of campaign`, [id])
+            const row = current.rows[0]
+            if (!row?.id) throw operationalError('COMMERCIAL_CAMPAIGN_NOT_FOUND', 404)
+            assertUnitAllowed(actor, row.unit_slug)
+            if (mutation.expectedRevision == null || count(row.revision) !== mutation.expectedRevision) {
+                throw operationalError('COMMERCIAL_CAMPAIGN_CONFLICT', 409)
+            }
+            if (state === row.state) throw operationalError('COMMERCIAL_CAMPAIGN_CHANGE_REQUIRED', 400)
+            await client.query(`update crm_atendimento.commercial_campaigns
+                set state=$2,revision=revision+1,updated_at=now()
+                where id=$1`, [id, state])
+            await recordCampaignEvent(client, {
+                campaignId: id, eventType: 'state_changed', actorRef, traceId: randomUUID(),
+                payload: { previousState: row.state, state,
+                    reasonDigest: digest('campaign-update-reason', { reason: mutation.reason }) },
+            })
+            return { campaign: await campaignProjection(client, id, actor) }
+        },
+    })
+}
+
+async function actionProjection(client, actionId, actor) {
+    const scope = requestedUnitScope(actor)
+    const dependencies = await operationalDependencies(client)
+    const [globalSourceStale] = await Promise.all([sourceStale(client, dependencies)])
+    const permission = permissionSql(dependencies)
+    const identityReview = identityReviewSql(dependencies)
+    const params = [actionId]
+    const where = ['action.id=$1', scopeWhere(scope, params)]
+    params.push(globalSourceStale)
+    const result = await client.query(`select action.id::text,action.segment_key,action.action_type,action.status,action.owner,
+            action.due_date,action.revision,action.outcome_code,action.created_at,action.updated_at,
+            unit.slug as unit_slug,${permission.status} as permission_status,${permission.expiresAt} as permission_expires_at,
+            $${params.length}::boolean as source_stale,${identityReview} as identity_in_review
+        from crm_atendimento.commercial_actions action
+        join crm_atendimento.units unit on unit.id=action.unit_id
+        ${permission.join}
+        where ${where.join(' and ')}`, params)
+    if (!result.rows[0]) throw operationalError('COMMERCIAL_ACTION_NOT_FOUND', 404)
+    return mapWalletAction(result.rows[0], actor)
+}
+
+async function actionForMutation(client, actionId, actor) {
+    const id = assertUuid(actionId, 'INVALID_COMMERCIAL_ACTION')
+    const result = await client.query(`select action.id::text,action.identity_id::text,action.revision,action.status,action.owner,
+            unit.slug as unit_slug
+        from crm_atendimento.commercial_actions action
+        join crm_atendimento.units unit on unit.id=action.unit_id
+        where action.id=$1 for update of action`, [id])
+    const action = result.rows[0]
+    if (!action?.id) throw operationalError('COMMERCIAL_ACTION_NOT_FOUND', 404)
+    assertUnitAllowed(actor, action.unit_slug)
+    return action
+}
+
+async function reassignAction(client, actionId, payload, actor) {
+    const id = assertUuid(actionId, 'INVALID_COMMERCIAL_ACTION')
+    const owner = safeOwner(payload?.owner, { required: true })
+    return runCommercialOperationMutation(client, {
+        actor,
+        operation: 'action_reassign',
+        payload,
+        fingerprintPayload: { actionId: id, owner, expectedRevision: payload?.expectedRevision, reason: text(payload?.reason) },
+        execute: async ({ mutation, actorRef }) => {
+            const action = await actionForMutation(client, id, actor)
+            if (mutation.expectedRevision == null || count(action.revision) !== mutation.expectedRevision) {
+                throw operationalError('COMMERCIAL_ACTION_CONFLICT', 409)
+            }
+            if (owner === action.owner) throw operationalError('COMMERCIAL_ACTION_REASSIGNMENT_UNCHANGED', 400)
+            await client.query(`update crm_atendimento.commercial_actions
+                set owner=$2,revision=revision+1,updated_by=$3,updated_at=now()
+                where id=$1`, [id, owner, actorRef])
+            const reasonDigest = digest('action-reassign-reason', { reason: mutation.reason })
+            await recordActionEvent(client, {
+                actionId: id, identityId: action.identity_id, previousStatus: action.status, status: action.status,
+                actorRef, traceId: randomUUID(),
+                details: { operation: 'reassign', ownerChanged: true, reasonDigest },
+            })
+            await synchronizeCampaignMembershipForAction(client, {
+                actionId: id, owner, status: action.status, actorRef, reasonDigest,
+            })
+            return { action: await actionProjection(client, id, actor) }
+        },
+    })
+}
+
+async function recordActionOutcome(client, actionId, payload, actor) {
+    const id = assertUuid(actionId, 'INVALID_COMMERCIAL_ACTION')
+    const outcomeCode = normalizeOutcomeCode(payload?.outcomeCode)
+    if (!outcomeCode) throw operationalError('INVALID_COMMERCIAL_OUTCOME', 400)
+    const nextStatus = OUTCOME_STATUSES[outcomeCode]
+    return runCommercialOperationMutation(client, {
+        actor,
+        // The migration deliberately keeps structured outcomes under the
+        // existing audited action-update operation; it does not create a send
+        // operation or consent mutation.
+        operation: 'action_update',
+        payload,
+        fingerprintPayload: { actionId: id, outcomeCode, expectedRevision: payload?.expectedRevision, reason: text(payload?.reason) },
+        execute: async ({ mutation, actorRef }) => {
+            const action = await actionForMutation(client, id, actor)
+            if (mutation.expectedRevision == null || count(action.revision) !== mutation.expectedRevision) {
+                throw operationalError('COMMERCIAL_ACTION_CONFLICT', 409)
+            }
+            await client.query(`update crm_atendimento.commercial_actions
+                set status=$2,outcome_code=$3,outcome_recorded_at=now(),
+                    completed_at=case when $2 in ('won_sale','returned','closed','cancelled') then now() else completed_at end,
+                    revision=revision+1,updated_by=$4,updated_at=now()
+                where id=$1`, [id, nextStatus, outcomeCode, actorRef])
+            const reasonDigest = digest('action-outcome-reason', { reason: mutation.reason })
+            await recordActionEvent(client, {
+                actionId: id, identityId: action.identity_id, previousStatus: action.status, status: nextStatus,
+                outcomeCode, actorRef, traceId: randomUUID(),
+                details: { operation: 'outcome', reasonDigest },
+            })
+            await synchronizeCampaignMembershipForAction(client, {
+                actionId: id, status: nextStatus, outcomeCode, actorRef, reasonDigest,
+            })
+            return {
+                action: await actionProjection(client, id, actor),
+                // This is an operational signal only. A distinct consent flow
+                // must review the request; this module never records it.
+                requiresSeparateConsentWorkflow: outcomeCode === 'opt_out_requested',
+            }
+        },
+    })
+}
+
+function normalizeAbsencePayload(payload) {
+    const unit = text(payload?.unit).toLowerCase()
+    const owner = safeOwner(payload?.owner, { required: true })
+    const absenceType = text(payload?.absenceType || payload?.type).toLowerCase()
+    const substituteOwner = payload?.substituteOwner == null || payload?.substituteOwner === ''
+        ? null : safeOwner(payload.substituteOwner, { required: true })
+    const absenceId = payload?.absenceId ? assertUuid(payload.absenceId, 'INVALID_COMMERCIAL_ABSENCE') : null
+    if (!UNIT_RE.test(unit)) throw operationalError('INVALID_COMMERCIAL_UNIT', 400)
+    if (!ABSENCE_TYPES.has(absenceType)) throw operationalError('INVALID_COMMERCIAL_ABSENCE_TYPE', 400)
+    const range = normalizeDateRange(payload?.startsAt, payload?.endsAt, 'INVALID_COMMERCIAL_ABSENCE_RANGE')
+    return { absenceId, unit, owner, absenceType, substituteOwner, ...range }
+}
+
+function mapAbsence(row = {}) {
+    return {
+        absenceId: text(row.id),
+        unit: text(row.unit_slug || row.unit),
+        owner: projectOwner(row.owner) || 'unassigned',
+        type: text(row.absence_type),
+        startsAt: dateOnly(row.starts_at),
+        endsAt: dateOnly(row.ends_at),
+        substituteOwner: projectOwner(row.substitute_owner),
+        revision: count(row.revision) || 1,
+        createdAt: iso(row.created_at),
+        updatedAt: iso(row.updated_at),
+    }
+}
+
+async function upsertAbsence(client, payload, actor) {
+    const absence = normalizeAbsencePayload(payload)
+    const unitSlug = assertUnitAllowed(actor, absence.unit)
+    return runCommercialOperationMutation(client, {
+        actor,
+        operation: 'absence_upsert',
+        payload,
+        fingerprintPayload: { ...absence, expectedRevision: payload?.expectedRevision, reason: text(payload?.reason) },
+        execute: async ({ mutation, actorRef }) => {
+            const unit = await resolveCampaignUnit(client, unitSlug)
+            const current = await client.query(`select absence.id::text,absence.owner,absence.absence_type,absence.starts_at,absence.ends_at,
+                    absence.substitute_owner,absence.revision,unit.slug as unit_slug,absence.created_at,absence.updated_at
+                from crm_atendimento.commercial_owner_absences absence
+                join crm_atendimento.units unit on unit.id=absence.unit_id
+                where ${absence.absenceId ? 'absence.id=$1' : 'absence.owner=$1 and absence.unit_id=$2 and absence.starts_at=$3 and absence.ends_at=$4'}
+                for update of absence`, absence.absenceId
+                ? [absence.absenceId]
+                : [absence.owner, unit.id, absence.startsAt, absence.endsAt])
+            const row = current.rows[0]
+            if (row) {
+                assertUnitAllowed(actor, row.unit_slug)
+                if (text(row.unit_slug).toLowerCase() !== unitSlug) {
+                    throw operationalError('COMMERCIAL_ABSENCE_UNIT_CONFLICT', 409)
+                }
+                if (mutation.expectedRevision == null || count(row.revision) !== mutation.expectedRevision) {
+                    throw operationalError('COMMERCIAL_ABSENCE_CONFLICT', 409)
+                }
+                await client.query(`update crm_atendimento.commercial_owner_absences
+                    set owner=$2,absence_type=$3,starts_at=$4,ends_at=$5,substitute_owner=$6,
+                        reason=$7,revision=revision+1,updated_by=$8,updated_at=now()
+                    where id=$1`, [
+                    row.id, absence.owner, absence.absenceType, absence.startsAt, absence.endsAt, absence.substituteOwner,
+                    `digest:${digest('absence-reason', { reason: mutation.reason })}`, actorRef,
+                ])
+                const updated = await client.query(`select absence.id::text,absence.owner,absence.absence_type,absence.starts_at,absence.ends_at,
+                        absence.substitute_owner,absence.revision,unit.slug as unit_slug,absence.created_at,absence.updated_at
+                    from crm_atendimento.commercial_owner_absences absence
+                    join crm_atendimento.units unit on unit.id=absence.unit_id where absence.id=$1`, [row.id])
+                return { absence: mapAbsence(updated.rows[0]) }
+            }
+            if (mutation.expectedRevision != null) throw operationalError('COMMERCIAL_ABSENCE_NOT_FOUND', 404)
+            const inserted = await client.query(`insert into crm_atendimento.commercial_owner_absences(
+                    owner,unit_id,absence_type,starts_at,ends_at,substitute_owner,reason,created_by,updated_by)
+                values($1,$2,$3,$4,$5,$6,$7,$8,$8)
+                returning id::text,owner,absence_type,starts_at,ends_at,substitute_owner,revision,created_at,updated_at`, [
+                absence.owner, unit.id, absence.absenceType, absence.startsAt, absence.endsAt, absence.substituteOwner,
+                `digest:${digest('absence-reason', { reason: mutation.reason })}`, actorRef,
+            ])
+            return { absence: mapAbsence({ ...inserted.rows[0], unit_slug: unitSlug }) }
+        },
+    })
+}
+
+async function rebalanceActions(client, scope, { lock = false } = {}) {
+    const params = []
+    const where = [scopeWhere(scope, params), `action.status=any($${params.push(ACTIVE_ACTION_STATUSES)}::text[])`]
+    const result = await client.query(`select action.id::text,action.identity_id::text,action.owner,action.status,action.revision,
+            unit.slug as unit_slug,
+            exists(select 1 from crm_atendimento.commercial_owner_absences absence
+                where absence.unit_id=action.unit_id and absence.owner=action.owner
+                  and current_date between absence.starts_at and absence.ends_at) as absent_owner
+        from crm_atendimento.commercial_actions action
+        join crm_atendimento.units unit on unit.id=action.unit_id
+        where ${where.join(' and ')}
+        order by action.due_date asc nulls last,action.id asc${lock ? ' for update of action' : ''}`, params)
+    return (result.rows || []).map((row) => ({ ...row, absentOwner: bool(row.absent_owner) }))
+}
+
+function projectRebalancePlan(actions, capacities) {
+    const normalizedActions = actions.map((action) => ({
+        ...action,
+        absentOwner: action.absentOwner === true || action.absent_owner === true,
+    }))
+    const moves = planWalletBalance(normalizedActions, capacities)
+    const byId = new Map(actions.map((action) => [text(action.id).toLowerCase(), action]))
+    return moves.map((move) => {
+        const action = byId.get(text(move.actionId).toLowerCase())
+        return {
+            actionId: text(move.actionId).toLowerCase(),
+            fromOwner: projectOwner(move.fromOwner),
+            toOwner: projectOwner(move.toOwner),
+            expectedRevision: count(action?.revision) || 1,
+            unit: text(action?.unit_slug) || null,
+        }
+    }).filter((move) => UUID_RE.test(move.actionId) && move.toOwner)
+}
+
+async function previewRebalance(pgPool, payload, actor) {
+    const capacities = normalizeCapacities(payload?.capacities)
+    const scope = requestedUnitScope(actor, payload?.unit)
+    const actions = await rebalanceActions(pgPool, scope)
+    const moves = projectRebalancePlan(actions, capacities)
+    return {
+        unit: scope.unit || null,
+        capacities,
+        totalEligibleActions: actions.length,
+        moves,
+        safety: operationSafety(),
+    }
+}
+
+async function applyRebalance(client, payload, actor) {
+    const capacities = normalizeCapacities(payload?.capacities)
+    const expectedRevisions = normalizeExpectedRevisions(payload?.expectedRevisions)
+    const scope = requestedUnitScope(actor, payload?.unit)
+    return runCommercialOperationMutation(client, {
+        actor,
+        operation: 'rebalance',
+        payload,
+        fingerprintPayload: {
+            unit: scope.unit || scope.unitSlugs || 'all', capacities, expectedRevisions,
+            reason: text(payload?.reason),
+        },
+        execute: async ({ mutation, actorRef }) => {
+            // A scope-specific lock establishes a single plan writer.  The
+            // action rows are then locked before their revisions are compared.
+            await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [
+                `commercial-operations:rebalance:${scope.unit || (scope.unitSlugs || ['all']).join(',')}`,
+            ])
+            const actions = await rebalanceActions(client, scope, { lock: true })
+            const moves = projectRebalancePlan(actions, capacities)
+            const plannedIds = new Set(moves.map((move) => move.actionId))
+            const expectedIds = Object.keys(expectedRevisions)
+            if (plannedIds.size !== expectedIds.length || expectedIds.some((id) => !plannedIds.has(id))) {
+                throw operationalError('COMMERCIAL_REBALANCE_PLAN_CONFLICT', 409)
+            }
+            if (moves.some((move) => expectedRevisions[move.actionId] !== move.expectedRevision)) {
+                throw operationalError('COMMERCIAL_REBALANCE_CONFLICT', 409)
+            }
+            const byId = new Map(actions.map((action) => [text(action.id).toLowerCase(), action]))
+            const applied = []
+            for (const move of moves) {
+                const action = byId.get(move.actionId)
+                if (!action || count(action.revision) !== move.expectedRevision) {
+                    throw operationalError('COMMERCIAL_REBALANCE_CONFLICT', 409)
+                }
+                await client.query(`update crm_atendimento.commercial_actions
+                    set owner=$2,revision=revision+1,updated_by=$3,updated_at=now()
+                    where id=$1`, [move.actionId, move.toOwner, actorRef])
+                await recordActionEvent(client, {
+                    actionId: move.actionId,
+                    identityId: action.identity_id,
+                    previousStatus: action.status,
+                    status: action.status,
+                    actorRef,
+                    traceId: randomUUID(),
+                    details: { operation: 'rebalance', ownerChanged: true, rebalance: true,
+                        reasonDigest: digest('rebalance-reason', { reason: mutation.reason }) },
+                })
+                const memberships = await client.query(`update crm_atendimento.commercial_campaign_members
+                    set owner=$2,revision=revision+1,updated_at=now()
+                    where action_id=$1
+                    returning id::text,campaign_id::text`, [move.actionId, move.toOwner])
+                for (const member of memberships.rows || []) {
+                    await recordCampaignEvent(client, {
+                        campaignId: member.campaign_id,
+                        memberId: member.id,
+                        eventType: 'rebalanced',
+                        actorRef,
+                        traceId: randomUUID(),
+                        payload: { fromOwner: move.fromOwner, toOwner: move.toOwner },
+                    })
+                }
+                applied.push({ ...move, revision: move.expectedRevision + 1 })
+            }
+            return { moves: applied, moved: applied.length }
+        },
+    })
+}
+
+function opaqueTimelineId(source, id) {
+    const prefix = /^[a-z_]{2,40}$/i.test(text(source)) ? text(source).toLowerCase() : 'event'
+    return `${prefix}:${stableOperationFingerprint({ prefix, id: text(id) }).slice(0, 24)}`
+}
+
+function timelineActionType(row) {
+    const outcome = normalizeOutcomeCode(row.outcome_code)
+    if (outcome === 'opt_out_requested') return 'opt_out'
+    if (text(row.status) === 'contacted' || outcome === 'no_response' || outcome === 'wrong_number') return 'contact'
+    if (text(row.status) === 'responded' || outcome === 'requested_follow_up') return 'response'
+    if (text(row.status) === 'scheduled' || outcome === 'scheduled') return 'appointment'
+    return 'action'
+}
+
+function projectTimeline(row) {
+    const event = projectCommercialTimelineEvent(row)
+    return { ...event, id: opaqueTimelineId(event.source || event.type, row.id || row.event_id) }
+}
+
+async function assertCustomer360Scope(pgPool, identityId, query, actor) {
+    const scope = requestedUnitScope(actor, query?.unit)
+    // Customer 360 must always be anchored to one unit.  Even a global actor
+    // cannot accidentally request an unbounded identity timeline.
+    if (!scope.unit) throw operationalError('COMMERCIAL_CUSTOMER_360_UNIT_REQUIRED', 400)
+    const dependencies = await campaignCohortDependencies(pgPool)
+    const permissions = await operationalDependencies(pgPool)
+    const stale = await sourceStale(pgPool, permissions)
+    await readCampaignCohort(pgPool, {
+        identityIds: [identityId],
+        unitSlug: scope.unit,
+        dependencies,
+        globalSourceStale: stale,
+    })
+    return { unit: scope.unit, dependencies: permissions, sourceStale: stale }
+}
+
+async function customer360(pgPool, identityId, query, actor) {
+    const id = assertUuid(identityId, 'INVALID_COMMERCIAL_IDENTITY')
+    const { unit, dependencies, sourceStale } = await assertCustomer360Scope(pgPool, id, query, actor)
+    const limit = normalizeLimit(query?.limit, 100, 200)
+    const eventLimit = Math.max(20, Math.min(100, limit))
+    const [actions, campaigns, permissions, attendance, sales, decisions] = await Promise.all([
+        pgPool.query(`select event.id::text,event.status,event.outcome_code,event.trace_id,event.recorded_by as actor,
+                event.created_at,unit.slug as unit_slug
+            from crm_atendimento.commercial_action_events event
+            join crm_atendimento.commercial_actions action on action.id=event.action_id
+            join crm_atendimento.units unit on unit.id=action.unit_id
+            where event.identity_id=$1 and unit.slug=$2
+            order by event.event_order desc limit $3`, [id, unit, eventLimit]),
+        pgPool.query(`select event.id::text,event.event_type,event.trace_id,event.actor_id as actor,event.created_at,
+                unit.slug as unit_slug,campaign.id::text as campaign_id,campaign.offer_id::text as offer_id
+            from crm_atendimento.commercial_campaign_members member
+            join crm_atendimento.commercial_campaigns campaign on campaign.id=member.campaign_id
+            join crm_atendimento.units unit on unit.id=campaign.unit_id
+            join crm_atendimento.commercial_campaign_events event on event.campaign_id=campaign.id and (event.member_id=member.id or event.member_id is null)
+            where member.identity_id=$1 and unit.slug=$2
+            order by event.event_order desc limit $3`, [id, unit, eventLimit]),
+        dependencies.permissions
+            ? pgPool.query(`select event.id::text,event.status,event.trace_id,event.recorded_by as actor,event.created_at
+                from crm_atendimento.commercial_contact_permission_events event
+                where event.identity_id=$1
+                order by event.created_at desc limit $2`, [id, eventLimit])
+            : Promise.resolve({ rows: [] }),
+        pgPool.query(`select attendance.id::text,attendance.service_date as occurred_at,unit.slug as unit_slug
+            from crm_atendimento.global_client_identity_members member
+            join crm_atendimento.attendance_client_links link on link.client_id=member.source_id::uuid
+            join crm_atendimento.attendances attendance on attendance.id=link.attendance_id and attendance.deleted_at is null
+            join crm_atendimento.units unit on unit.id=attendance.unit_id
+            where member.identity_id=$1 and member.source_type='attendance_client' and member.source_id ~ '^[0-9a-fA-F-]{36}$' and unit.slug=$2
+            order by attendance.service_date desc limit $3`, [id, unit, eventLimit]),
+        pgPool.query(`select sale.id::text,sale.occurred_on as occurred_at,unit.slug as unit_slug
+            from crm_atendimento.global_client_identity_members member
+            join crm_caixa.sales sale on sale.customer_id=member.source_id::uuid
+            join crm_atendimento.units unit on unit.id=sale.unit_id
+            where member.identity_id=$1 and member.source_type='caixa_customer' and member.source_id ~ '^[0-9a-fA-F-]{36}$' and unit.slug=$2
+            order by sale.occurred_on desc limit $3`, [id, unit, eventLimit]),
+        dependencies.identityReview
+            ? pgPool.query(`select decision.id::text,decision.decision as status,decision.created_at
+                from crm_atendimento.identity_review_decisions decision
+                where exists(select 1 from crm_atendimento.global_client_identity_members member
+                    where member.identity_id=$1 and (member.source_id=decision.source_id or member.source_id=decision.target_id))
+                order by decision.event_order desc limit $2`, [id, eventLimit])
+            : Promise.resolve({ rows: [] }),
+    ])
+    const events = [
+        ...(actions.rows || []).map((row) => projectTimeline({
+            id: row.id, type: timelineActionType(row), occurredAt: row.created_at, source: 'CRM ação', unit: row.unit_slug,
+            actor: row.actor, correlationId: row.trace_id, status: row.status,
+        })),
+        ...(campaigns.rows || []).map((row) => projectTimeline({
+            id: row.id, type: 'campaign', occurredAt: row.created_at, source: 'CRM campanha', unit: row.unit_slug,
+            actor: row.actor, correlationId: row.trace_id, campaignId: row.campaign_id, offerId: row.offer_id,
+            status: row.event_type,
+        })),
+        ...(permissions.rows || []).map((row) => projectTimeline({
+            id: row.id, type: 'permission', occurredAt: row.created_at, source: 'Governança de permissão', unit,
+            actor: row.actor, correlationId: row.trace_id, consentReview: row.status, status: row.status,
+        })),
+        ...(attendance.rows || []).map((row) => projectTimeline({
+            id: row.id, type: 'attendance', occurredAt: row.occurred_at, source: 'Atendimento', unit: row.unit_slug, status: 'confirmed',
+        })),
+        ...(sales.rows || []).map((row) => projectTimeline({
+            id: row.id, type: 'sale', occurredAt: row.occurred_at, source: 'Caixa', unit: row.unit_slug, status: 'confirmed',
+        })),
+        ...(decisions.rows || []).map((row) => projectTimeline({
+            id: row.id, type: 'identity_decision', occurredAt: row.created_at, source: 'Revisão de identidade', unit, status: row.status,
+        })),
+    ]
+    if (sourceStale) {
+        events.push(projectTimeline({
+            id: `source-freshness:${unit}`, type: 'quality_finding', occurredAt: new Date().toISOString(),
+            source: 'Clientes fontes', unit, status: 'source_stale',
+        }))
+    }
+    events.sort((left, right) => String(right.occurredAt || '').localeCompare(String(left.occurredAt || '')) || left.id.localeCompare(right.id))
+    return {
+        unit,
+        events: events.slice(0, limit),
+        partial: !dependencies.permissions || !dependencies.identityReview,
+        safety: operationSafety(),
+    }
+}
+
+export function createCommercialOperationsStore({ pool, databaseUrl } = {}) {
+    const pgPool = pool || createPgPool(databaseUrl || process.env.DATABASE_URL)
+
+    const assertReadAccess = async (actor) => {
+        requirePool(pgPool)
+        assertCommercialOperationsManager(actor)
+        await assertCommercialOperationsReady(pgPool)
+    }
+    const assertMutationAccess = (actor) => {
+        requirePool(pgPool)
+        assertCommercialOperationsManager(actor)
+    }
+
+    return {
+        async readiness(actor) {
+            requirePool(pgPool)
+            assertCommercialOperationsManager(actor)
+            return commercialOperationsReadiness(pgPool)
+        },
+
+        async wallet(query, actor) {
+            await assertReadAccess(actor)
+            return queryWallet(pgPool, query, actor)
+        },
+
+        async team(query, actor) {
+            await assertReadAccess(actor)
+            return queryTeam(pgPool, query, actor)
+        },
+
+        async campaigns(query, actor) {
+            await assertReadAccess(actor)
+            return listCampaigns(pgPool, query, actor)
+        },
+
+        async campaign(campaignId, query, actor) {
+            await assertReadAccess(actor)
+            return campaignDetail(pgPool, campaignId, query, actor)
+        },
+
+        async customer360(identityId, query, actor) {
+            await assertReadAccess(actor)
+            return customer360(pgPool, identityId, query, actor)
+        },
+
+        async previewRebalance(payload, actor) {
+            await assertReadAccess(actor)
+            return previewRebalance(pgPool, payload, actor)
+        },
+
+        async createCampaign(payload, actor) {
+            assertMutationAccess(actor)
+            return withPgTransaction(pgPool, (client) => createCampaign(client, payload, actor))
+        },
+
+        async updateCampaign(campaignId, payload, actor) {
+            assertMutationAccess(actor)
+            return withPgTransaction(pgPool, (client) => updateCampaign(client, campaignId, payload, actor))
+        },
+
+        async reassignAction(actionId, payload, actor) {
+            assertMutationAccess(actor)
+            return withPgTransaction(pgPool, (client) => reassignAction(client, actionId, payload, actor))
+        },
+
+        async recordOutcome(actionId, payload, actor) {
+            assertMutationAccess(actor)
+            return withPgTransaction(pgPool, (client) => recordActionOutcome(client, actionId, payload, actor))
+        },
+
+        async upsertAbsence(payload, actor) {
+            assertMutationAccess(actor)
+            return withPgTransaction(pgPool, (client) => upsertAbsence(client, payload, actor))
+        },
+
+        async applyRebalance(payload, actor) {
+            assertMutationAccess(actor)
+            return withPgTransaction(pgPool, (client) => applyRebalance(client, payload, actor))
+        },
+    }
+}
+
+export const __testables = {
+    ABSENCE_TYPES,
+    ACTION_STATUSES,
+    COMMERCIAL_REQUIRED_SOURCE_IDS,
+    COMMERCIAL_OPERATIONS_SAFETY_FLAGS,
+    activeActionStatuses: ACTIVE_ACTION_STATUSES,
+    actionFlagSql,
+    commercialOperationsUnitScope,
+    mapWalletAction,
+    mutationInput,
+    normalizeCapacities,
+    normalizeExpectedRevisions,
+    opaqueTimelineId,
+    operationSafety,
+    projectRebalancePlan,
+    projectTimeline,
+    requestedUnitScope,
+    runCommercialOperationMutation,
+    sourceStale,
+    timelineActionType,
+}

--- a/crm/api/server/atendimento/routes.js
+++ b/crm/api/server/atendimento/routes.js
@@ -2,6 +2,7 @@ import { createHmac, timingSafeEqual } from 'crypto'
 import express from 'express'
 import { createAtendimentoStore, canAccessAtendimento } from './store.js'
 import { createCommercialDataQualityStore } from './commercialDataQualityStore.js'
+import { createCommercialOperationsStore } from './commercialOperationsStore.js'
 import { createClientesSourceOperationsStore } from '../clientes/sourceOperationsStore.js'
 import { importAtendimentoFromGoogleSheet, importGerenciaFromGoogleSheet, readGerenciaChartIds } from './importer.js'
 import { atendimentoModuleUnavailable, readAtendimentoModuleControl } from './moduleControl.js'
@@ -187,6 +188,16 @@ function requestsClinicalCadenceApproval(payload) {
     return String(payload?.status || '').trim().toLowerCase() === 'approved'
 }
 
+function commercialOperationPayload(req) {
+    const body = req?.body && typeof req.body === 'object' && !Array.isArray(req.body) ? req.body : {}
+    const bodyKey = String(body.idempotencyKey || '').trim()
+    const headerKey = String(req?.headers?.['idempotency-key'] || '').trim()
+    if (bodyKey && headerKey && bodyKey !== headerKey) {
+        throw sourceOperationsError('COMMERCIAL_IDEMPOTENCY_KEY_MISMATCH', 400)
+    }
+    return { ...body, idempotencyKey: headerKey || bodyKey }
+}
+
 function isLocalRequest(req) {
     // Host is caller-controlled. Only the peer address may authorize the
     // unsigned local-development actor or the local mirror diagnostics.
@@ -260,6 +271,16 @@ export function createAtendimentoRouter(options = {}) {
         pool: options.commercialDataQualityPool,
         databaseUrl: options.databaseUrl,
     })
+    let commercialOperationsStore = options.commercialOperationsStore || null
+    const getCommercialOperationsStore = () => {
+        if (!commercialOperationsStore) {
+            commercialOperationsStore = createCommercialOperationsStore({
+                pool: options.commercialOperationsPool,
+                databaseUrl: options.databaseUrl,
+            })
+        }
+        return commercialOperationsStore
+    }
     let commercialSourceOperationsStore = options.commercialSourceOperationsStore || null
     const getCommercialSourceOperationsStore = () => {
         if (!commercialSourceOperationsStore) {
@@ -555,6 +576,143 @@ export function createAtendimentoRouter(options = {}) {
             // Missing schema, a pool failure or an unavailable dependency must
             // not disclose database details to the console.
             return json(res, 503, { ok: false, error: 'COMMERCIAL_SOURCE_OPERATIONS_UNAVAILABLE' })
+        }
+    })
+
+    // Commercial Operations v2 is intentionally separate from the legacy
+    // action store.  Its read models are PII-minimized, and every mutation
+    // below is an internal ledger/work-queue operation only: there is no send,
+    // consent write, campaign dispatch or automated contact route here.
+    expressRouter.get('/commercial/operations/readiness', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            const readiness = await getCommercialOperationsStore().readiness(req.atendimentoActor)
+            return json(res, readiness.ready ? 200 : 503, { ok: readiness.ready, ...readiness })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/operations/wallet', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialOperationsStore().wallet(req.query || {}, req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/operations/team', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialOperationsStore().team(req.query || {}, req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/operations/campaigns', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialOperationsStore().campaigns(req.query || {}, req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/operations/campaigns/:campaignId', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, {
+                ok: true,
+                ...(await getCommercialOperationsStore().campaign(String(req.params.campaignId || ''), req.query || {}, req.atendimentoActor)),
+            })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/operations/customer-360/:identityId', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, {
+                ok: true,
+                ...(await getCommercialOperationsStore().customer360(String(req.params.identityId || ''), req.query || {}, req.atendimentoActor)),
+            })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/operations/campaigns', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialOperationsStore().createCampaign(commercialOperationPayload(req), req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.patch('/commercial/operations/campaigns/:campaignId', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, {
+                ok: true,
+                ...(await getCommercialOperationsStore().updateCampaign(String(req.params.campaignId || ''), commercialOperationPayload(req), req.atendimentoActor)),
+            })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/operations/actions/:actionId/reassign', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, {
+                ok: true,
+                ...(await getCommercialOperationsStore().reassignAction(String(req.params.actionId || ''), commercialOperationPayload(req), req.atendimentoActor)),
+            })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/operations/actions/:actionId/outcome', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, {
+                ok: true,
+                ...(await getCommercialOperationsStore().recordOutcome(String(req.params.actionId || ''), commercialOperationPayload(req), req.atendimentoActor)),
+            })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/operations/absences', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialOperationsStore().upsertAbsence(commercialOperationPayload(req), req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/operations/rebalance/preview', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialOperationsStore().previewRebalance(req.body || {}, req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/operations/rebalance/apply', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialOperationsStore().applyRebalance(commercialOperationPayload(req), req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
         }
     })
 

--- a/docs/runbooks/clientes-commercial-operations-v2.md
+++ b/docs/runbooks/clientes-commercial-operations-v2.md
@@ -1,0 +1,143 @@
+# Clientes — Operações Comerciais v2
+
+Este runbook descreve o backend de operação comercial interna. Ele não
+autoriza promoção, escrita de consentimento, envio de mensagens, automação de
+campanha ou alteração de regras clínicas. A tranche mantém todos estes
+controles desligados por contrato, independentemente de variável de ambiente:
+
+```json
+{
+  "commercialContactWritesEnabled": false,
+  "messagesEnabled": false,
+  "automationEnabled": false,
+  "consentWritesEnabled": false,
+  "outboundDispatchEnabled": false
+}
+```
+
+Nenhuma rota v2 chama Harmonia, provider de WhatsApp, shell, fila de entrega,
+cadência clínica ou o gravador de permissões. `opt_out_requested` é somente um
+outcome estruturado e devolve `requiresSeparateConsentWorkflow=true`; a
+gravação de consentimento continua em seu fluxo próprio e fail-closed.
+
+## Superfícies e autorização
+
+As rotas ficam em `/commercial/operations/*` e usam o store injetável
+`crm/api/server/atendimento/commercialOperationsStore.js`, separado do store
+legado. Todas exigem a política já existente de Clientes (`GESTOR`) e o store
+repete a checagem de papel. Um gestor sem `allowedUnits` declarado recebe 403;
+ele nunca ganha leitura global por omissão. ADMIN global continua sujeito à
+assinatura de ator da API.
+
+| Rota | Uso | Dados retornados |
+| --- | --- | --- |
+| `GET /readiness` | Estado da migration e dos ledgers | Sem PII; flags hard-disabled. |
+| `GET /wallet` | Carteira paginada e filtros operacionais | IDs de ação, unidade, status, flags e datas; sem identidade, nome, telefone, e-mail ou notas. |
+| `GET /team` | Carga, SLA, outcomes agregados, ausências e duração média de estágios | Agregados por responsável; sem cliente. |
+| `GET /campaigns` e `/:campaignId` | Coortes congeladas e eventos | Snapshot allowlisted, contagens e referências opacas; sem membros individuais. |
+| `GET /customer-360/:identityId?unit=<slug>` | Timeline unit-bound | Projeção allowlisted, IDs de evento opacos e sem context/evidence bruto. |
+| `POST/PATCH` de operações | Campanha, outcome, reatribuição, ausência e rebalanceamento | Apenas trabalho interno auditado; nunca contato externo. |
+
+Customer 360 exige unidade explícita inclusive para administrador global. A
+identidade precisa ter prova atual de vínculo com a unidade antes da timeline;
+sem prova, o retorno é negado. Eventos globais são reduzidos à revisão de
+consentimento/decisão autorizada, nunca à evidência bruta da fonte.
+
+## Readiness de migration
+
+A operação só fica pronta quando a migration
+`20260807_commercial_operations_v2` está ativa e as relações abaixo estão
+presentes:
+
+- `commercial_actions` e seu ledger append-only `commercial_action_events`;
+- `commercial_operation_mutations` e `commercial_campaign_events`, ambos com
+  bloqueio de `UPDATE`, `DELETE` e `TRUNCATE`;
+- `commercial_campaigns`, `commercial_campaign_members` e
+  `commercial_owner_absences`.
+
+O readiness verifica os gatilhos herdados do ledger de ações e os gatilhos v2
+dos ledgers de mutation/campaign. Falha de schema, role, trigger ou migration
+mantém leitura e escrita v2 indisponíveis; não há fallback para tabelas
+parcialmente migradas.
+
+Aplique somente por entrypoint allowlisted e destino estrito já existente:
+
+```text
+npm --prefix crm/api run migrate-commercial-operations -- --dry-run
+npm --prefix crm/api run migrate-commercial-operations -- --apply
+npm --prefix crm/api run migrate-commercial-operations -- --rollback
+```
+
+O executor aceita somente o destino local aprovado. Para staging, a migration
+precisa entrar no release target-bound de Atendimento com backup e evidência
+de destino. Não passe `DATABASE_URL`, segredo, path, URL, shell, SSH, `eval`
+ou comando em variáveis/argumentos. Não existe caminho de produção nesta
+tranche.
+
+O rollback é não destrutivo: registra a migration como revertida e preserva
+ações, campanhas, memberships e evidências append-only. Para voltar o código,
+use o SHA anterior após confirmar que o readiness v2 deixa de ser anunciado;
+nunca apague um ledger para “desfazer” uma operação.
+
+## Concorrência, versão e auditoria
+
+Cada mutação requer:
+
+1. `Idempotency-Key` opaca (ou o mesmo `idempotencyKey` no corpo), nunca PII;
+2. justificativa sem PII;
+3. `expectedRevision` na alteração de ação, campanha, ausência ou plano de
+   rebalanceamento.
+
+O backend obtém primeiro um advisory lock HMAC da chave de idempotência, só
+então verifica readiness e consulta o ledger. Repetição com o mesmo payload
+reproduz a resposta; reutilização da chave com outro fingerprint retorna 409.
+As linhas mutáveis são travadas com `FOR UPDATE`; rebalanceamento acrescenta um
+lock por escopo de unidade e reconstrói o plano dentro da transação. O ledger
+guarda ator HMAC, fingerprint e resposta minimizada, sem chave bruta ou razão
+em texto.
+
+Campanhas congelam filtros, segmento/versão, corte, coorte, unidade,
+responsável, oferta, janela e control group. O control group é determinístico
+por hash do contexto e só pode conter membros elegíveis; nenhum membro em
+revisão, stale ou bloqueado é promovido a holdout. Mudanças de contexto são
+recusadas; somente o ciclo de vida da campanha muda com versão otimista. Uma
+coorte semanticamente idêntica é deduplicada sob lock de unidade/contexto.
+
+## Fontes e freshness
+
+Elegibilidade e Customer 360 leem somente checkpoints de fonte já validados.
+As fontes obrigatórias vêm do catálogo versionado de Clientes, incluindo
+Atendimento, cadastro, vendas, opt-outs Harmonia, bloqueios de permissão e o
+grafo de identidade. Cada uma precisa de último estado `complete`, snapshot
+completo comprovado, nenhuma reconciliação pendente e validação de até 48 h.
+Ausência, parcial, inválida, dead ou stale torna a condição `sourceStale=true`;
+nunca há promoção por falta de dado. Fontes opcionais continuam visíveis na
+operação de fontes, mas não transformam ausência em exclusão de cliente.
+
+## Verificação antes de revisão
+
+Em um worktree com dependências já disponíveis, execute os testes focais:
+
+```text
+node --test --test-concurrency=1 \
+  server/atendimento/__tests__/commercialOperations.test.js \
+  server/atendimento/__tests__/commercialOperationsMigration.test.js \
+  server/atendimento/__tests__/commercialOperationsStore.test.js \
+  server/atendimento/__tests__/routes.test.js
+```
+
+Também confirme:
+
+- `git diff --check` sem saída;
+- nenhum endpoint v2 contém provider, `Harmonia`, dispatch, webhook, shell ou
+  gravação de `commercial_contact_permissions`;
+- readiness saudável e readiness falho quando um trigger/registro de migration
+  faltar;
+- repetição, conflito de fingerprint, escopo de unidade vazio, revisão
+  otimista e rebalanceamento concorrente por fixtures sintéticas;
+- o retorno de carteira, equipe, campanha e timeline não contém telefone,
+  e-mail, nome de cliente, nota, `context` ou `evidence` bruto.
+
+CI deve executar a suíte completa da API com a árvore de dependências do
+release. Este runbook não substitui smoke autenticado de staging nem autoriza
+produção.


### PR DESCRIPTION
## Objetivo
Persistir séries analíticas explicáveis de Clientes sobre Operações v2: snapshots agregados, versões de segmentos, eventos idempotentes e experimentos, sem expor PII nem criar qualquer envio.

## Superfícies e segurança
- Migration somente aditiva; ledger e evidências append-only.
- Escritas de métricas/snapshots/eventos exigem ator interno `SYSTEM`, chave HMAC e idempotency key.
- Nenhuma rota pública é registrada nesta camada; não há consentimento, contato, dispatch ou automação.
- Roles de runtime recebem somente SELECT/INSERT/UPDATE mínimos e SELECT explícito no registro de migrations para readiness.

## Validação
- `node --test crm/api/server/atendimento/__tests__/commercialAnalytics.test.js` — 5/5 verde.
- `node --check` para store, migration e testes — verde.
- A suíte da store usará `pg` na CI; este worktree não reinstala dependências locais.

## Rollback
Não destrutivo: registrar rollback da migration, manter evidências e deixar a superfície sem rota/flag de escrita externa.