### PR TITLE
fix(ponto): preserve team rollout in staging

### DIFF
--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -1026,7 +1026,15 @@ jobs:
           timekeeping_id="$(node -e "process.stdout.write(require(process.argv[1]).candidateVersionId||'')" "$PONTO_ARTIFACT_DIR/surfaces/timekeeping/surface.json")"
           node - "$RUNNER_TEMP/identity-inputs.json" "$timekeeping_id" <<'NODE'
           const fs = require("fs");
-          const inputs = { target: process.env.STAGE, unit: "inventory", release_scope: "ponto", release_sha: process.env.RELEASE_SHA, bootstrap_finance_context: false, orchestrator_run_id: process.env.GITHUB_RUN_ID };
+          const inputs = {
+            target: process.env.STAGE,
+            unit: "inventory",
+            release_scope: "ponto",
+            release_sha: process.env.RELEASE_SHA,
+            bootstrap_finance_context: false,
+            unified_team_enabled: process.env.STAGE === "staging",
+            orchestrator_run_id: process.env.GITHUB_RUN_ID,
+          };
           if (process.env.STAGE === "staging") {
             inputs.preview_run_id = process.env.PREDECESSOR_RUN_ID;
             inputs.timekeeping_version_id = process.argv[3];

--- a/inventory/tests/onboardingConsistency.test.mjs
+++ b/inventory/tests/onboardingConsistency.test.mjs
@@ -189,3 +189,11 @@ test('unified team rollout is explicit, staging-only and fail-closed by default'
   assert.match(workflow, /--var "APP_VERSION:\$RELEASE_SHA"/);
   assert.match(workflow, /--var "UNIFIED_TEAM_ENABLED:\$unified_team_var"/);
 });
+
+test('the governed Ponto staging identity publisher preserves the unified-team flag', async () => {
+  const workflow = await readFile(
+    new URL('../../.github/workflows/ponto-progressive-release.yml', import.meta.url),
+    'utf8',
+  );
+  assert.match(workflow, /unified_team_enabled: process\.env\.STAGE === "staging"/);
+});


### PR DESCRIPTION
## Context
After binding the unified-team input in PR #1210, the composite Ponto staging publisher still omitted the flag and would have redeployed the Identity/Workforce surface with `team=false`, undoing the CRM staging rollout.

## Change
- pass `unified_team_enabled: true` only for the governed Ponto `staging` identity publisher;
- keep preview and production fail-closed/default-off;
- add a regression assertion for the staging-only binding.

## Validation
- `node inventory/tests/onboardingConsistency.test.mjs` (12 passing)
- `node .github/scripts/ponto-orchestrator-lease.test.mjs` (33 passing)
- `git diff --check`

No remote data or environment state is changed by this PR.