### PR TITLE
fix(api): allow bounded inventory binding latency

### DIFF
--- a/api/src/gateway.js
+++ b/api/src/gateway.js
@@ -8,6 +8,11 @@ const isOperationalProbe = (request) => request.method === 'GET' && ['/health', 
 const FINANCE_PROBE_TIMEOUT_MS = 3_000;
 const FINANCE_READ_TIMEOUT_MS = 3_000;
 const FINANCE_WRITE_TIMEOUT_MS = 5_000;
+// Inventory's authenticated routes traverse the service's rate-limiter
+// Durable Object before reaching D1. Keep this bounded, but above the public
+// probe budget so normal cold-start latency is not turned into a fabricated
+// 503 by the Core gateway.
+const INVENTORY_READ_TIMEOUT_MS = 3_000;
 const CLOUDFLARE_VERSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const NETWORK_CONTEXT_RE = /^v1:[A-Za-z0-9_-]{43}$/;
 const B64URL_SHA256_RE = /^[A-Za-z0-9_-]{43}$/;
@@ -134,7 +139,7 @@ export function createApiGateway({ inventoryHandler, timekeepingHandler, finance
 export { createGatewayHandler } from './router.js';
 
 export const handleGatewayRequest = createApiGateway({
-    inventoryHandler: (request, env) => fetchBoundService(request, env, 'INVENTORY', { timeoutMs: 800 }),
+    inventoryHandler: (request, env) => fetchBoundService(request, env, 'INVENTORY', { timeoutMs: INVENTORY_READ_TIMEOUT_MS }),
     timekeepingHandler: (request, env) => fetchBoundService(request, env, 'TIMEKEEPING', { timeoutMs: 800 }),
     financeDomainHandler: forwardFinanceToService,
 });

--- a/api/test/gateway.test.mjs
+++ b/api/test/gateway.test.mjs
@@ -230,6 +230,25 @@ test('default gateway reaches Inventory through the explicit service binding', a
     assert.equal(response.headers.get('x-request-id'), 'inventory-binding-1');
 });
 
+test('default gateway tolerates stateful Inventory binding latency beyond the public probe budget', async () => {
+    resetBoundServiceResilienceForTest();
+    const response = await handleGatewayRequest(
+        new Request('https://api.skincos.com.br/inventory/auth/me'),
+        {
+            INVENTORY: {
+                fetch: async () => {
+                    await new Promise((resolve) => setTimeout(resolve, 1_000));
+                    return new Response('inventory-auth-result', { status: 401 });
+                },
+            },
+        },
+        {},
+    );
+    assert.equal(response.status, 401);
+    assert.equal(await response.text(), 'inventory-auth-result');
+    assert.equal(response.headers.get('x-skincos-dependency-status'), 'live');
+});
+
 test('an unavailable optional Inventory binding degrades only its route and leaves gateway health operational', async () => {
     resetBoundServiceResilienceForTest();
     const inventory = await handleGatewayRequest(new Request('https://api.skincos.com.br/inventory/insumos'), {}, {});


### PR DESCRIPTION
## Context\nAuthenticated Inventory routes traverse the rate-limiter Durable Object before D1. The Core gateway timeout of 800ms converted normal cold-start latency into a synthetic 503.\n\n## Change\n- raise only the Inventory service-binding read deadline to a bounded 3s;\n- preserve fail-closed degradation for missing, timed-out, or 5xx dependencies;\n- add a regression test with a 1s authenticated response.\n\n## Validation\n- api gateway tests: 30/30 passed via invoke-skincos-wsl.ps1.\n- no production deployment included.\n\n## Follow-up\nAfter merge, promote the exact SHA to preview and staging and verify authenticated Inventory/Users routes through the Pages proxy.