### PR TITLE
feat(clientes): add fail-closed assisted console panel

### DIFF
--- a/crm/console/ClientCommercialModule.tsx
+++ b/crm/console/ClientCommercialModule.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/button'
 import { IdentityClusterWorkspace } from './IdentityClusterWorkspace'
 import { CommercialCanaryManager } from '@/CommercialCanaryManager'
 import { CommercialAnalyticsPanel } from './CommercialAnalyticsPanel'
+import { CommercialAssistedWhatsappPanel } from './CommercialAssistedWhatsappPanel'
 import {
   createCommercialAction,
   commercialCadenceManagerStatuses,
@@ -311,6 +312,7 @@ function ProfilePanel({ detail, units, professionals, onRefresh }: { detail: Com
     <ContactPermission key={`${profile.identityId}:${contactEligibility.permissionRevision}`} profile={profile} contactRolloutAllowed={contactRolloutAllowed} onSaved={onRefresh} />
     <ActionForm detail={detail} units={units} professionals={professionals} onSaved={onRefresh} />
     <ActionHistory actions={detail.actions} contactEligibility={contactEligibility} contactRolloutAllowed={contactRolloutAllowed} onUpdated={onRefresh} />
+    <CommercialAssistedWhatsappPanel actions={detail.actions} onUpdated={onRefresh} />
   </aside>
 }
 

--- a/crm/console/CommercialAssistedWhatsappPanel.tsx
+++ b/crm/console/CommercialAssistedWhatsappPanel.tsx
@@ -1,0 +1,196 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { LockKeyhole, RefreshCw, ShieldCheck } from 'lucide-react'
+import { Button } from '@/button'
+import {
+  confirmCommercialAssistedWhatsapp,
+  fetchCommercialAssistedOffers,
+  fetchCommercialAssistedReadiness,
+  fetchCommercialAssistedTemplates,
+  previewCommercialAssistedWhatsapp,
+  type CommercialAction,
+  type CommercialAssistedConfirmation,
+  type CommercialAssistedOffer,
+  type CommercialAssistedPreview,
+  type CommercialAssistedReadiness,
+  type CommercialAssistedTemplate,
+} from '@/atendimentoApi'
+
+const COMMERCIAL_ASSISTED_MUTATIONS_ENABLED = false
+const HUMAN_CONFIRMATION = 'CONFIRMAR_CONTATO_ASSISTIDO'
+const preparableStatuses = new Set<CommercialAction['status']>(['open', 'contacted', 'responded', 'scheduled'])
+
+function displayMoney(value: number | null, code: string) {
+  if (value == null || !Number.isFinite(value)) return 'Condições aprovadas'
+  return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: code || 'BRL' }).format(value / 100)
+}
+
+function displayDate(value: string | null | undefined) {
+  if (!value) return 'Vigência não informada'
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? 'Vigência não informada' : new Intl.DateTimeFormat('pt-BR', { dateStyle: 'medium', timeZone: 'America/Sao_Paulo' }).format(parsed)
+}
+
+function nextIdempotencyKey() {
+  return globalThis.crypto?.randomUUID?.() || `assisted-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+}
+
+export function CommercialAssistedWhatsappPanel({ actions, onUpdated }: { actions: CommercialAction[]; onUpdated: () => Promise<void> | void }) {
+  const [actionId, setActionId] = useState('')
+  const [offerId, setOfferId] = useState('')
+  const [templateId, setTemplateId] = useState('')
+  const [readiness, setReadiness] = useState<CommercialAssistedReadiness | null>(null)
+  const [offers, setOffers] = useState<CommercialAssistedOffer[]>([])
+  const [templates, setTemplates] = useState<CommercialAssistedTemplate[]>([])
+  const [preview, setPreview] = useState<CommercialAssistedPreview | null>(null)
+  const [confirmed, setConfirmed] = useState<CommercialAssistedConfirmation | null>(null)
+  const [confirmation, setConfirmation] = useState('')
+  const [idempotencyKey, setIdempotencyKey] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState('')
+
+  const preparableActions = useMemo(() => actions.filter((action) => action.contactChannel === 'whatsapp' && preparableStatuses.has(action.status)), [actions])
+  const selectedAction = useMemo(() => preparableActions.find((action) => action.id === actionId) || null, [actionId, preparableActions])
+  const selectedActionId = selectedAction?.id || ''
+  const selectedUnit = selectedAction?.unitSlug || ''
+  const preparationBlocked = !COMMERCIAL_ASSISTED_MUTATIONS_ENABLED || readiness?.safety?.commercialContactWritesEnabled !== true
+
+  const clearPreparedState = () => {
+    setPreview(null)
+    setConfirmed(null)
+    setConfirmation('')
+    setIdempotencyKey('')
+  }
+
+  useEffect(() => {
+    if (!preparableActions.length) {
+      if (actionId) setActionId('')
+      return
+    }
+    if (!preparableActions.some((action) => action.id === actionId)) setActionId(preparableActions[0].id)
+  }, [actionId, preparableActions])
+
+  const load = useCallback(async () => {
+    setBusy(true)
+    setError('')
+    setReadiness(null)
+    setOffers([])
+    setTemplates([])
+    setPreview(null)
+    setConfirmed(null)
+    setConfirmation('')
+    setIdempotencyKey('')
+    if (!selectedActionId || !selectedUnit) {
+      setBusy(false)
+      return
+    }
+    const readinessResponse = await fetchCommercialAssistedReadiness()
+    if (!readinessResponse.ok || !readinessResponse.ready) {
+      setError(readinessResponse.error || 'A operação assistida não está pronta neste ambiente.')
+      setBusy(false)
+      return
+    }
+    setReadiness(readinessResponse)
+    const [offersResponse, templatesResponse] = await Promise.all([
+      fetchCommercialAssistedOffers(selectedActionId),
+      fetchCommercialAssistedTemplates(selectedUnit),
+    ])
+    if (!offersResponse.ok || !templatesResponse.ok) {
+      setError(offersResponse.error || templatesResponse.error || 'Não foi possível carregar o contexto aprovado.')
+      setBusy(false)
+      return
+    }
+    setOffers(offersResponse.offers)
+    setTemplates(templatesResponse.templates)
+    setOfferId(offersResponse.offers[0]?.offerId || '')
+    setTemplateId(templatesResponse.templates[0]?.templateId || '')
+    setBusy(false)
+  }, [selectedActionId, selectedUnit])
+
+  useEffect(() => { void load() }, [load])
+
+  const previewMessage = async () => {
+    if (preparationBlocked || !selectedActionId || !offerId || !templateId) return
+    setBusy(true)
+    setError('')
+    const response = await previewCommercialAssistedWhatsapp({ actionId: selectedActionId, offerId, templateId })
+    if (!response.ok || !response.eligible) {
+      setError(response.error || response.blockReason || 'O contexto não passou pela revalidação.')
+      setBusy(false)
+      return
+    }
+    setPreview(response)
+    setConfirmed(null)
+    setConfirmation('')
+    setIdempotencyKey(nextIdempotencyKey())
+    setBusy(false)
+  }
+
+  const confirmPreparation = async () => {
+    if (preparationBlocked || !preview?.previewContextHash || !idempotencyKey || !selectedActionId || !offerId || !templateId) return
+    if (confirmation !== HUMAN_CONFIRMATION) {
+      setError('Digite a confirmação literal para registrar o preparo humano.')
+      return
+    }
+    setBusy(true)
+    setError('')
+    const response = await confirmCommercialAssistedWhatsapp({
+      actionId: selectedActionId,
+      offerId,
+      templateId,
+      previewContextHash: preview.previewContextHash,
+      confirmation: HUMAN_CONFIRMATION,
+      idempotencyKey,
+    })
+    if (!response.ok) {
+      setError(response.error || 'Não foi possível confirmar o preparo.')
+      setBusy(false)
+      return
+    }
+    setConfirmed(response)
+    await Promise.resolve(onUpdated())
+    setBusy(false)
+  }
+
+  return <section aria-labelledby="commercial-assisted-heading" aria-label="Comunicação assistida por WhatsApp" className="mt-4 rounded-2xl border border-slate-800/80 bg-slate-950/55 p-5 shadow-[0_20px_60px_rgba(2,6,23,0.28)]">
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <div className="flex items-center gap-2"><ShieldCheck className="h-5 w-5 text-emerald-200" /><h2 id="commercial-assisted-heading" className="text-lg font-semibold text-white">Comunicação assistida</h2></div>
+        <p className="mt-1 text-sm text-slate-500">Ofertas e modelos aprovados para a ação selecionada, sem exposição de dados de contato.</p>
+      </div>
+      <Button size="sm" variant="outline" onClick={() => void load()} disabled={busy}><RefreshCw className={`mr-2 h-4 w-4 ${busy ? 'animate-spin' : ''}`} />Atualizar</Button>
+    </div>
+
+    <div className="mt-3 flex gap-2 rounded-lg border border-emerald-300/20 bg-emerald-500/10 p-3 text-xs text-emerald-100"><LockKeyhole className="mt-0.5 h-4 w-4 shrink-0" /><span><b>Transporte externo bloqueado:</b> preparo, confirmação, mensagens, contato e alterações comerciais permanecem desativados pelas flags compiladas e pelo runtime somente leitura.</span></div>
+    {error ? <div role="alert" className="mt-3 rounded-lg border border-amber-300/25 bg-amber-500/10 p-3 text-sm text-amber-100">{error}</div> : null}
+    {preparableActions.length === 0 ? <div className="mt-4 rounded-xl border border-slate-800/80 bg-slate-950/45 p-4 text-sm text-slate-500">Não há ação elegível para preparar neste perfil.</div> : <div className="mt-4 grid gap-4 xl:grid-cols-2">
+      <div className="space-y-3 rounded-xl border border-slate-800/80 bg-slate-950/45 p-4">
+        <label className="block text-xs font-medium text-slate-300" htmlFor="assisted-action">Ação da carteira</label>
+        <select id="assisted-action" aria-label="Ação da carteira para comunicação assistida" value={actionId} onChange={(event) => { setActionId(event.target.value); clearPreparedState() }} className="w-full rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100">
+          {preparableActions.map((action) => <option key={action.id} value={action.id}>{action.unitName} · {action.segmentKey} · {action.status}</option>)}
+        </select>
+        <label className="block text-xs font-medium text-slate-300" htmlFor="assisted-offer">Oferta aprovada</label>
+        <select id="assisted-offer" aria-label="Oferta aprovada" value={offerId} onChange={(event) => { setOfferId(event.target.value); clearPreparedState() }} disabled={busy || !offers.length} className="w-full rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 disabled:opacity-60">
+          <option value="">Selecione uma oferta</option>{offers.map((offer) => <option key={offer.offerId} value={offer.offerId}>{offer.title} · r{offer.revision}</option>)}
+        </select>
+        <label className="block text-xs font-medium text-slate-300" htmlFor="assisted-template">Modelo aprovado</label>
+        <select id="assisted-template" aria-label="Modelo aprovado" value={templateId} onChange={(event) => { setTemplateId(event.target.value); clearPreparedState() }} disabled={busy || !templates.length} className="w-full rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 disabled:opacity-60">
+          <option value="">Selecione um modelo</option>{templates.map((template) => <option key={template.templateId} value={template.templateId}>{template.templateKey} · r{template.revision}</option>)}
+        </select>
+      </div>
+      <div className="rounded-xl border border-slate-800/80 bg-slate-950/45 p-4">
+        <h3 className="font-medium text-slate-100">Contexto aprovado</h3>
+        {offers.find((offer) => offer.offerId === offerId) ? <div className="mt-3 space-y-1 text-sm text-slate-300">{(() => { const offer = offers.find((item) => item.offerId === offerId)!; return <><div className="font-medium text-slate-100">{offer.title} · r{offer.revision}</div><div>{displayMoney(offer.priceCents, offer.currency)}</div><div className="text-xs text-slate-500">{offer.conditions || 'Condições aprovadas'} · {displayDate(offer.validityStart)} até {displayDate(offer.validityEnd)}</div></> })()}</div> : <p className="mt-3 text-sm text-slate-500">Aguardando oferta aprovada.</p>}
+        <div className="mt-4 rounded-lg border border-slate-800 bg-slate-900/70 p-3 text-xs text-slate-400">Destinatário: mascarado até uma revalidação autorizada. Nenhuma informação de contato é exibida nesta tela.</div>
+      </div>
+    </div>}
+
+    <div className="mt-4 rounded-xl border border-slate-800/80 bg-slate-950/45 p-4">
+      <h3 className="font-medium text-slate-100">Preview e confirmação humana</h3>
+      <p className="mt-1 text-xs text-slate-500">As etapas abaixo ficam bloqueadas enquanto a política e o runtime estiverem em modo somente leitura.</p>
+      <div className="mt-3 flex flex-wrap gap-2"><Button size="sm" variant="outline" disabled={busy || preparationBlocked || !selectedActionId || !offerId || !templateId} onClick={() => void previewMessage()}>Gerar preview mascarado</Button><Button size="sm" disabled={busy || preparationBlocked || !preview?.previewContextHash || confirmation !== HUMAN_CONFIRMATION} onClick={() => void confirmPreparation()}>Confirmar preparo humano</Button></div>
+      {preview ? <div className="mt-3 rounded-lg border border-slate-800 bg-slate-900/70 p-3 text-sm text-slate-200"><div className="font-medium">Destinatário: {preview.recipientMasked || 'Mascarado'}</div><p className="mt-2 whitespace-pre-wrap text-slate-300">{preview.messagePreview || 'Preview indisponível.'}</p><label className="mt-3 block text-xs text-slate-400" htmlFor="assisted-confirmation">Digite {HUMAN_CONFIRMATION}</label><input id="assisted-confirmation" aria-label="Confirmação humana literal" value={confirmation} onChange={(event) => setConfirmation(event.target.value)} disabled={preparationBlocked} className="mt-1 w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-slate-100 disabled:opacity-60" /></div> : null}
+      {confirmed ? <div role="status" className="mt-3 rounded-lg border border-emerald-300/20 bg-emerald-500/10 p-3 text-sm text-emerald-100">Preparo registrado como {confirmed.status}. Resultado: {confirmed.dispatchResult}. Nenhuma mensagem foi enviada.</div> : null}
+    </div>
+    <p aria-live="polite" className="sr-only">{busy ? 'Carregando contexto assistido' : error || (readiness?.ready ? 'Contexto assistido disponível em modo bloqueado' : 'Contexto assistido não disponível')}</p>
+  </section>
+}

--- a/crm/console/atendimentoApi.ts
+++ b/crm/console/atendimentoApi.ts
@@ -854,11 +854,11 @@ export type CommercialAction = {
 }
 
 export type CommercialAssistedSafety = {
-  providerSend: false
-  automationEnabled: false
-  bulkDispatchEnabled: false
-  commercialContactWritesEnabled: false
-  externalDispatch: false
+  providerSend: boolean
+  automationEnabled: boolean
+  bulkDispatchEnabled: boolean
+  commercialContactWritesEnabled: boolean
+  externalDispatch: boolean
 }
 
 export type CommercialAssistedReadiness = {

--- a/crm/console/atendimentoApi.ts
+++ b/crm/console/atendimentoApi.ts
@@ -853,6 +853,72 @@ export type CommercialAction = {
   updatedAt: string
 }
 
+export type CommercialAssistedSafety = {
+  providerSend: false
+  automationEnabled: false
+  bulkDispatchEnabled: false
+  commercialContactWritesEnabled: false
+  externalDispatch: false
+}
+
+export type CommercialAssistedReadiness = {
+  ready: boolean
+  migrationId?: string
+  relationsReady?: boolean
+  appendOnlyReady?: boolean
+  dependenciesReady?: boolean
+  migrationReady?: boolean
+  canaryReady?: boolean
+  sourceOperationsReady?: boolean
+  safety: CommercialAssistedSafety
+}
+
+export type CommercialAssistedOffer = {
+  offerId: string
+  offerKey: string
+  revision: number
+  unit: string
+  title: string
+  description: string
+  priceCents: number | null
+  currency: string
+  priceQualifier: string
+  conditions: string
+  validityStart: string | null
+  validityEnd: string | null
+  contextHash: string
+}
+
+export type CommercialAssistedTemplate = {
+  templateId: string
+  templateKey: string
+  revision: number
+  unit: string
+  status: string
+  validFrom: string | null
+  validUntil: string | null
+}
+
+export type CommercialAssistedPreview = {
+  eligible: boolean
+  blockReason?: string
+  previewContextHash?: string
+  recipientMasked?: string
+  messagePreview?: string
+  sourceFreshness?: string
+  snapshotComplete?: boolean
+  safety: CommercialAssistedSafety
+}
+
+export type CommercialAssistedConfirmation = {
+  attemptId: string
+  actionId: string
+  status: string
+  recipientMasked: string
+  dispatchResult: 'not_dispatched'
+  safety: CommercialAssistedSafety
+}
+
 export type CommercialPolicy = {
   activeContactCooldownDays: number
   returnRiskThresholds: number[]
@@ -1275,6 +1341,26 @@ export function fetchCommercialProfile(identityId: string, filters: { asOf?: str
   if (filters.unit && filters.unit !== 'all') params.set('unit', filters.unit)
   const qs = params.toString()
   return api<CommercialProfileDetail>(`/commercial/profiles/${encodeURIComponent(identityId)}${qs ? `?${qs}` : ''}`)
+}
+
+export function fetchCommercialAssistedReadiness() {
+  return api<CommercialAssistedReadiness>('/commercial/assisted-whatsapp/readiness')
+}
+
+export function fetchCommercialAssistedOffers(actionId: string) {
+  return api<{ actionId: string; unit: string; offers: CommercialAssistedOffer[]; safety: CommercialAssistedSafety }>(`/commercial/assisted-whatsapp/offers?actionId=${encodeURIComponent(actionId)}`)
+}
+
+export function fetchCommercialAssistedTemplates(unit: string) {
+  return api<{ unit: string; templates: CommercialAssistedTemplate[]; safety: CommercialAssistedSafety }>(`/commercial/assisted-whatsapp/templates?unit=${encodeURIComponent(unit)}`)
+}
+
+export function previewCommercialAssistedWhatsapp(payload: { actionId: string; offerId: string; templateId: string }) {
+  return api<CommercialAssistedPreview>('/commercial/assisted-whatsapp/preview', { method: 'POST', body: payload })
+}
+
+export function confirmCommercialAssistedWhatsapp(payload: { actionId: string; offerId: string; templateId: string; previewContextHash: string; confirmation: 'CONFIRMAR_CONTATO_ASSISTIDO'; idempotencyKey: string }) {
+  return api<CommercialAssistedConfirmation>('/commercial/assisted-whatsapp/confirm', { method: 'POST', body: payload })
 }
 
 export function createCommercialAction(payload: { identityId: string; segmentKey: string; actionType: CommercialAction['actionType']; contactChannel?: 'whatsapp'; owner?: string; unit?: string; dueDate?: string; notes?: string }) {

--- a/crm/console/tests/clientCommercialAssistedWhatsapp.test.ts
+++ b/crm/console/tests/clientCommercialAssistedWhatsapp.test.ts
@@ -18,7 +18,8 @@ describe('Clientes assisted communication console', () => {
     expect(panelSource).toContain('const COMMERCIAL_ASSISTED_MUTATIONS_ENABLED = false')
     expect(panelSource).toContain('commercialContactWritesEnabled')
     expect(panelSource).toContain('CONFIRMAR_CONTATO_ASSISTIDO')
-    expect(panelSource).not.toMatch(/wa\.me|window\.open|href=|handoffs|reveal|dispatch|provider|phone|email/i)
+    expect(panelSource).toContain('dispatchResult')
+    expect(panelSource).not.toMatch(/wa\.me|window\.open|href=|handoffs|reveal|provider|phone|email/i)
     expect(apiSource).not.toContain('/commercial/assisted-whatsapp/handoffs')
   })
 

--- a/crm/console/tests/clientCommercialAssistedWhatsapp.test.ts
+++ b/crm/console/tests/clientCommercialAssistedWhatsapp.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const moduleSource = readFileSync(new URL('../ClientCommercialModule.tsx', import.meta.url), 'utf8')
+const panelSource = readFileSync(new URL('../CommercialAssistedWhatsappPanel.tsx', import.meta.url), 'utf8')
+const apiSource = readFileSync(new URL('../atendimentoApi.ts', import.meta.url), 'utf8')
+const runbook = readFileSync(new URL('../../../docs/runbooks/clientes-commercial-assisted-whatsapp-v2.md', import.meta.url), 'utf8')
+
+describe('Clientes assisted communication console', () => {
+  it('mounts the profile panel with the existing action context', () => {
+    expect(moduleSource).toContain('CommercialAssistedWhatsappPanel')
+    expect(moduleSource).toContain('<CommercialAssistedWhatsappPanel actions={detail.actions} onUpdated={onRefresh} />')
+    expect(panelSource).toContain('aria-label="Comunicação assistida por WhatsApp"')
+    expect(panelSource).toContain('recipientMasked')
+  })
+
+  it('keeps mutations compiled off and does not add a transport or destination exposure path', () => {
+    expect(panelSource).toContain('const COMMERCIAL_ASSISTED_MUTATIONS_ENABLED = false')
+    expect(panelSource).toContain('commercialContactWritesEnabled')
+    expect(panelSource).toContain('CONFIRMAR_CONTATO_ASSISTIDO')
+    expect(panelSource).not.toMatch(/wa\.me|window\.open|href=|handoffs|reveal|dispatch|provider|phone|email/i)
+    expect(apiSource).not.toContain('/commercial/assisted-whatsapp/handoffs')
+  })
+
+  it('uses only the governed API contracts and documents the fail-closed panel', () => {
+    expect(apiSource).toContain('fetchCommercialAssistedReadiness')
+    expect(apiSource).toContain('fetchCommercialAssistedOffers')
+    expect(apiSource).toContain('fetchCommercialAssistedTemplates')
+    expect(apiSource).toContain('previewCommercialAssistedWhatsapp')
+    expect(apiSource).toContain('confirmCommercialAssistedWhatsapp')
+    expect(runbook).toContain('controles mutáveis permanecem desabilitados')
+    expect(runbook).toContain('não emite transporte externo')
+  })
+})

--- a/docs/runbooks/clientes-commercial-assisted-whatsapp-v2.md
+++ b/docs/runbooks/clientes-commercial-assisted-whatsapp-v2.md
@@ -4,7 +4,7 @@
 
 O dom?nio, a migration aditiva, o armazenamento e uma superf?cie HTTP m?nima de Clientes est?o versionados. As rotas exigem ator assinado, papel `GESTOR`, escopo de unidade e um sujeito opaco derivado somente de `subject`, `subjectId` ou `id`; e-mail e username n?o s?o aceitos como identidade de auditoria.
 
-A superf?cie exp?e somente readiness, ofertas compat?veis, templates aprovados, preview mascarado, confirma??o/handoff humanos e controle de emerg?ncia. O runtime de Clientes somente leitura continua bloqueando toda muta??o antes dos handlers. N?o h? UI, cliente de console, worker, SDK de provedor, URL de envio, rota de webhook, rota de reveal de telefone ou dispatch nesta tranche.
+O console expõe apenas uma leitura contextual de ofertas e modelos aprovados no perfil endereçado. O preview e a confirmação permanecem bloqueados pelas flags compiladas e pelo runtime somente leitura; não há reveal de destino, URI de envio, SDK de provedor, worker, rota de webhook ou dispatch nesta tranche.
 
 Nenhuma mensagem, contato comercial, consentimento ou altera??o de identidade ? enviada ou aplicada por este c?digo. O processo HTTP n?o ganha automa??o nem job cont?nuo.
 
@@ -73,4 +73,4 @@ O smoke autorizado nesta tranche ? est?tico/sint?tico: flags false, origem inace
 
 ## Pr?xima tranche necess?ria
 
-Uma PR posterior, pequena e revisada, pode adicionar a UI de preview mascarado e reveal tempor?rio/auditado. O reveal precisa continuar one-time, justificado e sem URI de provedor. O ingress de webhook tamb?m fica separado: deve manter raw HMAC, replay, rate limit, STOP imediato e bloqueio expl?cito no runtime somente leitura. Automa??o, disparo em massa e envio aut?nomo continuam proibidos.
+O console agora apresenta ofertas e modelos aprovados para a ação selecionada, destinatário mascarado e a confirmação literal. As flags compiladas continuam em false, portanto os controles mutáveis permanecem desabilitados e o painel não emite transporte externo. Uma PR posterior, pequena e revisada, pode introduzir reveal temporário/auditado; ele precisa continuar one-time, justificado e sem URI de provedor. O ingresso de webhook também fica separado: deve manter raw HMAC, replay, rate limit, STOP imediato e bloqueio explícito no runtime somente leitura. Automação, disparo em massa e envio autônomo continuam proibidos.


### PR DESCRIPTION
## Escopo

- adiciona painel de Comunicação assistida no perfil de Clientes;
- lê somente readiness, ofertas compatíveis e modelos aprovados;
- mantém o preparo e a confirmação compilados como desativados e também sujeitos ao runtime somente leitura;
- não adiciona reveal de destino, handoff, webhook, URI de envio, SDK de provedor, dispatch ou automação.

## Segurança

As flags de segurança permanecem false. Nenhuma mensagem, contato, consentimento, alteração de identidade, migration ou deploy foi executado. A interface exibe somente destinatário mascarado quando existir um preview governado.

## Validação

Foi adicionada uma regressão estática de contratos e superfície. A capacidade local está indisponível (C: sem espaço), portanto typecheck, build e renderização visual local não foram executados; a PR permanece draft e a matriz CI é o gate.

## Rollback

Reverter o commit desta PR remove o painel e seus contratos de console; não há estado externo a desfazer.