### PR TITLE
fix(site): keep advance control visible between hands

### DIFF
--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -1329,6 +1329,8 @@ export default function BeautyMovementExperience({
                                     ? "Clique no baralho para distribuir esta mão."
                                     : tableSelected
                                       ? "Carta revelada. As outras cartas serão recolhidas antes da próxima mão."
+                                      : handStage === "ready"
+                                        ? "Escolha uma carta para liberar o avanço."
                                       : handStage === "held"
                                         ? "Escolha uma carta para liberar o avanço."
                                         : "A próxima mão está sendo preparada."}

--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -1322,10 +1322,16 @@ export default function BeautyMovementExperience({
                         ) : null}
                     </div>
 
-                    {finaleStage === "hidden" && tableIsUnlocked && tableSelected ? (
+                    {finaleStage === "hidden" ? (
                         <div className={styles.actAdvance}>
                             <p className={styles.advanceNote} role="status">
-                                Carta revelada. As outras cartas serão recolhidas antes da próxima mão.
+                                {waitingForInitialDeal
+                                    ? "Clique no baralho para distribuir esta mão."
+                                    : tableSelected
+                                      ? "Carta revelada. As outras cartas serão recolhidas antes da próxima mão."
+                                      : handStage === "held"
+                                        ? "Escolha uma carta para liberar o avanço."
+                                        : "A próxima mão está sendo preparada."}
                             </p>
                             {autoAdvanceActive ? (
                                 <div className={styles.autoAdvance} role="status" aria-live="polite">
@@ -1345,7 +1351,7 @@ export default function BeautyMovementExperience({
                                     className={styles.continueButton}
                                     type="button"
                                     onClick={() => moveToNextHand(displayedActIndex)}
-                                    disabled={handStage !== "held"}
+                                    disabled={!tableSelected || handStage !== "held"}
                                 >
                                     Continuar para {nextDefinition.label}
                                 </button>
@@ -1354,7 +1360,7 @@ export default function BeautyMovementExperience({
                                     className={styles.continueButton}
                                     type="button"
                                     onClick={beginFinale}
-                                    disabled={handStage !== "held"}
+                                    disabled={!tableSelected || handStage !== "held"}
                                 >
                                     Continuar para confirmar
                                 </button>

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -56,7 +56,9 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.doesNotMatch(experience, /preparedNote/);
     assert.doesNotMatch(experience, /choiceInstruction/);
     assert.match(experience, /Continuar para confirmar/);
-    assert.match(experience, /disabled=\{handStage !== "held"\}/);
+    assert.match(experience, /finaleStage === "hidden" \? \(/);
+    assert.match(experience, /disabled=\{!tableSelected \|\| handStage !== "held"\}/);
+    assert.match(experience, /Escolha uma carta para liberar o avanço/);
     assert.match(experience, /Seu presente de celebração/);
     assert.match(experience, /Seu presente será revelado após a confirmação/);
     assert.doesNotMatch(experience, /benefitPreview/);


### PR DESCRIPTION
Mantém o botão de avanço renderizado durante espera, distribuição, leitura e recolhimento. Ele permanece desabilitado até a escolha da mão atual e fica habilitado somente quando a mão está pronta. Testado na prévia local com a sequência Beleza → Movimento.