### PR TITLE
fix(crm): mount admin proxy on inventory gateway

### DIFF
--- a/crm/console/functions/api/crm/[[path]].ts
+++ b/crm/console/functions/api/crm/[[path]].ts
@@ -17,19 +17,30 @@ function isLoopbackTarget(value: string): boolean {
   }
 }
 
+export function buildCrmTargetUrl(targetOrigin: string, rest: string, search: string): string {
+  const targetUrl = new URL(targetOrigin)
+  const basePath = targetUrl.pathname.replace(/\/$/, '')
+  targetUrl.pathname = `${basePath}/inventory${rest.startsWith('/') ? '' : '/'}${rest}`
+  targetUrl.search = search
+  return targetUrl.toString()
+}
+
 export async function onRequest(context: any): Promise<Response> {
   const request: Request = context.request
   const url = new URL(request.url)
 
   // Incoming:  /api/crm/<rest>
-  // Outgoing:  https://api.skincos.com.br/<rest>
+  // Outgoing:  https://api.skincos.com.br/inventory/<rest>
+  //
+  // The Core gateway owns the public domain and mounts the Inventory/Identity
+  // Worker at /inventory. Keeping this boundary explicit prevents the CRM
+  // console from silently falling through to the gateway's route_not_found
+  // response when Users, onboarding or admin status routes are called.
   const prefix = '/api/crm'
   const rest = url.pathname.startsWith(prefix) ? url.pathname.slice(prefix.length) || '/' : url.pathname
 
   const targetOrigin = (context.env?.INSUMOS_API_TARGET as string | undefined) || 'https://api.skincos.com.br'
-  const targetUrl = new URL(targetOrigin)
-  targetUrl.pathname = `${rest.startsWith('/') ? '' : '/'}${rest}`
-  targetUrl.search = url.search
+  const targetUrl = new URL(buildCrmTargetUrl(targetOrigin, rest, url.search))
 
   const headers = sanitizeProxyRequestHeaders(request.headers)
 

--- a/crm/console/tests/crmProxyRoute.test.ts
+++ b/crm/console/tests/crmProxyRoute.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { buildCrmTargetUrl, onRequest } from '../functions/api/crm/[[path]]'
+
+function createContext(url: string, env: Record<string, unknown> = {}) {
+  return {
+    request: new Request(url, {
+      headers: { accept: 'application/json', cookie: 'session=synthetic' },
+    }),
+    env,
+  }
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('CRM API proxy mount', () => {
+  it('mounts admin and team routes on the Core gateway Inventory binding', () => {
+    expect(buildCrmTargetUrl('https://api-staging.skincos.com.br', '/admin/team', '?mode=config'))
+      .toBe('https://api-staging.skincos.com.br/inventory/admin/team?mode=config')
+  })
+
+  it('preserves a configured origin base path and query string', () => {
+    expect(buildCrmTargetUrl('https://api.example.test/base/', '/auth/me', '?status=active'))
+      .toBe('https://api.example.test/base/inventory/auth/me?status=active')
+  })
+
+  it('uses the canonical mount when the Pages handler proxies a request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{"success":true}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const response = await onRequest(createContext(
+      'https://crm-staging.skincos.com.br/api/crm/admin/team?mode=config',
+      { INSUMOS_API_TARGET: 'https://api-staging.skincos.com.br' },
+    ))
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect((fetchMock.mock.calls[0][0] as Request).url)
+      .toBe('https://api-staging.skincos.com.br/inventory/admin/team?mode=config')
+  })
+})


### PR DESCRIPTION
## Objetivo
Corrigir o adaptador Pages usado por Usuários/Equipe e pelo SystemStatus.

## Diagnóstico
O gateway Core monta o Worker Inventory/Identity em `/inventory`, mas `/api/crm/*` construía a URL upstream na raiz de `api.skincos.com.br`, gerando `route_not_found` antes da autenticação em staging.

## Alteração
- centraliza a montagem em `buildCrmTargetUrl`;
- preserva base path e query string;
- encaminha `/api/crm/*` para `/inventory/*`;
- adiciona teste do helper e do handler real.

## Validação
- `npm --prefix crm/console test -- --run tests/crmProxyRoute.test.ts` (3/3)
- `npm --prefix crm/console run typecheck`
- `npm --prefix crm/console run lint` (0 erros; 109 avisos preexistentes)
- `npm --prefix crm/console run build` (525,2 KiB inicial; orçamento 800 KiB)

Sem alteração de banco, secrets, flags ou produção.