### PR TITLE
feat(clientes): add fail-closed assisted communication domain

### DIFF
--- a/crm/api/scripts/migrate-atendimento-commercial-assisted-whatsapp.mjs
+++ b/crm/api/scripts/migrate-atendimento-commercial-assisted-whatsapp.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+import { createPgPool } from '../server/harmonia/store/pg.js'
+import {
+    applyCommercialAssistedMigration,
+    commercialAssistedMigrationPlan,
+    rollbackCommercialAssistedMigration,
+} from '../server/atendimento/commercialAssistedCommunicationMigration.js'
+import {
+    assertAtendimentoMigrationDestination,
+    ATENDIMENTO_MIGRATION_TARGETS,
+    isStrictAtendimentoMigrationDestination,
+} from '../server/atendimento/migrationDestination.js'
+
+const ALLOWED_ACTIONS = new Set(['--dry-run', '--apply', '--rollback'])
+const ALLOWED_TARGETS = new Set([ATENDIMENTO_MIGRATION_TARGETS.LOCAL, ATENDIMENTO_MIGRATION_TARGETS.STAGING])
+
+function commandError(code) {
+    const error = new Error(code)
+    error.code = code
+    return error
+}
+
+function parseTarget(args) {
+    const values = args.filter((arg) => arg.startsWith('--target='))
+    if (values.length > 1) throw commandError('COMMERCIAL_ASSISTED_TARGET_INVALID')
+    const target = values[0] ? values[0].slice('--target='.length) : ATENDIMENTO_MIGRATION_TARGETS.LOCAL
+    if (ALLOWED_TARGETS.has(target)) return target
+    throw commandError('COMMERCIAL_ASSISTED_TARGET_INVALID')
+}
+
+let pool = null
+
+try {
+    const args = process.argv.slice(2)
+    const target = parseTarget(args)
+    const actions = args.filter((arg) => ALLOWED_ACTIONS.has(arg))
+    const targetArgs = args.filter((arg) => arg.startsWith('--target='))
+    if (actions.length !== 1 || args.length !== actions.length + targetArgs.length) {
+        throw commandError('COMMERCIAL_ASSISTED_MIGRATION_ACTION_INVALID')
+    }
+    const action = actions[0].slice(2)
+    const databaseUrl = String(process.env.DATABASE_URL || '').trim()
+    if (!databaseUrl || !isStrictAtendimentoMigrationDestination(databaseUrl, target)) {
+        throw commandError('COMMERCIAL_ASSISTED_DESTINATION_UNSAFE')
+    }
+    pool = createPgPool(databaseUrl)
+    if (!pool) throw commandError('COMMERCIAL_ASSISTED_POOL_REQUIRED')
+
+    if (action === 'dry-run') {
+        const client = await pool.connect()
+        try {
+            await client.query('begin')
+            const identity = await assertAtendimentoMigrationDestination(client, databaseUrl, target)
+            const registry = await client.query(`select to_regclass('crm_atendimento.schema_migrations') as registry`)
+            await client.query('rollback')
+            process.stdout.write(`${JSON.stringify({ ok: true, action, target, identity, registryPresent: Boolean(registry.rows[0]?.registry), plan: commercialAssistedMigrationPlan() })}\n`)
+        } catch (error) {
+            try { await client.query('rollback') } catch { /* preserve guarded failure */ }
+            throw error
+        } finally {
+            client.release()
+        }
+    } else {
+        const result = action === 'apply'
+            ? await applyCommercialAssistedMigration({ pool, databaseUrl, target })
+            : await rollbackCommercialAssistedMigration({ pool, databaseUrl, target })
+        process.stdout.write(`${JSON.stringify({ ok: true, action, target, result, providerSend: false, externalDispatch: false, automationEnabled: false })}\n`)
+    }
+} catch (error) {
+    const code = /^[A-Z][A-Z0-9_]{1,100}$/.test(String(error?.code || ''))
+        ? error.code
+        : 'COMMERCIAL_ASSISTED_MIGRATION_FAILED'
+    process.stderr.write(`${JSON.stringify({ ok: false, code })}\n`)
+    process.exitCode = 1
+} finally {
+    if (pool) await pool.end()
+}

--- a/crm/api/server/atendimento/__tests__/commercialAssistedCommunication.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialAssistedCommunication.test.js
@@ -1,0 +1,92 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createHmac, randomBytes } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+
+import {
+    COMMERCIAL_ASSISTED_CONFIRMATION,
+    COMMERCIAL_ASSISTED_REVEAL_CONFIRMATION,
+    COMMERCIAL_ASSISTED_SAFETY_FLAGS,
+    actorReference,
+    assertNoDirectPii,
+    confirmationRequired,
+    maskPhone,
+    normalizeTemplatePayload,
+    offerContext,
+    renderMaskedPreview,
+    revealConfirmationRequired,
+    stableAssistedFingerprint,
+    templateContext,
+    verifyRawWebhookSignature,
+} from '../commercialAssistedCommunication.js'
+
+const secret = () => randomBytes(32).toString('base64url')
+const offerId = '11111111-1111-4111-8111-111111111111'
+const templateId = '22222222-2222-4222-8222-222222222222'
+const attemptId = '33333333-3333-4333-8333-333333333333'
+
+test('canonical offer and template evidence is stable, revision-bound and PII-free', () => {
+    const first = offerContext({
+        id: offerId, offer_key: 'toxina-fixture', revision: '4', unit_slug: 'centro', title: 'Oferta sint?tica',
+        description: 'Condi??es aprovadas', price_cents: 12500, currency: 'BRL', price_qualifier: 'a partir de',
+        conditions: 'Somente contexto comercial aprovado', validity_start: '2026-08-01', validity_end: '2026-08-31',
+        procedures: [{ id: '44444444-4444-4444-8444-444444444444', name: 'Procedimento sint?tico', quantity: 1, quantity_unit: 'sess?o' }],
+    })
+    const second = offerContext({
+        title: 'Oferta sint?tica', conditions: 'Somente contexto comercial aprovado', validity_end: '2026-08-31',
+        validity_start: '2026-08-01', price_qualifier: 'a partir de', currency: 'BRL', price_cents: 12500,
+        description: 'Condi??es aprovadas', unit_slug: 'centro', revision: 4, offer_key: 'toxina-fixture', id: offerId,
+        procedures: [{ quantity_unit: 'sess?o', quantity: 1, name: 'Procedimento sint?tico', id: '44444444-4444-4444-8444-444444444444' }],
+    })
+    const template = templateContext({ id: templateId, template_key: 'oferta-fixture', revision: '3', unit_slug: 'centro', body_template: 'Ol?, {{cliente}}. {{oferta}}: {{preco}}.', valid_from: '2026-08-01', valid_until: '2026-08-31' })
+
+    assert.equal(first.contextHash, second.contextHash)
+    assert.match(first.contextHash, /^[a-f0-9]{64}$/)
+    assert.equal(first.context.revision, 4)
+    assert.equal(template.context.revision, 3)
+    assert.match(template.contextHash, /^[a-f0-9]{64}$/)
+    assert.equal(stableAssistedFingerprint({ b: ['safe', 2], a: { z: false, y: null } }), stableAssistedFingerprint({ a: { y: null, z: false }, b: ['safe', 2] }))
+})
+
+test('nested PII and legacy actor fields are rejected before hashes or ledgers are produced', () => {
+    const key = secret()
+    assert.throws(() => assertNoDirectPii({ safe: { nested: { email: 'fixture@example.invalid' } } }), /COMMERCIAL_ASSISTED_PII_REJECTED/)
+    assert.throws(() => normalizeTemplatePayload({ templateKey: 'fixture-template', bodyTemplate: 'Texto aprovado', unit: 'centro', reason: 'Contato 000000000000' }), /COMMERCIAL_ASSISTED_TEMPLATE_PII_REJECTED/)
+    assert.throws(() => actorReference(key, { subject: 'legacy-subject', id: 'ignored' }), /ACTOR_IDENTITY_REQUIRED/)
+    assert.match(actorReference(key, { actorSubject: 'crm:gestor-fixture', id: 'ignored' }), /^actor:[a-f0-9]{64}$/)
+})
+
+test('preview presentation stays masked and confirmation tokens remain literal', () => {
+    const phone = '000000000000'
+    const masked = maskPhone(phone)
+    assert.equal(masked.includes(phone), false)
+    assert.match(masked, /0000$/)
+    assert.equal(confirmationRequired(COMMERCIAL_ASSISTED_CONFIRMATION), true)
+    assert.equal(revealConfirmationRequired(COMMERCIAL_ASSISTED_REVEAL_CONFIRMATION), true)
+    assert.throws(() => confirmationRequired('confirmar'), /COMMERCIAL_ASSISTED_HUMAN_CONFIRMATION_REQUIRED/)
+    assert.throws(() => revealConfirmationRequired('revelar'), /COMMERCIAL_ASSISTED_REVEAL_CONFIRMATION_REQUIRED/)
+    assert.equal(renderMaskedPreview({ bodyTemplate: '{{cliente}} {{oferta}} {{preco}} {{condicoes}}' }, { title: 'Oferta sint?tica', priceCents: 1000, currency: 'BRL', conditions: 'Aprovada' }).includes(phone), false)
+})
+
+test('raw webhook HMAC binds the exact body and timestamp and rejects replay substitution', () => {
+    const key = secret()
+    const timestamp = String(Date.now())
+    const raw = Buffer.from(JSON.stringify({ eventId: 'fixture-event-0001', attemptId, eventType: 'stop', occurredAt: '2026-08-07T12:00:00.000Z' }), 'utf8')
+    const signature = createHmac('sha256', key).update(Buffer.concat([Buffer.from(`${timestamp}.`, 'utf8'), raw])).digest('base64url')
+    assert.equal(verifyRawWebhookSignature({ rawBody: raw, timestamp, signature, secret: key }), true)
+    assert.equal(verifyRawWebhookSignature({ rawBody: Buffer.from(raw.toString('utf8').replace('stop', 'read')), timestamp, signature, secret: key }), false)
+    assert.equal(verifyRawWebhookSignature({ rawBody: raw, timestamp: String(Number(timestamp) - 600_001), signature, secret: key, now: Number(timestamp) }), false)
+})
+
+test('the inaccessible domain contains no provider SDK, click URI or activation flag', async () => {
+    const file = await readFile(fileURLToPath(new URL('../commercialAssistedCommunication.js', import.meta.url)), 'utf8')
+    assert.deepEqual(COMMERCIAL_ASSISTED_SAFETY_FLAGS, {
+        providerSend: false,
+        automationEnabled: false,
+        bulkDispatchEnabled: false,
+        commercialContactWritesEnabled: false,
+        externalDispatch: false,
+    })
+    assert.doesNotMatch(file, /wa[.]me|providerSend:\s*true|automationEnabled:\s*true|bulkDispatchEnabled:\s*true|externalDispatch:\s*true|\bfetch\s*\(/i)
+})

--- a/crm/api/server/atendimento/__tests__/commercialAssistedCommunicationMigration.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialAssistedCommunicationMigration.test.js
@@ -1,0 +1,75 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+    COMMERCIAL_ASSISTED_MIGRATION_ID,
+    __testables,
+    applyCommercialAssistedMigration,
+    commercialAssistedMigrationPlan,
+    parseCommercialAssistedMigrationAction,
+} from '../commercialAssistedCommunicationMigration.js'
+
+test('defines an additive, fail-closed assisted migration with non-destructive rollback', () => {
+    const plan = commercialAssistedMigrationPlan()
+    assert.equal(plan.id, COMMERCIAL_ASSISTED_MIGRATION_ID)
+    assert.equal(plan.outbound.providerSend, false)
+    assert.equal(plan.outbound.automationEnabled, false)
+    assert.match(plan.actionContextGuard, /immutable/i)
+    assert.match(plan.rollback, /Non-destructive/i)
+    assert.equal(parseCommercialAssistedMigrationAction(['--apply']), 'apply')
+    assert.equal(parseCommercialAssistedMigrationAction(['--rollback']), 'rollback')
+    assert.throws(() => parseCommercialAssistedMigrationAction(['--apply', '--rollback']), /COMMERCIAL_ASSISTED_MIGRATION_ACTION_INVALID/)
+})
+
+test('migration installs recursive PII defenses, append-only/no-truncate protections and replay-identical action guard', () => {
+    const statements = __testables.STATEMENTS.join('\n')
+    const readiness = __testables.triggerReadinessStatement()
+    assert.match(statements, /commercial_assisted_text_is_safe_v2/)
+    assert.match(statements, /commercial_assisted_json_is_safe_v2/)
+    assert.match(statements, /jsonb_each|jsonb_array_elements/)
+    assert.match(statements, /event_payload_hash/)
+    assert.match(statements, /commercial_assisted_action_context_immutable/)
+    assert.match(statements, /commercial assisted action snapshot mismatch/)
+    assert.match(statements, /commercial_assisted_offer_snapshots_no_truncate/)
+    assert.match(statements, /commercial_assisted_events_no_truncate/)
+    assert.match(readiness, /action_context_guard/)
+    assert.match(readiness, /no_truncate_0/)
+    assert.match(readiness, /prevent_commercial_assisted_evidence_mutation_v2/)
+    assert.equal(/\bdrop\s+(?:table|schema|database)\b/i.test(statements), false)
+})
+
+test('guarded migration grants schema_migrations read access but no destructive runtime privilege', async () => {
+    const calls = []
+    const client = {
+        async query(sql, params = []) {
+            calls.push({ sql, params })
+            if (/current_database\(\)/i.test(sql)) return { rows: [{ database_name: 'skincos_crm_local', database_user: 'admin', session_user: 'admin', read_only: 'off' }] }
+            if (/relation_0/i.test(sql)) return { rows: [{ every_prerequisite: true }] }
+            if (/select exists\(select 1 from pg_trigger/i.test(sql)) return { rows: [{ every_guard: true }] }
+            return { rows: [] }
+        },
+        release() {},
+    }
+    const report = await applyCommercialAssistedMigration({
+        pool: { connect: async () => client },
+        databaseUrl: 'postgresql:///skincos_crm_local?host=/var/run/postgresql',
+    })
+    assert.equal(report.applied, true)
+    assert.equal(report.runtimeRole, 'skincos')
+    const schema = calls.map((call) => call.sql).join('\n')
+    const grants = calls.filter((call) => /^grant /i.test(call.sql)).map((call) => call.sql).join('\n')
+    assert.match(schema, /select pg_advisory_xact_lock/)
+    assert.match(schema, /commercial_assisted_json_is_safe_v2/)
+    assert.match(grants, /grant select on table crm_atendimento[.]schema_migrations to skincos/i)
+    assert.equal(/\b(delete|truncate|references|trigger)\b/i.test(grants), false)
+    assert.equal(calls.some((call) => call.params.includes(COMMERCIAL_ASSISTED_MIGRATION_ID)), true)
+})
+
+test('refuses an unsafe migration destination before opening a database connection', async () => {
+    let connected = false
+    await assert.rejects(() => applyCommercialAssistedMigration({
+        pool: { connect: async () => { connected = true } },
+        databaseUrl: 'postgresql://admin@127.0.0.1:5432/skincos_crm_local',
+    }), /COMMERCIAL_ASSISTED_MIGRATION_DESTINATION_UNSAFE/)
+    assert.equal(connected, false)
+})

--- a/crm/api/server/atendimento/__tests__/commercialAssistedCommunicationPostgres.integration.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialAssistedCommunicationPostgres.integration.test.js
@@ -1,0 +1,118 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+
+import { createPgPool } from '../../harmonia/store/pg.js'
+import { __testables as migrationTestables } from '../commercialAssistedCommunicationMigration.js'
+
+const integrationUrl = String(process.env.CRM_ASSISTED_PG_TEST_DATABASE_URL || '').trim()
+
+function allowedIntegrationTarget(value) {
+    if (process.env.CRM_ASSISTED_PG_TEST_ENABLED !== '1' || !value) return false
+    try {
+        const url = new URL(value)
+        const database = decodeURIComponent(url.pathname || '').replace(/^\//, '')
+        return url.protocol === 'postgresql:' && ['127.0.0.1', 'localhost', '::1'].includes(url.hostname) && /(?:^|[_-])test$/i.test(database)
+    } catch {
+        return false
+    }
+}
+
+const enabled = allowedIntegrationTarget(integrationUrl)
+const actor = `actor:${'a'.repeat(64)}`
+const reason = `reason:${'b'.repeat(64)}`
+const hash = 'c'.repeat(64)
+const unitId = '11111111-1111-4111-8111-111111111111'
+const offerId = '22222222-2222-4222-8222-222222222222'
+const identityId = '33333333-3333-4333-8333-333333333333'
+const actionId = '44444444-4444-4444-8444-444444444444'
+
+test('PostgreSQL integration fixture binds the explicit action-context trigger without opening a database', async () => {
+    const migration = await readFile(fileURLToPath(new URL('../commercialAssistedCommunicationMigration.js', import.meta.url)), 'utf8')
+    assert.match(migration, /commercial_assisted_action_context_immutable/)
+    assert.match(migration, /commercial_assisted_json_is_safe_v2/)
+})
+
+async function bootstrapPrerequisites(client) {
+    const statements = [
+        'create schema if not exists crm_atendimento', 'create schema if not exists crm_caixa', 'create schema if not exists harmonia',
+        'create table if not exists crm_atendimento.schema_migrations(id text primary key, applied_at timestamptz, rolled_back_at timestamptz, details jsonb)',
+        'create table if not exists crm_atendimento.units(id uuid primary key, slug text unique not null)',
+        'create table if not exists crm_atendimento.global_client_identities(id uuid primary key)',
+        'create table if not exists crm_atendimento.global_client_identity_members(id uuid primary key)',
+        'create table if not exists crm_atendimento.commercial_actions(id uuid primary key)',
+        'create table if not exists crm_atendimento.commercial_offers(id uuid primary key)',
+        'create table if not exists crm_atendimento.commercial_offer_procedures(id uuid primary key)',
+        'create table if not exists crm_atendimento.commercial_contact_permissions(id uuid primary key)',
+        'create table if not exists crm_atendimento.commercial_contact_permission_events(id uuid primary key)',
+        'create table if not exists crm_atendimento.commercial_policy_config(id uuid primary key)',
+        'create table if not exists crm_atendimento.commercial_canary_cohorts(id uuid primary key)',
+        'create table if not exists crm_atendimento.commercial_canary_cohort_members(id uuid primary key)',
+        'create table if not exists crm_atendimento.commercial_canary_identity_validations(id uuid primary key)',
+        'create table if not exists crm_atendimento.clientes_source_operation_checkpoints(id uuid primary key)',
+        'create table if not exists crm_atendimento.app_client_registrations(id uuid primary key)',
+        'create table if not exists crm_atendimento.supplemental_lead_profiles(id uuid primary key)',
+        'create table if not exists crm_atendimento.attendance_client_links(id uuid primary key)',
+        'create table if not exists crm_atendimento.attendances(id uuid primary key)',
+        'create table if not exists crm_atendimento.procedures(id uuid primary key)',
+        'create table if not exists harmonia.contacts(id uuid primary key)',
+        'create table if not exists crm_caixa.customers(id uuid primary key)',
+        'create table if not exists crm_caixa.sales(id uuid primary key)',
+        'create table if not exists crm_caixa.sale_items(id uuid primary key)',
+    ]
+    for (const statement of statements) await client.query(statement)
+}
+
+test('PostgreSQL contract rejects direct/nested PII, preserves snapshots, serializes source locks and deduplicates STOP receipts', { skip: enabled ? false : 'set CRM_ASSISTED_PG_TEST_ENABLED=1 and a loopback *_test DATABASE_URL' }, async () => {
+    const pool = createPgPool(integrationUrl)
+    const client = await pool.connect()
+    let second = null
+    try {
+        await client.query('begin')
+        await bootstrapPrerequisites(client)
+        for (const statement of migrationTestables.STATEMENTS) await client.query(statement)
+        await client.query('insert into crm_atendimento.units(id,slug) values ($1,$2)', [unitId, 'centro'])
+        await client.query('insert into crm_atendimento.commercial_offers(id) values ($1)', [offerId])
+        await client.query('insert into crm_atendimento.global_client_identities(id) values ($1)', [identityId])
+        await client.query('insert into crm_atendimento.commercial_actions(id) values ($1)', [actionId])
+        const snapshot = await client.query(`insert into crm_atendimento.commercial_assisted_offer_snapshots(
+            offer_id,offer_revision,unit_id,unit_slug,context_hash,context,captured_by)
+            values ($1,1,$2,'centro',$3,$4::jsonb,$5) returning id`, [offerId, unitId, hash, JSON.stringify({ schemaVersion: 'fixture', offerId, title: 'Oferta sint?tica' }), actor])
+        const snapshotId = snapshot.rows[0].id
+        await assert.rejects(() => client.query('update crm_atendimento.commercial_assisted_offer_snapshots set context=$2::jsonb where id=$1', [snapshotId, JSON.stringify({ title: 'alterado' })]), /append-only/i)
+        await assert.rejects(() => client.query(`insert into crm_atendimento.commercial_assisted_offer_snapshots(
+            offer_id,offer_revision,unit_id,unit_slug,context_hash,context,captured_by)
+            values ($1,2,$2,'centro',$3,$4::jsonb,$5)`, [offerId, unitId, 'd'.repeat(64), JSON.stringify({ safe: { phone: '000000000000' } }), actor]), /check constraint/i)
+        await assert.rejects(() => client.query(`insert into crm_atendimento.commercial_assisted_templates(
+            template_key,revision,unit_id,status,body_template,created_by,reason_reference,idempotency_key,request_hash)
+            values ('fixture-template',1,$1,'draft','fixture@example.invalid',$2,$3,'fixture-template-key',$4)`, [unitId, actor, reason, hash]), /check constraint/i)
+        await client.query(`update crm_atendimento.commercial_actions set assisted_offer_snapshot_id=$2,
+            assisted_offer_context_hash=$3,assisted_offer_revision=1,assisted_offer_unit_slug='centro',
+            assisted_offer_actor_ref=$4,assisted_offer_recorded_at=now() where id=$1`, [actionId, snapshotId, hash, actor])
+        await assert.rejects(() => client.query(`update crm_atendimento.commercial_actions set assisted_offer_context_hash=$2 where id=$1`, [actionId, 'e'.repeat(64)]), /immutable/i)
+
+        second = await pool.connect()
+        const lockA = await client.query(`select pg_try_advisory_lock(hashtext($1),hashtext($2)) as acquired`, ['crm_atendimento.clientes_source_operations', 'consent.harmonia_opt_outs'])
+        const lockB = await second.query(`select pg_try_advisory_lock(hashtext($1),hashtext($2)) as acquired`, ['crm_atendimento.clientes_source_operations', 'consent.harmonia_opt_outs'])
+        assert.equal(lockA.rows[0].acquired, true)
+        assert.equal(lockB.rows[0].acquired, false)
+        await client.query(`select pg_advisory_unlock(hashtext($1),hashtext($2))`, ['crm_atendimento.clientes_source_operations', 'consent.harmonia_opt_outs'])
+
+        const template = await client.query(`insert into crm_atendimento.commercial_assisted_templates(
+            template_key,revision,unit_id,status,body_template,created_by,reason_reference,idempotency_key,request_hash)
+            values ('fixture-safe',1,$1,'draft','Texto seguro',$2,$3,'fixture-safe-key',$4) returning id`, [unitId, actor, reason, 'f'.repeat(64)])
+        const attempt = await client.query(`insert into crm_atendimento.commercial_assisted_attempts(
+            actor_reference,idempotency_key,request_hash,identity_id,action_id,unit_id,offer_snapshot_id,template_id,
+            offer_context_hash,template_context_hash,preview_context_hash,recipient_phone_hash,recipient_masked)
+            values ($1,'fixture-attempt-key',$2,$3,$4,$5,$6,$7,$2,$2,$2,$2,'???? 0000') returning id`, [actor, hash, identityId, actionId, unitId, snapshotId, template.rows[0].id])
+        const receipt = [hash, attempt.rows[0].id, 'stop', 'f'.repeat(64)]
+        await client.query(`insert into crm_atendimento.commercial_assisted_webhook_receipts(event_hash,attempt_id,event_type,event_payload_hash) values ($1,$2,$3,$4)`, receipt)
+        await assert.rejects(() => client.query(`insert into crm_atendimento.commercial_assisted_webhook_receipts(event_hash,attempt_id,event_type,event_payload_hash) values ($1,$2,$3,$4)`, receipt), /duplicate key/i)
+    } finally {
+        if (second) second.release()
+        try { await client.query('rollback') } catch { /* test target may have disconnected */ }
+        client.release()
+        await pool.end()
+    }
+})

--- a/crm/api/server/atendimento/__tests__/commercialAssistedCommunicationStore.test.js
+++ b/crm/api/server/atendimento/__tests__/commercialAssistedCommunicationStore.test.js
@@ -1,0 +1,139 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createHmac, randomBytes } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+
+import {
+    __testables,
+    commercialAssistedReadiness,
+    createCommercialAssistedCommunicationStore,
+} from '../commercialAssistedCommunicationStore.js'
+
+const identityId = '11111111-1111-4111-8111-111111111111'
+const attemptId = '22222222-2222-4222-8222-222222222222'
+const manager = Object.freeze({ actorSubject: 'crm:gestor-fixture', role: 'GESTOR', allowedUnits: ['centro'] })
+const hmacKey = () => randomBytes(32).toString('base64url')
+
+function availableRow() {
+    return {
+        offer_snapshots: true, templates: true, attempts: true, events: true, webhook_receipts: true,
+        control_mutations: true, handoffs: true, emergency_controls: true, registry: true,
+        permissions_read: true, sources_read: true, harmonia_read: true, actions_read: true, offers_read: true,
+        canary_read: true, identity_members_read: true, offer_dependencies_read: true, phone_sources_read: true,
+    }
+}
+
+function integrityRow() {
+    return {
+        snapshots_immutable: true, snapshots_no_truncate: true, templates_immutable: true, templates_no_truncate: true,
+        attempts_immutable: true, attempts_no_truncate: true, events_immutable: true, events_no_truncate: true,
+        receipts_immutable: true, receipts_no_truncate: true, controls_immutable: true, controls_no_truncate: true,
+        action_context_guard: true,
+    }
+}
+
+function readinessQuery(sql) {
+    if (sql.includes('commercial_assisted_action_context_immutable')) return { rows: [integrityRow()] }
+    if (sql.includes("to_regclass('crm_atendimento.commercial_assisted_offer_snapshots')")) return { rows: [availableRow()] }
+    if (sql.includes('from crm_atendimento.schema_migrations')) {
+        return { rows: [
+            { id: '20260807_commercial_assisted_whatsapp_v2' },
+            { id: '20260807_commercial_canary_selector_v2' },
+            { id: '20260807_clientes_source_operations_v2' },
+        ] }
+    }
+    throw new Error(`unexpected readiness query: ${sql}`)
+}
+
+test('RBAC requires an opaque actorSubject, preserves unit scope and readiness fails closed on a missing integrity guard', async () => {
+    assert.deepEqual(__testables.unitScope(manager), ['centro'])
+    assert.throws(() => __testables.actorRef(hmacKey(), { id: 'legacy-manager', role: 'GESTOR' }), /ACTOR_IDENTITY_REQUIRED/)
+    const store = createCommercialAssistedCommunicationStore({ pool: { query: async (sql) => readinessQuery(sql) } })
+    const readiness = await store.readiness(manager)
+    assert.equal(readiness.ready, true)
+    assert.equal(readiness.safety.providerSend, false)
+    await assert.rejects(() => store.readiness({ role: 'GESTOR', allowedUnits: ['centro'] }), /ACTOR_IDENTITY_REQUIRED/)
+
+    const missing = await commercialAssistedReadiness({
+        async query(sql) {
+            if (sql.includes('commercial_assisted_action_context_immutable')) return { rows: [{ ...integrityRow(), action_context_guard: false }] }
+            if (sql.includes("to_regclass('crm_atendimento.commercial_assisted_offer_snapshots')")) return { rows: [availableRow()] }
+            if (sql.includes('from crm_atendimento.schema_migrations')) return { rows: [{ id: '20260807_commercial_assisted_whatsapp_v2' }, { id: '20260807_commercial_canary_selector_v2' }, { id: '20260807_clientes_source_operations_v2' }] }
+            throw new Error(`unexpected query: ${sql}`)
+        },
+    })
+    assert.equal(missing.ready, false)
+    assert.equal(missing.appendOnlyReady, false)
+})
+
+test('source proof acquires every source transaction lock before rechecking freshness and fails closed for incomplete or busy sources', async () => {
+    const calls = []
+    const now = new Date().toISOString()
+    const healthy = await __testables.lockAndReadSourceHealth({
+        async query(sql, values = []) {
+            calls.push({ sql, values })
+            if (sql.includes('pg_try_advisory_xact_lock')) return { rows: [{ acquired: true }] }
+            if (sql.includes('clientes_source_operation_checkpoints')) return { rows: __testables.REQUIRED_SOURCE_IDS.map((source_id) => ({ source_id, last_status: 'complete', validated_snapshot_complete: true, reconciliation_required: false, validated_at: now })) }
+            throw new Error(`unexpected source query: ${sql}`)
+        },
+    })
+    assert.equal(healthy.status, 'healthy')
+    assert.equal(calls.filter((call) => call.sql.includes('pg_try_advisory_xact_lock')).length, __testables.REQUIRED_SOURCE_IDS.length)
+    assert.ok(calls.findIndex((call) => call.sql.includes('clientes_source_operation_checkpoints')) > calls.map((call) => call.sql).findLastIndex((sql) => sql.includes('pg_try_advisory_xact_lock')))
+
+    const incomplete = await __testables.lockAndReadSourceHealth({
+        async query(sql) {
+            if (sql.includes('pg_try_advisory_xact_lock')) return { rows: [{ acquired: true }] }
+            return { rows: __testables.REQUIRED_SOURCE_IDS.slice(1).map((source_id) => ({ source_id, last_status: 'complete', validated_snapshot_complete: true, reconciliation_required: false, validated_at: now })) }
+        },
+    })
+    assert.deepEqual(incomplete, { status: 'stale', snapshotComplete: false, observedSources: __testables.REQUIRED_SOURCE_IDS.length - 1 })
+    await assert.rejects(() => __testables.lockAndReadSourceHealth({ async query() { return { rows: [{ acquired: false }] } } }), /COMMERCIAL_ASSISTED_SOURCE_OPERATION_BUSY/)
+})
+
+test('raw signed webhook replay is atomically deduplicated before any STOP/permission write', async () => {
+    const secret = hmacKey()
+    const timestamp = String(Date.now())
+    const rawBody = Buffer.from(JSON.stringify({ eventId: 'fixture-event-0001', attemptId, eventType: 'stop', occurredAt: '2026-08-07T12:00:00.000Z' }), 'utf8')
+    const signature = createHmac('sha256', secret).update(Buffer.concat([Buffer.from(`${timestamp}.`, 'utf8'), rawBody])).digest('base64url')
+    const calls = []
+    let receiptValues = null
+    const client = {
+        release() {},
+        async query(sql, values = []) {
+            calls.push({ sql, values })
+            if (['begin', 'commit', 'rollback'].includes(sql) || sql.includes('pg_advisory_xact_lock')) return { rows: [] }
+            if (sql.includes('insert into crm_atendimento.commercial_assisted_webhook_receipts')) {
+                receiptValues = values
+                return { rows: [] }
+            }
+            if (sql.includes('from crm_atendimento.commercial_assisted_webhook_receipts')) {
+                return { rows: [{ attempt_id: attemptId, event_type: 'stop', event_payload_hash: receiptValues[3] }] }
+            }
+            throw new Error(`unexpected transactional query: ${sql}`)
+        },
+    }
+    const store = createCommercialAssistedCommunicationStore({
+        pool: { query: async (sql) => readinessQuery(sql), connect: async () => client }, auditHmacKey: secret,
+    })
+    const result = await store.processWebhook({ rawBody, timestamp, signature })
+    assert.equal(result.deduplicated, true)
+    assert.equal(calls.some((call) => /commercial_contact_permissions/i.test(call.sql)), false)
+    assert.equal(calls.some((call) => /event_payload_hash/i.test(call.sql)), true)
+})
+
+test('store contains explicit unit/canary/consent, snapshot, single-use handoff, emergency-off and monotonic STOP guards', async () => {
+    const source = await readFile(fileURLToPath(new URL('../commercialAssistedCommunicationStore.js', import.meta.url)), 'utf8')
+    assert.match(source, /COMMERCIAL_UNIT_FORBIDDEN/)
+    assert.match(source, /COMMERCIAL_ASSISTED_CANARY_REQUIRED/)
+    assert.match(source, /COMMERCIAL_ASSISTED_PERMISSION_REQUIRED/)
+    assert.match(source, /lockContactPhone\(client, phone\)[\s\S]*assertNoOptOut/)
+    assert.match(source, /for share of offer_snapshot/)
+    assert.match(source, /COMMERCIAL_ASSISTED_HANDOFF_UNAVAILABLE/)
+    assert.match(source, /state='revealed'/)
+    assert.match(source, /COMMERCIAL_ASSISTED_EMERGENCY_OFF/)
+    assert.match(source, /COMMERCIAL_ASSISTED_WEBHOOK_TRANSITION_INVALID/)
+    assert.match(source, /COMMERCIAL_ASSISTED_WEBHOOK_REPLAY_CONFLICT/)
+    assert.doesNotMatch(source, /wa[.]me|providerSend:\s*true|externalDispatch:\s*true|\bfetch\s*\(/i)
+})

--- a/crm/api/server/atendimento/commercialAssistedCommunication.js
+++ b/crm/api/server/atendimento/commercialAssistedCommunication.js
@@ -1,0 +1,324 @@
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const UNIT_RE = /^[a-z0-9][a-z0-9._-]{0,119}$/i
+const IDEMPOTENCY_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{7,159}$/
+const TEMPLATE_KEY_RE = /^[a-z0-9][a-z0-9._-]{1,95}$/
+const WEBHOOK_EVENT_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{7,191}$/
+const TEMPLATE_PLACEHOLDERS = new Set(['cliente', 'oferta', 'preco', 'condicoes'])
+const WEBHOOK_EVENT_TYPES = new Set(['delivered', 'read', 'replied', 'failed', 'stop'])
+const ASSISTED_HMAC_NAMESPACE = ['commercial', 'assisted'].join('-')
+const ASSISTED_HMAC_PURPOSE_SUFFIX_RE = /^[a-z][a-z0-9-]{1,95}-v[1-9][0-9]*$/
+
+// This must stay a compile-time safety contract. No environment variable can
+// turn a confirmation, a handoff or a webhook into provider dispatch.
+export const COMMERCIAL_ASSISTED_SAFETY_FLAGS = Object.freeze({
+    providerSend: false,
+    automationEnabled: false,
+    bulkDispatchEnabled: false,
+    commercialContactWritesEnabled: false,
+    externalDispatch: false,
+})
+
+export const COMMERCIAL_ASSISTED_CONFIRMATION = 'CONFIRMAR_CONTATO_ASSISTIDO'
+export const COMMERCIAL_ASSISTED_REVEAL_CONFIRMATION = 'REVELAR_DESTINATARIO_ASSISTIDO'
+export const COMMERCIAL_ASSISTED_MIGRATION_ID = '20260807_commercial_assisted_whatsapp_v2'
+
+function error(code, statusCode = 409) {
+    const value = new Error(code)
+    value.code = code
+    value.statusCode = statusCode
+    return value
+}
+
+function text(value) {
+    return String(value ?? '').trim()
+}
+
+function canonical(value) {
+    if (value === null || typeof value === 'string' || typeof value === 'boolean') return value
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value)) throw error('COMMERCIAL_ASSISTED_CANONICAL_VALUE_INVALID', 400)
+        return Object.is(value, -0) ? 0 : value
+    }
+    if (Array.isArray(value)) return value.map(canonical)
+    if (value && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
+        return Object.fromEntries(Object.keys(value).sort().map((key) => {
+            if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(key) || value[key] === undefined) {
+                throw error('COMMERCIAL_ASSISTED_CANONICAL_VALUE_INVALID', 400)
+            }
+            return [key, canonical(value[key])]
+        }))
+    }
+    throw error('COMMERCIAL_ASSISTED_CANONICAL_VALUE_INVALID', 400)
+}
+
+const DIRECT_PII_KEYS = new Set(['phone', 'email', 'telefone', 'recipient', 'rawphone', 'message', 'secret', 'token', 'cpf'])
+
+function normalizedMetadataKey(value) {
+    return String(value || '').toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
+function directPiiInText(value) {
+    const source = String(value || '')
+    return /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(source) || /(?:\+?\d[\s().-]*){8,}\d/.test(source)
+}
+
+export function containsDirectPii(value, seen = new WeakSet()) {
+    if (value === null || value === undefined || typeof value === 'number' || typeof value === 'boolean') return false
+    if (typeof value === 'string') return directPiiInText(value)
+    if (typeof value !== 'object') return true
+    if (seen.has(value)) return true
+    seen.add(value)
+    if (Array.isArray(value)) return value.some((entry) => containsDirectPii(entry, seen))
+    return Object.entries(value).some(([key, entry]) => DIRECT_PII_KEYS.has(normalizedMetadataKey(key)) || containsDirectPii(entry, seen))
+}
+
+export function assertNoDirectPii(value, code = 'COMMERCIAL_ASSISTED_PII_REJECTED') {
+    if (containsDirectPii(value)) throw error(code, 400)
+    return value
+}
+
+export function stableAssistedFingerprint(value) {
+    assertNoDirectPii(value, 'COMMERCIAL_ASSISTED_PII_REJECTED')
+    return createHash('sha256').update(JSON.stringify(canonical(value))).digest('hex')
+}
+
+export function assistedHmac(secret, purpose, value) {
+    const key = text(secret)
+    if (Buffer.byteLength(key, 'utf8') < 32) throw error('COMMERCIAL_ASSISTED_HMAC_KEY_REQUIRED', 503)
+    return createHmac('sha256', key).update(`${purpose}:${JSON.stringify(canonical(value))}`).digest('hex')
+}
+
+export function assistedHmacPurpose(suffix) {
+    const normalizedSuffix = text(suffix).toLowerCase()
+    if (!ASSISTED_HMAC_PURPOSE_SUFFIX_RE.test(normalizedSuffix)) throw error('COMMERCIAL_ASSISTED_HMAC_PURPOSE_INVALID', 400)
+    return `${ASSISTED_HMAC_NAMESPACE}-${normalizedSuffix}`
+}
+
+export function actorReference(secret, actor) {
+    const subject = text(actor?.actorSubject)
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:/|-]{0,159}$/.test(subject)) throw error('ACTOR_IDENTITY_REQUIRED', 401)
+    return `actor:${assistedHmac(secret, assistedHmacPurpose('actor-v1'), { subject })}`
+}
+
+export function normalizeUuid(value, code = 'COMMERCIAL_ASSISTED_ID_INVALID') {
+    const id = text(value).toLowerCase()
+    if (!UUID_RE.test(id)) throw error(code, 400)
+    return id
+}
+
+export function normalizeUnit(value) {
+    const unit = text(value).toLowerCase()
+    if (!UNIT_RE.test(unit)) throw error('COMMERCIAL_ASSISTED_UNIT_INVALID', 400)
+    return unit
+}
+
+export function normalizeIdempotencyKey(value) {
+    const key = text(value)
+    if (!IDEMPOTENCY_RE.test(key)) throw error('COMMERCIAL_ASSISTED_IDEMPOTENCY_KEY_INVALID', 400)
+    return key
+}
+
+export function normalizeReason(value, code = 'COMMERCIAL_ASSISTED_REASON_INVALID') {
+    const reason = text(value)
+    if (reason.length < 8 || reason.length > 500 || containsDirectPii(reason)) throw error(code, 400)
+    return reason
+}
+
+export function maskPhone(value) {
+    const digits = String(value || '').replace(/\D/g, '')
+    if (digits.length < 8) return 'Contato mascarado'
+    return `•••• •••• ${digits.slice(-4)}`
+}
+
+export function normalizeTemplatePayload(payload = {}) {
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) throw error('COMMERCIAL_ASSISTED_TEMPLATE_PAYLOAD_INVALID', 400)
+    const allowed = new Set(['templateKey', 'bodyTemplate', 'unit', 'status', 'validFrom', 'validUntil', 'reason', 'idempotencyKey'])
+    if (Object.keys(payload).some((key) => !allowed.has(key))) throw error('COMMERCIAL_ASSISTED_TEMPLATE_PAYLOAD_INVALID', 400)
+    assertNoDirectPii(payload, 'COMMERCIAL_ASSISTED_TEMPLATE_PII_REJECTED')
+    const templateKey = text(payload.templateKey).toLowerCase()
+    const bodyTemplate = String(payload.bodyTemplate || '').trim()
+    const unit = normalizeUnit(payload.unit)
+    const status = text(payload.status || 'draft').toLowerCase()
+    if (!TEMPLATE_KEY_RE.test(templateKey)) throw error('COMMERCIAL_ASSISTED_TEMPLATE_KEY_INVALID', 400)
+    if (!['draft', 'approved', 'disabled'].includes(status)) throw error('COMMERCIAL_ASSISTED_TEMPLATE_STATUS_INVALID', 400)
+    if (bodyTemplate.length < 1 || bodyTemplate.length > 2_000 || containsDirectPii(bodyTemplate)) {
+        throw error('COMMERCIAL_ASSISTED_TEMPLATE_BODY_INVALID', 400)
+    }
+    const placeholders = [...bodyTemplate.matchAll(/{{\s*([a-z_]+)\s*}}/g)].map((match) => match[1])
+    if (placeholders.some((placeholder) => !TEMPLATE_PLACEHOLDERS.has(placeholder))) {
+        throw error('COMMERCIAL_ASSISTED_TEMPLATE_PLACEHOLDER_INVALID', 400)
+    }
+    const validFrom = normalizeDate(payload.validFrom, 'COMMERCIAL_ASSISTED_TEMPLATE_VALID_FROM_INVALID')
+    const validUntil = normalizeDate(payload.validUntil, 'COMMERCIAL_ASSISTED_TEMPLATE_VALID_UNTIL_INVALID')
+    if (validFrom && validUntil && validUntil < validFrom) throw error('COMMERCIAL_ASSISTED_TEMPLATE_VALIDITY_INVALID', 400)
+    return {
+        templateKey,
+        bodyTemplate,
+        unit,
+        status,
+        validFrom,
+        validUntil,
+        reason: normalizeReason(payload.reason, 'COMMERCIAL_ASSISTED_TEMPLATE_REASON_INVALID'),
+    }
+}
+
+function normalizeDate(value, code) {
+    if (value === null || value === undefined || value === '') return null
+    const date = text(value).slice(0, 10)
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || Number.isNaN(Date.parse(`${date}T12:00:00Z`))) throw error(code, 400)
+    return date
+}
+
+export function offerContext(row = {}) {
+    const procedures = Array.isArray(row.procedures) ? row.procedures.map((procedure) => ({
+        id: text(procedure.id),
+        name: text(procedure.name),
+        quantity: Number(procedure.quantity || 1),
+        quantityUnit: text(procedure.quantityUnit || procedure.quantity_unit || 'unidade'),
+    })) : []
+    const context = {
+        schemaVersion: 'crm-commercial-offer-snapshot/v1',
+        offerId: normalizeUuid(row.offerId || row.id, 'COMMERCIAL_ASSISTED_OFFER_INVALID'),
+        offerKey: text(row.offerKey || row.offer_key),
+        revision: Number(row.revision || 0),
+        unit: normalizeUnit(row.unit || row.unitSlug || row.unit_slug),
+        title: text(row.title),
+        description: text(row.description),
+        priceCents: row.priceCents ?? row.price_cents ?? null,
+        currency: text(row.currency || 'BRL'),
+        priceQualifier: text(row.priceQualifier || row.price_qualifier),
+        installmentCount: row.installmentCount ?? row.installment_count ?? null,
+        installmentValueCents: row.installmentValueCents ?? row.installment_value_cents ?? null,
+        discountPercent: row.discountPercent ?? row.discount_percent ?? null,
+        conditions: text(row.conditions),
+        validityStart: normalizeDate(row.validityStart ?? row.validity_start, 'COMMERCIAL_ASSISTED_OFFER_VALIDITY_INVALID'),
+        validityEnd: normalizeDate(row.validityEnd ?? row.validity_end, 'COMMERCIAL_ASSISTED_OFFER_VALIDITY_INVALID'),
+        procedures,
+    }
+    assertNoDirectPii(context, 'COMMERCIAL_ASSISTED_OFFER_PII_REJECTED')
+    if (!context.offerKey || !Number.isInteger(context.revision) || context.revision < 1 || !context.title || !context.priceQualifier || !procedures.length) {
+        throw error('COMMERCIAL_ASSISTED_OFFER_INVALID', 400)
+    }
+    return { context, contextHash: stableAssistedFingerprint(context) }
+}
+
+export function templateContext(row = {}) {
+    const context = {
+        schemaVersion: 'crm-commercial-template-snapshot/v1',
+        templateId: normalizeUuid(row.id || row.templateId, 'COMMERCIAL_ASSISTED_TEMPLATE_INVALID'),
+        templateKey: text(row.template_key || row.templateKey),
+        revision: Number(row.revision || 0),
+        unit: normalizeUnit(row.unit_slug || row.unit || row.unitSlug),
+        bodyTemplate: String(row.body_template || row.bodyTemplate || '').trim(),
+        validFrom: normalizeDate(row.valid_from ?? row.validFrom, 'COMMERCIAL_ASSISTED_TEMPLATE_VALID_FROM_INVALID'),
+        validUntil: normalizeDate(row.valid_until ?? row.validUntil, 'COMMERCIAL_ASSISTED_TEMPLATE_VALID_UNTIL_INVALID'),
+    }
+    assertNoDirectPii(context, 'COMMERCIAL_ASSISTED_TEMPLATE_PII_REJECTED')
+    if (!TEMPLATE_KEY_RE.test(context.templateKey) || !Number.isInteger(context.revision) || context.revision < 1 ||
+        !context.bodyTemplate || context.bodyTemplate.length > 2_000 || containsDirectPii(context.bodyTemplate)) {
+        throw error('COMMERCIAL_ASSISTED_TEMPLATE_INVALID', 400)
+    }
+    return { context, contextHash: stableAssistedFingerprint(context) }
+}
+
+function formatOfferPrice(context) {
+    if (context.priceCents === null || context.priceCents === undefined) return 'Condições aprovadas disponíveis'
+    const amount = Number(context.priceCents) / 100
+    return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: context.currency || 'BRL' }).format(amount)
+}
+
+export function renderMaskedPreview(template, offer) {
+    const rendered = String(template.bodyTemplate || '')
+        .replace(/{{\s*cliente\s*}}/g, 'Cliente')
+        .replace(/{{\s*oferta\s*}}/g, offer.title)
+        .replace(/{{\s*preco\s*}}/g, formatOfferPrice(offer))
+        .replace(/{{\s*condicoes\s*}}/g, offer.conditions || 'Condições aprovadas')
+    return rendered.slice(0, 4_096)
+}
+
+export function confirmationRequired(value) {
+    if (text(value) !== COMMERCIAL_ASSISTED_CONFIRMATION) throw error('COMMERCIAL_ASSISTED_HUMAN_CONFIRMATION_REQUIRED', 409)
+    return true
+}
+
+export function revealConfirmationRequired(value) {
+    if (text(value) !== COMMERCIAL_ASSISTED_REVEAL_CONFIRMATION) throw error('COMMERCIAL_ASSISTED_REVEAL_CONFIRMATION_REQUIRED', 409)
+    return true
+}
+
+export function previewContextHash(value) {
+    return stableAssistedFingerprint({
+        version: 'commercial-assisted-preview/v1',
+        actionId: normalizeUuid(value.actionId, 'COMMERCIAL_ASSISTED_ACTION_INVALID'),
+        identityId: normalizeUuid(value.identityId, 'COMMERCIAL_ASSISTED_IDENTITY_INVALID'),
+        unit: normalizeUnit(value.unit),
+        offerContextHash: text(value.offerContextHash),
+        templateContextHash: text(value.templateContextHash),
+        recipientPhoneHash: text(value.recipientPhoneHash),
+        permissionRevision: Number(value.permissionRevision || 0),
+        sourceFreshness: text(value.sourceFreshness),
+        canaryValidation: text(value.canaryValidation),
+        // These two revisions are deliberately part of the preview proof. A
+        // confirmation cannot reuse a preview created before a policy or
+        // emergency-control change was observed.
+        policyVersion: text(value.policyVersion),
+        emergencyRevision: text(value.emergencyRevision),
+    })
+}
+
+const ALLOWED_TRANSITIONS = Object.freeze({
+    confirmed: new Set(['delivered', 'failed', 'stop']),
+    handed_off: new Set(['delivered', 'failed', 'stop']),
+    delivered: new Set(['read', 'replied', 'stop']),
+    read: new Set(['replied', 'stop']),
+    replied: new Set(['stop']),
+    failed: new Set(['stop']),
+    stop: new Set(),
+})
+
+export function canAdvanceAssistedState(currentState, nextState) {
+    const current = text(currentState || 'confirmed')
+    const next = text(nextState)
+    if (!WEBHOOK_EVENT_TYPES.has(next)) return false
+    return ALLOWED_TRANSITIONS[current]?.has(next) === true
+}
+
+export function normalizeWebhookPayload(value = {}) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) throw error('COMMERCIAL_ASSISTED_WEBHOOK_PAYLOAD_INVALID', 400)
+    const allowed = new Set(['eventId', 'attemptId', 'eventType', 'occurredAt'])
+    if (Object.keys(value).some((key) => !allowed.has(key))) throw error('COMMERCIAL_ASSISTED_WEBHOOK_PAYLOAD_INVALID', 400)
+    assertNoDirectPii(value, 'COMMERCIAL_ASSISTED_WEBHOOK_PAYLOAD_INVALID')
+    const eventId = text(value.eventId)
+    const eventType = text(value.eventType).toLowerCase()
+    const occurredAt = text(value.occurredAt)
+    if (!WEBHOOK_EVENT_RE.test(eventId) || !WEBHOOK_EVENT_TYPES.has(eventType) || !Number.isFinite(Date.parse(occurredAt))) {
+        throw error('COMMERCIAL_ASSISTED_WEBHOOK_PAYLOAD_INVALID', 400)
+    }
+    return { eventId, attemptId: normalizeUuid(value.attemptId, 'COMMERCIAL_ASSISTED_ATTEMPT_INVALID'), eventType, occurredAt: new Date(occurredAt).toISOString() }
+}
+
+export function verifyRawWebhookSignature({ rawBody, timestamp, signature, secret, now = Date.now(), maxAgeMs = 5 * 60_000 } = {}) {
+    const key = text(secret)
+    const ts = text(timestamp)
+    const supplied = text(signature).replace(/^sha256=/i, '')
+    if (Buffer.byteLength(key, 'utf8') < 32 || !Buffer.isBuffer(rawBody) || !ts || !supplied) return false
+    const timestampNumber = Number(ts)
+    if (!Number.isFinite(timestampNumber) || Math.abs(now - timestampNumber) > maxAgeMs) return false
+    const expected = createHmac('sha256', key).update(Buffer.concat([Buffer.from(`${ts}.`, 'utf8'), rawBody])).digest('base64url')
+    try {
+        const left = Buffer.from(supplied)
+        const right = Buffer.from(expected)
+        return left.length === right.length && timingSafeEqual(left, right)
+    } catch {
+        return false
+    }
+}
+
+export const __testables = {
+    ALLOWED_TRANSITIONS,
+    TEMPLATE_PLACEHOLDERS,
+    WEBHOOK_EVENT_TYPES,
+    canonical,
+}

--- a/crm/api/server/atendimento/commercialAssistedCommunication.js
+++ b/crm/api/server/atendimento/commercialAssistedCommunication.js
@@ -1,6 +1,7 @@
 import { createHash, createHmac, timingSafeEqual } from 'node:crypto'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const UUID_IN_TEXT_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi
 const UNIT_RE = /^[a-z0-9][a-z0-9._-]{0,119}$/i
 const IDEMPOTENCY_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{7,159}$/
 const TEMPLATE_KEY_RE = /^[a-z0-9][a-z0-9._-]{1,95}$/
@@ -61,7 +62,8 @@ function normalizedMetadataKey(value) {
 
 function directPiiInText(value) {
     const source = String(value || '')
-    return /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(source) || /(?:\+?\d[\s().-]*){8,}\d/.test(source)
+    const phoneSource = source.replace(UUID_IN_TEXT_RE, ' ')
+    return /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(source) || /(?:\+?\d[\s().-]*){8,}\d/.test(phoneSource)
 }
 
 export function containsDirectPii(value, seen = new WeakSet()) {

--- a/crm/api/server/atendimento/commercialAssistedCommunicationMigration.js
+++ b/crm/api/server/atendimento/commercialAssistedCommunicationMigration.js
@@ -1,0 +1,528 @@
+import {
+    assertAtendimentoMigrationDestination,
+    ATENDIMENTO_MIGRATION_TARGETS,
+    isStrictAtendimentoMigrationDestination,
+} from './migrationDestination.js'
+import { COMMERCIAL_ASSISTED_MIGRATION_ID } from './commercialAssistedCommunication.js'
+
+export { COMMERCIAL_ASSISTED_MIGRATION_ID }
+
+export const COMMERCIAL_ASSISTED_MIGRATION_ACTIONS = Object.freeze(['--apply', '--rollback'])
+
+const RUNTIME_ROLES = Object.freeze({
+    [ATENDIMENTO_MIGRATION_TARGETS.LOCAL]: 'skincos',
+    [ATENDIMENTO_MIGRATION_TARGETS.STAGING]: 'skincos_staging_crm_app',
+})
+
+const PREREQUISITE_RELATIONS = Object.freeze([
+    'crm_atendimento.schema_migrations',
+    'crm_atendimento.units',
+    'crm_atendimento.global_client_identities',
+    'crm_atendimento.global_client_identity_members',
+    'crm_atendimento.commercial_actions',
+    'crm_atendimento.commercial_offers',
+    'crm_atendimento.commercial_offer_procedures',
+    'crm_atendimento.commercial_contact_permissions',
+    'crm_atendimento.commercial_contact_permission_events',
+    'crm_atendimento.commercial_policy_config',
+    'crm_atendimento.commercial_canary_cohorts',
+    'crm_atendimento.commercial_canary_cohort_members',
+    'crm_atendimento.commercial_canary_identity_validations',
+    'crm_atendimento.clientes_source_operation_checkpoints',
+    'harmonia.contacts',
+    'crm_caixa.customers',
+    'crm_caixa.sales',
+    'crm_caixa.sale_items',
+    'crm_atendimento.app_client_registrations',
+    'crm_atendimento.supplemental_lead_profiles',
+    'crm_atendimento.attendance_client_links',
+    'crm_atendimento.attendances',
+    'crm_atendimento.procedures',
+])
+
+function migrationError(code) {
+    const error = new Error(code)
+    error.code = code
+    return error
+}
+
+function createTriggerIfMissing(relation, triggerName, triggerSql) {
+    return `do $$ begin
+        if not exists (select 1 from pg_trigger where tgrelid='${relation}'::regclass and tgname='${triggerName}') then
+            execute $trigger$${triggerSql}$trigger$;
+        end if;
+    end $$`
+}
+
+function runtimeGrantStatements(target) {
+    const role = RUNTIME_ROLES[target]
+    if (!role) throw migrationError('COMMERCIAL_ASSISTED_RUNTIME_ROLE_UNKNOWN')
+    return [
+        `revoke create on schema crm_atendimento from ${role}`,
+        `revoke update, delete, truncate, references, trigger on table crm_atendimento.commercial_assisted_offer_snapshots from ${role}`,
+        `revoke update, delete, truncate, references, trigger on table crm_atendimento.commercial_assisted_templates from ${role}`,
+        `revoke update, delete, truncate, references, trigger on table crm_atendimento.commercial_assisted_attempts from ${role}`,
+        `revoke update, delete, truncate, references, trigger on table crm_atendimento.commercial_assisted_events from ${role}`,
+        `revoke update, delete, truncate, references, trigger on table crm_atendimento.commercial_assisted_webhook_receipts from ${role}`,
+        `revoke update, delete, truncate, references, trigger on table crm_atendimento.commercial_assisted_control_mutations from ${role}`,
+        `revoke delete, truncate, references, trigger on table crm_atendimento.commercial_assisted_handoffs from ${role}`,
+        `revoke delete, truncate, references, trigger on table crm_atendimento.commercial_assisted_emergency_controls from ${role}`,
+        `grant usage on schema crm_atendimento to ${role}`,
+        `grant usage on schema crm_caixa to ${role}`,
+        `grant usage on schema harmonia to ${role}`,
+        `grant select on table crm_atendimento.schema_migrations to ${role}`,
+        `grant select on table crm_atendimento.units to ${role}`,
+        `grant select on table crm_atendimento.global_client_identity_members to ${role}`,
+        `grant select on table crm_atendimento.commercial_actions to ${role}`,
+        `grant select on table crm_atendimento.commercial_offers to ${role}`,
+        `grant select on table crm_atendimento.commercial_offer_procedures to ${role}`,
+        `grant select on table crm_atendimento.procedures to ${role}`,
+        `grant select on table crm_atendimento.attendance_client_links to ${role}`,
+        `grant select on table crm_atendimento.attendances to ${role}`,
+        `grant select on table crm_atendimento.commercial_contact_permissions to ${role}`,
+        `grant insert on table crm_atendimento.commercial_contact_permissions to ${role}`,
+        `grant update(status, evidence_source, evidence_reference, expires_at, recorded_by, revision, updated_at) on table crm_atendimento.commercial_contact_permissions to ${role}`,
+        `grant select, insert on table crm_atendimento.commercial_contact_permission_events to ${role}`,
+        `grant select on table crm_atendimento.commercial_policy_config to ${role}`,
+        `grant select on table crm_atendimento.commercial_canary_cohorts to ${role}`,
+        `grant select on table crm_atendimento.commercial_canary_cohort_members to ${role}`,
+        `grant select on table crm_atendimento.commercial_canary_identity_validations to ${role}`,
+        `grant select on table crm_atendimento.clientes_source_operation_checkpoints to ${role}`,
+        `grant select(phone_keys, unit_slugs, source_client_id) on table crm_atendimento.app_client_registrations to ${role}`,
+        `grant select(phone_keys, unit_slugs, source_profile_id) on table crm_atendimento.supplemental_lead_profiles to ${role}`,
+        `grant select(id, phone_key) on table crm_caixa.customers to ${role}`,
+        `grant select(id, customer_id, unit_id) on table crm_caixa.sales to ${role}`,
+        `grant select(sale_id, procedure_id, mapping_status) on table crm_caixa.sale_items to ${role}`,
+        `grant select(phone_raw, opted_out_at) on table harmonia.contacts to ${role}`,
+        `grant select, insert on table crm_atendimento.commercial_assisted_offer_snapshots to ${role}`,
+        `grant select, insert on table crm_atendimento.commercial_assisted_templates to ${role}`,
+        `grant select, insert on table crm_atendimento.commercial_assisted_attempts to ${role}`,
+        `grant select, insert on table crm_atendimento.commercial_assisted_events to ${role}`,
+        `grant select, insert on table crm_atendimento.commercial_assisted_webhook_receipts to ${role}`,
+        `grant select, insert on table crm_atendimento.commercial_assisted_control_mutations to ${role}`,
+        `grant select, insert, update(state, consumed_at, consumed_by, revoked_at) on table crm_atendimento.commercial_assisted_handoffs to ${role}`,
+        `grant select, insert, update(emergency_off, revision, reason_reference, updated_by, updated_at) on table crm_atendimento.commercial_assisted_emergency_controls to ${role}`,
+        `grant update(assisted_offer_snapshot_id, assisted_offer_context_hash, assisted_offer_revision, assisted_offer_unit_slug, assisted_offer_validity_end, assisted_campaign_id, assisted_offer_actor_ref, assisted_offer_recorded_at) on table crm_atendimento.commercial_actions to ${role}`,
+        `grant usage, select on sequence crm_atendimento.commercial_assisted_events_event_order_seq to ${role}`,
+    ]
+}
+
+const STATEMENTS = Object.freeze([
+    `create extension if not exists pgcrypto`,
+    `do $function$
+        begin
+            if to_regprocedure('crm_atendimento.commercial_assisted_text_is_safe_v2(text)') is null then
+                execute $create$
+                    create function crm_atendimento.commercial_assisted_text_is_safe_v2(value text)
+                    returns boolean language sql immutable strict as $body$
+                        select value !~* '[[:alnum:]._%+-]+@[[:alnum:].-]+[.][[:alpha:]]{2,}'
+                           and value !~ '(^|[^0-9])(?:[+]?[0-9][[:space:]().-]*){8,}[0-9]([^0-9]|$)'
+                    $body$
+                $create$;
+            end if;
+            if to_regprocedure('crm_atendimento.commercial_assisted_json_is_safe_v2(jsonb)') is null then
+                execute $create$
+                    create function crm_atendimento.commercial_assisted_json_is_safe_v2(value jsonb)
+                    returns boolean language plpgsql immutable strict as $body$
+                    declare item_key text; item_value jsonb;
+                    begin
+                        case jsonb_typeof(value)
+                            when 'object' then
+                                for item_key, item_value in select key, value from jsonb_each(value) loop
+                                    if lower(regexp_replace(item_key, '[^a-z0-9]', '', 'g')) = any(array['phone','email','telefone','recipient','rawphone','message','secret','token','cpf']) then
+                                        return false;
+                                    end if;
+                                    if not crm_atendimento.commercial_assisted_json_is_safe_v2(item_value) then return false; end if;
+                                end loop;
+                            when 'array' then
+                                for item_value in select value from jsonb_array_elements(value) loop
+                                    if not crm_atendimento.commercial_assisted_json_is_safe_v2(item_value) then return false; end if;
+                                end loop;
+                            when 'string' then
+                                return crm_atendimento.commercial_assisted_text_is_safe_v2(value #>> '{}');
+                            else return true;
+                        end case;
+                        return true;
+                    end
+                    $body$
+                $create$;
+            end if;
+        end
+    $function$`,
+    `create table if not exists crm_atendimento.commercial_assisted_offer_snapshots (
+        id uuid primary key default gen_random_uuid(),
+        offer_id uuid not null references crm_atendimento.commercial_offers(id) on delete restrict,
+        offer_revision integer not null check (offer_revision >= 1),
+        unit_id uuid not null references crm_atendimento.units(id) on delete restrict,
+        unit_slug text not null references crm_atendimento.units(slug) on delete restrict,
+        validity_start date,
+        validity_end date,
+        context_hash text not null check (context_hash ~ '^[a-f0-9]{64}$'),
+        context jsonb not null,
+        captured_by text not null check (captured_by ~ '^actor:[a-f0-9]{64}$'),
+        captured_at timestamptz not null default now(),
+        unique(offer_id, offer_revision, context_hash),
+        check (validity_end is null or validity_start is null or validity_end >= validity_start),
+        check (not (context ?| array['phone','email','telefone','e-mail','recipient','recipientPhone','rawPhone'])),
+        check (crm_atendimento.commercial_assisted_json_is_safe_v2(context))
+    )`,
+    `create table if not exists crm_atendimento.commercial_assisted_templates (
+        id uuid primary key default gen_random_uuid(),
+        template_key text not null check (template_key ~ '^[a-z0-9][a-z0-9._-]{1,95}$'),
+        revision integer not null check (revision >= 1),
+        unit_id uuid not null references crm_atendimento.units(id) on delete restrict,
+        status text not null check (status in ('draft','approved','disabled')),
+        body_template text not null check (char_length(body_template) between 1 and 2000),
+        valid_from date,
+        valid_until date,
+        approved_by text check (approved_by is null or approved_by ~ '^actor:[a-f0-9]{64}$'),
+        approved_at timestamptz,
+        created_by text not null check (created_by ~ '^actor:[a-f0-9]{64}$'),
+        reason_reference text not null check (reason_reference ~ '^reason:[a-f0-9]{64}$'),
+        idempotency_key text not null check (idempotency_key ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{7,159}$'),
+        request_hash text not null check (request_hash ~ '^[a-f0-9]{64}$'),
+        created_at timestamptz not null default now(),
+        unique(template_key, unit_id, revision),
+        unique(created_by, idempotency_key),
+        check (valid_until is null or valid_from is null or valid_until >= valid_from),
+        check (status <> 'approved' or (approved_by is not null and approved_at is not null)),
+        check (body_template !~* '[[:alnum:]._%+-]+@[[:alnum:].-]+\\.[[:alpha:]]{2,}'),
+        check (crm_atendimento.commercial_assisted_text_is_safe_v2(body_template))
+    )`,
+    `create table if not exists crm_atendimento.commercial_assisted_attempts (
+        id uuid primary key default gen_random_uuid(),
+        actor_reference text not null check (actor_reference ~ '^actor:[a-f0-9]{64}$'),
+        idempotency_key text not null check (idempotency_key ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{7,159}$'),
+        request_hash text not null check (request_hash ~ '^[a-f0-9]{64}$'),
+        identity_id uuid not null references crm_atendimento.global_client_identities(id) on delete restrict,
+        action_id uuid not null references crm_atendimento.commercial_actions(id) on delete restrict,
+        unit_id uuid not null references crm_atendimento.units(id) on delete restrict,
+        offer_snapshot_id uuid not null references crm_atendimento.commercial_assisted_offer_snapshots(id) on delete restrict,
+        template_id uuid not null references crm_atendimento.commercial_assisted_templates(id) on delete restrict,
+        offer_context_hash text not null check (offer_context_hash ~ '^[a-f0-9]{64}$'),
+        template_context_hash text not null check (template_context_hash ~ '^[a-f0-9]{64}$'),
+        preview_context_hash text not null check (preview_context_hash ~ '^[a-f0-9]{64}$'),
+        recipient_phone_hash text not null check (recipient_phone_hash ~ '^[a-f0-9]{64}$'),
+        recipient_masked text not null check (char_length(recipient_masked) between 4 and 80),
+        campaign_id uuid,
+        status text not null default 'confirmed' check (status = 'confirmed'),
+        provider_send boolean not null default false check (provider_send is false),
+        external_dispatch boolean not null default false check (external_dispatch is false),
+        created_at timestamptz not null default now(),
+        unique(actor_reference, idempotency_key),
+        check (recipient_masked !~ '(?:[0-9][^0-9]*){8,}'),
+        check (crm_atendimento.commercial_assisted_text_is_safe_v2(recipient_masked))
+    )`,
+    `create table if not exists crm_atendimento.commercial_assisted_events (
+        id uuid primary key default gen_random_uuid(),
+        event_order bigint generated always as identity,
+        attempt_id uuid references crm_atendimento.commercial_assisted_attempts(id) on delete restrict,
+        event_type text not null check (event_type in ('template_created','template_approved','previewed','confirmed','handoff_issued','destination_revealed','delivered','read','replied','failed','stop','blocked','emergency_off','emergency_rearmed','migration_rollback')),
+        actor_reference text not null check (actor_reference ~ '^(actor|service|migration):[A-Za-z0-9._:-]{1,128}$'),
+        correlation_hash text not null check (correlation_hash ~ '^[a-f0-9]{64}$'),
+        occurred_at timestamptz not null default now(),
+        payload jsonb not null default '{}'::jsonb,
+        created_at timestamptz not null default now(),
+        check (not (payload ?| array['phone','email','telefone','e-mail','name','recipient','rawBody','message','body','secret','token'])),
+        check (crm_atendimento.commercial_assisted_json_is_safe_v2(payload))
+    )`,
+    `create table if not exists crm_atendimento.commercial_assisted_webhook_receipts (
+        event_hash text primary key check (event_hash ~ '^[a-f0-9]{64}$'),
+        attempt_id uuid not null references crm_atendimento.commercial_assisted_attempts(id) on delete restrict,
+        event_type text not null check (event_type in ('delivered','read','replied','failed','stop')),
+        event_payload_hash text not null check (event_payload_hash ~ '^[a-f0-9]{64}$'),
+        received_at timestamptz not null default now()
+    )`,
+    `create table if not exists crm_atendimento.commercial_assisted_handoffs (
+        id uuid primary key default gen_random_uuid(),
+        attempt_id uuid not null references crm_atendimento.commercial_assisted_attempts(id) on delete restrict,
+        actor_reference text not null check (actor_reference ~ '^actor:[a-f0-9]{64}$'),
+        issue_idempotency_key text not null check (issue_idempotency_key ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{7,159}$'),
+        issue_request_hash text not null check (issue_request_hash ~ '^[a-f0-9]{64}$'),
+        token_hash text not null unique check (token_hash ~ '^[a-f0-9]{64}$'),
+        state text not null default 'issued' check (state in ('issued','revealed','revoked')),
+        expires_at timestamptz not null,
+        consumed_at timestamptz,
+        consumed_by text check (consumed_by is null or consumed_by ~ '^actor:[a-f0-9]{64}$'),
+        revoked_at timestamptz,
+        created_at timestamptz not null default now(),
+        unique(actor_reference, issue_idempotency_key)
+    )`,
+    `create table if not exists crm_atendimento.commercial_assisted_emergency_controls (
+        scope_key text primary key check (scope_key = 'global' or scope_key ~ '^unit:[a-z0-9][a-z0-9._-]{0,119}$'),
+        unit_slug text references crm_atendimento.units(slug) on delete restrict,
+        emergency_off boolean not null default false,
+        revision integer not null default 1 check (revision >= 1),
+        reason_reference text not null check (reason_reference ~ '^reason:[a-f0-9]{64}$'),
+        updated_by text not null check (updated_by ~ '^(actor|migration):[A-Za-z0-9._:-]{1,128}$'),
+        updated_at timestamptz not null default now(),
+        check ((scope_key='global' and unit_slug is null) or (scope_key=('unit:' || unit_slug) and unit_slug is not null))
+    )`,
+    `create table if not exists crm_atendimento.commercial_assisted_control_mutations (
+        id uuid primary key default gen_random_uuid(),
+        scope_key text not null references crm_atendimento.commercial_assisted_emergency_controls(scope_key) on delete restrict,
+        actor_reference text not null check (actor_reference ~ '^actor:[a-f0-9]{64}$'),
+        idempotency_key text not null check (idempotency_key ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{7,159}$'),
+        request_hash text not null check (request_hash ~ '^[a-f0-9]{64}$'),
+        resulting_revision integer not null check (resulting_revision >= 1),
+        emergency_off boolean not null,
+        created_at timestamptz not null default now(),
+        unique(actor_reference, idempotency_key)
+    )`,
+    `insert into crm_atendimento.commercial_assisted_emergency_controls(scope_key, unit_slug, emergency_off, reason_reference, updated_by)
+        values ('global', null, false, 'reason:0000000000000000000000000000000000000000000000000000000000000000', 'migration:commercial-assisted-v2')
+        on conflict(scope_key) do nothing`,
+    `alter table crm_atendimento.commercial_actions add column if not exists assisted_offer_snapshot_id uuid references crm_atendimento.commercial_assisted_offer_snapshots(id) on delete restrict`,
+    `alter table crm_atendimento.commercial_actions add column if not exists assisted_offer_context_hash text`,
+    `alter table crm_atendimento.commercial_actions add column if not exists assisted_offer_revision integer`,
+    `alter table crm_atendimento.commercial_actions add column if not exists assisted_offer_unit_slug text`,
+    `alter table crm_atendimento.commercial_actions add column if not exists assisted_offer_validity_end date`,
+    `alter table crm_atendimento.commercial_actions add column if not exists assisted_campaign_id uuid`,
+    `alter table crm_atendimento.commercial_actions add column if not exists assisted_offer_actor_ref text`,
+    `alter table crm_atendimento.commercial_actions add column if not exists assisted_offer_recorded_at timestamptz`,
+    `create unique index if not exists commercial_assisted_attempt_action_idx
+        on crm_atendimento.commercial_assisted_attempts(action_id)`,
+    `create index if not exists commercial_assisted_templates_lookup_idx
+        on crm_atendimento.commercial_assisted_templates(unit_id, template_key, revision desc)`,
+    `create index if not exists commercial_assisted_events_attempt_idx
+        on crm_atendimento.commercial_assisted_events(attempt_id, event_order desc)`,
+    `create index if not exists commercial_assisted_control_mutations_scope_idx
+        on crm_atendimento.commercial_assisted_control_mutations(scope_key, created_at desc)`,
+    `create index if not exists commercial_assisted_handoffs_attempt_idx
+        on crm_atendimento.commercial_assisted_handoffs(attempt_id, actor_reference, expires_at desc)`,
+    `do $function$
+        begin
+            if to_regprocedure('crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()') is null then
+                execute $create$
+                    create function crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()
+                    returns trigger language plpgsql as $body$
+                    begin
+                        raise exception 'commercial assisted evidence is append-only';
+                    end
+                    $body$
+                $create$;
+            end if;
+        end
+    $function$`,
+    `do $function$
+        begin
+            if to_regprocedure('crm_atendimento.enforce_commercial_assisted_action_context_v2()') is null then
+                execute $create$
+                    create function crm_atendimento.enforce_commercial_assisted_action_context_v2()
+                    returns trigger language plpgsql as $body$
+                    declare snapshot record;
+                    begin
+                        if old.assisted_offer_snapshot_id is not null then
+                            if new.assisted_offer_snapshot_id is distinct from old.assisted_offer_snapshot_id
+                                or new.assisted_offer_context_hash is distinct from old.assisted_offer_context_hash
+                                or new.assisted_offer_revision is distinct from old.assisted_offer_revision
+                                or new.assisted_offer_unit_slug is distinct from old.assisted_offer_unit_slug
+                                or new.assisted_offer_validity_end is distinct from old.assisted_offer_validity_end
+                                or new.assisted_campaign_id is distinct from old.assisted_campaign_id
+                                or new.assisted_offer_actor_ref is distinct from old.assisted_offer_actor_ref
+                                or new.assisted_offer_recorded_at is distinct from old.assisted_offer_recorded_at then
+                                raise exception 'commercial assisted action context is immutable';
+                            end if;
+                        elsif new.assisted_offer_snapshot_id is not null then
+                            if new.assisted_offer_context_hash is null or new.assisted_offer_revision is null
+                                or new.assisted_offer_unit_slug is null or new.assisted_offer_actor_ref !~ '^actor:[a-f0-9]{64}$'
+                                or new.assisted_offer_recorded_at is null then
+                                raise exception 'commercial assisted action context is incomplete';
+                            end if;
+                            select context_hash, offer_revision, unit_slug, validity_end into snapshot
+                              from crm_atendimento.commercial_assisted_offer_snapshots where id=new.assisted_offer_snapshot_id;
+                            if not found or new.assisted_offer_context_hash is distinct from snapshot.context_hash
+                                or new.assisted_offer_revision is distinct from snapshot.offer_revision
+                                or new.assisted_offer_unit_slug is distinct from snapshot.unit_slug
+                                or new.assisted_offer_validity_end is distinct from snapshot.validity_end then
+                                raise exception 'commercial assisted action snapshot mismatch';
+                            end if;
+                        elsif new.assisted_offer_context_hash is not null or new.assisted_offer_revision is not null
+                            or new.assisted_offer_unit_slug is not null or new.assisted_offer_validity_end is not null
+                            or new.assisted_campaign_id is not null or new.assisted_offer_actor_ref is not null
+                            or new.assisted_offer_recorded_at is not null then
+                            raise exception 'commercial assisted action context requires a snapshot';
+                        end if;
+                        return new;
+                    end
+                    $body$
+                $create$;
+            end if;
+        end
+    $function$`,
+    createTriggerIfMissing('crm_atendimento.commercial_assisted_offer_snapshots', 'commercial_assisted_offer_snapshots_immutable', `create trigger commercial_assisted_offer_snapshots_immutable before update or delete on crm_atendimento.commercial_assisted_offer_snapshots for each row execute function crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()`),
+    createTriggerIfMissing('crm_atendimento.commercial_assisted_offer_snapshots', 'commercial_assisted_offer_snapshots_no_truncate', `create trigger commercial_assisted_offer_snapshots_no_truncate before truncate on crm_atendimento.commercial_assisted_offer_snapshots for each statement execute function crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()`),
+    createTriggerIfMissing('crm_atendimento.commercial_assisted_templates', 'commercial_assisted_templates_immutable', `create trigger commercial_assisted_templates_immutable before update or delete on crm_atendimento.commercial_assisted_templates for each row execute function crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()`),
+    createTriggerIfMissing('crm_atendimento.commercial_assisted_templates', 'commercial_assisted_templates_no_truncate', `create trigger commercial_assisted_templates_no_truncate before truncate on crm_atendimento.commercial_assisted_templates for each statement execute function crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()`),
+    createTriggerIfMissing('crm_atendimento.commercial_assisted_attempts', 'commercial_assisted_attempts_immutable', `create trigger commercial_assisted_attempts_immutable before update or delete on crm_atendimento.commercial_assisted_attempts for each row execute function crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()`),
+    createTriggerIfMissing('crm_atendimento.commercial_assisted_attempts', 'commercial_assisted_attempts_no_truncate', `create trigger commercial_assisted_attempts_no_truncate before truncate on crm_atendimento.commercial_assisted_attempts for each statement execute function crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()`),
+    createTriggerIfMissing('crm_atendimento.commercial_assisted_events', 'commercial_assisted_events_immutable', `create trigger commercial_assisted_events_immutable before update or delete on crm_atendimento.commercial_assisted_events for each row execute function crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()`),
+    createTriggerIfMissing('crm_atendimento.commercial_assisted_events', 'commercial_assisted_events_no_truncate', `create trigger commercial_assisted_events_no_truncate before truncate on crm_atendimento.commercial_assisted_events for each statement execute function crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()`),
+    createTriggerIfMissing('crm_atendimento.commercial_assisted_webhook_receipts', 'commercial_assisted_webhook_receipts_immutable', `create trigger commercial_assisted_webhook_receipts_immutable before update or delete on crm_atendimento.commercial_assisted_webhook_receipts for each row execute function crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()`),
+    createTriggerIfMissing('crm_atendimento.commercial_assisted_webhook_receipts', 'commercial_assisted_webhook_receipts_no_truncate', `create trigger commercial_assisted_webhook_receipts_no_truncate before truncate on crm_atendimento.commercial_assisted_webhook_receipts for each statement execute function crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()`),
+    createTriggerIfMissing('crm_atendimento.commercial_assisted_control_mutations', 'commercial_assisted_control_mutations_immutable', `create trigger commercial_assisted_control_mutations_immutable before update or delete on crm_atendimento.commercial_assisted_control_mutations for each row execute function crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()`),
+    createTriggerIfMissing('crm_atendimento.commercial_assisted_control_mutations', 'commercial_assisted_control_mutations_no_truncate', `create trigger commercial_assisted_control_mutations_no_truncate before truncate on crm_atendimento.commercial_assisted_control_mutations for each statement execute function crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()`),
+    createTriggerIfMissing('crm_atendimento.commercial_actions', 'commercial_assisted_action_context_immutable', `create trigger commercial_assisted_action_context_immutable before update on crm_atendimento.commercial_actions for each row execute function crm_atendimento.enforce_commercial_assisted_action_context_v2()`),
+])
+
+function triggerReadinessStatement() {
+    const entries = [
+        ['commercial_assisted_offer_snapshots', 'commercial_assisted_offer_snapshots_immutable', 'commercial_assisted_offer_snapshots_no_truncate'],
+        ['commercial_assisted_templates', 'commercial_assisted_templates_immutable', 'commercial_assisted_templates_no_truncate'],
+        ['commercial_assisted_attempts', 'commercial_assisted_attempts_immutable', 'commercial_assisted_attempts_no_truncate'],
+        ['commercial_assisted_events', 'commercial_assisted_events_immutable', 'commercial_assisted_events_no_truncate'],
+        ['commercial_assisted_webhook_receipts', 'commercial_assisted_webhook_receipts_immutable', 'commercial_assisted_webhook_receipts_no_truncate'],
+        ['commercial_assisted_control_mutations', 'commercial_assisted_control_mutations_immutable', 'commercial_assisted_control_mutations_no_truncate'],
+    ]
+    const fields = entries.flatMap(([table, immutable, noTruncate], index) => [
+        `exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.${table}') and tgname='${immutable}' and tgenabled='O' and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()')) as immutable_${index}`,
+        `exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.${table}') and tgname='${noTruncate}' and tgenabled='O' and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()')) as no_truncate_${index}`,
+    ])
+    fields.push(`exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_actions') and tgname='commercial_assisted_action_context_immutable' and tgenabled='O' and tgfoid=to_regprocedure('crm_atendimento.enforce_commercial_assisted_action_context_v2()')) as action_context_guard`)
+    return `select ${fields.join(', ')}`
+}
+
+async function ensureRegistry(client) {
+    await client.query(`create schema if not exists crm_atendimento`)
+    await client.query(`create table if not exists crm_atendimento.schema_migrations (
+        id text primary key, applied_at timestamptz not null default now(), rolled_back_at timestamptz,
+        details jsonb not null default '{}'::jsonb
+    )`)
+}
+
+async function assertPrerequisites(client) {
+    const fields = PREREQUISITE_RELATIONS.map((relation, index) => `to_regclass('${relation}') is not null as relation_${index}`).join(', ')
+    const result = await client.query(`select ${fields}`)
+    if (!Object.values(result.rows[0] || {}).every(Boolean)) throw migrationError('COMMERCIAL_ASSISTED_MIGRATION_PREREQUISITES_MISSING')
+}
+
+async function assertDestination(client, databaseUrl, target) {
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw migrationError('COMMERCIAL_ASSISTED_MIGRATION_DESTINATION_UNSAFE')
+    try {
+        return await assertAtendimentoMigrationDestination(client, databaseUrl, target)
+    } catch {
+        throw migrationError('COMMERCIAL_ASSISTED_MIGRATION_DESTINATION_UNSAFE')
+    }
+}
+
+async function assertAppendOnly(client) {
+    const result = await client.query(triggerReadinessStatement())
+    if (!Object.values(result.rows[0] || {}).every(Boolean)) throw migrationError('COMMERCIAL_ASSISTED_APPEND_ONLY_GUARD_MISSING')
+}
+
+export function parseCommercialAssistedMigrationAction(args = []) {
+    const values = Array.isArray(args) ? args.map((value) => String(value)) : []
+    if (values.length !== 1 || !COMMERCIAL_ASSISTED_MIGRATION_ACTIONS.includes(values[0])) {
+        throw migrationError('COMMERCIAL_ASSISTED_MIGRATION_ACTION_INVALID')
+    }
+    return values[0] === '--apply' ? 'apply' : 'rollback'
+}
+
+export function commercialAssistedMigrationPlan() {
+    return {
+        id: COMMERCIAL_ASSISTED_MIGRATION_ID,
+        adds: [
+            'commercial_assisted_offer_snapshots',
+            'commercial_assisted_templates',
+            'commercial_assisted_attempts',
+            'commercial_assisted_events',
+            'commercial_assisted_webhook_receipts',
+            'commercial_assisted_control_mutations',
+            'commercial_assisted_handoffs',
+            'commercial_assisted_emergency_controls',
+            'commercial_actions.assisted_offer_snapshot_id',
+        ],
+        actionContextGuard: 'commercial_actions assisted offer context is immutable and replay-identical to its snapshot',
+        appendOnlyTables: [
+            'commercial_assisted_offer_snapshots',
+            'commercial_assisted_templates',
+            'commercial_assisted_attempts',
+            'commercial_assisted_events',
+            'commercial_assisted_webhook_receipts',
+            'commercial_assisted_control_mutations',
+        ],
+        outbound: { providerSend: false, automationEnabled: false, externalDispatch: false },
+        privacy: 'Only hashes, masked destination presentations and opaque actor references are retained. Raw provider payloads, phone numbers and provider secrets are never persisted.',
+        rollback: 'Non-destructive: evidence remains, all assisted emergency controls are closed, and the migration registry is marked rolled back.',
+    }
+}
+
+export async function applyCommercialAssistedMigration({ pool, databaseUrl, target = ATENDIMENTO_MIGRATION_TARGETS.LOCAL } = {}) {
+    if (!pool) throw migrationError('COMMERCIAL_ASSISTED_POOL_REQUIRED')
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw migrationError('COMMERCIAL_ASSISTED_MIGRATION_DESTINATION_UNSAFE')
+    const client = await pool.connect()
+    let transactionOpen = false
+    try {
+        await client.query('begin')
+        transactionOpen = true
+        await client.query(`set local lock_timeout = '3s'`)
+        await client.query(`set local statement_timeout = '60s'`)
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [COMMERCIAL_ASSISTED_MIGRATION_ID])
+        const destination = await assertDestination(client, databaseUrl, target)
+        await ensureRegistry(client)
+        await assertPrerequisites(client)
+        for (const statement of STATEMENTS) await client.query(statement)
+        await assertAppendOnly(client)
+        const grants = runtimeGrantStatements(target)
+        for (const statement of grants) await client.query(statement)
+        const report = {
+            ...commercialAssistedMigrationPlan(),
+            applied: true,
+            target,
+            database: destination.database,
+            runtimeRole: RUNTIME_ROLES[target],
+            runtimeGrants: grants,
+        }
+        await client.query(`insert into crm_atendimento.schema_migrations(id, applied_at, rolled_back_at, details)
+            values ($1, now(), null, $2::jsonb)
+            on conflict(id) do update set applied_at=excluded.applied_at, rolled_back_at=null, details=excluded.details`, [
+            COMMERCIAL_ASSISTED_MIGRATION_ID,
+            JSON.stringify(report),
+        ])
+        await client.query('commit')
+        transactionOpen = false
+        return report
+    } catch (error) {
+        if (transactionOpen) {
+            try { await client.query('rollback') } catch { /* preserve the original guarded failure */ }
+        }
+        throw error
+    } finally {
+        client.release()
+    }
+}
+
+export async function rollbackCommercialAssistedMigration({ pool, databaseUrl, target = ATENDIMENTO_MIGRATION_TARGETS.LOCAL } = {}) {
+    if (!pool) throw migrationError('COMMERCIAL_ASSISTED_POOL_REQUIRED')
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) throw migrationError('COMMERCIAL_ASSISTED_MIGRATION_DESTINATION_UNSAFE')
+    const client = await pool.connect()
+    let transactionOpen = false
+    try {
+        await client.query('begin')
+        transactionOpen = true
+        await client.query(`set local lock_timeout = '3s'`)
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [COMMERCIAL_ASSISTED_MIGRATION_ID])
+        await assertDestination(client, databaseUrl, target)
+        await ensureRegistry(client)
+        await client.query(`update crm_atendimento.commercial_assisted_emergency_controls
+            set emergency_off=true, revision=revision+1, reason_reference='reason:0000000000000000000000000000000000000000000000000000000000000000',
+                updated_by='migration:commercial-assisted-v2', updated_at=now()`)
+        await client.query(`insert into crm_atendimento.commercial_assisted_events(attempt_id,event_type,actor_reference,correlation_hash,payload)
+            values (null,'migration_rollback','migration:commercial-assisted-v2','0000000000000000000000000000000000000000000000000000000000000000','{"providerSend":false,"externalDispatch":false}'::jsonb)`)
+        await client.query(`insert into crm_atendimento.schema_migrations(id, applied_at, rolled_back_at, details)
+            values ($1, now(), now(), '{"rollback":"non-destructive","evidenceRetained":true,"providerSend":false}'::jsonb)
+            on conflict(id) do update set rolled_back_at=now(), details=excluded.details`, [COMMERCIAL_ASSISTED_MIGRATION_ID])
+        await client.query('commit')
+        transactionOpen = false
+        return { id: COMMERCIAL_ASSISTED_MIGRATION_ID, rolledBack: true, destructive: false, evidenceRetained: true, providerSend: false }
+    } catch (error) {
+        if (transactionOpen) {
+            try { await client.query('rollback') } catch { /* preserve the original guarded failure */ }
+        }
+        throw error
+    } finally {
+        client.release()
+    }
+}
+
+export const __testables = { PREREQUISITE_RELATIONS, STATEMENTS, runtimeGrantStatements, triggerReadinessStatement }

--- a/crm/api/server/atendimento/commercialAssistedCommunicationStore.js
+++ b/crm/api/server/atendimento/commercialAssistedCommunicationStore.js
@@ -1,0 +1,1098 @@
+import { createHash, randomBytes, randomUUID } from 'node:crypto'
+
+import { createPgPool, withPgTransaction } from '../harmonia/store/pg.js'
+import { lockContactPhone } from '../contactPhoneLock.js'
+import { requiredClientesSources } from '../clientes/sourceCatalog.js'
+import { CLIENTES_SOURCE_OPERATIONS_MIGRATION_ID } from '../clientes/sourceOperationsMigration.js'
+import { IDENTITY_GRAPH_LOCK_KEY } from './identityReviewWorkflow.js'
+import { COMMERCIAL_CANARY_LOCK_KEY, COMMERCIAL_CANARY_MIGRATION_ID } from './commercialCanaryMigration.js'
+import {
+    COMMERCIAL_ASSISTED_MIGRATION_ID,
+    COMMERCIAL_ASSISTED_SAFETY_FLAGS,
+    assertNoDirectPii,
+    actorReference,
+    assistedHmac,
+    assistedHmacPurpose,
+    canAdvanceAssistedState,
+    confirmationRequired,
+    maskPhone,
+    normalizeIdempotencyKey,
+    normalizeReason,
+    normalizeTemplatePayload,
+    normalizeUnit,
+    normalizeUuid,
+    normalizeWebhookPayload,
+    offerContext,
+    previewContextHash,
+    renderMaskedPreview,
+    verifyRawWebhookSignature,
+    revealConfirmationRequired,
+    templateContext,
+} from './commercialAssistedCommunication.js'
+
+const REQUIRED_SOURCE_IDS = Object.freeze(requiredClientesSources().map((source) => source.id).sort())
+const SOURCE_OPERATION_LOCK_NAMESPACE = 'crm_atendimento.clientes_source_operations'
+const PHONE_RE = /^\d{8,20}$/
+const REARM_CONFIRMATION = 'REARMAR_CONTATO_ASSISTIDO'
+
+function assistedError(code, statusCode = 409) {
+    const error = new Error(code)
+    error.code = code
+    error.statusCode = statusCode
+    return error
+}
+
+function text(value) {
+    return String(value ?? '').trim()
+}
+
+function bool(value) {
+    return value === true
+}
+
+function requirePool(pool) {
+    if (!pool) throw assistedError('DATABASE_URL_not_configured', 503)
+}
+
+function hmacKey(configured) {
+    const secret = text(configured || process.env.COMMERCIAL_ASSISTED_HMAC_KEY)
+    if (Buffer.byteLength(secret, 'utf8') < 32) throw assistedError('COMMERCIAL_ASSISTED_HMAC_KEY_REQUIRED', 503)
+    return secret
+}
+
+function assertCommercialManager(actor) {
+    const subject = text(actor?.actorSubject)
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:/|-]{0,159}$/.test(subject)) throw assistedError('ACTOR_IDENTITY_REQUIRED', 401)
+    const role = text(actor?.role).toUpperCase()
+    if (role === 'GESTOR' || role === 'ADMIN' || actor?.isGlobalAdmin === true) return
+    throw assistedError('FORBIDDEN', 403)
+}
+
+function unitScope(actor) {
+    if (actor?.isGlobalAdmin === true || text(actor?.role).toUpperCase() === 'ADMIN') return null
+    if (!Array.isArray(actor?.allowedUnits)) return []
+    return [...new Set(actor.allowedUnits.map((unit) => text(unit).toLowerCase()).filter((unit) => /^[a-z0-9][a-z0-9._-]{0,119}$/.test(unit)))].sort()
+}
+
+function assertUnitScope(actor, unit) {
+    const normalized = normalizeUnit(unit)
+    const scope = unitScope(actor)
+    if (scope !== null && (!scope.length || !scope.includes(normalized))) throw assistedError('COMMERCIAL_UNIT_FORBIDDEN', 403)
+    return normalized
+}
+
+function assertGlobalScope(actor) {
+    if (unitScope(actor) !== null) throw assistedError('COMMERCIAL_GLOBAL_SCOPE_REQUIRED', 403)
+}
+
+function actorRef(secret, actor) {
+    try {
+        return actorReference(secret, actor)
+    } catch (error) {
+        throw assistedError(error?.code || 'ACTOR_IDENTITY_REQUIRED', error?.statusCode || 401)
+    }
+}
+
+function reasonReference(secret, reason) {
+    return `reason:${assistedHmac(secret, assistedHmacPurpose('reason-v1'), { reason })}`
+}
+
+function phoneHash(secret, phone) {
+    return assistedHmac(secret, assistedHmacPurpose('phone-v1'), { phone: String(phone).replace(/\D/g, '') })
+}
+
+function requestHash(secret, operation, actorReferenceValue, payload) {
+    return assistedHmac(secret, assistedHmacPurpose('request-v1'), { operation, actorReference: actorReferenceValue, payload })
+}
+
+function correlationHash(secret, operation, payload) {
+    return assistedHmac(secret, assistedHmacPurpose('correlation-v1'), { operation, payload })
+}
+
+function publicSafety() {
+    return { ...COMMERCIAL_ASSISTED_SAFETY_FLAGS }
+}
+
+function mapAttempt(row = {}) {
+    return {
+        attemptId: text(row.id),
+        actionId: text(row.action_id),
+        status: text(row.status || 'confirmed'),
+        recipientMasked: text(row.recipient_masked),
+        createdAt: row.created_at || null,
+        providerSend: false,
+        externalDispatch: false,
+        safety: publicSafety(),
+    }
+}
+
+function mapTemplate(row = {}) {
+    return {
+        templateId: text(row.id),
+        templateKey: text(row.template_key),
+        revision: Number(row.revision || 0),
+        unit: text(row.unit_slug),
+        status: text(row.status),
+        bodyTemplate: text(row.body_template),
+        validFrom: row.valid_from ? String(row.valid_from).slice(0, 10) : null,
+        validUntil: row.valid_until ? String(row.valid_until).slice(0, 10) : null,
+        approvedAt: row.approved_at || null,
+    }
+}
+
+function statusFromEvent(eventType) {
+    if (eventType === 'destination_revealed') return 'handed_off'
+    return text(eventType || 'confirmed')
+}
+
+async function appendEvent(client, { attemptId = null, eventType, actorReference: eventActor, correlation, payload = {}, occurredAt = null }) {
+    assertNoDirectPii(payload, 'COMMERCIAL_ASSISTED_EVENT_PII_REJECTED')
+    await client.query(`insert into crm_atendimento.commercial_assisted_events(
+        attempt_id,event_type,actor_reference,correlation_hash,occurred_at,payload)
+        values ($1::uuid,$2,$3,$4,$5::timestamptz,$6::jsonb)`, [
+        attemptId || null,
+        eventType,
+        eventActor,
+        correlation,
+        occurredAt || new Date().toISOString(),
+        JSON.stringify(payload),
+    ])
+}
+
+const ASSISTED_APPEND_ONLY_TABLES = Object.freeze([
+    ['commercial_assisted_offer_snapshots', 'snapshots'],
+    ['commercial_assisted_templates', 'templates'],
+    ['commercial_assisted_attempts', 'attempts'],
+    ['commercial_assisted_events', 'events'],
+    ['commercial_assisted_webhook_receipts', 'receipts'],
+    ['commercial_assisted_control_mutations', 'controls'],
+])
+
+function assistedIntegrityReadinessStatement() {
+    const checks = ASSISTED_APPEND_ONLY_TABLES.flatMap(([table, key]) => [
+        `exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.${table}') and tgname='commercial_assisted_${table.slice('commercial_assisted_'.length)}_immutable' and tgenabled='O' and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()')) as ${key}_immutable`,
+        `exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.${table}') and tgname='commercial_assisted_${table.slice('commercial_assisted_'.length)}_no_truncate' and tgenabled='O' and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()')) as ${key}_no_truncate`,
+    ])
+    checks.push(`exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_actions') and tgname='commercial_assisted_action_context_immutable' and tgenabled='O' and tgfoid=to_regprocedure('crm_atendimento.enforce_commercial_assisted_action_context_v2()')) as action_context_guard`)
+    return `select ${checks.join(', ')}`
+}
+
+export async function commercialAssistedReadiness(db) {
+    const result = await db.query(`select
+        to_regclass('crm_atendimento.commercial_assisted_offer_snapshots') is not null as offer_snapshots,
+        to_regclass('crm_atendimento.commercial_assisted_templates') is not null as templates,
+        to_regclass('crm_atendimento.commercial_assisted_attempts') is not null as attempts,
+        to_regclass('crm_atendimento.commercial_assisted_events') is not null as events,
+        to_regclass('crm_atendimento.commercial_assisted_webhook_receipts') is not null as webhook_receipts,
+        to_regclass('crm_atendimento.commercial_assisted_control_mutations') is not null as control_mutations,
+        to_regclass('crm_atendimento.commercial_assisted_handoffs') is not null as handoffs,
+        to_regclass('crm_atendimento.commercial_assisted_emergency_controls') is not null as emergency_controls,
+        to_regclass('crm_atendimento.schema_migrations') is not null as registry,
+        coalesce(has_table_privilege(current_user,to_regclass('crm_atendimento.commercial_contact_permissions'),'SELECT'),false) as permissions_read,
+        coalesce(has_table_privilege(current_user,to_regclass('crm_atendimento.clientes_source_operation_checkpoints'),'SELECT'),false) as sources_read,
+        coalesce(has_table_privilege(current_user,to_regclass('harmonia.contacts'),'SELECT'),false) as harmonia_read,
+        coalesce(has_table_privilege(current_user,to_regclass('crm_atendimento.commercial_actions'),'SELECT'),false) as actions_read,
+        coalesce(has_table_privilege(current_user,to_regclass('crm_atendimento.commercial_offers'),'SELECT'),false) as offers_read,
+        (coalesce(has_table_privilege(current_user,to_regclass('crm_atendimento.commercial_canary_cohorts'),'SELECT'),false)
+            and coalesce(has_table_privilege(current_user,to_regclass('crm_atendimento.commercial_canary_cohort_members'),'SELECT'),false)
+            and coalesce(has_table_privilege(current_user,to_regclass('crm_atendimento.commercial_canary_identity_validations'),'SELECT'),false)) as canary_read,
+        coalesce(has_table_privilege(current_user,to_regclass('crm_atendimento.global_client_identity_members'),'SELECT'),false) as identity_members_read,
+        (coalesce(has_table_privilege(current_user,to_regclass('crm_atendimento.commercial_offer_procedures'),'SELECT'),false)
+            and coalesce(has_table_privilege(current_user,to_regclass('crm_atendimento.procedures'),'SELECT'),false)
+            and coalesce(has_table_privilege(current_user,to_regclass('crm_atendimento.attendance_client_links'),'SELECT'),false)
+            and coalesce(has_table_privilege(current_user,to_regclass('crm_atendimento.attendances'),'SELECT'),false)
+            and coalesce(has_column_privilege(current_user,to_regclass('crm_caixa.sales'),'id','SELECT'),false)
+            and coalesce(has_column_privilege(current_user,to_regclass('crm_caixa.sales'),'customer_id','SELECT'),false)
+            and coalesce(has_column_privilege(current_user,to_regclass('crm_caixa.sales'),'unit_id','SELECT'),false)
+            and coalesce(has_column_privilege(current_user,to_regclass('crm_caixa.sale_items'),'sale_id','SELECT'),false)
+            and coalesce(has_column_privilege(current_user,to_regclass('crm_caixa.sale_items'),'procedure_id','SELECT'),false)
+            and coalesce(has_column_privilege(current_user,to_regclass('crm_caixa.sale_items'),'mapping_status','SELECT'),false)) as offer_dependencies_read,
+        (coalesce(has_column_privilege(current_user,to_regclass('crm_caixa.customers'),'phone_key','SELECT'),false)
+            and coalesce(has_column_privilege(current_user,to_regclass('crm_atendimento.app_client_registrations'),'phone_keys','SELECT'),false)
+            and coalesce(has_column_privilege(current_user,to_regclass('crm_atendimento.supplemental_lead_profiles'),'phone_keys','SELECT'),false)
+            and coalesce(has_column_privilege(current_user,to_regclass('harmonia.contacts'),'phone_raw','SELECT'),false)) as phone_sources_read,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_assisted_offer_snapshots')
+            and tgname='commercial_assisted_offer_snapshots_immutable' and tgenabled='O'
+            and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()')) as snapshots_immutable,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_assisted_templates')
+            and tgname='commercial_assisted_templates_immutable' and tgenabled='O'
+            and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()')) as templates_immutable,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_assisted_attempts')
+            and tgname='commercial_assisted_attempts_immutable' and tgenabled='O'
+            and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()')) as attempts_immutable,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_assisted_events')
+            and tgname='commercial_assisted_events_immutable' and tgenabled='O'
+            and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()')) as events_immutable,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_assisted_webhook_receipts')
+            and tgname='commercial_assisted_webhook_receipts_immutable' and tgenabled='O'
+            and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()')) as receipts_immutable,
+        exists(select 1 from pg_trigger where tgrelid=to_regclass('crm_atendimento.commercial_assisted_control_mutations')
+            and tgname='commercial_assisted_control_mutations_immutable' and tgenabled='O'
+            and tgfoid=to_regprocedure('crm_atendimento.prevent_commercial_assisted_evidence_mutation_v2()')) as controls_immutable`)
+    const integrity = await db.query(assistedIntegrityReadinessStatement())
+    const row = { ...(result.rows[0] || {}), ...(integrity.rows[0] || {}) }
+    const relationsReady = ['offer_snapshots', 'templates', 'attempts', 'events', 'webhook_receipts', 'control_mutations', 'handoffs', 'emergency_controls', 'registry']
+        .every((key) => bool(row[key]))
+    const appendOnlyReady = ['snapshots_immutable', 'snapshots_no_truncate', 'templates_immutable', 'templates_no_truncate',
+        'attempts_immutable', 'attempts_no_truncate', 'events_immutable', 'events_no_truncate',
+        'receipts_immutable', 'receipts_no_truncate', 'controls_immutable', 'controls_no_truncate', 'action_context_guard'].every((key) => bool(row[key]))
+    const dependenciesReady = [
+        'permissions_read', 'sources_read', 'harmonia_read', 'actions_read',
+        'offers_read', 'canary_read', 'identity_members_read', 'offer_dependencies_read', 'phone_sources_read',
+    ].every((key) => bool(row[key]))
+    let migrationReady = false
+    let canaryReady = false
+    let sourceOperationsReady = false
+    if (relationsReady) {
+        const migration = await db.query(`select id from crm_atendimento.schema_migrations
+            where id=any($1::text[]) and rolled_back_at is null`, [[COMMERCIAL_ASSISTED_MIGRATION_ID, COMMERCIAL_CANARY_MIGRATION_ID, CLIENTES_SOURCE_OPERATIONS_MIGRATION_ID]])
+        const ids = new Set(migration.rows.map((entry) => String(entry.id)))
+        migrationReady = ids.has(COMMERCIAL_ASSISTED_MIGRATION_ID)
+        canaryReady = ids.has(COMMERCIAL_CANARY_MIGRATION_ID)
+        sourceOperationsReady = ids.has(CLIENTES_SOURCE_OPERATIONS_MIGRATION_ID)
+    }
+    return {
+        ready: relationsReady && appendOnlyReady && dependenciesReady && migrationReady && canaryReady && sourceOperationsReady,
+        migrationId: COMMERCIAL_ASSISTED_MIGRATION_ID,
+        relationsReady,
+        appendOnlyReady,
+        dependenciesReady,
+        migrationReady,
+        canaryReady,
+        sourceOperationsReady,
+        safety: publicSafety(),
+    }
+}
+
+async function assertReady(db) {
+    const readiness = await commercialAssistedReadiness(db)
+    if (!readiness.ready) throw assistedError('COMMERCIAL_ASSISTED_NOT_READY')
+    return readiness
+}
+
+async function lockBoundary(client, identityId) {
+    await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [IDENTITY_GRAPH_LOCK_KEY])
+    await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [COMMERCIAL_CANARY_LOCK_KEY])
+    await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [`commercial-assisted:${identityId}`])
+}
+
+async function readSourceHealth(client) {
+    const result = await client.query(`select source_id,last_status,validated_snapshot_complete,reconciliation_required,validated_at
+        from crm_atendimento.clientes_source_operation_checkpoints
+        where source_id=any($1::text[]) for share`, [REQUIRED_SOURCE_IDS])
+    const rows = result.rows || []
+    const bySource = new Map(rows.map((row) => [String(row.source_id), row]))
+    const complete = REQUIRED_SOURCE_IDS.every((sourceId) => bySource.has(sourceId))
+    const healthy = complete && REQUIRED_SOURCE_IDS.every((sourceId) => {
+        const row = bySource.get(sourceId) || {}
+        const observedAt = row.validated_at ? new Date(row.validated_at).getTime() : 0
+        return row.last_status === 'complete' && row.validated_snapshot_complete === true && row.reconciliation_required !== true &&
+            Number.isFinite(observedAt) && observedAt >= Date.now() - 24 * 60 * 60 * 1000
+    })
+    const snapshotsComplete = complete && REQUIRED_SOURCE_IDS.every((sourceId) => bySource.get(sourceId)?.validated_snapshot_complete === true)
+    return { status: healthy ? 'healthy' : 'stale', snapshotComplete: snapshotsComplete, observedSources: bySource.size }
+}
+
+async function lockAndReadSourceHealth(client) {
+    for (const sourceId of REQUIRED_SOURCE_IDS) {
+        const lock = await client.query(`select pg_try_advisory_xact_lock(hashtext($1),hashtext($2)) as acquired`, [SOURCE_OPERATION_LOCK_NAMESPACE, sourceId])
+        if (lock.rows[0]?.acquired !== true) throw assistedError('COMMERCIAL_ASSISTED_SOURCE_OPERATION_BUSY', 503)
+    }
+    // The proof is read only after every source lock has been acquired.
+    return readSourceHealth(client)
+}
+
+async function readEmergencyControls(client, unit) {
+    const result = await client.query(`select scope_key, emergency_off, revision
+        from crm_atendimento.commercial_assisted_emergency_controls
+        where scope_key=any($1::text[]) for share`, [['global', `unit:${unit}`]])
+    const byScope = new Map(result.rows.map((row) => [String(row.scope_key), row]))
+    const global = byScope.get('global')
+    if (!global) throw assistedError('COMMERCIAL_ASSISTED_EMERGENCY_CONTROL_NOT_READY')
+    const scoped = byScope.get(`unit:${unit}`)
+    if (global.emergency_off === true || scoped?.emergency_off === true) throw assistedError('COMMERCIAL_ASSISTED_EMERGENCY_OFF')
+    return {
+        globalRevision: Number(global.revision || 0),
+        unitRevision: Number(scoped?.revision || 0),
+    }
+}
+
+async function readAction(client, actionId) {
+    // Acquire the graph boundary before the row lock. Identity review and
+    // canary mutation already serialize on this key; doing it in the inverse
+    // order would permit a deadlock between a revalidation and graph change.
+    await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [IDENTITY_GRAPH_LOCK_KEY])
+    const result = await client.query(`select action.id::text as id, action.identity_id::text as identity_id, action.status,
+        unit.id::text as unit_id, unit.slug as unit_slug,
+        action.assisted_offer_snapshot_id::text as assisted_offer_snapshot_id
+        from crm_atendimento.commercial_actions action
+        join crm_atendimento.units unit on unit.id=action.unit_id
+        where action.id=$1::uuid for update of action`, [actionId])
+    const action = result.rows[0]
+    if (!action?.id || !action.unit_id || !action.unit_slug) throw assistedError('COMMERCIAL_ASSISTED_ACTION_NOT_FOUND', 404)
+    if (!['open', 'contacted', 'responded', 'scheduled'].includes(String(action.status))) throw assistedError('COMMERCIAL_ASSISTED_ACTION_NOT_ACTIVE')
+    return action
+}
+
+async function assertCanary(client, identityId, unit, policyVersion) {
+    const result = await client.query(`select validation.validation_type, validation.revision, validation.expires_at,
+            cohort.policy_version, member.source_freshness, member.eligibility_status
+        from crm_atendimento.commercial_canary_cohort_members member
+        join crm_atendimento.commercial_canary_cohorts cohort on cohort.id=member.cohort_id
+        join crm_atendimento.commercial_canary_identity_validations validation
+          on validation.identity_id=member.identity_id and validation.unit_slug=member.unit_slug
+        where member.identity_id=$1::uuid and member.unit_slug=$2 and cohort.status='active'
+        for share of member,cohort,validation`, [identityId, unit])
+    const row = result.rows[0]
+    if (!row || row.policy_version !== policyVersion || row.source_freshness !== 'healthy' || row.eligibility_status !== 'eligible' ||
+        !['synthetic', 'explicit_approved'].includes(String(row.validation_type)) ||
+        (row.expires_at && new Date(row.expires_at).getTime() <= Date.now())) {
+        throw assistedError('COMMERCIAL_ASSISTED_CANARY_REQUIRED')
+    }
+    return { validationType: row.validation_type, validationRevision: Number(row.revision || 0) }
+}
+
+async function readPermission(client, identityId) {
+    const result = await client.query(`select status, expires_at, revision
+        from crm_atendimento.commercial_contact_permissions
+        where identity_id=$1::uuid and channel='whatsapp' for share`, [identityId])
+    const permission = result.rows[0]
+    if (!permission || permission.status !== 'granted') throw assistedError('COMMERCIAL_ASSISTED_PERMISSION_REQUIRED')
+    if (permission.expires_at && new Date(permission.expires_at).getTime() <= Date.now()) {
+        throw assistedError('COMMERCIAL_ASSISTED_PERMISSION_EXPIRED')
+    }
+    return { revision: Number(permission.revision || 0), expiresAt: permission.expires_at || null }
+}
+
+async function correlatedPhones(client, identityId, unit) {
+    const result = await client.query(`with phone_candidates as (
+        select customer.phone_key::text as phone_key
+          from crm_atendimento.global_client_identity_members member
+          join crm_caixa.customers customer on customer.id=member.source_id::uuid
+          join crm_caixa.sales sale on sale.customer_id=customer.id
+          join crm_atendimento.units sale_unit on sale_unit.id=sale.unit_id
+         where member.identity_id=$1::uuid and member.source_type='caixa_customer'
+           and member.source_id ~ '^[0-9a-fA-F-]{36}$' and sale_unit.slug=$2
+        union
+        select phone.phone_key::text as phone_key
+          from crm_atendimento.global_client_identity_members member
+          join crm_atendimento.app_client_registrations app on app.source_client_id=member.source_id
+          cross join lateral jsonb_array_elements_text(coalesce(app.phone_keys,'[]'::jsonb)) phone(phone_key)
+          cross join lateral jsonb_array_elements_text(coalesce(app.unit_slugs,'[]'::jsonb)) scope(unit_slug)
+         where member.identity_id=$1::uuid and member.source_type='app_registration' and scope.unit_slug=$2
+        union
+        select phone.phone_key::text as phone_key
+          from crm_atendimento.global_client_identity_members member
+          join crm_atendimento.supplemental_lead_profiles lead on lead.source_profile_id=member.source_id
+          cross join lateral jsonb_array_elements_text(coalesce(lead.phone_keys,'[]'::jsonb)) phone(phone_key)
+          cross join lateral jsonb_array_elements_text(coalesce(lead.unit_slugs,'[]'::jsonb)) scope(unit_slug)
+         where member.identity_id=$1::uuid and member.source_type='lead_profile' and scope.unit_slug=$2
+    ) select distinct regexp_replace(phone_key,'\\D','','g') as phone_key
+      from phone_candidates where regexp_replace(phone_key,'\\D','','g') ~ '^\\d{8,20}$'`, [identityId, unit])
+    const phones = [...new Set(result.rows.map((row) => text(row.phone_key).replace(/\D/g, '')).filter((phone) => PHONE_RE.test(phone)))].sort()
+    if (phones.length !== 1) throw assistedError('COMMERCIAL_ASSISTED_PHONE_UNCORRELATED')
+    return phones[0]
+}
+
+async function assertNoOptOut(client, phone) {
+    const result = await client.query(`select opted_out_at from harmonia.contacts where phone_raw=$1 for update`, [phone])
+    if (result.rows.some((row) => row.opted_out_at != null)) throw assistedError('COMMERCIAL_ASSISTED_OPT_OUT_RECORDED')
+}
+
+async function assertCooldown(client, { identityId, actionId, days }) {
+    const result = await client.query(`select id from crm_atendimento.commercial_actions
+        where identity_id=$1::uuid and id<>$2::uuid and contacted_at >= now()-($3::int*interval '1 day')
+        order by contacted_at desc limit 1`, [identityId, actionId, days])
+    if (result.rows[0]?.id) throw assistedError('COMMERCIAL_ASSISTED_COOLDOWN_ACTIVE')
+}
+
+async function readPolicy(client) {
+    const result = await client.query(`select commercial_contact_writes_enabled, active_contact_cooldown_days,
+        md5(concat_ws('|',active_contact_cooldown_days::text,return_risk_thresholds::text,commercial_contact_writes_enabled::text,
+            commercial_contact_canary_identity_ids::text,extract(epoch from updated_at)::text)) as policy_version
+        from crm_atendimento.commercial_policy_config where singleton=true for share`)
+    const policy = result.rows[0]
+    if (!policy || policy.commercial_contact_writes_enabled !== true) throw assistedError('COMMERCIAL_CONTACT_ROLLOUT_DISABLED')
+    return { cooldownDays: Number(policy.active_contact_cooldown_days || 30), policyVersion: text(policy.policy_version) }
+}
+
+async function readOffer(client, offerId, unit, identityId) {
+    const offerResult = await client.query(`select offer.*, unit.slug as unit_slug
+        from crm_atendimento.commercial_offers offer
+        join crm_atendimento.units unit on unit.id=offer.unit_id
+        where offer.id=$1::uuid and offer.status='active' and offer.approved_by is not null and offer.approved_at is not null
+          and unit.slug=$2 and (offer.validity_start is null or offer.validity_start<=current_date)
+          and (offer.validity_end is null or offer.validity_end>=current_date)
+        for share of offer`, [offerId, unit])
+    const offer = offerResult.rows[0]
+    if (!offer) throw assistedError('COMMERCIAL_ASSISTED_OFFER_UNAVAILABLE')
+    const procedures = await client.query(`select procedure.id::text as id, procedure.name, offer_procedure.quantity, offer_procedure.quantity_unit
+        from crm_atendimento.commercial_offer_procedures offer_procedure
+        join crm_atendimento.procedures procedure on procedure.id=offer_procedure.procedure_id
+        where offer_procedure.offer_id=$1::uuid order by offer_procedure.display_order,procedure.name for share of offer_procedure,procedure`, [offerId])
+    const compatible = await client.query(`select exists(
+        select 1 from crm_atendimento.commercial_offer_procedures offer_procedure
+        where offer_procedure.offer_id=$1::uuid and (
+            exists(select 1 from crm_atendimento.global_client_identity_members member
+                join crm_atendimento.attendance_client_links client_link on client_link.client_id=member.source_id::uuid
+                join crm_atendimento.attendances attendance on attendance.id=client_link.attendance_id
+                where member.identity_id=$2::uuid and member.source_type='attendance_client'
+                  and attendance.unit_id=$3::uuid and attendance.deleted_at is null
+                  and attendance.procedure_id=offer_procedure.procedure_id)
+            or exists(select 1 from crm_atendimento.global_client_identity_members member
+                join crm_caixa.sales sale on sale.customer_id=member.source_id::uuid
+                join crm_caixa.sale_items item on item.sale_id=sale.id and item.mapping_status='mapped'
+                where member.identity_id=$2::uuid and member.source_type='caixa_customer'
+                  and member.source_id ~ '^[0-9a-fA-F-]{36}$' and sale.unit_id=$3::uuid
+                  and item.procedure_id=offer_procedure.procedure_id)
+        )) as compatible`, [offerId, identityId, offer.unit_id])
+    if (compatible.rows[0]?.compatible !== true) throw assistedError('COMMERCIAL_ASSISTED_OFFER_PROCEDURE_INCOMPATIBLE')
+    return offerContext({ ...offer, procedures: procedures.rows })
+}
+
+async function readTemplate(client, templateId, unit) {
+    const result = await client.query(`select template.*, unit.slug as unit_slug
+        from crm_atendimento.commercial_assisted_templates template
+        join crm_atendimento.units unit on unit.id=template.unit_id
+        where template.id=$1::uuid and unit.slug=$2 and template.status='approved'
+          and (template.valid_from is null or template.valid_from<=current_date)
+          and (template.valid_until is null or template.valid_until>=current_date)
+          and not exists(select 1 from crm_atendimento.commercial_assisted_templates newer
+              where newer.template_key=template.template_key and newer.unit_id=template.unit_id and newer.revision>template.revision)
+        for share of template`, [templateId, unit])
+    if (!result.rows[0]) throw assistedError('COMMERCIAL_ASSISTED_TEMPLATE_UNAVAILABLE')
+    return templateContext(result.rows[0])
+}
+
+async function campaignForAction(client, actionId, identityId, unitId) {
+    const available = await client.query(`select to_regclass('crm_atendimento.commercial_campaign_members') as members`)
+    if (!available.rows[0]?.members) return null
+    const campaign = await client.query(`select campaign_id::text as campaign_id
+        from crm_atendimento.commercial_campaign_members
+        where action_id=$1::uuid and identity_id=$2::uuid and unit_id=$3::uuid
+        order by created_at desc limit 1`, [actionId, identityId, unitId])
+    return campaign.rows[0]?.campaign_id || null
+}
+
+async function buildContext(client, { actionId, offerId, templateId, actor, secret }) {
+    const action = await readAction(client, actionId)
+    assertUnitScope(actor, action.unit_slug)
+    await lockBoundary(client, action.identity_id)
+    const policy = await readPolicy(client)
+    const [canary, permission, sources, emergency] = await Promise.all([
+        assertCanary(client, action.identity_id, action.unit_slug, policy.policyVersion),
+        readPermission(client, action.identity_id),
+        lockAndReadSourceHealth(client),
+        readEmergencyControls(client, action.unit_slug),
+    ])
+    if (sources.status !== 'healthy' || !sources.snapshotComplete) throw assistedError('COMMERCIAL_ASSISTED_SOURCES_STALE')
+    const phone = await correlatedPhones(client, action.identity_id, action.unit_slug)
+    const recipientPhoneHash = phoneHash(secret, phone)
+    await lockContactPhone(client, phone)
+    await assertNoOptOut(client, phone)
+    await assertCooldown(client, { identityId: action.identity_id, actionId: action.id, days: policy.cooldownDays })
+    const [offer, template, campaignId] = await Promise.all([
+        readOffer(client, offerId, action.unit_slug, action.identity_id),
+        readTemplate(client, templateId, action.unit_slug),
+        campaignForAction(client, action.id, action.identity_id, action.unit_id),
+    ])
+    const previewHash = previewContextHash({
+        actionId: action.id,
+        identityId: action.identity_id,
+        unit: action.unit_slug,
+        offerContextHash: offer.contextHash,
+        templateContextHash: template.contextHash,
+        recipientPhoneHash,
+        permissionRevision: permission.revision,
+        sourceFreshness: sources.status,
+        canaryValidation: `${canary.validationType}:${canary.validationRevision}`,
+        policyVersion: policy.policyVersion,
+        emergencyRevision: `${emergency.globalRevision}:${emergency.unitRevision}`,
+    })
+    return {
+        action,
+        policy,
+        canary,
+        permission,
+        sources,
+        emergency,
+        phone,
+        recipientPhoneHash,
+        recipientMasked: maskPhone(phone),
+        offer,
+        template,
+        campaignId,
+        previewHash,
+    }
+}
+
+async function snapshotOffer(client, { offer, action, actorReference: capturedBy }) {
+    await client.query(`insert into crm_atendimento.commercial_assisted_offer_snapshots(
+        offer_id,offer_revision,unit_id,unit_slug,validity_start,validity_end,context_hash,context,captured_by)
+        values ($1::uuid,$2,$3::uuid,$4,$5::date,$6::date,$7,$8::jsonb,$9)
+        on conflict(offer_id,offer_revision,context_hash) do nothing`, [
+        offer.context.offerId,
+        offer.context.revision,
+        action.unit_id,
+        action.unit_slug,
+        offer.context.validityStart,
+        offer.context.validityEnd,
+        offer.contextHash,
+        JSON.stringify(offer.context),
+        capturedBy,
+    ])
+    const result = await client.query(`select id::text as id from crm_atendimento.commercial_assisted_offer_snapshots
+        where offer_id=$1::uuid and offer_revision=$2 and context_hash=$3 for share`, [
+        offer.context.offerId,
+        offer.context.revision,
+        offer.contextHash,
+    ])
+    if (!result.rows[0]?.id) throw assistedError('COMMERCIAL_ASSISTED_OFFER_SNAPSHOT_UNAVAILABLE')
+    return result.rows[0].id
+}
+
+async function persistActionOfferContext(client, { action, snapshotId, offer, campaignId, actorReference: value }) {
+    if (action.assisted_offer_snapshot_id && action.assisted_offer_snapshot_id !== snapshotId) {
+        throw assistedError('COMMERCIAL_ASSISTED_ACTION_CONTEXT_CONFLICT')
+    }
+    await client.query(`update crm_atendimento.commercial_actions set
+        assisted_offer_snapshot_id=coalesce(assisted_offer_snapshot_id,$2::uuid),
+        assisted_offer_context_hash=coalesce(assisted_offer_context_hash,$3),
+        assisted_offer_revision=coalesce(assisted_offer_revision,$4),
+        assisted_offer_unit_slug=coalesce(assisted_offer_unit_slug,$5),
+        assisted_offer_validity_end=coalesce(assisted_offer_validity_end,$6::date),
+        assisted_campaign_id=coalesce(assisted_campaign_id,$7::uuid),
+        assisted_offer_actor_ref=coalesce(assisted_offer_actor_ref,$8),
+        assisted_offer_recorded_at=coalesce(assisted_offer_recorded_at,now())
+        where id=$1::uuid`, [
+        action.id,
+        snapshotId,
+        offer.contextHash,
+        offer.context.revision,
+        action.unit_slug,
+        offer.context.validityEnd,
+        campaignId,
+        value,
+    ])
+}
+
+async function priorAttempt(client, actorReferenceValue, idempotencyKey, hash) {
+    const result = await client.query(`select id,action_id,status,recipient_masked,created_at,request_hash
+        from crm_atendimento.commercial_assisted_attempts
+        where actor_reference=$1 and idempotency_key=$2 for key share`, [actorReferenceValue, idempotencyKey])
+    const row = result.rows[0]
+    if (!row) return null
+    if (row.request_hash !== hash) throw assistedError('COMMERCIAL_ASSISTED_IDEMPOTENCY_CONFLICT')
+    return { ...mapAttempt(row), idempotent: true }
+}
+
+async function currentState(client, attemptId) {
+    const result = await client.query(`select event_type from crm_atendimento.commercial_assisted_events
+        where attempt_id=$1::uuid and event_type in ('confirmed','destination_revealed','delivered','read','replied','failed','stop')
+        order by event_order desc limit 1 for share`, [attemptId])
+    return statusFromEvent(result.rows[0]?.event_type || 'confirmed')
+}
+
+async function setSafetyStop(client, { identityId, actorReference: value, eventHash }) {
+    const prior = await client.query(`select status,revision from crm_atendimento.commercial_contact_permissions
+        where identity_id=$1::uuid and channel='whatsapp' for update`, [identityId])
+    const previous = prior.rows[0] || {}
+    if (String(previous.status || '').toLowerCase() === 'denied') return Number(previous.revision || 0)
+    const persisted = await client.query(`insert into crm_atendimento.commercial_contact_permissions(
+        identity_id,channel,status,evidence_source,evidence_reference,expires_at,recorded_by)
+        values ($1::uuid,'whatsapp','denied','assisted_whatsapp_stop',$2,null,$3)
+        on conflict(identity_id,channel) do update set status='denied', evidence_source=excluded.evidence_source,
+          evidence_reference=excluded.evidence_reference, expires_at=null, recorded_by=excluded.recorded_by,
+          revision=crm_atendimento.commercial_contact_permissions.revision+1, updated_at=now()
+        returning revision`, [identityId, `stop:${eventHash}`, value])
+    await client.query(`insert into crm_atendimento.commercial_contact_permission_events(
+        identity_id,channel,previous_status,status,evidence_source,evidence_reference,expires_at,recorded_by,trace_id)
+        values ($1::uuid,'whatsapp',$2,'denied','assisted_whatsapp_stop',$3,null,$4,$5::uuid)`, [
+        identityId,
+        previous.status || null,
+        `stop:${eventHash}`,
+        value,
+        randomUUID(),
+    ])
+    return Number(persisted.rows[0]?.revision || 0)
+}
+
+export function createCommercialAssistedCommunicationStore({ pool, databaseUrl, auditHmacKey } = {}) {
+    const pgPool = pool || createPgPool(databaseUrl || process.env.DATABASE_URL)
+    const secret = () => hmacKey(auditHmacKey)
+
+    return {
+        async readiness(actor) {
+            requirePool(pgPool)
+            assertCommercialManager(actor)
+            return commercialAssistedReadiness(pgPool)
+        },
+
+        async availableOffers(query = {}, actor) {
+            requirePool(pgPool)
+            assertCommercialManager(actor)
+            await assertReady(pgPool)
+            const actionId = normalizeUuid(query.actionId, 'COMMERCIAL_ASSISTED_ACTION_INVALID')
+            return withPgTransaction(pgPool, async (client) => {
+                const action = await readAction(client, actionId)
+                assertUnitScope(actor, action.unit_slug)
+                const rows = await client.query(`select offer.*, unit.slug as unit_slug
+                    from crm_atendimento.commercial_offers offer
+                    join crm_atendimento.units unit on unit.id=offer.unit_id
+                    where unit.slug=$1 and offer.status='active' and offer.approved_by is not null and offer.approved_at is not null
+                      and (offer.validity_start is null or offer.validity_start<=current_date)
+                      and (offer.validity_end is null or offer.validity_end>=current_date)
+                    order by offer.updated_at desc`, [action.unit_slug])
+                const offers = []
+                for (const row of rows.rows) {
+                    try {
+                        const context = await readOffer(client, row.id, action.unit_slug, action.identity_id)
+                        offers.push({ ...context.context, contextHash: context.contextHash })
+                    } catch (error) {
+                        if (error?.code !== 'COMMERCIAL_ASSISTED_OFFER_PROCEDURE_INCOMPATIBLE') throw error
+                    }
+                }
+                return { actionId: action.id, unit: action.unit_slug, offers, safety: publicSafety() }
+            })
+        },
+
+        async listTemplates(query = {}, actor) {
+            requirePool(pgPool)
+            assertCommercialManager(actor)
+            await assertReady(pgPool)
+            const unit = assertUnitScope(actor, query.unit)
+            const result = await pgPool.query(`select template.*, unit.slug as unit_slug
+                from crm_atendimento.commercial_assisted_templates template
+                join crm_atendimento.units unit on unit.id=template.unit_id
+                where unit.slug=$1 and template.status='approved'
+                  and (template.valid_from is null or template.valid_from<=current_date)
+                  and (template.valid_until is null or template.valid_until>=current_date)
+                  and not exists(select 1 from crm_atendimento.commercial_assisted_templates newer
+                    where newer.template_key=template.template_key and newer.unit_id=template.unit_id and newer.revision>template.revision)
+                order by template.template_key,template.revision desc`, [unit])
+            return { unit, templates: result.rows.map(mapTemplate), safety: publicSafety() }
+        },
+
+        async createTemplate(payload = {}, actor) {
+            requirePool(pgPool)
+            assertCommercialManager(actor)
+            await assertReady(pgPool)
+            const normalized = normalizeTemplatePayload(payload)
+            if (normalized.status === 'approved' && actor?.isGlobalAdmin !== true) {
+                throw assistedError('COMMERCIAL_ASSISTED_TEMPLATE_APPROVAL_FORBIDDEN', 403)
+            }
+            const unit = assertUnitScope(actor, normalized.unit)
+            const key = normalizeIdempotencyKey(payload.idempotencyKey)
+            const keySecret = secret()
+            const value = actorRef(keySecret, actor)
+            const hash = requestHash(keySecret, 'template_create', value, { ...normalized, reason: reasonReference(keySecret, normalized.reason) })
+            return withPgTransaction(pgPool, async (client) => {
+                await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [`commercial-assisted-template:${unit}:${normalized.templateKey}`])
+                const prior = await client.query(`select id,revision,template_key,status,request_hash from crm_atendimento.commercial_assisted_templates
+                    where created_by=$1 and idempotency_key=$2 for key share`, [value, key])
+                if (prior.rows[0]) {
+                    if (prior.rows[0].request_hash !== hash) throw assistedError('COMMERCIAL_ASSISTED_IDEMPOTENCY_CONFLICT')
+                    return { template: { templateId: prior.rows[0].id, templateKey: prior.rows[0].template_key, revision: Number(prior.rows[0].revision), status: prior.rows[0].status }, idempotent: true, safety: publicSafety() }
+                }
+                const unitRow = await client.query(`select id::text as id from crm_atendimento.units where slug=$1 for share`, [unit])
+                if (!unitRow.rows[0]?.id) throw assistedError('COMMERCIAL_ASSISTED_UNIT_NOT_FOUND', 404)
+                const revision = await client.query(`select coalesce(max(revision),0)::int+1 as revision
+                    from crm_atendimento.commercial_assisted_templates where unit_id=$1::uuid and template_key=$2`, [unitRow.rows[0].id, normalized.templateKey])
+                const inserted = await client.query(`insert into crm_atendimento.commercial_assisted_templates(
+                    template_key,revision,unit_id,status,body_template,valid_from,valid_until,approved_by,approved_at,created_by,reason_reference,idempotency_key,request_hash)
+                    values ($1,$2,$3::uuid,$4,$5,$6::date,$7::date,case when $4='approved' then $8 else null end,
+                      case when $4='approved' then now() else null end,$8,$9,$10,$11)
+                    returning id::text as id,revision,status`, [
+                    normalized.templateKey,
+                    Number(revision.rows[0]?.revision || 1),
+                    unitRow.rows[0].id,
+                    normalized.status,
+                    normalized.bodyTemplate,
+                    normalized.validFrom,
+                    normalized.validUntil,
+                    value,
+                    reasonReference(keySecret, normalized.reason),
+                    key,
+                    hash,
+                ])
+                const row = inserted.rows[0]
+                await appendEvent(client, {
+                    eventType: normalized.status === 'approved' ? 'template_approved' : 'template_created',
+                    actorReference: value,
+                    correlation: correlationHash(keySecret, 'template_create', { id: row.id, revision: row.revision }),
+                    payload: { templateKey: normalized.templateKey, revision: Number(row.revision), unit, status: row.status, providerSend: false },
+                })
+                return { template: { templateId: row.id, templateKey: normalized.templateKey, revision: Number(row.revision), status: row.status }, idempotent: false, safety: publicSafety() }
+            })
+        },
+
+        async preview(payload = {}, actor) {
+            requirePool(pgPool)
+            assertCommercialManager(actor)
+            await assertReady(pgPool)
+            const actionId = normalizeUuid(payload.actionId, 'COMMERCIAL_ASSISTED_ACTION_INVALID')
+            const offerId = normalizeUuid(payload.offerId, 'COMMERCIAL_ASSISTED_OFFER_INVALID')
+            const templateId = normalizeUuid(payload.templateId, 'COMMERCIAL_ASSISTED_TEMPLATE_INVALID')
+            const keySecret = secret()
+            const value = actorRef(keySecret, actor)
+            try {
+                return await withPgTransaction(pgPool, async (client) => {
+                    const context = await buildContext(client, { actionId, offerId, templateId, actor, secret: keySecret })
+                    await appendEvent(client, {
+                        eventType: 'previewed',
+                        actorReference: value,
+                        correlation: correlationHash(keySecret, 'preview', { actionId, offerId, templateId, previewHash: context.previewHash }),
+                        payload: { actionId, offerId, templateId, unit: context.action.unit_slug, recipientMasked: context.recipientMasked, providerSend: false },
+                    })
+                    return {
+                        eligible: true,
+                        previewContextHash: context.previewHash,
+                        actionId,
+                        unit: context.action.unit_slug,
+                        recipientMasked: context.recipientMasked,
+                        offer: { ...context.offer.context, contextHash: context.offer.contextHash },
+                        template: { templateId, templateKey: context.template.context.templateKey, revision: context.template.context.revision },
+                        messagePreview: renderMaskedPreview(context.template.context, context.offer.context),
+                        sourceFreshness: context.sources.status,
+                        snapshotComplete: context.sources.snapshotComplete,
+                        permissionExpiresAt: context.permission.expiresAt,
+                        canaryValidation: context.canary.validationType,
+                        safety: publicSafety(),
+                    }
+                })
+            } catch (error) {
+                if (Number(error?.statusCode) && Number(error.statusCode) < 500) {
+                    return { eligible: false, blockReason: error.code || error.message, providerSend: false, externalDispatch: false, safety: publicSafety() }
+                }
+                throw error
+            }
+        },
+
+        async confirm(payload = {}, actor) {
+            requirePool(pgPool)
+            assertCommercialManager(actor)
+            await assertReady(pgPool)
+            confirmationRequired(payload.confirmation)
+            const actionId = normalizeUuid(payload.actionId, 'COMMERCIAL_ASSISTED_ACTION_INVALID')
+            const offerId = normalizeUuid(payload.offerId, 'COMMERCIAL_ASSISTED_OFFER_INVALID')
+            const templateId = normalizeUuid(payload.templateId, 'COMMERCIAL_ASSISTED_TEMPLATE_INVALID')
+            const previewHash = text(payload.previewContextHash)
+            if (!/^[a-f0-9]{64}$/.test(previewHash)) throw assistedError('COMMERCIAL_ASSISTED_PREVIEW_CONTEXT_INVALID', 400)
+            const idempotencyKey = normalizeIdempotencyKey(payload.idempotencyKey)
+            const keySecret = secret()
+            const value = actorRef(keySecret, actor)
+            const hash = requestHash(keySecret, 'confirm', value, { actionId, offerId, templateId, previewHash })
+            return withPgTransaction(pgPool, async (client) => {
+                const action = await readAction(client, actionId)
+                await lockBoundary(client, action.identity_id)
+                const prior = await priorAttempt(client, value, idempotencyKey, hash)
+                if (prior) return prior
+                const context = await buildContext(client, { actionId, offerId, templateId, actor, secret: keySecret })
+                if (context.previewHash !== previewHash) throw assistedError('COMMERCIAL_ASSISTED_PREVIEW_STALE')
+                const snapshotId = await snapshotOffer(client, { offer: context.offer, action: context.action, actorReference: value })
+                await persistActionOfferContext(client, { action: context.action, snapshotId, offer: context.offer, campaignId: context.campaignId, actorReference: value })
+                const inserted = await client.query(`insert into crm_atendimento.commercial_assisted_attempts(
+                    actor_reference,idempotency_key,request_hash,identity_id,action_id,unit_id,offer_snapshot_id,template_id,
+                    offer_context_hash,template_context_hash,preview_context_hash,recipient_phone_hash,recipient_masked,campaign_id,provider_send,external_dispatch)
+                    values ($1,$2,$3,$4::uuid,$5::uuid,$6::uuid,$7::uuid,$8::uuid,$9,$10,$11,$12,$13,$14::uuid,false,false)
+                    returning id,action_id,status,recipient_masked,created_at`, [
+                    value,
+                    idempotencyKey,
+                    hash,
+                    context.action.identity_id,
+                    context.action.id,
+                    context.action.unit_id,
+                    snapshotId,
+                    context.template.context.templateId,
+                    context.offer.contextHash,
+                    context.template.contextHash,
+                    previewHash,
+                    context.recipientPhoneHash,
+                    context.recipientMasked,
+                    context.campaignId,
+                ])
+                const attempt = inserted.rows[0]
+                await appendEvent(client, {
+                    attemptId: attempt.id,
+                    eventType: 'confirmed',
+                    actorReference: value,
+                    correlation: correlationHash(keySecret, 'confirm', { attemptId: attempt.id, hash }),
+                    payload: {
+                        actionId,
+                        offerContextHash: context.offer.contextHash,
+                        templateContextHash: context.template.contextHash,
+                        unit: context.action.unit_slug,
+                        campaignPresent: !!context.campaignId,
+                        permissionRevision: context.permission.revision,
+                        sourceFreshness: context.sources.status,
+                        snapshotComplete: context.sources.snapshotComplete,
+                        providerSend: false,
+                        externalDispatch: false,
+                    },
+                })
+                return { ...mapAttempt(attempt), idempotent: false, humanConfirmed: true, dispatchResult: 'not_dispatched', safety: publicSafety() }
+            })
+        },
+
+        async issueHandoff(payload = {}, actor) {
+            requirePool(pgPool)
+            assertCommercialManager(actor)
+            await assertReady(pgPool)
+            confirmationRequired(payload.confirmation)
+            const attemptId = normalizeUuid(payload.attemptId, 'COMMERCIAL_ASSISTED_ATTEMPT_INVALID')
+            const idempotencyKey = normalizeIdempotencyKey(payload.idempotencyKey)
+            const keySecret = secret()
+            const value = actorRef(keySecret, actor)
+            const hash = requestHash(keySecret, 'handoff_issue', value, { attemptId })
+            return withPgTransaction(pgPool, async (client) => {
+                await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [IDENTITY_GRAPH_LOCK_KEY])
+                const attemptResult = await client.query(`select attempt.id::text as id,attempt.action_id::text as action_id,
+                    attempt.identity_id::text as identity_id,offer_snapshot.offer_id::text as offer_id,attempt.template_id::text as template_id
+                    from crm_atendimento.commercial_assisted_attempts attempt
+                    join crm_atendimento.commercial_assisted_offer_snapshots offer_snapshot on offer_snapshot.id=attempt.offer_snapshot_id
+                    where attempt.id=$1::uuid and attempt.actor_reference=$2 for update of attempt for share of offer_snapshot`, [attemptId, value])
+                const attempt = attemptResult.rows[0]
+                if (!attempt) throw assistedError('COMMERCIAL_ASSISTED_ATTEMPT_NOT_FOUND', 404)
+                const context = await buildContext(client, { actionId: attempt.action_id, offerId: attempt.offer_id, templateId: attempt.template_id, actor, secret: keySecret })
+                const existing = await client.query(`select id::text as id,state,attempt_id::text as attempt_id,issue_request_hash from crm_atendimento.commercial_assisted_handoffs
+                    where actor_reference=$1 and issue_idempotency_key=$2 for key share`, [value, idempotencyKey])
+                if (existing.rows[0]) {
+                    if (existing.rows[0].issue_request_hash !== hash || existing.rows[0].attempt_id !== attemptId) {
+                        throw assistedError('COMMERCIAL_ASSISTED_IDEMPOTENCY_CONFLICT')
+                    }
+                    return { attemptId, handoffAlreadyIssued: true, providerSend: false, externalDispatch: false, safety: publicSafety() }
+                }
+                if (await currentState(client, attemptId) !== 'confirmed') throw assistedError('COMMERCIAL_ASSISTED_HANDOFF_UNAVAILABLE')
+                const active = await client.query(`select id::text as id from crm_atendimento.commercial_assisted_handoffs
+                    where attempt_id=$1::uuid and actor_reference=$2 and state='issued' and expires_at>now() for update`, [attemptId, value])
+                if (active.rows[0]?.id) throw assistedError('COMMERCIAL_ASSISTED_HANDOFF_ALREADY_ACTIVE')
+                const token = randomBytes(32).toString('base64url')
+                const tokenHash = assistedHmac(keySecret, assistedHmacPurpose('handoff-token-v1'), { token })
+                const handoff = await client.query(`insert into crm_atendimento.commercial_assisted_handoffs(
+                    attempt_id,actor_reference,issue_idempotency_key,issue_request_hash,token_hash,expires_at)
+                    values ($1::uuid,$2,$3,$4,$5,now()+interval '5 minutes') returning id::text as id,expires_at`, [
+                    attemptId,
+                    value,
+                    idempotencyKey,
+                    hash,
+                    tokenHash,
+                ])
+                await appendEvent(client, {
+                    attemptId,
+                    eventType: 'handoff_issued',
+                    actorReference: value,
+                    correlation: correlationHash(keySecret, 'handoff_issue', { attemptId, handoffId: handoff.rows[0]?.id, previewHash: context.previewHash }),
+                    payload: { expiresAt: handoff.rows[0]?.expires_at || null, providerSend: false, externalDispatch: false },
+                })
+                return {
+                    attemptId,
+                    handoffToken: token,
+                    expiresAt: handoff.rows[0]?.expires_at || null,
+                    destinationMasked: context.recipientMasked,
+                    providerSend: false,
+                    externalDispatch: false,
+                    safety: publicSafety(),
+                }
+            })
+        },
+
+        async revealHandoff(token, payload = {}, actor) {
+            requirePool(pgPool)
+            assertCommercialManager(actor)
+            await assertReady(pgPool)
+            revealConfirmationRequired(payload.confirmation)
+            normalizeReason(payload.reason, 'COMMERCIAL_ASSISTED_REVEAL_REASON_INVALID')
+            const suppliedToken = text(token)
+            if (!/^[A-Za-z0-9_-]{32,128}$/.test(suppliedToken)) throw assistedError('COMMERCIAL_ASSISTED_HANDOFF_TOKEN_INVALID', 400)
+            const keySecret = secret()
+            const value = actorRef(keySecret, actor)
+            const tokenHash = assistedHmac(keySecret, assistedHmacPurpose('handoff-token-v1'), { token: suppliedToken })
+            return withPgTransaction(pgPool, async (client) => {
+                await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [IDENTITY_GRAPH_LOCK_KEY])
+                const handoffResult = await client.query(`select handoff.id::text as handoff_id,handoff.attempt_id::text as attempt_id,handoff.state,handoff.expires_at,
+                    attempt.action_id::text as action_id,attempt.identity_id::text as identity_id,attempt.recipient_phone_hash,
+                    offer_snapshot.offer_id::text as offer_id,attempt.template_id::text as template_id
+                    from crm_atendimento.commercial_assisted_handoffs handoff
+                    join crm_atendimento.commercial_assisted_attempts attempt on attempt.id=handoff.attempt_id
+                    join crm_atendimento.commercial_assisted_offer_snapshots offer_snapshot on offer_snapshot.id=attempt.offer_snapshot_id
+                    where handoff.token_hash=$1 and handoff.actor_reference=$2 for update of handoff,attempt for share of offer_snapshot`, [tokenHash, value])
+                const handoff = handoffResult.rows[0]
+                if (!handoff || handoff.state !== 'issued' || new Date(handoff.expires_at).getTime() <= Date.now()) {
+                    throw assistedError('COMMERCIAL_ASSISTED_HANDOFF_UNAVAILABLE')
+                }
+                const context = await buildContext(client, { actionId: handoff.action_id, offerId: handoff.offer_id, templateId: handoff.template_id, actor, secret: keySecret })
+                if (context.recipientPhoneHash !== handoff.recipient_phone_hash) throw assistedError('COMMERCIAL_ASSISTED_PHONE_CHANGED')
+                await client.query(`update crm_atendimento.commercial_assisted_handoffs
+                    set state='revealed', consumed_at=now(), consumed_by=$2 where id=$1::uuid and state='issued'`, [handoff.handoff_id, value])
+                await appendEvent(client, {
+                    attemptId: handoff.attempt_id,
+                    eventType: 'destination_revealed',
+                    actorReference: value,
+                    correlation: correlationHash(keySecret, 'handoff_reveal', { attemptId: handoff.attempt_id, handoffId: handoff.handoff_id }),
+                    payload: { reasonReference: reasonReference(keySecret, text(payload.reason)), providerSend: false, externalDispatch: false },
+                })
+                // This is the only PII-bearing response in the feature. It is a
+                // direct, one-time POST response after RBAC, literal confirmation
+                // and an append-only reveal event; no URL, log or persisted field
+                // receives the phone number.
+                return { attemptId: handoff.attempt_id, destination: context.phone, destinationMasked: context.recipientMasked, providerSend: false, externalDispatch: false, safety: publicSafety() }
+            })
+        },
+
+        async emergencyControls(query = {}, actor) {
+            requirePool(pgPool)
+            assertCommercialManager(actor)
+            await assertReady(pgPool)
+            const scope = text(query.unit)
+            if (scope) assertUnitScope(actor, scope)
+            else assertGlobalScope(actor)
+            const keys = scope ? ['global', `unit:${normalizeUnit(scope)}`] : ['global']
+            const controls = await pgPool.query(`select scope_key,unit_slug,emergency_off,revision,updated_at
+                from crm_atendimento.commercial_assisted_emergency_controls where scope_key=any($1::text[]) order by scope_key`, [keys])
+            const projected = controls.rows.map((row) => ({ scope: row.scope_key, unit: row.unit_slug || null, emergencyOff: row.emergency_off === true, revision: Number(row.revision || 0), updatedAt: row.updated_at || null }))
+            if (scope && !projected.some((control) => control.scope === `unit:${normalizeUnit(scope)}`)) {
+                // Unit controls are opt-in rows. Expose their conservative
+                // virtual starting revision without turning a GET into a write.
+                projected.push({ scope: `unit:${normalizeUnit(scope)}`, unit: normalizeUnit(scope), emergencyOff: false, revision: 1, updatedAt: null })
+            }
+            return { controls: projected, safety: publicSafety() }
+        },
+
+        async setEmergencyControl(payload = {}, actor) {
+            requirePool(pgPool)
+            assertCommercialManager(actor)
+            await assertReady(pgPool)
+            const emergencyOff = payload.emergencyOff === true
+            const unit = text(payload.unit)
+            if (unit) assertUnitScope(actor, unit)
+            else assertGlobalScope(actor)
+            if (!emergencyOff && text(payload.confirmation) !== REARM_CONFIRMATION) throw assistedError('COMMERCIAL_ASSISTED_REARM_CONFIRMATION_REQUIRED', 409)
+            const expectedRevision = Number(payload.expectedRevision)
+            if (!Number.isInteger(expectedRevision) || expectedRevision < 1) throw assistedError('COMMERCIAL_ASSISTED_EMERGENCY_VERSION_REQUIRED', 409)
+            const reason = normalizeReason(payload.reason, 'COMMERCIAL_ASSISTED_EMERGENCY_REASON_INVALID')
+            const idempotencyKey = normalizeIdempotencyKey(payload.idempotencyKey)
+            const scopeKey = unit ? `unit:${normalizeUnit(unit)}` : 'global'
+            const keySecret = secret()
+            const value = actorRef(keySecret, actor)
+            const hash = requestHash(keySecret, 'emergency_control', value, { scopeKey, emergencyOff, expectedRevision, reason: reasonReference(keySecret, reason) })
+            return withPgTransaction(pgPool, async (client) => {
+                await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [`commercial-assisted-emergency:${scopeKey}`])
+                const prior = await client.query(`select resulting_revision,emergency_off,request_hash
+                    from crm_atendimento.commercial_assisted_control_mutations
+                    where actor_reference=$1 and idempotency_key=$2 for key share`, [value, idempotencyKey])
+                if (prior.rows[0]) {
+                    if (prior.rows[0].request_hash !== hash) throw assistedError('COMMERCIAL_ASSISTED_IDEMPOTENCY_CONFLICT')
+                    const current = await client.query(`select updated_at from crm_atendimento.commercial_assisted_emergency_controls where scope_key=$1 for share`, [scopeKey])
+                    return { scope: scopeKey, emergencyOff: prior.rows[0].emergency_off === true, revision: Number(prior.rows[0].resulting_revision), updatedAt: current.rows[0]?.updated_at || null, idempotent: true, providerSend: false, externalDispatch: false, safety: publicSafety() }
+                }
+                if (unit) {
+                    await client.query(`insert into crm_atendimento.commercial_assisted_emergency_controls(
+                        scope_key,unit_slug,emergency_off,reason_reference,updated_by)
+                        values ($1,$2,false,$3,$4) on conflict(scope_key) do nothing`, [
+                        scopeKey,
+                        normalizeUnit(unit),
+                        reasonReference(keySecret, reason),
+                        value,
+                    ])
+                }
+                const current = await client.query(`select revision from crm_atendimento.commercial_assisted_emergency_controls where scope_key=$1 for update`, [scopeKey])
+                const revision = Number(current.rows[0]?.revision || 0)
+                if (revision !== expectedRevision) throw assistedError('COMMERCIAL_ASSISTED_EMERGENCY_CONFLICT')
+                const updated = await client.query(`update crm_atendimento.commercial_assisted_emergency_controls
+                    set emergency_off=$2,revision=revision+1,reason_reference=$3,updated_by=$4,updated_at=now()
+                    where scope_key=$1 returning revision,updated_at`, [scopeKey, emergencyOff, reasonReference(keySecret, reason), value])
+                await client.query(`insert into crm_atendimento.commercial_assisted_control_mutations(
+                    scope_key,actor_reference,idempotency_key,request_hash,resulting_revision,emergency_off)
+                    values ($1,$2,$3,$4,$5,$6)`, [
+                    scopeKey,
+                    value,
+                    idempotencyKey,
+                    hash,
+                    Number(updated.rows[0]?.revision || 0),
+                    emergencyOff,
+                ])
+                await appendEvent(client, {
+                    eventType: emergencyOff ? 'emergency_off' : 'emergency_rearmed',
+                    actorReference: value,
+                    correlation: correlationHash(keySecret, 'emergency_control', { scopeKey, idempotencyKey, hash }),
+                    payload: { scope: scopeKey, emergencyOff, providerSend: false, externalDispatch: false },
+                })
+                return { scope: scopeKey, emergencyOff, revision: Number(updated.rows[0]?.revision || 0), updatedAt: updated.rows[0]?.updated_at || null, idempotent: false, providerSend: false, externalDispatch: false, safety: publicSafety() }
+            })
+        },
+
+        async processWebhook(input = {}) {
+            requirePool(pgPool)
+            await assertReady(pgPool)
+            if (!input || typeof input !== 'object' || Array.isArray(input)) throw assistedError('COMMERCIAL_ASSISTED_WEBHOOK_INPUT_INVALID', 400)
+            const allowed = new Set(['rawBody', 'timestamp', 'signature'])
+            if (Object.keys(input).some((key) => !allowed.has(key))) throw assistedError('COMMERCIAL_ASSISTED_WEBHOOK_INPUT_INVALID', 400)
+            const rawBody = input.rawBody
+            const keySecret = secret()
+            if (!verifyRawWebhookSignature({ rawBody, timestamp: input.timestamp, signature: input.signature, secret: keySecret })) {
+                throw assistedError('COMMERCIAL_ASSISTED_WEBHOOK_SIGNATURE_INVALID', 401)
+            }
+            let event
+            try { event = normalizeWebhookPayload(JSON.parse(rawBody.toString('utf8'))) } catch (error) {
+                if (error?.code) throw error
+                throw assistedError('COMMERCIAL_ASSISTED_WEBHOOK_PAYLOAD_INVALID', 400)
+            }
+            const service = 'service:commercial-assisted-webhook'
+            const eventHash = assistedHmac(keySecret, assistedHmacPurpose('webhook-event-v1'), { eventId: event.eventId })
+            const eventPayloadHash = createHash('sha256').update(rawBody).digest('hex')
+            return withPgTransaction(pgPool, async (client) => {
+                await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [IDENTITY_GRAPH_LOCK_KEY])
+                const receipt = await client.query(`insert into crm_atendimento.commercial_assisted_webhook_receipts(event_hash,attempt_id,event_type,event_payload_hash)
+                    values ($1,$2::uuid,$3,$4) on conflict(event_hash) do nothing returning event_hash`, [eventHash, event.attemptId, event.eventType, eventPayloadHash])
+                if (!receipt.rows[0]?.event_hash) {
+                    const prior = await client.query(`select attempt_id::text as attempt_id,event_type,event_payload_hash
+                        from crm_atendimento.commercial_assisted_webhook_receipts where event_hash=$1 for share`, [eventHash])
+                    const saved = prior.rows[0]
+                    if (!saved || saved.attempt_id !== event.attemptId || saved.event_type !== event.eventType || saved.event_payload_hash !== eventPayloadHash) throw assistedError('COMMERCIAL_ASSISTED_WEBHOOK_REPLAY_CONFLICT')
+                    return { accepted: true, deduplicated: true, providerSend: false, externalDispatch: false, safety: publicSafety() }
+                }
+                const attempt = await client.query(`select attempt.id::text as id,attempt.identity_id::text as identity_id,attempt.action_id::text as action_id,
+                    unit.slug as unit_slug, offer_snapshot.offer_id::text as offer_id,attempt.template_id::text as template_id
+                    from crm_atendimento.commercial_assisted_attempts attempt
+                    join crm_atendimento.units unit on unit.id=attempt.unit_id
+                    join crm_atendimento.commercial_assisted_offer_snapshots offer_snapshot on offer_snapshot.id=attempt.offer_snapshot_id
+                    where attempt.id=$1::uuid for update of attempt for share of offer_snapshot`, [event.attemptId])
+                const row = attempt.rows[0]
+                if (!row) throw assistedError('COMMERCIAL_ASSISTED_ATTEMPT_NOT_FOUND', 404)
+                const current = await currentState(client, row.id)
+                if (!canAdvanceAssistedState(current, event.eventType)) throw assistedError('COMMERCIAL_ASSISTED_WEBHOOK_TRANSITION_INVALID')
+                if (event.eventType !== 'stop' && current === 'confirmed') throw assistedError('COMMERCIAL_ASSISTED_WEBHOOK_HANDOFF_REQUIRED')
+                let permissionRevision = null
+                if (event.eventType === 'stop') {
+                    try {
+                        const phone = await correlatedPhones(client, row.identity_id, row.unit_slug)
+                        await lockContactPhone(client, phone)
+                    } catch (error) {
+                        if (error?.code !== 'COMMERCIAL_ASSISTED_PHONE_UNCORRELATED') throw error
+                    }
+                    await lockBoundary(client, row.identity_id)
+                    permissionRevision = await setSafetyStop(client, { identityId: row.identity_id, actorReference: service, eventHash })
+                }
+                await appendEvent(client, { attemptId: row.id, eventType: event.eventType, actorReference: service, correlation: eventHash,
+                    occurredAt: event.occurredAt, payload: { source: 'signed_webhook', eventHash, eventPayloadHash, stopApplied: event.eventType === 'stop', permissionRevision, providerSend: false, externalDispatch: false } })
+                return { accepted: true, deduplicated: false, eventType: event.eventType, stopApplied: event.eventType === 'stop', providerSend: false, externalDispatch: false, safety: publicSafety() }
+            })
+        },
+    }
+}
+
+export const __testables = {
+    REQUIRED_SOURCE_IDS,
+    REARM_CONFIRMATION,
+    actorRef,
+    campaignForAction,
+    lockAndReadSourceHealth,
+    correlatedPhones,
+    mapAttempt,
+    phoneHash,
+    publicSafety,
+    requestHash,
+    SOURCE_OPERATION_LOCK_NAMESPACE,
+    statusFromEvent,
+    unitScope,
+}

--- a/docs/runbooks/clientes-commercial-assisted-whatsapp-v2.md
+++ b/docs/runbooks/clientes-commercial-assisted-whatsapp-v2.md
@@ -1,0 +1,80 @@
+# Clientes ? comunica??o comercial assistida v2
+
+## Estado desta tranche
+
+Este artefato define apenas o dom?nio, a migration aditiva, o armazenamento e os testes da comunica??o assistida. N?o h? rota HTTP, cliente de console, worker, template de runtime, flag de ambiente, SDK de provedor, URL `wa.me` ou integra??o de envio nesta tranche. Portanto o dom?nio permanece inalcan??vel e fail-closed ap?s o merge.
+
+Nenhuma mensagem, contato comercial, consentimento ou altera??o de identidade ? enviada ou aplicada por este c?digo. O processo HTTP n?o ganha uma nova rota e nenhum job cont?nuo ? alterado.
+
+## Flags compiladas
+
+As flags n?o s?o lidas de vari?veis de ambiente e devem permanecer exatamente assim:
+
+| Flag | Valor |
+| --- | --- |
+| `providerSend` | `false` |
+| `automationEnabled` | `false` |
+| `bulkDispatchEnabled` | `false` |
+| `commercialContactWritesEnabled` | `false` |
+| `externalDispatch` | `false` |
+
+Uma integra??o futura deve preservar essas flags como default e introduzir uma PR separada para qualquer superf?cie alcan??vel. Ela precisa revalidar permiss?o, expira??o, opt-out, fonte completa/fresh, unidade, can?rio, cooldown e emerg?ncia no instante da a??o humana.
+
+## Migra??o aditiva e revers?vel
+
+O comando ? um CLI nativo com gram?tica fechada: uma a??o (`--dry-run`, `--apply` ou `--rollback`) e, opcionalmente, um target permitido (`local` ou `staging`). Ele n?o avalia shell, SSH, `eval`, comandos de ambiente ou entradas arbitr?rias.
+
+O `DATABASE_URL` ? lido somente da configura??o privada do migrador; nunca deve ser escrito no reposit?rio, logs, artefatos ou issue. Antes de qualquer execu??o, confirme que o release ? um SHA imut?vel e que o destino ? o banco/role permitido pelo validador de destino.
+
+```text
+node crm/api/scripts/migrate-atendimento-commercial-assisted-whatsapp.mjs --dry-run --target=local
+node crm/api/scripts/migrate-atendimento-commercial-assisted-whatsapp.mjs --apply --target=local
+node crm/api/scripts/migrate-atendimento-commercial-assisted-whatsapp.mjs --rollback --target=local
+```
+
+Para staging, use somente o target expl?cito e a credencial privada do migrador dedicada:
+
+```text
+node crm/api/scripts/migrate-atendimento-commercial-assisted-whatsapp.mjs --dry-run --target=staging
+```
+
+Esta PR n?o adiciona a migration ao runner de staging e n?o habilita deploy. A aplica??o em staging exige uma tranche posterior com preflight, backup, evid?ncia de destino, smoke sint?tico e rollback aprovado. Produ??o permanece fora de escopo.
+
+O rollback ? n?o destrutivo: conserva snapshots, attempts, eventos e receipts; fecha os controles de emerg?ncia e registra o rollback no ledger. N?o use `DROP`, `TRUNCATE`, altera??o manual de evid?ncia ou SQL ad hoc para "limpar" o dom?nio.
+
+## Privacidade e auditoria
+
+Somente hashes, refer?ncias opacas de ator, m?scaras de destino e metadados allowlisted podem ser persistidos. Telefone, e-mail, nome de cliente, payload bruto, corpo da mensagem, segredo e token s?o proibidos tanto no dom?nio quanto nas constraints SQL recursivas de JSON/texto.
+
+O sujeito do ator precisa estar em `actorSubject`; campos legados como `id`, `subjectId` ou e-mail n?o s?o aceitos para a refer?ncia audit?vel. N?o inclua PII em justificativas, logs, m?tricas, testes de smoke, tickets ou outputs do operador.
+
+Snapshots de oferta, templates, attempts, eventos, receipts e muta??es de controle s?o append-only. A a??o comercial aceita contexto de oferta apenas uma vez: atualiza??es id?nticas s?o permitidas para replay, e qualquer diverg?ncia entre a??o e snapshot ? rejeitada pelo trigger.
+
+## STOP, replay e emerg?ncia
+
+O dom?nio preparado para webhook aceita somente bytes brutos assinados (raw HMAC), timestamp dentro da janela e payload allowlisted. O receipt ? deduplicado atomicamente por evento e digest do payload; reutiliza??o de um ID de evento com conte?do diferente ? rejeitada. Eventos seguem transi??es monot?nicas.
+
+Um STOP futuro precisa obter o lock compartilhado de telefone antes de gravar o bloqueio de contato e repetir o recebimento n?o pode reabrir ou duplicar a permiss?o. Nesta tranche n?o existe endpoint para invocar esse caminho, logo n?o h? webhook p?blico ou provider configurado.
+
+O controle de emerg?ncia global ou por unidade j? ? modelado, versionado e audit?vel, mas n?o h? UI/rota nesta tranche. Em incidente antes da integra??o futura, mantenha todas as flags acima em `false`, n?o exponha o dom?nio e fa?a rollback n?o destrutivo caso uma migration tenha sido aplicada. N?o invente um SQL operacional manual para rearmar contato.
+
+## Valida??o e smoke sint?tico
+
+A su?te padr?o da API j? descobre os testes em `crm/api/server/atendimento/__tests__/*.test.js`:
+
+```text
+npm --prefix crm/api test
+```
+
+O teste PostgreSQL ? opt-in. Ele s? abre conex?o quando ambos estiverem configurados no ambiente privado:
+
+- `CRM_ASSISTED_PG_TEST_ENABLED=1`;
+- `CRM_ASSISTED_PG_TEST_DATABASE_URL` apontando para loopback e para um banco dedicado cujo nome termina em `_test` ou `-test`.
+
+O teste roda dentro de transa??o e faz rollback. Ele prova, quando o banco dedicado existe, rejei??o de PII direto/aninhado, imutabilidade de snapshot, trigger de contexto da a??o, concorr?ncia de lock de fonte e deduplica??o de receipt STOP. N?o execute com banco compartilhado, staging ou produ??o.
+
+O smoke autorizado nesta tranche ? est?tico/sint?tico: flags false, origem inacess?vel, HMAC sint?tico, corpo sem PII e aus?ncia de URI de envio. N?o realize click-to-send, n?o cadastre consentimento e n?o use qualquer identidade real.
+
+## Pr?xima tranche necess?ria
+
+Uma PR posterior, pequena e revisada, pode conectar rotas internas/UI a este dom?nio. Antes disso ela precisa incluir RBAC, escopo de unidade, assinatura de ator, revalida??o transacional, can?rio vazio por default, HMAC de webhook em segredo privado, observabilidade sem PII, emergency-off operacional allowlisted, testes de regress?o e evid?ncia de staging sint?tico. Automa??o ou envio em massa continuam proibidos.


### PR DESCRIPTION
## Escopo

Esta PR adiciona nove artefatos de dominio/API ainda **inalcancaveis**: dominio, store, migration CLI, quatro testes e runbook.

- Sem routes, UI, provider SDK, URI de telefone, dispatch, deploy ou mudanca de flag externa.
- `providerSend`, `automationEnabled`, `bulkDispatchEnabled`, `commercialContactWritesEnabled` e `externalDispatch` permanecem `false`.
- A migration e aditiva, nao esta registrada no runner de staging e nao foi aplicada.
- Nenhum cliente real, mensagem, consentimento, alteracao de identidade ou ambiente externo foi acionado.

## Controles incluidos

- HMAC sobre bytes brutos, timestamp curto, replay/dedupe atomico e transicoes monotonicamente validas;
- actorSubject opaco, RBAC/unidade/canario/consentimento/emergency-off fail-closed;
- locks de telefone e de fontes, revalidacao de freshness e snapshot/revisao imutaveis;
- PII recusada recursivamente no dominio e na defesa SQL; somente destinatario mascarado e persistivel;
- no dispatch e no outbound provider path.

## Validacao

No HEAD `c86d8ee6c50333cad7158327ed487b359ba6e810`, CI Smoke, JS/TS, Focused validation, Gitleaks, Semgrep, CodeQL, Dependency Audit, arquitetura e Escala UI E2E estao verdes. A integracao PostgreSQL e opt-in: exige `CRM_ASSISTED_PG_TEST_ENABLED=1` e URL loopback de banco `*_test`.

A suite local nao foi executada: C: esta sem espaco e o npm no WSL apresentou I/O. Nao houve instalacao, migration ou deploy local.

## Rollback

Antes de qualquer migration, fechar/reverter esta entrega ou apagar a branch nao altera dados. Depois de merge, reverter o merge commit registrado pelo GitHub. Se uma migration for aplicada em tranche futura, usar apenas o rollback operacional nao destrutivo documentado no runbook; nao executar DDL ou SQL ad hoc.