### PR TITLE
test(ponto): honor governed termination reason in staging journey

### DIFF
--- a/crm/console/scripts/ponto-staging-journey.cjs
+++ b/crm/console/scripts/ponto-staging-journey.cjs
@@ -293,7 +293,7 @@ async function main() {
       const deprovision = await post(
         adminPage,
         `/api/insumos/admin/onboarding/${encodeURIComponent(fixture.onboardingId)}/status`,
-        { accountStatus: 'TERMINATED' },
+        { accountStatus: 'TERMINATED', reason: 'Synthetic staging deprovisioning' },
         `identity-status-${fixtureKey}`,
       )
       recordCleanupRequest(deprovision)

--- a/inventory/tests/onboardingConsistency.test.mjs
+++ b/inventory/tests/onboardingConsistency.test.mjs
@@ -80,6 +80,12 @@ test('onboarding status changes stay hierarchical, synchronized, audited and fai
   assert.match(admin, /IDENTITY_ONBOARDING_MANAGED/);
 });
 
+test('authenticated staging journey exercises the governed termination reason contract', async () => {
+  const journey = await readFile(new URL('../../crm/console/scripts/ponto-staging-journey.cjs', import.meta.url), 'utf8');
+  const deprovisionBlock = journey.slice(journey.indexOf('const deprovision'), journey.indexOf('const list = await api', journey.indexOf('const deprovision')));
+  assert.match(deprovisionBlock, /accountStatus: 'TERMINATED', reason: 'Synthetic staging deprovisioning'/);
+});
+
 test('unified team management is explicit about RBAC, scope, idempotency and aggregate telemetry', async () => {
   const admin = await readFile(new URL('../src/routes/admin.js', import.meta.url), 'utf8');
   const localApi = await readFile(new URL('../../crm/api/server.js', import.meta.url), 'utf8');


### PR DESCRIPTION
## Objetivo\n\nCorrige o fixture sintético autenticado do Ponto para cumprir o contrato de desligamento governado da Identity/Workforce.\n\n## Alterações\n\n- envia motivo explícito no status TERMINATED;\n- adiciona regressão estática no onboarding consistency test;\n- preserva a exigência de TEAM_TERMINATION_REASON_REQUIRED na API.\n\n## Validação\n\n- node --check crm/console/scripts/ponto-staging-journey.cjs;\n- inventory/tests/onboardingConsistency.test.mjs (13/13);\n- git diff --check.\n\n## Contexto\n\nA falha foi observada no rollout governado de staging #31267286272, durante a jornada sintética #31268208718, com resposta 400/TEAM_TERMINATION_REASON_REQUIRED. Nenhum relaxamento de segurança foi feito.