### PR TITLE
fix(staging): mirror team unit containment in smoke

### DIFF
--- a/crm/console/scripts/insumos-staging-rbac-smoke.cjs
+++ b/crm/console/scripts/insumos-staging-rbac-smoke.cjs
@@ -24,7 +24,7 @@ const canonical = ['novo-hamburgo', 'barra-shopping-sul']
 const expectedTeamMemberIds = (config) => {
   const allowed = new Set(config.fixture.expectedUnits)
   return fixture.teamMembers
-    .filter((member) => config.admin || member.units.some((unit) => allowed.has(unit)))
+    .filter((member) => config.admin || (member.units.length > 0 && member.units.every((unit) => allowed.has(unit))))
     .map((member) => String(member.onboardingId))
     .sort()
 }


### PR DESCRIPTION
Corrects the synthetic Users/Equipe RBAC expectation to match the deployed containment rule: every target unit must be within the actor scope. A one-unit manager must not see the multi-unit member, while both-unit managers and ADMIN retain the expected rows. Validation: smoke syntax check, fixture test, and git diff --check. No runtime or production changes.