### PR TITLE
chore(clientes): attest Cloudflare account scope

### DIFF
--- a/.github/workflows/atendimento-cloudflare-capability-probe.yml
+++ b/.github/workflows/atendimento-cloudflare-capability-probe.yml
@@ -62,8 +62,8 @@ jobs:
           account_errors="$(jq -r '[.errors[]? | ((.code // "unknown") + ": " + (.message // ""))] | join("; ")' "$tmp/account.json")"
           tunnel_errors="$(jq -r '[.errors[]? | ((.code // "unknown") + ": " + (.message // ""))] | join("; ")' "$tmp/tunnels.json")"
           zone_errors="$(jq -r '[.errors[]? | ((.code // "unknown") + ": " + (.message // ""))] | join("; ")' "$tmp/zones.json")"
-          printf 'account_http=%s tunnel_list_http=%s zone_http=%s account_read=%s tunnel_list_read=%s zone_read=%s zone_count=%s existing_dedicated_tunnels=%s\n' \
-            "$account_http" "$tunnel_http" "$zone_http" "$account_ok" "$tunnel_ok" "$zone_ok" "$zone_count" "$existing_count"
+          printf 'account_id=%s account_http=%s tunnel_list_http=%s zone_http=%s account_read=%s tunnel_list_read=%s zone_read=%s zone_count=%s existing_dedicated_tunnels=%s\n' \
+            "$CLOUDFLARE_ACCOUNT_ID" "$account_http" "$tunnel_http" "$zone_http" "$account_ok" "$tunnel_ok" "$zone_ok" "$zone_count" "$existing_count"
           [[ -z "$account_errors" ]] || printf 'account_error=%s\n' "$account_errors"
           [[ -z "$tunnel_errors" ]] || printf 'tunnel_list_error=%s\n' "$tunnel_errors"
           [[ -z "$zone_errors" ]] || printf 'zone_error=%s\n' "$zone_errors"


### PR DESCRIPTION
Prints the non-secret Cloudflare account identifier alongside the existing capability probe result. This is needed to build the fixed host-side tunnel credential after the authorized tunnel creation; no secret value is logged and apply remains manual-only.