### PR TITLE
test(rbac): stop consultant scenario at team denial

### DIFF
--- a/crm/console/scripts/insumos-staging-rbac-smoke.cjs
+++ b/crm/console/scripts/insumos-staging-rbac-smoke.cjs
@@ -129,6 +129,8 @@ async function runScenario(browser, config) {
     const teamValidation = { configStatus: teamConfig.status, listStatus: null, visibleMembers: null, denied: Boolean(config.teamDenied) }
     if (config.teamDenied) {
       assert(teamConfig.status === 403, `${config.fixture.id}: Consultor must be denied Users/Equipe access, got ${teamConfig.status}`)
+      assertRequestBounds()
+      return { id: config.fixture.id, result: 'team-denied', scopes, requests, team: teamValidation }
     } else {
       assert(teamConfig.status === 200 && teamConfig.json?.data?.enabled === true && teamConfig.json?.data?.legacyEscalaEditor === false, `${config.fixture.id}: unified Users/Equipe config failed (${teamConfig.status})`)
       const teamList = await api(page, `/api/crm/admin/team?status=ACTIVE&q=${encodeURIComponent(fixture.prefix)}`)


### PR DESCRIPTION
## Context\n\nThe staging RBAC journey already validates CONSULTOR access to /api/crm/admin/team?mode=config as 403. The consultant navigation policy intentionally exposes Atendimento and Ponto, not Insumos, so continuing into the Insumos UI made the smoke fail on an expected hidden module.\n\n## Change\n\n- return a sanitized 	eam-denied scenario result after the explicit 403;\n- preserve request-bound assertions;\n- keep all Gestor/ADMIN Insumos data and unit-isolation scenarios unchanged.\n\n## Validation\n\n- 
ode --check crm/console/scripts/insumos-staging-rbac-smoke.cjs;\n- git diff --check;\n- no runtime, database, credentials, or production target changes.