### PR TITLE
fix(ponto): attest terminal gate failures before rollback

### DIFF
--- a/.github/scripts/ponto-child-mutation-attestation.mjs
+++ b/.github/scripts/ponto-child-mutation-attestation.mjs
@@ -1,0 +1,48 @@
+const GATED_CHILD_WORKFLOWS = new Set([
+  ".github/workflows/deploy-timekeeping.yml",
+  ".github/workflows/deploy-core-workers.yml",
+  ".github/workflows/deploy-crm-pages.yml",
+  ".github/workflows/cloudflare-workers-sync-ponto-secrets.yml",
+  ".github/workflows/cloudflare-pages-sync-ponto.yml",
+]);
+
+const TERMINAL_FAILURES = new Set(["failure", "startup_failure"]);
+
+const normalizedWorkflowPath = (value) => String(value || "").split("@")[0];
+
+/**
+ * A reusable Ponto child cannot mutate a surface before its coordination gate
+ * succeeds. This predicate is deliberately narrower than “the child failed”:
+ * it only accepts a terminal first-attempt run whose only executed job is the
+ * reusable coordination gate and whose downstream jobs were all skipped.
+ */
+export function attestTerminalPreMutationGateFailure({ run, jobs }) {
+  const workflowPath = normalizedWorkflowPath(run?.path);
+  if (
+    !GATED_CHILD_WORKFLOWS.has(workflowPath)
+    || run?.status !== "completed"
+    || !TERMINAL_FAILURES.has(String(run?.conclusion || ""))
+    || Number(run?.run_attempt || 0) !== 1
+    || !Array.isArray(jobs)
+    || jobs.length < 1
+  ) return null;
+
+  const completedJobs = jobs.filter((job) => job?.status === "completed");
+  const coordination = completedJobs.filter((job) => job?.name === "coordination / consume");
+  const downstream = completedJobs.filter((job) => job?.name !== "coordination / consume");
+  if (
+    completedJobs.length !== jobs.length
+    || coordination.length !== 1
+    || coordination[0]?.conclusion !== "failure"
+    || downstream.some((job) => job?.conclusion !== "skipped")
+  ) return null;
+
+  return {
+    workflowPath,
+    coordinationJobId: String(coordination[0]?.id || ""),
+    downstreamJobCount: downstream.length,
+    reason: "terminal-pre-mutation-gate-failure",
+    mutationStarted: false,
+  };
+}
+

--- a/.github/scripts/ponto-child-mutation-attestation.test.mjs
+++ b/.github/scripts/ponto-child-mutation-attestation.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { attestTerminalPreMutationGateFailure } from "./ponto-child-mutation-attestation.mjs";
+
+const run = (overrides = {}) => ({
+  path: ".github/workflows/deploy-core-workers.yml@refs/heads/main",
+  status: "completed",
+  conclusion: "failure",
+  run_attempt: 1,
+  ...overrides,
+});
+
+test("attests a terminal coordination-gate failure as pre-mutation", () => {
+  const result = attestTerminalPreMutationGateFailure({
+    run: run(),
+    jobs: [
+      { id: 1, name: "coordination / consume", status: "completed", conclusion: "failure" },
+      { id: 2, name: "promotion", status: "completed", conclusion: "skipped" },
+      { id: 3, name: "deploy", status: "completed", conclusion: "skipped" },
+    ],
+  });
+  assert.deepEqual(result, {
+    workflowPath: ".github/workflows/deploy-core-workers.yml",
+    coordinationJobId: "1",
+    downstreamJobCount: 2,
+    reason: "terminal-pre-mutation-gate-failure",
+    mutationStarted: false,
+  });
+});
+
+test("does not attest an ambiguous child with any executed downstream job", () => {
+  assert.equal(attestTerminalPreMutationGateFailure({
+    run: run(),
+    jobs: [
+      { id: 1, name: "coordination / consume", status: "completed", conclusion: "failure" },
+      { id: 2, name: "deploy", status: "completed", conclusion: "failure" },
+    ],
+  }), null);
+});
+
+test("does not attest a cancelled child, rerun, or non-canonical workflow", () => {
+  const jobs = [
+    { id: 1, name: "coordination / consume", status: "completed", conclusion: "failure" },
+    { id: 2, name: "deploy", status: "completed", conclusion: "skipped" },
+  ];
+  assert.equal(attestTerminalPreMutationGateFailure({ run: run({ conclusion: "cancelled" }), jobs }), null);
+  assert.equal(attestTerminalPreMutationGateFailure({ run: run({ run_attempt: 2 }), jobs }), null);
+  assert.equal(attestTerminalPreMutationGateFailure({ run: run({ path: ".github/workflows/module-availability.yml" }), jobs }), null);
+});
+

--- a/.github/scripts/ponto-emergency-stop.mjs
+++ b/.github/scripts/ponto-emergency-stop.mjs
@@ -8,6 +8,7 @@ import {
   transitionCapabilityDocument,
   verifyCapabilityDocument,
 } from "./ponto-orchestrator-lease.mjs";
+import { attestTerminalPreMutationGateFailure } from "./ponto-child-mutation-attestation.mjs";
 
 const COORDINATOR_TITLE = /^Ponto (staging|pilot|canary|production|rollback) ([0-9a-f]{40}) orchestrator=([1-9][0-9]*)$/;
 const CAPABILITY_CHECK_NAME =
@@ -226,6 +227,7 @@ if (invokedAsScript) {
   const unprovenChildren = new Map();
   const invalidCoordinatorIds = new Set();
   const capabilityInvalidationErrors = [];
+  const jobsByRunId = new Map();
   const completedWindowRuns = new Map();
   const completedWindowScans = new Set();
   let completedCoordinatorDiscoveryDone = false;
@@ -349,6 +351,27 @@ if (invokedAsScript) {
         throw new Error("child capability check is ambiguous");
       }
       if (!candidates.length) {
+        if (record.live?.status === "completed") {
+          let jobs = jobsByRunId.get(record.runId);
+          if (!jobsByRunId.has(record.runId)) {
+            try {
+              const payload = await request(`/repos/${repository}/actions/runs/${record.runId}/jobs?per_page=100`);
+              jobs = Array.isArray(payload?.jobs) ? payload.jobs : null;
+            } catch {
+              jobs = null;
+            }
+            jobsByRunId.set(record.runId, jobs);
+          }
+          const preMutation = attestTerminalPreMutationGateFailure({
+            run: record.live,
+            jobs,
+          });
+          if (preMutation) {
+            record.capabilityAuthorization = preMutation.reason;
+            record.mutationStarted = false;
+            return true;
+          }
+        }
         record.capabilityAuthorization = "absent";
         return false;
       }

--- a/.github/scripts/ponto-watchdog-journal.mjs
+++ b/.github/scripts/ponto-watchdog-journal.mjs
@@ -10,6 +10,7 @@ import {
   resolveCapabilityVerifier,
   verifyCapabilityDocument,
 } from "./ponto-orchestrator-lease.mjs";
+import { attestTerminalPreMutationGateFailure } from "./ponto-child-mutation-attestation.mjs";
 
 const DISPATCH_NONCE = /^[0-9a-f]{32}$/;
 const hasExactNonceTitle = (title, expectedPrefix) => {
@@ -365,6 +366,7 @@ export async function reconstructWatchdogJournal({
   const downloads = [];
   const unresolved = [];
   const ignoredUnprovenChildren = [];
+  const jobsByRunId = new Map();
   let acceptedChildren = 0;
   let capabilityChecks = null;
   let coordinatorWorkflowId = coordinatorWorkflow.id;
@@ -400,6 +402,19 @@ export async function reconstructWatchdogJournal({
       capabilityVerifier,
     });
   };
+  const jobsFor = async (run) => {
+    const runId = String(run?.id || "");
+    if (!runId) return null;
+    if (!jobsByRunId.has(runId)) {
+      try {
+        const payload = await request(`/repos/${repository}/actions/runs/${runId}/jobs?per_page=100`);
+        jobsByRunId.set(runId, Array.isArray(payload?.jobs) ? payload.jobs : null);
+      } catch {
+        jobsByRunId.set(runId, null);
+      }
+    }
+    return jobsByRunId.get(runId);
+  };
   fs.mkdirSync(path.join(artifactRoot, "runs"), { recursive: true });
   for (const [surface, specification] of applicableSurfaces) {
     const saved = savedBySurface.get(surface);
@@ -426,17 +441,24 @@ export async function reconstructWatchdogJournal({
             trustedIds.add(String(run.id));
             capabilityByRun.set(String(run.id), capability);
           } else {
+            const preMutation = attestTerminalPreMutationGateFailure({
+              run,
+              jobs: await jobsFor(run),
+            });
             const failure = {
               surface,
               runId: String(run.id),
-              reason: "capability-absent",
+              reason: preMutation?.reason || "capability-absent",
+              ...(preMutation ? { mutationStarted: false } : {}),
             };
             ignoredUnprovenChildren.push(failure);
-            unresolved.push({
-              surface,
-              runId: String(run.id),
-              reason: "canonical-correlated-child-untrusted",
-            });
+            if (!preMutation) {
+              unresolved.push({
+                surface,
+                runId: String(run.id),
+                reason: "canonical-correlated-child-untrusted",
+              });
+            }
           }
         } catch (error) {
           const failure = {
@@ -452,16 +474,23 @@ export async function reconstructWatchdogJournal({
           });
         }
       } else {
+        const preMutation = attestTerminalPreMutationGateFailure({
+          run,
+          jobs: await jobsFor(run),
+        });
         ignoredUnprovenChildren.push({
           surface,
           runId: String(run.id),
-          reason: "durable-journal-anchor-absent",
+          reason: preMutation?.reason || "durable-journal-anchor-absent",
+          ...(preMutation ? { mutationStarted: false } : {}),
         });
-        unresolved.push({
-          surface,
-          runId: String(run.id),
-          reason: "canonical-correlated-child-untrusted",
-        });
+        if (!preMutation) {
+          unresolved.push({
+            surface,
+            runId: String(run.id),
+            reason: "canonical-correlated-child-untrusted",
+          });
+        }
       }
     }
     if (matches.length > 1) {

--- a/.github/scripts/ponto-watchdog-journal.test.mjs
+++ b/.github/scripts/ponto-watchdog-journal.test.mjs
@@ -306,3 +306,46 @@ test("watchdog refuses rollback for a terminal exact-title child with no signed 
   }]);
   assert.equal(fs.existsSync(path.join(root, "runs/timekeeping.json")), false);
 });
+
+test("watchdog accepts an exact terminal coordination-gate failure with no mutation", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ponto-watchdog-pre-mutation-"));
+  const child = run(
+    10,
+    "deploy-core-workers.yml",
+    `Core inventory staging ${sha} orchestrator=99 nonce=${"1".repeat(32)}`,
+  );
+  child.conclusion = "failure";
+  const request = scopedRequest([child], async (pathname) => {
+    if (pathname.includes(`/commits/${sha}/check-runs?`)) {
+      return { check_runs: [] };
+    }
+    if (pathname.endsWith(`/actions/runs/10/jobs?per_page=100`)) {
+      return {
+        jobs: [
+          { id: 1, name: "coordination / consume", status: "completed", conclusion: "failure" },
+          { id: 2, name: "promotion", status: "completed", conclusion: "skipped" },
+          { id: 3, name: "deploy", status: "completed", conclusion: "skipped" },
+        ],
+      };
+    }
+  });
+  const report = await reconstructWatchdogJournal({
+    repository,
+    repositoryId,
+    capabilityPublicKeysJson,
+    coordinatorRunId: "99",
+    releaseSha: sha,
+    stage: "staging",
+    artifactRoot: root,
+    request,
+  });
+  assert.equal(report.passed, true);
+  assert.deepEqual(report.unresolved, []);
+  assert.deepEqual(report.ignoredUnprovenChildren, [{
+    surface: "identityWorkforce",
+    runId: "10",
+    reason: "terminal-pre-mutation-gate-failure",
+    mutationStarted: false,
+  }]);
+  assert.equal(fs.existsSync(path.join(root, "runs/identity.json")), false);
+});


### PR DESCRIPTION
Context: a failed pre-release child can remain correlated to a later watchdog and block recovery even when it failed in the reusable coordination gate before any publisher job ran. Change: attest only first-attempt terminal failures where coordination / consume failed and every downstream job is completed/skipped; keep ambiguous and unproven children fail-closed; apply the same proof in watchdog journal reconstruction and emergency-stop reconciliation; add unit and journal regression coverage. Validation: git diff --check and Node syntax checks passed; WSL test invocation was attempted but the host WSL runtime stopped returning output, so required CI is the validation gate. No catalog, Cloudflare, database, or production state was changed by this PR.