### PR TITLE
fix(clientes): bound staging migrator connections

### DIFF
--- a/crm/api/scripts/atendimento-staging-maintenance-lock.mjs
+++ b/crm/api/scripts/atendimento-staging-maintenance-lock.mjs
@@ -1,0 +1,41 @@
+// Keep this value compatible with the original full-run migration lock so a
+// release using the older runner still excludes new staging mutation paths.
+export const ATENDIMENTO_STAGING_MUTATION_LOCK_KEY = 'skincos:atendimento:staging:migrations:v1'
+// Two sessions are needed by the full-run migration (gate + work). A third is
+// reserved only so a competing fixed entrypoint can connect, observe the
+// shared lock, and fail before any mutation rather than receive SQLSTATE 53300.
+export const ATENDIMENTO_STAGING_MIGRATOR_CONNECTION_LIMIT = 3
+export const ATENDIMENTO_STAGING_MIGRATION_POOL_MAX = 2
+export const ATENDIMENTO_STAGING_QUALITY_REFRESH_POOL_MAX = 2
+export const HARMONIA_STAGING_MIGRATION_POOL_MAX = 1
+
+export async function acquireAtendimentoStagingMutationLock(client, unavailableCode) {
+    const result = await client.query(
+        'select pg_try_advisory_lock(hashtext($1)) as acquired',
+        [ATENDIMENTO_STAGING_MUTATION_LOCK_KEY],
+    )
+    if (result?.rows?.[0]?.acquired !== true) {
+        const error = new Error(unavailableCode)
+        error.code = unavailableCode
+        throw error
+    }
+}
+
+export async function releaseAtendimentoStagingMutationLock(client) {
+    await client.query(
+        'select pg_advisory_unlock(hashtext($1))',
+        [ATENDIMENTO_STAGING_MUTATION_LOCK_KEY],
+    )
+}
+
+export async function assertAtendimentoStagingMigratorConnectionLimit(client) {
+    const result = await client.query(
+        'select rolconnlimit = $1 as valid from pg_roles where rolname = current_user',
+        [ATENDIMENTO_STAGING_MIGRATOR_CONNECTION_LIMIT],
+    )
+    if (result?.rows?.[0]?.valid !== true) {
+        const error = new Error('ATENDIMENTO_STAGING_MIGRATOR_CONNECTION_LIMIT_INVALID')
+        error.code = 'ATENDIMENTO_STAGING_MIGRATOR_CONNECTION_LIMIT_INVALID'
+        throw error
+    }
+}

--- a/crm/api/scripts/atendimento-staging-maintenance-lock.test.mjs
+++ b/crm/api/scripts/atendimento-staging-maintenance-lock.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+    acquireAtendimentoStagingMutationLock,
+    assertAtendimentoStagingMigratorConnectionLimit,
+    ATENDIMENTO_STAGING_MIGRATOR_CONNECTION_LIMIT,
+    ATENDIMENTO_STAGING_MIGRATION_POOL_MAX,
+    ATENDIMENTO_STAGING_MUTATION_LOCK_KEY,
+    ATENDIMENTO_STAGING_QUALITY_REFRESH_POOL_MAX,
+    HARMONIA_STAGING_MIGRATION_POOL_MAX,
+    releaseAtendimentoStagingMutationLock,
+} from './atendimento-staging-maintenance-lock.mjs'
+
+test('staging mutation gate uses the compatible full-run lock and exact three-session role budget', async () => {
+    const calls = []
+    const client = {
+        async query(sql, values) {
+            calls.push({ sql, values })
+            if (sql.includes('pg_try_advisory_lock')) return { rows: [{ acquired: true }] }
+            if (sql.includes('rolconnlimit')) return { rows: [{ valid: true }] }
+            if (sql.includes('pg_advisory_unlock')) return { rows: [{ unlocked: true }] }
+            throw new Error(`unexpected query: ${sql}`)
+        },
+    }
+
+    await acquireAtendimentoStagingMutationLock(client, 'TEST_LOCK_UNAVAILABLE')
+    await assertAtendimentoStagingMigratorConnectionLimit(client)
+    await releaseAtendimentoStagingMutationLock(client)
+
+    assert.equal(ATENDIMENTO_STAGING_MUTATION_LOCK_KEY, 'skincos:atendimento:staging:migrations:v1')
+    assert.equal(ATENDIMENTO_STAGING_MIGRATOR_CONNECTION_LIMIT, 3)
+    assert.equal(ATENDIMENTO_STAGING_MIGRATION_POOL_MAX, 2)
+    assert.equal(ATENDIMENTO_STAGING_QUALITY_REFRESH_POOL_MAX, 2)
+    assert.equal(HARMONIA_STAGING_MIGRATION_POOL_MAX, 1)
+    assert.deepEqual(calls[0].values, [ATENDIMENTO_STAGING_MUTATION_LOCK_KEY])
+    assert.deepEqual(calls[1].values, [ATENDIMENTO_STAGING_MIGRATOR_CONNECTION_LIMIT])
+    assert.deepEqual(calls[2].values, [ATENDIMENTO_STAGING_MUTATION_LOCK_KEY])
+})
+
+test('staging mutation gate and connection contract fail closed', async () => {
+    await assert.rejects(
+        acquireAtendimentoStagingMutationLock({
+            async query() { return { rows: [{ acquired: false }] } },
+        }, 'TEST_LOCK_UNAVAILABLE'),
+        /TEST_LOCK_UNAVAILABLE/,
+    )
+    await assert.rejects(
+        assertAtendimentoStagingMigratorConnectionLimit({
+            async query() { return { rows: [{ valid: false }] } },
+        }),
+        /ATENDIMENTO_STAGING_MIGRATOR_CONNECTION_LIMIT_INVALID/,
+    )
+})

--- a/crm/api/scripts/migrate-atendimento-commercial-analytics.mjs
+++ b/crm/api/scripts/migrate-atendimento-commercial-analytics.mjs
@@ -21,7 +21,10 @@ function parseTarget(args) {
     const values = args.filter((arg) => arg.startsWith('--target='))
     if (values.length > 1) throw commandError('COMMERCIAL_ANALYTICS_TARGET_INVALID')
     const target = values[0] ? values[0].slice('--target='.length) : ATENDIMENTO_MIGRATION_TARGETS.LOCAL
-    if ([ATENDIMENTO_MIGRATION_TARGETS.LOCAL, ATENDIMENTO_MIGRATION_TARGETS.STAGING].includes(target)) return target
+    if (target === ATENDIMENTO_MIGRATION_TARGETS.STAGING) {
+        throw commandError('COMMERCIAL_ANALYTICS_STAGING_REQUIRES_CONTROLLED_RUNNER')
+    }
+    if (target === ATENDIMENTO_MIGRATION_TARGETS.LOCAL) return target
     throw commandError('COMMERCIAL_ANALYTICS_TARGET_INVALID')
 }
 

--- a/crm/api/scripts/migrate-atendimento-commercial-assisted-whatsapp.mjs
+++ b/crm/api/scripts/migrate-atendimento-commercial-assisted-whatsapp.mjs
@@ -12,7 +12,6 @@ import {
 } from '../server/atendimento/migrationDestination.js'
 
 const ALLOWED_ACTIONS = new Set(['--dry-run', '--apply', '--rollback'])
-const ALLOWED_TARGETS = new Set([ATENDIMENTO_MIGRATION_TARGETS.LOCAL, ATENDIMENTO_MIGRATION_TARGETS.STAGING])
 
 function commandError(code) {
     const error = new Error(code)
@@ -24,7 +23,10 @@ function parseTarget(args) {
     const values = args.filter((arg) => arg.startsWith('--target='))
     if (values.length > 1) throw commandError('COMMERCIAL_ASSISTED_TARGET_INVALID')
     const target = values[0] ? values[0].slice('--target='.length) : ATENDIMENTO_MIGRATION_TARGETS.LOCAL
-    if (ALLOWED_TARGETS.has(target)) return target
+    if (target === ATENDIMENTO_MIGRATION_TARGETS.STAGING) {
+        throw commandError('COMMERCIAL_ASSISTED_STAGING_REQUIRES_CONTROLLED_RUNNER')
+    }
+    if (target === ATENDIMENTO_MIGRATION_TARGETS.LOCAL) return target
     throw commandError('COMMERCIAL_ASSISTED_TARGET_INVALID')
 }
 

--- a/crm/api/scripts/migrate-atendimento-commercial-operations.mjs
+++ b/crm/api/scripts/migrate-atendimento-commercial-operations.mjs
@@ -21,7 +21,10 @@ function parseTarget(args) {
     const values = args.filter((arg) => arg.startsWith('--target='))
     if (values.length > 1) throw commandError('COMMERCIAL_OPERATIONS_TARGET_INVALID')
     const value = values[0] ? values[0].slice('--target='.length) : ATENDIMENTO_MIGRATION_TARGETS.LOCAL
-    if (value === ATENDIMENTO_MIGRATION_TARGETS.LOCAL || value === ATENDIMENTO_MIGRATION_TARGETS.STAGING) return value
+    if (value === ATENDIMENTO_MIGRATION_TARGETS.STAGING) {
+        throw commandError('COMMERCIAL_OPERATIONS_STAGING_REQUIRES_CONTROLLED_RUNNER')
+    }
+    if (value === ATENDIMENTO_MIGRATION_TARGETS.LOCAL) return value
     throw commandError('COMMERCIAL_OPERATIONS_TARGET_INVALID')
 }
 

--- a/crm/api/scripts/migrate-atendimento-staging-runtime.test.mjs
+++ b/crm/api/scripts/migrate-atendimento-staging-runtime.test.mjs
@@ -4,8 +4,17 @@ import {
   parseAtendimentoStagingMigrationAction,
   runAtendimentoStagingMigration,
   ATENDIMENTO_STAGING_MIGRATIONS,
+  ATENDIMENTO_STAGING_MIGRATION_POOL_MAX,
   ATENDIMENTO_STAGING_MIGRATION_LOCK_KEY,
+  ATENDIMENTO_STAGING_MIGRATOR_CONNECTION_LIMIT,
 } from './migrate-atendimento-staging.mjs'
+import { runHarmoniaMigration } from './migrate-harmonia-schema.mjs'
+
+function deferred() {
+  let resolve
+  const promise = new Promise((done) => { resolve = done })
+  return { promise, resolve }
+}
 
 test('staging migration parser accepts exactly one explicit action', () => {
   assert.equal(parseAtendimentoStagingMigrationAction(['--dry-run']), 'dry-run')
@@ -40,6 +49,7 @@ test('staging migration runner takes a dedicated advisory lock before inspecting
     async query(sql, values) {
       calls.push({ sql, values })
       if (sql.includes('pg_try_advisory_lock')) return { rows: [{ acquired: true }] }
+      if (sql.includes('rolconnlimit')) return { rows: [{ valid: true }] }
       if (sql.includes('pg_advisory_unlock')) return { rows: [{ unlocked: true }] }
       throw new Error(`unexpected lock query: ${sql}`)
     },
@@ -55,20 +65,82 @@ test('staging migration runner takes a dedicated advisory lock before inspecting
     release() {},
   }
   let connects = 0
+  let leased = 0
+  let maxLeased = 0
+  let poolOptions = null
   const report = await runAtendimentoStagingMigration({
     databaseUrl,
     action: 'dry-run',
     createRunId: () => 'synthetic-run',
-    createPool: () => ({
-      async connect() { return connects++ === 0 ? lockClient : identityClient },
-      async end() { ended = true },
-    }),
+    createPool: (_, options) => {
+      poolOptions = options
+      return {
+        async connect() {
+          const client = [lockClient, identityClient][connects++]
+          assert.ok(client, 'the staging migration runner must not lease a third client')
+          leased += 1
+          maxLeased = Math.max(maxLeased, leased)
+          let releasedClient = false
+          return {
+            query: client.query.bind(client),
+            release() {
+              if (releasedClient) return
+              releasedClient = true
+              leased -= 1
+              client.release()
+            },
+          }
+        },
+        async end() { ended = true },
+      }
+    },
     assertDestination: async () => ({ database: 'skincos_staging', user: 'skincos_staging_crm_owner', target: 'staging' }),
   })
   assert.equal(report.runId, 'synthetic-run')
+  assert.equal(ATENDIMENTO_STAGING_MIGRATOR_CONNECTION_LIMIT, 3)
+  assert.deepEqual(poolOptions, { max: ATENDIMENTO_STAGING_MIGRATION_POOL_MAX })
+  assert.equal(ATENDIMENTO_STAGING_MIGRATION_POOL_MAX, 2)
+  assert.equal(connects, 2)
+  assert.equal(maxLeased, 2)
+  assert.equal(leased, 0)
   assert.equal(calls[0].sql.includes('pg_try_advisory_lock'), true)
   assert.deepEqual(calls[0].values, [ATENDIMENTO_STAGING_MIGRATION_LOCK_KEY])
+  assert.deepEqual(calls[1].values, [ATENDIMENTO_STAGING_MIGRATOR_CONNECTION_LIMIT])
   assert.equal(calls.at(-1).sql.includes('pg_advisory_unlock'), true)
+  assert.equal(released, true)
+  assert.equal(ended, true)
+})
+
+test('staging migration refuses a role below the connection contract before requesting its second client', async () => {
+  const databaseUrl = 'postgresql://skincos_staging_migrator_login:synthetic@127.0.0.1:5432/skincos_staging?sslmode=require&uselibpqcompat=true'
+  let connects = 0
+  let released = false
+  let ended = false
+  await assert.rejects(
+    runAtendimentoStagingMigration({
+      databaseUrl,
+      action: 'dry-run',
+      createPool: (_, options) => ({
+        async connect() {
+          connects += 1
+          assert.equal(connects, 1, 'a role below the contract must never reach the second checkout')
+          assert.deepEqual(options, { max: ATENDIMENTO_STAGING_MIGRATION_POOL_MAX })
+          return {
+            async query(sql) {
+              if (sql.includes('pg_try_advisory_lock')) return { rows: [{ acquired: true }] }
+              if (sql.includes('rolconnlimit')) return { rows: [{ valid: false }] }
+              if (sql.includes('pg_advisory_unlock')) return { rows: [{ unlocked: true }] }
+              throw new Error(`unexpected query: ${sql}`)
+            },
+            release() { released = true },
+          }
+        },
+        async end() { ended = true },
+      }),
+    }),
+    /ATENDIMENTO_STAGING_MIGRATOR_CONNECTION_LIMIT_INVALID/,
+  )
+  assert.equal(connects, 1)
   assert.equal(released, true)
   assert.equal(ended, true)
 })
@@ -96,6 +168,116 @@ test('staging migration fails closed when the advisory lock is already held', as
     /ATENDIMENTO_STAGING_MIGRATION_LOCK_UNAVAILABLE/,
   )
   assert.equal(ended, true)
+})
+
+test('an active two-client migration lets one Harmonia contender observe the shared lock without writes', async () => {
+  const databaseUrl = 'postgresql://skincos_staging_migrator_login:synthetic@127.0.0.1:5432/skincos_staging?sslmode=require&uselibpqcompat=true'
+  const identityEntered = deferred()
+  const continueIdentity = deferred()
+  let mutationLockHeld = false
+  let activeConnections = 0
+  let maxActiveConnections = 0
+  let primaryPoolOptions = null
+  let contenderPoolOptions = null
+  let primaryEnded = false
+  let contenderEnded = false
+
+  const lease = (client) => {
+    activeConnections += 1
+    maxActiveConnections = Math.max(maxActiveConnections, activeConnections)
+    let released = false
+    return {
+      query: client.query.bind(client),
+      release() {
+        if (released) return
+        released = true
+        activeConnections -= 1
+        client.release?.()
+      },
+    }
+  }
+  const lockClient = {
+    async query(sql) {
+      if (sql.includes('pg_try_advisory_lock')) {
+        assert.equal(mutationLockHeld, false)
+        mutationLockHeld = true
+        return { rows: [{ acquired: true }] }
+      }
+      if (sql.includes('rolconnlimit')) return { rows: [{ valid: true }] }
+      if (sql.includes('pg_advisory_unlock')) {
+        mutationLockHeld = false
+        return { rows: [{ unlocked: true }] }
+      }
+      throw new Error(`unexpected primary lock query: ${sql}`)
+    },
+  }
+  const identityClient = {
+    async query(sql) {
+      if (sql === 'begin' || sql === 'commit') return { rows: [] }
+      if (sql.includes("to_regclass('crm_atendimento.schema_migrations')")) return { rows: [{ registry: null }] }
+      throw new Error(`unexpected primary identity query: ${sql}`)
+    },
+  }
+  const primary = runAtendimentoStagingMigration({
+    databaseUrl,
+    action: 'dry-run',
+    createPool: (_, options) => {
+      primaryPoolOptions = options
+      let index = 0
+      return {
+        async connect() {
+          const client = [lockClient, identityClient][index++]
+          assert.ok(client, 'the primary migration must stay inside its two-client pool budget')
+          return lease(client)
+        },
+        async end() { primaryEnded = true },
+      }
+    },
+    assertDestination: async () => {
+      identityEntered.resolve()
+      await continueIdentity.promise
+      return { database: 'skincos_staging', user: 'skincos_staging_migrator_login', target: 'staging' }
+    },
+  })
+
+  await identityEntered.promise
+  assert.equal(activeConnections, 2)
+  await assert.rejects(
+    runHarmoniaMigration({
+      databaseUrl,
+      target: 'staging',
+      action: 'dry-run',
+      createPool: (_, options) => {
+        contenderPoolOptions = options
+        return {
+          async connect() {
+            return lease({
+              async query(sql) {
+                if (sql.includes('pg_try_advisory_lock')) {
+                  assert.equal(mutationLockHeld, true)
+                  return { rows: [{ acquired: false }] }
+                }
+                if (sql === 'rollback') return { rows: [] }
+                throw new Error(`unexpected contender query: ${sql}`)
+              },
+            })
+          },
+          async end() { contenderEnded = true },
+        }
+      },
+    }),
+    /HARMONIA_STAGING_MIGRATION_LOCK_UNAVAILABLE/,
+  )
+  assert.equal(maxActiveConnections, 3)
+  assert.deepEqual(primaryPoolOptions, { max: ATENDIMENTO_STAGING_MIGRATION_POOL_MAX })
+  assert.deepEqual(contenderPoolOptions, { max: 1 })
+  assert.equal(contenderEnded, true)
+
+  continueIdentity.resolve()
+  await primary
+  assert.equal(activeConnections, 0)
+  assert.equal(mutationLockHeld, false)
+  assert.equal(primaryEnded, true)
 })
 
 

--- a/crm/api/scripts/migrate-atendimento-staging.mjs
+++ b/crm/api/scripts/migrate-atendimento-staging.mjs
@@ -10,6 +10,14 @@
 import { randomUUID } from 'node:crypto'
 import { createPgPool } from '../server/harmonia/store/pg.js'
 import {
+    acquireAtendimentoStagingMutationLock,
+    assertAtendimentoStagingMigratorConnectionLimit,
+    ATENDIMENTO_STAGING_MIGRATOR_CONNECTION_LIMIT,
+    ATENDIMENTO_STAGING_MIGRATION_POOL_MAX,
+    ATENDIMENTO_STAGING_MUTATION_LOCK_KEY,
+    releaseAtendimentoStagingMutationLock,
+} from './atendimento-staging-maintenance-lock.mjs'
+import {
     assertAtendimentoMigrationDestination,
     ATENDIMENTO_MIGRATION_TARGETS,
     isStrictAtendimentoMigrationDestination,
@@ -78,7 +86,8 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 export const ATENDIMENTO_STAGING_MIGRATION_TARGET = ATENDIMENTO_MIGRATION_TARGETS.STAGING
-export const ATENDIMENTO_STAGING_MIGRATION_LOCK_KEY = 'skincos:atendimento:staging:migrations:v1'
+export const ATENDIMENTO_STAGING_MIGRATION_LOCK_KEY = ATENDIMENTO_STAGING_MUTATION_LOCK_KEY
+export { ATENDIMENTO_STAGING_MIGRATOR_CONNECTION_LIMIT, ATENDIMENTO_STAGING_MIGRATION_POOL_MAX }
 export const ATENDIMENTO_STAGING_MIGRATIONS = Object.freeze([
     { id: '20260718_atendimento_professional_identity_v1', apply: applyProfessionalIdentityMigration, rollback: rollbackProfessionalIdentityMigration },
     { id: '20260718_atendimento_write_safety_v1', apply: applyAtendimentoWriteSafetyMigration, rollback: rollbackAtendimentoWriteSafetyMigration },
@@ -124,21 +133,20 @@ export async function runAtendimentoStagingMigration({
     if (!normalizedUrl || !isStrictAtendimentoMigrationDestination(normalizedUrl, target)) {
         throw new Error('DATABASE_URL deve apontar exclusivamente para skincos_staging via loopback TLS e o login migrator.')
     }
-    const pool = createPool(normalizedUrl)
+    // The session-scoped mutation lock remains checked out for the entire run.
+    // Every listed migration uses one additional client in serial order, so the
+    // executor pool budget is exactly two; a third role session is reserved
+    // only for a competing fixed entrypoint to fail on the shared lock.
+    const pool = createPool(normalizedUrl, { max: ATENDIMENTO_STAGING_MIGRATION_POOL_MAX })
     if (!pool) throw new Error('Não foi possível criar o pool staging.')
     const runId = createRunId()
     let lockClient = null
     let lockAcquired = false
     try {
         lockClient = await pool.connect()
-        const lock = await lockClient.query(
-            'select pg_try_advisory_lock(hashtext($1)) as acquired',
-            [ATENDIMENTO_STAGING_MIGRATION_LOCK_KEY],
-        )
-        lockAcquired = lock.rows[0]?.acquired === true
-        if (!lockAcquired) {
-            throw new Error('ATENDIMENTO_STAGING_MIGRATION_LOCK_UNAVAILABLE')
-        }
+        await acquireAtendimentoStagingMutationLock(lockClient, 'ATENDIMENTO_STAGING_MIGRATION_LOCK_UNAVAILABLE')
+        lockAcquired = true
+        await assertAtendimentoStagingMigratorConnectionLimit(lockClient)
 
         const client = await pool.connect()
         try {
@@ -177,10 +185,7 @@ export async function runAtendimentoStagingMigration({
         if (lockClient) {
             if (lockAcquired) {
                 try {
-                    await lockClient.query(
-                        'select pg_advisory_unlock(hashtext($1))',
-                        [ATENDIMENTO_STAGING_MIGRATION_LOCK_KEY],
-                    )
+                    await releaseAtendimentoStagingMutationLock(lockClient)
                 } catch {
                     // The pool close still releases a session-scoped advisory lock.
                 }

--- a/crm/api/scripts/migrate-clinical-approval.mjs
+++ b/crm/api/scripts/migrate-clinical-approval.mjs
@@ -13,16 +13,21 @@ import {
 const args = process.argv.slice(2)
 const targetArg = args.find((arg) => arg.startsWith('--target='))
 const targetValue = targetArg ? targetArg.slice('--target='.length) : 'local'
-const target = targetValue === 'staging' ? ATENDIMENTO_MIGRATION_TARGETS.STAGING : targetValue === 'local' ? ATENDIMENTO_MIGRATION_TARGETS.LOCAL : null
+if (targetValue === ATENDIMENTO_MIGRATION_TARGETS.STAGING) {
+    const error = new Error('CLINICAL_APPROVAL_STAGING_REQUIRES_CONTROLLED_RUNNER')
+    error.code = 'CLINICAL_APPROVAL_STAGING_REQUIRES_CONTROLLED_RUNNER'
+    throw error
+}
+const target = targetValue === 'local' ? ATENDIMENTO_MIGRATION_TARGETS.LOCAL : null
 const databaseUrl = String(process.env.DATABASE_URL || '').trim()
 const dryRun = args.includes('--dry-run')
 if (dryRun && args.some((arg) => arg !== '--dry-run' && !arg.startsWith('--target='))) throw new Error('Argumentos incompatíveis.')
 if (!dryRun && args.some((arg) => arg !== '--apply' && arg !== '--rollback' && !arg.startsWith('--target='))) throw new Error('Argumentos incompatíveis.')
 const action = dryRun ? 'dry-run' : parseClinicalApprovalMigrationAction(args.filter((arg) => arg === '--apply' || arg === '--rollback'))
 if (!target || !databaseUrl || !isStrictAtendimentoMigrationDestination(databaseUrl, target)) {
-    throw new Error('DATABASE_URL deve apontar exclusivamente para o espelho local ou staging loopback autorizado.')
+    throw new Error('DATABASE_URL deve apontar exclusivamente para o espelho local autorizado.')
 }
-if (target !== ATENDIMENTO_MIGRATION_TARGETS.LOCAL && target !== ATENDIMENTO_MIGRATION_TARGETS.STAGING) throw new Error('Destino inválido.')
+if (target !== ATENDIMENTO_MIGRATION_TARGETS.LOCAL) throw new Error('Destino inválido.')
 
 if (action === 'dry-run') {
     console.log(JSON.stringify({ action, target, migration: '20260806_clinical_cadence_approval_v1', destinationGuard: 'passed', writes: false }, null, 2))

--- a/crm/api/scripts/migrate-harmonia-schema.mjs
+++ b/crm/api/scripts/migrate-harmonia-schema.mjs
@@ -4,6 +4,12 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 
 import { createPgPool } from '../server/harmonia/store/pg.js'
 import { harmoniaMigrationStatements, defaultUnitsSeedRows } from '../server/harmonia/store/migrate.js'
+import {
+    acquireAtendimentoStagingMutationLock,
+    assertAtendimentoStagingMigratorConnectionLimit,
+    HARMONIA_STAGING_MIGRATION_POOL_MAX,
+    releaseAtendimentoStagingMutationLock,
+} from './atendimento-staging-maintenance-lock.mjs'
 
 export const HARMONIA_MIGRATION_ID = '20260805_harmonia_worker_foundation_v1'
 
@@ -139,15 +145,23 @@ async function writeCheckpoint(checkpointPath, { target, databaseUrl, state, rel
     return destination
 }
 
-export async function runHarmoniaMigration({ databaseUrl, target: targetValue, action = 'dry-run', checkpointPath, releaseSha } = {}) {
+export async function runHarmoniaMigration({ databaseUrl, target: targetValue, action = 'dry-run', checkpointPath, releaseSha, createPool = createPgPool } = {}) {
     const target = assertHarmoniaMigrationDestination(databaseUrl, targetValue)
     if (!['dry-run', 'apply'].includes(action)) throw new Error('action must be dry-run or apply')
-    const pool = createPgPool(databaseUrl)
+    // Harmonia itself is serial and needs one client. Pinning it to one leaves
+    // the role's remaining budget available for the shared lock gate.
+    const pool = createPool(databaseUrl, target === 'staging' ? { max: HARMONIA_STAGING_MIGRATION_POOL_MAX } : undefined)
     if (!pool) throw new Error('DATABASE_URL is required')
 
     try {
         const client = await pool.connect()
+        let mutationLockAcquired = false
         try {
+            if (target === 'staging') {
+                await acquireAtendimentoStagingMutationLock(client, 'HARMONIA_STAGING_MIGRATION_LOCK_UNAVAILABLE')
+                mutationLockAcquired = true
+                await assertAtendimentoStagingMigratorConnectionLimit(client)
+            }
             await client.query('begin')
             await client.query("select pg_advisory_xact_lock(hashtextextended('skincos:harmonia-schema-migration', 0))")
             const before = await queryState(client)
@@ -194,6 +208,9 @@ export async function runHarmoniaMigration({ databaseUrl, target: targetValue, a
             try { await client.query('rollback') } catch { /* preserve original error */ }
             throw error
         } finally {
+            if (mutationLockAcquired) {
+                try { await releaseAtendimentoStagingMutationLock(client) } catch { /* connection cleanup releases the lock too */ }
+            }
             client.release()
         }
     } finally {

--- a/crm/api/scripts/refresh-commercial-data-quality-staging.mjs
+++ b/crm/api/scripts/refresh-commercial-data-quality-staging.mjs
@@ -2,6 +2,12 @@
 import { createPgPool } from '../server/harmonia/store/pg.js'
 import { createCommercialDataQualityStore } from '../server/atendimento/commercialDataQualityStore.js'
 import {
+    acquireAtendimentoStagingMutationLock,
+    assertAtendimentoStagingMigratorConnectionLimit,
+    ATENDIMENTO_STAGING_QUALITY_REFRESH_POOL_MAX,
+    releaseAtendimentoStagingMutationLock,
+} from './atendimento-staging-maintenance-lock.mjs'
+import {
     assertAtendimentoMigrationDestination,
     ATENDIMENTO_MIGRATION_TARGETS,
     isStrictAtendimentoMigrationDestination,
@@ -13,14 +19,18 @@ if (!databaseUrl || !isStrictAtendimentoMigrationDestination(databaseUrl, ATENDI
     throw new Error('DATABASE_URL deve apontar exclusivamente para o staging TLS via loopback.')
 }
 
-const pool = createPgPool(databaseUrl)
+// Reserve one session for the shared staging mutation gate and at most one for
+// the serial quality transaction. The role keeps one additional session only
+// for a competing fixed entrypoint to fail on the shared mutation lock.
+const pool = createPgPool(databaseUrl, { max: ATENDIMENTO_STAGING_QUALITY_REFRESH_POOL_MAX })
+let lockClient = null
+let lockAcquired = false
 try {
-    const client = await pool.connect()
-    try {
-        await assertAtendimentoMigrationDestination(client, databaseUrl, ATENDIMENTO_MIGRATION_TARGETS.STAGING)
-    } finally {
-        client.release()
-    }
+    lockClient = await pool.connect()
+    await acquireAtendimentoStagingMutationLock(lockClient, 'ATENDIMENTO_STAGING_QUALITY_LOCK_UNAVAILABLE')
+    lockAcquired = true
+    await assertAtendimentoStagingMigratorConnectionLimit(lockClient)
+    await assertAtendimentoMigrationDestination(lockClient, databaseUrl, ATENDIMENTO_MIGRATION_TARGETS.STAGING)
     const result = await createCommercialDataQualityStore({ pool, databaseUrl }).refresh({
         id: 'clientes-staging-data-quality-refresh',
         role: 'ADMIN',
@@ -39,5 +49,11 @@ try {
         })),
     }, null, 2))
 } finally {
+    if (lockClient) {
+        if (lockAcquired) {
+            try { await releaseAtendimentoStagingMutationLock(lockClient) } catch { /* connection cleanup releases the lock too */ }
+        }
+        lockClient.release()
+    }
     await pool.end()
 }

--- a/crm/api/server/harmonia/store/pg.js
+++ b/crm/api/server/harmonia/store/pg.js
@@ -1,14 +1,16 @@
 import pg from 'pg'
 
-export function createPgPool(databaseUrl) {
+export function createPgPool(databaseUrl, options = {}) {
     const url = String(databaseUrl || '').trim()
     if (!url) return null
+    const max = Number(options?.max ?? 10)
+    if (!Number.isSafeInteger(max) || max < 1) throw new Error('PG_POOL_MAX_INVALID')
 
     const { Pool } = pg
     return new Pool({
         connectionString: url,
         ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : undefined,
-        max: 10,
+        max,
     })
 }
 
@@ -26,4 +28,3 @@ export async function withPgTransaction(pool, fn) {
         client.release()
     }
 }
-

--- a/docs/operations/clientes-clinical-approval-runbook.md
+++ b/docs/operations/clientes-clinical-approval-runbook.md
@@ -25,10 +25,12 @@ npm run migrate-clinical-approval -- --target=local --apply
 npm run migrate-clinical-approval -- --target=local --rollback
 ```
 
-O destino é validado contra o espelho local ou o PostgreSQL staging loopback
-com login migrator. Produção é rejeitada. A migration é aditiva e registra o
-estado em `clinical_approval.schema_migrations`; rollback preserva schema,
-ledgers e triggers.
+O CLI de domínio valida exclusivamente o espelho local. `--target=staging` é
+recusado para que staging só passe pelo runner de release target-bound de
+Atendimento, com lock compartilhado, backup privado e a ordem completa de
+migrations. Produção é rejeitada. A migration é aditiva e registra o estado em
+`clinical_approval.schema_migrations`; rollback preserva schema, ledgers e
+triggers.
 
 ## Operação
 

--- a/docs/runbooks/clientes-commercial-analytics-v2.md
+++ b/docs/runbooks/clientes-commercial-analytics-v2.md
@@ -52,16 +52,24 @@ As rotas `/api/atendimento/commercial/analytics/*` exigem o mesmo papel Clientes
 
 ## Migração, rollback e grants
 
-O comando nativo aceita exclusivamente uma ação e o target local/staging:
+O comando de domínio aceita exclusivamente uma ação no espelho local:
 
 ```powershell
 # apenas no boundary WSL aprovado; não use shell vindo de Environment/GitHub variable
-npm run migrate-commercial-analytics -- --dry-run --target=staging
-npm run migrate-commercial-analytics -- --apply --target=staging
-npm run migrate-commercial-analytics -- --rollback --target=staging
+npm run migrate-commercial-analytics -- --dry-run --target=local
+npm run migrate-commercial-analytics -- --apply --target=local
+npm run migrate-commercial-analytics -- --rollback --target=local
 ```
 
-Ele exige `DATABASE_URL` que passe pela verificação estrita de destino e não executa argumentos arbitrários. Apply e rollback abrem uma transação antes de obter o advisory lock de migration, portanto o lock e cada passo da mudança permanecem atômicos. A role de runtime recebe apenas `USAGE` de schema e `SELECT`/DML mínimo para as relações listadas, incluindo `SELECT crm_atendimento.schema_migrations`; não recebe DDL, DELETE ou TRUNCATE. A role de migration permanece separada.
+`--target=staging` é recusado: staging só pode usar o runner de release
+target-bound de Atendimento, que obtém o lock compartilhado, cria o backup
+privado e executa a ordem completa de migrations. Ele exige `DATABASE_URL` que
+passe pela verificação estrita de destino e não executa argumentos arbitrários.
+Apply e rollback abrem uma transação antes de obter o advisory lock de
+migration, portanto o lock e cada passo da mudança permanecem atômicos. A role
+de runtime recebe apenas `USAGE` de schema e `SELECT`/DML mínimo para as
+relações listadas, incluindo `SELECT crm_atendimento.schema_migrations`; não
+recebe DDL, DELETE ou TRUNCATE. A role de migration permanece separada.
 
 Rollback é não destrutivo: marca o registry como rolled back e retém snapshots, assignments e evidência. Para rollback operacional, desabilite primeiro o experimento (se houver), registre o SHA predecessor, rode `--rollback` no mesmo target aprovado e valide readiness 503/fail-closed. Não remova tabelas nem dados de coorte.
 

--- a/docs/runbooks/clientes-commercial-assisted-whatsapp-v2.md
+++ b/docs/runbooks/clientes-commercial-assisted-whatsapp-v2.md
@@ -24,7 +24,7 @@ Uma integra??o futura deve preservar essas flags como default e introduzir uma P
 
 ## Migra??o aditiva e revers?vel
 
-O comando ? um CLI nativo com gram?tica fechada: uma a??o (`--dry-run`, `--apply` ou `--rollback`) e, opcionalmente, um target permitido (`local` ou `staging`). Ele n?o avalia shell, SSH, `eval`, comandos de ambiente ou entradas arbitr?rias.
+O comando ? um CLI nativo com gram?tica fechada: uma a??o (`--dry-run`, `--apply` ou `--rollback`) e o target local. `--target=staging` ? recusado: staging usa exclusivamente o runner de release target-bound de Atendimento, com lock compartilhado, backup privado e a ordem completa de migrations. Ele n?o avalia shell, SSH, `eval`, comandos de ambiente ou entradas arbitr?rias.
 
 O `DATABASE_URL` ? lido somente da configura??o privada do migrador; nunca deve ser escrito no reposit?rio, logs, artefatos ou issue. Antes de qualquer execu??o, confirme que o release ? um SHA imut?vel e que o destino ? o banco/role permitido pelo validador de destino.
 

--- a/docs/runbooks/clientes-production-readonly-runtime.md
+++ b/docs/runbooks/clientes-production-readonly-runtime.md
@@ -69,7 +69,12 @@ literais `CHAVE=valor` pelo Node, nunca com `source`, `eval` ou `bash -c`.
    invólucro obrigatório `lockdown-atendimento-staging-runtime.sh` os revoga
    com o administrador local do PostgreSQL. A migration exige controle
    `maintenance` com o SHA esperado e a unidade isolada inativa, obtém lock
-   advisory no banco e só então executa. O app fica sem DDL, DML, uso de
+   advisory no banco e só então executa. O login migrador tem `CONNECTION
+   LIMIT 3`: o runner retém no máximo duas sessões (lock completo + trabalho)
+   e a terceira serve somente para que um único refresh de qualidade ou
+   migration Harmonia concorrente observe o mesmo lock e falhe antes de
+   escrever; os pools desses entrypoints são fixados em `2`, `2` e `1`,
+   respectivamente. O app fica sem DDL, DML, uso de
    sequences, `SET ROLE` para qualquer papel pai, atributos privilegiados,
    execução de funções `SECURITY DEFINER` em schemas de aplicação ou acesso a
    `harmonia.contacts`; a instalação e a validação recusam prosseguir se a

--- a/scripts/provision-atendimento-staging.sh
+++ b/scripts/provision-atendimento-staging.sh
@@ -50,7 +50,8 @@ done
 if [[ "$ACTION" == "--dry-run" ]]; then
   run_postgres_clean --dbname=postgres --set=ON_ERROR_STOP=1 --tuples-only --no-align <<SQL
 select 'database=' || datname from pg_database where datname = '$DB_NAME';
-select 'role=' || rolname || ':login=' || rolcanlogin from pg_roles where rolname in ('$APP_ROLE', '$MIGRATOR_ROLE', '$OWNER_ROLE');
+select 'role=' || rolname || ':login=' || rolcanlogin || ':connection_limit=' || rolconnlimit
+  from pg_roles where rolname in ('$APP_ROLE', '$MIGRATOR_ROLE', '$OWNER_ROLE');
 SQL
   for path in "$ATENDIMENTO_CONFIG" "$MIGRATOR_CONFIG" "$CONTROL_FILE"; do
     if /usr/bin/sudo -n /usr/bin/test -f "$path"; then echo "present=$path"; else echo "missing=$path"; fi
@@ -89,6 +90,7 @@ run_postgres_clean --dbname=postgres --set=ON_ERROR_STOP=1 <<SQL
 alter role $APP_ROLE password :'app_password';
 alter role $MIGRATOR_ROLE password :'migrator_password';
 alter role $MIGRATOR_ROLE inherit;
+alter role $MIGRATOR_ROLE connection limit 3;
 alter role $APP_ROLE noinherit;
 alter role $APP_ROLE set default_transaction_read_only = on;
 revoke $OWNER_ROLE from $APP_ROLE;

--- a/scripts/tests/clientes-production-readonly-runtime.test.mjs
+++ b/scripts/tests/clientes-production-readonly-runtime.test.mjs
@@ -95,6 +95,16 @@ test('staging release, control and application role remain fixed and read-only',
   const control = read('scripts/set-atendimento-staging-control.sh')
   const backup = read('scripts/backup-atendimento-staging.sh')
   const stagingMigration = read('scripts/run-atendimento-staging-migration.sh')
+  const migrationRunner = read('crm/api/scripts/migrate-atendimento-staging.mjs')
+  const qualityRefresh = read('crm/api/scripts/refresh-commercial-data-quality-staging.mjs')
+  const harmoniaMigration = read('crm/api/scripts/migrate-harmonia-schema.mjs')
+  const pgPool = read('crm/api/server/harmonia/store/pg.js')
+  const domainOnlyMigrationCli = [
+    ['crm/api/scripts/migrate-clinical-approval.mjs', 'CLINICAL_APPROVAL_STAGING_REQUIRES_CONTROLLED_RUNNER'],
+    ['crm/api/scripts/migrate-atendimento-commercial-analytics.mjs', 'COMMERCIAL_ANALYTICS_STAGING_REQUIRES_CONTROLLED_RUNNER'],
+    ['crm/api/scripts/migrate-atendimento-commercial-operations.mjs', 'COMMERCIAL_OPERATIONS_STAGING_REQUIRES_CONTROLLED_RUNNER'],
+    ['crm/api/scripts/migrate-atendimento-commercial-assisted-whatsapp.mjs', 'COMMERCIAL_ASSISTED_STAGING_REQUIRES_CONTROLLED_RUNNER'],
+  ]
   const lockdown = read('scripts/lockdown-atendimento-staging-runtime.sh')
   const installer = read('scripts/runtime/install-atendimento-staging-service.sh')
   const rollback = read('scripts/runtime/rollback-atendimento-staging.sh')
@@ -139,6 +149,8 @@ test('staging release, control and application role remain fixed and read-only',
   for (const sql of provisionSql) {
     assert.doesNotMatch(sql, /^\s*#/m, 'PostgreSQL heredocs must use SQL comments, never shell # comments')
   }
+  assert.match(provisionSql[0], /rolconnlimit/)
+  assert.match(provisionSql[1], /alter role \$MIGRATOR_ROLE connection limit 3;/)
   assert.match(provisionSql[1], /^-- The isolated application has no safe direct Caixa projection yet\. Do not$/m)
   assert.match(provision, /readonly BACKUP_ROOT='\/var\/backups\/skincos\/clientes\/staging-control'/)
   assert.match(provision, /ATENDIMENTO_READINESS_TOKEN=\$readiness_token/)
@@ -177,6 +189,50 @@ test('staging release, control and application role remain fixed and read-only',
   assert.match(stagingMigration, /trap 'exit 143' TERM/)
   assert.match(stagingMigration, /trap '' HUP INT TERM/)
   assert.match(stagingMigration, /keeping the isolated service ineligible/)
+  assert.match(migrationRunner, /ATENDIMENTO_STAGING_MIGRATOR_CONNECTION_LIMIT/)
+  assert.match(migrationRunner, /ATENDIMENTO_STAGING_MIGRATION_POOL_MAX/)
+  assert.match(migrationRunner, /createPool\(normalizedUrl, \{ max: ATENDIMENTO_STAGING_MIGRATION_POOL_MAX \}\)/)
+  assert.match(migrationRunner, /assertAtendimentoStagingMigratorConnectionLimit\(lockClient\)/)
+  assert.match(qualityRefresh, /ATENDIMENTO_STAGING_QUALITY_REFRESH_POOL_MAX/)
+  assert.match(qualityRefresh, /acquireAtendimentoStagingMutationLock\(lockClient, 'ATENDIMENTO_STAGING_QUALITY_LOCK_UNAVAILABLE'\)/)
+  assert.match(qualityRefresh, /assertAtendimentoStagingMigratorConnectionLimit\(lockClient\)/)
+  assert.ok(qualityRefresh.lastIndexOf('acquireAtendimentoStagingMutationLock') < qualityRefresh.indexOf(').refresh('))
+  assert.match(harmoniaMigration, /target === 'staging' \? \{ max: HARMONIA_STAGING_MIGRATION_POOL_MAX \} : undefined/)
+  assert.match(harmoniaMigration, /acquireAtendimentoStagingMutationLock\(client, 'HARMONIA_STAGING_MIGRATION_LOCK_UNAVAILABLE'\)/)
+  assert.match(harmoniaMigration, /assertAtendimentoStagingMigratorConnectionLimit\(client\)/)
+  assert.ok(harmoniaMigration.lastIndexOf('acquireAtendimentoStagingMutationLock') < harmoniaMigration.indexOf("await client.query('begin')"))
+  assert.match(pgPool, /export function createPgPool\(databaseUrl, options = \{\}\)/)
+  assert.match(pgPool, /const max = Number\(options\?\.max \?\? 10\)/)
+  assert.match(pgPool, /max,\r?\n/)
+  for (const [relative, code] of domainOnlyMigrationCli) {
+    const cli = read(relative)
+    assert.match(cli, new RegExp(`if \\(.*ATENDIMENTO_MIGRATION_TARGETS\\.STAGING.*\\)[\\s\\S]{0,180}${code}`), `${relative} must reject staging before creating a pool`)
+    assert.ok(cli.indexOf(code) < cli.indexOf('pool = createPgPool(databaseUrl)'), `${relative} must reject staging before a pool can connect`)
+  }
+  const serialMigrationModules = [
+    'crm/api/server/atendimento/professionalIdentityMigration.js',
+    'crm/api/server/atendimento/writeSafetyMigration.js',
+    'crm/api/server/atendimento/commercialContactMigration.js',
+    'crm/api/server/atendimento/commercialContactRolloutMigration.js',
+    'crm/api/server/atendimento/clientIdentityMaterializationMigration.js',
+    'crm/api/server/atendimento/commercialActionLedgerMigration.js',
+    'crm/api/server/atendimento/commercialDataQualityMigration.js',
+    'crm/api/server/clientes/sourceOperationsMigration.js',
+    'crm/api/server/atendimento/identityReviewMigration.js',
+    'crm/api/server/atendimento/identityClusterWorkspaceMigration.js',
+    'crm/api/server/clinical/clinicalApprovalMigration.js',
+    'crm/api/server/atendimento/commercialOperationsMigration.js',
+    'crm/api/server/atendimento/commercialAnalyticsMigration.js',
+    'crm/api/server/atendimento/commercialCanaryMigration.js',
+    'crm/api/server/atendimento/commercialAssistedCommunicationMigration.js',
+  ]
+  for (const relative of serialMigrationModules) {
+    const migrationSource = read(relative)
+    assert.equal((migrationSource.match(/\bpool\.connect\(\)/g) || []).length, 2, `${relative} must use one client for each apply and rollback path`)
+    assert.equal((migrationSource.match(/\bclient\.release\(\)/g) || []).length, 2, `${relative} must release the client in both paths`)
+    assert.doesNotMatch(migrationSource, /\bpool\.query\(/, `${relative} must not open an unbounded pool query path`)
+    assert.doesNotMatch(migrationSource, /Promise\.all(?:Settled)?\(/, `${relative} must keep migration queries serial`)
+  }
   assert.match(lockdown, /readonly DB_NAME='skincos_staging'/)
   assert.match(lockdown, /readonly APP_ROLE='skincos_staging_crm_app'/)
   assert.match(lockdown, /\/usr\/bin\/sudo -n -u postgres \/usr\/bin\/psql/)


### PR DESCRIPTION
# Summary

Corrige o contrato de capacidade do migrador isolado de Clientes em staging.

A falha raiz foi o papel `skincos_staging_migrator_login` com `CONNECTION LIMIT 1`, embora o runner controlado mantenha o lock advisory em uma sessão e abra uma segunda sessão de trabalho. O contrato agora é explícito e fail-closed:

- provisiona `CONNECTION LIMIT 3`: duas sessões para o runner principal e uma terceira somente para um contender observar o lock compartilhado e recusar antes de qualquer escrita;
- fixa o pool do runner principal em `max:2`, quality refresh em `max:2` e Harmonia staging em `max:1`, sem alterar o default global;
- usa a mesma chave de lock nos três entrypoints mutáveis de staging e valida o limite de role antes do trabalho;
- torna os quatro CLIs de domínio locais-only, recusando `--target=staging` antes de criar pool/conexão;
- atualiza os runbooks e regressões de capacidade, serialidade e bypass.

## Type of change

- [x] Fix
- [x] Docs
- [x] Security

## Checklist

- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [x] Docs updated
- [x] Security review do contrato de lock/limite e bypass de entrypoints
- [ ] Performance impact measured (não aplicável: mudança de gate de migração)

## Links

- Issue: falha pré-escrita de staging com PostgreSQL 53300 para o login migrador.
- Design/ADR: runner de staging target-bound, com manutenção/backup/rollback já versionados.
- Migration steps: após merge, o próximo operador faz somente o preflight/provisionamento autorizado do release imutável; nenhum provisionamento, migration, restart ou ação de host foi executado por esta PR.

## Screenshots / Evidence

Validação local aprovada:

- `bash -n scripts/provision-atendimento-staging.sh`;
- sintaxe Node de todos os arquivos alterados;
- `node --test crm/api/scripts/atendimento-staging-maintenance-lock.test.mjs` (2/2);
- `node scripts/tests/clientes-production-readonly-runtime.test.mjs` (8/8);
- `git diff --check`;
- revisão independente: nenhum P0/P1 após fechar os quatro bypasses de CLI.

O teste dinâmico `migrate-atendimento-staging-runtime.test.mjs` não iniciou localmente porque este worktree não possui o pacote `pg`; nenhuma dependência foi instalada ou reutilizada. A CI fresca é a prova complementar requerida.