### PR TITLE
fix(clientes): grant source migration registry read

### DIFF
--- a/crm/api/server/clientes/__tests__/sourceOperationsMigration.test.js
+++ b/crm/api/server/clientes/__tests__/sourceOperationsMigration.test.js
@@ -29,6 +29,7 @@ test('source operations v2 migration is additive, PII-free and grants no destruc
     assert.match(sql, /encrypted boolean not null check \(encrypted\)/)
     assert.doesNotMatch(grants, /grant\s+(?:all privileges|delete|truncate)/)
     assert.match(grants, /revoke update, delete, truncate, references, trigger/)
+    assert.match(grants, /grant select on table crm_atendimento\.schema_migrations to skincos_staging_crm_app/)
     assert.match(grants, /select, insert, update on table crm_atendimento\.clientes_source_operation_runs/)
     assert.match(grants, /select, insert on table crm_atendimento\.clientes_source_operation_events/)
 })

--- a/crm/api/server/clientes/sourceOperationsMigration.js
+++ b/crm/api/server/clientes/sourceOperationsMigration.js
@@ -41,6 +41,10 @@ function runtimeGrantStatements(target) {
         `revoke update, delete, truncate, references, trigger on table crm_atendimento.clientes_source_operation_dead_letters from ${role}`,
         `revoke update, delete, truncate, references, trigger on table crm_atendimento.clientes_source_operation_rollbacks from ${role}`,
         `grant usage on schema crm_atendimento to ${role}`,
+        // The operational readiness probe records and verifies the applied
+        // migration. Without this read grant, a least-privilege runtime role
+        // would fail closed forever after an otherwise valid migration.
+        `grant select on table crm_atendimento.schema_migrations to ${role}`,
         `grant select, insert, update on table crm_atendimento.clientes_source_operation_runs to ${role}`,
         `grant select, insert, update on table crm_atendimento.clientes_source_operation_checkpoints to ${role}`,
         `grant select, insert on table crm_atendimento.clientes_source_operation_backups to ${role}`,


### PR DESCRIPTION
## Correção de runtime
A operação contínua de fontes já verifica `crm_atendimento.schema_migrations` na readiness, mas o grant de runtime não permitia a leitura desse ledger para `skincos_staging_crm_app`. Em staging, isso faria a surface ficar fail-closed mesmo após uma migration válida.

## Mudança
- concede somente `SELECT` no ledger de migrations aos roles runtime local/staging;
- adiciona regressão que fixa o grant explícito para staging;
- não amplia DDL, escrita comercial, acesso a PII, nem permissões destrutivas.

## Validação
- `git diff --check` verde.
- A execução WSL local está indisponível neste host no momento (o wrapper retorna 1 sem saída até para `node --version`); nenhuma dependência foi instalada. A matriz CI fresca é o gate de teste requerido.

Rollback: revert de `418b9db6`. Nenhuma migration ou ambiente foi aplicado.