### PR TITLE
fix(ponto): bind unified team core intent

### DIFF
--- a/.github/scripts/ponto-orchestrator-lease.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.mjs
@@ -53,6 +53,7 @@ const GOVERNED_INTENT_SCHEMAS = {
     target: stringField("staging"),
     unit: stringField("all"),
     bootstrap_finance_context: booleanField(false),
+    unified_team_enabled: booleanField(false),
     release_sha: stringField(),
     preview_run_id: stringField(),
     staging_run_id: stringField(),
@@ -243,7 +244,7 @@ export function expectedGovernedRunName(workflowPath, inputs) {
     ".github/workflows/deploy-timekeeping.yml":
       `Timekeeping ${value("target")} ${value("release_sha")} ${suffix}`,
     ".github/workflows/deploy-core-workers.yml":
-      `Core ${value("unit")} ${value("target")} ${value("release_sha")} ${suffix}`,
+      `Core ${value("unit")} ${value("target")} team=${value("unified_team_enabled")} ${value("release_sha")} ${suffix}`,
     ".github/workflows/deploy-crm-pages.yml":
       `CRM Pages ${value("target")} ${value("release_sha")} ${suffix}`,
     ".github/workflows/cloudflare-workers-sync-ponto-secrets.yml":

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -489,6 +489,39 @@ test("typed intent binds every dispatch input and derives the exact nonce run na
   ), /unknown inputs/);
 });
 
+test("core intent binds unified-team rollout and derives the exact team-aware run name", () => {
+  const input = {
+    target: "staging",
+    unit: "inventory",
+    bootstrap_finance_context: false,
+    unified_team_enabled: true,
+    release_sha: releaseSha,
+    release_scope: "ponto",
+    orchestrator_run_id: orchestratorRunId,
+    orchestrator_stage: stage,
+    orchestrator_issuer_run_id: orchestratorRunId,
+    orchestrator_nonce: dispatchNonce,
+  };
+  const enabled = canonicalizeGovernedIntent(
+    ".github/workflows/deploy-core-workers.yml",
+    input,
+  );
+  const disabled = canonicalizeGovernedIntent(
+    ".github/workflows/deploy-core-workers.yml",
+    { ...input, unified_team_enabled: false },
+  );
+  assert.equal(enabled.normalizedInputs.unified_team_enabled, true);
+  assert.notEqual(enabled.digest, disabled.digest);
+  assert.equal(
+    expectedGovernedRunName(".github/workflows/deploy-core-workers.yml", enabled.normalizedInputs),
+    `Core inventory staging team=true ${releaseSha} orchestrator=${orchestratorRunId} nonce=${dispatchNonce}`,
+  );
+  assert.equal(
+    expectedGovernedRunName(".github/workflows/deploy-core-workers.yml", disabled.normalizedInputs),
+    `Core inventory staging team=false ${releaseSha} orchestrator=${orchestratorRunId} nonce=${dispatchNonce}`,
+  );
+});
+
 test("issued capability is Ed25519-bound to target, root, issuer, child, nonce, and typed intent", () => {
   const { canonical, check, document } = issuedCapability();
   assert.equal(check.status, "in_progress");


### PR DESCRIPTION
## Context
The unified-team rollout adds `unified_team_enabled` to the governed `deploy-core-workers.yml` intent, but Ponto's canonical intent schema did not accept or bind it. The first governed staging promotion therefore failed closed before the Core Inventory child capability was issued.

## Change
- bind `unified_team_enabled` as a typed boolean in the Core Worker governed intent;
- include the exact `team=true|false` value in the expected governed run name;
- add a regression test proving the digest and run-name change with the flag.

## Validation
- `node .github/scripts/ponto-orchestrator-lease.test.mjs` (33 passing)
- `node .github/scripts/ponto-dispatch-workflow.test.mjs` (7 passing)
- `git diff --check`

This PR is limited to the orchestration contract. No remote data, flags, or production surfaces are changed by the branch.