### PR TITLE
fix(clientes): prevent PII audit actor fallbacks

### DIFF
--- a/crm/api/server/atendimento/__tests__/actorSubject.test.js
+++ b/crm/api/server/atendimento/__tests__/actorSubject.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { actorSubject, opaqueActorSubject } from '../actorSubject.js'
+
+test('accepts bounded opaque audit subjects', () => {
+    assert.equal(opaqueActorSubject('crm:operator-1'), 'crm:operator-1')
+    assert.equal(actorSubject({ subject: 'crm:operator-1', id: 'legacy-ignored' }), 'crm:operator-1')
+    assert.equal(actorSubject({ subjectId: 'subject/1' }), 'subject/1')
+    assert.equal(actorSubject({ id: 'operator_1' }), 'operator_1')
+})
+
+test('rejects PII-shaped or malformed audit subject fallbacks', () => {
+    for (const value of [
+        '',
+        'operator@example.com',
+        'Maria da Silva',
+        ' operator-1 ',
+        'operator\n1',
+        'x'.repeat(161),
+    ]) {
+        assert.equal(opaqueActorSubject(value), value === ' operator-1 ' ? 'operator-1' : null)
+    }
+    assert.equal(actorSubject({ username: 'operator@example.com', email: 'operator@example.com' }), null)
+})

--- a/crm/api/server/atendimento/__tests__/commercialDataQualityRoutes.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialDataQualityRoutes.test.js
@@ -125,3 +125,23 @@ test('marks an omitted GESTOR unit claim as absent rather than an empty scope', 
     assert.equal(actor?.allowedUnits, undefined)
     assert.equal(actor?.allowedUnitsDeclared, false)
 })
+
+test('rejects email-only signed and development session actors before audit attribution', () => {
+    const emailOnly = Buffer.from(JSON.stringify({ email: 'gestor@example.com', role: 'GESTOR' })).toString('base64url')
+    assert.equal(__testables.parseActorHeader({ headers: { 'x-crm-user': emailOnly } }), null)
+    const emailAsId = Buffer.from(JSON.stringify({ id: 'gestor@example.com', role: 'GESTOR' })).toString('base64url')
+    assert.equal(__testables.parseActorHeader({ headers: { 'x-crm-user': emailAsId } }), null)
+
+    assert.equal(__testables.devSessionActor({}, () => ({ user: { email: 'gestor@example.com', role: 'GESTOR' } })), null)
+
+    const actor = __testables.devSessionActor({}, () => ({ user: {
+        subject: 'crm:gestor-1',
+        email: 'gestor@example.com',
+        role: 'GESTOR',
+    } }))
+    assert.equal(actor?.id, 'crm:gestor-1')
+    assert.equal(actor?.email, 'gestor@example.com')
+
+    const signedOpaque = Buffer.from(JSON.stringify({ id: 'crm:gestor-2', username: 'gestor@example.com', role: 'GESTOR' })).toString('base64url')
+    assert.equal(__testables.parseActorHeader({ headers: { 'x-crm-user': signedOpaque } })?.id, 'crm:gestor-2')
+})

--- a/crm/api/server/atendimento/__tests__/commercialDataQualityStore.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialDataQualityStore.test.js
@@ -456,3 +456,10 @@ test('refuses to suppress an actively observed finding', async () => {
     assert.equal(transactionCalls.at(-1), 'rollback')
     assert.equal(released, true)
 })
+
+test('accepts only opaque actor subjects for append-only quality events', () => {
+    assert.equal(__testables.actorIdentity({ id: 'quality-operator-1' }), 'quality-operator-1')
+    assert.equal(__testables.actorIdentity({ subject: 'quality:operator-1', email: 'operator@example.com' }), 'quality:operator-1')
+    assert.throws(() => __testables.actorIdentity({ email: 'operator@example.com' }), /ACTOR_IDENTITY_REQUIRED/)
+    assert.throws(() => __testables.actorIdentity({ id: 'operator@example.com' }), /ACTOR_IDENTITY_REQUIRED/)
+})

--- a/crm/api/server/atendimento/__tests__/store.test.js
+++ b/crm/api/server/atendimento/__tests__/store.test.js
@@ -86,6 +86,9 @@ test('enforces unit scope for mutations and includes revision, formula and idemp
     assert.throws(() => assertActorCanMutateUnit(actor, { slug: 'barra-shopping-sul' }), /UNIT_FORBIDDEN/)
     assert.throws(() => assertActorCanMutateUnit({ role: 'INJETOR', allowedUnits: [] }, { slug: 'novo-hamburgo' }), /UNIT_FORBIDDEN/)
     assert.equal(actorIdentityForMutation({ id: 'operator-1', role: 'INJETOR' }), 'operator-1')
+    assert.equal(actorIdentityForMutation({ subject: 'operator:1', email: 'operator@example.com' }), 'operator:1')
+    assert.throws(() => actorIdentityForMutation({ email: 'operator@example.com', role: 'INJETOR' }), /ACTOR_IDENTITY_REQUIRED/)
+    assert.throws(() => actorIdentityForMutation({ id: 'operator@example.com', role: 'INJETOR' }), /ACTOR_IDENTITY_REQUIRED/)
     assert.throws(() => actorIdentityForMutation({ role: 'INJETOR' }), /ACTOR_IDENTITY_REQUIRED/)
     const migration = atendimentoMigrationStatements().join('\n')
     assert.match(migration, /revision integer/i)
@@ -1797,7 +1800,7 @@ test('persists nullable conversion results idempotently and never reuses a non-a
     ]
     const fakePool = createFakePool([...stateHandlers, ...buildConversionPoolHandlers()])
     const store = createAtendimentoStore({ pool: fakePool })
-    const actor = { role: 'GESTOR' }
+    const actor = { id: 'gestor-conversion-fixture', role: 'GESTOR' }
 
     const first = await store.managementConversionReport({ unit: 'novo-hamburgo', date: '2026-06-07', from: '2026-06-01', to: '2026-06-07' }, actor, { persist: true })
     const second = await store.managementConversionReport({ unit: 'novo-hamburgo', date: '2026-06-14', from: '2026-06-08', to: '2026-06-14' }, actor, { persist: true })

--- a/crm/api/server/atendimento/actorSubject.js
+++ b/crm/api/server/atendimento/actorSubject.js
@@ -1,0 +1,15 @@
+// Actor subjects cross signed boundaries and are later written into audit and
+// idempotency ledgers. Keep them opaque and reject e-mail/name fallbacks at
+// the first shared boundary instead of attempting to redact append-only data.
+const OPAQUE_SUBJECT = /^[A-Za-z0-9][A-Za-z0-9._:/|-]{0,159}$/
+
+export function opaqueActorSubject(value) {
+    const subject = String(value ?? '').trim()
+    return OPAQUE_SUBJECT.test(subject) ? subject : null
+}
+
+export function actorSubject(actor) {
+    return opaqueActorSubject(actor?.subject || actor?.subjectId || actor?.id)
+}
+
+export const __testables = { OPAQUE_SUBJECT }

--- a/crm/api/server/atendimento/commercialDataQualityStore.js
+++ b/crm/api/server/atendimento/commercialDataQualityStore.js
@@ -1,5 +1,6 @@
 import { createPgPool, withPgTransaction } from '../harmonia/store/pg.js'
 import { COMMERCIAL_DATA_QUALITY_MIGRATION_ID } from './commercialDataQualityMigration.js'
+import { actorSubject } from './actorSubject.js'
 
 export const COMMERCIAL_DATA_QUALITY_SOURCE_STALE_THRESHOLD_HOURS = 48
 export const COMMERCIAL_DATA_QUALITY_REFRESH_LOCK_KEY = 'commercial-data-quality:refresh'
@@ -176,9 +177,9 @@ function requirePool(pool) {
 }
 
 function actorIdentity(actor) {
-    const identity = String(actor?.id || actor?.username || actor?.email || '').trim()
+    const identity = actorSubject(actor)
     if (!identity) throw qualityError('ACTOR_IDENTITY_REQUIRED', 401)
-    return identity.slice(0, 160)
+    return identity
 }
 
 function assertCommercialQualityManager(actor) {
@@ -745,6 +746,7 @@ export function createCommercialDataQualityStore(options = {}) {
 }
 
 export const __testables = {
+    actorIdentity,
     assertCommercialQualityManager,
     assertFindingId,
     commercialObservationTransition,

--- a/crm/api/server/atendimento/routes.js
+++ b/crm/api/server/atendimento/routes.js
@@ -6,6 +6,7 @@ import { createClientesSourceOperationsStore } from '../clientes/sourceOperation
 import { importAtendimentoFromGoogleSheet, importGerenciaFromGoogleSheet, readGerenciaChartIds } from './importer.js'
 import { atendimentoModuleUnavailable, readAtendimentoModuleControl } from './moduleControl.js'
 import { createClinicalApprovalStore } from '../clinical/clinicalApprovalStore.js'
+import { actorSubject } from './actorSubject.js'
 
 const json = (res, status, body, headers = {}) => {
     res.status(status)
@@ -59,8 +60,10 @@ function parseActorHeader(req) {
         const actor = JSON.parse(b64UrlDecode(encoded))
         if (!actor || typeof actor !== 'object') return null
         const rawRole = actor.role
+        const id = actorSubject(actor)
+        if (!id) return null
         return {
-            id: String(actor.id || actor.username || actor.email || '').trim(),
+            id,
             username: actor.username ? String(actor.username) : undefined,
             email: actor.email ? String(actor.email) : undefined,
             name: actor.name ? String(actor.name) : undefined,
@@ -102,8 +105,10 @@ function devSessionActor(req, getDevSession) {
     const user = session?.user || null
     if (!user) return null
     const rawRole = user.role
+    const id = actorSubject(user)
+    if (!id) return null
     return {
-        id: String(user.username || user.email || '').trim(),
+        id,
         username: user.username ? String(user.username) : undefined,
         email: user.email ? String(user.email) : undefined,
         name: user.displayName ? String(user.displayName) : undefined,
@@ -852,6 +857,7 @@ export const __testables = {
     projectCommercialSourceOperation,
     requestsClinicalCadenceApproval,
     parseActorHeader,
+    devSessionActor,
     isLocalRequest,
     atendimentoReadOnlyRuntime,
     atendimentoClientesOnlyRuntime,

--- a/crm/api/server/atendimento/store.js
+++ b/crm/api/server/atendimento/store.js
@@ -1,6 +1,7 @@
 import { createHmac, randomUUID } from 'node:crypto'
 import { createPgPool, withPgTransaction } from '../harmonia/store/pg.js'
 import { lockContactPhone } from '../contactPhoneLock.js'
+import { actorSubject } from './actorSubject.js'
 import {
     buildConversionReportFromRawRows,
     buildScheduleDropdowns,
@@ -581,14 +582,17 @@ function requirePool(pool) {
 }
 
 function actorLabel(actor) {
-    return String(actor?.username || actor?.email || actor?.id || actor?.role || 'system').trim() || 'system'
+    if (actor === null || actor === undefined) return 'system'
+    const identity = actorSubject(actor)
+    if (!identity) throw mutationError('ACTOR_IDENTITY_REQUIRED', 401)
+    return identity
 }
 
 // Mutation idempotency and audit attribution must never fall back to a role.
 // Two distinct operators with the same role would otherwise share an
 // idempotency namespace and could receive each other's persisted response.
 export function actorIdentityForMutation(actor) {
-    const identity = String(actor?.id || actor?.username || actor?.email || '').trim()
+    const identity = actorSubject(actor)
     if (!identity) throw mutationError('ACTOR_IDENTITY_REQUIRED', 401)
     return identity
 }


### PR DESCRIPTION
## Objetivo
Fecha a via de PII em atribuicao de ator para os ledgers append-only de Atendimento/Clientes.

## Alteracoes
- Introduz um validador compartilhado para subjects opacos, limitados e sem formato de e-mail.
- Recusa headers assinados e sessoes de desenvolvimento sem subject seguro.
- Remove fallbacks `username`/`email` do ledger de mutacoes e da fila de qualidade.
- Mantem `null` explicito apenas para atores internos `system`; demais mutacoes falham fechadas.
- Cobre subject seguro, e-mail-only, id no formato de e-mail e preservacao de actor id seguro.

## Validacao
- `node --test server/atendimento/__tests__/actorSubject.test.js` — 2/2 verde via runtime WSL.
- `node --check` para todos os arquivos alterados — verde.
- As suites que importam `express`/`pg` nao puderam rodar localmente porque este worktree nao possui dependencias; nenhuma instalacao foi executada. CI deve executar a matriz completa.

## Seguranca e rollback
Nenhuma migration, ambiente, dado operacional ou mensagem foi alterado. Rollback: revert de `dfc5c62b`.