### PR TITLE
fix(site): finish Beauty Movement card-table interaction

### DIFF
--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -278,8 +278,8 @@
 .deckPrompt {
   position: absolute;
   z-index: 3;
-  bottom: 50px;
-  left: calc(50% + 68px);
+  bottom: 148px;
+  left: 50%;
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -297,6 +297,7 @@
   white-space: nowrap;
   box-shadow: 0 8px 18px rgba(48, 48, 48, 0.1);
   pointer-events: none;
+  transform: translateX(-50%);
 }
 
 .deckPrompt::before {
@@ -305,6 +306,18 @@
   border-radius: 999px;
   background: var(--bm-yellow);
   content: "";
+}
+
+.deckPromptArrow {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 50%;
+  color: var(--bm-yellow-ink);
+  font-family: var(--font-brand-ui);
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1;
+  transform: translateX(-50%);
 }
 
 .deckCard {

--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -264,6 +264,11 @@
   cursor: pointer;
 }
 
+.deckStage:enabled .deckCard,
+.deckStage:enabled .deckBrandLogo {
+  cursor: pointer;
+}
+
 .deckStage:focus-visible {
   outline: 3px solid var(--bm-yellow);
   outline-offset: 7px;

--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -438,18 +438,6 @@
   margin: 2px auto 0;
 }
 
-.finaleCardGridSettled .finaleCard {
-  animation: finaleCardsReappear 760ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
-}
-
-.finaleCardGridSettled .finaleCard:nth-child(2) {
-  animation-delay: 80ms;
-}
-
-.finaleCardGridSettled .finaleCard:nth-child(3) {
-  animation-delay: 160ms;
-}
-
 .finaleCard {
   position: relative;
   min-height: 360px;
@@ -475,7 +463,7 @@
 }
 
 .tableStage[data-hand-stage="finale"] .finaleCard {
-  animation: finaleReturnToDeck 1060ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
+  animation: finaleCardsReappear 760ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
 }
 
 .tableStage[data-hand-stage="finale"] .finaleCard:nth-child(2) {
@@ -873,29 +861,6 @@
   to {
     opacity: 1;
     transform: translate3d(0, 0, 0) rotate(0deg) scale(1);
-  }
-}
-
-@keyframes finaleReturnToDeck {
-  0% {
-    opacity: 1;
-    transform: translate3d(0, 0, 0) rotate(0deg) scale(1);
-  }
-
-  34% {
-    opacity: 1;
-    transform: translate3d(0, -18px, 0) rotate(calc(var(--finale-rotate) * 0.32)) scale(1.08);
-  }
-
-  68% {
-    opacity: 0.82;
-    transform: translate3d(calc(var(--finale-x) * 0.62), calc(var(--finale-y) * 0.58), 0)
-      rotate(calc(var(--finale-rotate) * 0.68)) scale(0.82);
-  }
-
-  100% {
-    opacity: 0;
-    transform: translate3d(var(--finale-x), var(--finale-y), 0) rotate(var(--finale-rotate)) scale(0.58);
   }
 }
 

--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -256,17 +256,19 @@
   border: 0;
   background: transparent;
   color: inherit;
-  cursor: default;
+  cursor: pointer;
   transform: translateX(-50%);
 }
 
-.deckStage:enabled {
+.deckStage .deckCard,
+.deckStage .deckBrandLogo {
   cursor: pointer;
 }
 
-.deckStage:enabled .deckCard,
-.deckStage:enabled .deckBrandLogo {
-  cursor: pointer;
+.deckStage:disabled,
+.deckStage:disabled .deckCard,
+.deckStage:disabled .deckBrandLogo {
+  cursor: default;
 }
 
 .deckStage:focus-visible {

--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -597,7 +597,6 @@
 }
 
 .tableStage[data-hand-stage="reveal"] .cardButton:not(.cardButtonSelected) {
-  animation: cardReturnToDeck 680ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
   pointer-events: none;
 }
 
@@ -610,9 +609,7 @@
 }
 
 .tableStage[data-hand-stage="held"] .cardButton:not(.cardButtonSelected) {
-  opacity: 0;
   pointer-events: none;
-  transform: translate3d(var(--deal-x), var(--deal-y), 0) rotate(var(--deal-rotate)) scale(0.76);
 }
 
 .tableStage[data-hand-stage="collect"] .cardButton:not(.cardButtonSelected) {

--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -1312,7 +1312,7 @@ export default function BeautyMovementExperience({
                                 {reading.map(renderFinaleCard)}
                             </div>
                         ) : finaleStage === "confirmation" || finaleStage === "result" ? (
-                            <div className={`${styles.finaleCardGrid} ${styles.finaleCardGridSettled}`} role="group" aria-label="Cartas finais">
+                            <div className={styles.finaleCardGrid} role="group" aria-label="Cartas finais">
                                 {reading.map(renderFinaleCard)}
                             </div>
                         ) : finaleStage === "hidden" && !waitingForInitialDeal ? (

--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -1301,7 +1301,10 @@ export default function BeautyMovementExperience({
                                 id="beauty-movement-deck-prompt"
                                 role="note"
                             >
-                                Clique no baralho <span aria-hidden="true">↗</span>
+                                Clique no baralho
+                                <span className={styles.deckPromptArrow} aria-hidden="true">
+                                    ↓
+                                </span>
                             </span>
                         ) : null}
                         {finaleStage === "collecting" ? (

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -130,6 +130,7 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(styles, /\.inlineFinale/);
     assert.match(styles, /\.deckPrompt/);
     assert.match(styles, /\.deckStage[\s\S]*bottom: 18px/);
+    assert.match(styles, /\.deckStage:enabled \.deckCard,[\s\S]*\.deckStage:enabled \.deckBrandLogo[\s\S]*cursor: pointer/);
     assert.match(styles, /--deal-y: 122px/);
     assert.match(styles, /\.progressItemCurrent \.progressButton[\s\S]*background: var\(--bm-yellow\)/);
     assert.match(styles, /\.progressButton \{[\s\S]*min-height: 44px/);

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -63,7 +63,7 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.doesNotMatch(experience, /Ver minha leitura/);
     assert.doesNotMatch(experience, /actsStack|revealedStrip/);
     assert.doesNotMatch(experience, /BeautyMovementModalReading/);
-    assert.match(experience, /finaleCardGridSettled/);
+    assert.doesNotMatch(experience, /finaleCardGridSettled/);
     assert.match(experience, /aria-label="Cartas finais"/);
     assert.match(experience, /className=\{styles\.cardSparkles\}/);
     assert.match(experience, /className=\{styles\.deckStage\}/);
@@ -123,12 +123,13 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     );
     assert.doesNotMatch(styles, /\.tableStage\[data-hand-stage="deal"\] \.cardButton:nth-child\(2\)[^}]*animation-delay/);
     assert.doesNotMatch(styles, /\.tableStage\[data-hand-stage="deal"\] \.cardButton:nth-child\(3\)[^}]*animation-delay/);
-    assert.match(styles, /@keyframes finaleReturnToDeck/);
+    assert.doesNotMatch(styles, /@keyframes finaleReturnToDeck/);
     assert.match(styles, /@keyframes finaleCardsReappear/);
+    assert.match(styles, /\.tableStage\[data-hand-stage="finale"\] \.finaleCard\s*\{\s*animation: finaleCardsReappear/);
+    assert.doesNotMatch(styles, /\.finaleCardGridSettled/);
     assert.match(styles, /@keyframes finaleIllustrationPulse/);
     assert.match(styles, /@keyframes finaleIllustrationPulse[\s\S]*100%[\s\S]*opacity: 1/);
     assert.match(styles, /\.finaleCardGrid/);
-    assert.match(styles, /\.finaleCardGridSettled/);
     assert.match(styles, /\.inlineFinale/);
     assert.match(styles, /\.deckPrompt/);
     assert.match(styles, /\.deckPrompt[\s\S]*bottom: 148px/);

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -103,6 +103,22 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(styles, /@keyframes cardSelectedReturnToDeck/);
     assert.match(styles, /@keyframes cardFlipToDeck/);
     assert.match(styles, /@keyframes cardDealFromDeck/);
+    assert.match(
+        styles,
+        /\.tableStage\[data-hand-stage="reveal"\] \.cardButton:not\(\.cardButtonSelected\)\s*\{\s*pointer-events: none;\s*\}/,
+    );
+    assert.match(
+        styles,
+        /\.tableStage\[data-hand-stage="held"\] \.cardButton:not\(\.cardButtonSelected\)\s*\{\s*pointer-events: none;\s*\}/,
+    );
+    assert.doesNotMatch(
+        styles,
+        /\.tableStage\[data-hand-stage="reveal"\] \.cardButton:not\(\.cardButtonSelected\)[^}]*animation:\s*cardReturnToDeck/,
+    );
+    assert.doesNotMatch(
+        styles,
+        /\.tableStage\[data-hand-stage="held"\] \.cardButton:not\(\.cardButtonSelected\)[^}]*(?:opacity:\s*0|transform:\s*translate3d\(var\(--deal-x\))/,
+    );
     assert.doesNotMatch(styles, /\.tableStage\[data-hand-stage="deal"\] \.cardButton:nth-child\(2\)[^}]*animation-delay/);
     assert.doesNotMatch(styles, /\.tableStage\[data-hand-stage="deal"\] \.cardButton:nth-child\(3\)[^}]*animation-delay/);
     assert.match(styles, /@keyframes finaleReturnToDeck/);

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -137,7 +137,8 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(styles, /\.deckPromptArrow[\s\S]*top: calc\(100% \+ 4px\)/);
     assert.match(styles, /\.deckPromptArrow[\s\S]*transform: translateX\(-50%\)/);
     assert.match(styles, /\.deckStage[\s\S]*bottom: 18px/);
-    assert.match(styles, /\.deckStage:enabled \.deckCard,[\s\S]*\.deckStage:enabled \.deckBrandLogo[\s\S]*cursor: pointer/);
+    assert.match(styles, /\.deckStage \.(?:deckCard|deckBrandLogo)[\s\S]*cursor: pointer/);
+    assert.match(styles, /\.deckStage:disabled,[\s\S]*\.deckStage:disabled \.deckBrandLogo[\s\S]*cursor: default/);
     assert.match(styles, /--deal-y: 122px/);
     assert.match(styles, /\.progressItemCurrent \.progressButton[\s\S]*background: var\(--bm-yellow\)/);
     assert.match(styles, /\.progressButton \{[\s\S]*min-height: 44px/);

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -74,6 +74,8 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(experience, /event\.key !== "Enter" && event\.key !== " " && event\.key !== "Spacebar"/);
     assert.match(experience, /onKeyDown=\{handleDeckKeyDown\}/);
     assert.match(experience, /className=\{styles\.deckPrompt\}/);
+    assert.match(experience, /className=\{styles\.deckPromptArrow\}/);
+    assert.doesNotMatch(experience, /Clique no baralho <span aria-hidden="true">↗<\/span>/);
     assert.match(experience, /role="note"/);
     assert.doesNotMatch(experience, /<button\s+className=\{styles\.deckPrompt\}/);
     assert.match(experience, /data-deck-state=\{/);
@@ -129,6 +131,10 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(styles, /\.finaleCardGridSettled/);
     assert.match(styles, /\.inlineFinale/);
     assert.match(styles, /\.deckPrompt/);
+    assert.match(styles, /\.deckPrompt[\s\S]*bottom: 148px/);
+    assert.match(styles, /\.deckPrompt[\s\S]*left: 50%/);
+    assert.match(styles, /\.deckPromptArrow[\s\S]*top: calc\(100% \+ 4px\)/);
+    assert.match(styles, /\.deckPromptArrow[\s\S]*transform: translateX\(-50%\)/);
     assert.match(styles, /\.deckStage[\s\S]*bottom: 18px/);
     assert.match(styles, /\.deckStage:enabled \.deckCard,[\s\S]*\.deckStage:enabled \.deckBrandLogo[\s\S]*cursor: pointer/);
     assert.match(styles, /--deal-y: 122px/);


### PR DESCRIPTION
## What changed\n\n- keeps the three successive card hands on the table during the five-second reading wait;\n- places the prompt above the deck and preserves the final cards on the table;\n- makes the deck cursor explicitly interactive only before the initial deal and default after it is disabled.\n\n## Validation\n\n- focused Beauty Movement continuous-flow test passed;\n- local browser QA on the current preview passed Enter and Space activation, initial pointer cursor, and post-deal disabled state.\n\n## Scope\n\nUI-only follow-up on top of the already integrated Beauty Movement invitation and rate-limit work. Production remains fail-closed pending official campaign inputs.