### PR TITLE
feat(clientes): add governed commercial analytics

### DIFF
--- a/crm/api/package.json
+++ b/crm/api/package.json
@@ -27,6 +27,7 @@
     "migrate-commercial-action-ledger": "node scripts/migrate-atendimento-commercial-action-ledger.mjs",
     "migrate-commercial-data-quality": "node scripts/migrate-atendimento-commercial-data-quality.mjs",
     "migrate-commercial-operations": "node scripts/migrate-atendimento-commercial-operations.mjs",
+    "migrate-commercial-analytics": "node scripts/migrate-atendimento-commercial-analytics.mjs",
     "migrate-clinical-approval": "node scripts/migrate-clinical-approval.mjs",
     "migrate-identity-clusters": "node scripts/migrate-atendimento-identity-clusters.mjs",
     "migrate-atendimento-staging": "node scripts/migrate-atendimento-staging.mjs",

--- a/crm/api/scripts/migrate-atendimento-commercial-analytics.mjs
+++ b/crm/api/scripts/migrate-atendimento-commercial-analytics.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+import { createPgPool } from '../server/harmonia/store/pg.js'
+import {
+    applyCommercialAnalyticsMigration,
+    commercialAnalyticsMigrationPlan,
+    rollbackCommercialAnalyticsMigration,
+} from '../server/atendimento/commercialAnalyticsMigration.js'
+import {
+    assertAtendimentoMigrationDestination,
+    ATENDIMENTO_MIGRATION_TARGETS,
+    isStrictAtendimentoMigrationDestination,
+} from '../server/atendimento/migrationDestination.js'
+
+function commandError(code) {
+    const error = new Error(code)
+    error.code = code
+    return error
+}
+
+function parseTarget(args) {
+    const values = args.filter((arg) => arg.startsWith('--target='))
+    if (values.length > 1) throw commandError('COMMERCIAL_ANALYTICS_TARGET_INVALID')
+    const target = values[0] ? values[0].slice('--target='.length) : ATENDIMENTO_MIGRATION_TARGETS.LOCAL
+    if ([ATENDIMENTO_MIGRATION_TARGETS.LOCAL, ATENDIMENTO_MIGRATION_TARGETS.STAGING].includes(target)) return target
+    throw commandError('COMMERCIAL_ANALYTICS_TARGET_INVALID')
+}
+
+let pool = null
+try {
+    const args = process.argv.slice(2)
+    const target = parseTarget(args)
+    const actions = args.filter((arg) => ['--dry-run', '--apply', '--rollback'].includes(arg))
+    if (actions.length !== 1 || args.length !== actions.length + args.filter((arg) => arg.startsWith('--target=')).length) {
+        throw commandError('COMMERCIAL_ANALYTICS_MIGRATION_ACTION_INVALID')
+    }
+    const action = actions[0].slice(2)
+    const databaseUrl = String(process.env.DATABASE_URL || '').trim()
+    if (!databaseUrl || !isStrictAtendimentoMigrationDestination(databaseUrl, target)) {
+        throw commandError('COMMERCIAL_ANALYTICS_DESTINATION_UNSAFE')
+    }
+    pool = createPgPool(databaseUrl)
+    if (!pool) throw commandError('COMMERCIAL_ANALYTICS_POOL_REQUIRED')
+    if (action === 'dry-run') {
+        const client = await pool.connect()
+        try {
+            await client.query('begin')
+            const identity = await assertAtendimentoMigrationDestination(client, databaseUrl, target)
+            const registry = await client.query(`select to_regclass('crm_atendimento.schema_migrations') as registry`)
+            await client.query('rollback')
+            process.stdout.write(`${JSON.stringify({
+                ok: true, action, target, identity, registryPresent: Boolean(registry.rows[0]?.registry),
+                plan: commercialAnalyticsMigrationPlan(), commercialContactWritesEnabled: false,
+                messagingEnabled: false, consentWritesEnabled: false,
+            })}\n`)
+        } catch (error) {
+            try { await client.query('rollback') } catch { /* preserve guarded failure */ }
+            throw error
+        } finally {
+            client.release()
+        }
+    } else {
+        const result = action === 'apply'
+            ? await applyCommercialAnalyticsMigration({ pool, databaseUrl, target })
+            : await rollbackCommercialAnalyticsMigration({ pool, databaseUrl, target })
+        process.stdout.write(`${JSON.stringify({
+            ok: true, action, target, result, commercialContactWritesEnabled: false,
+            messagingEnabled: false, autonomousMessagingEnabled: false, consentWritesEnabled: false,
+        })}\n`)
+    }
+} catch (error) {
+    const code = /^[A-Z][A-Z0-9_]{1,100}$/.test(String(error?.code || ''))
+        ? error.code
+        : 'COMMERCIAL_ANALYTICS_MIGRATION_FAILED'
+    process.stderr.write(`${JSON.stringify({ ok: false, code })}\n`)
+    process.exitCode = 1
+} finally {
+    if (pool) await pool.end()
+}

--- a/crm/api/server/atendimento/__tests__/commercialAnalytics.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialAnalytics.test.js
@@ -1,0 +1,189 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+import {
+    COMMERCIAL_ANALYTICS_SAFETY_FLAGS,
+    COMMERCIAL_ANALYTICS_DEFAULT_ATTRIBUTION_WINDOW,
+    calculateExperimentLift,
+    deterministicExperimentVariant,
+    normalizeSegmentCriteria,
+} from '../commercialAnalytics.js'
+import { __testables, commercialAnalyticsReadiness } from '../commercialAnalyticsStore.js'
+
+const actor = Object.freeze({
+    subject: 'crm:gestor-analytics', id: 'legacy-ignored', role: 'GESTOR',
+    allowedUnits: ['centro'], allowedUnitsDeclared: true,
+})
+
+function readinessRow() {
+    return {
+        mutations: true, definitions: true, versions: true, memberships: true, windows: true,
+        experiments: true, assignments: true, events: true, migration_registry: true,
+        migration_read: true, mutations_read: true, mutations_write: true, definitions_read: true, definitions_write: true,
+        versions_read: true, versions_write: true, memberships_read: true, memberships_write: true, windows_read: true,
+        windows_write: true, experiments_read: true, experiments_write: true, assignments_read: true, assignments_write: true,
+        events_write: true, events_sequence_write: true, source_units_read: true, source_identity_members_read: true,
+        source_attendance_links_read: true, source_attendances_read: true, source_sales_read: true, source_sale_items_read: true,
+        source_actions_read: true, source_campaigns_read: true, source_campaign_members_read: true, source_permissions_read: true,
+        source_checkpoints_read: true, source_quality_findings_read: true, source_quality_events_read: true,
+        mutations_immutable: true, mutations_no_truncate: true, memberships_immutable: true, memberships_no_truncate: true,
+        assignments_immutable: true, assignments_no_truncate: true, events_immutable: true, events_no_truncate: true,
+    }
+}
+
+test('segment criteria accepts only the explicit snake_case analytics DSL', () => {
+    assert.deepEqual(normalizeSegmentCriteria({
+        minimum_visits: 3, requires_permission: true, identity_quality: 'confirmed_multi_source',
+        procedure_ids: ['botox', 'laser'], sales_classifications: ['mapped'],
+    }), {
+        identity_quality: 'confirmed_multi_source', minimum_visits: 3, procedure_ids: ['botox', 'laser'],
+        requires_permission: true, sales_classifications: ['mapped'],
+    })
+    assert.throws(() => normalizeSegmentCriteria({ minimumVisits: 3 }), { code: 'SEGMENT_CRITERIA_CAMEL_CASE_FORBIDDEN' })
+    assert.throws(() => normalizeSegmentCriteria({ unknown_metric: 3 }), { code: 'SEGMENT_CRITERIA_KEY_NOT_ALLOWED' })
+    assert.throws(() => normalizeSegmentCriteria({ customer_email: 'masked@example.test' }), { code: 'SEGMENT_CRITERIA_PII_ALIAS_FORBIDDEN' })
+    assert.throws(() => normalizeSegmentCriteria({ minimum_visits: { value: 3 } }), { code: 'SEGMENT_CRITERIA_NESTED_VALUE_FORBIDDEN' })
+    assert.throws(() => normalizeSegmentCriteria({ procedure_ids: ['phone_number'] }), { code: 'SEGMENT_CRITERIA_VALUE_INVALID' })
+})
+
+test('analytics safety flags and deterministic holdout assignment remain non-contacting', () => {
+    assert.deepEqual(COMMERCIAL_ANALYTICS_SAFETY_FLAGS, {
+        commercialContactWritesEnabled: false, messagesEnabled: false,
+        autonomousMessagingEnabled: false, consentWritesEnabled: false,
+    })
+    assert.deepEqual(COMMERCIAL_ANALYTICS_DEFAULT_ATTRIBUTION_WINDOW, {
+        responseDays: 7, scheduledDays: 14, attendedDays: 30, purchasedDays: 30, returnedDays: 60,
+    })
+    const input = {
+        experimentId: '11111111-1111-4111-8111-111111111111',
+        identityId: '22222222-2222-4222-8222-222222222222', controlGroupPercent: 25,
+    }
+    assert.equal(deterministicExperimentVariant(input), deterministicExperimentVariant(input))
+    assert.match(deterministicExperimentVariant(input), /^(treatment|control)$/)
+})
+
+test('lift keeps observed, attributed and incremental calculations separate and warns below an adequate sample', () => {
+    const insufficient = calculateExperimentLift([
+        { variant: 'treatment', population: 10, conversions: 3, revenue: 300 },
+        { variant: 'control', population: 10, conversions: 1, revenue: 100 },
+    ])
+    assert.equal(insufficient.warning, 'INSUFFICIENT_EXPERIMENT_SAMPLE')
+    assert.equal(insufficient.confidenceInterval95, null)
+    const adequate = calculateExperimentLift([
+        { variant: 'treatment', population: 100, conversions: 30, revenue: 3000 },
+        { variant: 'control', population: 100, conversions: 20, revenue: 1500 },
+    ])
+    assert.equal(adequate.adequateSample, true)
+    assert.equal(adequate.observedLift, 0.1)
+    assert.equal(adequate.incrementalConversions, 10)
+    assert.equal(adequate.incrementalRevenue, 1500)
+    assert.ok(adequate.confidenceInterval95)
+})
+
+test('analytics readiness requires the registry grant, append-only assignments and an applied migration', async () => {
+    const readiness = await commercialAnalyticsReadiness({
+        async query(sql) {
+            if (sql.includes("to_regclass('crm_atendimento.commercial_analytics_mutations')")) return { rows: [readinessRow()] }
+            if (sql.includes('from crm_atendimento.schema_migrations where id=$1')) return { rows: [{ id: '20260807_commercial_analytics_v2' }] }
+            throw new Error(`unexpected sql: ${sql}`)
+        },
+    })
+    assert.equal(readiness.ready, true)
+    assert.equal(readiness.appendOnlyReady, true)
+    assert.equal(readiness.grantsReady, true)
+    assert.equal(readiness.safety.messagesEnabled, false)
+
+    const incomplete = await commercialAnalyticsReadiness({
+        async query(sql) {
+            if (sql.includes("to_regclass('crm_atendimento.commercial_analytics_mutations')")) return { rows: [{ ...readinessRow(), migration_read: false, assignments_immutable: false }] }
+            throw new Error(`unexpected sql: ${sql}`)
+        },
+    })
+    assert.equal(incomplete.ready, false)
+    assert.equal(incomplete.grantsReady, false)
+    assert.equal(incomplete.appendOnlyReady, false)
+})
+
+test('idempotency locks before readiness or ledger reads and actor subject never falls back to email', async () => {
+    assert.equal(__testables.actorPrincipal(actor), 'crm:gestor-analytics')
+    assert.throws(() => __testables.actorPrincipal({ username: 'operator@example.test', email: 'operator@example.test' }), { code: 'ACTOR_IDENTITY_REQUIRED' })
+    const before = process.env.ATENDIMENTO_ACTOR_HMAC_KEY
+    process.env.ATENDIMENTO_ACTOR_HMAC_KEY = 'a'.repeat(32)
+    const calls = []
+    const client = {
+        async query(sql, values = []) {
+            calls.push({ sql, values })
+            if (sql.includes('pg_advisory_xact_lock')) return { rows: [] }
+            if (sql.includes("to_regclass('crm_atendimento.commercial_analytics_mutations')")) return { rows: [readinessRow()] }
+            if (sql.includes('from crm_atendimento.schema_migrations where id=$1')) return { rows: [{ id: '20260807_commercial_analytics_v2' }] }
+            if (sql.includes('from crm_atendimento.commercial_analytics_mutations')) return { rows: [] }
+            if (sql.includes('insert into crm_atendimento.commercial_analytics_mutations')) return { rows: [] }
+            throw new Error(`unexpected sql: ${sql}`)
+        },
+    }
+    try {
+        const result = await __testables.runAnalyticsMutation(client, {
+            actor, operation: 'segment_create',
+            payload: { idempotencyKey: 'segment:opaque-key-123', reason: 'Ajuste de segmento seguro', expectedRevision: 0 },
+            fingerprintPayload: { key: 'safe_segment' }, options: { allowCreateRevision: true },
+            execute: async () => ({ result: 'stored' }),
+        })
+        assert.equal(result.idempotent, false)
+        assert.match(calls[0].sql, /pg_advisory_xact_lock/)
+        assert.equal(calls.slice(1).some((call) => call.sql.includes('commercial_analytics_mutations') && call.sql.includes('from')), true)
+        assert.equal(JSON.stringify(calls).includes('segment:opaque-key-123'), false)
+        assert.equal(JSON.stringify(calls).includes('Ajuste de segmento seguro'), false)
+    } finally {
+        if (before === undefined) delete process.env.ATENDIMENTO_ACTOR_HMAC_KEY
+        else process.env.ATENDIMENTO_ACTOR_HMAC_KEY = before
+    }
+})
+
+test('analytics assignment uses the exact Operations crossover advisory-lock namespace', async () => {
+    const calls = []
+    await __testables.lockExperimentIdentity({ async query(sql, values) { calls.push({ sql, values }); return { rows: [] } } },
+    '33333333-3333-4333-8333-333333333333', '22222222-2222-4222-8222-222222222222')
+    assert.match(calls[0].sql, /pg_advisory_xact_lock/)
+    assert.equal(calls[0].values[0], 'commercial-experiment-crossover:33333333-3333-4333-8333-333333333333:22222222-2222-4222-8222-222222222222')
+})
+
+test('attribution rejects a cross-unit funnel even for a global analytics manager', async () => {
+    const attributionWindowId = '44444444-4444-4444-8444-444444444444'
+    const db = {
+        async query(sql) {
+            if (sql.includes('from crm_atendimento.units unit')) {
+                return { rows: [
+                    { id: '55555555-5555-4555-8555-555555555555', slug: 'centro' },
+                    { id: '66666666-6666-4666-8666-666666666666', slug: 'zona-sul' },
+                ] }
+            }
+            if (sql.includes('from crm_atendimento.commercial_attribution_windows')) {
+                return { rows: [{ id: attributionWindowId, unit_id: '55555555-5555-4555-8555-555555555555' }] }
+            }
+            throw new Error(`unexpected sql: ${sql}`)
+        },
+    }
+    await assert.rejects(
+        __testables.commercialFunnel(db, { attributionWindowId }, { subject: 'crm:global-analytics', role: 'ADMIN', isGlobalAdmin: true }),
+        { code: 'COMMERCIAL_ANALYTICS_WINDOW_UNIT_SCOPE_REQUIRED' },
+    )
+})
+
+test('experiment revenue query deduplicates a sale shared by duplicate source members', async () => {
+    const source = await readFile(new URL('../commercialAnalyticsStore.js', import.meta.url), 'utf8')
+    assert.match(source, /sales_rows as \(\s*select distinct assignment\.identity_id,sale\.id as sale_id/s)
+    assert.match(source, /left join sales_rows on sales_rows\.identity_id=assignment\.identity_id/)
+})
+
+test('Operations retains the shared holdout guard in campaign create, action reassign and rebalance', async () => {
+    const source = await readFile(new URL('../commercialOperationsStore.js', import.meta.url), 'utf8')
+    assert.match(source, /commercial-experiment-crossover:\$\{unit\}:\$\{identityId\}/)
+    for (const operation of ['createCampaign', 'reassignAction', 'applyRebalance']) {
+        const start = source.indexOf(`async function ${operation}`)
+        assert.notEqual(start, -1)
+        const next = source.indexOf('\nasync function ', start + 1)
+        const block = source.slice(start, next === -1 ? undefined : next)
+        assert.match(block, /assertNoActiveExperimentHoldout/)
+    }
+})

--- a/crm/api/server/atendimento/__tests__/commercialAnalyticsMigration.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialAnalyticsMigration.test.js
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+import {
+    __testables,
+    applyCommercialAnalyticsMigration,
+    commercialAnalyticsMigrationPlan,
+} from '../commercialAnalyticsMigration.js'
+import { COMMERCIAL_ANALYTICS_MIGRATION_ID } from '../commercialAnalytics.js'
+
+test('commercial analytics migration is additive, PII-rejecting and has only least-privilege runtime access', () => {
+    const plan = commercialAnalyticsMigrationPlan()
+    const sql = __testables.STATEMENTS.join('\n').toLowerCase()
+    const grants = __testables.runtimeGrantStatements('staging').join('\n').toLowerCase()
+    assert.equal(plan.id, COMMERCIAL_ANALYTICS_MIGRATION_ID)
+    assert.match(plan.segmentPolicy, /snake_case/i)
+    assert.match(plan.experimentPolicy, /commercial-experiment-crossover/i)
+    assert.equal(plan.safety.messagesEnabled, false)
+    assert.match(sql, /valid_commercial_segment_criteria/)
+    assert.match(sql, /item\.key ~ '\[a-z\]'/)
+    assert.match(sql, /email\|e_\?mail\|phone\|telefone/)
+    assert.match(sql, /jsonb_array_length\(item\.value\) = 0/)
+    assert.match(sql, /procedure_ids' and jsonb_array_length\(item\.value\) > 50/)
+    assert.match(sql, /sales_classifications' and jsonb_array_length\(item\.value\) > 2/)
+    assert.match(sql, /address\|endereco\|contact\|contato\|pii\|alias\|raw\|evidence\|context/)
+    assert.match(sql, /commercial_experiment_assignments/)
+    assert.match(sql, /commercial_experiment_assignments_immutable/)
+    assert.match(sql, /before update or delete/)
+    assert.match(sql, /before truncate/)
+    assert.ok(__testables.PREREQUISITE_RELATIONS.includes('crm_atendimento.global_client_identities'))
+    assert.doesNotMatch(sql, /drop\s+table/)
+    assert.doesNotMatch(sql, /on delete cascade/)
+    assert.match(grants, /grant select on table crm_atendimento\.schema_migrations to skincos_staging_crm_app/)
+    assert.match(grants, /grant select, insert on table crm_atendimento\.commercial_experiment_assignments/)
+    assert.match(grants, /grant usage on schema crm_caixa to skincos_staging_crm_app/)
+    assert.doesNotMatch(grants, /grant\s+(?:all privileges|delete|truncate)/)
+})
+
+test('commercial analytics migration refuses an unsafe destination before connecting', async () => {
+    let connected = false
+    await assert.rejects(() => applyCommercialAnalyticsMigration({
+        pool: { connect: async () => { connected = true } },
+        databaseUrl: 'postgresql://unsafe.example.invalid/skincos_crm_local', target: 'production',
+    }), { code: 'COMMERCIAL_ANALYTICS_MIGRATION_DESTINATION_UNSAFE' })
+    assert.equal(connected, false)
+})
+
+test('commercial analytics migration holds its advisory lock in an explicit transaction and rolls back failures', async () => {
+    const source = await readFile(new URL('../commercialAnalyticsMigration.js', import.meta.url), 'utf8')
+    for (const migration of ['applyCommercialAnalyticsMigration', 'rollbackCommercialAnalyticsMigration']) {
+        const start = source.indexOf(`export async function ${migration}`)
+        assert.notEqual(start, -1)
+        const end = source.indexOf('\nexport ', start + 1)
+        const block = source.slice(start, end === -1 ? undefined : end)
+        assert.match(block, /await client\.query\('begin'\)/)
+        assert.match(block, /set local lock_timeout/)
+        assert.match(block, /pg_advisory_xact_lock/)
+        assert.match(block, /await client\.query\('commit'\)/)
+        assert.match(block, /await client\.query\('rollback'\)/)
+    }
+})

--- a/crm/api/server/atendimento/__tests__/routes.test.js
+++ b/crm/api/server/atendimento/__tests__/routes.test.js
@@ -374,3 +374,59 @@ test('routes Commercial Operations through its injected store with a single opaq
     assert.equal(mismatch.state.status, 400)
     assert.equal(calls.length, beforeForbidden)
 })
+
+test('routes Commercial Analytics through its injected, non-contacting store and preserves RBAC/idempotency', async () => {
+    const calls = []
+    const analytics = {
+        async readiness(actor) { calls.push(['readiness', actor.id]); return { ready: true, safety: { messagesEnabled: false, commercialContactWritesEnabled: false } } },
+        async quality(query, actor) { calls.push(['quality', query, actor.id]); return { coverage: [], safety: { messagesEnabled: false } } },
+        async funnel(query, actor) { calls.push(['funnel', query, actor.id]); return { observed: {}, safety: { messagesEnabled: false } } },
+        async segments(query, actor) { calls.push(['segments', query, actor.id]); return { segments: [], safety: { messagesEnabled: false } } },
+        async attributionWindows(query, actor) { calls.push(['windows', query, actor.id]); return { windows: [], safety: { messagesEnabled: false } } },
+        async experiments(query, actor) { calls.push(['experiments', query, actor.id]); return { experiments: [], safety: { messagesEnabled: false } } },
+        async experimentMetrics(id, actor) { calls.push(['metrics', id, actor.id]); return { safety: { messagesEnabled: false } } },
+        async createSegment(payload, actor) { calls.push(['createSegment', payload, actor.id]); return { definitionId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', safety: { messagesEnabled: false, commercialContactWritesEnabled: false } } },
+        async createSegmentVersion() { throw new Error('not used') },
+        async snapshotSegment() { throw new Error('not used') },
+        async upsertAttributionWindow() { throw new Error('not used') },
+        async createExperiment() { throw new Error('not used') },
+        async updateExperimentState() { throw new Error('not used') },
+    }
+    const routes = captureAtendimentoRoutes({}, { commercialAnalyticsStore: analytics })
+    const actor = { id: 'gestor-analytics', role: 'GESTOR', allowedModules: ['atendimento'], allowedUnits: ['centro'], allowedUnitsDeclared: true }
+
+    const readiness = captureResponse()
+    await routes.get('GET /commercial/analytics/readiness')({ atendimentoActor: actor }, readiness)
+    assert.equal(readiness.state.status, 200)
+    assert.equal(readiness.state.body.safety.commercialContactWritesEnabled, false)
+
+    const quality = captureResponse()
+    await routes.get('GET /commercial/analytics/quality')({ atendimentoActor: actor, query: { unit: 'centro' } }, quality)
+    assert.equal(quality.state.status, 200)
+    assert.deepEqual(calls[1], ['quality', { unit: 'centro' }, 'gestor-analytics'])
+
+    const create = captureResponse()
+    await routes.get('POST /commercial/analytics/segments')({
+        atendimentoActor: actor,
+        headers: { 'idempotency-key': 'analytics:segment:001' },
+        body: { idempotencyKey: 'analytics:segment:001', reason: 'Coorte analítica sintética' },
+    }, create)
+    assert.equal(create.state.status, 200)
+    assert.equal(calls[2][0], 'createSegment')
+    assert.equal(calls[2][1].idempotencyKey, 'analytics:segment:001')
+
+    const beforeForbidden = calls.length
+    const forbidden = captureResponse()
+    await routes.get('GET /commercial/analytics/funnel')({ atendimentoActor: { ...actor, role: 'GERENTE' }, query: {} }, forbidden)
+    assert.equal(forbidden.state.status, 403)
+    assert.equal(calls.length, beforeForbidden)
+
+    const mismatch = captureResponse()
+    await routes.get('POST /commercial/analytics/segments')({
+        atendimentoActor: actor, headers: { 'idempotency-key': 'analytics:segment:002' },
+        body: { idempotencyKey: 'analytics:segment:003', reason: 'Coorte analítica sintética' },
+    }, mismatch)
+    assert.equal(mismatch.state.status, 400)
+    assert.equal(calls.length, beforeForbidden)
+    assert.equal([...routes.keys()].some((key) => /commercial\/analytics\/(?:send|message|dispatch|consent)/i.test(key)), false)
+})

--- a/crm/api/server/atendimento/commercialAnalytics.js
+++ b/crm/api/server/atendimento/commercialAnalytics.js
@@ -287,7 +287,7 @@ export function calculateExperimentLift(rows = []) {
     return {
         treatment: { ...groups.treatment, conversionRate: treatmentRate },
         control: { ...groups.control, conversionRate: controlRate },
-        observedLift: lift,
+        observedLift: lift == null ? null : Math.round(lift * 10_000) / 10_000,
         incrementalConversions: lift == null ? null : Math.round(lift * groups.treatment.population * 10_000) / 10_000,
         incrementalRevenue: groups.control.population && groups.treatment.population
             ? Math.round((groups.treatment.revenue - (groups.control.revenue / groups.control.population) * groups.treatment.population) * 100) / 100

--- a/crm/api/server/atendimento/commercialAnalytics.js
+++ b/crm/api/server/atendimento/commercialAnalytics.js
@@ -1,0 +1,305 @@
+import { createHash } from 'node:crypto'
+
+// This module is intentionally a narrow, PII-free analytics contract.  It
+// accepts only explicit segment criteria and turns no observation into a
+// communication, permission write, or clinical recommendation.
+export const COMMERCIAL_ANALYTICS_MIGRATION_ID = '20260807_commercial_analytics_v2'
+
+export const COMMERCIAL_ANALYTICS_SAFETY_FLAGS = Object.freeze({
+    commercialContactWritesEnabled: false,
+    messagesEnabled: false,
+    autonomousMessagingEnabled: false,
+    consentWritesEnabled: false,
+})
+
+export const COMMERCIAL_ANALYTICS_FUNNEL_STAGES = Object.freeze([
+    'eligible', 'selected', 'action_created', 'contacted', 'delivered',
+    'responded', 'scheduled', 'attended', 'purchased', 'returned',
+])
+
+export const COMMERCIAL_EXPERIMENT_STATES = Object.freeze(['draft', 'active', 'closed', 'disabled'])
+export const COMMERCIAL_EXPERIMENT_VARIANTS = Object.freeze(['treatment', 'control', 'excluded'])
+// These are explicit policy defaults, not an implicit indefinite attribution
+// fallback.  Every persisted row remains versioned and may override them.
+export const COMMERCIAL_ANALYTICS_DEFAULT_ATTRIBUTION_WINDOW = Object.freeze({
+    responseDays: 7,
+    scheduledDays: 14,
+    attendedDays: 30,
+    purchasedDays: 30,
+    returnedDays: 60,
+})
+export const COMMERCIAL_SEGMENT_CRITERIA_KEYS = Object.freeze([
+    'minimum_lifetime_sales',
+    'minimum_visits',
+    'minimum_recency_days',
+    'maximum_recency_days',
+    'minimum_lifetime_sales_percentile',
+    'minimum_visits_percentile',
+    'requires_permission',
+    'requires_phone_correlation',
+    'requires_fresh_sources',
+    'source_freshness_max_hours',
+    'identity_quality',
+    'procedure_ids',
+    'sales_classifications',
+])
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const UNIT_RE = /^[a-z0-9][a-z0-9._-]{0,119}$/
+const KEY_RE = /^[a-z][a-z0-9_]{2,80}$/
+const ID_RE = /^[A-Za-z0-9._:-]{8,200}$/
+const PII_ALIAS_RE = /(email|e_?mail|phone|telefone|whatsapp|name|nome|cpf|address|endereco|contact|contato|pii|alias|raw|evidence|context)/i
+const criterionKeys = new Set(COMMERCIAL_SEGMENT_CRITERIA_KEYS)
+const salesClassifications = new Set(['mapped', 'unmapped'])
+const identityQualities = new Set(['confirmed_multi_source', 'unresolved_single_source'])
+
+function text(value) {
+    return typeof value === 'string' ? value.trim() : String(value ?? '').trim()
+}
+
+function containsPiiLikeValue(value) {
+    const raw = text(value)
+    return raw.includes('@') || /\d{7,}/.test(raw)
+}
+
+function plainObject(value) {
+    return !!value && typeof value === 'object' && !Array.isArray(value) &&
+        (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null)
+}
+
+function boundedInteger(value, { minimum = 0, maximum = 1_000_000, code }) {
+    const parsed = Number(value)
+    if (!Number.isInteger(parsed) || parsed < minimum || parsed > maximum) throw commercialAnalyticsError(code)
+    return parsed
+}
+
+function parseDateTime(value, code) {
+    const parsed = new Date(value)
+    if (Number.isNaN(parsed.getTime())) throw commercialAnalyticsError(code)
+    return parsed.toISOString()
+}
+
+export function commercialAnalyticsError(code, statusCode = 400) {
+    const error = new Error(code)
+    error.code = code
+    error.statusCode = statusCode
+    return error
+}
+
+export function stableAnalyticsFingerprint(value) {
+    const normalize = (candidate) => {
+        if (candidate === null || typeof candidate !== 'object') return candidate
+        if (Array.isArray(candidate)) return candidate.map(normalize)
+        return Object.fromEntries(Object.keys(candidate).sort().map((key) => [key, normalize(candidate[key])]))
+    }
+    return createHash('sha256').update(JSON.stringify(normalize(value))).digest('hex')
+}
+
+/**
+ * Validates a deliberately small DSL.  There is no generic JSON filter
+ * language: camelCase, unknown keys, nested objects and contact-like aliases
+ * are all rejected before criteria reaches storage or SQL.
+ */
+export function normalizeSegmentCriteria(value) {
+    if (!plainObject(value)) throw commercialAnalyticsError('SEGMENT_CRITERIA_OBJECT_REQUIRED')
+    const keys = Object.keys(value)
+    if (!keys.length || keys.length > COMMERCIAL_SEGMENT_CRITERIA_KEYS.length) {
+        throw commercialAnalyticsError('SEGMENT_CRITERIA_REQUIRED')
+    }
+    const normalized = {}
+    for (const key of keys.sort()) {
+        if (/[A-Z]/.test(key)) throw commercialAnalyticsError('SEGMENT_CRITERIA_CAMEL_CASE_FORBIDDEN')
+        if (PII_ALIAS_RE.test(key)) throw commercialAnalyticsError('SEGMENT_CRITERIA_PII_ALIAS_FORBIDDEN')
+        if (!criterionKeys.has(key)) throw commercialAnalyticsError('SEGMENT_CRITERIA_KEY_NOT_ALLOWED')
+        const candidate = value[key]
+        if (candidate && typeof candidate === 'object' && !Array.isArray(candidate)) {
+            throw commercialAnalyticsError('SEGMENT_CRITERIA_NESTED_VALUE_FORBIDDEN')
+        }
+        if (key === 'minimum_lifetime_sales') {
+            normalized[key] = Number(candidate)
+            if (!Number.isFinite(normalized[key]) || normalized[key] < 0 || normalized[key] > 1_000_000_000) {
+                throw commercialAnalyticsError('SEGMENT_CRITERIA_VALUE_INVALID')
+            }
+            continue
+        }
+        if (['minimum_visits', 'minimum_recency_days', 'maximum_recency_days', 'source_freshness_max_hours'].includes(key)) {
+            normalized[key] = boundedInteger(candidate, {
+                minimum: key === 'source_freshness_max_hours' ? 1 : 0,
+                maximum: key === 'source_freshness_max_hours' ? 24 * 30 : 365 * 20,
+                code: 'SEGMENT_CRITERIA_VALUE_INVALID',
+            })
+            continue
+        }
+        if (['minimum_lifetime_sales_percentile', 'minimum_visits_percentile'].includes(key)) {
+            normalized[key] = boundedInteger(candidate, { minimum: 1, maximum: 100, code: 'SEGMENT_CRITERIA_VALUE_INVALID' })
+            continue
+        }
+        if (['requires_permission', 'requires_phone_correlation', 'requires_fresh_sources'].includes(key)) {
+            if (typeof candidate !== 'boolean') throw commercialAnalyticsError('SEGMENT_CRITERIA_VALUE_INVALID')
+            normalized[key] = candidate
+            continue
+        }
+        if (key === 'identity_quality') {
+            const quality = text(candidate)
+            if (!identityQualities.has(quality)) throw commercialAnalyticsError('SEGMENT_CRITERIA_VALUE_INVALID')
+            normalized[key] = quality
+            continue
+        }
+        if (key === 'procedure_ids') {
+            if (!Array.isArray(candidate) || !candidate.length || candidate.length > 50) throw commercialAnalyticsError('SEGMENT_CRITERIA_VALUE_INVALID')
+            const values = [...new Set(candidate.map(text))].sort()
+            if (values.some((item) => !/^[a-z0-9][a-z0-9._-]{0,119}$/i.test(item) || PII_ALIAS_RE.test(item))) {
+                throw commercialAnalyticsError('SEGMENT_CRITERIA_VALUE_INVALID')
+            }
+            normalized[key] = values
+            continue
+        }
+        if (key === 'sales_classifications') {
+            if (!Array.isArray(candidate) || !candidate.length || candidate.length > salesClassifications.size) {
+                throw commercialAnalyticsError('SEGMENT_CRITERIA_VALUE_INVALID')
+            }
+            const values = [...new Set(candidate.map((item) => text(item).toLowerCase()))].sort()
+            if (values.some((item) => !salesClassifications.has(item))) throw commercialAnalyticsError('SEGMENT_CRITERIA_VALUE_INVALID')
+            normalized[key] = values
+        }
+    }
+    if (normalized.minimum_recency_days != null && normalized.maximum_recency_days != null &&
+        normalized.minimum_recency_days > normalized.maximum_recency_days) {
+        throw commercialAnalyticsError('SEGMENT_CRITERIA_RANGE_INVALID')
+    }
+    return normalized
+}
+
+export function normalizeAnalyticsMutation(payload = {}, { requireReason = true, allowCreateRevision = false } = {}) {
+    const input = plainObject(payload) ? payload : {}
+    const idempotencyKey = text(input.idempotencyKey)
+    const reason = text(input.reason)
+    const expectedRevision = input.expectedRevision == null || input.expectedRevision === '' ? null : Number(input.expectedRevision)
+    if (!ID_RE.test(idempotencyKey) || containsPiiLikeValue(idempotencyKey)) {
+        throw commercialAnalyticsError('COMMERCIAL_ANALYTICS_IDEMPOTENCY_KEY_REQUIRED')
+    }
+    if (requireReason && (reason.length < 3 || reason.length > 1_000 || containsPiiLikeValue(reason))) {
+        throw commercialAnalyticsError('COMMERCIAL_ANALYTICS_REASON_INVALID')
+    }
+    if (expectedRevision != null && (!Number.isInteger(expectedRevision) || expectedRevision < (allowCreateRevision ? 0 : 1))) {
+        throw commercialAnalyticsError('COMMERCIAL_ANALYTICS_EXPECTED_REVISION_INVALID')
+    }
+    return { idempotencyKey, reason, expectedRevision }
+}
+
+export function normalizeSegmentPayload(payload = {}) {
+    const input = plainObject(payload) ? payload : {}
+    const name = text(input.name)
+    const key = text(input.key).toLowerCase()
+    const unit = text(input.unit).toLowerCase()
+    if (!name || name.length > 120 || containsPiiLikeValue(name)) throw commercialAnalyticsError('SEGMENT_NAME_INVALID')
+    if (!KEY_RE.test(key)) throw commercialAnalyticsError('SEGMENT_KEY_INVALID')
+    if (!UNIT_RE.test(unit)) throw commercialAnalyticsError('SEGMENT_UNIT_INVALID')
+    return {
+        name,
+        key,
+        unit,
+        criteria: normalizeSegmentCriteria(input.criteria),
+        mutation: normalizeAnalyticsMutation(input, { allowCreateRevision: true }),
+    }
+}
+
+export function normalizeAttributionWindowPayload(payload = {}) {
+    const input = plainObject(payload) ? payload : {}
+    const key = text(input.key).toLowerCase()
+    const unit = text(input.unit).toLowerCase()
+    if (!KEY_RE.test(key)) throw commercialAnalyticsError('ATTRIBUTION_WINDOW_KEY_INVALID')
+    if (!UNIT_RE.test(unit)) throw commercialAnalyticsError('ATTRIBUTION_WINDOW_UNIT_INVALID')
+    const startsAt = parseDateTime(input.startsAt, 'ATTRIBUTION_WINDOW_RANGE_INVALID')
+    const endsAt = input.endsAt ? parseDateTime(input.endsAt, 'ATTRIBUTION_WINDOW_RANGE_INVALID') : null
+    if (endsAt && endsAt <= startsAt) throw commercialAnalyticsError('ATTRIBUTION_WINDOW_RANGE_INVALID')
+    return {
+        key,
+        unit,
+        startsAt,
+        endsAt,
+        responseDays: boundedInteger(input.responseDays ?? COMMERCIAL_ANALYTICS_DEFAULT_ATTRIBUTION_WINDOW.responseDays, { minimum: 1, maximum: 60, code: 'ATTRIBUTION_WINDOW_VALUE_INVALID' }),
+        scheduledDays: boundedInteger(input.scheduledDays ?? COMMERCIAL_ANALYTICS_DEFAULT_ATTRIBUTION_WINDOW.scheduledDays, { minimum: 1, maximum: 120, code: 'ATTRIBUTION_WINDOW_VALUE_INVALID' }),
+        attendedDays: boundedInteger(input.attendedDays ?? COMMERCIAL_ANALYTICS_DEFAULT_ATTRIBUTION_WINDOW.attendedDays, { minimum: 1, maximum: 180, code: 'ATTRIBUTION_WINDOW_VALUE_INVALID' }),
+        purchasedDays: boundedInteger(input.purchasedDays ?? COMMERCIAL_ANALYTICS_DEFAULT_ATTRIBUTION_WINDOW.purchasedDays, { minimum: 1, maximum: 180, code: 'ATTRIBUTION_WINDOW_VALUE_INVALID' }),
+        returnedDays: boundedInteger(input.returnedDays ?? COMMERCIAL_ANALYTICS_DEFAULT_ATTRIBUTION_WINDOW.returnedDays, { minimum: 1, maximum: 365, code: 'ATTRIBUTION_WINDOW_VALUE_INVALID' }),
+        mutation: normalizeAnalyticsMutation(input, { allowCreateRevision: true }),
+    }
+}
+
+export function normalizeExperimentPayload(payload = {}) {
+    const input = plainObject(payload) ? payload : {}
+    const name = text(input.name)
+    const unit = text(input.unit).toLowerCase()
+    const segmentVersionId = text(input.segmentVersionId).toLowerCase()
+    const attributionWindowId = text(input.attributionWindowId).toLowerCase()
+    const startsAt = parseDateTime(input.startsAt, 'COMMERCIAL_EXPERIMENT_RANGE_INVALID')
+    const endsAt = parseDateTime(input.endsAt, 'COMMERCIAL_EXPERIMENT_RANGE_INVALID')
+    const controlGroupPercent = boundedInteger(input.controlGroupPercent, { minimum: 1, maximum: 99, code: 'COMMERCIAL_EXPERIMENT_CONTROL_INVALID' })
+    if (!name || name.length > 120 || containsPiiLikeValue(name)) throw commercialAnalyticsError('COMMERCIAL_EXPERIMENT_NAME_INVALID')
+    if (!UNIT_RE.test(unit)) throw commercialAnalyticsError('COMMERCIAL_EXPERIMENT_UNIT_INVALID')
+    if (!UUID_RE.test(segmentVersionId) || !UUID_RE.test(attributionWindowId)) throw commercialAnalyticsError('COMMERCIAL_EXPERIMENT_REFERENCE_INVALID')
+    if (endsAt <= startsAt) throw commercialAnalyticsError('COMMERCIAL_EXPERIMENT_RANGE_INVALID')
+    return {
+        name,
+        unit,
+        segmentVersionId,
+        attributionWindowId,
+        startsAt,
+        endsAt,
+        controlGroupPercent,
+        mutation: normalizeAnalyticsMutation(input, { allowCreateRevision: true }),
+    }
+}
+
+export function deterministicExperimentVariant({ experimentId, identityId, controlGroupPercent }) {
+    if (!UUID_RE.test(text(experimentId)) || !UUID_RE.test(text(identityId))) {
+        throw commercialAnalyticsError('COMMERCIAL_EXPERIMENT_ASSIGNMENT_INVALID')
+    }
+    const percent = boundedInteger(controlGroupPercent, { minimum: 1, maximum: 99, code: 'COMMERCIAL_EXPERIMENT_CONTROL_INVALID' })
+    const bucket = Number.parseInt(stableAnalyticsFingerprint({ experimentId: text(experimentId), identityId: text(identityId) }).slice(0, 8), 16) % 100
+    return bucket < percent ? 'control' : 'treatment'
+}
+
+export function calculateExperimentLift(rows = []) {
+    const groups = {
+        treatment: { population: 0, conversions: 0, revenue: 0 },
+        control: { population: 0, conversions: 0, revenue: 0 },
+    }
+    for (const row of Array.isArray(rows) ? rows : []) {
+        const variant = text(row?.variant)
+        if (!Object.hasOwn(groups, variant)) continue
+        const population = Math.max(0, Number(row?.population || 0))
+        const conversions = Math.max(0, Number(row?.conversions || 0))
+        const revenue = Math.max(0, Number(row?.revenue || 0))
+        groups[variant].population += population
+        groups[variant].conversions += Math.min(population, conversions)
+        groups[variant].revenue += revenue
+    }
+    const treatmentRate = groups.treatment.population ? groups.treatment.conversions / groups.treatment.population : null
+    const controlRate = groups.control.population ? groups.control.conversions / groups.control.population : null
+    const lift = treatmentRate == null || controlRate == null ? null : treatmentRate - controlRate
+    const adequateSample = groups.treatment.population >= 30 && groups.control.population >= 30
+    const standardError = adequateSample && lift != null
+        ? Math.sqrt((treatmentRate * (1 - treatmentRate) / groups.treatment.population) +
+            (controlRate * (1 - controlRate) / groups.control.population))
+        : null
+    return {
+        treatment: { ...groups.treatment, conversionRate: treatmentRate },
+        control: { ...groups.control, conversionRate: controlRate },
+        observedLift: lift,
+        incrementalConversions: lift == null ? null : Math.round(lift * groups.treatment.population * 10_000) / 10_000,
+        incrementalRevenue: groups.control.population && groups.treatment.population
+            ? Math.round((groups.treatment.revenue - (groups.control.revenue / groups.control.population) * groups.treatment.population) * 100) / 100
+            : null,
+        confidenceInterval95: standardError == null || lift == null
+            ? null
+            : { lower: lift - 1.96 * standardError, upper: lift + 1.96 * standardError },
+        adequateSample,
+        warning: adequateSample ? null : 'INSUFFICIENT_EXPERIMENT_SAMPLE',
+    }
+}
+
+export function commercialAnalyticsSafety() {
+    return { ...COMMERCIAL_ANALYTICS_SAFETY_FLAGS }
+}

--- a/crm/api/server/atendimento/commercialAnalyticsMigration.js
+++ b/crm/api/server/atendimento/commercialAnalyticsMigration.js
@@ -1,0 +1,356 @@
+import { assertAtendimentoMigrationDestination, isStrictAtendimentoMigrationDestination, ATENDIMENTO_MIGRATION_TARGETS } from './migrationDestination.js'
+import { COMMERCIAL_ANALYTICS_MIGRATION_ID } from './commercialAnalytics.js'
+
+const RUNTIME_ROLES = Object.freeze({
+    [ATENDIMENTO_MIGRATION_TARGETS.LOCAL]: 'skincos',
+    [ATENDIMENTO_MIGRATION_TARGETS.STAGING]: 'skincos_staging_crm_app',
+})
+
+const PREREQUISITE_RELATIONS = Object.freeze([
+    'crm_atendimento.schema_migrations',
+    'crm_atendimento.units',
+    'crm_atendimento.global_client_identities',
+    'crm_atendimento.global_client_identity_members',
+    'crm_atendimento.attendance_client_links',
+    'crm_atendimento.attendances',
+    'crm_atendimento.commercial_actions',
+    'crm_atendimento.commercial_campaigns',
+    'crm_atendimento.commercial_campaign_members',
+    'crm_atendimento.commercial_data_quality_findings',
+    'crm_atendimento.commercial_data_quality_finding_events',
+    'crm_atendimento.commercial_contact_permissions',
+    'crm_atendimento.clientes_source_operation_checkpoints',
+    'crm_caixa.sales',
+    'crm_caixa.sale_items',
+])
+
+function migrationError(code) {
+    const error = new Error(code)
+    error.code = code
+    return error
+}
+
+function triggerIfMissing(relation, name, statement) {
+    return `do $$ begin
+        if not exists (select 1 from pg_trigger where tgrelid='${relation}'::regclass and tgname='${name}') then
+            ${statement};
+        end if;
+    end $$`
+}
+
+function runtimeGrantStatements(target) {
+    const role = RUNTIME_ROLES[target]
+    if (!role) throw migrationError('COMMERCIAL_ANALYTICS_RUNTIME_ROLE_UNKNOWN')
+    return [
+        `grant usage on schema crm_atendimento to ${role}`,
+        `grant usage on schema crm_caixa to ${role}`,
+        // Both the Analytics readiness endpoint and the Operations crossover
+        // guard read the registry. The runtime role never receives DDL.
+        `grant select on table crm_atendimento.schema_migrations to ${role}`,
+        `grant select on table crm_atendimento.commercial_data_quality_findings to ${role}`,
+        `grant select on table crm_atendimento.commercial_data_quality_finding_events to ${role}`,
+        `grant select on table crm_atendimento.clientes_source_operation_checkpoints to ${role}`,
+        `grant select on table crm_atendimento.commercial_actions to ${role}`,
+        `grant select on table crm_atendimento.commercial_campaigns to ${role}`,
+        `grant select on table crm_atendimento.commercial_campaign_members to ${role}`,
+        `grant select on table crm_atendimento.commercial_contact_permissions to ${role}`,
+        // Segment snapshots consume only aggregate activity from these exact
+        // source relations.  Do not substitute a blanket schema grant: the
+        // runtime receives neither identities' PII fields nor DDL.
+        `grant select on table crm_atendimento.units to ${role}`,
+        `grant select on table crm_atendimento.global_client_identity_members to ${role}`,
+        `grant select on table crm_atendimento.attendance_client_links to ${role}`,
+        `grant select on table crm_atendimento.attendances to ${role}`,
+        `grant select on table crm_caixa.sales to ${role}`,
+        `grant select on table crm_caixa.sale_items to ${role}`,
+        `grant select on table crm_atendimento.commercial_analytics_mutations to ${role}`,
+        `grant insert on table crm_atendimento.commercial_analytics_mutations to ${role}`,
+        `grant select, insert, update on table crm_atendimento.commercial_segment_definitions to ${role}`,
+        `grant select, insert on table crm_atendimento.commercial_segment_versions to ${role}`,
+        `grant select, insert on table crm_atendimento.commercial_segment_memberships to ${role}`,
+        `grant select, insert, update on table crm_atendimento.commercial_attribution_windows to ${role}`,
+        `grant select, insert, update on table crm_atendimento.commercial_experiments to ${role}`,
+        // This SELECT is intentionally explicit: Operations checks this table
+        // under the shared crossover advisory-lock namespace before every
+        // campaign/reassign/rebalance mutation.
+        `grant select, insert on table crm_atendimento.commercial_experiment_assignments to ${role}`,
+        `grant select, insert on table crm_atendimento.commercial_analytics_events to ${role}`,
+        `grant usage, select on sequence crm_atendimento.commercial_analytics_events_event_order_seq to ${role}`,
+    ]
+}
+
+const STATEMENTS = Object.freeze([
+    `create extension if not exists pgcrypto`,
+    `create schema if not exists crm_atendimento`,
+    `create or replace function crm_atendimento.valid_commercial_segment_criteria(payload jsonb)
+        returns boolean language plpgsql immutable as $$
+        declare item record;
+        begin
+            if jsonb_typeof(payload) <> 'object' or payload = '{}'::jsonb then return false; end if;
+            for item in select key, value from jsonb_each(payload) loop
+                if item.key ~ '[A-Z]' or item.key !~ '^[a-z][a-z0-9_]*$' then return false; end if;
+                if lower(item.key) ~ '(email|e_?mail|phone|telefone|whatsapp|name|nome|cpf|address|endereco|contact|contato|pii|alias|raw|evidence|context)' then return false; end if;
+                if item.key not in (
+                    'minimum_lifetime_sales','minimum_visits','minimum_recency_days','maximum_recency_days',
+                    'minimum_lifetime_sales_percentile','minimum_visits_percentile','requires_permission',
+                    'requires_phone_correlation','requires_fresh_sources','source_freshness_max_hours',
+                    'identity_quality','procedure_ids','sales_classifications'
+                ) then return false; end if;
+                if item.key in ('requires_permission','requires_phone_correlation','requires_fresh_sources')
+                    and jsonb_typeof(item.value) <> 'boolean' then return false; end if;
+                if item.key in ('minimum_lifetime_sales','minimum_visits','minimum_recency_days','maximum_recency_days',
+                    'minimum_lifetime_sales_percentile','minimum_visits_percentile','source_freshness_max_hours')
+                    and jsonb_typeof(item.value) <> 'number' then return false; end if;
+                if item.key = 'identity_quality'
+                    and (jsonb_typeof(item.value) <> 'string' or item.value #>> '{}' not in ('confirmed_multi_source','unresolved_single_source')) then return false; end if;
+                if item.key in ('procedure_ids','sales_classifications') then
+                    if jsonb_typeof(item.value) <> 'array' or jsonb_array_length(item.value) = 0 then return false; end if;
+                    if item.key = 'procedure_ids' and jsonb_array_length(item.value) > 50 then return false; end if;
+                    if item.key = 'sales_classifications' and jsonb_array_length(item.value) > 2 then return false; end if;
+                    if exists(select 1 from jsonb_array_elements(item.value) value where jsonb_typeof(value) <> 'string') then return false; end if;
+                    if item.key = 'procedure_ids' and exists(select 1 from jsonb_array_elements_text(item.value) value where value !~* '^[a-z0-9][a-z0-9._-]{0,119}$' or value ~* '(email|e_?mail|phone|telefone|whatsapp|name|nome|cpf|address|endereco|contact|contato|pii|alias|raw|evidence|context)') then return false; end if;
+                    if item.key = 'sales_classifications' and exists(select 1 from jsonb_array_elements_text(item.value) value where value not in ('mapped','unmapped')) then return false; end if;
+                end if;
+            end loop;
+            if (payload ? 'minimum_recency_days') and (payload ? 'maximum_recency_days')
+                and (payload->>'minimum_recency_days')::numeric > (payload->>'maximum_recency_days')::numeric then return false; end if;
+            return true;
+        end $$`,
+    `create table if not exists crm_atendimento.commercial_analytics_mutations (
+        id uuid primary key default gen_random_uuid(),
+        mutation_key text not null check (mutation_key ~ '^[A-Za-z0-9._:-]{8,240}$'),
+        operation text not null check (operation in ('segment_create','segment_version','segment_snapshot','attribution_window_upsert','experiment_create','experiment_state')),
+        actor_id text not null check (char_length(actor_id) between 1 and 160 and actor_id !~ '[@]'),
+        request_fingerprint text not null check (request_fingerprint ~ '^[a-f0-9]{64}$'),
+        response jsonb not null default '{}'::jsonb check (jsonb_typeof(response) = 'object'),
+        created_at timestamptz not null default now(),
+        unique(mutation_key, operation)
+    )`,
+    `create table if not exists crm_atendimento.commercial_segment_definitions (
+        id uuid primary key default gen_random_uuid(),
+        unit_id uuid not null references crm_atendimento.units(id) on delete restrict,
+        segment_key text not null check (segment_key ~ '^[a-z][a-z0-9_]{2,80}$'),
+        name text not null check (char_length(btrim(name)) between 1 and 120 and name !~ '[@]'),
+        criteria jsonb not null check (crm_atendimento.valid_commercial_segment_criteria(criteria)),
+        status text not null default 'draft' check (status in ('draft','active','disabled')),
+        revision integer not null default 1 check (revision >= 1),
+        created_by text not null check (char_length(created_by) between 1 and 160 and created_by !~ '[@]'),
+        updated_by text not null check (char_length(updated_by) between 1 and 160 and updated_by !~ '[@]'),
+        created_at timestamptz not null default now(),
+        updated_at timestamptz not null default now(),
+        unique(unit_id, segment_key)
+    )`,
+    `create table if not exists crm_atendimento.commercial_segment_versions (
+        id uuid primary key default gen_random_uuid(),
+        definition_id uuid not null references crm_atendimento.commercial_segment_definitions(id) on delete restrict,
+        version integer not null check (version >= 1),
+        criteria jsonb not null check (crm_atendimento.valid_commercial_segment_criteria(criteria)),
+        criteria_fingerprint text not null check (criteria_fingerprint ~ '^[a-f0-9]{64}$'),
+        effective_from timestamptz not null,
+        effective_until timestamptz,
+        population_count integer not null default 0 check (population_count >= 0),
+        distribution jsonb not null default '{}'::jsonb check (jsonb_typeof(distribution) = 'object'),
+        snapshot_at timestamptz,
+        author text not null check (char_length(author) between 1 and 160 and author !~ '[@]'),
+        created_at timestamptz not null default now(),
+        check (effective_until is null or effective_until > effective_from),
+        unique(definition_id, version)
+    )`,
+    `create table if not exists crm_atendimento.commercial_segment_memberships (
+        id uuid primary key default gen_random_uuid(),
+        segment_version_id uuid not null references crm_atendimento.commercial_segment_versions(id) on delete restrict,
+        identity_id uuid not null references crm_atendimento.global_client_identities(id) on delete restrict,
+        unit_id uuid not null references crm_atendimento.units(id) on delete restrict,
+        eligible boolean not null,
+        criteria_fingerprint text not null check (criteria_fingerprint ~ '^[a-f0-9]{64}$'),
+        snapshot_at timestamptz not null default now(),
+        unique(segment_version_id, identity_id)
+    )`,
+    `create table if not exists crm_atendimento.commercial_attribution_windows (
+        id uuid primary key default gen_random_uuid(),
+        unit_id uuid not null references crm_atendimento.units(id) on delete restrict,
+        window_key text not null check (window_key ~ '^[a-z][a-z0-9_]{2,80}$'),
+        revision integer not null check (revision >= 1),
+        state text not null default 'active' check (state in ('active','superseded','disabled')),
+        starts_at timestamptz not null,
+        ends_at timestamptz,
+        response_days integer not null check (response_days between 1 and 60),
+        scheduled_days integer not null check (scheduled_days between 1 and 120),
+        attended_days integer not null check (attended_days between 1 and 180),
+        purchased_days integer not null check (purchased_days between 1 and 180),
+        returned_days integer not null check (returned_days between 1 and 365),
+        created_by text not null check (char_length(created_by) between 1 and 160 and created_by !~ '[@]'),
+        created_at timestamptz not null default now(),
+        updated_at timestamptz not null default now(),
+        check (ends_at is null or ends_at > starts_at),
+        unique(unit_id, window_key, revision)
+    )`,
+    `create table if not exists crm_atendimento.commercial_experiments (
+        id uuid primary key default gen_random_uuid(),
+        unit_id uuid not null references crm_atendimento.units(id) on delete restrict,
+        name text not null check (char_length(btrim(name)) between 1 and 120 and name !~ '[@]'),
+        segment_version_id uuid not null references crm_atendimento.commercial_segment_versions(id) on delete restrict,
+        attribution_window_id uuid not null references crm_atendimento.commercial_attribution_windows(id) on delete restrict,
+        control_group_percent integer not null check (control_group_percent between 1 and 99),
+        state text not null default 'draft' check (state in ('draft','active','closed','disabled')),
+        revision integer not null default 1 check (revision >= 1),
+        starts_at timestamptz not null,
+        ends_at timestamptz not null,
+        policy_version text not null check (policy_version ~ '^[a-f0-9]{64}$'),
+        author text not null check (char_length(author) between 1 and 160 and author !~ '[@]'),
+        created_at timestamptz not null default now(),
+        updated_at timestamptz not null default now(),
+        check (ends_at > starts_at)
+    )`,
+    `create table if not exists crm_atendimento.commercial_experiment_assignments (
+        id uuid primary key default gen_random_uuid(),
+        experiment_id uuid not null references crm_atendimento.commercial_experiments(id) on delete restrict,
+        identity_id uuid not null references crm_atendimento.global_client_identities(id) on delete restrict,
+        unit_id uuid not null references crm_atendimento.units(id) on delete restrict,
+        variant text not null check (variant in ('treatment','control','excluded')),
+        eligibility_fingerprint text not null check (eligibility_fingerprint ~ '^[a-f0-9]{64}$'),
+        assigned_at timestamptz not null default now(),
+        unique(experiment_id, identity_id)
+    )`,
+    `create table if not exists crm_atendimento.commercial_analytics_events (
+        id uuid primary key default gen_random_uuid(),
+        event_order bigint generated always as identity,
+        event_type text not null check (event_type in ('segment_defined','segment_versioned','segment_snapshot','attribution_window_versioned','experiment_created','experiment_assigned','experiment_state_changed')),
+        entity_type text not null check (entity_type in ('segment_definition','segment_version','attribution_window','experiment')),
+        entity_id uuid not null,
+        actor_id text not null check (char_length(actor_id) between 1 and 160 and actor_id !~ '[@]'),
+        trace_id uuid not null,
+        count_value integer check (count_value is null or count_value >= 0),
+        fingerprint text check (fingerprint is null or fingerprint ~ '^[a-f0-9]{64}$'),
+        created_at timestamptz not null default now()
+    )`,
+    `create index if not exists commercial_segment_definitions_unit_idx on crm_atendimento.commercial_segment_definitions(unit_id, updated_at desc)`,
+    `create index if not exists commercial_segment_versions_definition_idx on crm_atendimento.commercial_segment_versions(definition_id, version desc)`,
+    `create index if not exists commercial_segment_memberships_version_unit_idx on crm_atendimento.commercial_segment_memberships(segment_version_id, unit_id, eligible)`,
+    `create index if not exists commercial_attribution_windows_unit_key_idx on crm_atendimento.commercial_attribution_windows(unit_id, window_key, revision desc)`,
+    `create index if not exists commercial_experiments_unit_state_idx on crm_atendimento.commercial_experiments(unit_id, state, starts_at, ends_at)`,
+    `create index if not exists commercial_experiment_assignments_identity_idx on crm_atendimento.commercial_experiment_assignments(identity_id, unit_id, variant)`,
+    `create index if not exists commercial_analytics_events_entity_idx on crm_atendimento.commercial_analytics_events(entity_type, entity_id, event_order desc)`,
+    `create or replace function crm_atendimento.prevent_commercial_analytics_ledger_mutation()
+        returns trigger language plpgsql as $$ begin
+            raise exception 'commercial analytics evidence is append-only';
+        end $$`,
+    triggerIfMissing('crm_atendimento.commercial_analytics_mutations', 'commercial_analytics_mutations_immutable',
+        `create trigger commercial_analytics_mutations_immutable before update or delete on crm_atendimento.commercial_analytics_mutations for each row execute function crm_atendimento.prevent_commercial_analytics_ledger_mutation()`),
+    triggerIfMissing('crm_atendimento.commercial_analytics_mutations', 'commercial_analytics_mutations_no_truncate',
+        `create trigger commercial_analytics_mutations_no_truncate before truncate on crm_atendimento.commercial_analytics_mutations for each statement execute function crm_atendimento.prevent_commercial_analytics_ledger_mutation()`),
+    triggerIfMissing('crm_atendimento.commercial_segment_memberships', 'commercial_segment_memberships_immutable',
+        `create trigger commercial_segment_memberships_immutable before update or delete on crm_atendimento.commercial_segment_memberships for each row execute function crm_atendimento.prevent_commercial_analytics_ledger_mutation()`),
+    triggerIfMissing('crm_atendimento.commercial_segment_memberships', 'commercial_segment_memberships_no_truncate',
+        `create trigger commercial_segment_memberships_no_truncate before truncate on crm_atendimento.commercial_segment_memberships for each statement execute function crm_atendimento.prevent_commercial_analytics_ledger_mutation()`),
+    triggerIfMissing('crm_atendimento.commercial_experiment_assignments', 'commercial_experiment_assignments_immutable',
+        `create trigger commercial_experiment_assignments_immutable before update or delete on crm_atendimento.commercial_experiment_assignments for each row execute function crm_atendimento.prevent_commercial_analytics_ledger_mutation()`),
+    triggerIfMissing('crm_atendimento.commercial_experiment_assignments', 'commercial_experiment_assignments_no_truncate',
+        `create trigger commercial_experiment_assignments_no_truncate before truncate on crm_atendimento.commercial_experiment_assignments for each statement execute function crm_atendimento.prevent_commercial_analytics_ledger_mutation()`),
+    triggerIfMissing('crm_atendimento.commercial_analytics_events', 'commercial_analytics_events_immutable',
+        `create trigger commercial_analytics_events_immutable before update or delete on crm_atendimento.commercial_analytics_events for each row execute function crm_atendimento.prevent_commercial_analytics_ledger_mutation()`),
+    triggerIfMissing('crm_atendimento.commercial_analytics_events', 'commercial_analytics_events_no_truncate',
+        `create trigger commercial_analytics_events_no_truncate before truncate on crm_atendimento.commercial_analytics_events for each statement execute function crm_atendimento.prevent_commercial_analytics_ledger_mutation()`),
+])
+
+async function ensureRegistry(client) {
+    await client.query(`create schema if not exists crm_atendimento`)
+    await client.query(`create table if not exists crm_atendimento.schema_migrations (
+        id text primary key, applied_at timestamptz not null default now(), rolled_back_at timestamptz,
+        details jsonb not null default '{}'::jsonb
+    )`)
+}
+
+async function assertPrerequisites(client) {
+    const fields = PREREQUISITE_RELATIONS.map((relation, index) => `to_regclass('${relation}') as relation_${index}`).join(', ')
+    const result = await client.query(`select ${fields}`)
+    if (!Object.values(result.rows[0] || {}).every(Boolean)) throw migrationError('COMMERCIAL_ANALYTICS_MIGRATION_PREREQUISITES_MISSING')
+}
+
+export function commercialAnalyticsMigrationPlan() {
+    return {
+        id: COMMERCIAL_ANALYTICS_MIGRATION_ID,
+        adds: [
+            'commercial_analytics_mutations', 'commercial_segment_definitions', 'commercial_segment_versions',
+            'commercial_segment_memberships', 'commercial_attribution_windows', 'commercial_experiments',
+            'commercial_experiment_assignments', 'commercial_analytics_events',
+        ],
+        segmentPolicy: 'Only the explicit snake_case criteria DSL is persisted. CamelCase, unknown keys, nested objects and contact-like aliases are rejected in both API validation and PostgreSQL constraints.',
+        experimentPolicy: 'Assignments are deterministic, persisted and locked with the shared commercial-experiment-crossover namespace before any read/write decision.',
+        attributionDefaults: { responseDays: 7, scheduledDays: 14, attendedDays: 30, purchasedDays: 30, returnedDays: 60 },
+        runtimeAccess: 'The runtime role receives SELECT on schema_migrations and analytic read sources, plus only the DML required for append-only evidence and versioned configuration. It receives no DDL.',
+        safety: { commercialContactWritesEnabled: false, messagesEnabled: false, consentWritesEnabled: false },
+        rollback: 'Non-destructive: analytics evidence, snapshots and assignments remain retained; only the registry row records rollback.',
+    }
+}
+
+export async function applyCommercialAnalyticsMigration({ pool, databaseUrl, target = ATENDIMENTO_MIGRATION_TARGETS.LOCAL }) {
+    if (!pool) throw migrationError('COMMERCIAL_ANALYTICS_MIGRATION_POOL_REQUIRED')
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw migrationError('COMMERCIAL_ANALYTICS_MIGRATION_DESTINATION_UNSAFE')
+    const client = await pool.connect()
+    let transactionOpen = false
+    try {
+        await client.query('begin')
+        transactionOpen = true
+        await client.query(`set local lock_timeout = '3s'`)
+        await client.query(`set local statement_timeout = '60s'`)
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [COMMERCIAL_ANALYTICS_MIGRATION_ID])
+        await assertAtendimentoMigrationDestination(client, databaseUrl, target)
+        await ensureRegistry(client)
+        await assertPrerequisites(client)
+        for (const statement of STATEMENTS) await client.query(statement)
+        const grants = runtimeGrantStatements(target)
+        for (const statement of grants) await client.query(statement)
+        const report = {
+            ...commercialAnalyticsMigrationPlan(),
+            applied: true,
+            target,
+            runtimeRole: RUNTIME_ROLES[target],
+            runtimeGrants: grants,
+        }
+        await client.query(`insert into crm_atendimento.schema_migrations(id, applied_at, rolled_back_at, details)
+            values ($1, now(), null, $2::jsonb)
+            on conflict(id) do update set applied_at=excluded.applied_at, rolled_back_at=null, details=excluded.details`,
+        [COMMERCIAL_ANALYTICS_MIGRATION_ID, JSON.stringify(report)])
+        await client.query('commit')
+        transactionOpen = false
+        return report
+    } catch (error) {
+        if (transactionOpen) {
+            try { await client.query('rollback') } catch { /* preserve original migration error */ }
+        }
+        throw error
+    } finally {
+        client.release()
+    }
+}
+
+export async function rollbackCommercialAnalyticsMigration({ pool, databaseUrl, target = ATENDIMENTO_MIGRATION_TARGETS.LOCAL }) {
+    if (!pool) throw migrationError('COMMERCIAL_ANALYTICS_MIGRATION_POOL_REQUIRED')
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw migrationError('COMMERCIAL_ANALYTICS_MIGRATION_DESTINATION_UNSAFE')
+    const client = await pool.connect()
+    let transactionOpen = false
+    try {
+        await client.query('begin')
+        transactionOpen = true
+        await client.query(`set local lock_timeout = '3s'`)
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [COMMERCIAL_ANALYTICS_MIGRATION_ID])
+        await assertAtendimentoMigrationDestination(client, databaseUrl, target)
+        await ensureRegistry(client)
+        await client.query(`insert into crm_atendimento.schema_migrations(id, applied_at, rolled_back_at, details)
+            values ($1, now(), now(), '{"rollback":"non-destructive","evidenceRetained":true}'::jsonb)
+            on conflict(id) do update set rolled_back_at=now(), details=excluded.details`, [COMMERCIAL_ANALYTICS_MIGRATION_ID])
+        await client.query('commit')
+        transactionOpen = false
+        return { id: COMMERCIAL_ANALYTICS_MIGRATION_ID, rolledBack: true, destructive: false, evidenceRetained: true }
+    } catch (error) {
+        if (transactionOpen) {
+            try { await client.query('rollback') } catch { /* preserve original migration error */ }
+        }
+        throw error
+    } finally {
+        client.release()
+    }
+}
+
+export const __testables = { STATEMENTS, runtimeGrantStatements, PREREQUISITE_RELATIONS }

--- a/crm/api/server/atendimento/commercialAnalyticsStore.js
+++ b/crm/api/server/atendimento/commercialAnalyticsStore.js
@@ -1,0 +1,1289 @@
+import { createHmac, randomUUID } from 'node:crypto'
+import { createPgPool, withPgTransaction } from '../harmonia/store/pg.js'
+import { actorSubject } from './actorSubject.js'
+import { commercialOperationsUnitScope } from './commercialOperationsStore.js'
+import {
+    COMMERCIAL_ANALYTICS_MIGRATION_ID,
+    COMMERCIAL_ANALYTICS_SAFETY_FLAGS,
+    COMMERCIAL_EXPERIMENT_STATES,
+    calculateExperimentLift,
+    commercialAnalyticsError,
+    commercialAnalyticsSafety,
+    deterministicExperimentVariant,
+    normalizeAttributionWindowPayload,
+    normalizeAnalyticsMutation,
+    normalizeExperimentPayload,
+    normalizeSegmentCriteria,
+    normalizeSegmentPayload,
+    stableAnalyticsFingerprint,
+} from './commercialAnalytics.js'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const UNIT_RE = /^[a-z0-9][a-z0-9._-]{0,119}$/
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+const OWNER_RE = /^[A-Za-zÀ-ÿ0-9._:+\- ]{1,160}$/
+const MAX_SEGMENT_CANDIDATES = 50_000
+
+function text(value) {
+    return typeof value === 'string' ? value.trim() : String(value ?? '').trim()
+}
+
+function bool(value) {
+    return value === true || value === 't' || value === 1 || value === '1'
+}
+
+function number(value, fallback = 0) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function analyticsError(code, statusCode = 409) {
+    return commercialAnalyticsError(code, statusCode)
+}
+
+function requirePool(pool) {
+    if (!pool || typeof pool.query !== 'function') throw analyticsError('COMMERCIAL_ANALYTICS_POOL_REQUIRED', 503)
+    return pool
+}
+
+function actorPrincipal(actor) {
+    const subject = actorSubject(actor)
+    if (!subject) throw analyticsError('ACTOR_IDENTITY_REQUIRED', 401)
+    return subject
+}
+
+function assertAnalyticsManager(actor) {
+    const role = text(actor?.role).toUpperCase()
+    if (role === 'GESTOR' || role === 'ADMIN' || actor?.isGlobalAdmin === true) return
+    throw analyticsError('FORBIDDEN', 403)
+}
+
+function auditSecret() {
+    const secret = text(process.env.ATENDIMENTO_ACTOR_HMAC_KEY || process.env.ESCALA_ACTOR_HMAC_KEY || process.env.CRM_ESCALA_HMAC_KEY)
+    if (secret.length < 32) throw analyticsError('COMMERCIAL_ANALYTICS_AUDIT_KEY_REQUIRED', 503)
+    return secret
+}
+
+function digest(purpose, value) {
+    return createHmac('sha256', auditSecret()).update(`${purpose}:${stableAnalyticsFingerprint(value)}`).digest('hex')
+}
+
+function actorReference(actor) {
+    return `actor:${digest('commercial-analytics-actor', { actor: actorPrincipal(actor) })}`
+}
+
+function assertUuid(value, code = 'COMMERCIAL_ANALYTICS_ID_INVALID') {
+    const id = text(value).toLowerCase()
+    if (!UUID_RE.test(id)) throw analyticsError(code, 400)
+    return id
+}
+
+function normalizeUnit(value, code = 'COMMERCIAL_ANALYTICS_UNIT_INVALID') {
+    const unit = text(value).toLowerCase()
+    if (!UNIT_RE.test(unit)) throw analyticsError(code, 400)
+    return unit
+}
+
+function requestedScope(actor, query = {}) {
+    const scope = commercialOperationsUnitScope(actor)
+    const requested = text(query?.unit).toLowerCase()
+    if (scope === null) {
+        if (!requested || requested === 'all') return { unit: null, unitSlugs: null, global: true }
+        return { unit: normalizeUnit(requested), unitSlugs: null, global: true }
+    }
+    if (!scope.length) throw analyticsError('COMMERCIAL_UNIT_FORBIDDEN', 403)
+    if (!requested || requested === 'all') return { unit: null, unitSlugs: scope, global: false }
+    const unit = normalizeUnit(requested)
+    if (!scope.includes(unit)) throw analyticsError('COMMERCIAL_UNIT_FORBIDDEN', 403)
+    return { unit, unitSlugs: [unit], global: false }
+}
+
+async function resolveUnit(client, actor, unitValue) {
+    const unit = normalizeUnit(unitValue)
+    const scope = commercialOperationsUnitScope(actor)
+    if (scope !== null && (!scope.length || !scope.includes(unit))) throw analyticsError('COMMERCIAL_UNIT_FORBIDDEN', 403)
+    const result = await client.query(`select id::text,slug from crm_atendimento.units where slug=$1`, [unit])
+    if (!result.rows[0]?.id) throw analyticsError('COMMERCIAL_ANALYTICS_UNIT_NOT_FOUND', 404)
+    return { id: String(result.rows[0].id), slug: String(result.rows[0].slug) }
+}
+
+function scopeClause(scope, params, column = 'unit.slug') {
+    if (scope.unit) {
+        params.push(scope.unit)
+        return `${column}=$${params.length}`
+    }
+    if (scope.unitSlugs) {
+        params.push(scope.unitSlugs)
+        return `${column}=any($${params.length}::text[])`
+    }
+    return 'true'
+}
+
+function mapReadiness(row = {}, migrationReady = false) {
+    const relations = ['mutations', 'definitions', 'versions', 'memberships', 'windows', 'experiments', 'assignments', 'events', 'migration_registry']
+    const triggers = [
+        'mutations_immutable', 'mutations_no_truncate', 'memberships_immutable', 'memberships_no_truncate',
+        'assignments_immutable', 'assignments_no_truncate', 'events_immutable', 'events_no_truncate',
+    ]
+    const grants = [
+        'migration_read', 'mutations_read', 'mutations_write', 'definitions_read', 'definitions_write',
+        'versions_read', 'versions_write', 'memberships_read', 'memberships_write', 'windows_read', 'windows_write',
+        'experiments_read', 'experiments_write', 'assignments_read', 'assignments_write',
+        'events_write', 'events_sequence_write', 'source_units_read', 'source_identity_members_read',
+        'source_attendance_links_read', 'source_attendances_read', 'source_sales_read', 'source_sale_items_read',
+        'source_actions_read', 'source_campaigns_read', 'source_campaign_members_read', 'source_permissions_read',
+        'source_checkpoints_read', 'source_quality_findings_read', 'source_quality_events_read',
+    ]
+    const relationsReady = relations.every((key) => bool(row[key]))
+    const appendOnlyReady = triggers.every((key) => bool(row[key]))
+    const grantsReady = grants.every((key) => bool(row[key]))
+    return {
+        ready: relationsReady && appendOnlyReady && grantsReady && migrationReady,
+        migrationId: COMMERCIAL_ANALYTICS_MIGRATION_ID,
+        relationsReady,
+        appendOnlyReady,
+        grantsReady,
+        migrationReady,
+        safety: commercialAnalyticsSafety(),
+    }
+}
+
+export async function commercialAnalyticsReadiness(db) {
+    try {
+        const availability = await db.query(`select
+            to_regclass('crm_atendimento.commercial_analytics_mutations') is not null as mutations,
+            to_regclass('crm_atendimento.commercial_segment_definitions') is not null as definitions,
+            to_regclass('crm_atendimento.commercial_segment_versions') is not null as versions,
+            to_regclass('crm_atendimento.commercial_segment_memberships') is not null as memberships,
+            to_regclass('crm_atendimento.commercial_attribution_windows') is not null as windows,
+            to_regclass('crm_atendimento.commercial_experiments') is not null as experiments,
+            to_regclass('crm_atendimento.commercial_experiment_assignments') is not null as assignments,
+            to_regclass('crm_atendimento.commercial_analytics_events') is not null as events,
+            to_regclass('crm_atendimento.schema_migrations') is not null as migration_registry,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.schema_migrations'), 'SELECT'), false) as migration_read,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_analytics_mutations'), 'SELECT'), false) as mutations_read,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_analytics_mutations'), 'INSERT'), false) as mutations_write,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_segment_definitions'), 'SELECT'), false) as definitions_read,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_segment_definitions'), 'INSERT, UPDATE'), false) as definitions_write,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_segment_versions'), 'SELECT'), false) as versions_read,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_segment_versions'), 'INSERT'), false) as versions_write,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_segment_memberships'), 'SELECT'), false) as memberships_read,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_segment_memberships'), 'INSERT'), false) as memberships_write,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_attribution_windows'), 'SELECT'), false) as windows_read,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_attribution_windows'), 'INSERT, UPDATE'), false) as windows_write,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_experiment_assignments'), 'SELECT'), false) as assignments_read,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_experiment_assignments'), 'INSERT'), false) as assignments_write,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_experiments'), 'SELECT'), false) as experiments_read,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_experiments'), 'INSERT, UPDATE'), false) as experiments_write,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_analytics_events'), 'INSERT'), false) as events_write,
+            coalesce(has_sequence_privilege(current_user, to_regclass('crm_atendimento.commercial_analytics_events_event_order_seq'), 'USAGE'), false) as events_sequence_write,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.units'), 'SELECT'), false) as source_units_read,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.global_client_identity_members'), 'SELECT'), false) as source_identity_members_read,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.attendance_client_links'), 'SELECT'), false) as source_attendance_links_read,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.attendances'), 'SELECT'), false) as source_attendances_read,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_caixa.sales'), 'SELECT'), false) as source_sales_read,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_caixa.sale_items'), 'SELECT'), false) as source_sale_items_read,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_actions'), 'SELECT'), false) as source_actions_read,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_campaigns'), 'SELECT'), false) as source_campaigns_read,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_campaign_members'), 'SELECT'), false) as source_campaign_members_read,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_contact_permissions'), 'SELECT'), false) as source_permissions_read,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.clientes_source_operation_checkpoints'), 'SELECT'), false) as source_checkpoints_read,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_data_quality_findings'), 'SELECT'), false) as source_quality_findings_read,
+            coalesce(has_table_privilege(current_user, to_regclass('crm_atendimento.commercial_data_quality_finding_events'), 'SELECT'), false) as source_quality_events_read,
+            exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_analytics_mutations')
+                and tgname='commercial_analytics_mutations_immutable' and tgenabled='O'
+                and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_analytics_ledger_mutation()')) as mutations_immutable,
+            exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_analytics_mutations')
+                and tgname='commercial_analytics_mutations_no_truncate' and tgenabled='O'
+                and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_analytics_ledger_mutation()')) as mutations_no_truncate,
+            exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_segment_memberships')
+                and tgname='commercial_segment_memberships_immutable' and tgenabled='O'
+                and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_analytics_ledger_mutation()')) as memberships_immutable,
+            exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_segment_memberships')
+                and tgname='commercial_segment_memberships_no_truncate' and tgenabled='O'
+                and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_analytics_ledger_mutation()')) as memberships_no_truncate,
+            exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_experiment_assignments')
+                and tgname='commercial_experiment_assignments_immutable' and tgenabled='O'
+                and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_analytics_ledger_mutation()')) as assignments_immutable,
+            exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_experiment_assignments')
+                and tgname='commercial_experiment_assignments_no_truncate' and tgenabled='O'
+                and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_analytics_ledger_mutation()')) as assignments_no_truncate,
+            exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_analytics_events')
+                and tgname='commercial_analytics_events_immutable' and tgenabled='O'
+                and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_analytics_ledger_mutation()')) as events_immutable,
+            exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_analytics_events')
+                and tgname='commercial_analytics_events_no_truncate' and tgenabled='O'
+                and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_analytics_ledger_mutation()')) as events_no_truncate`)
+        const row = availability.rows[0] || {}
+        if (!row.migration_registry || !row.migration_read) return mapReadiness(row, false)
+        const migration = await db.query(`select id from crm_atendimento.schema_migrations where id=$1 and rolled_back_at is null`, [COMMERCIAL_ANALYTICS_MIGRATION_ID])
+        return mapReadiness(row, !!migration.rows[0]?.id)
+    } catch {
+        return { ...mapReadiness({}, false), readinessUnavailable: true }
+    }
+}
+
+async function assertReady(db) {
+    const readiness = await commercialAnalyticsReadiness(db)
+    if (!readiness.ready) throw analyticsError('COMMERCIAL_ANALYTICS_NOT_READY')
+    return readiness
+}
+
+function mutationContext(actor, operation, payload, fingerprintPayload, options = {}) {
+    const mutation = normalizeAnalyticsMutation(payload, options)
+    const actorRef = actorReference(actor)
+    const mutationKey = `ca:${digest('commercial-analytics-idempotency', { actorRef, operation, idempotencyKey: mutation.idempotencyKey })}`
+    const requestFingerprint = digest('commercial-analytics-request', { actorRef, operation, payload: fingerprintPayload })
+    return { mutation, actorRef, mutationKey, requestFingerprint }
+}
+
+async function runAnalyticsMutation(client, { actor, operation, payload, fingerprintPayload, options = {}, execute }) {
+    const context = mutationContext(actor, operation, payload, fingerprintPayload, options)
+    // The advisory lock is deliberately first. No readiness, ledger or mutable
+    // row is read until this idempotency namespace is serialized.
+    await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [context.mutationKey])
+    await assertReady(client)
+    const existing = await client.query(`select request_fingerprint,response
+        from crm_atendimento.commercial_analytics_mutations
+        where mutation_key=$1 and operation=$2 for update`, [context.mutationKey, operation])
+    if (existing.rows[0]) {
+        if (text(existing.rows[0].request_fingerprint) !== context.requestFingerprint) {
+            throw analyticsError('COMMERCIAL_ANALYTICS_IDEMPOTENCY_CONFLICT')
+        }
+        return { ...(existing.rows[0].response || {}), idempotent: true, safety: commercialAnalyticsSafety() }
+    }
+    const response = await execute(context)
+    await client.query(`insert into crm_atendimento.commercial_analytics_mutations(
+            mutation_key,operation,actor_id,request_fingerprint,response)
+        values($1,$2,$3,$4,$5::jsonb)`, [
+        context.mutationKey, operation, context.actorRef, context.requestFingerprint, JSON.stringify(response || {}),
+    ])
+    return { ...(response || {}), idempotent: false, safety: commercialAnalyticsSafety() }
+}
+
+async function recordAnalyticsEvent(client, { eventType, entityType, entityId, actorRef, countValue = null, fingerprint = null }) {
+    await client.query(`insert into crm_atendimento.commercial_analytics_events(
+            event_type,entity_type,entity_id,actor_id,trace_id,count_value,fingerprint)
+        values($1,$2,$3,$4,$5,$6,$7)`, [
+        eventType, entityType, entityId, actorRef, randomUUID(), countValue, fingerprint,
+    ])
+}
+
+function percentile(values, ratio) {
+    const sorted = values.map((value) => number(value)).filter((value) => value >= 0).sort((left, right) => left - right)
+    if (!sorted.length) return 0
+    return sorted[Math.max(0, Math.min(sorted.length - 1, Math.ceil(sorted.length * ratio) - 1))]
+}
+
+function candidateIdentityQuality(row) {
+    return number(row.source_type_count) >= 2 ? 'confirmed_multi_source' : 'unresolved_single_source'
+}
+
+function candidateMatchesCriteria(row, criteria, benchmarks) {
+    if (criteria.minimum_lifetime_sales != null && number(row.lifetime_sales) < criteria.minimum_lifetime_sales) return false
+    if (criteria.minimum_visits != null && number(row.visit_count) < criteria.minimum_visits) return false
+    if (criteria.minimum_recency_days != null && (row.recency_days == null || number(row.recency_days) < criteria.minimum_recency_days)) return false
+    if (criteria.maximum_recency_days != null && (row.recency_days == null || number(row.recency_days) > criteria.maximum_recency_days)) return false
+    if (criteria.minimum_lifetime_sales_percentile != null && number(row.lifetime_sales) < benchmarks.sales) return false
+    if (criteria.minimum_visits_percentile != null && number(row.visit_count) < benchmarks.visits) return false
+    if (criteria.requires_permission === true && !bool(row.has_permission)) return false
+    if (criteria.requires_phone_correlation === true && !bool(row.phone_correlated)) return false
+    if (criteria.requires_fresh_sources === true && bool(row.source_stale)) return false
+    if (criteria.source_freshness_max_hours != null && number(row.source_freshness_hours, Number.POSITIVE_INFINITY) > criteria.source_freshness_max_hours) return false
+    if (criteria.identity_quality && candidateIdentityQuality(row) !== criteria.identity_quality) return false
+    if (criteria.procedure_ids?.length && !criteria.procedure_ids.some((id) => (row.procedure_ids || []).map(String).includes(id))) return false
+    if (criteria.sales_classifications?.length) {
+        const classifications = []
+        if (number(row.sale_count) > 0 && number(row.unmapped_sale_items) === 0) classifications.push('mapped')
+        if (number(row.unmapped_sale_items) > 0) classifications.push('unmapped')
+        if (!criteria.sales_classifications.some((item) => classifications.includes(item))) return false
+    }
+    return true
+}
+
+async function segmentCandidates(client, unitId) {
+    const result = await client.query(`with attendance_members as (
+            select distinct member.identity_id,member.source_id::uuid as client_id
+            from crm_atendimento.global_client_identity_members member
+            where member.source_type='attendance_client' and member.source_id ~ '^[0-9a-fA-F-]{36}$'
+        ), attendance_activity as (
+            select member.identity_id,attendance.unit_id,count(distinct attendance.service_date)::int as visit_count,
+                max(attendance.service_date) as last_attendance,
+                coalesce(array_agg(distinct attendance.procedure_id::text) filter(where attendance.procedure_id is not null), '{}'::text[]) as procedure_ids
+            from attendance_members member
+            join crm_atendimento.attendance_client_links link on link.client_id=member.client_id
+            join crm_atendimento.attendances attendance on attendance.id=link.attendance_id
+            where attendance.deleted_at is null
+            group by member.identity_id,attendance.unit_id
+        ), sale_members as (
+            select distinct member.identity_id,member.source_id::uuid as customer_id
+            from crm_atendimento.global_client_identity_members member
+            where member.source_type='caixa_customer' and member.source_id ~ '^[0-9a-fA-F-]{36}$'
+        ), sale_activity as (
+            select member.identity_id,sale.unit_id,count(distinct sale.id)::int as sale_count,
+                coalesce(sum(sale.total),0)::numeric as lifetime_sales,
+                count(item.id) filter(where coalesce(item.mapping_status,'pending') <> 'mapped')::int as unmapped_sale_items
+            from sale_members member
+            join crm_caixa.sales sale on sale.customer_id=member.customer_id
+            left join crm_caixa.sale_items item on item.sale_id=sale.id
+            group by member.identity_id,sale.unit_id
+        ), identity_units as (
+            select identity_id,unit_id from attendance_activity
+            union
+            select identity_id,unit_id from sale_activity
+        ), freshness as (
+            select coalesce(bool_or(checkpoint.last_status <> 'complete' or checkpoint.validated_snapshot_complete is not true or
+                checkpoint.reconciliation_required is true or checkpoint.validated_at is null or checkpoint.validated_at < now() - interval '48 hours'), true) as source_stale,
+                coalesce(max(extract(epoch from now()-checkpoint.validated_at)/3600) filter(where checkpoint.validated_at is not null), 1000000)::int as source_freshness_hours
+            from crm_atendimento.clientes_source_operation_checkpoints checkpoint
+        )
+        select unit_identity.identity_id::text,unit_identity.unit_id::text,
+            coalesce(attendance.visit_count,0)::int as visit_count,
+            attendance.last_attendance,
+            case when attendance.last_attendance is null then null else (current_date-attendance.last_attendance)::int end as recency_days,
+            coalesce(attendance.procedure_ids,'{}'::text[]) as procedure_ids,
+            coalesce(sale.sale_count,0)::int as sale_count,
+            coalesce(sale.lifetime_sales,0)::numeric as lifetime_sales,
+            coalesce(sale.unmapped_sale_items,0)::int as unmapped_sale_items,
+            (select count(distinct source_member.source_type)::int from crm_atendimento.global_client_identity_members source_member where source_member.identity_id=unit_identity.identity_id) as source_type_count,
+            exists(select 1 from crm_atendimento.commercial_contact_permissions permission
+                where permission.identity_id=unit_identity.identity_id and permission.channel='whatsapp' and permission.status='granted'
+                  and (permission.expires_at is null or permission.expires_at > now())) as has_permission,
+            exists(select 1 from crm_atendimento.global_client_identity_members source_member where source_member.identity_id=unit_identity.identity_id and source_member.source_type='attendance_client')
+              and exists(select 1 from crm_atendimento.global_client_identity_members source_member where source_member.identity_id=unit_identity.identity_id and source_member.source_type='caixa_customer') as phone_correlated,
+            freshness.source_stale,freshness.source_freshness_hours
+        from identity_units unit_identity
+        left join attendance_activity attendance on attendance.identity_id=unit_identity.identity_id and attendance.unit_id=unit_identity.unit_id
+        left join sale_activity sale on sale.identity_id=unit_identity.identity_id and sale.unit_id=unit_identity.unit_id
+        cross join freshness
+        where unit_identity.unit_id=$1::uuid
+        order by unit_identity.identity_id
+        limit $2`, [unitId, MAX_SEGMENT_CANDIDATES + 1])
+    if ((result.rows || []).length > MAX_SEGMENT_CANDIDATES) throw analyticsError('SEGMENT_SNAPSHOT_TOO_LARGE')
+    return result.rows || []
+}
+
+function mapSegment(row = {}) {
+    return {
+        id: text(row.id),
+        unit: text(row.unit_slug),
+        key: text(row.segment_key),
+        name: text(row.name),
+        criteria: row.criteria && typeof row.criteria === 'object' ? row.criteria : {},
+        status: text(row.status),
+        revision: number(row.revision),
+        currentVersionId: text(row.current_version_id) || null,
+        currentVersion: number(row.current_version) || null,
+        populationCount: number(row.population_count),
+        snapshotAt: row.snapshot_at || null,
+        updatedAt: row.updated_at || null,
+    }
+}
+
+function mapWindow(row = {}) {
+    return {
+        id: text(row.id), unit: text(row.unit_slug), key: text(row.window_key), revision: number(row.revision), state: text(row.state),
+        startsAt: row.starts_at || null, endsAt: row.ends_at || null,
+        responseDays: number(row.response_days), scheduledDays: number(row.scheduled_days), attendedDays: number(row.attended_days),
+        purchasedDays: number(row.purchased_days), returnedDays: number(row.returned_days), updatedAt: row.updated_at || null,
+    }
+}
+
+function mapExperiment(row = {}) {
+    return {
+        id: text(row.id), unit: text(row.unit_slug), name: text(row.name), state: text(row.state), revision: number(row.revision),
+        segmentVersionId: text(row.segment_version_id), attributionWindowId: text(row.attribution_window_id),
+        controlGroupPercent: number(row.control_group_percent), startsAt: row.starts_at || null, endsAt: row.ends_at || null,
+        policyVersion: text(row.policy_version), assignments: number(row.assignment_count), treatmentAssignments: number(row.treatment_assignments),
+        controlAssignments: number(row.control_assignments), excludedAssignments: number(row.excluded_assignments), updatedAt: row.updated_at || null,
+    }
+}
+
+async function createSegmentDefinition(client, payload, actor) {
+    const input = normalizeSegmentPayload(payload)
+    return runAnalyticsMutation(client, {
+        actor,
+        operation: 'segment_create',
+        payload,
+        fingerprintPayload: { segment: { name: input.name, key: input.key, unit: input.unit, criteria: input.criteria, expectedRevision: input.mutation.expectedRevision } },
+        options: { allowCreateRevision: true },
+        execute: async ({ actorRef, mutation }) => {
+            const unit = await resolveUnit(client, actor, input.unit)
+            await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [`commercial-analytics-segment:${unit.id}:${input.key}`])
+            const existing = await client.query(`select id::text,revision from crm_atendimento.commercial_segment_definitions
+                where unit_id=$1::uuid and segment_key=$2 for update`, [unit.id, input.key])
+            let definitionId
+            let revision
+            if (existing.rows[0]) {
+                if (mutation.expectedRevision !== number(existing.rows[0].revision)) throw analyticsError('COMMERCIAL_ANALYTICS_REVISION_CONFLICT')
+                revision = number(existing.rows[0].revision) + 1
+                definitionId = String(existing.rows[0].id)
+                await client.query(`update crm_atendimento.commercial_segment_definitions
+                    set name=$2,criteria=$3::jsonb,status='active',revision=$4,updated_by=$5,updated_at=now()
+                    where id=$1::uuid`, [definitionId, input.name, JSON.stringify(input.criteria), revision, actorRef])
+            } else {
+                if (mutation.expectedRevision != null && mutation.expectedRevision !== 0) throw analyticsError('COMMERCIAL_ANALYTICS_REVISION_CONFLICT')
+                const created = await client.query(`insert into crm_atendimento.commercial_segment_definitions(
+                        unit_id,segment_key,name,criteria,status,revision,created_by,updated_by)
+                    values($1::uuid,$2,$3,$4::jsonb,'active',1,$5,$5) returning id::text,revision`,
+                [unit.id, input.key, input.name, JSON.stringify(input.criteria), actorRef])
+                definitionId = String(created.rows[0]?.id || '')
+                revision = number(created.rows[0]?.revision)
+                if (!definitionId || !revision) throw analyticsError('COMMERCIAL_ANALYTICS_SEGMENT_CREATE_FAILED', 500)
+            }
+            const criteriaFingerprint = stableAnalyticsFingerprint(input.criteria)
+            const version = await client.query(`insert into crm_atendimento.commercial_segment_versions(
+                    definition_id,version,criteria,criteria_fingerprint,effective_from,author)
+                values($1::uuid,$2,$3::jsonb,$4,now(),$5) returning id::text`,
+            [definitionId, revision, JSON.stringify(input.criteria), criteriaFingerprint, actorRef])
+            const versionId = String(version.rows[0]?.id || '')
+            if (!versionId) throw analyticsError('COMMERCIAL_ANALYTICS_SEGMENT_VERSION_CREATE_FAILED', 500)
+            await recordAnalyticsEvent(client, {
+                eventType: 'segment_defined', entityType: 'segment_definition', entityId: definitionId, actorRef, fingerprint: criteriaFingerprint,
+            })
+            await recordAnalyticsEvent(client, {
+                eventType: 'segment_versioned', entityType: 'segment_version', entityId: versionId, actorRef, fingerprint: criteriaFingerprint,
+            })
+            return { definitionId, versionId, revision, unit: unit.slug, criteriaFingerprint }
+        },
+    })
+}
+
+function normalizeSegmentVersionInput(definitionId, payload = {}) {
+    const input = payload && typeof payload === 'object' && !Array.isArray(payload) ? payload : {}
+    const effectiveFrom = input.effectiveFrom ? new Date(input.effectiveFrom) : new Date()
+    const effectiveUntil = input.effectiveUntil ? new Date(input.effectiveUntil) : null
+    if (Number.isNaN(effectiveFrom.getTime()) || (effectiveUntil && (Number.isNaN(effectiveUntil.getTime()) || effectiveUntil <= effectiveFrom))) {
+        throw analyticsError('SEGMENT_VERSION_RANGE_INVALID', 400)
+    }
+    const mutation = normalizeAnalyticsMutation(input)
+    if (mutation.expectedRevision == null) throw analyticsError('COMMERCIAL_ANALYTICS_EXPECTED_REVISION_REQUIRED', 400)
+    return {
+        definitionId: assertUuid(definitionId, 'SEGMENT_DEFINITION_ID_INVALID'),
+        criteria: normalizeSegmentCriteria(input.criteria),
+        effectiveFrom: effectiveFrom.toISOString(),
+        effectiveUntil: effectiveUntil?.toISOString() || null,
+        mutation,
+    }
+}
+
+async function createSegmentVersion(client, definitionId, payload, actor) {
+    const input = normalizeSegmentVersionInput(definitionId, payload)
+    return runAnalyticsMutation(client, {
+        actor,
+        operation: 'segment_version',
+        payload,
+        fingerprintPayload: { definitionId: input.definitionId, criteria: input.criteria, effectiveFrom: input.effectiveFrom, effectiveUntil: input.effectiveUntil, expectedRevision: input.mutation.expectedRevision },
+        execute: async ({ actorRef, mutation }) => {
+            const current = await client.query(`select definition.id::text,definition.unit_id::text,definition.revision,definition.segment_key
+                from crm_atendimento.commercial_segment_definitions definition where definition.id=$1::uuid for update`, [input.definitionId])
+            const definition = current.rows[0]
+            if (!definition) throw analyticsError('SEGMENT_DEFINITION_NOT_FOUND', 404)
+            const unitScope = commercialOperationsUnitScope(actor)
+            if (unitScope !== null) {
+                const unit = await client.query(`select slug from crm_atendimento.units where id=$1::uuid`, [definition.unit_id])
+                if (!unitScope.includes(text(unit.rows[0]?.slug))) throw analyticsError('COMMERCIAL_UNIT_FORBIDDEN', 403)
+            }
+            if (mutation.expectedRevision !== number(definition.revision)) throw analyticsError('COMMERCIAL_ANALYTICS_REVISION_CONFLICT')
+            const revision = number(definition.revision) + 1
+            const criteriaFingerprint = stableAnalyticsFingerprint(input.criteria)
+            await client.query(`update crm_atendimento.commercial_segment_definitions
+                set criteria=$2::jsonb,revision=$3,updated_by=$4,updated_at=now() where id=$1::uuid`,
+            [definition.id, JSON.stringify(input.criteria), revision, actorRef])
+            const created = await client.query(`insert into crm_atendimento.commercial_segment_versions(
+                    definition_id,version,criteria,criteria_fingerprint,effective_from,effective_until,author)
+                values($1::uuid,$2,$3::jsonb,$4,$5,$6,$7) returning id::text`,
+            [definition.id, revision, JSON.stringify(input.criteria), criteriaFingerprint, input.effectiveFrom, input.effectiveUntil, actorRef])
+            const versionId = String(created.rows[0]?.id || '')
+            if (!versionId) throw analyticsError('COMMERCIAL_ANALYTICS_SEGMENT_VERSION_CREATE_FAILED', 500)
+            await recordAnalyticsEvent(client, {
+                eventType: 'segment_versioned', entityType: 'segment_version', entityId: versionId, actorRef, fingerprint: criteriaFingerprint,
+            })
+            return { definitionId: String(definition.id), versionId, revision, criteriaFingerprint }
+        },
+    })
+}
+
+function normalizeSnapshotInput(versionId, payload = {}) {
+    const input = payload && typeof payload === 'object' && !Array.isArray(payload) ? payload : {}
+    const mutation = normalizeAnalyticsMutation(input)
+    if (mutation.expectedRevision == null) throw analyticsError('COMMERCIAL_ANALYTICS_EXPECTED_REVISION_REQUIRED', 400)
+    return {
+        versionId: assertUuid(versionId, 'SEGMENT_VERSION_ID_INVALID'),
+        unit: normalizeUnit(input.unit, 'SEGMENT_UNIT_INVALID'),
+        mutation,
+    }
+}
+
+async function materializeSegmentSnapshot(client, versionId, payload, actor) {
+    const input = normalizeSnapshotInput(versionId, payload)
+    return runAnalyticsMutation(client, {
+        actor,
+        operation: 'segment_snapshot',
+        payload,
+        fingerprintPayload: { versionId: input.versionId, unit: input.unit, expectedRevision: input.mutation.expectedRevision },
+        execute: async ({ actorRef, mutation }) => {
+            const unit = await resolveUnit(client, actor, input.unit)
+            const result = await client.query(`select version.id::text,version.version as version_number,version.criteria,version.criteria_fingerprint,version.snapshot_at,
+                    version.population_count,definition.id::text as definition_id,definition.revision,definition.unit_id::text
+                from crm_atendimento.commercial_segment_versions version
+                join crm_atendimento.commercial_segment_definitions definition on definition.id=version.definition_id
+                where version.id=$1::uuid and definition.unit_id=$2::uuid for update`, [input.versionId, unit.id])
+            const version = result.rows[0]
+            if (!version) throw analyticsError('SEGMENT_VERSION_NOT_FOUND', 404)
+            if (mutation.expectedRevision !== number(version.revision)) throw analyticsError('COMMERCIAL_ANALYTICS_REVISION_CONFLICT')
+            if (number(version.version_number) !== number(version.revision)) throw analyticsError('SEGMENT_VERSION_STALE')
+            if (version.snapshot_at) {
+                return { versionId: String(version.id), populationCount: number(version.population_count), snapshotAt: version.snapshot_at, deduplicated: true }
+            }
+            const criteria = normalizeSegmentCriteria(version.criteria)
+            const candidates = await segmentCandidates(client, unit.id)
+            const benchmarks = {
+                sales: criteria.minimum_lifetime_sales_percentile == null ? 0 : percentile(candidates.map((candidate) => candidate.lifetime_sales), criteria.minimum_lifetime_sales_percentile / 100),
+                visits: criteria.minimum_visits_percentile == null ? 0 : percentile(candidates.map((candidate) => candidate.visit_count), criteria.minimum_visits_percentile / 100),
+            }
+            const eligible = candidates.filter((candidate) => candidateMatchesCriteria(candidate, criteria, benchmarks))
+            const identityIds = eligible.map((candidate) => assertUuid(candidate.identity_id, 'SEGMENT_CANDIDATE_ID_INVALID'))
+            if (identityIds.length) {
+                await client.query(`insert into crm_atendimento.commercial_segment_memberships(
+                        segment_version_id,identity_id,unit_id,eligible,criteria_fingerprint)
+                    select $1::uuid,identity_id,$2::uuid,true,$3
+                    from unnest($4::uuid[]) as candidate(identity_id)`,
+                [version.id, unit.id, version.criteria_fingerprint, identityIds])
+            }
+            const distribution = {
+                candidateCount: candidates.length,
+                eligibleCount: eligible.length,
+                sourceStaleCandidates: candidates.filter((candidate) => bool(candidate.source_stale)).length,
+                confirmedMultiSourceEligible: eligible.filter((candidate) => candidateIdentityQuality(candidate) === 'confirmed_multi_source').length,
+                benchmarks,
+            }
+            const updated = await client.query(`update crm_atendimento.commercial_segment_versions
+                set population_count=$2,distribution=$3::jsonb,snapshot_at=now()
+                where id=$1::uuid returning snapshot_at`, [version.id, eligible.length, JSON.stringify(distribution)])
+            await recordAnalyticsEvent(client, {
+                eventType: 'segment_snapshot', entityType: 'segment_version', entityId: version.id, actorRef,
+                countValue: eligible.length, fingerprint: version.criteria_fingerprint,
+            })
+            return {
+                versionId: String(version.id), populationCount: eligible.length,
+                snapshotAt: updated.rows[0]?.snapshot_at || null, distribution,
+            }
+        },
+    })
+}
+
+async function upsertAttributionWindow(client, payload, actor) {
+    const input = normalizeAttributionWindowPayload(payload)
+    return runAnalyticsMutation(client, {
+        actor,
+        operation: 'attribution_window_upsert',
+        payload,
+        fingerprintPayload: { ...input, mutation: { expectedRevision: input.mutation.expectedRevision } },
+        options: { allowCreateRevision: true },
+        execute: async ({ actorRef, mutation }) => {
+            const unit = await resolveUnit(client, actor, input.unit)
+            await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [`commercial-analytics-window:${unit.id}:${input.key}`])
+            const latestResult = await client.query(`select id::text,revision from crm_atendimento.commercial_attribution_windows
+                where unit_id=$1::uuid and window_key=$2 order by revision desc limit 1 for update`, [unit.id, input.key])
+            const latest = latestResult.rows[0]
+            if (latest && mutation.expectedRevision !== number(latest.revision)) throw analyticsError('COMMERCIAL_ANALYTICS_REVISION_CONFLICT')
+            if (!latest && mutation.expectedRevision != null && mutation.expectedRevision !== 0) throw analyticsError('COMMERCIAL_ANALYTICS_REVISION_CONFLICT')
+            if (latest) await client.query(`update crm_atendimento.commercial_attribution_windows set state='superseded',updated_at=now() where id=$1::uuid`, [latest.id])
+            const revision = latest ? number(latest.revision) + 1 : 1
+            const created = await client.query(`insert into crm_atendimento.commercial_attribution_windows(
+                    unit_id,window_key,revision,state,starts_at,ends_at,response_days,scheduled_days,attended_days,purchased_days,returned_days,created_by)
+                values($1::uuid,$2,$3,'active',$4,$5,$6,$7,$8,$9,$10,$11) returning id::text`, [
+                unit.id, input.key, revision, input.startsAt, input.endsAt, input.responseDays, input.scheduledDays,
+                input.attendedDays, input.purchasedDays, input.returnedDays, actorRef,
+            ])
+            const windowId = String(created.rows[0]?.id || '')
+            if (!windowId) throw analyticsError('ATTRIBUTION_WINDOW_CREATE_FAILED', 500)
+            const fingerprint = stableAnalyticsFingerprint({ key: input.key, unit: unit.slug, revision, startsAt: input.startsAt, endsAt: input.endsAt,
+                responseDays: input.responseDays, scheduledDays: input.scheduledDays, attendedDays: input.attendedDays, purchasedDays: input.purchasedDays, returnedDays: input.returnedDays })
+            await recordAnalyticsEvent(client, {
+                eventType: 'attribution_window_versioned', entityType: 'attribution_window', entityId: windowId, actorRef, fingerprint,
+            })
+            return { windowId, revision, unit: unit.slug, fingerprint }
+        },
+    })
+}
+
+function normalizeExperimentStateInput(experimentId, payload = {}) {
+    const input = payload && typeof payload === 'object' && !Array.isArray(payload) ? payload : {}
+    const state = text(input.state).toLowerCase()
+    if (!COMMERCIAL_EXPERIMENT_STATES.includes(state)) throw analyticsError('COMMERCIAL_EXPERIMENT_STATE_INVALID', 400)
+    const mutation = normalizeAnalyticsMutation(input)
+    if (mutation.expectedRevision == null) throw analyticsError('COMMERCIAL_ANALYTICS_EXPECTED_REVISION_REQUIRED', 400)
+    return {
+        experimentId: assertUuid(experimentId, 'COMMERCIAL_EXPERIMENT_ID_INVALID'),
+        state,
+        mutation,
+    }
+}
+
+async function lockExperimentIdentity(client, unitId, identityId) {
+    // This is intentionally byte-for-byte the Operations namespace.  An
+    // experiment assignment and campaign/reassign/rebalance therefore cannot
+    // make contradictory decisions for one identity concurrently.
+    await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [
+        `commercial-experiment-crossover:${unitId}:${identityId}`,
+    ])
+}
+
+async function createExperiment(client, payload, actor) {
+    const input = normalizeExperimentPayload(payload)
+    return runAnalyticsMutation(client, {
+        actor,
+        operation: 'experiment_create',
+        payload,
+        fingerprintPayload: {
+            name: input.name, unit: input.unit, segmentVersionId: input.segmentVersionId,
+            attributionWindowId: input.attributionWindowId, startsAt: input.startsAt,
+            endsAt: input.endsAt, controlGroupPercent: input.controlGroupPercent,
+            expectedRevision: input.mutation.expectedRevision,
+        },
+        options: { allowCreateRevision: true },
+        execute: async ({ actorRef, mutation }) => {
+            if (mutation.expectedRevision != null && mutation.expectedRevision !== 0) {
+                throw analyticsError('COMMERCIAL_ANALYTICS_REVISION_CONFLICT')
+            }
+            const unit = await resolveUnit(client, actor, input.unit)
+            const segmentResult = await client.query(`select version.id::text,version.criteria_fingerprint,version.snapshot_at,
+                    definition.unit_id::text,definition.revision,version.version as version_number
+                from crm_atendimento.commercial_segment_versions version
+                join crm_atendimento.commercial_segment_definitions definition on definition.id=version.definition_id
+                where version.id=$1::uuid and definition.unit_id=$2::uuid for share`, [input.segmentVersionId, unit.id])
+            const segment = segmentResult.rows[0]
+            if (!segment) throw analyticsError('COMMERCIAL_EXPERIMENT_SEGMENT_NOT_FOUND', 404)
+            if (!segment.snapshot_at || number(segment.version_number) !== number(segment.revision)) {
+                throw analyticsError('COMMERCIAL_EXPERIMENT_SEGMENT_SNAPSHOT_REQUIRED')
+            }
+            const windowResult = await client.query(`select id::text,state from crm_atendimento.commercial_attribution_windows
+                where id=$1::uuid and unit_id=$2::uuid for share`, [input.attributionWindowId, unit.id])
+            const window = windowResult.rows[0]
+            if (!window || text(window.state) !== 'active') throw analyticsError('COMMERCIAL_EXPERIMENT_WINDOW_NOT_ACTIVE')
+            const policyVersion = stableAnalyticsFingerprint({
+                segmentVersionId: input.segmentVersionId,
+                segmentCriteriaFingerprint: text(segment.criteria_fingerprint),
+                attributionWindowId: input.attributionWindowId,
+                startsAt: input.startsAt,
+                endsAt: input.endsAt,
+                controlGroupPercent: input.controlGroupPercent,
+            })
+            const created = await client.query(`insert into crm_atendimento.commercial_experiments(
+                    unit_id,name,segment_version_id,attribution_window_id,control_group_percent,state,revision,starts_at,ends_at,policy_version,author)
+                values($1::uuid,$2,$3::uuid,$4::uuid,$5,'draft',1,$6,$7,$8,$9) returning id::text`, [
+                unit.id, input.name, input.segmentVersionId, input.attributionWindowId, input.controlGroupPercent,
+                input.startsAt, input.endsAt, policyVersion, actorRef,
+            ])
+            const experimentId = String(created.rows[0]?.id || '')
+            if (!experimentId) throw analyticsError('COMMERCIAL_EXPERIMENT_CREATE_FAILED', 500)
+            const memberships = await client.query(`select identity_id::text,criteria_fingerprint
+                from crm_atendimento.commercial_segment_memberships
+                where segment_version_id=$1::uuid and unit_id=$2::uuid and eligible is true
+                order by identity_id`, [input.segmentVersionId, unit.id])
+            if ((memberships.rows || []).length > MAX_SEGMENT_CANDIDATES) throw analyticsError('COMMERCIAL_EXPERIMENT_ASSIGNMENT_TOO_LARGE')
+            let treatmentAssignments = 0
+            let controlAssignments = 0
+            let excludedAssignments = 0
+            for (const membership of memberships.rows || []) {
+                const identityId = assertUuid(membership.identity_id, 'COMMERCIAL_EXPERIMENT_ASSIGNMENT_INVALID')
+                await lockExperimentIdentity(client, unit.id, identityId)
+                const overlap = await client.query(`select assignment.variant
+                    from crm_atendimento.commercial_experiment_assignments assignment
+                    join crm_atendimento.commercial_experiments experiment on experiment.id=assignment.experiment_id
+                    where assignment.unit_id=$1::uuid and assignment.identity_id=$2::uuid
+                      and assignment.variant in ('control','excluded')
+                      and experiment.state in ('draft','active')
+                      and experiment.starts_at < $4::timestamptz and experiment.ends_at > $3::timestamptz
+                    limit 1`, [unit.id, identityId, input.startsAt, input.endsAt])
+                const variant = overlap.rows[0]
+                    ? 'excluded'
+                    : deterministicExperimentVariant({ experimentId, identityId, controlGroupPercent: input.controlGroupPercent })
+                const eligibilityFingerprint = stableAnalyticsFingerprint({
+                    identityId, unit: unit.slug, segmentVersionId: input.segmentVersionId,
+                    criteriaFingerprint: text(membership.criteria_fingerprint), policyVersion,
+                })
+                await client.query(`insert into crm_atendimento.commercial_experiment_assignments(
+                    experiment_id,identity_id,unit_id,variant,eligibility_fingerprint)
+                    values($1::uuid,$2::uuid,$3::uuid,$4,$5)`, [experimentId, identityId, unit.id, variant, eligibilityFingerprint])
+                if (variant === 'treatment') treatmentAssignments += 1
+                else if (variant === 'control') controlAssignments += 1
+                else excludedAssignments += 1
+            }
+            await recordAnalyticsEvent(client, {
+                eventType: 'experiment_created', entityType: 'experiment', entityId: experimentId,
+                actorRef, countValue: memberships.rows.length, fingerprint: policyVersion,
+            })
+            return {
+                experimentId, unit: unit.slug, state: 'draft', policyVersion,
+                assignments: memberships.rows.length, treatmentAssignments, controlAssignments, excludedAssignments,
+            }
+        },
+    })
+}
+
+async function updateExperimentState(client, experimentId, payload, actor) {
+    const input = normalizeExperimentStateInput(experimentId, payload)
+    return runAnalyticsMutation(client, {
+        actor,
+        operation: 'experiment_state',
+        payload,
+        fingerprintPayload: { experimentId: input.experimentId, state: input.state, expectedRevision: input.mutation.expectedRevision },
+        execute: async ({ actorRef, mutation }) => {
+            const result = await client.query(`select experiment.id::text,experiment.state,experiment.revision,
+                    experiment.starts_at,experiment.ends_at,unit.slug as unit_slug
+                from crm_atendimento.commercial_experiments experiment
+                join crm_atendimento.units unit on unit.id=experiment.unit_id
+                where experiment.id=$1::uuid for update`, [input.experimentId])
+            const experiment = result.rows[0]
+            if (!experiment) throw analyticsError('COMMERCIAL_EXPERIMENT_NOT_FOUND', 404)
+            const scope = commercialOperationsUnitScope(actor)
+            if (scope !== null && !scope.includes(text(experiment.unit_slug))) throw analyticsError('COMMERCIAL_UNIT_FORBIDDEN', 403)
+            if (mutation.expectedRevision !== number(experiment.revision)) throw analyticsError('COMMERCIAL_ANALYTICS_REVISION_CONFLICT')
+            const current = text(experiment.state)
+            const transitions = {
+                draft: new Set(['active', 'disabled']),
+                active: new Set(['closed', 'disabled']),
+                closed: new Set(),
+                disabled: new Set(),
+            }
+            if (!transitions[current]?.has(input.state)) throw analyticsError('COMMERCIAL_EXPERIMENT_STATE_TRANSITION_INVALID')
+            if (input.state === 'active' && (new Date(experiment.starts_at) > new Date() || new Date(experiment.ends_at) <= new Date())) {
+                throw analyticsError('COMMERCIAL_EXPERIMENT_WINDOW_NOT_ACTIVE')
+            }
+            const nextRevision = number(experiment.revision) + 1
+            await client.query(`update crm_atendimento.commercial_experiments
+                set state=$2,revision=$3,updated_at=now() where id=$1::uuid`, [input.experimentId, input.state, nextRevision])
+            await recordAnalyticsEvent(client, {
+                eventType: 'experiment_state_changed', entityType: 'experiment', entityId: input.experimentId, actorRef,
+            })
+            return { experimentId: input.experimentId, unit: text(experiment.unit_slug), state: input.state, revision: nextRevision }
+        },
+    })
+}
+
+function clampInteger(value, fallback, minimum, maximum) {
+    if (value == null || value === '') return fallback
+    const parsed = Number(value)
+    if (!Number.isInteger(parsed) || parsed < minimum || parsed > maximum) throw analyticsError('COMMERCIAL_ANALYTICS_QUERY_INVALID', 400)
+    return parsed
+}
+
+function optionalDate(value, code = 'COMMERCIAL_ANALYTICS_DATE_INVALID') {
+    if (value == null || value === '') return null
+    const parsed = new Date(value)
+    if (Number.isNaN(parsed.getTime())) throw analyticsError(code, 400)
+    return parsed.toISOString()
+}
+
+function optionalUuid(value, code) {
+    if (value == null || value === '') return null
+    return assertUuid(value, code)
+}
+
+function optionalHash(value, code = 'COMMERCIAL_ANALYTICS_POLICY_VERSION_INVALID') {
+    if (value == null || value === '') return null
+    const hash = text(value).toLowerCase()
+    if (!/^[a-f0-9]{64}$/.test(hash)) throw analyticsError(code, 400)
+    return hash
+}
+
+function optionalOwner(value) {
+    if (value == null || value === '') return null
+    const owner = text(value)
+    if (!OWNER_RE.test(owner) || owner.includes('@')) throw analyticsError('COMMERCIAL_ANALYTICS_OWNER_INVALID', 400)
+    return owner
+}
+
+async function scopedUnits(db, scope) {
+    const params = []
+    const where = scopeClause(scope, params, 'unit.slug')
+    const result = await db.query(`select unit.id::text,unit.slug from crm_atendimento.units unit
+        where ${where} order by unit.slug`, params)
+    if (!(result.rows || []).length) throw analyticsError('COMMERCIAL_UNIT_FORBIDDEN', 403)
+    return result.rows.map((row) => ({ id: assertUuid(row.id, 'COMMERCIAL_ANALYTICS_UNIT_INVALID'), slug: normalizeUnit(row.slug) }))
+}
+
+async function coverageSummary(db, units) {
+    const output = []
+    for (const unit of units) {
+        const candidates = await segmentCandidates(db, unit.id)
+        output.push({
+            unit: unit.slug,
+            identities: candidates.length,
+            confirmedIdentityCount: candidates.filter((candidate) => candidateIdentityQuality(candidate) === 'confirmed_multi_source').length,
+            permissionCount: candidates.filter((candidate) => bool(candidate.has_permission)).length,
+            phoneCorrelatedCount: candidates.filter((candidate) => bool(candidate.phone_correlated)).length,
+            salesClassifiedCount: candidates.filter((candidate) => number(candidate.sale_count) === 0 || number(candidate.unmapped_sale_items) === 0).length,
+        })
+    }
+    return output
+}
+
+function mapQualityRow(row = {}) {
+    return {
+        key: text(row.finding_key), severity: text(row.severity), status: text(row.status), observedCount: number(row.observed_count),
+        firstDetectedAt: row.first_detected_at || null, lastObservedAt: row.last_observed_at || null,
+        acknowledgedAt: row.acknowledged_at || null, resolvedAt: row.resolved_at || null, slaDueAt: row.sla_due_at || null,
+        startedAt: row.started_at || null,
+        ageHours: number(row.age_hours), recognitionHours: row.recognition_hours == null ? null : number(row.recognition_hours),
+        startHours: row.start_hours == null ? null : number(row.start_hours), resolutionHours: row.resolution_hours == null ? null : number(row.resolution_hours),
+        reopenCount: number(row.reopen_count), reopenRate: number(row.reopen_rate), ownerAssigned: bool(row.owner_assigned), slaBreached: bool(row.sla_breached),
+    }
+}
+
+async function qualityAnalytics(db, query, actor) {
+    const scope = requestedScope(actor, query)
+    const units = await scopedUnits(db, scope)
+    const days = clampInteger(query?.days, 30, 1, 366)
+    const coverage = await coverageSummary(db, units)
+    // Findings and source-operation ledgers are not unit-keyed.  A limited
+    // manager receives only the independently derived aggregate coverage of
+    // their declared units, never a global queue count by accident.
+    if (!scope.global) {
+        return {
+            scope: { units: units.map((unit) => unit.slug), global: false }, days, coverage,
+            findings: [], series: [], events: [], freshness: [],
+            partial: true,
+            partialReason: 'GLOBAL_QUALITY_AND_SOURCE_LEDGERS_NOT_UNIT_MATERIALIZED',
+            safety: commercialAnalyticsSafety(),
+        }
+    }
+    const [findings, series, history, freshness] = await Promise.all([
+        db.query(`with lifecycle as (
+                select finding_id,
+                    min(created_at) filter(where status='in_progress') as started_at,
+                    count(*) filter(where event_type='reopened')::int as reopen_count,
+                    count(*)::int as event_count
+                from crm_atendimento.commercial_data_quality_finding_events group by finding_id
+            )
+            select finding.finding_key,finding.severity,finding.status,finding.observed_count,finding.first_detected_at,
+                finding.last_observed_at,finding.acknowledged_at,finding.resolved_at,finding.sla_due_at,
+                extract(epoch from now()-coalesce(finding.first_detected_at,finding.created_at))/3600 as age_hours,
+                case when finding.acknowledged_at is null then null else extract(epoch from finding.acknowledged_at-coalesce(finding.first_detected_at,finding.created_at))/3600 end as recognition_hours,
+                case when lifecycle.started_at is null then null else extract(epoch from lifecycle.started_at-coalesce(finding.first_detected_at,finding.created_at))/3600 end as start_hours,
+                case when finding.resolved_at is null then null else extract(epoch from finding.resolved_at-coalesce(finding.first_detected_at,finding.created_at))/3600 end as resolution_hours,
+                lifecycle.started_at,coalesce(lifecycle.reopen_count,0)::int as reopen_count,
+                case when coalesce(lifecycle.event_count,0)=0 then 0 else round(coalesce(lifecycle.reopen_count,0)::numeric/lifecycle.event_count,4) end as reopen_rate,
+                (finding.owner is not null) as owner_assigned,
+                (finding.sla_due_at is not null and finding.sla_due_at < now() and finding.status not in ('resolved','suppressed')) as sla_breached
+            from crm_atendimento.commercial_data_quality_findings finding
+            left join lifecycle on lifecycle.finding_id=finding.id
+            order by finding.severity, finding.last_observed_at desc nulls last`),
+        db.query(`select finding.finding_key,date_trunc('day',event.created_at) as observed_on,
+                max(event.observed_count)::int as observed_count,count(*)::int as event_count
+            from crm_atendimento.commercial_data_quality_finding_events event
+            join crm_atendimento.commercial_data_quality_findings finding on finding.id=event.finding_id
+            where event.created_at >= now() - make_interval(days => $1)
+            group by finding.finding_key,date_trunc('day',event.created_at)
+            order by observed_on asc,finding.finding_key asc`, [days]),
+        db.query(`select finding.finding_key,event.event_type,event.status,event.observed_count,event.created_at
+            from crm_atendimento.commercial_data_quality_finding_events event
+            join crm_atendimento.commercial_data_quality_findings finding on finding.id=event.finding_id
+            where event.created_at >= now() - make_interval(days => $1)
+            order by event.event_order desc limit 250`, [days]),
+        db.query(`select source_id,last_status,validated_snapshot_complete,validated_at,applied_at,last_read_at,
+                last_records_read,last_records_applied,last_divergences,retry_count,consecutive_failures,last_error_code,
+                extract(epoch from now()-coalesce(validated_at,last_read_at,last_attempt_at))/3600 as freshness_hours
+            from crm_atendimento.clientes_source_operation_checkpoints order by source_id`),
+    ])
+    return {
+        scope: { units: units.map((unit) => unit.slug), global: true }, days, coverage,
+        findings: (findings.rows || []).map(mapQualityRow),
+        series: (series.rows || []).map((row) => ({ key: text(row.finding_key), observedOn: row.observed_on, observedCount: number(row.observed_count), eventCount: number(row.event_count) })),
+        events: (history.rows || []).map((row) => ({ key: text(row.finding_key), eventType: text(row.event_type), status: text(row.status), observedCount: number(row.observed_count), createdAt: row.created_at || null })),
+        freshness: (freshness.rows || []).map((row) => ({
+            sourceId: text(row.source_id), status: text(row.last_status), snapshotComplete: bool(row.validated_snapshot_complete),
+            validatedAt: row.validated_at || null, appliedAt: row.applied_at || null, lastReadAt: row.last_read_at || null,
+            recordsRead: number(row.last_records_read), recordsApplied: number(row.last_records_applied), divergences: number(row.last_divergences),
+            retries: number(row.retry_count), consecutiveFailures: number(row.consecutive_failures), errorCode: text(row.last_error_code) || null,
+            freshnessHours: row.freshness_hours == null ? null : number(row.freshness_hours),
+        })),
+        partial: false,
+        safety: commercialAnalyticsSafety(),
+    }
+}
+
+async function listSegments(db, query, actor) {
+    const scope = requestedScope(actor, query)
+    const params = []
+    const where = scopeClause(scope, params, 'unit.slug')
+    const result = await db.query(`select definition.id::text,unit.slug as unit_slug,definition.segment_key,definition.name,
+            definition.criteria,definition.status,definition.revision,definition.updated_at,
+            version.id::text as current_version_id,version.version as current_version,version.population_count,version.snapshot_at
+        from crm_atendimento.commercial_segment_definitions definition
+        join crm_atendimento.units unit on unit.id=definition.unit_id
+        left join lateral (
+            select id,version,population_count,snapshot_at from crm_atendimento.commercial_segment_versions
+            where definition_id=definition.id order by version desc limit 1
+        ) version on true
+        where ${where}
+        order by unit.slug,definition.segment_key`, params)
+    return {
+        scope: { units: (await scopedUnits(db, scope)).map((unit) => unit.slug), global: scope.global },
+        segments: (result.rows || []).map(mapSegment), safety: commercialAnalyticsSafety(),
+    }
+}
+
+async function listAttributionWindows(db, query, actor) {
+    const scope = requestedScope(actor, query)
+    const params = []
+    const where = scopeClause(scope, params, 'unit.slug')
+    const result = await db.query(`select window.id::text,unit.slug as unit_slug,window.window_key,window.revision,window.state,
+            window.starts_at,window.ends_at,window.response_days,window.scheduled_days,window.attended_days,
+            window.purchased_days,window.returned_days,window.updated_at
+        from crm_atendimento.commercial_attribution_windows window
+        join crm_atendimento.units unit on unit.id=window.unit_id
+        where ${where}
+        order by unit.slug,window.window_key,window.revision desc`, params)
+    return {
+        scope: { units: (await scopedUnits(db, scope)).map((unit) => unit.slug), global: scope.global },
+        windows: (result.rows || []).map(mapWindow), safety: commercialAnalyticsSafety(),
+    }
+}
+
+async function listExperiments(db, query, actor) {
+    const scope = requestedScope(actor, query)
+    const params = []
+    const where = scopeClause(scope, params, 'unit.slug')
+    const result = await db.query(`select experiment.id::text,unit.slug as unit_slug,experiment.name,experiment.state,experiment.revision,
+            experiment.segment_version_id::text,experiment.attribution_window_id::text,experiment.control_group_percent,
+            experiment.starts_at,experiment.ends_at,experiment.policy_version,experiment.updated_at,
+            count(assignment.id)::int as assignment_count,
+            count(assignment.id) filter(where assignment.variant='treatment')::int as treatment_assignments,
+            count(assignment.id) filter(where assignment.variant='control')::int as control_assignments,
+            count(assignment.id) filter(where assignment.variant='excluded')::int as excluded_assignments
+        from crm_atendimento.commercial_experiments experiment
+        join crm_atendimento.units unit on unit.id=experiment.unit_id
+        left join crm_atendimento.commercial_experiment_assignments assignment on assignment.experiment_id=experiment.id
+        where ${where}
+        group by experiment.id,unit.slug
+        order by experiment.starts_at desc,experiment.id`, params)
+    return {
+        scope: { units: (await scopedUnits(db, scope)).map((unit) => unit.slug), global: scope.global },
+        experiments: (result.rows || []).map(mapExperiment), safety: commercialAnalyticsSafety(),
+    }
+}
+
+function normalizeFunnelQuery(query = {}) {
+    const startAt = optionalDate(query.startAt || query.start)
+    const endAt = optionalDate(query.endAt || query.end)
+    if (startAt && endAt && endAt <= startAt) throw analyticsError('COMMERCIAL_ANALYTICS_DATE_RANGE_INVALID', 400)
+    const segment = query.segment == null || query.segment === '' ? null : text(query.segment)
+    if (segment && !/^[A-Za-z0-9._-]{1,120}$/.test(segment)) throw analyticsError('COMMERCIAL_ANALYTICS_SEGMENT_INVALID', 400)
+    const channel = query.channel == null || query.channel === '' ? null : text(query.channel).toLowerCase()
+    if (channel && channel !== 'whatsapp') throw analyticsError('COMMERCIAL_ANALYTICS_CHANNEL_INVALID', 400)
+    return {
+        campaignId: optionalUuid(query.campaignId || query.campaign, 'COMMERCIAL_ANALYTICS_CAMPAIGN_INVALID'),
+        segmentVersionId: optionalUuid(query.segmentVersionId, 'COMMERCIAL_ANALYTICS_SEGMENT_VERSION_INVALID'),
+        attributionWindowId: optionalUuid(query.attributionWindowId, 'COMMERCIAL_ANALYTICS_WINDOW_INVALID'),
+        offerId: optionalUuid(query.offerId || query.offer, 'COMMERCIAL_ANALYTICS_OFFER_INVALID'),
+        policyVersion: optionalHash(query.policyVersion),
+        owner: optionalOwner(query.owner), channel, segment, startAt, endAt,
+    }
+}
+
+function funnelStages(row = {}, prefix = '') {
+    return {
+        eligible: number(row[`${prefix}eligible`]), selected: number(row[`${prefix}selected`]),
+        action_created: number(row[`${prefix}action_created`]), contacted: number(row[`${prefix}contacted`]),
+        // There is deliberately no delivery provider in this tranche.  Keeping
+        // this at zero prevents a human click/attempt from being misreported
+        // as delivered.
+        delivered: 0,
+        responded: number(row[`${prefix}responded`]), scheduled: number(row[`${prefix}scheduled`]),
+        attended: number(row[`${prefix}attended`]), purchased: number(row[`${prefix}purchased`]), returned: number(row[`${prefix}returned`]),
+    }
+}
+
+async function selectedAttributionWindow(db, unitIds, id) {
+    if (!id) return null
+    const result = await db.query(`select id::text,unit_id::text,window_key,revision,state,starts_at,ends_at,response_days,scheduled_days,attended_days,purchased_days,returned_days,updated_at
+        from crm_atendimento.commercial_attribution_windows
+        where id=$1::uuid and unit_id=any($2::uuid[]) and state='active'`, [id, unitIds])
+    if (!result.rows[0]) throw analyticsError('COMMERCIAL_ANALYTICS_WINDOW_NOT_FOUND', 404)
+    return result.rows[0]
+}
+
+async function commercialFunnel(db, query, actor) {
+    const scope = requestedScope(actor, query)
+    const filters = normalizeFunnelQuery(query)
+    const units = await scopedUnits(db, scope)
+    const unitIds = units.map((unit) => unit.id)
+    const window = await selectedAttributionWindow(db, unitIds, filters.attributionWindowId)
+    if (window && units.length !== 1) {
+        throw analyticsError('COMMERCIAL_ANALYTICS_WINDOW_UNIT_SCOPE_REQUIRED', 400)
+    }
+    const params = [unitIds]
+    const campaignWhere = ['campaign.unit_id=any($1::uuid[])']
+    const actionWhere = ['action.unit_id=any($1::uuid[])']
+    if (filters.campaignId) {
+        params.push(filters.campaignId)
+        campaignWhere.push(`campaign.id=$${params.length}::uuid`)
+    }
+    if (filters.segment) {
+        params.push(filters.segment)
+        campaignWhere.push(`campaign.segment_key=$${params.length}`)
+    }
+    if (filters.offerId) {
+        params.push(filters.offerId)
+        campaignWhere.push(`campaign.offer_id=$${params.length}::uuid`)
+    }
+    if (filters.owner) {
+        params.push(filters.owner)
+        campaignWhere.push(`campaign.owner=$${params.length}`)
+        actionWhere.push(`action.owner=$${params.length}`)
+    }
+    if (filters.channel) {
+        params.push(filters.channel)
+        actionWhere.push(`action.contact_channel=$${params.length}`)
+    }
+    if (filters.startAt) {
+        params.push(filters.startAt)
+        actionWhere.push(`action.created_at >= $${params.length}::timestamptz`)
+    }
+    if (filters.endAt) {
+        params.push(filters.endAt)
+        actionWhere.push(`action.created_at < $${params.length}::timestamptz`)
+    }
+    const policyParam = params.push(filters.policyVersion) 
+    const segmentVersionParam = params.push(filters.segmentVersionId)
+    const windowParams = window
+        ? [window.response_days, window.scheduled_days, window.attended_days, window.purchased_days, window.returned_days]
+        : [null, null, null, null, null]
+    const responseDays = params.push(windowParams[0])
+    const scheduledDays = params.push(windowParams[1])
+    const attendedDays = params.push(windowParams[2])
+    const purchasedDays = params.push(windowParams[3])
+    const returnedDays = params.push(windowParams[4])
+    const result = await db.query(`with cohort as (
+            select member.identity_id,member.action_id
+            from crm_atendimento.commercial_campaign_members member
+            join crm_atendimento.commercial_campaigns campaign on campaign.id=member.campaign_id
+            where $${policyParam}::text is null and ${campaignWhere.join(' and ')}
+            union
+            select assignment.identity_id,null::uuid as action_id
+            from crm_atendimento.commercial_experiment_assignments assignment
+            join crm_atendimento.commercial_experiments experiment on experiment.id=assignment.experiment_id
+            where $${policyParam}::text is not null and experiment.unit_id=any($1::uuid[])
+              and experiment.policy_version=$${policyParam}::text and assignment.variant <> 'excluded'
+        ), eligible_population as (
+            select membership.identity_id from crm_atendimento.commercial_segment_memberships membership
+            where membership.unit_id=any($1::uuid[]) and membership.eligible is true
+              and $${policyParam}::text is null
+              and ($${segmentVersionParam}::uuid is null or membership.segment_version_id=$${segmentVersionParam}::uuid)
+            union
+            select assignment.identity_id
+            from crm_atendimento.commercial_experiment_assignments assignment
+            join crm_atendimento.commercial_experiments experiment on experiment.id=assignment.experiment_id
+            where $${policyParam}::text is not null and experiment.unit_id=any($1::uuid[])
+              and experiment.policy_version=$${policyParam}::text and assignment.variant <> 'excluded'
+        ), action_rows as (
+            select distinct action.id,action.identity_id,action.status,action.outcome_code,action.created_at,
+                coalesce(action.outcome_recorded_at,action.updated_at) as outcome_at
+            from crm_atendimento.commercial_actions action
+            join cohort on cohort.identity_id=action.identity_id and (cohort.action_id is null or cohort.action_id=action.id)
+            where ${actionWhere.join(' and ')}
+        )
+        select (select count(distinct identity_id)::int from eligible_population) as eligible,
+            (select count(distinct identity_id)::int from cohort) as selected,
+            (select count(distinct identity_id)::int from action_rows) as action_created,
+            (select count(distinct identity_id)::int from action_rows where status in ('contacted','responded','scheduled','won_sale','returned','closed') or outcome_code is not null) as contacted,
+            (select count(distinct identity_id)::int from action_rows where status in ('responded','scheduled','won_sale','returned') or outcome_code in ('requested_follow_up','scheduled','attended','sale','clinical_return','opt_out_requested')) as responded,
+            (select count(distinct identity_id)::int from action_rows where status='scheduled' or outcome_code='scheduled') as scheduled,
+            (select count(distinct identity_id)::int from action_rows where outcome_code='attended') as attended,
+            (select count(distinct identity_id)::int from action_rows where status='won_sale' or outcome_code='sale') as purchased,
+            (select count(distinct identity_id)::int from action_rows where status='returned' or outcome_code='clinical_return') as returned,
+            case when $${responseDays}::int is null then null else (select count(distinct identity_id)::int from action_rows where (status in ('responded','scheduled','won_sale','returned') or outcome_code in ('requested_follow_up','scheduled','attended','sale','clinical_return','opt_out_requested')) and outcome_at <= created_at + make_interval(days=>$${responseDays}::int)) end as attributed_responded,
+            case when $${scheduledDays}::int is null then null else (select count(distinct identity_id)::int from action_rows where (status='scheduled' or outcome_code='scheduled') and outcome_at <= created_at + make_interval(days=>$${scheduledDays}::int)) end as attributed_scheduled,
+            case when $${attendedDays}::int is null then null else (select count(distinct identity_id)::int from action_rows where outcome_code='attended' and outcome_at <= created_at + make_interval(days=>$${attendedDays}::int)) end as attributed_attended,
+            case when $${purchasedDays}::int is null then null else (select count(distinct identity_id)::int from action_rows where (status='won_sale' or outcome_code='sale') and outcome_at <= created_at + make_interval(days=>$${purchasedDays}::int)) end as attributed_purchased,
+            case when $${returnedDays}::int is null then null else (select count(distinct identity_id)::int from action_rows where (status='returned' or outcome_code='clinical_return') and outcome_at <= created_at + make_interval(days=>$${returnedDays}::int)) end as attributed_returned`, params)
+    const row = result.rows[0] || {}
+    const observed = funnelStages(row)
+    const attributed = window
+        ? {
+            ...observed,
+            responded: number(row.attributed_responded), scheduled: number(row.attributed_scheduled),
+            attended: number(row.attributed_attended), purchased: number(row.attributed_purchased), returned: number(row.attributed_returned),
+        }
+        : null
+    return {
+        scope: { units: units.map((unit) => unit.slug), global: scope.global }, filters: {
+            campaignId: filters.campaignId, segmentVersionId: filters.segmentVersionId, offerId: filters.offerId,
+            policyVersion: filters.policyVersion, channel: filters.channel, startAt: filters.startAt, endAt: filters.endAt,
+        },
+        observed, attributed, attributionWindow: window ? mapWindow({ ...window, unit_slug: units.length === 1 ? units[0].slug : 'multiple' }) : null,
+        incremental: null,
+        caveats: [
+            'DELIVERY_NOT_RECORDED_WITHOUT_A_PROVIDER',
+            ...(window ? [] : ['ATTRIBUTION_WINDOW_REQUIRED_FOR_ATTRIBUTED_CONVERSION']),
+            'INCREMENTAL_CONVERSION_IS_REPORTED_BY_EXPERIMENT_METRICS',
+        ],
+        safety: commercialAnalyticsSafety(),
+    }
+}
+
+async function experimentMetrics(db, experimentId, actor) {
+    const id = assertUuid(experimentId, 'COMMERCIAL_EXPERIMENT_ID_INVALID')
+    const experimentResult = await db.query(`select experiment.id::text,unit.id::text as unit_id,unit.slug as unit_slug,
+            experiment.name,experiment.state,experiment.revision,experiment.segment_version_id::text,
+            experiment.attribution_window_id::text,experiment.control_group_percent,experiment.starts_at,experiment.ends_at,
+            experiment.policy_version,experiment.updated_at,window.window_key,window.purchased_days
+        from crm_atendimento.commercial_experiments experiment
+        join crm_atendimento.units unit on unit.id=experiment.unit_id
+        join crm_atendimento.commercial_attribution_windows window on window.id=experiment.attribution_window_id
+        where experiment.id=$1::uuid`, [id])
+    const experiment = experimentResult.rows[0]
+    if (!experiment) throw analyticsError('COMMERCIAL_EXPERIMENT_NOT_FOUND', 404)
+    const scope = commercialOperationsUnitScope(actor)
+    if (scope !== null && !scope.includes(text(experiment.unit_slug))) throw analyticsError('COMMERCIAL_UNIT_FORBIDDEN', 403)
+    const result = await db.query(`with selected as (
+            select experiment.id,experiment.unit_id,experiment.starts_at,experiment.ends_at,window.purchased_days
+            from crm_atendimento.commercial_experiments experiment
+            join crm_atendimento.commercial_attribution_windows window on window.id=experiment.attribution_window_id
+            where experiment.id=$1::uuid
+        ), assignments as (
+            select assignment.identity_id,assignment.variant,selected.unit_id,selected.starts_at,selected.ends_at,selected.purchased_days
+            from crm_atendimento.commercial_experiment_assignments assignment
+            join selected on selected.id=assignment.experiment_id
+            where assignment.variant in ('treatment','control')
+        ), outcomes as (
+            select assignment.identity_id,
+                bool_or(action.status='won_sale' or action.outcome_code='sale') as observed_conversion,
+                bool_or((action.status='won_sale' or action.outcome_code='sale')
+                    and coalesce(action.outcome_recorded_at,action.updated_at) <= action.created_at + make_interval(days=>assignment.purchased_days)) as attributed_conversion
+            from assignments assignment
+            left join crm_atendimento.commercial_actions action on action.identity_id=assignment.identity_id and action.unit_id=assignment.unit_id
+                and action.created_at >= assignment.starts_at and action.created_at < least(now(),assignment.ends_at)
+            group by assignment.identity_id
+        ), sales_rows as (
+            select distinct assignment.identity_id,sale.id as sale_id,sale.total,sale.occurred_on,
+                assignment.starts_at,assignment.ends_at,assignment.purchased_days
+            from assignments assignment
+            left join crm_atendimento.global_client_identity_members member on member.identity_id=assignment.identity_id
+                and member.source_type='caixa_customer' and member.source_id ~ '^[0-9a-fA-F-]{36}$'
+            left join crm_caixa.sales sale on sale.customer_id=member.source_id::uuid and sale.unit_id=assignment.unit_id
+        ), revenues as (
+            select assignment.identity_id,
+                coalesce(sum(sales_rows.total) filter(where sales_rows.occurred_on >= assignment.starts_at::date and sales_rows.occurred_on < least(current_date + 1,assignment.ends_at::date + 1)),0)::numeric as observed_revenue,
+                coalesce(sum(sales_rows.total) filter(where sales_rows.occurred_on >= assignment.starts_at::date and sales_rows.occurred_on < least(current_date + 1,assignment.ends_at::date + 1,(assignment.starts_at + make_interval(days=>assignment.purchased_days))::date + 1)),0)::numeric as attributed_revenue
+            from assignments assignment
+            left join sales_rows on sales_rows.identity_id=assignment.identity_id
+            group by assignment.identity_id
+        )
+        select assignment.variant,count(*)::int as population,
+            count(*) filter(where outcomes.observed_conversion)::int as observed_conversions,
+            count(*) filter(where outcomes.attributed_conversion)::int as attributed_conversions,
+            coalesce(sum(revenues.observed_revenue),0)::numeric as observed_revenue,
+            coalesce(sum(revenues.attributed_revenue),0)::numeric as attributed_revenue
+        from assignments assignment
+        left join outcomes on outcomes.identity_id=assignment.identity_id
+        left join revenues on revenues.identity_id=assignment.identity_id
+        group by assignment.variant`, [id])
+    const rows = result.rows || []
+    const observed = calculateExperimentLift(rows.map((row) => ({
+        variant: row.variant, population: row.population, conversions: row.observed_conversions, revenue: row.observed_revenue,
+    })))
+    const attributed = calculateExperimentLift(rows.map((row) => ({
+        variant: row.variant, population: row.population, conversions: row.attributed_conversions, revenue: row.attributed_revenue,
+    })))
+    return {
+        experiment: mapExperiment({ ...experiment, assignment_count: 0, treatment_assignments: 0, control_assignments: 0, excluded_assignments: 0 }),
+        attribution: { windowId: text(experiment.attribution_window_id), key: text(experiment.window_key), purchasedDays: number(experiment.purchased_days) },
+        observed, attributed,
+        incremental: {
+            conversionLift: attributed.observedLift,
+            incrementalConversions: attributed.incrementalConversions,
+            incrementalRevenue: attributed.incrementalRevenue,
+            confidenceInterval95: attributed.confidenceInterval95,
+            adequateSample: attributed.adequateSample,
+            warning: attributed.warning,
+        },
+        safety: commercialAnalyticsSafety(),
+    }
+}
+
+export function createCommercialAnalyticsStore({ pool, databaseUrl } = {}) {
+    const pgPool = pool || createPgPool(databaseUrl || process.env.DATABASE_URL)
+    const assertReadAccess = async (actor) => {
+        requirePool(pgPool)
+        assertAnalyticsManager(actor)
+        await assertReady(pgPool)
+    }
+    const assertMutationAccess = (actor) => {
+        requirePool(pgPool)
+        assertAnalyticsManager(actor)
+    }
+    return {
+        async readiness(actor) {
+            requirePool(pgPool)
+            assertAnalyticsManager(actor)
+            return commercialAnalyticsReadiness(pgPool)
+        },
+        async quality(query, actor) {
+            await assertReadAccess(actor)
+            return qualityAnalytics(pgPool, query, actor)
+        },
+        async funnel(query, actor) {
+            await assertReadAccess(actor)
+            return commercialFunnel(pgPool, query, actor)
+        },
+        async segments(query, actor) {
+            await assertReadAccess(actor)
+            return listSegments(pgPool, query, actor)
+        },
+        async attributionWindows(query, actor) {
+            await assertReadAccess(actor)
+            return listAttributionWindows(pgPool, query, actor)
+        },
+        async experiments(query, actor) {
+            await assertReadAccess(actor)
+            return listExperiments(pgPool, query, actor)
+        },
+        async experimentMetrics(experimentId, actor) {
+            await assertReadAccess(actor)
+            return experimentMetrics(pgPool, experimentId, actor)
+        },
+        async createSegment(payload, actor) {
+            assertMutationAccess(actor)
+            return withPgTransaction(pgPool, (client) => createSegmentDefinition(client, payload, actor))
+        },
+        async createSegmentVersion(definitionId, payload, actor) {
+            assertMutationAccess(actor)
+            return withPgTransaction(pgPool, (client) => createSegmentVersion(client, definitionId, payload, actor))
+        },
+        async snapshotSegment(versionId, payload, actor) {
+            assertMutationAccess(actor)
+            return withPgTransaction(pgPool, (client) => materializeSegmentSnapshot(client, versionId, payload, actor))
+        },
+        async upsertAttributionWindow(payload, actor) {
+            assertMutationAccess(actor)
+            return withPgTransaction(pgPool, (client) => upsertAttributionWindow(client, payload, actor))
+        },
+        async createExperiment(payload, actor) {
+            assertMutationAccess(actor)
+            return withPgTransaction(pgPool, (client) => createExperiment(client, payload, actor))
+        },
+        async updateExperimentState(experimentId, payload, actor) {
+            assertMutationAccess(actor)
+            return withPgTransaction(pgPool, (client) => updateExperimentState(client, experimentId, payload, actor))
+        },
+    }
+}
+
+export const __testables = {
+    actorPrincipal,
+    candidateMatchesCriteria,
+    commercialFunnel,
+    createExperiment,
+    createSegmentDefinition,
+    experimentMetrics,
+    lockExperimentIdentity,
+    mapReadiness,
+    normalizeFunnelQuery,
+    requestedScope,
+    runAnalyticsMutation,
+}

--- a/crm/api/server/atendimento/routes.js
+++ b/crm/api/server/atendimento/routes.js
@@ -3,6 +3,7 @@ import express from 'express'
 import { createAtendimentoStore, canAccessAtendimento } from './store.js'
 import { createCommercialDataQualityStore } from './commercialDataQualityStore.js'
 import { createCommercialOperationsStore } from './commercialOperationsStore.js'
+import { createCommercialAnalyticsStore } from './commercialAnalyticsStore.js'
 import { createClientesSourceOperationsStore } from '../clientes/sourceOperationsStore.js'
 import { importAtendimentoFromGoogleSheet, importGerenciaFromGoogleSheet, readGerenciaChartIds } from './importer.js'
 import { atendimentoModuleUnavailable, readAtendimentoModuleControl } from './moduleControl.js'
@@ -285,6 +286,16 @@ export function createAtendimentoRouter(options = {}) {
             })
         }
         return commercialOperationsStore
+    }
+    let commercialAnalyticsStore = options.commercialAnalyticsStore || null
+    const getCommercialAnalyticsStore = () => {
+        if (!commercialAnalyticsStore) {
+            commercialAnalyticsStore = createCommercialAnalyticsStore({
+                pool: options.commercialAnalyticsPool,
+                databaseUrl: options.databaseUrl,
+            })
+        }
+        return commercialAnalyticsStore
     }
     let commercialSourceOperationsStore = options.commercialSourceOperationsStore || null
     const getCommercialSourceOperationsStore = () => {
@@ -844,6 +855,136 @@ export function createAtendimentoRouter(options = {}) {
         try {
             if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
             return json(res, 200, { ok: true, ...(await getCommercialOperationsStore().applyRebalance(commercialOperationPayload(req), req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    // Analytics is a governed, PII-minimized projection.  These configuration
+    // mutations only persist cohort/measurement evidence; they deliberately
+    // expose no messaging, consent or commercial-contact endpoint.
+    expressRouter.get('/commercial/analytics/readiness', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            const readiness = await getCommercialAnalyticsStore().readiness(req.atendimentoActor)
+            return json(res, readiness.ready ? 200 : 503, { ok: readiness.ready, ...readiness })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/analytics/quality', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialAnalyticsStore().quality(req.query || {}, req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/analytics/funnel', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialAnalyticsStore().funnel(req.query || {}, req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/analytics/segments', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialAnalyticsStore().segments(req.query || {}, req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/analytics/attribution-windows', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialAnalyticsStore().attributionWindows(req.query || {}, req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/analytics/experiments', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialAnalyticsStore().experiments(req.query || {}, req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/analytics/experiments/:experimentId/metrics', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialAnalyticsStore().experimentMetrics(String(req.params.experimentId || ''), req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/analytics/segments', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialAnalyticsStore().createSegment(commercialOperationPayload(req), req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/analytics/segments/:definitionId/versions', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, {
+                ok: true,
+                ...(await getCommercialAnalyticsStore().createSegmentVersion(String(req.params.definitionId || ''), commercialOperationPayload(req), req.atendimentoActor)),
+            })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/analytics/segments/versions/:versionId/snapshot', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, {
+                ok: true,
+                ...(await getCommercialAnalyticsStore().snapshotSegment(String(req.params.versionId || ''), commercialOperationPayload(req), req.atendimentoActor)),
+            })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/analytics/attribution-windows', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialAnalyticsStore().upsertAttributionWindow(commercialOperationPayload(req), req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/analytics/experiments', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialAnalyticsStore().createExperiment(commercialOperationPayload(req), req.atendimentoActor)) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/analytics/experiments/:experimentId/state', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, {
+                ok: true,
+                ...(await getCommercialAnalyticsStore().updateExperimentState(String(req.params.experimentId || ''), commercialOperationPayload(req), req.atendimentoActor)),
+            })
         } catch (error) {
             return errorResponse(res, error)
         }

--- a/crm/console/ClientCommercialModule.tsx
+++ b/crm/console/ClientCommercialModule.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle, CalendarClock, CheckCircle2, ChevronRight, CircleDollarS
 import { Button } from '@/button'
 import { IdentityClusterWorkspace } from './IdentityClusterWorkspace'
 import { CommercialCanaryManager } from '@/CommercialCanaryManager'
+import { CommercialAnalyticsPanel } from './CommercialAnalyticsPanel'
 import {
   createCommercialAction,
   commercialCadenceManagerStatuses,
@@ -824,6 +825,7 @@ export function ClientCommercialModule() {
     {workspaceView === 'quality' && commercialSourceOperationsBusy && !commercialSourceOperations ? <div role="status" className="rounded-xl border border-slate-800/80 bg-slate-950/55 p-4 text-sm text-slate-400">Carregando estado das fontes…</div> : null}
     {workspaceView === 'quality' && commercialSourceOperations ? <SourceOperationsPanel operations={commercialSourceOperations} loading={commercialSourceOperationsBusy} onRefresh={loadCommercialSourceOperations} /> : null}
     {workspaceView === 'quality' && commercialDataQuality ? <CommercialDataQualityPanel queue={commercialDataQuality} loading={commercialDataQualityBusy} onRefresh={loadCommercialDataQuality} /> : null}
+    {workspaceView === 'quality' ? <CommercialAnalyticsPanel units={units} /> : null}
     </ClientesWorkspaceSection> : null}
     {showProfileWorkspace ? <ClientesWorkspaceSection sectionKey="wallet">
     <>

--- a/crm/console/CommercialAnalyticsPanel.tsx
+++ b/crm/console/CommercialAnalyticsPanel.tsx
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { BarChart3, RefreshCw, ShieldCheck } from 'lucide-react'
+import { Button } from '@/button'
+import {
+  fetchCommercialAnalyticsAttributionWindows,
+  fetchCommercialAnalyticsExperimentMetrics,
+  fetchCommercialAnalyticsExperiments,
+  fetchCommercialAnalyticsFunnel,
+  fetchCommercialAnalyticsQuality,
+  fetchCommercialAnalyticsReadiness,
+  fetchCommercialAnalyticsSegments,
+  type CommercialAnalyticsAttributionWindow,
+  type CommercialAnalyticsExperiment,
+  type CommercialAnalyticsExperimentMetrics,
+  type CommercialAnalyticsFunnel,
+  type CommercialAnalyticsQuality,
+  type CommercialAnalyticsReadiness,
+  type CommercialAnalyticsSegment,
+} from '@/atendimentoApi'
+
+const number = new Intl.NumberFormat('pt-BR')
+const dateTime = new Intl.DateTimeFormat('pt-BR', { dateStyle: 'short', timeStyle: 'short', timeZone: 'America/Sao_Paulo' })
+const stageLabels: Record<string, string> = {
+  eligible: 'Elegíveis', selected: 'Selecionados', action_created: 'Ação criada', contacted: 'Contato registrado',
+  delivered: 'Entregues', responded: 'Responderam', scheduled: 'Agendaram', attended: 'Compareceram',
+  purchased: 'Compraram', returned: 'Retornaram',
+}
+
+function displayDate(value: string | null | undefined) {
+  if (!value) return '—'
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? '—' : dateTime.format(parsed)
+}
+
+function SafetyBanner() {
+  return <div className="mt-3 flex gap-2 rounded-lg border border-emerald-300/20 bg-emerald-500/10 p-3 text-xs text-emerald-100"><ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" /><span><b>Modo de observação e medição:</b> escrita comercial, envio de mensagens, automação e novas escritas de consentimento permanecem desativados. Esta tela não exibe dados de contato ou dados pessoais de clientes.</span></div>
+}
+
+function Stat({ label, value, detail }: { label: string; value: string | number; detail?: string }) {
+  return <div className="rounded-xl border border-slate-800/80 bg-slate-900/45 p-3"><div className="text-[11px] text-slate-500">{label}</div><div className="mt-1 text-base font-semibold text-slate-100">{value}</div>{detail ? <div className="mt-1 text-[11px] text-slate-500">{detail}</div> : null}</div>
+}
+
+function Funnel({ data }: { data: CommercialAnalyticsFunnel | null }) {
+  if (!data) return <div className="rounded-xl border border-slate-800/80 bg-slate-950/45 p-4 text-sm text-slate-500">O funil será exibido quando a projeção estiver disponível.</div>
+  return <div className="rounded-xl border border-slate-800/80 bg-slate-950/45 p-4"><div className="flex flex-wrap items-start justify-between gap-2"><div><h3 className="font-medium text-slate-100">Funil comercial observado</h3><p className="mt-1 text-xs text-slate-500">Atribuição só é calculada dentro de uma janela versionada. Entrega permanece zero sem provedor de envio.</p></div>{data.attributionWindow ? <span className="rounded-full border border-sky-300/20 bg-sky-500/10 px-2 py-1 text-[11px] text-sky-100">Janela {data.attributionWindow.key} r{data.attributionWindow.revision}</span> : <span className="rounded-full border border-amber-300/20 bg-amber-500/10 px-2 py-1 text-[11px] text-amber-100">Sem janela de atribuição</span>}</div><div className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-5">{Object.entries(data.observed).map(([stage, value]) => <Stat key={stage} label={stageLabels[stage] || stage} value={number.format(value)} detail={data.attributed ? `Atribuídos: ${number.format(data.attributed[stage] || 0)}` : undefined} />)}</div></div>
+}
+
+function SegmentTable({ segments }: { segments: CommercialAnalyticsSegment[] }) {
+  return <div className="overflow-x-auto rounded-xl border border-slate-800/80"><table className="min-w-full text-left text-xs"><thead className="bg-slate-900/80 text-slate-400"><tr><th className="px-3 py-2">Segmento</th><th className="px-3 py-2">Unidade</th><th className="px-3 py-2">Versão</th><th className="px-3 py-2">População</th><th className="px-3 py-2">Snapshot</th></tr></thead><tbody>{segments.length ? segments.map((segment) => <tr key={segment.id} className="border-t border-slate-800/80 text-slate-200"><td className="px-3 py-2"><div className="font-medium">{segment.name}</div><div className="text-[11px] text-slate-500">{segment.key}</div></td><td className="px-3 py-2">{segment.unit}</td><td className="px-3 py-2">r{segment.revision} · v{segment.currentVersion ?? '—'}</td><td className="px-3 py-2">{number.format(segment.populationCount)}</td><td className="px-3 py-2">{displayDate(segment.snapshotAt)}</td></tr>) : <tr><td colSpan={5} className="px-3 py-5 text-slate-500">Nenhuma definição de segmento permitida neste escopo.</td></tr>}</tbody></table></div>
+}
+
+function ExperimentTable({ experiments, windows }: { experiments: CommercialAnalyticsExperiment[]; windows: CommercialAnalyticsAttributionWindow[] }) {
+  const windowById = useMemo(() => new Map(windows.map((window) => [window.id, window])), [windows])
+  return <div className="overflow-x-auto rounded-xl border border-slate-800/80"><table className="min-w-full text-left text-xs"><thead className="bg-slate-900/80 text-slate-400"><tr><th className="px-3 py-2">Experimento</th><th className="px-3 py-2">Estado</th><th className="px-3 py-2">Coorte</th><th className="px-3 py-2">Controle</th><th className="px-3 py-2">Janela</th></tr></thead><tbody>{experiments.length ? experiments.map((experiment) => <tr key={experiment.id} className="border-t border-slate-800/80 text-slate-200"><td className="px-3 py-2"><div className="font-medium">{experiment.name}</div><div className="text-[11px] text-slate-500">{experiment.unit} · r{experiment.revision}</div></td><td className="px-3 py-2">{experiment.state}</td><td className="px-3 py-2">{number.format(experiment.assignments)} <span className="text-slate-500">({number.format(experiment.excludedAssignments)} excluídos)</span></td><td className="px-3 py-2">{experiment.controlGroupPercent}%</td><td className="px-3 py-2">{windowById.get(experiment.attributionWindowId)?.key || 'Retida'}</td></tr>) : <tr><td colSpan={5} className="px-3 py-5 text-slate-500">Nenhum experimento persistido neste escopo.</td></tr>}</tbody></table></div>
+}
+
+function ExperimentImpact({ metrics }: { metrics: CommercialAnalyticsExperimentMetrics | null }) {
+  if (!metrics) return null
+  const lift = metrics.incremental.conversionLift == null ? '—' : `${(metrics.incremental.conversionLift * 100).toFixed(1)} p.p.`
+  const revenue = metrics.incremental.incrementalRevenue == null ? '—' : new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(metrics.incremental.incrementalRevenue)
+  return <div className="mt-4 rounded-xl border border-slate-800/80 bg-slate-950/45 p-4"><h3 className="font-medium text-slate-100">Impacto incremental do experimento</h3><p className="mt-1 text-xs text-slate-500">Coorte {metrics.experiment.name} · janela {metrics.attribution.key}. Receita e conversões são limitadas à janela versionada.</p><div className="mt-3 grid gap-2 sm:grid-cols-3"><Stat label="Lift atribuído" value={lift} detail={metrics.incremental.adequateSample ? 'IC 95% disponível' : 'Amostra ainda insuficiente'} /><Stat label="Conversões incrementais" value={metrics.incremental.incrementalConversions == null ? '—' : number.format(metrics.incremental.incrementalConversions)} detail={`Tratamento: ${number.format(metrics.attributed.treatment.conversions)} · Controle: ${number.format(metrics.attributed.control.conversions)}`} /><Stat label="Receita incremental" value={revenue} detail={metrics.incremental.warning || 'Estimativa atribuída'} /></div></div>
+}
+
+export function CommercialAnalyticsPanel({ units }: { units: Array<{ slug: string; name: string }> }) {
+  const [unit, setUnit] = useState('all')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState('')
+  const [readiness, setReadiness] = useState<CommercialAnalyticsReadiness | null>(null)
+  const [quality, setQuality] = useState<CommercialAnalyticsQuality | null>(null)
+  const [funnel, setFunnel] = useState<CommercialAnalyticsFunnel | null>(null)
+  const [segments, setSegments] = useState<CommercialAnalyticsSegment[]>([])
+  const [windows, setWindows] = useState<CommercialAnalyticsAttributionWindow[]>([])
+  const [experiments, setExperiments] = useState<CommercialAnalyticsExperiment[]>([])
+  const [experimentMetrics, setExperimentMetrics] = useState<CommercialAnalyticsExperimentMetrics | null>(null)
+  const load = useCallback(async () => {
+    setBusy(true); setError('')
+    const filters = unit === 'all' ? {} : { unit }
+    const [nextReadiness, nextQuality, nextFunnel, nextSegments, nextWindows, nextExperiments] = await Promise.all([
+      fetchCommercialAnalyticsReadiness(), fetchCommercialAnalyticsQuality(filters), fetchCommercialAnalyticsFunnel(filters),
+      fetchCommercialAnalyticsSegments(filters), fetchCommercialAnalyticsAttributionWindows(filters), fetchCommercialAnalyticsExperiments(filters),
+    ])
+    if (!nextReadiness.ok) setError(nextReadiness.error || 'A readiness de Analytics não está disponível neste ambiente.')
+    else setReadiness(nextReadiness)
+    if (nextQuality.ok) setQuality(nextQuality)
+    else if (!nextReadiness.ok) setQuality(null)
+    if (nextFunnel.ok) setFunnel(nextFunnel)
+    else setFunnel(null)
+    setSegments(nextSegments.ok ? nextSegments.segments : [])
+    setWindows(nextWindows.ok ? nextWindows.windows : [])
+    setExperiments(nextExperiments.ok ? nextExperiments.experiments : [])
+    if (nextExperiments.ok && nextExperiments.experiments[0]) {
+      const metrics = await fetchCommercialAnalyticsExperimentMetrics(nextExperiments.experiments[0].id)
+      setExperimentMetrics(metrics.ok ? metrics : null)
+    } else setExperimentMetrics(null)
+    setBusy(false)
+  }, [unit])
+  useEffect(() => { void load() }, [load])
+  const staleSources = quality?.freshness.filter((source) => !source.snapshotComplete || (source.freshnessHours != null && source.freshnessHours >= 24)).length || 0
+  return <section aria-labelledby="commercial-analytics-heading" className="rounded-2xl border border-slate-800/80 bg-slate-950/55 p-5 shadow-[0_20px_60px_rgba(2,6,23,0.28)]"><div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"><div><div className="flex items-center gap-2"><BarChart3 className="h-5 w-5 text-sky-200" /><h2 id="commercial-analytics-heading" className="text-lg font-semibold text-white">Analytics de Clientes</h2></div><p className="mt-1 text-sm text-slate-500">Séries de qualidade, funil, segmentos e experimentos com coortes persistidas — sem dados de contato.</p></div><div className="flex gap-2"><select aria-label="Unidade da análise" value={unit} onChange={(event) => setUnit(event.target.value)} className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100"><option value="all">Todas as unidades permitidas</option>{units.map((item) => <option key={item.slug} value={item.slug}>{item.name}</option>)}</select><Button size="sm" variant="outline" onClick={() => void load()} disabled={busy}><RefreshCw className={`mr-2 h-4 w-4 ${busy ? 'animate-spin' : ''}`} />Atualizar</Button></div></div><SafetyBanner />{error ? <div role="alert" className="mt-3 rounded-lg border border-amber-300/25 bg-amber-500/10 p-3 text-sm text-amber-100">{error}</div> : null}<div className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-4"><Stat label="Prontidão" value={readiness?.ready ? 'Pronto' : 'Fail-closed'} detail={readiness?.migrationId || 'Migration pendente'} /><Stat label="Cobertura de identidades" value={number.format(quality?.coverage.reduce((sum, item) => sum + item.identities, 0) || 0)} detail="Agregado apenas no escopo permitido" /><Stat label="Fontes a revisar" value={number.format(staleSources)} detail="Snapshot incompleto ou 24h+" /><Stat label="Experimentos" value={number.format(experiments.length)} detail="Coortes persistidas e auditáveis" /></div>{quality?.partial ? <div role="status" className="mt-3 rounded-lg border border-sky-300/20 bg-sky-500/10 p-3 text-xs text-sky-100">No escopo de unidade, a fila global e o ledger de fontes não são expostos. A cobertura abaixo foi derivada somente da unidade autorizada.</div> : null}<div className="mt-4 grid gap-4 xl:grid-cols-2"><Funnel data={funnel} /><div className="rounded-xl border border-slate-800/80 bg-slate-950/45 p-4"><h3 className="font-medium text-slate-100">Qualidade e freshness</h3><div className="mt-3 grid gap-2 sm:grid-cols-2">{quality?.coverage.map((item) => <Stat key={item.unit} label={item.unit} value={`${number.format(item.confirmedIdentityCount)}/${number.format(item.identities)}`} detail={`${number.format(item.permissionCount)} permissões · ${number.format(item.phoneCorrelatedCount)} telefones correlacionados`} />) || <p className="text-sm text-slate-500">Sem agregados disponíveis.</p>}</div>{quality && !quality.partial ? <div className="mt-3 text-xs text-slate-500">{quality.findings.length} finding(s), {quality.series.length} ponto(s) histórico(s) e {quality.freshness.length} fonte(s) observada(s).</div> : null}</div></div><ExperimentImpact metrics={experimentMetrics} /><div className="mt-4"><h3 className="mb-2 font-medium text-slate-100">Segmentos versionados</h3><SegmentTable segments={segments} /></div><div className="mt-4"><h3 className="mb-2 font-medium text-slate-100">Experimentos e janelas</h3><ExperimentTable experiments={experiments} windows={windows} /></div></section>
+}

--- a/crm/console/atendimentoApi.ts
+++ b/crm/console/atendimentoApi.ts
@@ -1406,6 +1406,124 @@ export function rejectClinicalApproval(id: string, payload: { expectedRevision: 
   return api<{ rule: ClinicalApprovalRule }>(`/clinical/approvals/${encodeURIComponent(id)}/reject`, { method: 'POST', body: payload, headers: { 'Idempotency-Key': payload.idempotencyKey } })
 }
 
+export type CommercialAnalyticsSafety = {
+  commercialContactWritesEnabled: false
+  messagesEnabled: false
+  autonomousMessagingEnabled: false
+  consentWritesEnabled: false
+}
+
+export type CommercialAnalyticsReadiness = {
+  ready: boolean
+  migrationId: string
+  relationsReady: boolean
+  appendOnlyReady: boolean
+  grantsReady: boolean
+  migrationReady: boolean
+  readinessUnavailable?: boolean
+  safety: CommercialAnalyticsSafety
+}
+
+export type CommercialAnalyticsCoverage = {
+  unit: string
+  identities: number
+  confirmedIdentityCount: number
+  permissionCount: number
+  phoneCorrelatedCount: number
+  salesClassifiedCount: number
+}
+
+export type CommercialAnalyticsQuality = {
+  scope: { units: string[]; global: boolean }
+  days: number
+  coverage: CommercialAnalyticsCoverage[]
+  findings: Array<{
+    key: string; severity: string; status: string; observedCount: number; firstDetectedAt: string | null; lastObservedAt: string | null
+    acknowledgedAt: string | null; resolvedAt: string | null; slaDueAt: string | null; startedAt: string | null; ageHours: number; recognitionHours: number | null
+    startHours: number | null; resolutionHours: number | null; reopenCount: number; reopenRate: number; ownerAssigned: boolean; slaBreached: boolean
+  }>
+  series: Array<{ key: string; observedOn: string; observedCount: number; eventCount: number }>
+  events: Array<{ key: string; eventType: string; status: string; observedCount: number; createdAt: string | null }>
+  freshness: Array<{
+    sourceId: string; status: string; snapshotComplete: boolean; validatedAt: string | null; appliedAt: string | null; lastReadAt: string | null
+    recordsRead: number; recordsApplied: number; divergences: number; retries: number; consecutiveFailures: number; errorCode: string | null; freshnessHours: number | null
+  }>
+  partial: boolean
+  partialReason?: string
+  safety: CommercialAnalyticsSafety
+}
+
+export type CommercialAnalyticsFunnel = {
+  scope: { units: string[]; global: boolean }
+  filters: { campaignId: string | null; segmentVersionId: string | null; offerId: string | null; policyVersion: string | null; channel: string | null; startAt: string | null; endAt: string | null }
+  observed: Record<string, number>
+  attributed: Record<string, number> | null
+  attributionWindow: { id: string; key: string; revision: number; responseDays: number; scheduledDays: number; attendedDays: number; purchasedDays: number; returnedDays: number } | null
+  incremental: null
+  caveats: string[]
+  safety: CommercialAnalyticsSafety
+}
+
+export type CommercialAnalyticsSegment = {
+  id: string; unit: string; key: string; name: string; criteria: Record<string, unknown>; status: string; revision: number
+  currentVersionId: string | null; currentVersion: number | null; populationCount: number; snapshotAt: string | null; updatedAt: string | null
+}
+
+export type CommercialAnalyticsAttributionWindow = {
+  id: string; unit: string; key: string; revision: number; state: string; startsAt: string | null; endsAt: string | null
+  responseDays: number; scheduledDays: number; attendedDays: number; purchasedDays: number; returnedDays: number; updatedAt: string | null
+}
+
+export type CommercialAnalyticsExperiment = {
+  id: string; unit: string; name: string; state: string; revision: number; segmentVersionId: string; attributionWindowId: string
+  controlGroupPercent: number; startsAt: string | null; endsAt: string | null; policyVersion: string; assignments: number
+  treatmentAssignments: number; controlAssignments: number; excludedAssignments: number; updatedAt: string | null
+}
+
+export type CommercialAnalyticsExperimentMetrics = {
+  experiment: CommercialAnalyticsExperiment
+  attribution: { windowId: string; key: string; purchasedDays: number }
+  observed: { treatment: { population: number; conversions: number; revenue: number; conversionRate: number | null }; control: { population: number; conversions: number; revenue: number; conversionRate: number | null } }
+  attributed: { treatment: { population: number; conversions: number; revenue: number; conversionRate: number | null }; control: { population: number; conversions: number; revenue: number; conversionRate: number | null } }
+  incremental: { conversionLift: number | null; incrementalConversions: number | null; incrementalRevenue: number | null; confidenceInterval95: { lower: number; upper: number } | null; adequateSample: boolean; warning: string | null }
+  safety: CommercialAnalyticsSafety
+}
+
+function analyticsQuery(filters: Record<string, string | number | undefined | null>) {
+  const params = new URLSearchParams()
+  Object.entries(filters).forEach(([key, value]) => { if (value != null && value !== '') params.set(key, String(value)) })
+  const query = params.toString()
+  return query ? `?${query}` : ''
+}
+
+export function fetchCommercialAnalyticsReadiness() {
+  return api<CommercialAnalyticsReadiness>('/commercial/analytics/readiness')
+}
+
+export function fetchCommercialAnalyticsQuality(filters: { unit?: string; days?: number } = {}) {
+  return api<CommercialAnalyticsQuality>(`/commercial/analytics/quality${analyticsQuery(filters)}`)
+}
+
+export function fetchCommercialAnalyticsFunnel(filters: { unit?: string; campaignId?: string; segmentVersionId?: string; attributionWindowId?: string; offerId?: string; policyVersion?: string; owner?: string; channel?: 'whatsapp'; startAt?: string; endAt?: string } = {}) {
+  return api<CommercialAnalyticsFunnel>(`/commercial/analytics/funnel${analyticsQuery(filters)}`)
+}
+
+export function fetchCommercialAnalyticsSegments(filters: { unit?: string } = {}) {
+  return api<{ scope: { units: string[]; global: boolean }; segments: CommercialAnalyticsSegment[]; safety: CommercialAnalyticsSafety }>(`/commercial/analytics/segments${analyticsQuery(filters)}`)
+}
+
+export function fetchCommercialAnalyticsAttributionWindows(filters: { unit?: string } = {}) {
+  return api<{ scope: { units: string[]; global: boolean }; windows: CommercialAnalyticsAttributionWindow[]; safety: CommercialAnalyticsSafety }>(`/commercial/analytics/attribution-windows${analyticsQuery(filters)}`)
+}
+
+export function fetchCommercialAnalyticsExperiments(filters: { unit?: string } = {}) {
+  return api<{ scope: { units: string[]; global: boolean }; experiments: CommercialAnalyticsExperiment[]; safety: CommercialAnalyticsSafety }>(`/commercial/analytics/experiments${analyticsQuery(filters)}`)
+}
+
+export function fetchCommercialAnalyticsExperimentMetrics(experimentId: string) {
+  return api<CommercialAnalyticsExperimentMetrics>(`/commercial/analytics/experiments/${encodeURIComponent(experimentId)}/metrics`)
+}
+
 export const __testables = {
   normalizeApiError,
   parseJson,

--- a/docs/runbooks/clientes-commercial-analytics-v2.md
+++ b/docs/runbooks/clientes-commercial-analytics-v2.md
@@ -1,0 +1,84 @@
+# Clientes Commercial Analytics v2
+
+## Escopo e limites
+
+Esta tranche cria uma projeção operacional de Analytics para Clientes. Ela mede qualidade, coortes, funil e experimentos; não é um mecanismo de contato. Todos os retornos de API incluem os controles abaixo e o Console os apresenta como modo de observação:
+
+```json
+{
+  "commercialContactWritesEnabled": false,
+  "messagesEnabled": false,
+  "autonomousMessagingEnabled": false,
+  "consentWritesEnabled": false
+}
+```
+
+Não há rota de envio, dispatch, mensagem ou escrita de consentimento neste domínio. A existência de uma ação comercial, de uma coorte ou de um grupo treatment não autoriza comunicação.
+
+## Modelo de dados e privacidade
+
+A migration aditiva `20260807_commercial_analytics_v2` cria:
+
+- `commercial_segment_definitions`, `commercial_segment_versions` e `commercial_segment_memberships` para critérios, revisões e snapshots imutáveis;
+- `commercial_attribution_windows` para janelas versionadas;
+- `commercial_experiments` e `commercial_experiment_assignments` para randomização persistida;
+- `commercial_analytics_mutations` e `commercial_analytics_events` para idempotência e evidência append-only.
+
+Os critérios de segmento usam exclusivamente a DSL snake_case abaixo. JSON arbitrário não é aceito:
+
+`minimum_lifetime_sales`, `minimum_visits`, `minimum_recency_days`, `maximum_recency_days`, `minimum_lifetime_sales_percentile`, `minimum_visits_percentile`, `requires_permission`, `requires_phone_correlation`, `requires_fresh_sources`, `source_freshness_max_hours`, `identity_quality`, `procedure_ids`, `sales_classifications`.
+
+O validador HTTP e a constraint PostgreSQL recusam camelCase, chaves desconhecidas, objetos aninhados e aliases de PII (telefone, e-mail, nome, CPF, endereço, contato, contexto, raw/evidence). Métricas, logs e UI retornam somente agregados, IDs opacos ou hashes; não retornam telefone, e-mail, nome do cliente ou payloads de fonte.
+
+## Janela de atribuição e experimentos
+
+Os defaults operacionais a configurar explicitamente em uma janela versionada são: resposta até 7 dias, agendamento até 14, comparecimento até 30, compra até 30 e retorno até 60. Sem uma janela persistida, o funil continua observável, mas `attributed` é `null` e não se pode alegar conversão atribuída.
+
+Uma janela de atribuição sempre pertence a uma única unidade. Uma consulta de funil com `attributionWindowId` deve declarar exatamente essa unidade; uma consulta multiunidade é recusada com `COMMERCIAL_ANALYTICS_WINDOW_UNIT_SCOPE_REQUIRED`, em vez de reaproveitar uma janela local como se fosse global. A projeção de receita deduplica vendas quando uma identidade possui mais de um vínculo de origem Caixa.
+
+Cada experimento exige um snapshot de segmento atual, uma janela ativa e uma unidade autorizada. A atribuição é determinística e persistida. Antes de qualquer decisão de assignment, Analytics obtém:
+
+`commercial-experiment-crossover:<unit_id>:<identity_id>`
+
+Esse é o mesmo advisory-lock namespace do Operations v2. Campaign create, action reassign e rebalance continuam verificando control/excluded sob esse lock; uma identidade com holdout ativo não pode sofrer crossover silencioso. Sobreposição com outro control/excluded é persistida como `excluded`, nunca convertida em tratamento. As assignments e seus ledgers são imutáveis.
+
+O endpoint de métricas separa conversão observada, atribuída dentro da janela e incremental. Intervalo de confiança só é devolvido para ambos os braços com pelo menos 30 indivíduos; caso contrário, retorna `INSUFFICIENT_EXPERIMENT_SAMPLE`. Receita é limitada ao período do experimento e à janela de compra, não é atribuída indefinidamente.
+
+## RBAC, escopo e readiness
+
+As rotas `/api/atendimento/commercial/analytics/*` exigem o mesmo papel Clientes (`GESTOR`) da superfície comercial. O store também exige `GESTOR`/`ADMIN` e nunca transforma ausência de `allowedUnits` em escopo global. Para gestor limitado a unidade, Analytics calcula cobertura agregada apenas das unidades declaradas e omite as filas globais de quality/source operations, que ainda não possuem chave de unidade.
+
+`GET /commercial/analytics/readiness` não faz mutação. Ela só retorna pronta quando as relações, os guards de update/delete/**truncate**, `SELECT` em `schema_migrations`, todos os grants de leitura/escrita mínimos (inclusive `USAGE` da sequence de eventos) e a migration aplicada estiverem presentes. Isso também satisfaz a dependência de readiness do guard de crossover em Operations.
+
+## Migração, rollback e grants
+
+O comando nativo aceita exclusivamente uma ação e o target local/staging:
+
+```powershell
+# apenas no boundary WSL aprovado; não use shell vindo de Environment/GitHub variable
+npm run migrate-commercial-analytics -- --dry-run --target=staging
+npm run migrate-commercial-analytics -- --apply --target=staging
+npm run migrate-commercial-analytics -- --rollback --target=staging
+```
+
+Ele exige `DATABASE_URL` que passe pela verificação estrita de destino e não executa argumentos arbitrários. Apply e rollback abrem uma transação antes de obter o advisory lock de migration, portanto o lock e cada passo da mudança permanecem atômicos. A role de runtime recebe apenas `USAGE` de schema e `SELECT`/DML mínimo para as relações listadas, incluindo `SELECT crm_atendimento.schema_migrations`; não recebe DDL, DELETE ou TRUNCATE. A role de migration permanece separada.
+
+Rollback é não destrutivo: marca o registry como rolled back e retém snapshots, assignments e evidência. Para rollback operacional, desabilite primeiro o experimento (se houver), registre o SHA predecessor, rode `--rollback` no mesmo target aprovado e valide readiness 503/fail-closed. Não remova tabelas nem dados de coorte.
+
+## Operação e observabilidade
+
+O Console exibe em **Clientes > Qualidade**:
+
+- cobertura por unidade e freshness/fila global somente para ator global;
+- histórico de findings, aging, reconhecimento, resolução, reabertura, ownership e SLA;
+- funil observado versus atribuído;
+- versões, snapshots, janelas e contagens de control/treatment/excluded.
+
+Alertas devem usar o ledger existente de fontes: preventivo antes de 24h sem validação e finding alto a partir de 48h. Um snapshot incompleto, uma fonte stale ou ausência de readiness bloqueia qualquer snapshot/experiment mutation; nada deve ser aposentado ou excluído por ausência de fonte.
+
+## Validação antes de promover
+
+1. Rode API unit/route/migration tests e a matriz CI; valide que `schema_migrations` é selecionável pela role de runtime.
+2. Em espelho local e staging isolado, execute dry-run, apply sintético, repetição da mesma idempotency key, revision conflict, snapshot, sobreposição control/excluded e rollback não destrutivo.
+3. Confirme que Operations bloqueia create campaign, reassign e rebalance para control/excluded ativos no mesmo advisory-lock namespace.
+4. Faça smoke autenticado com identidade sintética e confirme flags `false`; não envie mensagem, não abra escrita comercial e não altere consentimento.


### PR DESCRIPTION
## Scope

- Analytics criteria use an explicit allowlist only; generic JSON filters and PII-like aliases are rejected in both the API and PostgreSQL constraint.
- Persistent experiment assignment uses the shared holdout/crossover advisory-lock namespace, preventing silent treatment crossover.
- Analytics reads and aggregates are scoped by authorized unit; limited managers do not receive global quality/source ledgers.

## Safety and migration

- The default is fail-closed: commercial contact writes, consent writes, messaging, and autonomous messaging remain disabled. No communication endpoint is added.
- The migration is additive only and has not been applied in any environment by this PR.
- Test files are included. The local WSL suite is unavailable because of the observed local runtime/disk I/O limitation; CI is required before review or merge.

## Rollback

Rollback before any migration is: revert `ee428365515db914cbc010fce3f27b62a5ff090b` and remove the branch ref after closing the PR. Do not apply the migration in this tranche. The migration command's own rollback is non-destructive and preserves analytics evidence.

No deploy, migration, communication, or commercial write was executed by this PR.