### PR TITLE
fix(crm): recover unified team safety gates

### DIFF
--- a/crm/api/server.js
+++ b/crm/api/server.js
@@ -2110,13 +2110,22 @@ if (DEV_AUTH_ENABLED) {
         res.status(200).set('cache-control', 'no-store').json({ success: true, data, activeOnly: false, status: requestedStatus, summary: { members: data.length, pendingInvites: data.filter((member) => member.accountStatus === 'INVITED').length } })
     })
 
-    app.get('/api/crm/admin/users', async (_req, res) => {
+    app.get('/api/crm/admin/users', async (req, res) => {
+        const session = getDevSession(req) || getLocalProxySession(req)
+        const role = normalizeRole(session?.user?.role)
+        if (!['ADMIN', 'GESTOR', 'GERENTE'].includes(role)) {
+            return res.status(401).json({ ok: false, success: false, error: 'UNAUTHORIZED', code: 'UNAUTHORIZED' })
+        }
+        if (localUnifiedTeamEnabled) {
+            return res.status(410).json({ success: false, error: 'Use a gestão centralizada de equipe.', code: 'UNIFIED_TEAM_ROUTE_DISABLED' })
+        }
         const store = await loadLocalCrmStore()
         res.status(200).set('cache-control', 'no-store').json({ success: true, data: store.users })
     })
     app.post('/api/crm/admin/users', async (req, res) => {
         const session = requireDevAdmin(req, res)
         if (!session) return
+        if (localUnifiedTeamEnabled) return res.status(410).json({ success: false, error: 'Use a gestão centralizada de equipe e convites.', code: 'UNIFIED_TEAM_ROUTE_DISABLED' })
         const store = await loadLocalCrmStore()
         const body = req.body && typeof req.body === 'object' ? req.body : {}
         const username = String(body.username || '').trim()
@@ -2143,6 +2152,7 @@ if (DEV_AUTH_ENABLED) {
     app.put('/api/crm/admin/users/:username', async (req, res) => {
         const session = requireDevAdmin(req, res)
         if (!session) return
+        if (localUnifiedTeamEnabled) return res.status(410).json({ success: false, error: 'Use a gestão centralizada de equipe.', code: 'UNIFIED_TEAM_ROUTE_DISABLED' })
         const store = await loadLocalCrmStore()
         const username = String(req.params.username || '').trim()
         const idx = store.users.findIndex((u) => String(u?.username || '').toLowerCase() === username.toLowerCase())
@@ -2168,6 +2178,7 @@ if (DEV_AUTH_ENABLED) {
     app.post('/api/crm/admin/users/:username/reset-password', async (req, res) => {
         const session = requireDevAdmin(req, res)
         if (!session) return
+        if (localUnifiedTeamEnabled) return res.status(410).json({ success: false, error: 'A senha deve ser criada pelo próprio integrante.', code: 'UNIFIED_TEAM_ROUTE_DISABLED' })
         const store = await loadLocalCrmStore()
         const username = String(req.params.username || '').trim()
         const idx = store.users.findIndex((u) => String(u?.username || '').toLowerCase() === username.toLowerCase())

--- a/crm/console/SystemStatusModule.tsx
+++ b/crm/console/SystemStatusModule.tsx
@@ -91,6 +91,11 @@ type AdminUser = {
   updatedAt?: string | null
 }
 
+type UnifiedTeamConfig = {
+  enabled?: boolean
+  legacyEscalaEditor?: boolean
+}
+
 async function apiJson<T>(
   path: string,
   opts: {
@@ -141,6 +146,7 @@ export function SystemStatusModule() {
   const unitMonitorUnitKey = effectiveUnit
   const insumosUnit = effectiveUnit
   const [insumosMe, setInsumosMe] = React.useState<InsumosMe | null>(null)
+  const [unifiedTeamEnabled, setUnifiedTeamEnabled] = React.useState(false)
   const [loadingProgress, setLoadingProgress] = React.useState(0)
   const loadingStartedAtRef = React.useRef<number | null>(null)
 
@@ -186,6 +192,24 @@ export function SystemStatusModule() {
       return null
     }
   }, [])
+
+  const refreshTeamConfig = React.useCallback(async () => {
+    if (!hasInsumosSession) {
+      setUnifiedTeamEnabled(false)
+      return
+    }
+    try {
+      const out = await apiJson<{ success?: boolean; data?: UnifiedTeamConfig }>('/admin/team?mode=config')
+      setUnifiedTeamEnabled(Boolean(out?.data?.enabled))
+    } catch {
+      // Keep the legacy contingency if the feature-config route is unavailable.
+      setUnifiedTeamEnabled(false)
+    }
+  }, [hasInsumosSession])
+
+  React.useEffect(() => {
+    void refreshTeamConfig()
+  }, [refreshTeamConfig])
 
   const refresh = React.useCallback(async () => {
     setLoading(true)
@@ -323,6 +347,10 @@ export function SystemStatusModule() {
 
   const loadUsers = React.useCallback(async () => {
     if (!canManageUsers) return
+    if (unifiedTeamEnabled) {
+      setUsers([])
+      return
+    }
     setUsersLoading(true)
     try {
       const params = new URLSearchParams()
@@ -335,7 +363,7 @@ export function SystemStatusModule() {
     } finally {
       setUsersLoading(false)
     }
-  }, [canManageUsers, usersQuery])
+  }, [canManageUsers, unifiedTeamEnabled, usersQuery])
 
   const canViewAudit = hasInsumosSession && (insumosRole === 'GESTOR' || insumosRole === 'GERENTE')
   const loadAudit = React.useCallback(async () => {
@@ -621,6 +649,14 @@ export function SystemStatusModule() {
               <div className="text-sm text-blue-100/70">Faça login para ver funções administrativas.</div>
             ) : !canManageUsers ? (
               <div className="text-sm text-blue-100/70">Seu perfil ({insumosRole || '—'}) não tem permissão para usuários.</div>
+            ) : unifiedTeamEnabled ? (
+              <div className="rounded-xl border border-emerald-200/20 bg-emerald-200/5 p-4 space-y-3">
+                <div>
+                  <div className="text-sm font-medium text-emerald-50">Gestão centralizada ativa</div>
+                  <div className="mt-1 text-sm text-blue-100/70">Usuários, equipe, convites e vínculos operacionais são administrados no módulo Usuários.</div>
+                </div>
+                <Button onClick={() => { window.location.href = '/?module=users' }}>Abrir Usuários</Button>
+              </div>
             ) : (
               <>
                 <div className="flex flex-wrap items-center justify-between gap-2">
@@ -694,8 +730,6 @@ export function SystemStatusModule() {
                     </tbody>
                   </table>
                 </div>
-              </>
-            )}
 
             <Dialog open={userCreateOpen} onOpenChange={(o) => { setUserCreateOpen(o); if (!o) setOneTimePassword(null) }}>
               <DialogContent className="sm:max-w-xl">
@@ -772,6 +806,8 @@ export function SystemStatusModule() {
                 ) : null}
               </DialogContent>
             </Dialog>
+              </>
+            )}
           </CardContent>
         ) : null}
 

--- a/inventory/src/routes/admin.js
+++ b/inventory/src/routes/admin.js
@@ -1301,9 +1301,13 @@ export async function handleAdminRoutes({
 
   const teamMemberMatch = url.pathname.match(/^\/admin\/team\/([^/]+)$/);
   if (teamMemberMatch && request.method === 'PUT') {
+    let onboardingId = '';
+    let current = null;
+    let workforceSynchronized = false;
+    let localPersistenceStage = 'PREPARATION';
     try {
-      const onboardingId = decodeURIComponent(teamMemberMatch[1] || '').trim();
-      const current = await env.DB.prepare(`SELECT o.*, t.schedule_professional_id, t.schedule_status, t.schedule_role, t.schedule_shift, t.schedule_nickname, t.schedule_instagram, t.schedule_color, t.units_json AS schedule_units_json
+      onboardingId = decodeURIComponent(teamMemberMatch[1] || '').trim();
+      current = await env.DB.prepare(`SELECT o.*, t.schedule_professional_id, t.schedule_status, t.schedule_role, t.schedule_shift, t.schedule_nickname, t.schedule_instagram, t.schedule_color, t.units_json AS schedule_units_json
         FROM crm_employee_onboarding o LEFT JOIN crm_employee_team t ON t.onboarding_id=o.id WHERE o.id=? LIMIT 1`).bind(onboardingId).first();
       if (!current) return withCORS(JSON.stringify({ success: false, error: 'Membro da equipe não encontrado', code: 'TEAM_MEMBER_NOT_FOUND' }), { status: 404 }, appOrigin);
       if (!teamUnitsVisible(auth, current.units_json)) return withCORS(JSON.stringify({ success: false, error: 'Unidade fora do escopo do gestor', code: 'TEAM_UNITS_DENIED' }), { status: 403 }, appOrigin);
@@ -1349,7 +1353,9 @@ export async function handleAdminRoutes({
         department: nextDepartment,
         createdBy: String(auth?.user?.username || ''),
       }, requestId);
+      workforceSynchronized = true;
 
+      localPersistenceStage = 'ONBOARDING_UPDATE';
       const sets = ['full_name=?', 'profile=?', 'job_title=?', 'department_name=?', 'units_json=?', 'updated_at=?'];
       const values = [nextName, nextProfile.profile || nextProfile, displayJobTitle(nextProfile.profile || nextProfile), nextDepartment, JSON.stringify(nextUnits), new Date().toISOString()];
       if (nextPersonalEmail) {
@@ -1361,8 +1367,10 @@ export async function handleAdminRoutes({
         values.push(nextPhoneEncrypted, nextPhoneHash);
       }
       values.push(onboardingId);
-      await env.DB.prepare(`UPDATE crm_employee_onboarding SET ${sets.join(', ')} WHERE id=?`).bind(...values).run();
+      const onboardingUpdate = await env.DB.prepare(`UPDATE crm_employee_onboarding SET ${sets.join(', ')} WHERE id=?`).bind(...values).run();
+      if (Number(onboardingUpdate?.meta?.changes ?? 0) !== 1) throw new Error('TEAM_ONBOARDING_LOCAL_UPDATE_NOT_APPLIED');
 
+      localPersistenceStage = 'TEAM_UPDATE';
       const teamData = normalizeTeamData(body.team, nextUnits, {
         professionalId: current.schedule_professional_id,
         status: current.schedule_status,
@@ -1380,10 +1388,11 @@ export async function handleAdminRoutes({
         return withCORS(JSON.stringify({ success: false, error: 'As unidades operacionais devem estar dentro do escopo do cadastro', code: 'TEAM_UNITS_DENIED' }), { status: 403 }, appOrigin);
       }
       const nextScheduleProfessionalId = teamData.professionalId || current.schedule_professional_id || null;
-      await env.DB.prepare(`UPDATE crm_employee_team SET schedule_professional_id=?, schedule_status=?, schedule_role=?, schedule_shift=?, schedule_nickname=?, schedule_instagram=?, schedule_color=?, units_json=?, updated_at=? WHERE onboarding_id=?`).bind(
+      const teamUpdate = await env.DB.prepare(`UPDATE crm_employee_team SET schedule_professional_id=?, schedule_status=?, schedule_role=?, schedule_shift=?, schedule_nickname=?, schedule_instagram=?, schedule_color=?, units_json=?, updated_at=? WHERE onboarding_id=?`).bind(
         nextScheduleProfessionalId, teamData.status || null, teamData.role || null, teamData.shift || null,
         teamData.nickname || null, teamData.instagram || null, teamData.color || null, JSON.stringify(teamData.units), new Date().toISOString(), onboardingId,
       ).run();
+      if (Number(teamUpdate?.meta?.changes ?? 0) !== 1) throw new Error('TEAM_LOCAL_UPDATE_NOT_APPLIED');
       const scheduleState = hasScheduleIntent(teamData) || nextScheduleProfessionalId ? 'PENDING' : 'NOT_CONFIGURED';
       const scheduleSync = await persistScheduleSyncOperation({
         env,
@@ -1400,6 +1409,28 @@ export async function handleAdminRoutes({
       return withCORS(JSON.stringify({ success: true, data: publicTeamMember(updated, (links?.results || []).map(publicIdentityLink), scheduleSync?.scheduleSync || { state: scheduleState, professionalId: nextScheduleProfessionalId }) }), { status: 200 }, appOrigin);
     } catch (error) {
       const message = String(error?.message || 'TEAM_UPDATE_FAILED');
+      if (workforceSynchronized && ['ONBOARDING_UPDATE', 'TEAM_UPDATE'].includes(localPersistenceStage)) {
+        const now = new Date().toISOString();
+        const safeErrorCode = message.slice(0, 120);
+        await env.DB.prepare("UPDATE crm_employee_onboarding SET compensation_state='LOCAL_TEAM_UPDATE_PENDING', last_error_code=?, updated_at=? WHERE id=?")
+          .bind(safeErrorCode, now, onboardingId)
+          .run()
+          .catch(() => {});
+        await Promise.resolve(appendAuditLog?.({
+          env,
+          actor: auth.user.username,
+          role: auth.user.role,
+          ip,
+          userAgent,
+          action: 'EMPLOYEE_TEAM_COMPENSATION_PENDING',
+          entity: 'EMPLOYEE_ONBOARDING',
+          entityId: onboardingId,
+          unidade: normalizeAllowedUnits(current?.units_json).join(','),
+          after: { stage: localPersistenceStage, workforceSynchronized: true, requestId, failClosed: true },
+        })).catch(() => {});
+        await recordTeamTelemetry({ env, eventName: 'EMPLOYEE_TEAM_UPDATED', actorRole: auth.user.role, outcome: 'PENDING', itemCount: 1, unitCount: normalizeAllowedUnits(current?.units_json).length });
+        return withCORS(JSON.stringify({ success: false, error: 'Atualização local da equipe pendente de compensação', code: 'TEAM_LOCAL_PERSISTENCE_PENDING' }), { status: 503 }, appOrigin);
+      }
       const status = /^WORKFORCE_|^IDENTITY_|^SMTP_|^EMAIL_/.test(message) ? 503 : 500;
       return withCORS(JSON.stringify({ success: false, error: status === 503 ? 'Atualização da identidade pendente' : 'Não foi possível atualizar a equipe', code: message.slice(0, 120) }), { status }, appOrigin);
     }

--- a/inventory/src/routes/admin.js
+++ b/inventory/src/routes/admin.js
@@ -38,6 +38,10 @@ function unifiedTeamEnabled(env) {
   return ['1', 'true', 'yes', 'on'].includes(value);
 }
 
+function legacyUserRoutesDisabled(env) {
+  return unifiedTeamEnabled(env);
+}
+
 function slugifyCategory(value) {
   const s0 = String(value || '').trim().toLowerCase();
   if (!s0) return '';
@@ -1842,6 +1846,9 @@ export async function handleAdminRoutes({
 
   // GET /admin/users
   if (url.pathname === '/admin/users' && request.method === 'GET') {
+    if (legacyUserRoutesDisabled(env)) {
+      return withCORS(JSON.stringify({ success: false, error: 'Use a gestão centralizada de equipe.', code: 'UNIFIED_TEAM_ROUTE_DISABLED' }), { status: 410 }, appOrigin);
+    }
     try {
       const q = String(url.searchParams.get('q') || '').trim().toLowerCase();
       const limit = Math.max(1, Math.min(200, parseInt(url.searchParams.get('limit') || '100', 10) || 100));
@@ -1889,6 +1896,9 @@ export async function handleAdminRoutes({
 
   // POST /admin/users
   if (url.pathname === '/admin/users' && request.method === 'POST') {
+    if (legacyUserRoutesDisabled(env)) {
+      return withCORS(JSON.stringify({ success: false, error: 'Use a gestão centralizada de equipe e convites.', code: 'UNIFIED_TEAM_ROUTE_DISABLED' }), { status: 410 }, appOrigin);
+    }
     try {
       if (normalizeRole(auth?.user?.role) !== 'ADMIN' || String(env?.ALLOW_ADMIN_USER_PROVISIONING || '').trim().toLowerCase() !== 'true') {
         return withCORS(JSON.stringify({ success: false, error: 'Criação direta desabilitada. Use um convite autorizado.', code: 'INVITE_REQUIRED' }), { status: 403 }, appOrigin);
@@ -1985,6 +1995,9 @@ export async function handleAdminRoutes({
 
   // PUT /admin/users/:username
   if (url.pathname.startsWith('/admin/users/') && request.method === 'PUT') {
+    if (legacyUserRoutesDisabled(env)) {
+      return withCORS(JSON.stringify({ success: false, error: 'Use a gestão centralizada de equipe e convites.', code: 'UNIFIED_TEAM_ROUTE_DISABLED' }), { status: 410 }, appOrigin);
+    }
     try {
       const target = decodeURIComponent(url.pathname.slice('/admin/users/'.length)).trim();
       if (!target) return withCORS(JSON.stringify({ success: false, error: 'USERNAME_REQUIRED' }), { status: 400 }, appOrigin);
@@ -2085,6 +2098,9 @@ export async function handleAdminRoutes({
 
   // POST /admin/users/:username/reset-password
   if (url.pathname.startsWith('/admin/users/') && url.pathname.endsWith('/reset-password') && request.method === 'POST') {
+    if (legacyUserRoutesDisabled(env)) {
+      return withCORS(JSON.stringify({ success: false, error: 'A senha deve ser criada pelo próprio integrante após o convite.', code: 'UNIFIED_TEAM_ROUTE_DISABLED' }), { status: 410 }, appOrigin);
+    }
     try {
       const target = decodeURIComponent(url.pathname.slice('/admin/users/'.length, -'/reset-password'.length)).trim();
       if (!target) return withCORS(JSON.stringify({ success: false, error: 'USERNAME_REQUIRED' }), { status: 400 }, appOrigin);

--- a/inventory/src/routes/admin.js
+++ b/inventory/src/routes/admin.js
@@ -629,7 +629,10 @@ export async function handleAdminRoutes({
       if (onboardingHasUsername) {
         const usernameTaken = await env.DB.prepare(`SELECT 1 FROM ${usersTable} WHERE LOWER(username)=LOWER(?) LIMIT 1`).bind(requestedUsername).first();
         if (usernameTaken) return withCORS(JSON.stringify({ success: false, error: 'Este nome de usuário já está cadastrado', code: 'USERNAME_TAKEN' }), { status: 409 }, appOrigin);
-        const pendingUsername = await env.DB.prepare('SELECT 1 FROM crm_employee_onboarding WHERE LOWER(requested_username)=LOWER(?) AND id<>? AND account_status NOT IN (\'TERMINATED\', \'SUSPENDED\') LIMIT 1').bind(requestedUsername, id).first();
+        // Usernames are immutable login identifiers and remain reserved after
+        // suspension or termination so history and audit references cannot be
+        // rebound to another person.
+        const pendingUsername = await env.DB.prepare('SELECT 1 FROM crm_employee_onboarding WHERE LOWER(requested_username)=LOWER(?) AND id<>? LIMIT 1').bind(requestedUsername, id).first();
         if (pendingUsername) return withCORS(JSON.stringify({ success: false, error: 'Este nome de usuário já está reservado', code: 'USERNAME_TAKEN' }), { status: 409 }, appOrigin);
         if (invitesHasUsername) {
           const invitedUsername = await env.DB.prepare(`SELECT 1 FROM ${invitesTable} WHERE LOWER(requested_username)=LOWER(?) AND LOWER(invitee_email)<>LOWER(?) AND COALESCE(revoked, 0)=0 LIMIT 1`).bind(requestedUsername, input.corporateEmail).first();

--- a/inventory/tests/onboardingConsistency.test.mjs
+++ b/inventory/tests/onboardingConsistency.test.mjs
@@ -155,10 +155,14 @@ test('team usernames remain reserved across lifecycle history', async () => {
 
 test('centralized team mode disables every legacy password-management route', async () => {
   const admin = await readFile(new URL('../src/routes/admin.js', import.meta.url), 'utf8');
+  const localApi = await readFile(new URL('../../crm/api/server.js', import.meta.url), 'utf8');
   assert.equal((admin.match(/UNIFIED_TEAM_ROUTE_DISABLED/g) || []).length, 4);
   assert.match(admin, /A senha deve ser criada pelo próprio integrante/);
   assert.equal((admin.match(/legacyUserRoutesDisabled\(env\)/g) || []).length, 5);
   assert.ok((admin.match(/status: 410/g) || []).length >= 4);
+  assert.equal((localApi.match(/UNIFIED_TEAM_ROUTE_DISABLED/g) || []).length, 4);
+  assert.match(localApi, /const localUnifiedTeamEnabled =/);
+  assert.match(localApi, /Use a gestão centralizada de equipe/);
 });
 
 test('team telemetry accepts only aggregate fields and cannot persist identity PII', async () => {

--- a/inventory/tests/onboardingConsistency.test.mjs
+++ b/inventory/tests/onboardingConsistency.test.mjs
@@ -145,7 +145,9 @@ test('team edits expose a fail-closed local persistence compensation boundary', 
 
 test('team usernames remain reserved across lifecycle history', async () => {
   const admin = await readFile(new URL('../src/routes/admin.js', import.meta.url), 'utf8');
-  const usernameBlock = admin.slice(admin.indexOf('if (onboardingHasUsername) {'), admin.indexOf('const at = new Date().toISOString();'));
+  const usernameStart = admin.indexOf('if (onboardingHasUsername) {');
+  const usernameEnd = admin.indexOf('const at = new Date().toISOString();', usernameStart);
+  const usernameBlock = admin.slice(usernameStart, usernameEnd);
   assert.match(usernameBlock, /LOWER\(requested_username\)=LOWER\(\?\) AND id<>\?/);
   assert.doesNotMatch(usernameBlock, /account_status NOT IN/);
   const migration = await readFile(new URL('../migrations/0024_unified_team_identity.sql', import.meta.url), 'utf8');

--- a/inventory/tests/onboardingConsistency.test.mjs
+++ b/inventory/tests/onboardingConsistency.test.mjs
@@ -143,6 +143,16 @@ test('team edits expose a fail-closed local persistence compensation boundary', 
   assert.match(updateBlock, /outcome: 'PENDING'/);
 });
 
+test('team usernames remain reserved across lifecycle history', async () => {
+  const admin = await readFile(new URL('../src/routes/admin.js', import.meta.url), 'utf8');
+  const usernameBlock = admin.slice(admin.indexOf('if (onboardingHasUsername) {'), admin.indexOf('const at = new Date().toISOString();'));
+  assert.match(usernameBlock, /LOWER\(requested_username\)=LOWER\(\?\) AND id<>\?/);
+  assert.doesNotMatch(usernameBlock, /account_status NOT IN/);
+  const migration = await readFile(new URL('../migrations/0024_unified_team_identity.sql', import.meta.url), 'utf8');
+  assert.match(migration, /idx_crm_employee_onboarding_requested_username/);
+  assert.match(migration, /WHERE requested_username IS NOT NULL/);
+});
+
 test('team telemetry accepts only aggregate fields and cannot persist identity PII', async () => {
   const telemetry = await readFile(new URL('../src/services/teamTelemetry.js', import.meta.url), 'utf8');
   assert.match(telemetry, /item_count/);

--- a/inventory/tests/onboardingConsistency.test.mjs
+++ b/inventory/tests/onboardingConsistency.test.mjs
@@ -130,6 +130,19 @@ test('unified team management is explicit about RBAC, scope, idempotency and agg
   assert.match(localApi, /team\/:id\/activate/);
 });
 
+test('team edits expose a fail-closed local persistence compensation boundary', async () => {
+  const admin = await readFile(new URL('../src/routes/admin.js', import.meta.url), 'utf8');
+  const updateBlock = admin.slice(admin.indexOf('const teamMemberMatch'), admin.indexOf("if (url.pathname === '/admin/team' && request.method === 'GET')"));
+  assert.match(updateBlock, /let workforceSynchronized = false/);
+  assert.match(updateBlock, /localPersistenceStage = 'ONBOARDING_UPDATE'/);
+  assert.match(updateBlock, /localPersistenceStage = 'TEAM_UPDATE'/);
+  assert.match(updateBlock, /LOCAL_TEAM_UPDATE_PENDING/);
+  assert.match(updateBlock, /EMPLOYEE_TEAM_COMPENSATION_PENDING/);
+  assert.match(updateBlock, /TEAM_LOCAL_PERSISTENCE_PENDING/);
+  assert.match(updateBlock, /failClosed: true/);
+  assert.match(updateBlock, /outcome: 'PENDING'/);
+});
+
 test('team telemetry accepts only aggregate fields and cannot persist identity PII', async () => {
   const telemetry = await readFile(new URL('../src/services/teamTelemetry.js', import.meta.url), 'utf8');
   assert.match(telemetry, /item_count/);

--- a/inventory/tests/onboardingConsistency.test.mjs
+++ b/inventory/tests/onboardingConsistency.test.mjs
@@ -153,6 +153,14 @@ test('team usernames remain reserved across lifecycle history', async () => {
   assert.match(migration, /WHERE requested_username IS NOT NULL/);
 });
 
+test('centralized team mode disables every legacy password-management route', async () => {
+  const admin = await readFile(new URL('../src/routes/admin.js', import.meta.url), 'utf8');
+  assert.equal((admin.match(/UNIFIED_TEAM_ROUTE_DISABLED/g) || []).length, 4);
+  assert.match(admin, /A senha deve ser criada pelo próprio integrante/);
+  assert.equal((admin.match(/legacyUserRoutesDisabled\(env\)/g) || []).length, 5);
+  assert.ok((admin.match(/status: 410/g) || []).length >= 4);
+});
+
 test('team telemetry accepts only aggregate fields and cannot persist identity PII', async () => {
   const telemetry = await readFile(new URL('../src/services/teamTelemetry.js', import.meta.url), 'utf8');
   assert.match(telemetry, /item_count/);


### PR DESCRIPTION
## Escopo

Recupera para a linha canônica os hardenings de Usuários/Equipe que estavam apenas na linha candidata de staging.

## Alterações

- torna a persistência local de edição compensatória e fail-closed quando Workforce ou a projeção local não confirmam a operação;
- reserva nomes de usuário durante todo o histórico, inclusive após suspensão/desligamento;
- desativa as quatro rotas legadas de usuário/senha no Worker quando `UNIFIED_TEAM_ENABLED` está ativo;
- aplica o mesmo bloqueio ao adaptador local e exige sessão para leitura legada;
- remove o formulário antigo de usuários do Status quando a configuração centralizada é comprovadamente ativa e direciona para `?module=users`;
- reforça os testes de consistência e proveniência.

## Validação local

- `node --check crm/api/server.js` via wrapper WSL;
- `inventory/tests/onboardingConsistency.test.mjs`: 11/11;
- `inventory/tests/unifiedTeamMigrationPlan.test.mjs`: 4/4;
- `inventory/tests/unifiedTeamInventoryReport.test.mjs`: 4/4;
- `inventory/tests/invitePolicy.test.mjs`: 2/2;
- `identity/policy/employeeOnboarding.test.mjs`: 7/7;
- `git diff --check` limpo.

O typecheck/build do frontend fica para o CI porque este worktree isolado não possui dependências instaladas. Nenhuma migration, flag, convite, D1 ou deploy remoto é executado por este PR.