### PR TITLE
Simplify Beauty Movement finale confirmation

### DIFF
--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -98,6 +98,14 @@
   list-style: none;
 }
 
+.tableStage > .progress {
+  position: relative;
+  z-index: 2;
+  width: min(100%, 930px);
+  margin: -10px auto 0;
+  padding-bottom: 2px;
+}
+
 .progressItem {
   min-height: 0;
   background: transparent;
@@ -188,7 +196,6 @@
 }
 
 .tableStage,
-.confirmationStage,
 .resultStage {
   width: min(100%, 1040px);
   margin: clamp(24px, 3.5vw, 40px) auto 0;
@@ -391,7 +398,6 @@
   margin-top: 0;
 }
 
-.confirmationIntro h2,
 .resultLead h2 {
   margin: 10px 0 0;
   color: var(--bm-ink);
@@ -415,7 +421,6 @@
 }
 
 .actHeading p:last-child,
-.confirmationIntro > p:last-child,
 .resultLead > p:last-child {
   margin: 14px 0 0;
   color: var(--bm-muted);
@@ -460,8 +465,12 @@
   --finale-rotate: 8deg;
 }
 
-.tableStage[data-hand-stage="finale"] .deckCardTop {
+.tableStage[data-hand-stage="finale"][data-finale-stage="merging"] .deckCardTop {
   animation: deckReceivePulse 1120ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
+}
+
+.tableStage[data-hand-stage="finale"][data-finale-stage="collecting"] .finaleCardGridHolding .finaleCard {
+  animation: finaleCardsHold 880ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
 }
 
 .tableStage[data-hand-stage="finale"] .finaleCardGridMerging .finaleCard {
@@ -528,10 +537,75 @@
 
 .specialCardStage {
   display: grid;
-  width: min(100%, 380px);
+  gap: 18px;
+  width: min(100%, 520px);
   min-height: 430px;
   place-items: center;
   margin: 2px auto 0;
+}
+
+.specialCardConfirmation {
+  display: grid;
+  gap: 12px;
+  width: min(100%, 520px);
+  padding: 16px 18px;
+  border: 1px solid var(--bm-line-strong);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: var(--bm-shadow);
+  text-align: center;
+}
+
+.specialCardConfirmation:focus {
+  outline: 3px solid var(--bm-yellow);
+  outline-offset: 5px;
+}
+
+.specialCardConfirmation h2 {
+  margin: 0;
+  color: var(--bm-ink);
+  font-family: var(--font-brand-ui);
+  font-size: clamp(1.28rem, 3vw, 1.8rem);
+  font-weight: 700;
+  letter-spacing: -0.05em;
+  line-height: 1;
+}
+
+.specialCardConfirmation .consentField {
+  width: 100%;
+  text-align: left;
+}
+
+.specialCardConfirmation .primaryButton {
+  width: 100%;
+}
+
+.finaleHoldStatus {
+  display: grid;
+  justify-items: center;
+  gap: 3px;
+  margin: -4px auto 0;
+  color: var(--bm-muted);
+  text-align: center;
+}
+
+.finaleHoldStatus span {
+  font-family: var(--font-brand-ui);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.finaleHoldStatus strong {
+  color: var(--bm-ink);
+  font-family: var(--font-brand-ui);
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.finaleHoldStatus small {
+  font-size: 0.82rem;
 }
 
 .specialCard {
@@ -1066,6 +1140,24 @@
   }
 }
 
+@keyframes finaleCardsHold {
+  0% {
+    opacity: 0;
+    transform: translate3d(var(--finale-x), var(--finale-y), 0) rotate(var(--finale-rotate)) scale(0.58);
+  }
+
+  62% {
+    opacity: 1;
+    transform: translate3d(calc(var(--finale-x) * 0.08), calc(var(--finale-y) * 0.08), 0)
+      rotate(calc(var(--finale-rotate) * 0.12)) scale(1.04);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) rotate(0deg) scale(1);
+  }
+}
+
 @keyframes specialCardEnter {
   from {
     opacity: 0;
@@ -1456,7 +1548,6 @@
   text-wrap: balance;
 }
 
-.inlineFinale > .confirmationStage,
 .inlineFinale > .resultStage {
   width: 100%;
   margin: 0;
@@ -1546,7 +1637,6 @@
   transform: none;
 }
 
-.confirmationStage,
 .resultStage {
   display: grid;
   gap: 22px;
@@ -1555,45 +1645,16 @@
   padding: 24px;
 }
 
-.confirmationIntro,
 .resultLead {
   text-align: center;
 }
 
-.contactSummary,
-.confirmationForm,
 .invitationPanel,
 .benefitPanel {
   border: 1px solid var(--bm-line);
   border-radius: 10px;
   background: var(--bm-surface);
   box-shadow: var(--bm-shadow);
-}
-
-.contactSummary {
-  display: grid;
-  gap: 5px;
-  padding: 22px 24px;
-  text-align: center;
-}
-
-.contactSummary span,
-.contactSummary small {
-  color: var(--bm-muted);
-  font-size: 0.81rem;
-}
-
-.contactSummary strong {
-  color: var(--bm-ink);
-  font-family: var(--font-brand-ui);
-  font-size: 1.1rem;
-  letter-spacing: 0.02em;
-}
-
-.confirmationForm {
-  display: grid;
-  gap: 16px;
-  padding: clamp(20px, 4vw, 32px);
 }
 
 .consentField {
@@ -1619,11 +1680,6 @@
 
 .consentFieldInvalid {
   border-color: var(--bm-ink);
-}
-
-.confirmationForm .primaryButton {
-  width: 100%;
-  margin-top: 4px;
 }
 
 .invitationPanel h3,
@@ -1880,7 +1936,6 @@
     height: 112px;
   }
 
-  .confirmationStage,
   .resultStage {
     padding: 18px;
   }
@@ -1894,7 +1949,6 @@
     width: 100%;
   }
 
-  .inlineFinale > .confirmationStage,
   .inlineFinale > .resultStage {
     padding: 14px;
     border-radius: 10px;
@@ -1930,8 +1984,6 @@
     font-size: 2.2rem;
   }
 
-  .contactSummary,
-  .confirmationForm,
   .invitationPanel,
   .benefitPanel {
     border-radius: 8px;

--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -111,7 +111,7 @@ export type BeautyMovementExperienceProps = {
 };
 
 type HandStage = "waiting" | "ready" | "reveal" | "held" | "collect" | "deal" | "finale";
-type FinaleStage = "hidden" | "collecting" | "confirmation" | "result";
+type FinaleStage = "hidden" | "collecting" | "merging" | "confirmation" | "result";
 type SpecialCardKind = "velocity" | "discount" | "free_procedure" | "reserved";
 
 type ShareNavigator = Navigator & {
@@ -122,6 +122,7 @@ type ShareNavigator = Navigator & {
 const STORY_WIDTH = 1080;
 const STORY_HEIGHT = 1920;
 const AUTO_ADVANCE_SECONDS = 5;
+const FINALE_HOLD_SECONDS = 5;
 const HAND_REVEAL_MS = 1350;
 const HAND_COLLECT_MS = 720;
 const HAND_DEAL_MS = 880;
@@ -548,6 +549,7 @@ export default function BeautyMovementExperience({
     const [finaleStage, setFinaleStage] = useState<FinaleStage>(() =>
         initialState.confirmed ? "result" : initialReadingComplete ? "confirmation" : "hidden",
     );
+    const [finaleHoldRemaining, setFinaleHoldRemaining] = useState(0);
     const [autoAdvanceActive, setAutoAdvanceActive] = useState(false);
     const openedRef = useRef(false);
     const viewedActsRef = useRef(new Set<number>());
@@ -558,6 +560,7 @@ export default function BeautyMovementExperience({
     const scrollAnimationFrameRef = useRef<number | null>(null);
     const tableRef = useRef<HTMLElement | null>(null);
     const finaleRef = useRef<HTMLElement | null>(null);
+    const confirmationActionRef = useRef<HTMLElement | null>(null);
     const selectionsRef = useRef(selections);
     const displayedActIndexRef = useRef(displayedActIndex);
     const handStageRef = useRef(handStage);
@@ -614,10 +617,27 @@ export default function BeautyMovementExperience({
     }, [finaleStage, onTrack]);
 
     useEffect(() => {
-        if (finaleStage !== "confirmation" && finaleStage !== "result") return;
+        if (finaleStage === "confirmation") {
+            window.requestAnimationFrame(() => {
+                confirmationActionRef.current?.focus({ preventScroll: true });
+            });
+            return;
+        }
+        if (finaleStage !== "result") return;
         window.requestAnimationFrame(() => {
             finaleRef.current?.focus({ preventScroll: true });
         });
+    }, [finaleStage]);
+
+    useEffect(() => {
+        if (finaleStage !== "collecting") return;
+
+        setFinaleHoldRemaining(FINALE_HOLD_SECONDS);
+        const countdownTimer = window.setInterval(() => {
+            setFinaleHoldRemaining((current) => Math.max(0, current - 1));
+        }, 1000);
+
+        return () => window.clearInterval(countdownTimer);
     }, [finaleStage]);
 
     useEffect(() => {
@@ -773,15 +793,26 @@ export default function BeautyMovementExperience({
             setCurrentHandStage("finale");
             setCurrentFinaleStage("collecting");
             handTransitionTimerRef.current = window.setTimeout(() => {
-                handTransitionTimerRef.current = null;
                 if (!mountedRef.current) return;
-                transitionInFlightRef.current = false;
-                setCurrentHandStage("ready");
-                setCurrentFinaleStage(confirmed ? "result" : "confirmation");
-                window.requestAnimationFrame(() => {
-                    window.requestAnimationFrame(scrollToFinale);
-                });
-            }, motionDuration(HAND_FINALE_MS));
+                setFinaleHoldRemaining(0);
+                setCurrentFinaleStage("merging");
+                handTransitionTimerRef.current = window.setTimeout(() => {
+                    handTransitionTimerRef.current = null;
+                    if (!mountedRef.current) return;
+                    transitionInFlightRef.current = false;
+                    setCurrentHandStage("ready");
+                    setCurrentFinaleStage(confirmed ? "result" : "confirmation");
+                    if (confirmed) {
+                        window.requestAnimationFrame(() => {
+                            window.requestAnimationFrame(scrollToFinale);
+                        });
+                    } else {
+                        window.requestAnimationFrame(() => {
+                            confirmationActionRef.current?.focus({ preventScroll: true });
+                        });
+                    }
+                }, motionDuration(HAND_FINALE_MS));
+            }, FINALE_HOLD_SECONDS * 1000);
         }, motionDuration(HAND_COLLECT_MS));
     }
 
@@ -1101,53 +1132,34 @@ export default function BeautyMovementExperience({
         );
     }
 
-    function renderConfirmationStage() {
+    function renderConfirmationAction() {
         return (
-            <section className={styles.confirmationStage} aria-labelledby="beauty-movement-inline-confirmation-title">
-                <div className={styles.confirmationIntro}>
-                    <h2 id="beauty-movement-inline-confirmation-title">Confirme sua entrada na lista exclusiva.</h2>
-                    <p>Seus dados de contato já estão vinculados a este convite.</p>
-                </div>
-
-                <section className={styles.benefitPanel} aria-labelledby="beauty-movement-inline-confirmation-benefit-title">
-                    <p className={styles.sectionLabel}>Seu presente de celebração</p>
-                    <h3 id="beauty-movement-inline-confirmation-benefit-title">Seu presente será revelado após a confirmação.</h3>
-                    <p>A condição desta experiência está vinculada ao seu convite.</p>
-                    <p className={styles.benefitNote}>
-                        As cartas criam a leitura; elas não sorteiam nem alteram o presente reservado.
-                    </p>
-                </section>
-
-                <div className={styles.contactSummary}>
-                    <span>Contato vinculado</span>
-                    <strong>{initialState.invite.maskedWhatsapp}</strong>
-                    <small>E-mail e telefone já estão vinculados a este convite. Para corrigir dados, fale diretamente com a unidade.</small>
-                </div>
-
-                <div className={styles.confirmationForm}>
-                    <label className={`${styles.consentField} ${consentInvalid ? styles.consentFieldInvalid : ""}`.trim()}>
-                        <input
-                            type="checkbox"
-                            checked={operationalConsent}
-                            onChange={(event) => setOperationalConsent(event.target.checked)}
-                        />
-                        <span>
-                            Aceito entrar na lista exclusiva e receber comunicações operacionais sobre este evento.
-                        </span>
-                    </label>
-                    {consentInvalid ? <p className={styles.fieldError}>Confirme o aceite para seguir.</p> : null}
-
-                    {actionError ? <p className={styles.inlineError} role="alert">{actionError}</p> : null}
-
-                    <button
-                        className={styles.primaryButton}
-                        type="button"
-                        onClick={() => void handleConfirm()}
-                        disabled={isConfirming}
-                    >
-                        {isConfirming ? "Confirmando…" : "Confirmar minha entrada"}
-                    </button>
-                </div>
+            <section
+                className={styles.specialCardConfirmation}
+                ref={confirmationActionRef}
+                tabIndex={-1}
+                aria-labelledby="beauty-movement-special-confirmation-title"
+            >
+                <p className={styles.sectionLabel}>Confirmação</p>
+                <h2 id="beauty-movement-special-confirmation-title">Garanta seu presente e confirme presença.</h2>
+                <label className={`${styles.consentField} ${consentInvalid ? styles.consentFieldInvalid : ""}`.trim()}>
+                    <input
+                        type="checkbox"
+                        checked={operationalConsent}
+                        onChange={(event) => setOperationalConsent(event.target.checked)}
+                    />
+                    <span>Aceito entrar na lista exclusiva e receber comunicações operacionais sobre este evento.</span>
+                </label>
+                {consentInvalid ? <p className={styles.fieldError}>Confirme o aceite para seguir.</p> : null}
+                {actionError ? <p className={styles.inlineError} role="alert">{actionError}</p> : null}
+                <button
+                    className={styles.primaryButton}
+                    type="button"
+                    onClick={() => void handleConfirm()}
+                    disabled={isConfirming}
+                >
+                    {isConfirming ? "Confirmando…" : "Garantir presente e confirmar presença"}
+                </button>
             </section>
         );
     }
@@ -1268,34 +1280,6 @@ export default function BeautyMovementExperience({
                     </p>
                 </header>
 
-                <ol className={styles.progress} aria-label="Progresso da experiência">
-                    {BEAUTY_MOVEMENT_ACT_DEFINITIONS.map((act, index) => {
-                        const isDone = Boolean(selections[act.id]);
-                        const isCurrent = index === displayedActIndex;
-                        const isLocked = !isActUnlocked(index);
-                        return (
-                            <li
-                                className={`${styles.progressItem} ${isDone ? styles.progressItemDone : ""} ${isCurrent ? styles.progressItemCurrent : ""}`.trim()}
-                                key={act.id}
-                            >
-                                <button
-                                    className={styles.progressButton}
-                                    type="button"
-                                    onClick={scrollToTable}
-                                    disabled={!isCurrent}
-                                    aria-current={isCurrent ? "step" : undefined}
-                                    aria-label={`Acompanhar a mesa de cartas em ${act.label}${isLocked ? ", ainda bloqueada" : ""}`}
-                                >
-                                    <span className={styles.progressCopy}>
-                                        <strong>{act.label}</strong>
-                                        <small>{isDone ? "Escolha guardada" : act.progressLabel}</small>
-                                    </span>
-                                </button>
-                            </li>
-                        );
-                    })}
-                </ol>
-
                 <section
                     ref={tableRef}
                     className={styles.tableStage}
@@ -1303,7 +1287,36 @@ export default function BeautyMovementExperience({
                     aria-labelledby="table-stage-title"
                     data-hand-stage={handStage}
                     data-act-index={displayedActIndex}
+                    data-finale-stage={finaleStage}
                 >
+                    <ol className={styles.progress} aria-label="Progresso da experiência">
+                        {BEAUTY_MOVEMENT_ACT_DEFINITIONS.map((act, index) => {
+                            const isDone = Boolean(selections[act.id]);
+                            const isCurrent = index === displayedActIndex;
+                            const isLocked = !isActUnlocked(index);
+                            return (
+                                <li
+                                    className={`${styles.progressItem} ${isDone ? styles.progressItemDone : ""} ${isCurrent ? styles.progressItemCurrent : ""}`.trim()}
+                                    key={act.id}
+                                >
+                                    <button
+                                        className={styles.progressButton}
+                                        type="button"
+                                        onClick={scrollToTable}
+                                        disabled={!isCurrent}
+                                        aria-current={isCurrent ? "step" : undefined}
+                                        aria-label={`Acompanhar a mesa de cartas em ${act.label}${isLocked ? ", ainda bloqueada" : ""}`}
+                                    >
+                                        <span className={styles.progressCopy}>
+                                            <strong>{act.label}</strong>
+                                            <small>{isDone ? "Escolha guardada" : act.progressLabel}</small>
+                                        </span>
+                                    </button>
+                                </li>
+                            );
+                        })}
+                    </ol>
+
                     <div className={styles.actHeading}>
                         <h2 id="table-stage-title">{tableDefinition.label}</h2>
                         <p>{tableDefinition.prompt}</p>
@@ -1346,8 +1359,11 @@ export default function BeautyMovementExperience({
                                 </span>
                             </span>
                         ) : null}
-                        {finaleStage === "collecting" ? (
-                            <div className={`${styles.finaleCardGrid} ${styles.finaleCardGridMerging}`} aria-hidden="true">
+                        {finaleStage === "collecting" || finaleStage === "merging" ? (
+                            <div
+                                className={`${styles.finaleCardGrid} ${finaleStage === "merging" ? styles.finaleCardGridMerging : styles.finaleCardGridHolding}`}
+                                aria-hidden="true"
+                            >
                                 {reading.map(renderFinaleCard)}
                             </div>
                         ) : finaleStage === "confirmation" || finaleStage === "result" ? (
@@ -1356,11 +1372,19 @@ export default function BeautyMovementExperience({
                                 role="group"
                                 aria-label={finaleStage === "result" ? "Carta especial do benefício" : "Carta especial da celebração"}
                             >
+                                {finaleStage === "confirmation" ? renderConfirmationAction() : null}
                                 {renderSpecialCard(finaleStage === "result")}
                             </div>
                         ) : finaleStage === "hidden" && !waitingForInitialDeal ? (
                             <div className={styles.cardGrid} role="group" aria-label={`Cartas da etapa ${tableDefinition.label}`}>
                                 {tableCards.map(renderCard)}
+                            </div>
+                        ) : null}
+                        {finaleStage === "collecting" ? (
+                            <div className={styles.finaleHoldStatus} role="status" aria-live="polite">
+                                <span>Leitura reunida</span>
+                                <strong>{finaleHoldRemaining}s</strong>
+                                <small>A carta especial se forma em seguida.</small>
                             </div>
                         ) : null}
                     </div>
@@ -1420,7 +1444,7 @@ export default function BeautyMovementExperience({
                     </p>
                 ) : null}
 
-                {finaleStage === "confirmation" || finaleStage === "result" ? (
+                {finaleStage === "result" ? (
                     <section
                         ref={finaleRef}
                         className={styles.inlineFinale}
@@ -1434,7 +1458,7 @@ export default function BeautyMovementExperience({
                                 {finaleStage === "result" ? "O seu presente de celebração" : "Um último passo para confirmar"}
                             </h2>
                         </div>
-                        {finaleStage === "confirmation" ? renderConfirmationStage() : renderResultStage()}
+                        {renderResultStage()}
                     </section>
                 ) : null}
 

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -39,9 +39,12 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(experience, /transitionInFlightRef/);
     assert.match(experience, /confirmInFlightRef/);
     assert.match(experience, /setCurrentFinaleStage\("collecting"\)/);
+    assert.match(experience, /setCurrentFinaleStage\("merging"\)/);
+    assert.match(experience, /FINALE_HOLD_SECONDS = 5/);
+    assert.match(experience, /finaleHoldRemaining/);
     assert.match(experience, /HAND_FINALE_MS = 1120/);
     assert.match(experience, /className=\{styles\.inlineFinale\}/);
-    assert.match(experience, /renderConfirmationStage/);
+    assert.match(experience, /renderConfirmationAction/);
     assert.match(experience, /renderResultStage/);
     assert.match(experience, /automática em \{AUTO_ADVANCE_SECONDS\} segundos/);
     assert.doesNotMatch(experience, /confirmationTriggerRef/);
@@ -59,10 +62,10 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(experience, /finaleStage === "hidden" \? \(/);
     assert.match(experience, /disabled=\{!tableSelected \|\| handStage !== "held"\}/);
     assert.match(experience, /Escolha uma carta para liberar o avanço/);
-    assert.match(experience, /Seu presente de celebração/);
-    assert.match(experience, /Seu presente será revelado após a confirmação/);
+    assert.match(experience, /Garanta seu presente e confirme presença/);
+    assert.doesNotMatch(experience, /Seu presente será revelado após a confirmação/);
     assert.match(experience, /email: null/);
-    assert.match(experience, /E-mail e telefone já estão vinculados/);
+    assert.doesNotMatch(experience, /E-mail e telefone já estão vinculados/);
     assert.doesNotMatch(experience, /beauty-movement-inline-email|E-mail <em>opcional|voce@email\.com/);
     assert.doesNotMatch(experience, /benefitPreview/);
     assert.doesNotMatch(experience, /Ver minha leitura/);
@@ -130,6 +133,8 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.doesNotMatch(styles, /\.tableStage\[data-hand-stage="deal"\] \.cardButton:nth-child\(3\)[^}]*animation-delay/);
     assert.doesNotMatch(styles, /@keyframes finaleReturnToDeck/);
     assert.match(styles, /@keyframes finaleCardsMerge/);
+    assert.match(styles, /@keyframes finaleCardsHold/);
+    assert.match(styles, /finaleCardGridHolding/);
     assert.match(
         styles,
         /\.tableStage\[data-hand-stage="finale"\] \.finaleCardGridMerging \.finaleCard\s*\{\s*animation: finaleCardsMerge/,
@@ -139,6 +144,8 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(styles, /@keyframes finaleIllustrationPulse[\s\S]*100%[\s\S]*opacity: 1/);
     assert.match(styles, /\.finaleCardGrid/);
     assert.match(styles, /\.specialCardStage/);
+    assert.match(styles, /\.specialCardConfirmation/);
+    assert.match(styles, /\.finaleHoldStatus/);
     assert.match(styles, /\.specialCard/);
     assert.match(styles, /@keyframes specialCardFlip/);
     assert.match(styles, /@keyframes specialCardIconFloat/);
@@ -153,14 +160,18 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(styles, /\.deckStage:disabled,[\s\S]*\.deckStage:disabled \.deckBrandLogo[\s\S]*cursor: default/);
     assert.match(styles, /--deal-y: 122px/);
     assert.match(styles, /\.progressItemCurrent \.progressButton[\s\S]*background: var\(--bm-yellow\)/);
+    assert.match(styles, /\.tableStage > \.progress[\s\S]*margin: -10px auto 0/);
     assert.match(styles, /\.progressButton \{[\s\S]*min-height: 44px/);
     assert.match(styles, /cardIllustration svg > \*/);
     assert.match(styles, /\.cardBrandMark/);
     assert.doesNotMatch(styles, /\.actsStack|\.revealedStrip|\.reopenReading/);
     assert.match(experience, /<BrandMark/);
+    assert.ok(experience.indexOf("className={styles.tableStage}") < experience.indexOf("className={styles.progress}"));
     assert.match(experience, /aria-hidden=\{!isSelected\}/);
     assert.match(experience, /BeautyMovementCardIllustration/);
     assert.match(experience, /function renderSpecialCard/);
+    assert.match(experience, /className=\{styles\.specialCardConfirmation\}/);
+    assert.match(experience, /Garantir presente e confirmar presença/);
     assert.match(experience, /finaleCardGridMerging/);
     assert.match(experience, /Carta especial do benefício/);
     assert.doesNotMatch(experience, /aria-label="Cartas finais"/);
@@ -176,4 +187,6 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(illustrations, /celebracao-encontro/);
     assert.match(campaignStyles, /background: #fafafa/i);
     assert.doesNotMatch(campaignStyles, /Georgia|coral|plum|linear-gradient|#fffaf2/i);
+    assert.doesNotMatch(experience, /confirmationStage|confirmationIntro|contactSummary|confirmationForm/);
+    assert.doesNotMatch(styles, /confirmationStage|confirmationIntro|contactSummary|confirmationForm/);
 });


### PR DESCRIPTION
﻿## O que mudou
- move o progresso para o topo da mesa, junto da seção ativa;
- mantém as três cartas finais na mesa durante uma espera visível de 5s;
- separa coleta, espera e junção em uma animação final;
- remove a antiga seção de confirmação e o campo de e-mail;
- coloca consentimento e o CTA Garantir presente e confirmar presença acima da carta especial;
- preserva o resultado configurado, integrações e contrato de confirmação.

## Validação
- prévia local em http://127.0.0.1:3417/beleza-em-movimento/local-preview;
- jornada real no Browser: distribuição, três escolhas, retenção de 5s, carta especial e confirmação;
- console sem erros;
- testes e TypeScript já validados no snapshot nativo da prévia; a execução adicional no worktree Windows ficou impedida apenas pela ausência de node_modules local.

Sem deploy de produção.
