### PR TITLE
fix(atendimento): version staging core schema bootstrap

### DIFF
--- a/crm/api/scripts/migrate-atendimento-staging-runtime.test.mjs
+++ b/crm/api/scripts/migrate-atendimento-staging-runtime.test.mjs
@@ -60,6 +60,7 @@ test('staging migration runner takes a dedicated advisory lock before inspecting
       calls.push({ sql })
       if (sql === 'begin' || sql === 'commit') return { rows: [] }
       if (sql.includes("to_regclass('crm_atendimento.schema_migrations')")) return { rows: [{ registry: null }] }
+      if (sql.includes('from unnest($1::text[])')) return { rows: [] }
       throw new Error(`unexpected identity query: ${sql}`)
     },
     release() {},
@@ -215,6 +216,7 @@ test('an active two-client migration lets one Harmonia contender observe the sha
     async query(sql) {
       if (sql === 'begin' || sql === 'commit') return { rows: [] }
       if (sql.includes("to_regclass('crm_atendimento.schema_migrations')")) return { rows: [{ registry: null }] }
+      if (sql.includes('from unnest($1::text[])')) return { rows: [] }
       throw new Error(`unexpected primary identity query: ${sql}`)
     },
   }
@@ -283,6 +285,7 @@ test('an active two-client migration lets one Harmonia contender observe the sha
 
 test('staging migration includes every Clientes schema domain in dependency order', () => {
   const ids = ATENDIMENTO_STAGING_MIGRATIONS.map((migration) => migration.id)
+  assert.equal(ids[0], '20260808_atendimento_core_schema_v1')
   const source = ids.indexOf('20260807_clientes_source_operations_v2')
   const clusters = ids.indexOf('20260807_identity_cluster_workspace_v2')
   const operations = ids.indexOf('20260807_commercial_operations_v2')

--- a/crm/api/scripts/migrate-atendimento-staging.mjs
+++ b/crm/api/scripts/migrate-atendimento-staging.mjs
@@ -67,6 +67,13 @@ import {
     rollbackIdentityClusterWorkspaceMigration,
 } from '../server/atendimento/identityClusterWorkspaceMigration.js'
 import {
+    applyAtendimentoCoreSchemaMigration,
+    rollbackAtendimentoCoreSchemaMigration,
+    ATENDIMENTO_CORE_SCHEMA_MIGRATION_ID,
+    atendimentoCoreSchemaMigrationPlan,
+    inspectAtendimentoCoreSchema,
+} from '../server/atendimento/coreSchemaMigration.js'
+import {
     applyCommercialOperationsMigration,
     rollbackCommercialOperationsMigration,
 } from '../server/atendimento/commercialOperationsMigration.js'
@@ -89,6 +96,7 @@ export const ATENDIMENTO_STAGING_MIGRATION_TARGET = ATENDIMENTO_MIGRATION_TARGET
 export const ATENDIMENTO_STAGING_MIGRATION_LOCK_KEY = ATENDIMENTO_STAGING_MUTATION_LOCK_KEY
 export { ATENDIMENTO_STAGING_MIGRATOR_CONNECTION_LIMIT, ATENDIMENTO_STAGING_MIGRATION_POOL_MAX }
 export const ATENDIMENTO_STAGING_MIGRATIONS = Object.freeze([
+    { id: ATENDIMENTO_CORE_SCHEMA_MIGRATION_ID, apply: applyAtendimentoCoreSchemaMigration, rollback: rollbackAtendimentoCoreSchemaMigration },
     { id: '20260718_atendimento_professional_identity_v1', apply: applyProfessionalIdentityMigration, rollback: rollbackProfessionalIdentityMigration },
     { id: '20260718_atendimento_write_safety_v1', apply: applyAtendimentoWriteSafetyMigration, rollback: rollbackAtendimentoWriteSafetyMigration },
     { id: '20260804_commercial_contact_controls_v1', apply: applyCommercialContactMigration, rollback: rollbackCommercialContactMigration },
@@ -161,9 +169,19 @@ export async function runAtendimentoStagingMigration({
                     from crm_atendimento.schema_migrations
                     order by id`)
                 : { rows: [] }
+            const coreSchema = await inspectAtendimentoCoreSchema(client)
             await client.query('commit')
             if (action === 'dry-run') {
-                return { runId, action, target, identity, registryPresent: Boolean(registryExists.rows[0]?.registry), migrations: registry.rows }
+                return {
+                    runId,
+                    action,
+                    target,
+                    identity,
+                    registryPresent: Boolean(registryExists.rows[0]?.registry),
+                    coreSchema,
+                    coreSchemaPlan: atendimentoCoreSchemaMigrationPlan(),
+                    migrations: registry.rows,
+                }
             }
         } catch (error) {
             try { await client.query('rollback') } catch { /* preserve original error */ }

--- a/crm/api/server/atendimento/__tests__/coreSchemaMigration.test.js
+++ b/crm/api/server/atendimento/__tests__/coreSchemaMigration.test.js
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+    __testables,
+    atendimentoCoreSchemaMigrationPlan,
+    inspectAtendimentoCoreSchema,
+} from '../coreSchemaMigration.js'
+
+test('core Atendimento schema plan is derived from the canonical store and includes commercial offers', () => {
+    assert.ok(__testables.CORE_SCHEMA_RELATIONS.includes('crm_atendimento.commercial_offers'))
+    assert.equal(new Set(__testables.CORE_SCHEMA_RELATIONS).size, __testables.CORE_SCHEMA_RELATIONS.length)
+    assert.equal(atendimentoCoreSchemaMigrationPlan().relationCount, __testables.CORE_SCHEMA_RELATIONS.length)
+})
+
+test('core schema inspection reports missing relations without writing', async () => {
+    const calls = []
+    const schema = await inspectAtendimentoCoreSchema({
+        async query(sql, values) {
+            calls.push({ sql, values })
+            return {
+                rows: [
+                    { relation_name: 'crm_atendimento.commercial_offers', present: false },
+                    { relation_name: 'crm_atendimento.units', present: true },
+                ],
+            }
+        },
+    })
+
+    assert.equal(calls.length, 1)
+    assert.match(calls[0].sql, /from unnest\(\$1::text\[\]\)/)
+    assert.equal(calls[0].values.length, 1)
+    assert.equal(schema.ready, false)
+    assert.deepEqual(schema.missing, ['crm_atendimento.commercial_offers'])
+})

--- a/crm/api/server/atendimento/coreSchemaMigration.js
+++ b/crm/api/server/atendimento/coreSchemaMigration.js
@@ -1,0 +1,164 @@
+import { migrateAtendimento, atendimentoMigrationStatements } from './store.js'
+import {
+    assertAtendimentoMigrationDestination,
+    ATENDIMENTO_MIGRATION_TARGETS,
+    isStrictAtendimentoMigrationDestination,
+} from './migrationDestination.js'
+
+export const ATENDIMENTO_CORE_SCHEMA_MIGRATION_ID = '20260808_atendimento_core_schema_v1'
+
+const CORE_SCHEMA_RELATIONS = Object.freeze([
+    ...new Set(atendimentoMigrationStatements()
+        .flatMap((statement) => [...statement.matchAll(/create table if not exists\s+(crm_atendimento\.[a-z0-9_]+)/gi)])
+        .map((match) => match[1])),
+])
+
+function migrationError(code) {
+    const error = new Error(code)
+    error.code = code
+    return error
+}
+
+async function ensureRegistry(client) {
+    await client.query(`create schema if not exists crm_atendimento`)
+    await client.query(`create table if not exists crm_atendimento.schema_migrations (
+        id text primary key,
+        applied_at timestamptz not null default now(),
+        rolled_back_at timestamptz,
+        details jsonb not null default '{}'::jsonb
+    )`)
+}
+
+export async function inspectAtendimentoCoreSchema(client) {
+    const result = await client.query(`
+        select relation_name,
+               to_regclass(relation_name) is not null as present
+          from unnest($1::text[]) as requested(relation_name)
+         order by relation_name
+    `, [CORE_SCHEMA_RELATIONS])
+    const relations = result.rows.map((row) => ({
+        relation: String(row.relation_name),
+        present: row.present === true,
+    }))
+    return {
+        ready: relations.every((relation) => relation.present),
+        relations,
+        missing: relations.filter((relation) => !relation.present).map((relation) => relation.relation),
+    }
+}
+
+async function assertDestination(client, databaseUrl, target) {
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) {
+        throw migrationError('ATENDIMENTO_CORE_SCHEMA_DESTINATION_UNSAFE')
+    }
+    try {
+        return await assertAtendimentoMigrationDestination(client, databaseUrl, target)
+    } catch {
+        throw migrationError('ATENDIMENTO_CORE_SCHEMA_DESTINATION_UNSAFE')
+    }
+}
+
+export function atendimentoCoreSchemaMigrationPlan() {
+    return {
+        id: ATENDIMENTO_CORE_SCHEMA_MIGRATION_ID,
+        source: 'crm_atendimento.store.migrateAtendimento',
+        relationCount: CORE_SCHEMA_RELATIONS.length,
+        relations: [...CORE_SCHEMA_RELATIONS],
+        behavior: 'idempotent additive schema bootstrap; existing data and tables are preserved',
+        rollback: 'non-destructive; schema and data are retained, registry state is marked rolled back',
+        runtimeAccess: 'no runtime grants are changed here; feature migrations and the staging seal own access policy',
+    }
+}
+
+export async function applyAtendimentoCoreSchemaMigration({
+    pool,
+    databaseUrl,
+    target = ATENDIMENTO_MIGRATION_TARGETS.LOCAL,
+} = {}) {
+    if (!pool) throw migrationError('ATENDIMENTO_CORE_SCHEMA_POOL_REQUIRED')
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) {
+        throw migrationError('ATENDIMENTO_CORE_SCHEMA_DESTINATION_UNSAFE')
+    }
+    const client = await pool.connect()
+    let transactionOpen = false
+    try {
+        await client.query('begin')
+        transactionOpen = true
+        await client.query(`set local lock_timeout = '3s'`)
+        await client.query(`set local statement_timeout = '120s'`)
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [ATENDIMENTO_CORE_SCHEMA_MIGRATION_ID])
+        const destination = await assertDestination(client, databaseUrl, target)
+        await migrateAtendimento(client)
+        const schema = await inspectAtendimentoCoreSchema(client)
+        if (!schema.ready) throw migrationError('ATENDIMENTO_CORE_SCHEMA_INCOMPLETE')
+        await ensureRegistry(client)
+        const report = {
+            ...atendimentoCoreSchemaMigrationPlan(),
+            applied: true,
+            target,
+            database: destination.database,
+            schema,
+        }
+        await client.query(`insert into crm_atendimento.schema_migrations(id, applied_at, rolled_back_at, details)
+            values ($1, now(), null, $2::jsonb)
+            on conflict(id) do update set applied_at = excluded.applied_at, rolled_back_at = null, details = excluded.details`, [
+            ATENDIMENTO_CORE_SCHEMA_MIGRATION_ID,
+            JSON.stringify(report),
+        ])
+        await client.query('commit')
+        transactionOpen = false
+        return report
+    } catch (error) {
+        if (transactionOpen) {
+            try { await client.query('rollback') } catch { /* preserve original failure */ }
+        }
+        throw error
+    } finally {
+        client.release()
+    }
+}
+
+export async function rollbackAtendimentoCoreSchemaMigration({
+    pool,
+    databaseUrl,
+    target = ATENDIMENTO_MIGRATION_TARGETS.LOCAL,
+} = {}) {
+    if (!pool) throw migrationError('ATENDIMENTO_CORE_SCHEMA_POOL_REQUIRED')
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) {
+        throw migrationError('ATENDIMENTO_CORE_SCHEMA_DESTINATION_UNSAFE')
+    }
+    const client = await pool.connect()
+    let transactionOpen = false
+    try {
+        await client.query('begin')
+        transactionOpen = true
+        await client.query(`set local lock_timeout = '3s'`)
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [ATENDIMENTO_CORE_SCHEMA_MIGRATION_ID])
+        await assertDestination(client, databaseUrl, target)
+        await ensureRegistry(client)
+        await client.query(`insert into crm_atendimento.schema_migrations(id, applied_at, rolled_back_at, details)
+            values ($1, now(), now(), '{"rollback":"non-destructive","schemaRetained":true}'::jsonb)
+            on conflict(id) do update set rolled_back_at = now(), details = excluded.details`, [
+            ATENDIMENTO_CORE_SCHEMA_MIGRATION_ID,
+        ])
+        await client.query('commit')
+        transactionOpen = false
+        return {
+            id: ATENDIMENTO_CORE_SCHEMA_MIGRATION_ID,
+            rolledBack: true,
+            destructive: false,
+            schemaRetained: true,
+        }
+    } catch (error) {
+        if (transactionOpen) {
+            try { await client.query('rollback') } catch { /* preserve original failure */ }
+        }
+        throw error
+    } finally {
+        client.release()
+    }
+}
+
+export const __testables = Object.freeze({
+    CORE_SCHEMA_RELATIONS,
+})

--- a/docs/runbooks/atendimento-independent-release.md
+++ b/docs/runbooks/atendimento-independent-release.md
@@ -60,8 +60,12 @@ estar inativa; o runner obtém lock advisory no banco durante todo o fluxo.
 
 ## Gaps que bloqueiam ativação
 
-1. Staging precisa ter as migrations aditivas de fontes e aprovação clínica
-   aplicadas e validadas. Até isso ocorrer, `readiness` deve responder `503`.
+1. Staging precisa ter o schema-base `20260808_atendimento_core_schema_v1` e as
+   migrations aditivas de fontes, operações e aprovação clínica aplicadas e
+   validadas pelo runner fixo. O schema-base é derivado de
+   `migrateAtendimento`, executado somente pelo login migrador/owner; o processo
+   da aplicação nunca faz bootstrap de DDL. Até todos esses itens ocorrerem,
+   `readiness` deve responder `503`.
 2. O banco de produção dedicado e os roles separados precisam de backup,
    provisionamento e prova de grants mínimos; o app não pode ter DDL nem acesso
    a contato bruto de Harmonia/Caixa.

--- a/docs/runbooks/clientes-production-readonly-runtime.md
+++ b/docs/runbooks/clientes-production-readonly-runtime.md
@@ -110,10 +110,16 @@ literais `CHAVE=valor` pelo Node, nunca com `source`, `eval` ou `bash -c`.
      --source-root /opt/skincos/releases/<sha-main>/source
    ```
 
-   Antes de qualquer `--apply` da migration, prove o plano de migrations
-   aditivas de fontes, clusters, operações, analytics e aprovação clínica. Se
-   elas ainda não existirem no staging, readiness deve continuar `503`; não
-   contorne isso com grants, schema automático ou flag. O preparador recusa um
+   O primeiro item do runner é `20260808_atendimento_core_schema_v1`: ele
+   reconcilia, de forma idempotente e transacional, o schema-base oficial de
+   `crm_atendimento` e o registra no journal. O `--dry-run` lista as relações
+   ausentes em `coreSchema.missing`; nenhuma relação é criada nessa etapa.
+   Antes de qualquer `--apply` das migrations, prove também o plano de
+   migrations aditivas de fontes, clusters, operações, analytics e aprovação
+   clínica. Se elas ainda não existirem no staging, readiness deve continuar
+   `503`; não contorne isso com grants, bootstrap automático do processo da
+   aplicação ou flag. O schema-base só pode ser aplicado pelo runner fixo, com
+   o login migrador/owner e sob o backup/selagem descritos acima. O preparador recusa um
    SHA que não seja exatamente o `origin/main` buscado e grava a linhagem
    imutável com o predecessor confirmado. Não há túnel nem DNS de staging nesta tranche. A prova de liveness de
    staging é feita somente pelo validador nativo, no listener loopback fixo;


### PR DESCRIPTION
## O que mudou

- adiciona `20260808_atendimento_core_schema_v1`, migration idempotente do schema-base oficial do Atendimento;
- faz o `--dry-run` relatar relações ausentes em `coreSchema.missing`;
- executa o bootstrap somente no runner de staging, sob o login migrador promovido ao owner, com transação, advisory lock e timeout;
- registra a migration no journal e oferece rollback não destrutivo, preservando schema e dados;
- documenta a separação entre schema-base controlado e o processo read-only da aplicação.

## Motivo

O staging schema-managed tinha as migrations incrementais registradas, mas faltava `crm_atendimento.commercial_offers`, relação criada pelo schema-base do Atendimento. Isso fazia `20260807_commercial_operations_v2` falhar com `COMMERCIAL_OPERATIONS_PREREQUISITES_MISSING`.

## Segurança e operação

- destino continua restrito a `skincos_staging` via loopback TLS e login migrador;
- nenhuma flag de escrita, convite, WhatsApp, DNS, túnel ou produção é alterada;
- o selador de grants permanece obrigatório após o runner;
- rollback não remove tabelas nem dados.

## Validação

- `crm/api`: 478 testes aprovados, 2 ignorados, 0 falhas;
- runner de staging focado: 7/7;
- migration do schema-base: 2/2;
- `git diff --check`: aprovado.

## Próximo passo operacional

Após os checks do PR, preparar a release nativa, manter Atendimento em `maintenance`, executar backup + `--dry-run` + `--apply`, confirmar journal e grants read-only, e só então repetir readiness/smoke do staging.