### PR TITLE
fix(clientes): correct staging provision SQL comments

### DIFF
--- a/docs/runbooks/clientes-production-readonly-runtime.md
+++ b/docs/runbooks/clientes-production-readonly-runtime.md
@@ -55,7 +55,9 @@ literais `CHAVE=valor` pelo Node, nunca com `source`, `eval` ou `bash -c`.
    readiness no env privado e concede ao app apenas `SELECT`/`USAGE`; ele não
    abre uma rota nem inicia uma unidade. O invólucro da migration só executa
    a cópia imutável já preparada: isso garante o mesmo conjunto de dependências
-   e a linhagem que a futura unidade consumirá. Em todo `--apply` ou
+   e a linhagem que a futura unidade consumirá. Os heredocs enviados ao
+   PostgreSQL usam apenas comentários SQL `--` (nunca comentários de shell `#`).
+   O teste de contrato verifica isso antes de qualquer `--apply`. Em todo `--apply` ou
    `--rollback` de migration, depois dos gates e imediatamente antes do runner,
    ele cria e verifica exatamente um dump privado e único em
    `/var/backups/skincos/clientes/staging`; a evidência contém somente SHA-256,

--- a/scripts/provision-atendimento-staging.sh
+++ b/scripts/provision-atendimento-staging.sh
@@ -107,9 +107,9 @@ grant usage, select, update on all sequences in schema crm_atendimento, crm_caix
 revoke all privileges on schema crm_atendimento, crm_caixa, crm_sessions, harmonia from $APP_ROLE;
 revoke all privileges on all tables in schema crm_atendimento, crm_caixa, crm_sessions, harmonia from $APP_ROLE;
 revoke all privileges on all sequences in schema crm_atendimento, crm_caixa, crm_sessions, harmonia from $APP_ROLE;
-# The isolated application has no safe direct Caixa projection yet. Do not
-# give it source-system reads during provisioning; terminal lockdown removes
-# temporary migration compatibility grants before the runtime can start.
+-- The isolated application has no safe direct Caixa projection yet. Do not
+-- give it source-system reads during provisioning; terminal lockdown removes
+-- temporary migration compatibility grants before the runtime can start.
 grant usage on schema crm_atendimento, crm_sessions to $APP_ROLE;
 grant select on all tables in schema crm_atendimento, crm_sessions to $APP_ROLE;
 grant usage, create on schema harmonia to $MIGRATOR_ROLE;

--- a/scripts/tests/clientes-production-readonly-runtime.test.mjs
+++ b/scripts/tests/clientes-production-readonly-runtime.test.mjs
@@ -14,6 +14,12 @@ function assertNoDynamicShell(relative) {
   assert.doesNotMatch(text, /^\s*(?:exec\s+)?bash\s+-c\b/m, `${relative} must not create a shell command string`)
 }
 
+function sqlHeredocs(script, relative) {
+  const heredocs = [...script.matchAll(/<<SQL\r?\n([\s\S]*?)\r?\nSQL/g)].map((match) => match[1])
+  assert.ok(heredocs.length > 0, `${relative} must contain SQL heredocs covered by this regression`)
+  return heredocs
+}
+
 test('isolated Clientes unit starts only the dedicated read-only entrypoint', () => {
   const unit = read('ops/runtime/units/crm-atendimento-production.service')
   assert.match(unit, /Description=.*Clientes.*read-only/)
@@ -128,6 +134,12 @@ test('staging release, control and application role remain fixed and read-only',
   assert.match(provision, /random_hex\(\)/)
   assert.match(provision, /\\set app_password/)
   assert.doesNotMatch(provision, /--set=app_password|--set=migrator_password/)
+  const provisionSql = sqlHeredocs(provision, 'scripts/provision-atendimento-staging.sh')
+  assert.equal(provisionSql.length, 2, 'staging provision must keep both SQL payloads under regression coverage')
+  for (const sql of provisionSql) {
+    assert.doesNotMatch(sql, /^\s*#/m, 'PostgreSQL heredocs must use SQL comments, never shell # comments')
+  }
+  assert.match(provisionSql[1], /^-- The isolated application has no safe direct Caixa projection yet\. Do not$/m)
   assert.match(provision, /readonly BACKUP_ROOT='\/var\/backups\/skincos\/clientes\/staging-control'/)
   assert.match(provision, /ATENDIMENTO_READINESS_TOKEN=\$readiness_token/)
   assert.match(provision, /"state":"maintenance"/)


### PR DESCRIPTION
## Correção

O provisionamento de staging parava no PostgreSQL porque três comentários dentro do heredoc SQL usavam `#`, sintaxe válida apenas para o shell.

Este PR:

- substitui esses comentários por `--`, a sintaxe SQL válida;
- adiciona uma regressão que extrai os dois heredocs SQL do provisionador e rejeita qualquer comentário iniciado por `#`;
- documenta o contrato no runbook de staging.

## Impacto e contenção

Não altera schema, grants, roles, flags, unidade, dados ou serviços. Não houve `--apply`, acesso ao host, banco, restart ou nova ação de staging por este PR. O staging permanece inativo sob o lockdown já executado.

## Validação

- sintaxe: `bash -n scripts/provision-atendimento-staging.sh`;
- contrato focal: `node scripts/tests/clientes-production-readonly-runtime.test.mjs` — 8/8;
- inspeção independente dos 2 heredocs SQL: nenhum comentário `#`;
- `git diff --check`.

O PR permanece em rascunho até a CI fresca concluir.