### PR TITLE
fix(site): respect Cloudflare rate-limit capacity

### DIFF
--- a/website/docs/security/SETUP_CLOUDFLARE_SECURITY_SYNC.md
+++ b/website/docs/security/SETUP_CLOUDFLARE_SECURITY_SYNC.md
@@ -5,6 +5,11 @@ Este repositório inclui um script versionado para manter configurações de seg
 - Bot Fight Mode (best-effort)
 - Rate limiting para `POST /api/booking/request`
 
+O limite de regras `http_ratelimit` da zona é respeitado. A jornada Cartas da
+Beleza aplica seus limites por convite/IP dentro do Worker e no D1 isolado; ela
+não adiciona regras de borda nesta zona para não disputar a única regra
+disponível com o endpoint de agendamento.
+
 ## Como roda
 
 - Manual/agenda: workflow `Sync Website Cloudflare Security` (`.github/workflows/sync-website-cloudflare-security.yml`)

--- a/website/scripts/cloudflare-sync-security.mjs
+++ b/website/scripts/cloudflare-sync-security.mjs
@@ -15,32 +15,6 @@ const DESIRED_RULES = [
       mitigation_timeout: 10,
     },
   },
-  {
-    ref: "ef_beauty_movement_session_rl_v1",
-    description: "EF: rate limit beauty movement invite exchange (managed by repo)",
-    expression: '(http.request.uri.path eq "/api/beleza-em-movimento/session" and http.request.method eq "POST")',
-    action: "block",
-    enabled: true,
-    ratelimit: {
-      characteristics: ["cf.colo.id", "ip.src"],
-      period: 10,
-      requests_per_period: 4,
-      mitigation_timeout: 10,
-    },
-  },
-  {
-    ref: "ef_beauty_movement_mutation_rl_v1",
-    description: "EF: rate limit beauty movement journey mutations (managed by repo)",
-    expression: '((http.request.uri.path eq "/api/beleza-em-movimento/reveal" or http.request.uri.path eq "/api/beleza-em-movimento/confirm") and http.request.method eq "POST")',
-    action: "block",
-    enabled: true,
-    ratelimit: {
-      characteristics: ["cf.colo.id", "ip.src"],
-      period: 10,
-      requests_per_period: 12,
-      mitigation_timeout: 10,
-    },
-  },
 ];
 
 function env(name, fallback = "") {


### PR DESCRIPTION
## Resumo
- respeita o limite de uma regra `http_ratelimit` da zona;
- mantém a proteção de `POST /api/booking/request` na borda;
- documenta que Cartas da Beleza usa rate limit por convite/IP no Worker + D1.

## Evidência
A promoção do site em 2026-08-08 concluiu o deploy do Worker, mas a sincronização falhou porque a zona rejeitou 3 regras com `exceeded the maximum number of rules in the phase http_ratelimit: 3 out of 1`. Esta alteração alinha o script ao limite real sem remover o rate limit próprio da campanha.