### PR TITLE
feat(site): reveal configured benefit special card

### DIFF
--- a/website/src/components/BeautyMovementCardIllustration.tsx
+++ b/website/src/components/BeautyMovementCardIllustration.tsx
@@ -255,6 +255,52 @@ export default function BeautyMovementCardIllustration({ cardId }: BeautyMovemen
                 </>
             );
             break;
+        case "reward-reserved":
+            art = (
+                <>
+                    <rect x="39" y="36" width="82" height="88" rx="10" {...strokeProps} />
+                    <path d="M 54 63 H 106 M 54 82 H 94 M 54 101 H 82" {...strokeProps} />
+                    <path d="M 80 22 V 39 M 80 121 V 138" {...accentStrokeProps} />
+                    <AccentDot cx={38} cy={48} r={3} />
+                    <AccentDot cx={122} cy={112} r={3} />
+                </>
+            );
+            break;
+        case "reward-procedure":
+            art = (
+                <>
+                    <circle cx="80" cy="75" r="42" {...strokeProps} />
+                    <path d="M 64 110 L 58 139 L 80 127 L 102 139 L 96 110" {...strokeProps} />
+                    <path d="M 80 46 L 87 67 L 109 68 L 92 81 L 98 103 L 80 90 L 62 103 L 68 81 L 51 68 L 73 67 Z" {...accentStrokeProps} />
+                    <AccentDot cx={39} cy={42} r={3} />
+                    <AccentDot cx={121} cy={42} r={3} />
+                </>
+            );
+            break;
+        case "reward-discount":
+            art = (
+                <>
+                    <path d="M 30 55 L 62 28 H 126 V 92 L 94 124 H 30 Z" {...strokeProps} />
+                    <circle cx="103" cy="52" r="6" {...accentFillProps} />
+                    <path d="M 50 100 L 104 46" {...accentStrokeProps} />
+                    <circle cx="57" cy="75" r="7" {...strokeProps} />
+                    <circle cx="94" cy="96" r="7" {...strokeProps} />
+                    <path d="M 30 55 V 124 H 94" {...accentStrokeProps} opacity="0.8" />
+                </>
+            );
+            break;
+        case "reward-velocity":
+            art = (
+                <>
+                    <circle cx="80" cy="80" r="48" {...strokeProps} />
+                    <path d="M 49 50 L 63 110 L 80 80 L 97 110 L 111 50" {...strokeProps} />
+                    <path d="M 22 128 C 47 143 113 143 138 128" {...accentStrokeProps} />
+                    <path d="M 31 32 C 56 16 104 16 129 32" {...accentStrokeProps} opacity="0.78" />
+                    <AccentDot cx={35} cy={128} r={3} />
+                    <AccentDot cx={125} cy={128} r={3} />
+                </>
+            );
+            break;
         default:
             art = <DefaultArt />;
     }

--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -464,16 +464,16 @@
   animation: deckReceivePulse 1120ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
 }
 
-.tableStage[data-hand-stage="finale"] .finaleCard {
-  animation: finaleCardsReappear 760ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
+.tableStage[data-hand-stage="finale"] .finaleCardGridMerging .finaleCard {
+  animation: finaleCardsMerge 1120ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
 }
 
-.tableStage[data-hand-stage="finale"] .finaleCard:nth-child(2) {
+.tableStage[data-hand-stage="finale"] .finaleCardGridMerging .finaleCard:nth-child(2) {
+  animation-delay: 40ms;
+}
+
+.tableStage[data-hand-stage="finale"] .finaleCardGridMerging .finaleCard:nth-child(3) {
   animation-delay: 80ms;
-}
-
-.tableStage[data-hand-stage="finale"] .finaleCard:nth-child(3) {
-  animation-delay: 160ms;
 }
 
 .finaleCardFace {
@@ -524,6 +524,165 @@
   font-weight: 700;
   letter-spacing: -0.06em;
   line-height: 0.95;
+}
+
+.specialCardStage {
+  display: grid;
+  width: min(100%, 380px);
+  min-height: 430px;
+  place-items: center;
+  margin: 2px auto 0;
+}
+
+.specialCard {
+  width: min(100%, 360px);
+  min-height: 430px;
+  perspective: 1200px;
+  animation: specialCardEnter 820ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
+}
+
+.specialCardInner {
+  position: relative;
+  min-height: inherit;
+  transform-style: preserve-3d;
+}
+
+.specialCard[data-special-state="revealed"] .specialCardInner {
+  animation: specialCardFlip 980ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
+}
+
+.specialCardFace {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+  gap: 14px;
+  overflow: hidden;
+  padding: 28px;
+  border-radius: 14px;
+  backface-visibility: hidden;
+  text-align: center;
+}
+
+.specialCardBack {
+  border: 1px solid var(--bm-ink);
+  background: var(--bm-ink);
+  box-shadow: var(--bm-shadow);
+  color: var(--bm-surface);
+}
+
+.specialCardBack::before,
+.specialCardBack::after {
+  position: absolute;
+  width: 230px;
+  height: 230px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 50%;
+  content: "";
+}
+
+.specialCardBack::before {
+  top: -92px;
+  left: -64px;
+}
+
+.specialCardBack::after {
+  right: -84px;
+  bottom: -118px;
+  border-color: rgba(245, 179, 1, 0.58);
+}
+
+.specialCardBack > *,
+.specialCardFront > * {
+  position: relative;
+  z-index: 1;
+}
+
+.specialCardBrand {
+  width: 88px;
+  height: 78px;
+  object-fit: contain;
+  opacity: 0.94;
+}
+
+.specialCardBackLabel,
+.specialCardKind {
+  color: var(--bm-yellow);
+  font-family: var(--font-brand-ui);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.specialCardBack strong,
+.specialCardFront strong {
+  max-width: 290px;
+  font-family: var(--font-brand-ui);
+  font-size: clamp(1.7rem, 4vw, 2.55rem);
+  font-weight: 700;
+  letter-spacing: -0.06em;
+  line-height: 0.98;
+}
+
+.specialCardBack > span:not(.specialCardBrand):not(.specialCardBackLabel):not(.specialCardSeal) {
+  max-width: 250px;
+  color: rgba(250, 250, 250, 0.8);
+  font-family: var(--font-brand-text);
+  line-height: 1.5;
+}
+
+.specialCardSeal {
+  color: var(--bm-yellow);
+  font-size: 2.2rem;
+  line-height: 1;
+}
+
+.specialCardFront {
+  transform: rotateY(180deg);
+  border: 1px solid var(--bm-line-strong);
+  border-top: 3px solid var(--bm-yellow);
+  background: var(--bm-surface);
+  box-shadow: var(--bm-shadow);
+  color: var(--bm-ink);
+}
+
+.specialCardIllustration {
+  display: grid;
+  width: 122px;
+  height: 122px;
+  place-items: center;
+  margin: 2px auto 0;
+  color: var(--bm-ink);
+}
+
+.specialCardIllustration svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  animation: specialCardIconFloat 4.8s ease-in-out 820ms infinite alternate;
+}
+
+.specialCardCopy {
+  max-width: 275px;
+  color: var(--bm-muted);
+  font-family: var(--font-brand-text);
+  line-height: 1.5;
+}
+
+.specialCardMeta {
+  display: inline-flex;
+  max-width: 280px;
+  padding: 8px 12px;
+  border: 1px solid var(--bm-line);
+  border-radius: 999px;
+  color: var(--bm-ink);
+  font-family: var(--font-brand-ui);
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
 }
 
 .cardButton {
@@ -881,6 +1040,65 @@
   to {
     opacity: 1;
     transform: translate3d(0, 0, 0) rotate(0deg) scale(1);
+  }
+}
+
+@keyframes finaleCardsMerge {
+  0% {
+    opacity: 0;
+    transform: translate3d(var(--finale-x), var(--finale-y), 0) rotate(var(--finale-rotate)) scale(0.58);
+  }
+
+  42% {
+    opacity: 1;
+    transform: translate3d(calc(var(--finale-x) * 0.08), calc(var(--finale-y) * 0.08), 0)
+      rotate(calc(var(--finale-rotate) * 0.12)) scale(1.04);
+  }
+
+  64% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) rotate(0deg) scale(1);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translate3d(var(--finale-x), var(--finale-merge-y, 0px), 0) rotate(0deg) scale(0.24);
+  }
+}
+
+@keyframes specialCardEnter {
+  from {
+    opacity: 0;
+    transform: translateY(26px) scale(0.82);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes specialCardFlip {
+  0% {
+    transform: rotateY(0deg) scale(0.92);
+  }
+
+  56% {
+    transform: rotateY(188deg) scale(1.04);
+  }
+
+  100% {
+    transform: rotateY(180deg) scale(1);
+  }
+}
+
+@keyframes specialCardIconFloat {
+  from {
+    transform: translate3d(0, 0, 0) rotate(-1deg);
+  }
+
+  to {
+    transform: translate3d(0, -7px, 0) rotate(1deg);
   }
 }
 
@@ -1645,19 +1863,31 @@
   .finaleCard:nth-child(1) {
     --finale-x: 0px;
     --finale-y: 122px;
+    --finale-merge-y: 0px;
     --finale-rotate: 0deg;
   }
 
   .finaleCard:nth-child(2) {
     --finale-x: 0px;
     --finale-y: 470px;
+    --finale-merge-y: -348px;
     --finale-rotate: 0deg;
   }
 
   .finaleCard:nth-child(3) {
     --finale-x: 0px;
     --finale-y: 818px;
+    --finale-merge-y: -696px;
     --finale-rotate: 0deg;
+  }
+
+  .specialCardStage,
+  .specialCard {
+    min-height: 410px;
+  }
+
+  .specialCardFace {
+    padding: 24px;
   }
 
   .cardGrid .cardButton {

--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -112,6 +112,7 @@ export type BeautyMovementExperienceProps = {
 
 type HandStage = "waiting" | "ready" | "reveal" | "held" | "collect" | "deal" | "finale";
 type FinaleStage = "hidden" | "collecting" | "confirmation" | "result";
+type SpecialCardKind = "velocity" | "discount" | "free_procedure" | "reserved";
 
 type ShareNavigator = Navigator & {
     canShare?: (data?: ShareData) => boolean;
@@ -1035,6 +1036,85 @@ export default function BeautyMovementExperience({
         );
     }
 
+    function renderSpecialCard(revealed: boolean) {
+        const kind: SpecialCardKind = revealed
+            ? hasCourtesyClass
+                ? "velocity"
+                : initialState.benefit?.type === "discount"
+                  ? "discount"
+                  : initialState.benefit?.type === "free_procedure"
+                    ? "free_procedure"
+                    : "reserved"
+            : "reserved";
+        const benefit = initialState.benefit;
+        const velocity = initialState.velocity;
+        const iconId =
+            kind === "velocity"
+                ? "reward-velocity"
+                : kind === "discount"
+                  ? "reward-discount"
+                  : kind === "free_procedure"
+                    ? "reward-procedure"
+                    : "reward-reserved";
+        const kindLabel =
+            kind === "velocity"
+                ? "AULA-CORTESIA"
+                : kind === "discount"
+                  ? "CONDIÇÃO ESPECIAL"
+                  : kind === "free_procedure"
+                    ? "CORTESIA DE CELEBRAÇÃO"
+                    : "PRESENTE RESERVADO";
+        const title =
+            kind === "velocity"
+                ? velocity?.label?.trim() || "Aula-cortesia Velocity"
+                : kind === "discount" || kind === "free_procedure"
+                  ? benefit?.procedureName || "Cuidado reservado"
+                  : "Seu presente está reservado";
+        const description =
+            kind === "velocity"
+                ? velocity?.text || "Sua aula será confirmada pela equipe da unidade após o contato."
+                : kind === "discount" || kind === "free_procedure"
+                  ? benefit?.displayText || "Um cuidado especial para celebrar o seu momento."
+                  : "Confirme sua entrada para revelar a condição preparada para você.";
+        const meta =
+            kind === "discount" && benefit?.discount
+                ? formatRewardDiscount(benefit.discount)
+                : kind === "free_procedure"
+                  ? "Procedimento gratuito"
+                  : kind === "velocity"
+                    ? "Seu movimento também faz parte da celebração"
+                    : "Carta final da celebração";
+
+        return (
+            <article
+                className={styles.specialCard}
+                data-special-state={revealed ? "revealed" : "locked"}
+                aria-label={revealed ? `Carta especial: ${title}` : "Carta especial reservada"}
+            >
+                <div className={styles.specialCardInner}>
+                    <div className={`${styles.specialCardFace} ${styles.specialCardBack}`} aria-hidden={revealed}>
+                        <BrandMark className={styles.specialCardBrand} tone="light" title="" />
+                        <span className={styles.specialCardBackLabel}>CARTA ESPECIAL</span>
+                        <strong>A soma da sua leitura está pronta.</strong>
+                        <span>Confirme sua entrada para revelar o presente reservado.</span>
+                        <span className={styles.specialCardSeal} aria-hidden="true">
+                            ✦
+                        </span>
+                    </div>
+                    <div className={`${styles.specialCardFace} ${styles.specialCardFront}`} aria-hidden={!revealed}>
+                        <span className={styles.specialCardKind}>{kindLabel}</span>
+                        <span className={styles.specialCardIllustration} aria-hidden="true">
+                            <BeautyMovementCardIllustration cardId={iconId} />
+                        </span>
+                        <strong>{title}</strong>
+                        <span className={styles.specialCardCopy}>{description}</span>
+                        <span className={styles.specialCardMeta}>{meta}</span>
+                    </div>
+                </div>
+            </article>
+        );
+    }
+
     function renderConfirmationStage() {
         return (
             <section className={styles.confirmationStage} aria-labelledby="beauty-movement-inline-confirmation-title">
@@ -1308,12 +1388,16 @@ export default function BeautyMovementExperience({
                             </span>
                         ) : null}
                         {finaleStage === "collecting" ? (
-                            <div className={styles.finaleCardGrid} aria-hidden="true">
+                            <div className={`${styles.finaleCardGrid} ${styles.finaleCardGridMerging}`} aria-hidden="true">
                                 {reading.map(renderFinaleCard)}
                             </div>
                         ) : finaleStage === "confirmation" || finaleStage === "result" ? (
-                            <div className={styles.finaleCardGrid} role="group" aria-label="Cartas finais">
-                                {reading.map(renderFinaleCard)}
+                            <div
+                                className={styles.specialCardStage}
+                                role="group"
+                                aria-label={finaleStage === "result" ? "Carta especial do benefício" : "Carta especial da celebração"}
+                            >
+                                {renderSpecialCard(finaleStage === "result")}
                             </div>
                         ) : finaleStage === "hidden" && !waitingForInitialDeal ? (
                             <div className={styles.cardGrid} role="group" aria-label={`Cartas da etapa ${tableDefinition.label}`}>

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -48,7 +48,7 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(experience, /className=\{styles\.progressButton\}/);
     assert.match(experience, /disabled=\{!isCurrent\}/);
     assert.match(experience, /className=\{styles\.progressCopy\}/);
-    assert.match(experience, /role="group" aria-label="Cartas finais"/);
+    assert.match(experience, /className=\{styles\.specialCardStage\}/);
     assert.match(experience, /role="group" aria-label=\{`Cartas da etapa \$\{tableDefinition\.label\}`\}/);
     assert.doesNotMatch(experience, /role="list" aria-label="Cartas finais"/);
     assert.doesNotMatch(experience, /className=\{styles\.progressNumber\}/);
@@ -66,7 +66,7 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.doesNotMatch(experience, /actsStack|revealedStrip/);
     assert.doesNotMatch(experience, /BeautyMovementModalReading/);
     assert.doesNotMatch(experience, /finaleCardGridSettled/);
-    assert.match(experience, /aria-label="Cartas finais"/);
+    assert.match(experience, /aria-label=\{finaleStage === "result" \? "Carta especial do benefício"/);
     assert.match(experience, /className=\{styles\.cardSparkles\}/);
     assert.match(experience, /className=\{styles\.deckStage\}/);
     assert.match(experience, /type HandStage = "waiting"/);
@@ -126,12 +126,19 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.doesNotMatch(styles, /\.tableStage\[data-hand-stage="deal"\] \.cardButton:nth-child\(2\)[^}]*animation-delay/);
     assert.doesNotMatch(styles, /\.tableStage\[data-hand-stage="deal"\] \.cardButton:nth-child\(3\)[^}]*animation-delay/);
     assert.doesNotMatch(styles, /@keyframes finaleReturnToDeck/);
-    assert.match(styles, /@keyframes finaleCardsReappear/);
-    assert.match(styles, /\.tableStage\[data-hand-stage="finale"\] \.finaleCard\s*\{\s*animation: finaleCardsReappear/);
+    assert.match(styles, /@keyframes finaleCardsMerge/);
+    assert.match(
+        styles,
+        /\.tableStage\[data-hand-stage="finale"\] \.finaleCardGridMerging \.finaleCard\s*\{\s*animation: finaleCardsMerge/,
+    );
     assert.doesNotMatch(styles, /\.finaleCardGridSettled/);
     assert.match(styles, /@keyframes finaleIllustrationPulse/);
     assert.match(styles, /@keyframes finaleIllustrationPulse[\s\S]*100%[\s\S]*opacity: 1/);
     assert.match(styles, /\.finaleCardGrid/);
+    assert.match(styles, /\.specialCardStage/);
+    assert.match(styles, /\.specialCard/);
+    assert.match(styles, /@keyframes specialCardFlip/);
+    assert.match(styles, /@keyframes specialCardIconFloat/);
     assert.match(styles, /\.inlineFinale/);
     assert.match(styles, /\.deckPrompt/);
     assert.match(styles, /\.deckPrompt[\s\S]*bottom: 148px/);
@@ -150,9 +157,17 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(experience, /<BrandMark/);
     assert.match(experience, /aria-hidden=\{!isSelected\}/);
     assert.match(experience, /BeautyMovementCardIllustration/);
+    assert.match(experience, /function renderSpecialCard/);
+    assert.match(experience, /finaleCardGridMerging/);
+    assert.match(experience, /Carta especial do benefício/);
+    assert.doesNotMatch(experience, /aria-label="Cartas finais"/);
     assert.match(experience, /function drawStoryCardIllustration/);
     assert.match(experience, /drawStoryCardIllustration\(context, line\.cardId/);
     assert.match(experience, /getStoryCanvasFont\("--font-brand-ui"/);
+    assert.match(illustrations, /case "reward-reserved"/);
+    assert.match(illustrations, /case "reward-procedure"/);
+    assert.match(illustrations, /case "reward-discount"/);
+    assert.match(illustrations, /case "reward-velocity"/);
     assert.doesNotMatch(experience, /Arial, sans-serif/);
     assert.match(illustrations, /beleza-presenca/);
     assert.match(illustrations, /celebracao-encontro/);


### PR DESCRIPTION
## Summary\n- compose the three selected cards into a single special card after the finale deal\n- keep the special card locked before confirmation and reveal the preconfigured Velocity or Espaço Facial benefit after consent\n- add branded reward illustrations and merge/flip motion\n\n## Validation\n- local preview at /beleza-em-movimento/local-preview\n- full synthetic Beauty Movement test set: 31 passed\n- focused continuous-flow test: passed\n- browser journey: three reveals, finale merge, consent, Velocity special card and Lavieen care block\n\nBenefits remain preconfigured by invite; cards do not derive eligibility or rewards.