### PR TITLE
fix(atendimento): restore staging readiness contract

### DIFF
--- a/crm/api/scripts/migrate-atendimento-staging-runtime.test.mjs
+++ b/crm/api/scripts/migrate-atendimento-staging-runtime.test.mjs
@@ -60,6 +60,7 @@ test('staging migration runner takes a dedicated advisory lock before inspecting
       calls.push({ sql })
       if (sql === 'begin' || sql === 'commit') return { rows: [] }
       if (sql.includes("to_regclass('crm_atendimento.schema_migrations')")) return { rows: [{ registry: null }] }
+      if (sql.includes('from unnest($1::text[])')) return { rows: [] }
       throw new Error(`unexpected identity query: ${sql}`)
     },
     release() {},
@@ -215,6 +216,7 @@ test('an active two-client migration lets one Harmonia contender observe the sha
     async query(sql) {
       if (sql === 'begin' || sql === 'commit') return { rows: [] }
       if (sql.includes("to_regclass('crm_atendimento.schema_migrations')")) return { rows: [{ registry: null }] }
+      if (sql.includes('from unnest($1::text[])')) return { rows: [] }
       throw new Error(`unexpected primary identity query: ${sql}`)
     },
   }
@@ -283,6 +285,7 @@ test('an active two-client migration lets one Harmonia contender observe the sha
 
 test('staging migration includes every Clientes schema domain in dependency order', () => {
   const ids = ATENDIMENTO_STAGING_MIGRATIONS.map((migration) => migration.id)
+  assert.equal(ids[0], '20260808_atendimento_core_schema_v1')
   const source = ids.indexOf('20260807_clientes_source_operations_v2')
   const clusters = ids.indexOf('20260807_identity_cluster_workspace_v2')
   const operations = ids.indexOf('20260807_commercial_operations_v2')

--- a/crm/api/scripts/migrate-atendimento-staging.mjs
+++ b/crm/api/scripts/migrate-atendimento-staging.mjs
@@ -67,6 +67,13 @@ import {
     rollbackIdentityClusterWorkspaceMigration,
 } from '../server/atendimento/identityClusterWorkspaceMigration.js'
 import {
+    applyAtendimentoCoreSchemaMigration,
+    rollbackAtendimentoCoreSchemaMigration,
+    ATENDIMENTO_CORE_SCHEMA_MIGRATION_ID,
+    atendimentoCoreSchemaMigrationPlan,
+    inspectAtendimentoCoreSchema,
+} from '../server/atendimento/coreSchemaMigration.js'
+import {
     applyCommercialOperationsMigration,
     rollbackCommercialOperationsMigration,
 } from '../server/atendimento/commercialOperationsMigration.js'
@@ -89,6 +96,7 @@ export const ATENDIMENTO_STAGING_MIGRATION_TARGET = ATENDIMENTO_MIGRATION_TARGET
 export const ATENDIMENTO_STAGING_MIGRATION_LOCK_KEY = ATENDIMENTO_STAGING_MUTATION_LOCK_KEY
 export { ATENDIMENTO_STAGING_MIGRATOR_CONNECTION_LIMIT, ATENDIMENTO_STAGING_MIGRATION_POOL_MAX }
 export const ATENDIMENTO_STAGING_MIGRATIONS = Object.freeze([
+    { id: ATENDIMENTO_CORE_SCHEMA_MIGRATION_ID, apply: applyAtendimentoCoreSchemaMigration, rollback: rollbackAtendimentoCoreSchemaMigration },
     { id: '20260718_atendimento_professional_identity_v1', apply: applyProfessionalIdentityMigration, rollback: rollbackProfessionalIdentityMigration },
     { id: '20260718_atendimento_write_safety_v1', apply: applyAtendimentoWriteSafetyMigration, rollback: rollbackAtendimentoWriteSafetyMigration },
     { id: '20260804_commercial_contact_controls_v1', apply: applyCommercialContactMigration, rollback: rollbackCommercialContactMigration },
@@ -161,9 +169,19 @@ export async function runAtendimentoStagingMigration({
                     from crm_atendimento.schema_migrations
                     order by id`)
                 : { rows: [] }
+            const coreSchema = await inspectAtendimentoCoreSchema(client)
             await client.query('commit')
             if (action === 'dry-run') {
-                return { runId, action, target, identity, registryPresent: Boolean(registryExists.rows[0]?.registry), migrations: registry.rows }
+                return {
+                    runId,
+                    action,
+                    target,
+                    identity,
+                    registryPresent: Boolean(registryExists.rows[0]?.registry),
+                    coreSchema,
+                    coreSchemaPlan: atendimentoCoreSchemaMigrationPlan(),
+                    migrations: registry.rows,
+                }
             }
         } catch (error) {
             try { await client.query('rollback') } catch { /* preserve original error */ }

--- a/crm/api/server/atendimento/__tests__/coreSchemaMigration.test.js
+++ b/crm/api/server/atendimento/__tests__/coreSchemaMigration.test.js
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+    __testables,
+    atendimentoCoreSchemaMigrationPlan,
+    inspectAtendimentoCoreSchema,
+} from '../coreSchemaMigration.js'
+
+test('core Atendimento schema plan is derived from the canonical store and includes commercial offers', () => {
+    assert.ok(__testables.CORE_SCHEMA_RELATIONS.includes('crm_atendimento.commercial_offers'))
+    assert.equal(new Set(__testables.CORE_SCHEMA_RELATIONS).size, __testables.CORE_SCHEMA_RELATIONS.length)
+    assert.equal(atendimentoCoreSchemaMigrationPlan().relationCount, __testables.CORE_SCHEMA_RELATIONS.length)
+})
+
+test('core schema inspection reports missing relations without writing', async () => {
+    const calls = []
+    const schema = await inspectAtendimentoCoreSchema({
+        async query(sql, values) {
+            calls.push({ sql, values })
+            return {
+                rows: [
+                    { relation_name: 'crm_atendimento.commercial_offers', present: false },
+                    { relation_name: 'crm_atendimento.units', present: true },
+                ],
+            }
+        },
+    })
+
+    assert.equal(calls.length, 1)
+    assert.match(calls[0].sql, /from unnest\(\$1::text\[\]\)/)
+    assert.equal(calls[0].values.length, 1)
+    assert.equal(schema.ready, false)
+    assert.deepEqual(schema.missing, ['crm_atendimento.commercial_offers'])
+})

--- a/crm/api/server/atendimento/__tests__/isolatedRuntime.test.js
+++ b/crm/api/server/atendimento/__tests__/isolatedRuntime.test.js
@@ -236,6 +236,8 @@ test('store readiness requires the expected database, app role, schema and read-
     assert.match(queries[0], /has_table_privilege\(current_user, c\.oid, 'INSERT'\)/)
     assert.match(queries[0], /session_user as session_database_user/)
     assert.match(queries[0], /pg_has_role\(current_user, candidate\.oid, 'SET'\)/)
+    assert.doesNotMatch(queries[0], /pg_roles current_role/)
+    assert.match(queries[0], /pg_roles role_record/)
     assert.match(queries[0], /p\.prosecdef/)
     assert.match(queries[0], /n\.nspname in \('harmonia', 'crm_caixa'\)/)
     assert.match(queries[0], /clientes_source_operation_runs/)

--- a/crm/api/server/atendimento/coreSchemaMigration.js
+++ b/crm/api/server/atendimento/coreSchemaMigration.js
@@ -1,0 +1,164 @@
+import { migrateAtendimento, atendimentoMigrationStatements } from './store.js'
+import {
+    assertAtendimentoMigrationDestination,
+    ATENDIMENTO_MIGRATION_TARGETS,
+    isStrictAtendimentoMigrationDestination,
+} from './migrationDestination.js'
+
+export const ATENDIMENTO_CORE_SCHEMA_MIGRATION_ID = '20260808_atendimento_core_schema_v1'
+
+const CORE_SCHEMA_RELATIONS = Object.freeze([
+    ...new Set(atendimentoMigrationStatements()
+        .flatMap((statement) => [...statement.matchAll(/create table if not exists\s+(crm_atendimento\.[a-z0-9_]+)/gi)])
+        .map((match) => match[1])),
+])
+
+function migrationError(code) {
+    const error = new Error(code)
+    error.code = code
+    return error
+}
+
+async function ensureRegistry(client) {
+    await client.query(`create schema if not exists crm_atendimento`)
+    await client.query(`create table if not exists crm_atendimento.schema_migrations (
+        id text primary key,
+        applied_at timestamptz not null default now(),
+        rolled_back_at timestamptz,
+        details jsonb not null default '{}'::jsonb
+    )`)
+}
+
+export async function inspectAtendimentoCoreSchema(client) {
+    const result = await client.query(`
+        select relation_name,
+               to_regclass(relation_name) is not null as present
+          from unnest($1::text[]) as requested(relation_name)
+         order by relation_name
+    `, [CORE_SCHEMA_RELATIONS])
+    const relations = result.rows.map((row) => ({
+        relation: String(row.relation_name),
+        present: row.present === true,
+    }))
+    return {
+        ready: relations.every((relation) => relation.present),
+        relations,
+        missing: relations.filter((relation) => !relation.present).map((relation) => relation.relation),
+    }
+}
+
+async function assertDestination(client, databaseUrl, target) {
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) {
+        throw migrationError('ATENDIMENTO_CORE_SCHEMA_DESTINATION_UNSAFE')
+    }
+    try {
+        return await assertAtendimentoMigrationDestination(client, databaseUrl, target)
+    } catch {
+        throw migrationError('ATENDIMENTO_CORE_SCHEMA_DESTINATION_UNSAFE')
+    }
+}
+
+export function atendimentoCoreSchemaMigrationPlan() {
+    return {
+        id: ATENDIMENTO_CORE_SCHEMA_MIGRATION_ID,
+        source: 'crm_atendimento.store.migrateAtendimento',
+        relationCount: CORE_SCHEMA_RELATIONS.length,
+        relations: [...CORE_SCHEMA_RELATIONS],
+        behavior: 'idempotent additive schema bootstrap; existing data and tables are preserved',
+        rollback: 'non-destructive; schema and data are retained, registry state is marked rolled back',
+        runtimeAccess: 'no runtime grants are changed here; feature migrations and the staging seal own access policy',
+    }
+}
+
+export async function applyAtendimentoCoreSchemaMigration({
+    pool,
+    databaseUrl,
+    target = ATENDIMENTO_MIGRATION_TARGETS.LOCAL,
+} = {}) {
+    if (!pool) throw migrationError('ATENDIMENTO_CORE_SCHEMA_POOL_REQUIRED')
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) {
+        throw migrationError('ATENDIMENTO_CORE_SCHEMA_DESTINATION_UNSAFE')
+    }
+    const client = await pool.connect()
+    let transactionOpen = false
+    try {
+        await client.query('begin')
+        transactionOpen = true
+        await client.query(`set local lock_timeout = '3s'`)
+        await client.query(`set local statement_timeout = '120s'`)
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [ATENDIMENTO_CORE_SCHEMA_MIGRATION_ID])
+        const destination = await assertDestination(client, databaseUrl, target)
+        await migrateAtendimento(client)
+        const schema = await inspectAtendimentoCoreSchema(client)
+        if (!schema.ready) throw migrationError('ATENDIMENTO_CORE_SCHEMA_INCOMPLETE')
+        await ensureRegistry(client)
+        const report = {
+            ...atendimentoCoreSchemaMigrationPlan(),
+            applied: true,
+            target,
+            database: destination.database,
+            schema,
+        }
+        await client.query(`insert into crm_atendimento.schema_migrations(id, applied_at, rolled_back_at, details)
+            values ($1, now(), null, $2::jsonb)
+            on conflict(id) do update set applied_at = excluded.applied_at, rolled_back_at = null, details = excluded.details`, [
+            ATENDIMENTO_CORE_SCHEMA_MIGRATION_ID,
+            JSON.stringify(report),
+        ])
+        await client.query('commit')
+        transactionOpen = false
+        return report
+    } catch (error) {
+        if (transactionOpen) {
+            try { await client.query('rollback') } catch { /* preserve original failure */ }
+        }
+        throw error
+    } finally {
+        client.release()
+    }
+}
+
+export async function rollbackAtendimentoCoreSchemaMigration({
+    pool,
+    databaseUrl,
+    target = ATENDIMENTO_MIGRATION_TARGETS.LOCAL,
+} = {}) {
+    if (!pool) throw migrationError('ATENDIMENTO_CORE_SCHEMA_POOL_REQUIRED')
+    if (!isStrictAtendimentoMigrationDestination(databaseUrl, target)) {
+        throw migrationError('ATENDIMENTO_CORE_SCHEMA_DESTINATION_UNSAFE')
+    }
+    const client = await pool.connect()
+    let transactionOpen = false
+    try {
+        await client.query('begin')
+        transactionOpen = true
+        await client.query(`set local lock_timeout = '3s'`)
+        await client.query(`select pg_advisory_xact_lock(hashtext($1))`, [ATENDIMENTO_CORE_SCHEMA_MIGRATION_ID])
+        await assertDestination(client, databaseUrl, target)
+        await ensureRegistry(client)
+        await client.query(`insert into crm_atendimento.schema_migrations(id, applied_at, rolled_back_at, details)
+            values ($1, now(), now(), '{"rollback":"non-destructive","schemaRetained":true}'::jsonb)
+            on conflict(id) do update set rolled_back_at = now(), details = excluded.details`, [
+            ATENDIMENTO_CORE_SCHEMA_MIGRATION_ID,
+        ])
+        await client.query('commit')
+        transactionOpen = false
+        return {
+            id: ATENDIMENTO_CORE_SCHEMA_MIGRATION_ID,
+            rolledBack: true,
+            destructive: false,
+            schemaRetained: true,
+        }
+    } catch (error) {
+        if (transactionOpen) {
+            try { await client.query('rollback') } catch { /* preserve original failure */ }
+        }
+        throw error
+    } finally {
+        client.release()
+    }
+}
+
+export const __testables = Object.freeze({
+    CORE_SCHEMA_RELATIONS,
+})

--- a/crm/api/server/atendimento/store.js
+++ b/crm/api/server/atendimento/store.js
@@ -5888,11 +5888,11 @@ export function createAtendimentoStore(options = {}) {
                                 and pg_has_role(current_user, candidate.oid, 'SET')
                         )
                         and not exists (
-                            select 1 from pg_roles current_role
-                            where current_role.rolname = current_user
-                                and (current_role.rolsuper or current_role.rolcreatedb
-                                    or current_role.rolcreaterole or current_role.rolreplication
-                                    or current_role.rolbypassrls)
+                            select 1 from pg_roles role_record
+                            where role_record.rolname = current_user
+                                and (role_record.rolsuper or role_record.rolcreatedb
+                                    or role_record.rolcreaterole or role_record.rolreplication
+                                    or role_record.rolbypassrls)
                         )
                         and not exists (
                             select 1

--- a/docs/runbooks/atendimento-independent-release.md
+++ b/docs/runbooks/atendimento-independent-release.md
@@ -60,8 +60,12 @@ estar inativa; o runner obtém lock advisory no banco durante todo o fluxo.
 
 ## Gaps que bloqueiam ativação
 
-1. Staging precisa ter as migrations aditivas de fontes e aprovação clínica
-   aplicadas e validadas. Até isso ocorrer, `readiness` deve responder `503`.
+1. Staging precisa ter o schema-base `20260808_atendimento_core_schema_v1` e as
+   migrations aditivas de fontes, operações e aprovação clínica aplicadas e
+   validadas pelo runner fixo. O schema-base é derivado de
+   `migrateAtendimento`, executado somente pelo login migrador/owner; o processo
+   da aplicação nunca faz bootstrap de DDL. Até todos esses itens ocorrerem,
+   `readiness` deve responder `503`.
 2. O banco de produção dedicado e os roles separados precisam de backup,
    provisionamento e prova de grants mínimos; o app não pode ter DDL nem acesso
    a contato bruto de Harmonia/Caixa.

--- a/docs/runbooks/clientes-production-readonly-runtime.md
+++ b/docs/runbooks/clientes-production-readonly-runtime.md
@@ -110,10 +110,16 @@ literais `CHAVE=valor` pelo Node, nunca com `source`, `eval` ou `bash -c`.
      --source-root /opt/skincos/releases/<sha-main>/source
    ```
 
-   Antes de qualquer `--apply` da migration, prove o plano de migrations
-   aditivas de fontes, clusters, operações, analytics e aprovação clínica. Se
-   elas ainda não existirem no staging, readiness deve continuar `503`; não
-   contorne isso com grants, schema automático ou flag. O preparador recusa um
+   O primeiro item do runner é `20260808_atendimento_core_schema_v1`: ele
+   reconcilia, de forma idempotente e transacional, o schema-base oficial de
+   `crm_atendimento` e o registra no journal. O `--dry-run` lista as relações
+   ausentes em `coreSchema.missing`; nenhuma relação é criada nessa etapa.
+   Antes de qualquer `--apply` das migrations, prove também o plano de
+   migrations aditivas de fontes, clusters, operações, analytics e aprovação
+   clínica. Se elas ainda não existirem no staging, readiness deve continuar
+   `503`; não contorne isso com grants, bootstrap automático do processo da
+   aplicação ou flag. O schema-base só pode ser aplicado pelo runner fixo, com
+   o login migrador/owner e sob o backup/selagem descritos acima. O preparador recusa um
    SHA que não seja exatamente o `origin/main` buscado e grava a linhagem
    imutável com o predecessor confirmado. Não há túnel nem DNS de staging nesta tranche. A prova de liveness de
    staging é feita somente pelo validador nativo, no listener loopback fixo;

--- a/scripts/run-atendimento-staging-migration.sh
+++ b/scripts/run-atendimento-staging-migration.sh
@@ -39,11 +39,11 @@ readonly BACKUP_SCRIPT="$RELEASE_ROOT/scripts/backup-atendimento-staging.sh"
 readonly SERVICE='crm-atendimento-staging.service'
 LOCKDOWN_REQUIRED=0
 [[ "$RELEASE_ROOT" =~ ^/opt/skincos/releases/[0-9a-f]{40}/source$ ]] || { echo 'Staging release root is invalid.' >&2; exit 64; }
-[[ -f "$RUNNER" ]] || { echo 'Fixed staging migration runner is unavailable in the immutable release.' >&2; exit 78; }
-[[ -f "$RELEASE_VALIDATOR" ]] || { echo 'Immutable release validator is unavailable.' >&2; exit 78; }
-[[ -f "$CONTROL_VALIDATOR" ]] || { echo 'Strict staging control validator is unavailable.' >&2; exit 78; }
-[[ -x "$RUNTIME_GRANT_LOCKDOWN" ]] || { echo 'Fixed staging read-only grant lockdown is unavailable.' >&2; exit 78; }
-[[ -x "$BACKUP_SCRIPT" ]] || { echo 'Fixed staging backup helper is unavailable in the immutable release.' >&2; exit 78; }
+run_sudo_clean /usr/bin/test -f "$RUNNER" || { echo 'Fixed staging migration runner is unavailable in the immutable release.' >&2; exit 78; }
+run_sudo_clean /usr/bin/test -f "$RELEASE_VALIDATOR" || { echo 'Immutable release validator is unavailable.' >&2; exit 78; }
+run_sudo_clean /usr/bin/test -f "$CONTROL_VALIDATOR" || { echo 'Strict staging control validator is unavailable.' >&2; exit 78; }
+run_sudo_clean /usr/bin/test -x "$RUNTIME_GRANT_LOCKDOWN" || { echo 'Fixed staging read-only grant lockdown is unavailable.' >&2; exit 78; }
+run_sudo_clean /usr/bin/test -x "$BACKUP_SCRIPT" || { echo 'Fixed staging backup helper is unavailable in the immutable release.' >&2; exit 78; }
 
 # The Node runner reads one fixed root-owned file as literal key/value data.
 # It always resolves dependencies from the immutable release that was already

--- a/scripts/runtime/install-atendimento-staging-service.sh
+++ b/scripts/runtime/install-atendimento-staging-service.sh
@@ -73,7 +73,7 @@ cleanup_artifacts() {
   fi
 }
 trap cleanup_artifacts EXIT
-/usr/bin/sed \
+run_sudo_clean /usr/bin/sed \
   -e "s|__REPO_ROOT__|$SOURCE_ROOT|g" \
   -e "s|__STATE_ROOT__|$STATE_ROOT|g" \
   -e "s|__CONFIG_ROOT__|$CONFIG_ROOT|g" \

--- a/scripts/tests/clientes-production-readonly-runtime.test.mjs
+++ b/scripts/tests/clientes-production-readonly-runtime.test.mjs
@@ -81,6 +81,7 @@ test('native scripts parse fixed configuration without dynamic shell evaluation'
   assert.match(stagingMigration, /\/opt\/skincos\/releases\/\$RELEASE_SHA\/source/)
   assert.match(stagingMigration, /validate-atendimento-release\.mjs/)
   assert.match(stagingMigration, /--release-sha "\$RELEASE_SHA" --target staging/)
+  assert.match(stagingMigration, /run_sudo_clean \/usr\/bin\/test -f "\$RUNNER"/)
   assert.doesNotMatch(stagingMigration, /ROOT_DIR=.*BASH_SOURCE/)
 
   const qualityRefresh = read('crm/api/scripts/run-atendimento-staging-quality-refresh.mjs')
@@ -305,6 +306,7 @@ test('staging release, control and application role remain fixed and read-only',
   assert.match(installer, /mktemp -d \/tmp\/atendimento-staging-unit\.XXXXXX/)
   assert.match(installer, /readonly SERVICE='crm-atendimento-staging\.service'/)
   assert.match(installer, /\/usr\/bin\/systemd-analyze verify/)
+  assert.match(installer, /run_sudo_clean \/usr\/bin\/sed/)
   assert.match(installer, /\/usr\/bin\/systemctl enable "\$SERVICE"/)
   assert.match(installer, /\/usr\/bin\/systemctl restart "\$SERVICE"/)
   assert.match(installer, /unit_backup='none'/)
@@ -450,6 +452,7 @@ test('staging validation attests only the fixed loopback runtime and strict stag
   assert.match(validation, /RELEASE_VALIDATOR="\$RELEASE_ROOT\/crm\/api\/scripts\/validate-atendimento-release\.mjs"/)
   assert.match(validation, /"\$RELEASE_VALIDATOR" --source-root "\$RELEASE_ROOT" --release-sha "\$RELEASE_SHA" --target staging/)
   assert.match(validation, /\/usr\/bin\/cmp -s "\$rendered" "\$UNIT_FILE"/)
+  assert.match(validation, /run_sudo_clean \/usr\/bin\/sed/)
   assert.match(validation, /\/proc\/\$main_pid\/cmdline/)
   assert.match(validation, /--noproxy '\*'/)
   assert.match(validation, /http:\/\/127\.0\.0\.1:\$PORT\/health/)

--- a/scripts/validate-atendimento-staging-readonly.sh
+++ b/scripts/validate-atendimento-staging-readonly.sh
@@ -74,7 +74,7 @@ protected_before="$(snapshot_protected_services)"
 render_dir="$(/usr/bin/mktemp -d)"
 rendered="$render_dir/crm-atendimento-staging.service"
 trap '/usr/bin/rm -f "$rendered"; /usr/bin/rmdir "$render_dir" 2>/dev/null || true' EXIT
-/usr/bin/sed \
+run_sudo_clean /usr/bin/sed \
   -e "s|__REPO_ROOT__|$RELEASE_ROOT|g" \
   -e "s|__STATE_ROOT__|/var/lib/skincos-runtime|g" \
   -e "s|__CONFIG_ROOT__|/etc/skincos|g" \


### PR DESCRIPTION
## O que mudou

- corrige o SQL de readiness do Atendimento: `current_role` era usado como alias reservado do PostgreSQL e gerava `42601`;
- torna o alias explícito (`role_record`) e adiciona regressão;
- permite que o operador `admin` execute migration, instalação e validador contra releases root-owned, usando apenas os helpers sudo fixos para leituras necessárias;
- mantém controle, serviço, grants e arquivos de release estritamente isolados.

## Evidência do problema

No staging `c5c7f70fe8d3e39c2193633659ab06b787472071`, health, assinatura, replay e bloqueio de escrita passaram, mas readiness falhou com erro PostgreSQL `42601` perto de `current_role`. Nenhum dado foi alterado pelo diagnóstico; o runtime permaneceu read-only.

## Validação

- readiness/store focados: 65/65;
- contrato nativo staging/produção: 8/8;
- `git diff --check`: aprovado;
- nenhum endpoint público, flag de escrita, túnel, DNS ou produção foi alterado.

## Próximo passo operacional

Após os checks, preparar a release deste SHA, manter staging em `maintenance`, repetir o dry-run idempotente, aplicar/selar se necessário, ativar a unit dedicada e executar o validador nativo completo.