### PR TITLE
fix(ponto): accept terminal pre-mutation recovery custody

### DIFF
--- a/.github/scripts/ponto-recovery-evidence.mjs
+++ b/.github/scripts/ponto-recovery-evidence.mjs
@@ -42,7 +42,13 @@ export function normalizeRecoveryEvidence({
   const watchdogChildrenValid = Array.isArray(reconciliation?.children)
     ? reconciliation.children.every((run) =>
       run?.status === "completed"
-      && ["issued", "consumed", "invalidated", "invalidated-before-cancel"].includes(
+      && [
+        "issued",
+        "consumed",
+        "invalidated",
+        "invalidated-before-cancel",
+        "terminal-pre-mutation-gate-failure",
+      ].includes(
         String(run?.capabilityState || run?.capabilityAuthorization || ""),
       ))
     : Number.isSafeInteger(reconciliation?.discoveredChildren)

--- a/.github/scripts/ponto-recovery-evidence.test.mjs
+++ b/.github/scripts/ponto-recovery-evidence.test.mjs
@@ -186,6 +186,33 @@ test("watchdog evidence normalizes only capability-authorized terminal children"
   assert.equal(normalized.childReconciliation.discoveredChildren, 1);
 });
 
+test("watchdog evidence accepts a terminal child that failed before mutation", () => {
+  const normalized = normalizeRecoveryEvidence({
+    reconciliation: {
+      schemaVersion: 1,
+      target,
+      children: [{
+        runId: "7",
+        status: "completed",
+        capabilityAuthorization: "terminal-pre-mutation-gate-failure",
+      }],
+      unresolved: [],
+      passed: true,
+      credentialsIncluded: false,
+      piiIncluded: false,
+    },
+    maintenance,
+    propagation,
+    sourceMode: "watchdog",
+    coordinatorRunId,
+    emergencyRunId,
+    releaseSha: sha,
+    stage,
+    target,
+  });
+  assert.equal(normalized.childReconciliation.discoveredChildren, 1);
+});
+
 test("watchdog evidence accepts validated aggregate child custody", () => {
   const normalized = normalizeRecoveryEvidence({
     reconciliation: {


### PR DESCRIPTION
## Summary
- accept the existing terminal-pre-mutation-gate-failure custody state during watchdog recovery normalization
- keep the recovery contract fail-closed for non-terminal or unproven children
- add focused regression coverage

## Validation
- node --test .github/scripts/ponto-recovery-evidence.test.mjs .github/scripts/ponto-emergency-stop.test.mjs .github/scripts/ponto-watchdog-journal.test.mjs (22 passed)

This is the minimal correction for the material watchdog recovery failure observed during the governed Ponto release.