### PR TITLE
fix(site): use invite contact data at confirmation

### DIFF
--- a/website/docs/beauty-movement-phase1-input-template.md
+++ b/website/docs/beauty-movement-phase1-input-template.md
@@ -88,8 +88,9 @@ jurídica e operacional específica.
   de privacidade: `[PENDENTE]`.
 - CPF e histórico de procedimentos: fora do D1, frontend, URL, relatório e
   analytics; nenhum dado bruto deve ser carregado (**consolidado no plano**).
-- Campos do convite: `invite_ref`, nome, WhatsApp, e-mail opcional, paleta,
-  `reward_id`, `velocity_benefit`, expiração e status do convite. O procedimento,
+- Campos do convite: `invite_ref`, nome, WhatsApp, e-mail já vinculado na lista,
+  paleta, `reward_id`, `velocity_benefit`, expiração e status do convite. O
+  procedimento,
   desconto e condições ficam no catálogo privado de recompensas.
 - Consentimento: aceite operacional separado de qualquer marketing futuro;
   redação jurídica final: `[PENDENTE]`.

--- a/website/docs/beauty-movement-planning-spec-draft.md
+++ b/website/docs/beauty-movement-planning-spec-draft.md
@@ -152,7 +152,8 @@ dados preexistentes após gate de privacidade.
 3. Navegação compacta de progresso, com a etapa atual em amarelo.
 4. Mesa única: baralho clicável, primeira mão e revelação.
 5. Recolhimento e distribuição da segunda e terceira mão.
-6. Confirmação inline com WhatsApp mascarado, e-mail opcional e aceite.
+6. Confirmação inline com WhatsApp mascarado, contatos já vinculados e aceite;
+   a interface não solicita novamente o e-mail.
 7. Resultado inline: três cartas finais ilustradas, síntese, convite, benefício
    reservado, condições, CTA de equipe e Story.
 8. Footer real do site.
@@ -167,7 +168,7 @@ O cadastro ocorre após a terceira carta.
 | Campo/estado | Tratamento planejado |
 | --- | --- |
 | WhatsApp | já vinculado ao convite e exibido mascarado |
-| E-mail | opcional; não substitui e-mail pré-registrado |
+| E-mail | já vinculado ao convite; não é solicitado nem substituído no frontend |
 | Consentimento | um aceite operacional para lista e comunicações do evento |
 | CPF | nunca chega ao D1, frontend, URL, relatório ou analytics |
 | Histórico de procedimentos | somente ambiente privado, se houver gate aprovado |

--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -1418,13 +1418,6 @@
   line-height: 1.45;
 }
 
-.fieldHint {
-  margin: 0;
-  color: var(--bm-muted);
-  font-size: 0.88rem;
-  line-height: 1.45;
-}
-
 .inlineError {
   width: min(100%, 640px);
   margin: 24px auto 0;
@@ -1601,49 +1594,6 @@
   display: grid;
   gap: 16px;
   padding: clamp(20px, 4vw, 32px);
-}
-
-.formField {
-  display: grid;
-  gap: 8px;
-}
-
-.formField > span {
-  color: var(--bm-ink);
-  font-family: var(--font-brand-ui);
-  font-size: 0.79rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-}
-
-.formField em {
-  color: var(--bm-muted);
-  font-family: var(--font-brand-text);
-  font-size: 0.82rem;
-  font-style: normal;
-  font-weight: 500;
-  letter-spacing: 0;
-}
-
-.formField input {
-  width: 100%;
-  min-height: 52px;
-  padding: 0 16px;
-  border: 1px solid var(--bm-line-strong);
-  border-radius: 8px;
-  outline: none;
-  background: var(--bm-surface);
-  color: var(--bm-ink);
-  transition: border-color 160ms ease, box-shadow 160ms ease;
-}
-
-.formField input:focus {
-  border-color: var(--bm-ink);
-  box-shadow: 0 0 0 4px rgba(48, 48, 48, 0.12);
-}
-
-.formField input[aria-invalid="true"] {
-  border-color: var(--bm-ink);
 }
 
 .consentField {

--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -119,7 +119,6 @@ type ShareNavigator = Navigator & {
     share?: (data?: ShareData) => Promise<void>;
 };
 
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const STORY_WIDTH = 1080;
 const STORY_HEIGHT = 1920;
 const AUTO_ADVANCE_SECONDS = 5;
@@ -154,15 +153,6 @@ function getSelectionsFromReveals(
 function getCurrentActIndex(selections: BeautyMovementSelections): number {
     const index = BEAUTY_MOVEMENT_ACTS.findIndex((act) => !selections[act]);
     return index === -1 ? BEAUTY_MOVEMENT_ACTS.length : index;
-}
-
-function sanitizeEmail(value: string): string | null {
-    const normalized = value.trim().toLowerCase();
-    return normalized || null;
-}
-
-function isEmailValid(value: string): boolean {
-    return value.length === 0 || EMAIL_PATTERN.test(value);
 }
 
 function formatRewardDiscount(discount: NonNullable<BeautyMovementBenefit["discount"]>): string {
@@ -549,7 +539,6 @@ export default function BeautyMovementExperience({
         initialState.confirmed || initialReadingComplete ? "ready" : "waiting",
     );
     const [confirmed, setConfirmed] = useState(initialState.confirmed);
-    const [email, setEmail] = useState("");
     const [operationalConsent, setOperationalConsent] = useState(false);
     const [confirmationAttempted, setConfirmationAttempted] = useState(false);
     const [revealPendingCardId, setRevealPendingCardId] = useState<string | null>(null);
@@ -650,9 +639,6 @@ export default function BeautyMovementExperience({
         () => getBeautyMovementReading(initialState.palette, selections),
         [initialState.palette, selections],
     );
-    const emailValue = sanitizeEmail(email) ?? "";
-    const emailInvalid = confirmationAttempted && !isEmailValid(emailValue);
-    const emailAlreadyRegistered = initialState.invite.emailRegistered === true;
     const consentInvalid = confirmationAttempted && !operationalConsent;
     const partnerName = initialState.campaign.partnerName?.trim() || "Velocity";
     const primaryWhatsappLabel = initialState.campaign.whatsappLabel?.trim() || "Falar com a equipe";
@@ -888,13 +874,13 @@ export default function BeautyMovementExperience({
         setConfirmationAttempted(true);
         setActionError(null);
 
-        if (!operationalConsent || !isEmailValid(emailValue)) return;
+        if (!operationalConsent) return;
 
         confirmInFlightRef.current = true;
         setIsConfirming(true);
         try {
             await onConfirm?.({
-                email: emailValue || null,
+                email: null,
                 operationalConsent: true,
             });
             if (!mountedRef.current) return;
@@ -1135,37 +1121,10 @@ export default function BeautyMovementExperience({
                 <div className={styles.contactSummary}>
                     <span>Contato vinculado</span>
                     <strong>{initialState.invite.maskedWhatsapp}</strong>
-                    <small>Para corrigir dados, fale diretamente com a unidade.</small>
+                    <small>E-mail e telefone já estão vinculados a este convite. Para corrigir dados, fale diretamente com a unidade.</small>
                 </div>
 
                 <div className={styles.confirmationForm}>
-                    <label className={styles.formField} htmlFor="beauty-movement-inline-email">
-                        <span>
-                            E-mail <em>opcional</em>
-                        </span>
-                        <input
-                            id="beauty-movement-inline-email"
-                            type="email"
-                            autoComplete="email"
-                            value={email}
-                            onChange={(event) => setEmail(event.target.value)}
-                            disabled={emailAlreadyRegistered}
-                            aria-invalid={emailInvalid || undefined}
-                            aria-describedby={emailInvalid ? "beauty-movement-inline-email-error" : undefined}
-                            placeholder="voce@email.com"
-                        />
-                    </label>
-                    {emailAlreadyRegistered ? (
-                        <p className={styles.fieldHint}>
-                            E-mail já cadastrado. Para corrigir dados, fale diretamente com a unidade.
-                        </p>
-                    ) : null}
-                    {emailInvalid ? (
-                        <p className={styles.fieldError} id="beauty-movement-inline-email-error">
-                            Confira o formato do e-mail ou deixe este campo em branco.
-                        </p>
-                    ) : null}
-
                     <label className={`${styles.consentField} ${consentInvalid ? styles.consentFieldInvalid : ""}`.trim()}>
                         <input
                             type="checkbox"

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -61,6 +61,9 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(experience, /Escolha uma carta para liberar o avanço/);
     assert.match(experience, /Seu presente de celebração/);
     assert.match(experience, /Seu presente será revelado após a confirmação/);
+    assert.match(experience, /email: null/);
+    assert.match(experience, /E-mail e telefone já estão vinculados/);
+    assert.doesNotMatch(experience, /beauty-movement-inline-email|E-mail <em>opcional|voce@email\.com/);
     assert.doesNotMatch(experience, /benefitPreview/);
     assert.doesNotMatch(experience, /Ver minha leitura/);
     assert.doesNotMatch(experience, /actsStack|revealedStrip/);


### PR DESCRIPTION
## Alteração\n\nRemove o campo de e-mail da confirmação da experiência Cartas da Beleza em Movimento. O convite já contém os dados de contato; a UI exibe essa informação e envia email: null sem substituir o dado privado do convite.\n\n## Validação\n\n- 127 testes sintéticos passaram\n- TypeScript (	sc --noEmit) passou\n- Prévia local atualizada em /beleza-em-movimento/local-preview\n- Jornada Browser: distribuição, três escolhas, confirmação sem input de e-mail, carta especial e benefício configurado\n- Sem deploy de produção