### PR TITLE
feat(clientes): expose assisted communication controls

### DIFF
--- a/crm/api/package.json
+++ b/crm/api/package.json
@@ -28,6 +28,7 @@
     "migrate-commercial-data-quality": "node scripts/migrate-atendimento-commercial-data-quality.mjs",
     "migrate-commercial-operations": "node scripts/migrate-atendimento-commercial-operations.mjs",
     "migrate-commercial-analytics": "node scripts/migrate-atendimento-commercial-analytics.mjs",
+    "migrate-commercial-assisted-whatsapp": "node scripts/migrate-atendimento-commercial-assisted-whatsapp.mjs",
     "migrate-clinical-approval": "node scripts/migrate-clinical-approval.mjs",
     "migrate-identity-clusters": "node scripts/migrate-atendimento-identity-clusters.mjs",
     "migrate-atendimento-staging": "node scripts/migrate-atendimento-staging.mjs",

--- a/crm/api/scripts/migrate-atendimento-staging-runtime.test.mjs
+++ b/crm/api/scripts/migrate-atendimento-staging-runtime.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test'
 import {
   parseAtendimentoStagingMigrationAction,
   runAtendimentoStagingMigration,
+  ATENDIMENTO_STAGING_MIGRATIONS,
 } from './migrate-atendimento-staging.mjs'
 
 test('staging migration parser accepts exactly one explicit action', () => {
@@ -27,4 +28,16 @@ test('staging migration runner rejects an unapproved destination before creating
     /DATABASE_URL deve apontar exclusivamente/,
   )
   assert.equal(created, false)
+})
+
+
+test('staging migration keeps assisted communication after its source and canary prerequisites', () => {
+  const ids = ATENDIMENTO_STAGING_MIGRATIONS.map((migration) => migration.id)
+  const source = ids.indexOf('20260807_clientes_source_operations_v2')
+  const canary = ids.indexOf('20260807_commercial_canary_selector_v2')
+  const assisted = ids.indexOf('20260807_commercial_assisted_whatsapp_v2')
+  assert.ok(source >= 0)
+  assert.ok(canary > source)
+  assert.equal(assisted, ids.length - 1)
+  assert.ok(assisted > canary)
 })

--- a/crm/api/scripts/migrate-atendimento-staging.mjs
+++ b/crm/api/scripts/migrate-atendimento-staging.mjs
@@ -55,6 +55,10 @@ import {
     rollbackIdentityReviewWorkflowMigration,
 } from '../server/atendimento/identityReviewMigration.js'
 import {
+    applyCommercialAssistedMigration,
+    rollbackCommercialAssistedMigration,
+} from '../server/atendimento/commercialAssistedCommunicationMigration.js'
+import {
     applyClinicalApprovalMigration,
     rollbackClinicalApprovalMigration,
 } from '../server/clinical/clinicalApprovalMigration.js'
@@ -77,6 +81,8 @@ export const ATENDIMENTO_STAGING_MIGRATIONS = Object.freeze([
     // source-quality controls. Keep it last so a clean staging bootstrap
     // cannot create a partially usable canary schema.
     { id: '20260807_commercial_canary_selector_v2', apply: applyCommercialCanaryMigration, rollback: rollbackCommercialCanaryMigration },
+    // Assisted communication depends on source freshness, materialized identities and the canary registry. It remains disabled until its own guarded runtime controls exist.
+    { id: '20260807_commercial_assisted_whatsapp_v2', apply: applyCommercialAssistedMigration, rollback: rollbackCommercialAssistedMigration },
 ])
 
 export function parseAtendimentoStagingMigrationAction(args = []) {

--- a/crm/api/server/atendimento/__tests__/routes.test.js
+++ b/crm/api/server/atendimento/__tests__/routes.test.js
@@ -430,3 +430,96 @@ test('routes Commercial Analytics through its injected, non-contacting store and
     assert.equal(calls.length, beforeForbidden)
     assert.equal([...routes.keys()].some((key) => /commercial\/analytics\/(?:send|message|dispatch|consent)/i.test(key)), false)
 })
+
+
+test('adapts only opaque signed subjects for the assisted ledger', () => {
+  assert.equal(__testables.commercialAssistedActor({ id: 'gestor-assisted', role: 'GESTOR' }).actorSubject, 'gestor-assisted')
+  assert.throws(() => __testables.commercialAssistedActor({ role: 'GESTOR', email: 'email-only' }), /ACTOR_IDENTITY_REQUIRED/)
+})
+
+test('routes assisted WhatsApp through its injected domain without publishing transport, raw reveal, or webhook ingress', async () => {
+  const calls = []
+  const safety = { providerSend: false, automationEnabled: false, bulkDispatchEnabled: false, commercialContactWritesEnabled: false, externalDispatch: false }
+  const assisted = {
+    async readiness(actor) { calls.push(['readiness', actor.actorSubject]); return { ready: true, safety } },
+    async availableOffers(query, actor) { calls.push(['offers', query, actor.actorSubject]); return { offers: [], safety } },
+    async listTemplates(query, actor) { calls.push(['templates', query, actor.actorSubject]); return { templates: [], safety } },
+    async createTemplate(payload, actor) { calls.push(['createTemplate', payload, actor.actorSubject]); return { template: { templateId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' }, safety } },
+    async preview(payload, actor) { calls.push(['preview', payload, actor.actorSubject]); return { eligible: false, providerSend: false, externalDispatch: false, safety } },
+    async confirm(payload, actor) { calls.push(['confirm', payload, actor.actorSubject]); return { dispatchResult: 'not_dispatched', providerSend: false, externalDispatch: false, safety } },
+    async issueHandoff(payload, actor) { calls.push(['handoff', payload, actor.actorSubject]); return { destinationMasked: '***-****', providerSend: false, externalDispatch: false, safety } },
+    async emergencyControls(query, actor) { calls.push(['controls', query, actor.actorSubject]); return { controls: [], safety } },
+    async setEmergencyControl(payload, actor) { calls.push(['setControl', payload, actor.actorSubject]); return { emergencyOff: true, providerSend: false, externalDispatch: false, safety } },
+  }
+  const routes = captureAtendimentoRoutes({}, { commercialAssistedCommunicationStore: assisted })
+  const actor = { id: 'gestor-assisted', role: 'GESTOR', allowedModules: ['atendimento'], allowedUnits: ['centro'], allowedUnitsDeclared: true }
+  const routeKey = (...parts) => parts.join('-')
+  const templateKey = routeKey('assisted', 'template', '001')
+  const confirmKey = routeKey('assisted', 'confirm', '001')
+  const handoffKey = routeKey('assisted', 'handoff', '001')
+  const stopKey = routeKey('assisted', 'stop', '001')
+  const mismatchHeader = routeKey('assisted', 'confirm', '002')
+  const mismatchBody = routeKey('assisted', 'confirm', '003')
+
+  const readiness = captureResponse()
+  await routes.get('GET /commercial/assisted-whatsapp/readiness')({ atendimentoActor: actor }, readiness)
+  assert.equal(readiness.state.status, 200)
+  assert.equal(readiness.state.body.safety.providerSend, false)
+
+  const offers = captureResponse()
+  await routes.get('GET /commercial/assisted-whatsapp/offers')({ atendimentoActor: actor, query: { actionId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' } }, offers)
+  assert.equal(offers.state.status, 200)
+  assert.deepEqual(calls[1], ['offers', { actionId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' }, 'gestor-assisted'])
+
+  const template = captureResponse()
+  await routes.get('POST /commercial/assisted-whatsapp/templates')({ atendimentoActor: actor, headers: { 'idempotency-key': templateKey }, body: { idempotencyKey: templateKey, unit: 'centro' } }, template)
+  assert.equal(template.state.status, 200)
+  assert.equal(calls[2][0], 'createTemplate')
+  assert.equal(calls[2][1].idempotencyKey, templateKey)
+
+  const preview = captureResponse()
+  await routes.get('POST /commercial/assisted-whatsapp/preview')({ atendimentoActor: actor, headers: {}, body: { actionId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' } }, preview)
+  assert.equal(preview.state.status, 200)
+  assert.equal(calls[3][0], 'preview')
+
+  const confirm = captureResponse()
+  await routes.get('POST /commercial/assisted-whatsapp/confirm')({ atendimentoActor: actor, headers: { 'idempotency-key': confirmKey }, body: { idempotencyKey: confirmKey } }, confirm)
+  assert.equal(confirm.state.status, 200)
+  assert.equal(confirm.state.body.dispatchResult, 'not_dispatched')
+
+  const handoff = captureResponse()
+  await routes.get('POST /commercial/assisted-whatsapp/handoffs')({ atendimentoActor: actor, headers: { 'idempotency-key': handoffKey }, body: { idempotencyKey: handoffKey } }, handoff)
+  assert.equal(handoff.state.status, 200)
+  assert.equal(handoff.state.body.destinationMasked, '***-****')
+
+  const controls = captureResponse()
+  await routes.get('GET /commercial/assisted-whatsapp/emergency-controls')({ atendimentoActor: actor, query: { unit: 'centro' } }, controls)
+  assert.equal(controls.state.status, 200)
+  assert.deepEqual(calls[6], ['controls', { unit: 'centro' }, 'gestor-assisted'])
+
+  const setControl = captureResponse()
+  await routes.get('PUT /commercial/assisted-whatsapp/emergency-controls')({ atendimentoActor: actor, headers: { 'idempotency-key': stopKey }, body: { idempotencyKey: stopKey, unit: 'centro', emergencyOff: true, expectedRevision: 1, reason: 'Teste sint?tico.' } }, setControl)
+  assert.equal(setControl.state.status, 200)
+  assert.equal(calls[7][0], 'setControl')
+
+  const beforeForbidden = calls.length
+  const forbidden = captureResponse()
+  await routes.get('GET /commercial/assisted-whatsapp/readiness')({ atendimentoActor: { ...actor, role: 'GERENTE' } }, forbidden)
+  assert.equal(forbidden.state.status, 403)
+  assert.equal(calls.length, beforeForbidden)
+
+  const mismatch = captureResponse()
+  await routes.get('POST /commercial/assisted-whatsapp/confirm')({ atendimentoActor: actor, headers: { 'idempotency-key': mismatchHeader }, body: { idempotencyKey: mismatchBody } }, mismatch)
+  assert.equal(mismatch.state.status, 400)
+  assert.equal(calls.length, beforeForbidden)
+
+  assert.equal([...routes.keys()].some((key) => /assisted-whatsapp\/(?:send|message|dispatch|webhook|reveal)/i.test(key)), false)
+})
+
+test('maps an unavailable assisted migration to a read-only safe 503', async () => {
+  const routes = captureAtendimentoRoutes({}, { commercialAssistedCommunicationStore: { async readiness() { return { ready: false, reason: 'MIGRATION_PENDING' } } } })
+  const response = captureResponse()
+  await routes.get('GET /commercial/assisted-whatsapp/readiness')({ atendimentoActor: { id: 'gestor-readiness', role: 'GESTOR' } }, response)
+  assert.equal(response.state.status, 503)
+  assert.deepEqual(response.state.body, { ok: false, ready: false, reason: 'MIGRATION_PENDING' })
+})

--- a/crm/api/server/atendimento/routes.js
+++ b/crm/api/server/atendimento/routes.js
@@ -4,6 +4,7 @@ import { createAtendimentoStore, canAccessAtendimento } from './store.js'
 import { createCommercialDataQualityStore } from './commercialDataQualityStore.js'
 import { createCommercialOperationsStore } from './commercialOperationsStore.js'
 import { createCommercialAnalyticsStore } from './commercialAnalyticsStore.js'
+import { createCommercialAssistedCommunicationStore } from './commercialAssistedCommunicationStore.js'
 import { createClientesSourceOperationsStore } from '../clientes/sourceOperationsStore.js'
 import { importAtendimentoFromGoogleSheet, importGerenciaFromGoogleSheet, readGerenciaChartIds } from './importer.js'
 import { atendimentoModuleUnavailable, readAtendimentoModuleControl } from './moduleControl.js'
@@ -133,6 +134,14 @@ function isCommercialManager(actor) {
     // boundary at the API too, so a direct signed request cannot bypass the
     // role policy enforced by the frontend registry.
     return role === 'GESTOR'
+}
+
+function commercialAssistedActor(actor) {
+    const subject = actorSubject(actor)
+    if (!subject) throw sourceOperationsError('ACTOR_IDENTITY_REQUIRED', 401)
+    // The assisted ledger accepts only an opaque subject. This adapts the
+    // already-signed actor without admitting e-mail or username fallbacks.
+    return { ...actor, actorSubject: subject }
 }
 
 function sourceOperationsError(code, statusCode = 403) {
@@ -296,6 +305,17 @@ export function createAtendimentoRouter(options = {}) {
             })
         }
         return commercialAnalyticsStore
+    }
+    let commercialAssistedCommunicationStore = options.commercialAssistedCommunicationStore || null
+    const getCommercialAssistedCommunicationStore = () => {
+        if (!commercialAssistedCommunicationStore) {
+            commercialAssistedCommunicationStore = createCommercialAssistedCommunicationStore({
+                pool: options.commercialAssistedCommunicationPool,
+                databaseUrl: options.databaseUrl,
+                auditHmacKey: options.commercialAssistedHmacKey,
+            })
+        }
+        return commercialAssistedCommunicationStore
     }
     let commercialSourceOperationsStore = options.commercialSourceOperationsStore || null
     const getCommercialSourceOperationsStore = () => {
@@ -990,6 +1010,92 @@ export function createAtendimentoRouter(options = {}) {
         }
     })
 
+    // Assisted communication only prepares governed, human-confirmed work.
+    // No provider, URL, raw destination, webhook ingress, or dispatch route is
+    // registered here; the read-only runtime blocks every mutation before this
+    // handler boundary.
+    expressRouter.get('/commercial/assisted-whatsapp/readiness', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            const readiness = await getCommercialAssistedCommunicationStore().readiness(commercialAssistedActor(req.atendimentoActor))
+            return json(res, readiness.ready ? 200 : 503, { ok: readiness.ready, ...readiness })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/assisted-whatsapp/offers', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialAssistedCommunicationStore().availableOffers(req.query || {}, commercialAssistedActor(req.atendimentoActor))) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/assisted-whatsapp/templates', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialAssistedCommunicationStore().listTemplates(req.query || {}, commercialAssistedActor(req.atendimentoActor))) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/assisted-whatsapp/templates', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialAssistedCommunicationStore().createTemplate(commercialOperationPayload(req), commercialAssistedActor(req.atendimentoActor))) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/assisted-whatsapp/preview', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialAssistedCommunicationStore().preview(commercialOperationPayload(req), commercialAssistedActor(req.atendimentoActor))) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/assisted-whatsapp/confirm', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialAssistedCommunicationStore().confirm(commercialOperationPayload(req), commercialAssistedActor(req.atendimentoActor))) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.post('/commercial/assisted-whatsapp/handoffs', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialAssistedCommunicationStore().issueHandoff(commercialOperationPayload(req), commercialAssistedActor(req.atendimentoActor))) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.get('/commercial/assisted-whatsapp/emergency-controls', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialAssistedCommunicationStore().emergencyControls(req.query || {}, commercialAssistedActor(req.atendimentoActor))) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
+    expressRouter.put('/commercial/assisted-whatsapp/emergency-controls', async (req, res) => {
+        try {
+            if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
+            return json(res, 200, { ok: true, ...(await getCommercialAssistedCommunicationStore().setEmergencyControl(commercialOperationPayload(req), commercialAssistedActor(req.atendimentoActor))) })
+        } catch (error) {
+            return errorResponse(res, error)
+        }
+    })
+
     expressRouter.post('/commercial/data-quality/refresh', async (req, res) => {
         try {
             if (!isCommercialManager(req.atendimentoActor)) return json(res, 403, { ok: false, error: 'FORBIDDEN' })
@@ -1280,6 +1386,7 @@ export function createAtendimentoRouter(options = {}) {
 export const __testables = {
     errorPayload,
     isCommercialManager,
+    commercialAssistedActor,
     assertCommercialSourceOperationsAccess,
     projectCommercialSourceOperation,
     requestsClinicalCadenceApproval,

--- a/docs/runbooks/clientes-commercial-assisted-whatsapp-v2.md
+++ b/docs/runbooks/clientes-commercial-assisted-whatsapp-v2.md
@@ -2,9 +2,11 @@
 
 ## Estado desta tranche
 
-Este artefato define apenas o dom?nio, a migration aditiva, o armazenamento e os testes da comunica??o assistida. N?o h? rota HTTP, cliente de console, worker, template de runtime, flag de ambiente, SDK de provedor, URL `wa.me` ou integra??o de envio nesta tranche. Portanto o dom?nio permanece inalcan??vel e fail-closed ap?s o merge.
+O dom?nio, a migration aditiva, o armazenamento e uma superf?cie HTTP m?nima de Clientes est?o versionados. As rotas exigem ator assinado, papel `GESTOR`, escopo de unidade e um sujeito opaco derivado somente de `subject`, `subjectId` ou `id`; e-mail e username n?o s?o aceitos como identidade de auditoria.
 
-Nenhuma mensagem, contato comercial, consentimento ou altera??o de identidade ? enviada ou aplicada por este c?digo. O processo HTTP n?o ganha uma nova rota e nenhum job cont?nuo ? alterado.
+A superf?cie exp?e somente readiness, ofertas compat?veis, templates aprovados, preview mascarado, confirma??o/handoff humanos e controle de emerg?ncia. O runtime de Clientes somente leitura continua bloqueando toda muta??o antes dos handlers. N?o h? UI, cliente de console, worker, SDK de provedor, URL de envio, rota de webhook, rota de reveal de telefone ou dispatch nesta tranche.
+
+Nenhuma mensagem, contato comercial, consentimento ou altera??o de identidade ? enviada ou aplicada por este c?digo. O processo HTTP n?o ganha automa??o nem job cont?nuo.
 
 ## Flags compiladas
 
@@ -32,13 +34,7 @@ node crm/api/scripts/migrate-atendimento-commercial-assisted-whatsapp.mjs --appl
 node crm/api/scripts/migrate-atendimento-commercial-assisted-whatsapp.mjs --rollback --target=local
 ```
 
-Para staging, use somente o target expl?cito e a credencial privada do migrador dedicada:
-
-```text
-node crm/api/scripts/migrate-atendimento-commercial-assisted-whatsapp.mjs --dry-run --target=staging
-```
-
-Esta PR n?o adiciona a migration ao runner de staging e n?o habilita deploy. A aplica??o em staging exige uma tranche posterior com preflight, backup, evid?ncia de destino, smoke sint?tico e rollback aprovado. Produ??o permanece fora de escopo.
+O runner de staging registra a migration apenas depois de source operations e do seletor de can?rio. Esta altera??o n?o executa o runner, n?o aplica migration, n?o habilita deploy e n?o abre escrita comercial. Staging ainda exige preflight, backup, destino/role comprovados, smoke sint?tico e rollback; produ??o permanece fora de escopo t?cnico.
 
 O rollback ? n?o destrutivo: conserva snapshots, attempts, eventos e receipts; fecha os controles de emerg?ncia e registra o rollback no ledger. N?o use `DROP`, `TRUNCATE`, altera??o manual de evid?ncia ou SQL ad hoc para "limpar" o dom?nio.
 
@@ -54,9 +50,9 @@ Snapshots de oferta, templates, attempts, eventos, receipts e muta??es de contro
 
 O dom?nio preparado para webhook aceita somente bytes brutos assinados (raw HMAC), timestamp dentro da janela e payload allowlisted. O receipt ? deduplicado atomicamente por evento e digest do payload; reutiliza??o de um ID de evento com conte?do diferente ? rejeitada. Eventos seguem transi??es monot?nicas.
 
-Um STOP futuro precisa obter o lock compartilhado de telefone antes de gravar o bloqueio de contato e repetir o recebimento n?o pode reabrir ou duplicar a permiss?o. Nesta tranche n?o existe endpoint para invocar esse caminho, logo n?o h? webhook p?blico ou provider configurado.
+N?o h? endpoint de webhook nesta tranche: ele ser? exposto apenas junto de um ingress dedicado, autenticado, rate-limited e compat?vel com o runtime somente leitura. Um STOP futuro precisa obter o lock compartilhado de telefone antes de gravar o bloqueio de contato e repetir o recebimento n?o pode reabrir ou duplicar a permiss?o.
 
-O controle de emerg?ncia global ou por unidade j? ? modelado, versionado e audit?vel, mas n?o h? UI/rota nesta tranche. Em incidente antes da integra??o futura, mantenha todas as flags acima em `false`, n?o exponha o dom?nio e fa?a rollback n?o destrutivo caso uma migration tenha sido aplicada. N?o invente um SQL operacional manual para rearmar contato.
+O controle de emerg?ncia global ou por unidade ? modelado, versionado e audit?vel. A rota autenticada de gestor continua sujeita ao runtime somente leitura; o rearm exige confirma??o expl?cita e vers?o esperada. Em incidente, mantenha todas as flags acima em `false`, n?o exponha transporte externo e fa?a rollback n?o destrutivo caso uma migration tenha sido aplicada. N?o invente SQL operacional manual para rearmar contato.
 
 ## Valida??o e smoke sint?tico
 
@@ -77,4 +73,4 @@ O smoke autorizado nesta tranche ? est?tico/sint?tico: flags false, origem inace
 
 ## Pr?xima tranche necess?ria
 
-Uma PR posterior, pequena e revisada, pode conectar rotas internas/UI a este dom?nio. Antes disso ela precisa incluir RBAC, escopo de unidade, assinatura de ator, revalida??o transacional, can?rio vazio por default, HMAC de webhook em segredo privado, observabilidade sem PII, emergency-off operacional allowlisted, testes de regress?o e evid?ncia de staging sint?tico. Automa??o ou envio em massa continuam proibidos.
+Uma PR posterior, pequena e revisada, pode adicionar a UI de preview mascarado e reveal tempor?rio/auditado. O reveal precisa continuar one-time, justificado e sem URI de provedor. O ingress de webhook tamb?m fica separado: deve manter raw HMAC, replay, rate limit, STOP imediato e bloqueio expl?cito no runtime somente leitura. Automa??o, disparo em massa e envio aut?nomo continuam proibidos.


### PR DESCRIPTION
## Objetivo

Exp?e a camada HTTP autenticada da comunica??o comercial assistida de Clientes, preservando o dom?nio j? integrado e mantendo qualquer transporte externo inacess?vel.

## Inclu?do

- rotas `GESTOR` para readiness, ofertas compat?veis, templates, preview mascarado, confirma??o/handoff e emergency-off;
- adapta??o estrita de `actorSubject` opaco na fronteira de rota, sem fallback para e-mail ou username;
- registro da migration assistida ap?s source operations e can?rio no runner de staging, sem executar o runner;
- regress?es de RBAC, idempot?ncia, readiness 503, aus?ncia de rotas de transporte e ordem de migration;
- runbook atualizado.

## Explicitamente fora de escopo

Sem UI, reveal de telefone, webhook/ingress, URI/SDK de provedor, dispatch, automa??o, mensagens, deploy ou migration aplicada. O runtime somente leitura continua bloqueando todas as muta??es e as flags de envio permanecem `false`.

## Valida??o e rollback

Valida??o local de Node/WSL est? bloqueada por capacidade do host; o patch foi validado por ?ncoras est?ticas e ser? coberto pela matriz CI. Rollback: revert do commit desta PR; nenhuma migration ou ambiente ? alterado por ela.
