### PR TITLE
fix(ponto): attest gateway metadata separately

### DIFF
--- a/.github/scripts/ponto-staging-core-provenance-recovery.test.mjs
+++ b/.github/scripts/ponto-staging-core-provenance-recovery.test.mjs
@@ -31,6 +31,8 @@ test("Core provenance recovery is staging-only, exact, and fail-closed", () => {
   assert.match(workflow, /ponto-automatic-rollback\.mjs/);
   assert.match(workflow, /activeVersions\[0\]\?\.percentage !== 100/);
   assert.match(workflow, /body\?\.availability\?\.state !== "maintenance"/);
+  assert.match(workflow, /body\?\.versionMetadata\?\.gatewayEnvironment !== "staging"/);
+  assert.match(workflow, /x-skincos-gateway-environment/);
   assert.match(workflow, /name: Upload immutable Core provenance recovery evidence[\s\S]*?if: always\(\)/);
   assert.doesNotMatch(workflow, /target:\s*production/);
 });

--- a/.github/workflows/ponto-staging-core-provenance-recovery.yml
+++ b/.github/workflows/ponto-staging-core-provenance-recovery.yml
@@ -468,7 +468,8 @@ jobs:
             || body?.ok !== false
             || body?.ready !== false
             || body?.availability?.state !== "maintenance"
-            || String(response.headers.get("x-skincos-gateway-version-id") || "").toLowerCase() !== incumbent.surface.versionId.toLowerCase()
+            || body?.versionMetadata?.gatewayEnvironment !== "staging"
+            || String(response.headers.get("x-skincos-gateway-environment") || "").toLowerCase() !== "staging"
           ) throw new Error("staging Ponto health did not prove maintenance on the restored Core incumbent");
           NODE
 


### PR DESCRIPTION
## Correção\n\nO recovery #1214 restaurou o Core candidato para o incumbent e registrou passed=true, mas a prova terminal esperava que o header de versão do gateway fosse o version ID do Worker Core. São superfícies distintas.\n\nA prova agora mantém a attestation direta do Worker como autoridade para o Core e valida no health apenas maintenance + ambiente staging do gateway. Inclui regressão estática.\n\n## Evidência observada\n\n- recovery run: 31272083749;\n- rollback report: passed=true, ctiveVersionId=e71704e3-0d6d-4327-83cf-3121010995b1, candidate 0% / incumbent 100%;\n- health real: maintenance, gateway environment staging; o header do gateway não é comparável ao Worker Core.\n\nSem mudança em produção ou dados de negócio.