### PR TITLE
fix(clientes): parse Cloudflare capability responses safely

### DIFF
--- a/.github/workflows/atendimento-cloudflare-capability-probe.yml
+++ b/.github/workflows/atendimento-cloudflare-capability-probe.yml
@@ -59,9 +59,9 @@ jobs:
           zone_count="$(jq 'if (.result | type) == "array" then (.result | length) else 0 end' "$tmp/zones.json")"
           existing_id="$(jq -r --arg name "$tunnel_name" 'if (.result | type) == "array" then [.result[] | select(type == "object" and .name == $name and (.deleted_at == null or .deleted_at == "")) | .id][0] // empty else empty end' "$tmp/tunnels.json")"
           existing_count="$(jq --arg name "$tunnel_name" 'if (.result | type) == "array" then [.result[] | select(type == "object" and .name == $name and (.deleted_at == null or .deleted_at == "")) | .id] | length else 0 end' "$tmp/tunnels.json")"
-          account_errors="$(jq -r '[.errors[]? | "\(.code // "unknown"): (.message // "")"] | join("; ")' "$tmp/account.json")"
-          tunnel_errors="$(jq -r '[.errors[]? | "\(.code // "unknown"): (.message // "")"] | join("; ")' "$tmp/tunnels.json")"
-          zone_errors="$(jq -r '[.errors[]? | "\(.code // "unknown"): (.message // "")"] | join("; ")' "$tmp/zones.json")"
+          account_errors="$(jq -r '[.errors[]? | ((.code // "unknown") + ": " + (.message // ""))] | join("; ")' "$tmp/account.json")"
+          tunnel_errors="$(jq -r '[.errors[]? | ((.code // "unknown") + ": " + (.message // ""))] | join("; ")' "$tmp/tunnels.json")"
+          zone_errors="$(jq -r '[.errors[]? | ((.code // "unknown") + ": " + (.message // ""))] | join("; ")' "$tmp/zones.json")"
           printf 'account_http=%s tunnel_list_http=%s zone_http=%s account_read=%s tunnel_list_read=%s zone_read=%s zone_count=%s existing_dedicated_tunnels=%s\n' \
             "$account_http" "$tunnel_http" "$zone_http" "$account_ok" "$tunnel_ok" "$zone_ok" "$zone_count" "$existing_count"
           [[ -z "$account_errors" ]] || printf 'account_error=%s\n' "$account_errors"

--- a/.github/workflows/atendimento-cloudflare-capability-probe.yml
+++ b/.github/workflows/atendimento-cloudflare-capability-probe.yml
@@ -56,11 +56,17 @@ jobs:
           account_ok="$(jq -r '.success // false' "$tmp/account.json")"
           tunnel_ok="$(jq -r '.success // false' "$tmp/tunnels.json")"
           zone_ok="$(jq -r '.success // false' "$tmp/zones.json")"
-          zone_count="$(jq '[.result // []] | length' "$tmp/zones.json")"
-          existing_id="$(jq -r --arg name "$tunnel_name" '[.result // []][] | select(.name == $name and (.deleted_at == null or .deleted_at == "")) | .id' "$tmp/tunnels.json" | head -n1)"
-          existing_count="$(jq --arg name "$tunnel_name" '[.result // []][] | select(.name == $name and (.deleted_at == null or .deleted_at == "")) | .id] | length' "$tmp/tunnels.json")"
+          zone_count="$(jq 'if (.result | type) == "array" then (.result | length) else 0 end' "$tmp/zones.json")"
+          existing_id="$(jq -r --arg name "$tunnel_name" 'if (.result | type) == "array" then [.result[] | select(type == "object" and .name == $name and (.deleted_at == null or .deleted_at == "")) | .id][0] // empty else empty end' "$tmp/tunnels.json")"
+          existing_count="$(jq --arg name "$tunnel_name" 'if (.result | type) == "array" then [.result[] | select(type == "object" and .name == $name and (.deleted_at == null or .deleted_at == "")) | .id] | length else 0 end' "$tmp/tunnels.json")"
+          account_errors="$(jq -r '[.errors[]? | "\(.code // "unknown"): (.message // "")"] | join("; ")' "$tmp/account.json")"
+          tunnel_errors="$(jq -r '[.errors[]? | "\(.code // "unknown"): (.message // "")"] | join("; ")' "$tmp/tunnels.json")"
+          zone_errors="$(jq -r '[.errors[]? | "\(.code // "unknown"): (.message // "")"] | join("; ")' "$tmp/zones.json")"
           printf 'account_http=%s tunnel_list_http=%s zone_http=%s account_read=%s tunnel_list_read=%s zone_read=%s zone_count=%s existing_dedicated_tunnels=%s\n' \
             "$account_http" "$tunnel_http" "$zone_http" "$account_ok" "$tunnel_ok" "$zone_ok" "$zone_count" "$existing_count"
+          [[ -z "$account_errors" ]] || printf 'account_error=%s\n' "$account_errors"
+          [[ -z "$tunnel_errors" ]] || printf 'tunnel_list_error=%s\n' "$tunnel_errors"
+          [[ -z "$zone_errors" ]] || printf 'zone_error=%s\n' "$zone_errors"
 
           [[ "$account_http" =~ ^2[0-9][0-9]$ && "$tunnel_http" =~ ^2[0-9][0-9]$ && "$zone_http" =~ ^2[0-9][0-9]$ && "$account_ok" == true && "$tunnel_ok" == true && "$zone_ok" == true ]] || {
             echo 'Cloudflare capability probe failed closed.' >&2


### PR DESCRIPTION
The first account-scoped capability run reached Cloudflare but the response parser assumed every tunnel result was an object. This narrow fix handles non-list responses, emits only HTTP/error summaries, and remains apply=false by default. No Cloudflare resource was mutated by the failed probe.