### PR TITLE
fix(staging): capture Atendimento backups outside protected directory

### DIFF
--- a/scripts/backup-atendimento-staging.sh
+++ b/scripts/backup-atendimento-staging.sh
@@ -22,6 +22,7 @@ readonly BACKUP_DIR='/var/backups/skincos/clientes/staging'
 readonly DATABASE='skincos_staging'
 readonly STAMP="$(/usr/bin/date -u +%Y%m%dT%H%M%SZ)"
 OUTPUT=''
+TEMP_OUTPUT=''
 
 [[ $# -eq 0 ]] || { echo "Usage: $0" >&2; exit 64; }
 for command_path in /usr/bin/sudo /usr/bin/env /usr/bin/pg_dump /usr/bin/sha256sum /usr/bin/install /usr/bin/mktemp /usr/bin/chmod /usr/bin/chown /usr/bin/rm /usr/bin/awk /usr/bin/test /usr/bin/stat; do
@@ -30,6 +31,9 @@ done
 /usr/bin/sudo -n /usr/bin/true
 output_created=0
 cleanup_partial_output() {
+  if [[ -n "$TEMP_OUTPUT" ]]; then
+    run_sudo_clean /usr/bin/rm -f -- "$TEMP_OUTPUT" || true
+  fi
   if [[ "$output_created" == '1' ]]; then
     run_sudo_clean /usr/bin/rm -f -- "$OUTPUT" || true
   fi
@@ -52,10 +56,24 @@ run_sudo_clean /usr/bin/test -f "$OUTPUT"
 run_sudo_clean /usr/bin/test -O "$OUTPUT"
 readonly OUTPUT
 output_created=1
-run_sudo_clean /usr/bin/chown postgres:postgres "$OUTPUT"
-run_postgres_dump_clean --format=custom --no-owner --no-privileges --dbname="$DATABASE" --file="$OUTPUT"
-run_sudo_clean /usr/bin/chown root:root "$OUTPUT"
-run_sudo_clean /usr/bin/chmod 0600 "$OUTPUT"
+# The backup directory is intentionally not traversable by the postgres role.
+# Capture into a root-created, mode-0600 temporary file under /tmp, then copy
+# the completed dump into the fixed root-private destination. This preserves
+# the no-caller-destination contract without granting postgres directory access
+# to the rollback artifact.
+TEMP_OUTPUT="$(run_sudo_clean /usr/bin/mktemp '/tmp/skincos-clientes-staging-preapply.XXXXXX.dump')"
+if [[ ! "$TEMP_OUTPUT" =~ ^/tmp/skincos-clientes-staging-preapply\.[A-Za-z0-9]{6}\.dump$ ]]; then
+  echo 'Temporary backup output path was not generated from the fixed contract.' >&2
+  exit 1
+fi
+run_sudo_clean /usr/bin/test -f "$TEMP_OUTPUT"
+run_sudo_clean /usr/bin/chown postgres:postgres "$TEMP_OUTPUT"
+run_sudo_clean /usr/bin/chmod 0600 "$TEMP_OUTPUT"
+run_postgres_dump_clean --format=custom --no-owner --no-privileges --dbname="$DATABASE" --file="$TEMP_OUTPUT"
+run_sudo_clean /usr/bin/test -s "$TEMP_OUTPUT"
+run_sudo_clean /usr/bin/install -m 0600 -o root -g root "$TEMP_OUTPUT" "$OUTPUT"
+run_sudo_clean /usr/bin/rm -f -- "$TEMP_OUTPUT"
+TEMP_OUTPUT=''
 backup_metadata="$(run_sudo_clean /usr/bin/stat -c '%U:%G:%a' "$OUTPUT")"
 [[ "$backup_metadata" == 'root:root:600' ]] || {
   echo 'Backup ownership or mode does not satisfy the private rollback contract.' >&2


### PR DESCRIPTION
## Objetivo
Corrigir o checkpoint de backup do runtime isolado de Atendimento em staging.

## Problema observado
O diretório de backup é root-private e não permite travessia pelo usuário `postgres`. O helper criava o arquivo final nesse diretório e tentava entregar o mesmo arquivo ao `pg_dump`, causando `Permission denied` antes da migration.

## Correção
- captura o dump em arquivo temporário privado em `/tmp`;
- executa `pg_dump` como `postgres` sem expor o destino de rollback;
- instala o dump concluído no caminho root-private fixo;
- preserva unicidade, hash, ownership `root:root`, modo `0600` e cleanup em falhas.

## Validação
- `git diff --check`;
- `bash -n scripts/backup-atendimento-staging.sh`;
- `npm run staging:scripts:validate`;
- backup real de `skincos_staging`: `private=true unique=true`, hash registrado no log operacional privado.

## Rollback
Reverter o commit/PR; nenhum dado de aplicação foi alterado pela correção.