### PR TITLE
feat(governance): coordinate global release mutations

### DIFF
--- a/.github/actions/global-coordination-acquire/action.yml
+++ b/.github/actions/global-coordination-acquire/action.yml
@@ -1,0 +1,70 @@
+name: Acquire global coordination lease
+description: Acquire and persist a global coordination lease outside the checkout
+inputs:
+  required:
+    description: Whether the caller must acquire a remote lease
+    required: true
+  enabled:
+    description: Repository-level activation switch
+    required: true
+  coordinator_url:
+    description: HTTPS global coordinator endpoint
+    required: true
+  shared_secret:
+    description: Shared custody secret passed only in process environment
+    required: true
+  resource:
+    description: Canonical resource key to acquire
+    required: true
+  module:
+    description: Release-closure module represented by the lease
+    required: true
+  source_sha:
+    description: Exact source commit whose dependency closure is acquired
+    required: true
+  proof_file:
+    description: Absolute runner-temporary path for the lease proof
+    required: true
+  inputs_json:
+    description: Optional JSON inputs bound into the immutable lease intent
+    required: false
+    default: '{}'
+runs:
+  using: composite
+  steps:
+    - name: Acquire remote custody
+      if: ${{ inputs.required == 'true' }}
+      shell: bash
+      env:
+        SKINCOS_GLOBAL_COORDINATOR_URL: ${{ inputs.coordinator_url }}
+        SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ inputs.shared_secret }}
+        GLOBAL_ENABLED: ${{ inputs.enabled }}
+        GLOBAL_RESOURCE: ${{ inputs.resource }}
+        GLOBAL_MODULE: ${{ inputs.module }}
+        GLOBAL_SOURCE_SHA: ${{ inputs.source_sha }}
+        GLOBAL_PROOF_FILE: ${{ inputs.proof_file }}
+        GLOBAL_INPUTS_JSON: ${{ inputs.inputs_json }}
+        GLOBAL_IDEMPOTENCY_KEY: github:${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ inputs.resource }}
+      run: |
+        set -euo pipefail
+        [[ "$GLOBAL_ENABLED" == true ]] || { echo 'Global coordination is not active'; exit 1; }
+        [[ -n "$SKINCOS_GLOBAL_COORDINATOR_URL" && -n "$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" ]] || { echo 'Global coordination custody is unavailable'; exit 1; }
+        [[ "$GLOBAL_SOURCE_SHA" =~ ^[0-9a-fA-F]{40}$ ]] || { echo 'Global coordination source SHA is invalid'; exit 1; }
+        [[ "$GLOBAL_PROOF_FILE" != "$GITHUB_WORKSPACE"/* ]] || { echo 'Global coordination proof must live outside the repository'; exit 1; }
+        mkdir -p "$(dirname "$GLOBAL_PROOF_FILE")"
+        inputs_file="$RUNNER_TEMP/skincos-global-coordination-inputs.json"
+        printf '%s' "$GLOBAL_INPUTS_JSON" > "$inputs_file"
+        node -e 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));' "$inputs_file"
+        if ! git cat-file -e "${GLOBAL_SOURCE_SHA}^{commit}" 2>/dev/null; then
+          git fetch --no-tags origin "$GLOBAL_SOURCE_SHA"
+        fi
+        git cat-file -e "${GLOBAL_SOURCE_SHA}^{commit}"
+        SKINCOS_GLOBAL_COORDINATOR_URL="$SKINCOS_GLOBAL_COORDINATOR_URL" \
+        SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET="$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" \
+          node scripts/codex-global-coordination-workflow.mjs acquire \
+            --resource "$GLOBAL_RESOURCE" \
+            --module "$GLOBAL_MODULE" \
+            --source "$GLOBAL_SOURCE_SHA" \
+            --proof-file "$GLOBAL_PROOF_FILE" \
+            --inputs-file "$inputs_file" \
+            --idempotency-key "$GLOBAL_IDEMPOTENCY_KEY"

--- a/.github/actions/global-coordination-acquire/action.yml
+++ b/.github/actions/global-coordination-acquire/action.yml
@@ -33,7 +33,9 @@ runs:
   using: composite
   steps:
     - name: Acquire remote custody
-      if: ${{ inputs.required == 'true' }}
+      # Production mutations cannot opt out merely because the authority has
+      # not been provisioned yet. They must fail closed at this boundary.
+      if: ${{ inputs.required == 'true' || github.event.inputs.target == 'production' }}
       shell: bash
       env:
         SKINCOS_GLOBAL_COORDINATOR_URL: ${{ inputs.coordinator_url }}

--- a/.github/actions/global-coordination-check/action.yml
+++ b/.github/actions/global-coordination-check/action.yml
@@ -42,10 +42,11 @@ runs:
         GLOBAL_RESOURCE: ${{ inputs.resource }}
         GLOBAL_MODULE: ${{ inputs.module }}
         GLOBAL_SOURCE_SHA: ${{ inputs.source_sha }}
+        GLOBAL_ENABLED: ${{ inputs.enabled }}
         GLOBAL_PROOF_FILE: ${{ runner.temp }}/skincos-global-coordination-proof-check.json
       run: |
         set -euo pipefail
-        [[ "${{ inputs.enabled }}" == true ]] || { echo 'Global coordination is not active'; exit 1; }
+        [[ "$GLOBAL_ENABLED" == true ]] || { echo 'Global coordination is not active'; exit 1; }
         [[ -n "$SKINCOS_GLOBAL_COORDINATOR_URL" && -n "$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" ]] || { echo 'Global coordination custody is unavailable'; exit 1; }
         [[ "$GLOBAL_SOURCE_SHA" =~ ^[0-9a-fA-F]{40}$ ]] || { echo 'Global coordination source SHA is invalid'; exit 1; }
         if [[ -n "${GLOBAL_PROOF_FILE_INPUT:-}" ]]; then

--- a/.github/actions/global-coordination-check/action.yml
+++ b/.github/actions/global-coordination-check/action.yml
@@ -19,6 +19,9 @@ inputs:
   source_sha:
     description: Exact source commit whose dependency closure is observed
     required: true
+  observed_source_sha:
+    description: Optional explicit current-main source commit used for the observed closure
+    required: false
   enabled:
     description: Repository-level activation switch
     required: true
@@ -42,6 +45,7 @@ runs:
         GLOBAL_RESOURCE: ${{ inputs.resource }}
         GLOBAL_MODULE: ${{ inputs.module }}
         GLOBAL_SOURCE_SHA: ${{ inputs.source_sha }}
+        GLOBAL_OBSERVED_SOURCE_SHA: ${{ inputs.observed_source_sha }}
         GLOBAL_ENABLED: ${{ inputs.enabled }}
         GLOBAL_PROOF_FILE: ${{ runner.temp }}/skincos-global-coordination-proof-check.json
       run: |
@@ -49,6 +53,16 @@ runs:
         [[ "$GLOBAL_ENABLED" == true ]] || { echo 'Global coordination is not active'; exit 1; }
         [[ -n "$SKINCOS_GLOBAL_COORDINATOR_URL" && -n "$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" ]] || { echo 'Global coordination custody is unavailable'; exit 1; }
         [[ "$GLOBAL_SOURCE_SHA" =~ ^[0-9a-fA-F]{40}$ ]] || { echo 'Global coordination source SHA is invalid'; exit 1; }
+        if [[ -z "$GLOBAL_OBSERVED_SOURCE_SHA" ]]; then
+          git fetch --no-tags --force origin main:refs/remotes/origin/main
+          GLOBAL_OBSERVED_SOURCE_SHA="$(git rev-parse refs/remotes/origin/main)"
+        fi
+        [[ "$GLOBAL_OBSERVED_SOURCE_SHA" =~ ^[0-9a-fA-F]{40}$ ]] || { echo 'Observed main source SHA is invalid'; exit 1; }
+        if ! git cat-file -e "${GLOBAL_SOURCE_SHA}^{commit}" 2>/dev/null; then
+          git fetch --no-tags origin "$GLOBAL_SOURCE_SHA"
+        fi
+        git cat-file -e "${GLOBAL_SOURCE_SHA}^{commit}"
+        git cat-file -e "${GLOBAL_OBSERVED_SOURCE_SHA}^{commit}"
         if [[ -n "${GLOBAL_PROOF_FILE_INPUT:-}" ]]; then
           GLOBAL_PROOF_FILE="$GLOBAL_PROOF_FILE_INPUT"
         else
@@ -66,4 +80,5 @@ runs:
             --proof-file "$GLOBAL_PROOF_FILE" \
             --resource "$GLOBAL_RESOURCE" \
             --module "$GLOBAL_MODULE" \
-            --source "$GLOBAL_SOURCE_SHA"
+            --source "$GLOBAL_OBSERVED_SOURCE_SHA" \
+            --candidate-source "$GLOBAL_SOURCE_SHA"

--- a/.github/actions/global-coordination-check/action.yml
+++ b/.github/actions/global-coordination-check/action.yml
@@ -1,0 +1,68 @@
+name: Check global coordination lease
+description: Renew and authorize the remote lease immediately before a governed mutation
+inputs:
+  required:
+    description: Whether the caller must present a remote lease
+    required: true
+  proof_b64:
+    description: Base64 encoded proof emitted by the coordination job
+    required: false
+  proof_file:
+    description: Absolute runner-temporary path containing the lease proof
+    required: false
+  resource:
+    description: Canonical resource key expected by the mutation
+    required: true
+  module:
+    description: Release-closure module used for the observed source
+    required: true
+  source_sha:
+    description: Exact source commit whose dependency closure is observed
+    required: true
+  enabled:
+    description: Repository-level activation switch
+    required: true
+  coordinator_url:
+    description: HTTPS global coordinator endpoint
+    required: true
+  shared_secret:
+    description: Shared custody secret passed only in process environment
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Renew and authorize remote custody
+      if: ${{ inputs.required == 'true' }}
+      shell: bash
+      env:
+        SKINCOS_GLOBAL_COORDINATOR_URL: ${{ inputs.coordinator_url }}
+        SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ inputs.shared_secret }}
+        GLOBAL_PROOF_B64: ${{ inputs.proof_b64 }}
+        GLOBAL_PROOF_FILE_INPUT: ${{ inputs.proof_file }}
+        GLOBAL_RESOURCE: ${{ inputs.resource }}
+        GLOBAL_MODULE: ${{ inputs.module }}
+        GLOBAL_SOURCE_SHA: ${{ inputs.source_sha }}
+        GLOBAL_PROOF_FILE: ${{ runner.temp }}/skincos-global-coordination-proof-check.json
+      run: |
+        set -euo pipefail
+        [[ "${{ inputs.enabled }}" == true ]] || { echo 'Global coordination is not active'; exit 1; }
+        [[ -n "$SKINCOS_GLOBAL_COORDINATOR_URL" && -n "$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" ]] || { echo 'Global coordination custody is unavailable'; exit 1; }
+        [[ "$GLOBAL_SOURCE_SHA" =~ ^[0-9a-fA-F]{40}$ ]] || { echo 'Global coordination source SHA is invalid'; exit 1; }
+        if [[ -n "${GLOBAL_PROOF_FILE_INPUT:-}" ]]; then
+          GLOBAL_PROOF_FILE="$GLOBAL_PROOF_FILE_INPUT"
+        else
+          [[ -n "$GLOBAL_PROOF_B64" ]] || { echo 'Global coordination proof is missing'; exit 1; }
+          printf '%s' "$GLOBAL_PROOF_B64" | base64 -d > "$GLOBAL_PROOF_FILE"
+        fi
+        [[ -f "$GLOBAL_PROOF_FILE" ]] || { echo 'Global coordination proof file is missing'; exit 1; }
+        SKINCOS_GLOBAL_COORDINATOR_URL="$SKINCOS_GLOBAL_COORDINATOR_URL" \
+        SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET="$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" \
+          node scripts/codex-global-coordination-workflow.mjs renew \
+            --proof-file "$GLOBAL_PROOF_FILE"
+        SKINCOS_GLOBAL_COORDINATOR_URL="$SKINCOS_GLOBAL_COORDINATOR_URL" \
+        SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET="$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" \
+          node scripts/codex-global-coordination-workflow.mjs check \
+            --proof-file "$GLOBAL_PROOF_FILE" \
+            --resource "$GLOBAL_RESOURCE" \
+            --module "$GLOBAL_MODULE" \
+            --source "$GLOBAL_SOURCE_SHA"

--- a/.github/actions/global-coordination-check/action.yml
+++ b/.github/actions/global-coordination-check/action.yml
@@ -35,7 +35,9 @@ runs:
   using: composite
   steps:
     - name: Renew and authorize remote custody
-      if: ${{ inputs.required == 'true' }}
+      # Production mutations cannot opt out merely because the authority has
+      # not been provisioned yet. They must fail closed at this boundary.
+      if: ${{ inputs.required == 'true' || github.event.inputs.target == 'production' }}
       shell: bash
       env:
         SKINCOS_GLOBAL_COORDINATOR_URL: ${{ inputs.coordinator_url }}

--- a/.github/actions/global-coordination-release/action.yml
+++ b/.github/actions/global-coordination-release/action.yml
@@ -1,0 +1,36 @@
+name: Release global coordination lease
+description: Release a global coordination lease when a governed job exits
+inputs:
+  required:
+    description: Whether the caller acquired a remote lease
+    required: true
+  coordinator_url:
+    description: HTTPS global coordinator endpoint
+    required: true
+  shared_secret:
+    description: Shared custody secret passed only in process environment
+    required: true
+  proof_file:
+    description: Absolute runner-temporary path containing the lease proof
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Release remote custody
+      if: ${{ inputs.required == 'true' }}
+      shell: bash
+      env:
+        SKINCOS_GLOBAL_COORDINATOR_URL: ${{ inputs.coordinator_url }}
+        SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ inputs.shared_secret }}
+        GLOBAL_PROOF_FILE: ${{ inputs.proof_file }}
+      run: |
+        set -euo pipefail
+        [[ -n "$SKINCOS_GLOBAL_COORDINATOR_URL" && -n "$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" ]] || { echo 'Global coordination custody is unavailable'; exit 1; }
+        if [[ ! -f "$GLOBAL_PROOF_FILE" ]]; then
+          echo 'No global coordination proof was acquired; nothing to release'
+          exit 0
+        fi
+        SKINCOS_GLOBAL_COORDINATOR_URL="$SKINCOS_GLOBAL_COORDINATOR_URL" \
+        SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET="$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" \
+          node scripts/codex-global-coordination-workflow.mjs release \
+            --proof-file "$GLOBAL_PROOF_FILE"

--- a/.github/actions/global-coordination-release/action.yml
+++ b/.github/actions/global-coordination-release/action.yml
@@ -17,7 +17,9 @@ runs:
   using: composite
   steps:
     - name: Release remote custody
-      if: ${{ inputs.required == 'true' }}
+      # Production mutations cannot opt out merely because the authority has
+      # not been provisioned yet. They must fail closed at this boundary.
+      if: ${{ inputs.required == 'true' || github.event.inputs.target == 'production' }}
       shell: bash
       env:
         SKINCOS_GLOBAL_COORDINATOR_URL: ${{ inputs.coordinator_url }}

--- a/.github/scripts/ponto-dispatch-run-match.mjs
+++ b/.github/scripts/ponto-dispatch-run-match.mjs
@@ -6,12 +6,13 @@ export function matchesDispatchedRun(item, {
   dispatchRequestedAt,
   expectedDisplayTitle,
   dispatchNonce,
+  headShaMatches,
 }) {
   // REST workflow-run objects expose the canonical workflow file path without
   // a ref suffix. Branch and immutable source are attested independently below.
   return item?.workflow_id === workflowId
     && item?.path === expectedPath
-    && item?.head_sha === orchestratorHeadSha
+    && (typeof headShaMatches === "function" ? headShaMatches(item?.head_sha) : item?.head_sha === orchestratorHeadSha)
     && Number.isFinite(Date.parse(String(item?.created_at || "")))
     && Date.parse(String(item.created_at)) >= Date.parse(dispatchRequestedAt) - 2_000
     && (

--- a/.github/scripts/ponto-dispatch-run-match.test.mjs
+++ b/.github/scripts/ponto-dispatch-run-match.test.mjs
@@ -36,3 +36,10 @@ test("matches only a run created for the current dispatch", () => {
     path: ".github/workflows/other.yml",
   }, expected), false);
 });
+
+test("allows a current main head when the caller supplies a closure validator", () => {
+  assert.equal(matchesDispatchedRun({ ...current, head_sha: "b".repeat(40) }, {
+    ...expected,
+    headShaMatches: (headSha) => headSha === "b".repeat(40),
+  }), true);
+});

--- a/.github/scripts/ponto-dispatch-workflow.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.mjs
@@ -1,8 +1,15 @@
 import crypto from "node:crypto";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { matchesDispatchedRun } from "./ponto-dispatch-run-match.mjs";
+import {
+  assertDependencyClosureUnchanged,
+  dependencyClosureForSource,
+  lockScopeFor,
+  normalizeResourceKey,
+} from "../../scripts/codex-global-coordinator.mjs";
 import {
   capabilityCheckName,
   capabilityExternalId,
@@ -38,6 +45,49 @@ export function assertMainShaUnchanged(orchestratorSha, mainSha) {
     throw new Error("main advanced after the immutable Ponto coordinator was selected");
   }
   return expected;
+}
+
+export function assertPontoDependencyClosureUnchanged(orchestratorDigest, mainDigest) {
+  return assertDependencyClosureUnchanged(orchestratorDigest, mainDigest);
+}
+
+export function globalResourceFor(workflow, inputs) {
+  const target = String(inputs?.target || "").trim().toLowerCase();
+  const stage = String(inputs?.stage || inputs?.orchestrator_stage || "").trim().toLowerCase();
+  const lifecycle = target || stage;
+  const environment = target || stage;
+  if (!["preview", "staging", "pilot", "canary", "production", "rollback"].includes(lifecycle)) return "";
+  if (workflow === "deploy-timekeeping.yml" && inputs.release_scope === "ponto") return normalizeResourceKey(`deploy:timekeeping:${environment}`);
+  if (workflow === "deploy-core-workers.yml" && inputs.release_scope === "ponto" && ["api", "inventory"].includes(inputs.unit)) {
+    return normalizeResourceKey(`deploy:core-${inputs.unit}:${environment}`);
+  }
+  if (workflow === "deploy-crm-pages.yml" && inputs.release_scope === "ponto") return normalizeResourceKey(`deploy:crm-pages:${environment}`);
+  if (workflow === "cloudflare-workers-sync-ponto-secrets.yml") return normalizeResourceKey(`cloudflare:ponto-workers:${environment}`);
+  if (workflow === "cloudflare-pages-sync-ponto.yml") return normalizeResourceKey(`cloudflare:ponto-pages:${environment}`);
+  if (["timekeeping-staging-journey.yml", "ponto-staging-rollback-drill.yml", "ponto-production-baseline.yml", "ponto-production-slo.yml"].includes(workflow)) {
+    return normalizeResourceKey(`release:ponto`);
+  }
+  if (workflow === "module-availability.yml" && inputs.module === "timekeeping") return normalizeResourceKey("release:ponto");
+  return "";
+}
+
+function localCommitAvailable(commit) {
+  try {
+    execFileSync("git", ["cat-file", "-e", `${commit}^{commit}`], { cwd: path.resolve(import.meta.dirname, "../.."), stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function ensureCommitAvailable(commit) {
+  if (localCommitAvailable(commit)) return;
+  execFileSync("git", ["fetch", "--no-tags", "origin", commit], { cwd: path.resolve(import.meta.dirname, "../.."), stdio: "ignore" });
+  if (!localCommitAvailable(commit)) throw new Error("current main commit could not be fetched for dependency-closure attestation");
+}
+
+function pontoDependencyClosureDigest(sourceCommit) {
+  return dependencyClosureForSource({ module: "ponto", sourceCommit }).digest;
 }
 
 export function governedLeaseKeyFor(workflow, inputs) {
@@ -160,7 +210,13 @@ const request = async (pathname, init = {}) => {
 };
 
 const currentMain = await request(`/repos/${repository}/commits/main`);
-assertMainShaUnchanged(orchestratorHeadSha, currentMain?.sha);
+const currentMainSha = String(currentMain?.sha || "").trim().toLowerCase();
+if (!/^[0-9a-f]{40}$/.test(currentMainSha)) throw new Error("current main SHA is unavailable");
+ensureCommitAvailable(currentMainSha);
+assertPontoDependencyClosureUnchanged(
+  pontoDependencyClosureDigest(orchestratorHeadSha),
+  pontoDependencyClosureDigest(currentMainSha),
+);
 
 const inputs = JSON.parse(fs.readFileSync(inputsFile, "utf8"));
 inputs.orchestrator_run_id = correlation;
@@ -261,6 +317,10 @@ fs.writeFileSync(outputFile, `${JSON.stringify({
   orchestratorRunId: correlation,
   dispatchNonce,
   leaseKey,
+  resourceKey: globalResourceFor(workflow, normalizedIntent || inputs),
+  lockScope: globalResourceFor(workflow, normalizedIntent || inputs)
+    ? lockScopeFor(globalResourceFor(workflow, normalizedIntent || inputs))
+    : "",
   intentDigest,
 }, null, 2)}\n`, { mode: 0o600 });
 await request(`/repos/${repository}/actions/workflows/${encodeURIComponent(workflow)}/dispatches`, {

--- a/.github/scripts/ponto-dispatch-workflow.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.mjs
@@ -11,6 +11,14 @@ import {
   normalizeResourceKey,
 } from "../../scripts/codex-global-coordinator.mjs";
 import {
+  acquireGlobalLease,
+  buildLeaseRequest,
+  checkGlobalLease,
+  proofForLease,
+  releaseGlobalLease,
+  renewGlobalLease,
+} from "../../scripts/codex-global-coordination-client.mjs";
+import {
   capabilityCheckName,
   capabilityExternalId,
   canonicalizeGovernedIntent,
@@ -58,7 +66,7 @@ export function globalResourceFor(workflow, inputs) {
   const environment = target || stage;
   if (!["preview", "staging", "pilot", "canary", "production", "rollback"].includes(lifecycle)) return "";
   if (workflow === "deploy-timekeeping.yml" && inputs.release_scope === "ponto") return normalizeResourceKey(`deploy:timekeeping:${environment}`);
-  if (workflow === "deploy-core-workers.yml" && inputs.release_scope === "ponto" && ["api", "inventory"].includes(inputs.unit)) {
+  if (workflow === "deploy-core-workers.yml" && inputs.release_scope === "ponto" && ["api", "inventory", "all"].includes(inputs.unit)) {
     return normalizeResourceKey(`deploy:core-${inputs.unit}:${environment}`);
   }
   if (workflow === "deploy-crm-pages.yml" && inputs.release_scope === "ponto") return normalizeResourceKey(`deploy:crm-pages:${environment}`);
@@ -88,6 +96,90 @@ function ensureCommitAvailable(commit) {
 
 function pontoDependencyClosureDigest(sourceCommit) {
   return dependencyClosureForSource({ module: "ponto", sourceCommit }).digest;
+}
+
+function globalCoordinationRequired() {
+  const value = String(process.env.SKINCOS_GLOBAL_COORDINATION_REQUIRED || "").trim().toLowerCase();
+  if (value && value !== "true" && value !== "false") throw new Error("SKINCOS_GLOBAL_COORDINATION_REQUIRED must be true or false");
+  return value === "true";
+}
+
+function globalCoordinationOwner({ repository, correlation, workflow, stage, actor, runId }) {
+  return {
+    provider: "github",
+    missionId: `github:${repository}:${correlation}`,
+    threadId: `${workflow}:${correlation}:${stage || "preview"}`,
+    actor: actor || "github-actions",
+    runId,
+  };
+}
+
+function sourceTreeForCommit(commit) {
+  return execFileSync("git", ["rev-parse", `${commit}^{tree}`], {
+    cwd: path.resolve(import.meta.dirname, "../.."),
+    encoding: "utf8",
+  }).trim().toLowerCase();
+}
+
+async function acquireGlobalDispatchLease({ resourceKey, workflow, inputs, repository, correlation, stage, actor, runId, sourceCommit, dependencyClosureDigest }) {
+  if (!globalCoordinationRequired()) return null;
+  if (!resourceKey) throw new Error(`global coordination resource is undefined for ${workflow}`);
+  const url = String(process.env.SKINCOS_GLOBAL_COORDINATOR_URL || "").trim();
+  const secret = String(process.env.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET || "").trim();
+  if (!url || !secret) throw new Error("global coordination authority custody is unavailable");
+  const owner = globalCoordinationOwner({ repository, correlation, workflow, stage, actor, runId });
+  const intent = {
+    module: "ponto",
+    workflow,
+    sourceCommit,
+    sourceTree: sourceTreeForCommit(sourceCommit),
+    dependencyClosureDigest,
+    inputs,
+  };
+  const idempotencyKey = `ponto:${correlation}:${workflow}:${resourceKey}:${stage || "preview"}`;
+  const request = buildLeaseRequest({
+    operation: "mutation",
+    resource: resourceKey,
+    owner,
+    intent,
+    idempotencyKey,
+    ttlMs: 900_000,
+  });
+  const result = await acquireGlobalLease({ request, url });
+  if (result.passed !== true || !result.lease) {
+    throw new Error(`global coordination lease acquisition failed: ${result.reason || "unknown"}`);
+  }
+  return {
+    proof: proofForLease(result.lease),
+    url,
+    lastRenewedAt: Date.now(),
+  };
+}
+
+async function revalidateGlobalDispatchLease(lease, { resourceKey, observedDependencyClosureDigest }) {
+  if (!lease) return;
+  if (Date.now() - lease.lastRenewedAt >= 5 * 60 * 1000) {
+    const renewed = await renewGlobalLease({ proof: lease.proof, ttlMs: 900_000, url: lease.url });
+    if (renewed.passed !== true || !renewed.lease) throw new Error(`global coordination lease renewal failed: ${renewed.reason || "unknown"}`);
+    lease.proof = proofForLease(renewed.lease);
+    lease.lastRenewedAt = Date.now();
+  }
+  const checked = await checkGlobalLease({
+    proof: lease.proof,
+    url: lease.url,
+    authorization: {
+      expectedResource: resourceKey,
+      expectedIntentDigest: lease.proof.intentDigest,
+      observedDependencyClosureDigest,
+    },
+  });
+  if (checked.passed !== true) throw new Error(`global coordination mutation authorization failed: ${checked.reason || "unknown"}`);
+}
+
+async function releaseGlobalDispatchLease(lease) {
+  if (!lease) return;
+  const released = await releaseGlobalLease({ proof: lease.proof, url: lease.url });
+  if (released.passed !== true) throw new Error(`global coordination lease release failed: ${released.reason || "unknown"}`);
 }
 
 export function governedLeaseKeyFor(workflow, inputs) {
@@ -299,6 +391,21 @@ if (leaseKey) {
     || parentRun?.display_title !== `Ponto ${process.env.STAGE} ${orchestratorHeadSha} orchestrator=${correlation}`
   ) throw new Error("active Ponto coordinator cannot issue a child-bound capability");
 }
+const globalResourceKey = globalResourceFor(workflow, normalizedIntent || inputs);
+const globalDispatchLease = await acquireGlobalDispatchLease({
+  resourceKey: globalResourceKey,
+  workflow,
+  inputs: normalizedIntent || inputs,
+  repository,
+  correlation,
+  stage: String(process.env.STAGE || inputs.stage || inputs.target || "preview").trim().toLowerCase(),
+  actor: String(process.env.GITHUB_ACTOR || "github-actions").trim(),
+  runId: issuerRunId,
+  sourceCommit: orchestratorHeadSha,
+  dependencyClosureDigest: pontoDependencyClosureDigest(orchestratorHeadSha),
+});
+let globalDispatchLeaseReleased = false;
+try {
 fs.mkdirSync(path.dirname(outputFile), { recursive: true });
 fs.writeFileSync(outputFile, `${JSON.stringify({
   schemaVersion: 1,
@@ -317,12 +424,31 @@ fs.writeFileSync(outputFile, `${JSON.stringify({
   orchestratorRunId: correlation,
   dispatchNonce,
   leaseKey,
-  resourceKey: globalResourceFor(workflow, normalizedIntent || inputs),
-  lockScope: globalResourceFor(workflow, normalizedIntent || inputs)
-    ? lockScopeFor(globalResourceFor(workflow, normalizedIntent || inputs))
+  resourceKey: globalResourceKey,
+  lockScope: globalResourceKey
+    ? lockScopeFor(globalResourceKey)
     : "",
   intentDigest,
+  globalCoordination: globalDispatchLease ? {
+    required: true,
+    resourceKey: globalResourceKey,
+    lockScope: lockScopeFor(globalResourceKey),
+    fencingToken: globalDispatchLease.proof.fencingToken,
+  } : { required: false },
 }, null, 2)}\n`, { mode: 0o600 });
+const dispatchMain = await request(`/repos/${repository}/commits/main`);
+const dispatchMainSha = String(dispatchMain?.sha || "").trim().toLowerCase();
+if (!/^[0-9a-f]{40}$/.test(dispatchMainSha)) throw new Error("current main SHA is unavailable before child dispatch");
+ensureCommitAvailable(dispatchMainSha);
+const dispatchClosureDigest = pontoDependencyClosureDigest(dispatchMainSha);
+assertPontoDependencyClosureUnchanged(
+  pontoDependencyClosureDigest(orchestratorHeadSha),
+  dispatchClosureDigest,
+);
+await revalidateGlobalDispatchLease(globalDispatchLease, {
+  resourceKey: globalResourceKey,
+  observedDependencyClosureDigest: dispatchClosureDigest,
+});
 await request(`/repos/${repository}/actions/workflows/${encodeURIComponent(workflow)}/dispatches`, {
   method: "POST",
   headers: { "content-type": "application/json" },
@@ -334,6 +460,8 @@ await request(`/repos/${repository}/actions/workflows/${encodeURIComponent(workf
     ])),
   }),
 });
+await releaseGlobalDispatchLease(globalDispatchLease);
+globalDispatchLeaseReleased = true;
 
 let run;
 let persistedRunId = "";
@@ -601,6 +729,12 @@ const sanitized = {
   headSha: run.head_sha,
   repository,
   url: run.html_url,
+  resourceKey: globalResourceKey,
+  lockScope: globalResourceKey ? lockScopeFor(globalResourceKey) : "",
+  globalCoordination: globalDispatchLease ? {
+    required: true,
+    fencingToken: globalDispatchLease.proof.fencingToken,
+  } : { required: false },
 };
 fs.mkdirSync(path.dirname(outputFile), { recursive: true });
 fs.writeFileSync(outputFile, `${JSON.stringify(sanitized, null, 2)}\n`, { mode: 0o600 });
@@ -609,6 +743,9 @@ if (run.conclusion !== "success") {
 }
 if (output) fs.appendFileSync(output, `run_id=${run.id}\nrun_url=${run.html_url}\n`);
 process.stdout.write(`${workflow} completed successfully as run ${run.id}.\n`);
+} finally {
+  if (!globalDispatchLeaseReleased) await releaseGlobalDispatchLease(globalDispatchLease);
+}
 }
 
 const invokedAsScript = process.argv[1]

--- a/.github/scripts/ponto-dispatch-workflow.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.mjs
@@ -27,6 +27,7 @@ import {
   resolveCapabilityVerifier,
   verifyCapabilityDocument,
 } from "./ponto-orchestrator-lease.mjs";
+import { assertPontoSourceClosureUnchanged } from "./ponto-source-closure.mjs";
 
 export const isBodylessResponseStatus = (status) => status === 202 || status === 204;
 export const readGitHubResponse = (response) => (
@@ -45,15 +46,6 @@ export const dispatchTimeoutMsFor = (workflow, configuredTimeoutMs) => Math.max(
   configuredTimeoutMs,
   minimumDispatchTimeoutMsByWorkflow[workflow] || 0,
 );
-
-export function assertMainShaUnchanged(orchestratorSha, mainSha) {
-  const expected = String(orchestratorSha || "").trim().toLowerCase();
-  const observed = String(mainSha || "").trim().toLowerCase();
-  if (!/^[0-9a-f]{40}$/.test(expected) || observed !== expected) {
-    throw new Error("main advanced after the immutable Ponto coordinator was selected");
-  }
-  return expected;
-}
 
 export function assertPontoDependencyClosureUnchanged(orchestratorDigest, mainDigest) {
   return assertDependencyClosureUnchanged(orchestratorDigest, mainDigest);
@@ -124,6 +116,7 @@ function sourceTreeForCommit(commit) {
 async function acquireGlobalDispatchLease({ resourceKey, workflow, inputs, repository, correlation, stage, actor, runId, sourceCommit, dependencyClosureDigest }) {
   if (!globalCoordinationRequired()) return null;
   if (!resourceKey) throw new Error(`global coordination resource is undefined for ${workflow}`);
+  if (resourceKey === "release:ponto" && compositeCoordinationProofFile()) return null;
   const url = String(process.env.SKINCOS_GLOBAL_COORDINATOR_URL || "").trim();
   const secret = String(process.env.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET || "").trim();
   if (!url || !secret) throw new Error("global coordination authority custody is unavailable");
@@ -180,6 +173,54 @@ async function releaseGlobalDispatchLease(lease) {
   if (!lease) return;
   const released = await releaseGlobalLease({ proof: lease.proof, url: lease.url });
   if (released.passed !== true) throw new Error(`global coordination lease release failed: ${released.reason || "unknown"}`);
+}
+
+function compositeCoordinationProofFile() {
+  const value = String(process.env.PONTO_ORCHESTRATOR_COORDINATION_PROOF_FILE || "").trim();
+  return value || null;
+}
+
+function writeCompositeCoordinationProof(file, lease) {
+  const resolved = path.resolve(file);
+  const repositoryRoot = path.resolve(import.meta.dirname, "../..");
+  if (resolved === repositoryRoot || resolved.startsWith(`${repositoryRoot}${path.sep}`)) {
+    throw new Error("Ponto composite coordination proof must remain outside the checkout");
+  }
+  fs.mkdirSync(path.dirname(resolved), { recursive: true, mode: 0o700 });
+  const temporary = `${resolved}.tmp.${process.pid}`;
+  fs.writeFileSync(temporary, `${JSON.stringify(proofForLease(lease), null, 2)}\n`, { mode: 0o600 });
+  fs.renameSync(temporary, resolved);
+}
+
+async function revalidatePontoCompositeLease({ observedDependencyClosureDigest }) {
+  if (!globalCoordinationRequired()) return false;
+  const proofFile = compositeCoordinationProofFile();
+  if (!proofFile) return false;
+  const url = String(process.env.SKINCOS_GLOBAL_COORDINATOR_URL || "").trim();
+  if (!url || !String(process.env.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET || "").trim()) {
+    throw new Error("global coordination authority custody is unavailable");
+  }
+  const proof = JSON.parse(fs.readFileSync(proofFile, "utf8"));
+  if (proof.resource !== "release:ponto") throw new Error("Ponto composite proof resource is invalid");
+  const renewed = await renewGlobalLease({ proof, ttlMs: 900_000, url });
+  if (renewed.passed !== true || !renewed.lease) {
+    throw new Error(`Ponto composite lease renewal failed: ${renewed.reason || "unknown"}`);
+  }
+  const renewedProof = proofForLease(renewed.lease);
+  writeCompositeCoordinationProof(proofFile, renewed.lease);
+  const checked = await checkGlobalLease({
+    proof: renewedProof,
+    url,
+    authorization: {
+      expectedResource: "release:ponto",
+      expectedIntentDigest: renewedProof.intentDigest,
+      observedDependencyClosureDigest,
+    },
+  });
+  if (checked.passed !== true) {
+    throw new Error(`Ponto composite coordination authorization failed: ${checked.reason || "unknown"}`);
+  }
+  return true;
 }
 
 export function governedLeaseKeyFor(workflow, inputs) {
@@ -301,6 +342,16 @@ const request = async (pathname, init = {}) => {
   return readGitHubResponse(response);
 };
 
+const cancelActiveChildBestEffort = async (candidate) => {
+  if (!candidate || candidate.status === "completed") return;
+  try {
+    await request(`/repos/${repository}/actions/runs/${candidate.id}/cancel`, { method: "POST" });
+  } catch {
+    // The coordinator still fails closed; a missing cancellation response is
+    // recorded by the failed parent run and never authorizes another mutation.
+  }
+};
+
 const currentMain = await request(`/repos/${repository}/commits/main`);
 const currentMainSha = String(currentMain?.sha || "").trim().toLowerCase();
 if (!/^[0-9a-f]{40}$/.test(currentMainSha)) throw new Error("current main SHA is unavailable");
@@ -309,6 +360,9 @@ assertPontoDependencyClosureUnchanged(
   pontoDependencyClosureDigest(orchestratorHeadSha),
   pontoDependencyClosureDigest(currentMainSha),
 );
+await revalidatePontoCompositeLease({
+  observedDependencyClosureDigest: pontoDependencyClosureDigest(currentMainSha),
+});
 
 const inputs = JSON.parse(fs.readFileSync(inputsFile, "utf8"));
 inputs.orchestrator_run_id = correlation;
@@ -405,6 +459,7 @@ const globalDispatchLease = await acquireGlobalDispatchLease({
   dependencyClosureDigest: pontoDependencyClosureDigest(orchestratorHeadSha),
 });
 let globalDispatchLeaseReleased = false;
+let compositeLeaseLastRenewedAt = Date.now();
 try {
 fs.mkdirSync(path.dirname(outputFile), { recursive: true });
 fs.writeFileSync(outputFile, `${JSON.stringify({
@@ -445,6 +500,8 @@ assertPontoDependencyClosureUnchanged(
   pontoDependencyClosureDigest(orchestratorHeadSha),
   dispatchClosureDigest,
 );
+await revalidatePontoCompositeLease({ observedDependencyClosureDigest: dispatchClosureDigest });
+compositeLeaseLastRenewedAt = Date.now();
 await revalidateGlobalDispatchLease(globalDispatchLease, {
   resourceKey: globalResourceKey,
   observedDependencyClosureDigest: dispatchClosureDigest,
@@ -469,6 +526,20 @@ let capabilityIssued = false;
 let capabilityCheckId = 0;
 let capabilityCheckAppId = 0;
 while (Date.now() - startedAt < timeoutMs) {
+  if (compositeCoordinationProofFile() && Date.now() - compositeLeaseLastRenewedAt >= 5 * 60 * 1000) {
+    try {
+      const observedMain = await request(`/repos/${repository}/commits/main`);
+      const observedMainSha = String(observedMain?.sha || "").trim().toLowerCase();
+      if (!/^[0-9a-f]{40}$/.test(observedMainSha)) throw new Error("current main SHA is unavailable during child dispatch");
+      ensureCommitAvailable(observedMainSha);
+      const observedClosureDigest = pontoDependencyClosureDigest(observedMainSha);
+      await revalidatePontoCompositeLease({ observedDependencyClosureDigest: observedClosureDigest });
+      compositeLeaseLastRenewedAt = Date.now();
+    } catch (coordinationError) {
+      await cancelActiveChildBestEffort(run);
+      throw coordinationError;
+    }
+  }
   const payload = await request(`/repos/${repository}/actions/workflows/${encodeURIComponent(workflow)}/runs?event=workflow_dispatch&branch=main&per_page=50`);
   const matches = (payload.workflow_runs || [])
     .filter((item) => matchesDispatchedRun(item, {
@@ -481,6 +552,10 @@ while (Date.now() - startedAt < timeoutMs) {
         ? expectedGovernedRunName(expectedPath, normalizedIntent)
         : undefined,
       dispatchNonce: leaseKey ? dispatchNonce : undefined,
+      // The immutable release SHA remains the artifact identity. The run is
+      // dispatched from main, so its head may advance independently while its
+      // Ponto dependency closure remains unchanged.
+      headShaMatches: () => true,
     }));
   if (matches.length > 1) {
     throw new Error(`dispatched ${workflow} correlation is ambiguous`);
@@ -490,6 +565,12 @@ while (Date.now() - startedAt < timeoutMs) {
     run = await request(`/repos/${repository}/actions/runs/${run.id}`);
     const childRunId = String(run.id);
     const expectedDisplayTitle = expectedGovernedRunName(expectedPath, normalizedIntent);
+    const childHeadSha = String(run.head_sha || "").trim().toLowerCase();
+    try {
+      assertPontoSourceClosureUnchanged(orchestratorHeadSha, childHeadSha);
+    } catch {
+      throw new Error("dispatched Ponto child source closure differs from the immutable release");
+    }
     if (
       run.workflow_id !== workflowMetadata.id
       || !pathMatchesMainRef(run.path, expectedPath)
@@ -498,7 +579,6 @@ while (Date.now() - startedAt < timeoutMs) {
       || run.conclusion != null
       || run.event !== "workflow_dispatch"
       || run.head_branch !== "main"
-      || run.head_sha !== orchestratorHeadSha
       || run.name !== expectedDisplayTitle
       || run.display_title !== expectedDisplayTitle
       || String(run?.repository?.id || "") !== repositoryId
@@ -650,13 +730,17 @@ if (
   run.workflow_id !== workflowMetadata.id
   || !pathMatchesMainRef(run.path, expectedPath)
   || run.run_attempt !== 1
-  || run.head_sha !== orchestratorHeadSha
   || run.event !== "workflow_dispatch"
   || run.head_branch !== "main"
   || run.repository?.full_name !== repository
   || run.head_repository?.full_name !== repository
 ) {
   throw new Error(`${workflow} run ${run.id} failed provenance or success checks`);
+}
+try {
+  assertPontoSourceClosureUnchanged(orchestratorHeadSha, String(run.head_sha || "").trim().toLowerCase());
+} catch {
+  throw new Error(`${workflow} run ${run.id} executed outside the immutable Ponto dependency closure`);
 }
 if (leaseKey && (
   String(run.id) !== persistedRunId

--- a/.github/scripts/ponto-dispatch-workflow.test.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.test.mjs
@@ -3,7 +3,9 @@ import crypto from "node:crypto";
 import test from "node:test";
 import {
   assertMainShaUnchanged,
+  assertPontoDependencyClosureUnchanged,
   dispatchTimeoutMsFor,
+  globalResourceFor,
   governedLeaseKeyFor,
   isBodylessResponseStatus,
   readGitHubResponse,
@@ -82,6 +84,23 @@ test("child dispatch refuses a coordinator SHA after main advances", () => {
     () => assertMainShaUnchanged(sha, "b".repeat(40)),
     /main advanced after the immutable Ponto coordinator was selected/,
   );
+});
+
+test("child dispatch keeps an immutable release valid across unrelated main changes", () => {
+  const digest = "c".repeat(64);
+  assert.equal(assertPontoDependencyClosureUnchanged(digest, digest).valid, true);
+  assert.throws(
+    () => assertPontoDependencyClosureUnchanged(digest, "d".repeat(64)),
+    /relevant dependency-closure input changed/,
+  );
+});
+
+test("Ponto child mutations expose the canonical global resource and conflict scope", () => {
+  assert.equal(globalResourceFor("deploy-timekeeping.yml", { release_scope: "ponto", target: "staging" }), "deploy:timekeeping:staging");
+  assert.equal(globalResourceFor("cloudflare-pages-sync-ponto.yml", { target: "staging" }), "cloudflare:ponto-pages:staging");
+  assert.equal(globalResourceFor("module-availability.yml", { module: "timekeeping", target: "production" }), "release:ponto");
+  assert.equal(globalResourceFor("ponto-production-baseline.yml", { orchestrator_stage: "pilot" }), "release:ponto");
+  assert.equal(globalResourceFor("deploy-core-workers.yml", { release_scope: "general", unit: "api", target: "production" }), "");
 });
 
 test("governed success requires one exact Ed25519-consumed capability check", () => {

--- a/.github/scripts/ponto-dispatch-workflow.test.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.test.mjs
@@ -98,6 +98,8 @@ test("child dispatch keeps an immutable release valid across unrelated main chan
 test("Ponto child mutations expose the canonical global resource and conflict scope", () => {
   assert.equal(globalResourceFor("deploy-timekeeping.yml", { release_scope: "ponto", target: "staging" }), "deploy:timekeeping:staging");
   assert.equal(globalResourceFor("cloudflare-pages-sync-ponto.yml", { target: "staging" }), "cloudflare:ponto-pages:staging");
+  assert.equal(globalResourceFor("deploy-core-workers.yml", { release_scope: "ponto", unit: "api", target: "staging" }), "deploy:core-api:staging");
+  assert.equal(globalResourceFor("deploy-core-workers.yml", { release_scope: "ponto", unit: "all", target: "staging" }), "deploy:core-all:staging");
   assert.equal(globalResourceFor("module-availability.yml", { module: "timekeeping", target: "production" }), "release:ponto");
   assert.equal(globalResourceFor("ponto-production-baseline.yml", { orchestrator_stage: "pilot" }), "release:ponto");
   assert.equal(globalResourceFor("deploy-core-workers.yml", { release_scope: "general", unit: "api", target: "production" }), "");

--- a/.github/scripts/ponto-dispatch-workflow.test.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.test.mjs
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import crypto from "node:crypto";
 import test from "node:test";
 import {
-  assertMainShaUnchanged,
   assertPontoDependencyClosureUnchanged,
   dispatchTimeoutMsFor,
   globalResourceFor,
@@ -75,15 +74,6 @@ test("preview dispatches never require a capability while every governed mutatio
     release_scope: "general",
     unit: "api",
   }), "");
-});
-
-test("child dispatch refuses a coordinator SHA after main advances", () => {
-  const sha = "a".repeat(40);
-  assert.equal(assertMainShaUnchanged(sha, sha.toUpperCase()), sha);
-  assert.throws(
-    () => assertMainShaUnchanged(sha, "b".repeat(40)),
-    /main advanced after the immutable Ponto coordinator was selected/,
-  );
 });
 
 test("child dispatch keeps an immutable release valid across unrelated main changes", () => {

--- a/.github/scripts/ponto-emergency-stop.mjs
+++ b/.github/scripts/ponto-emergency-stop.mjs
@@ -9,10 +9,12 @@ import {
   verifyCapabilityDocument,
 } from "./ponto-orchestrator-lease.mjs";
 import { attestTerminalPreMutationGateFailure } from "./ponto-child-mutation-attestation.mjs";
+import { pontoSourceClosureMatches } from "./ponto-source-closure.mjs";
 
 const COORDINATOR_TITLE = /^Ponto (staging|pilot|canary|production|rollback) ([0-9a-f]{40}) orchestrator=([1-9][0-9]*)$/;
 const CAPABILITY_CHECK_NAME =
   /^ponto-lease\/([a-z][a-z0-9-]{1,63})\/([1-9][0-9]*)\/([0-9a-f]{32})$/;
+const FULL_SHA = /^[0-9a-f]{40}$/i;
 export const NON_TERMINAL_STATUSES = ["queued", "in_progress", "waiting", "pending", "requested"];
 const NON_TERMINAL = new Set(NON_TERMINAL_STATUSES);
 const ALLOWED_HIGH_RISK_EVENTS = new Set(["workflow_dispatch", "schedule"]);
@@ -327,11 +329,13 @@ if (invokedAsScript) {
     record.capabilityInventoryScans = (record.capabilityInventoryScans || 0) + 1;
     const run = record.live;
     try {
+      const releaseSha = String(record.releaseSha || "").trim().toLowerCase();
+      if (!FULL_SHA.test(releaseSha)) throw new Error("child release identity is unavailable");
       const checks = [];
       let exhausted = false;
       for (let page = 1; page <= 20; page += 1) {
         const payload = await request(
-          `/repos/${repository}/commits/${run.head_sha}/check-runs?filter=all&per_page=100&page=${page}`,
+          `/repos/${repository}/commits/${releaseSha}/check-runs?filter=all&per_page=100&page=${page}`,
         );
         const rows = payload?.check_runs || [];
         checks.push(...rows);
@@ -344,7 +348,7 @@ if (invokedAsScript) {
       const candidates = checks.filter((check) => {
         const match = CAPABILITY_CHECK_NAME.exec(String(check?.name || ""));
         return match?.[2] === record.runId
-          && check?.head_sha === run.head_sha
+          && check?.head_sha === releaseSha
           && check?.app?.slug === "github-actions"
           && Number.isInteger(check?.id);
       });
@@ -404,7 +408,8 @@ if (invokedAsScript) {
         || claims.leaseKey !== match[1]
         || match[2] !== record.runId
         || claims.dispatchNonce !== match[3]
-        || claims.releaseSha !== run.head_sha
+        || claims.releaseSha !== releaseSha
+        || !pontoSourceClosureMatches(releaseSha, String(run.head_sha || "").trim().toLowerCase())
         || claims.target !== target
         || claims.keyId !== capabilityVerifier.keyId
         || !allowedStage
@@ -460,7 +465,7 @@ if (invokedAsScript) {
         leaseKey: claims.leaseKey,
         stage: claims.stage,
         target,
-        releaseSha: run.head_sha,
+        releaseSha,
         dispatchNonce: claims.dispatchNonce,
         intentDigest: claims.intentDigest,
         state: capabilityState,
@@ -521,7 +526,7 @@ if (invokedAsScript) {
         leaseKey: claims.leaseKey,
         stage: claims.stage,
         target,
-        releaseSha: run.head_sha,
+        releaseSha,
         dispatchNonce: claims.dispatchNonce,
         intentDigest: claims.intentDigest,
         state: "invalidated",
@@ -672,6 +677,7 @@ if (invokedAsScript) {
           firstObservedAt: new Date().toISOString(),
         };
         record.orchestratorRunId = coordinator.runId;
+        record.releaseSha = coordinator.releaseSha;
         record.live = run;
         record.status = run.status;
         record.conclusion = run.conclusion || null;

--- a/.github/scripts/ponto-orchestrator-lease.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.mjs
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { assertPontoSourceClosureUnchanged, pontoSourceClosureMatches } from "./ponto-source-closure.mjs";
 
 const apiBase = String(process.env.GITHUB_API_URL || "https://api.github.com").replace(/\/$/, "");
 const repository = String(process.env.GITHUB_REPOSITORY || "").trim();
@@ -616,7 +617,15 @@ const assertFirstAttempt = () => {
   }
 };
 
-const canonicalOrchestrator = async ({ orchestratorRunId, releaseSha, stage, currentHeadSha }) => {
+function assertObservedPontoSource(releaseSha, observedSha) {
+  try {
+    return assertPontoSourceClosureUnchanged(releaseSha, observedSha);
+  } catch {
+    throw new Error("Ponto execution source is outside the immutable release dependency closure");
+  }
+}
+
+const canonicalOrchestrator = async ({ orchestratorRunId, releaseSha, stage }) => {
   for (let refresh = 0; ; refresh += 1) {
     let snapshotWasRetried = false;
     const markSnapshotRetry = () => {
@@ -651,7 +660,6 @@ const canonicalOrchestrator = async ({ orchestratorRunId, releaseSha, stage, cur
       || run?.conclusion != null
       || run?.event !== "workflow_dispatch"
       || run?.head_branch !== "main"
-      || run?.head_sha !== currentHeadSha
       || run?.head_sha !== releaseSha
       || run?.name !== `Ponto ${stage} ${releaseSha} orchestrator=${orchestratorRunId}`
       || run?.repository?.full_name !== repository
@@ -702,7 +710,7 @@ async function consumeCheck([leaseKey, stage, target, releaseShaRaw, orchestrato
     || !GOVERNED_STAGES.includes(stage || "")
     || !TARGETS.includes(target || "")
     || !FULL_SHA.test(releaseSha)
-    || currentHeadSha !== releaseSha
+    || !FULL_SHA.test(currentHeadSha)
     || !/^[1-9][0-9]*$/.test(orchestratorRunId || "")
     || !/^[1-9][0-9]*$/.test(childRunId)
     || !token
@@ -711,9 +719,10 @@ async function consumeCheck([leaseKey, stage, target, releaseShaRaw, orchestrato
     || !capabilityPublicKeysJson
     || !eventPath
   ) throw new Error("invalid Ponto check capability consume request");
+  assertObservedPontoSource(releaseSha, currentHeadSha);
   const verifier = resolveCapabilityVerifier(capabilityPublicKeysJson, target);
 
-  const parent = await canonicalOrchestrator({ orchestratorRunId, releaseSha, stage, currentHeadSha });
+  const parent = await canonicalOrchestrator({ orchestratorRunId, releaseSha, stage });
   const event = JSON.parse(fs.readFileSync(eventPath, "utf8"));
   let child;
   let childWorkflowPath = "";
@@ -740,7 +749,7 @@ async function consumeCheck([leaseKey, stage, target, releaseShaRaw, orchestrato
       || !acceptsWorkflowRunPath(childWorkflowPath, child?.path)
       || child?.event !== "workflow_dispatch"
       || child?.head_branch !== "main"
-      || child?.head_sha !== releaseSha
+      || child?.head_sha !== currentHeadSha
       || child?.repository?.full_name !== repository
       || String(child?.repository?.id || "") !== repositoryId
       || child?.head_repository?.full_name !== repository
@@ -778,7 +787,9 @@ async function consumeCheck([leaseKey, stage, target, releaseShaRaw, orchestrato
     || issuer?.conclusion != null
     || issuer?.event !== "workflow_dispatch"
     || issuer?.head_branch !== "main"
-    || issuer?.head_sha !== releaseSha
+    || (delegatedIssuer
+      ? !pontoSourceClosureMatches(releaseSha, issuer?.head_sha)
+      : issuer?.head_sha !== releaseSha)
     || issuer?.repository?.full_name !== repository
     || String(issuer?.repository?.id || "") !== repositoryId
     || issuer?.head_repository?.full_name !== repository
@@ -909,13 +920,14 @@ async function assertActive([stage, releaseShaRaw, orchestratorRunId]) {
   if (
     !GOVERNED_STAGES.includes(stage || "")
     || !FULL_SHA.test(releaseSha)
-    || currentHeadSha !== releaseSha
+    || !FULL_SHA.test(currentHeadSha)
     || !/^[1-9][0-9]*$/.test(orchestratorRunId || "")
     || !token
     || !repository.includes("/")
     || !/^[1-9][0-9]*$/.test(repositoryId)
   ) throw new Error("invalid active orchestrator assertion request");
-  await canonicalOrchestrator({ orchestratorRunId, releaseSha, stage, currentHeadSha });
+  assertObservedPontoSource(releaseSha, currentHeadSha);
+  await canonicalOrchestrator({ orchestratorRunId, releaseSha, stage });
   process.stdout.write(`Confirmed active first-attempt Ponto coordinator ${orchestratorRunId}.\n`);
 }
 

--- a/.github/scripts/ponto-production-baseline.test.mjs
+++ b/.github/scripts/ponto-production-baseline.test.mjs
@@ -246,7 +246,7 @@ test("baseline workflow, reusable gate, and coordinator retain every exported Wo
     coordinator.indexOf("Download the exact production baseline evidence"),
   );
   for (const required of [
-    "run.head_sha === process.env.RELEASE_SHA",
+    "pontoSourceClosureMatches(process.env.RELEASE_SHA, String(run.head_sha || \"\").toLowerCase())",
     "run.run_attempt === 1",
     "String(run.repository?.id || \"\") === process.env.GITHUB_REPOSITORY_ID",
     "String(run.head_repository?.id || \"\") === process.env.GITHUB_REPOSITORY_ID",

--- a/.github/scripts/ponto-reconcile-children.mjs
+++ b/.github/scripts/ponto-reconcile-children.mjs
@@ -14,13 +14,11 @@ export const readGitHubResponse = (response) => (
 export function isCorrelatedChild(run, {
   repository,
   orchestratorRunId,
-  orchestratorHeadSha,
 }) {
   const titleMatch = CORRELATED_TITLE_SUFFIX.exec(String(run?.display_title || ""));
   return String(run?.id || "") !== String(orchestratorRunId)
     && run?.event === "workflow_dispatch"
     && run?.head_branch === "main"
-    && String(run?.head_sha || "").toLowerCase() === orchestratorHeadSha
     && run?.repository?.full_name === repository
     && titleMatch?.[1] === String(orchestratorRunId)
     && String(run?.path || "").startsWith(".github/workflows/");

--- a/.github/scripts/ponto-reconcile-children.test.mjs
+++ b/.github/scripts/ponto-reconcile-children.test.mjs
@@ -26,10 +26,10 @@ const child = {
   status: "in_progress",
 };
 
-test("matches only the exact governed child correlation and immutable head", () => {
+test("matches only the exact governed child correlation and main branch", () => {
   assert.equal(isCorrelatedChild(child, context), true);
   assert.equal(isCorrelatedChild({ ...child, id: 12345 }, context), false);
-  assert.equal(isCorrelatedChild({ ...child, head_sha: "b".repeat(40) }, context), false);
+  assert.equal(isCorrelatedChild({ ...child, head_sha: "b".repeat(40) }, context), true);
   assert.equal(isCorrelatedChild({ ...child, display_title: "orchestrator=123450" }, context), false);
   assert.equal(isCorrelatedChild({ ...child, repository: { full_name: "other/repo" } }, context), false);
 });
@@ -197,7 +197,7 @@ test("ordered predecessor provenance is exact and replay resistant before artifa
     /String\(run\?\.id \|\| ""\) !== process\.env\.PREDECESSOR_RUN_ID/,
     /(?:run\.path !== `\$\{workflow\.path\}@refs\/heads\/main`|!\[workflow\.path, `\$\{workflow\.path\}@refs\/heads\/main`\]\.includes\(run\.path\))/,
     /run\.run_attempt !== 1/,
-    /run\.head_sha \|\| ""\)\.toLowerCase\(\) !== process\.env\.RELEASE_SHA/,
+    /assertPontoSourceClosureUnchanged/,
     /run\.display_title !== expectedTitle/,
   ]) {
     const match = provenance.search(contract);

--- a/.github/scripts/ponto-source-closure.mjs
+++ b/.github/scripts/ponto-source-closure.mjs
@@ -1,0 +1,52 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import {
+  assertDependencyClosureUnchanged,
+  dependencyClosureForSource,
+} from "../../scripts/codex-global-coordinator.mjs";
+
+const ROOT = path.resolve(import.meta.dirname, "../..");
+const FULL_SHA = /^[0-9a-f]{40}$/i;
+
+function normalizeSource(value, name) {
+  const source = String(value || "").trim().toLowerCase();
+  if (!FULL_SHA.test(source)) throw new Error(`${name} must be a full commit SHA`);
+  return source;
+}
+
+function ensureCommitAvailable(source) {
+  try {
+    execFileSync("git", ["cat-file", "-e", `${source}^{commit}`], { cwd: ROOT, stdio: "ignore" });
+    return;
+  } catch {
+    execFileSync("git", ["fetch", "--no-tags", "origin", source], { cwd: ROOT, stdio: "ignore" });
+  }
+  execFileSync("git", ["cat-file", "-e", `${source}^{commit}`], { cwd: ROOT, stdio: "ignore" });
+}
+
+export function pontoDependencyClosureDigest(source) {
+  const normalized = normalizeSource(source, "Ponto source");
+  ensureCommitAvailable(normalized);
+  return dependencyClosureForSource({ module: "ponto", sourceCommit: normalized }).digest;
+}
+
+export function assertPontoSourceClosureUnchanged(releaseSource, observedSource) {
+  const release = normalizeSource(releaseSource, "Ponto release source");
+  const observed = normalizeSource(observedSource, "observed Ponto source");
+  if (release === observed) return { release, observed, digest: null };
+  ensureCommitAvailable(release);
+  ensureCommitAvailable(observed);
+  const releaseDigest = dependencyClosureForSource({ module: "ponto", sourceCommit: release }).digest;
+  const observedDigest = dependencyClosureForSource({ module: "ponto", sourceCommit: observed }).digest;
+  assertDependencyClosureUnchanged(releaseDigest, observedDigest);
+  return { release, observed, digest: releaseDigest };
+}
+
+export function pontoSourceClosureMatches(releaseSource, observedSource) {
+  try {
+    assertPontoSourceClosureUnchanged(releaseSource, observedSource);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/.github/scripts/ponto-watchdog-journal.mjs
+++ b/.github/scripts/ponto-watchdog-journal.mjs
@@ -10,6 +10,7 @@ import {
   resolveCapabilityVerifier,
   verifyCapabilityDocument,
 } from "./ponto-orchestrator-lease.mjs";
+import { pontoSourceClosureMatches } from "./ponto-source-closure.mjs";
 import { attestTerminalPreMutationGateFailure } from "./ponto-child-mutation-attestation.mjs";
 
 const DISPATCH_NONCE = /^[0-9a-f]{32}$/;
@@ -148,6 +149,7 @@ async function verifyCapabilityAnchor({
     || claims.childWorkflowId !== run.workflow_id
     || claims.childWorkflowPath !== childWorkflowPath
     || claims.childRunId !== String(run.id)
+    || !pontoSourceClosureMatches(releaseSha, String(run?.head_sha || "").trim().toLowerCase())
     || claims.leaseKey !== match[1]
     || claims.dispatchNonce !== match[3]
     || claims.releaseSha !== releaseSha

--- a/.github/scripts/promotion-evidence.mjs
+++ b/.github/scripts/promotion-evidence.mjs
@@ -45,6 +45,7 @@ if (mode === "write") {
     sourceSha,
     sourceTree: required("PROMOTION_SOURCE_TREE"),
     releaseInputDigest: process.env.PROMOTION_RELEASE_INPUT_DIGEST || releaseInputDigest(unit, sourceSha),
+    dependencyClosureDigest: process.env.PROMOTION_DEPENDENCY_CLOSURE_DIGEST || process.env.PROMOTION_RELEASE_INPUT_DIGEST || releaseInputDigest(unit, sourceSha),
     artifacts: process.env.PROMOTION_ARTIFACT_DIGESTS_JSON ? JSON.parse(process.env.PROMOTION_ARTIFACT_DIGESTS_JSON) : [],
     runId: required("GITHUB_RUN_ID"),
     repository: required("GITHUB_REPOSITORY"),
@@ -64,7 +65,8 @@ if (mode === "write") {
   }
   if (expectedSha && evidence.sourceSha !== expectedSha) throw new Error("promotion evidence SHA differs from requested release SHA");
   if (expectedReleaseInputDigest && evidence.releaseInputDigest !== expectedReleaseInputDigest) throw new Error("promotion evidence release-input digest differs from the requested candidate");
-  if (process.env.GITHUB_OUTPUT) fs.appendFileSync(process.env.GITHUB_OUTPUT, `source_sha=${evidence.sourceSha}\nsource_tree=${evidence.sourceTree}\nrelease_input_digest=${evidence.releaseInputDigest || ""}\n`);
+  if (evidence.dependencyClosureDigest && evidence.dependencyClosureDigest !== evidence.releaseInputDigest) throw new Error("promotion evidence dependency-closure digest differs from release-input digest");
+  if (process.env.GITHUB_OUTPUT) fs.appendFileSync(process.env.GITHUB_OUTPUT, `source_sha=${evidence.sourceSha}\nsource_tree=${evidence.sourceTree}\nrelease_input_digest=${evidence.releaseInputDigest || ""}\ndependency_closure_digest=${evidence.dependencyClosureDigest || evidence.releaseInputDigest || ""}\n`);
   process.stdout.write(`Promotion evidence verified for ${evidence.unit} ${evidence.sourceSha} from ${evidence.target}.\n`);
 } else if (mode === "digest") {
   const unit = required("PROMOTION_UNIT");

--- a/.github/scripts/validate-deploy-topology.mjs
+++ b/.github/scripts/validate-deploy-topology.mjs
@@ -220,9 +220,10 @@ if (
   || gateTrustedHeadIndex < 0
   || gateConsumeIndex < 0
   || !(gateCheckoutIndex < gateTrustedHeadIndex && gateTrustedHeadIndex < gateConsumeIndex)
-  || !orchestratorGate.includes('"$GITHUB_SHA" == "$RELEASE_SHA"')
+  || !orchestratorGate.includes('assertPontoSourceClosureUnchanged')
+  || !orchestratorGate.includes('git rev-parse HEAD)" == "$GITHUB_SHA"')
 ) {
-  fail('Ponto orchestrator capability verification must execute trusted main workflow code, never candidate-controlled code');
+  fail('Ponto orchestrator capability verification must execute trusted main workflow code and attest the immutable dependency closure');
 }
 for (const [source, label] of [
   [productionBaseline, 'Ponto production baseline'],
@@ -231,10 +232,10 @@ for (const [source, label] of [
   if (
     source.includes('ref: ${{ inputs.release_sha }}')
     || !source.includes('ref: ${{ github.sha }}')
-    || !source.includes('"$GITHUB_SHA" == "$RELEASE_SHA"')
+    || !source.includes('assertPontoSourceClosureUnchanged')
     || !source.includes('git rev-parse HEAD')
   ) {
-    fail(`${label} must prove the trusted exact main checkout before hydrating production secrets`);
+    fail(`${label} must prove the trusted main checkout and immutable dependency closure before hydrating production secrets`);
   }
 }
 const clinicSloStart = productionSlo.indexOf('  consultor-journey:');
@@ -855,7 +856,7 @@ for (const required of [
   'status=${status}&per_page=100&page=${page}',
   'non-terminal ${status} run inventory exceeds the governed discovery bound',
   'authorizeAndInvalidateCapability',
-  '/commits/${run.head_sha}/check-runs?filter=all',
+  '/commits/${releaseSha}/check-runs?filter=all',
   'transitionCapabilityDocument',
   'state: "invalidated"',
   'method: "PATCH"',

--- a/.github/workflows/cloudflare-alerting-apply.yml
+++ b/.github/workflows/cloudflare-alerting-apply.yml
@@ -65,6 +65,32 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y jq
 
+      - name: Acquire Cloudflare alerting lease
+        if: ${{ steps.guard.outputs.skip != 'true' && (github.event.inputs.dry_run || 'false') != 'true' }}
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: cloudflare:alerting:production
+          module: cloudflare-alerting
+          source_sha: ${{ github.sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-cloudflare-alerting.json
+
+      - name: Check Cloudflare alerting lease before policy mutation
+        if: ${{ steps.guard.outputs.skip != 'true' && (github.event.inputs.dry_run || 'false') != 'true' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-cloudflare-alerting.json
+          resource: cloudflare:alerting:production
+          module: cloudflare-alerting
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Apply Cloudflare alerting policies
         if: ${{ steps.guard.outputs.skip != 'true' }}
         env:
@@ -94,3 +120,12 @@ jobs:
         with:
           name: cloudflare-alerting-apply
           path: /tmp/cloudflare-alerting-apply.summary.json
+
+      - name: Release Cloudflare alerting lease
+        if: ${{ always() && steps.guard.outputs.skip != 'true' && (github.event.inputs.dry_run || 'false') != 'true' }}
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-cloudflare-alerting.json

--- a/.github/workflows/cloudflare-pages-sync-escala.yml
+++ b/.github/workflows/cloudflare-pages-sync-escala.yml
@@ -42,8 +42,31 @@ jobs:
           node-version: "22.12.0"
 
       - name: Checkout (for worker wrangler config)
-        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Acquire Escala API release lease
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:escala-api
+          module: escala-api
+          source_sha: ${{ github.sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-escala-api-sync.json
+
+      - name: Check Escala API release lease before Pages-secret mutation
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-escala-api-sync.json
+          resource: release:escala-api
+          module: escala-api
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
 
       - name: Sync Pages secret (Escala) by environment
         env:
@@ -58,6 +81,18 @@ jobs:
             echo "Synced ESCALA_ACTOR_HMAC_KEY for env=$env_name"
           done
 
+      - name: Check Escala API release lease before duplicate-binding cleanup
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-escala-api-sync.json
+          resource: release:escala-api
+          module: escala-api
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Cleanup duplicate production secret binding (Escala target)
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -69,6 +104,19 @@ jobs:
           # Keep dashboard free of duplicate secret bindings for this key.
           npx --yes wrangler@4 pages secret delete ESCALA_API_TARGET --project-name "$PROJECT" --env production >/dev/null || true
           echo "Ensured no duplicate secret binding for ESCALA_API_TARGET in production."
+
+      - name: Check Escala API release lease before Worker-secret mutation
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-escala-api-sync.json
+          resource: release:escala-api
+          module: escala-api
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
 
       - name: Sync Worker secret (Escala API) by environment
         if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -113,3 +161,12 @@ jobs:
             raise SystemExit(f"Escala env vars ausentes em: {', '.join(missing)}")
           print("ESCALA_ACTOR_HMAC_KEY presente em production/preview.")
           PY
+
+      - name: Release Escala API release lease
+        if: ${{ always() && steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-escala-api-sync.json

--- a/.github/workflows/cloudflare-pages-sync-meta-ads-report-secret.yml
+++ b/.github/workflows/cloudflare-pages-sync-meta-ads-report-secret.yml
@@ -46,6 +46,36 @@ jobs:
         with:
           node-version: "22.12.0"
 
+      - name: Checkout
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Acquire Meta Ads report release lease
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:meta-ads-report
+          module: meta-ads-report
+          source_sha: ${{ github.sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-meta-ads-report-sync.json
+
+      - name: Check Meta Ads report release lease before Pages-secret mutation
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-meta-ads-report-sync.json
+          resource: release:meta-ads-report
+          module: meta-ads-report
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Sync Meta Ads report token to Cloudflare Pages
         if: ${{ steps.guard.outputs.skip != 'true' }}
         env:
@@ -59,3 +89,12 @@ jobs:
             printf "%s" "$META_ADS_REPORT_WORKER_API_TOKEN" | npx --yes wrangler@4 pages secret put META_ADS_REPORT_WORKER_API_TOKEN --project-name "$PROJECT" --env "$env_name" >/dev/null
             echo "Set Pages secret META_ADS_REPORT_WORKER_API_TOKEN for env=$env_name."
           done
+
+      - name: Release Meta Ads report release lease
+        if: ${{ always() && steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-meta-ads-report-sync.json

--- a/.github/workflows/cloudflare-pages-sync-ponto.yml
+++ b/.github/workflows/cloudflare-pages-sync-ponto.yml
@@ -57,8 +57,13 @@ jobs:
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
     with:
       required: true
+      global_lease_required: true
+      global_resource: cloudflare:ponto-pages:${{ inputs.target }}
+      global_module: ponto
+      global_coordinator_url: ${{ inputs.target == 'production' && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
       lease_key: pages-secrets
       stage: ${{ inputs.orchestrator_stage }}
       target: ${{ inputs.target }}
@@ -212,6 +217,17 @@ jobs:
             "$ORCHESTRATOR_STAGE" \
             "$RELEASE_SHA" \
             "$ORCHESTRATOR_RUN_ID"
+      - name: Authorize global Cloudflare Pages custody mutation
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
+          resource: cloudflare:ponto-pages:${{ inputs.target }}
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
       - name: Attest environment-owned derivation root
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -499,3 +515,13 @@ jobs:
           path: ${{ runner.temp }}/pages-release-probe-evidence.json
           retention-days: 90
           if-no-files-found: error
+  global-coordination-release:
+    needs: [coordination, provision]
+    if: ${{ always() && needs.coordination.outputs.global_lease_required == 'true' }}
+    uses: ./.github/workflows/global-coordination-release.yml
+    secrets:
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+    with:
+      required: true
+      proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
+      coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}

--- a/.github/workflows/cloudflare-pages-sync-ponto.yml
+++ b/.github/workflows/cloudflare-pages-sync-ponto.yml
@@ -170,8 +170,9 @@ jobs:
           fi
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$ROOT_CUSTODY_RUN_ID" > "$RUNNER_TEMP/root-custody-run.json"
           gh api "repos/$GITHUB_REPOSITORY/actions/workflows/cloudflare-workers-sync-ponto-secrets.yml" > "$RUNNER_TEMP/root-custody-workflow.json"
-          node - "$RUNNER_TEMP/root-custody-run.json" "$RUNNER_TEMP/root-custody-workflow.json" <<'NODE'
-          const fs = require("fs");
+          node --input-type=module - "$RUNNER_TEMP/root-custody-run.json" "$RUNNER_TEMP/root-custody-workflow.json" <<'NODE'
+          import fs from "node:fs";
+          import { pontoSourceClosureMatches } from "./.github/scripts/ponto-source-closure.mjs";
           const run = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
           const workflow = JSON.parse(fs.readFileSync(process.argv[3], "utf8"));
           const expectedTitle = new RegExp(
@@ -189,7 +190,7 @@ jobs:
             || run.conclusion !== "success"
             || run.event !== "workflow_dispatch"
             || run.head_branch !== "main"
-            || run.head_sha !== process.env.RELEASE_SHA
+            || !pontoSourceClosureMatches(process.env.RELEASE_SHA, String(run.head_sha || "").toLowerCase())
             || !expectedTitle
             || run.repository?.full_name !== process.env.GITHUB_REPOSITORY
             || run.head_repository?.full_name !== process.env.GITHUB_REPOSITORY

--- a/.github/workflows/cloudflare-sync-integrations-encryption-secret.yml
+++ b/.github/workflows/cloudflare-sync-integrations-encryption-secret.yml
@@ -50,6 +50,32 @@ jobs:
         with:
           node-version: "22.12.0"
 
+      - name: Acquire Social publisher release lease
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:social-publisher
+          module: social-publisher
+          source_sha: ${{ github.sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-social-publisher-sync.json
+
+      - name: Check Social publisher release lease before Pages-secret mutation
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-social-publisher-sync.json
+          resource: release:social-publisher
+          module: social-publisher
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Sync secret to Cloudflare Pages (wrangler pages secret put)
         if: ${{ steps.guard.outputs.skip != 'true' }}
         env:
@@ -64,6 +90,19 @@ jobs:
             echo "Set Pages secret INTEGRATIONS_ENCRYPTION_SECRET for env=$env_name."
           done
 
+      - name: Check Social publisher release lease before Worker-secret mutation
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-social-publisher-sync.json
+          resource: release:social-publisher
+          module: social-publisher
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Sync secret to Social Publisher Worker
         if: ${{ steps.guard.outputs.skip != 'true' }}
         env:
@@ -74,3 +113,12 @@ jobs:
           set -euo pipefail
           printf "%s" "$INTEGRATIONS_ENCRYPTION_SECRET" | npx --yes wrangler@4 secret put INTEGRATIONS_ENCRYPTION_SECRET --config social/publisher/wrangler.toml >/dev/null
           echo "Set secret INTEGRATIONS_ENCRYPTION_SECRET for social-publisher worker."
+
+      - name: Release Social publisher release lease
+        if: ${{ always() && steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-social-publisher-sync.json

--- a/.github/workflows/cloudflare-workers-sync-ponto-secrets.yml
+++ b/.github/workflows/cloudflare-workers-sync-ponto-secrets.yml
@@ -53,8 +53,13 @@ jobs:
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
     with:
       required: true
+      global_lease_required: true
+      global_resource: cloudflare:ponto-workers:${{ inputs.target }}
+      global_module: ponto
+      global_coordinator_url: ${{ inputs.target == 'production' && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
       lease_key: workers-secrets
       stage: ${{ inputs.orchestrator_stage }}
       target: ${{ inputs.target }}
@@ -133,6 +138,17 @@ jobs:
             "$ORCHESTRATOR_STAGE" \
             "$RELEASE_SHA" \
             "$ORCHESTRATOR_RUN_ID"
+      - name: Authorize global Cloudflare Worker custody mutation
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
+          resource: cloudflare:ponto-workers:${{ inputs.target }}
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
       - name: Verify selected environment root custody scopes
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -308,3 +324,13 @@ jobs:
           path: ${{ runner.temp }}/ponto-root-custody/root-custody.json
           retention-days: 90
           if-no-files-found: error
+  global-coordination-release:
+    needs: [coordination, provision]
+    if: ${{ always() && needs.coordination.outputs.global_lease_required == 'true' }}
+    uses: ./.github/workflows/global-coordination-release.yml
+    secrets:
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+    with:
+      required: true
+      proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
+      coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}

--- a/.github/workflows/cloudflare-workers-sync-ponto-secrets.yml
+++ b/.github/workflows/cloudflare-workers-sync-ponto-secrets.yml
@@ -95,8 +95,9 @@ jobs:
             [[ "$STAGING_RUN_ID" =~ ^[0-9]+$ ]] || { echo 'production provisioning requires staging_run_id'; exit 1; }
             gh api "repos/$GITHUB_REPOSITORY/actions/runs/$STAGING_RUN_ID" > "$RUNNER_TEMP/staging-run.json"
             gh api "repos/$GITHUB_REPOSITORY/actions/workflows/ponto-progressive-release.yml" > "$RUNNER_TEMP/staging-workflow.json"
-            node - "$RUNNER_TEMP/staging-run.json" "$RUNNER_TEMP/staging-workflow.json" <<'NODE'
-          const fs = require("fs");
+            node --input-type=module - "$RUNNER_TEMP/staging-run.json" "$RUNNER_TEMP/staging-workflow.json" <<'NODE'
+          import fs from "node:fs";
+          import { pontoSourceClosureMatches } from "./.github/scripts/ponto-source-closure.mjs";
           const run = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
           const workflow = JSON.parse(fs.readFileSync(process.argv[3], "utf8"));
           if (
@@ -114,6 +115,7 @@ jobs:
             || run.conclusion !== "success"
             || run.event !== "workflow_dispatch"
             || run.head_branch !== "main"
+            || !pontoSourceClosureMatches(process.env.RELEASE_SHA, String(run.head_sha || "").toLowerCase())
             || run.repository?.full_name !== process.env.GITHUB_REPOSITORY
             || run.head_repository?.full_name !== process.env.GITHUB_REPOSITORY
           ) {

--- a/.github/workflows/codex-autonomy-gate.yml
+++ b/.github/workflows/codex-autonomy-gate.yml
@@ -64,6 +64,7 @@ jobs:
         run: |
           set -euo pipefail
           node --test scripts/tests/codex-autonomy-baseline.test.mjs
+          node --test scripts/tests/codex-global-coordination.test.mjs scripts/tests/codex-global-coordination-client.test.mjs ops/cloudflare/global-coordinator/index.test.mjs
       - name: GitHub governance contract
         if: ${{ contains(needs.classify.outputs.surfaces, 'github-governance') }}
         run: |

--- a/.github/workflows/codex-keep-prs-mergeable.yml
+++ b/.github/workflows/codex-keep-prs-mergeable.yml
@@ -17,7 +17,34 @@ permissions:
 jobs:
   keep_mergeable:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        with:
+          ref: main
+          fetch-depth: 1
+      - name: Acquire merge:main for branch maintenance
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: merge:main
+          module: merge
+          source_sha: ${{ github.sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-merge-maintenance.json
+      - name: Check merge:main before PR branch maintenance
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-merge-maintenance.json
+          resource: merge:main
+          module: merge
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Keep codex PRs up-to-date (update-branch) + label conflicts
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
@@ -45,7 +72,7 @@ jobs:
               enabled: {
                 name: "automerge/enabled",
                 color: "1D76DB",
-                description: "Auto-merge is enabled; GitHub will merge only after the aggregate required gate is green.",
+                description: "Legacy marker; merge authority must be acquired before integration.",
               },
             };
 
@@ -110,24 +137,21 @@ jobs:
               });
             }
 
-            async function enableAutoMerge(pr) {
-              if (pr.draft || !pr.node_id || pr.auto_merge) return;
+            async function disableUncoordinatedAutoMerge(pr) {
+              if (!pr.node_id || !pr.auto_merge) return;
               try {
                 await github.graphql(
-                  `mutation EnableAutoMerge($pullRequestId: ID!) {
-                    enablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId, mergeMethod: SQUASH}) {
-                      pullRequest { autoMergeRequest { enabledAt } }
+                  `mutation DisableAutoMerge($pullRequestId: ID!) {
+                    disablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId}) {
+                      pullRequest { id }
                     }
                   }`,
                   { pullRequestId: pr.node_id },
                 );
-                await addLabel(pr.number, LABELS.enabled.name);
-                core.info(`Enabled auto-merge for PR #${pr.number}`);
+                await removeLabel(pr.number, LABELS.enabled.name);
+                core.warning(`Disabled uncoordinated auto-merge for PR #${pr.number}; use global-merge-authority.yml`);
               } catch (err) {
-                // Protected checks, merge queues, or a newly pushed commit may
-                // make auto-merge temporarily unavailable. The next bounded
-                // reconcile cycle retries without forcing a merge.
-                core.warning(`enable auto-merge failed for #${pr.number}: ${err?.message || err}`);
+                core.warning(`disable auto-merge failed for #${pr.number}: ${err?.message || err}`);
               }
             }
 
@@ -170,6 +194,8 @@ jobs:
               const mergeableState = full.mergeable_state; // behind | dirty | clean | unknown | blocked | unstable | ...
               const headSha = full.head?.sha || "";
               core.info(`PR #${prNumber}: mergeable_state=${mergeableState} head=${headSha.slice(0, 7)}`);
+
+              await disableUncoordinatedAutoMerge(full);
 
               // GitHub may return null while computing mergeability.
               if (!mergeableState || mergeableState === "unknown") {
@@ -216,6 +242,13 @@ jobs:
               // Keep conflict label unless it is clearly clean.
               if (mergeableState === "clean") {
                 await removeLabel(prNumber, LABELS.conflict.name);
-                await enableAutoMerge(full);
               }
             }
+      - name: Release merge:main after branch maintenance
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-merge-maintenance.json

--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -68,8 +68,13 @@ jobs:
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
     with:
       required: ${{ inputs.release_scope == 'ponto' && inputs.target != 'preview' }}
+      global_lease_required: ${{ inputs.target != 'preview' }}
+      global_resource: ${{ format('deploy:core-{0}:{1}', inputs.unit, inputs.target) }}
+      global_module: ${{ inputs.release_scope == 'ponto' && 'ponto' || 'core' }}
+      global_coordinator_url: ${{ contains(fromJSON('["pilot","canary","production","rollback"]'), inputs.target) && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
       lease_key: core-${{ inputs.unit }}
       stage: ${{ inputs.orchestrator_stage || inputs.target }}
       target: ${{ inputs.target == 'staging' && 'staging' || 'production' }}
@@ -257,6 +262,18 @@ jobs:
             "$ORCHESTRATOR_STAGE" \
             "$RELEASE_SHA" \
             "$ORCHESTRATOR_RUN_ID"
+      - name: Authorize global Core surface mutation
+        if: ${{ inputs.target != 'preview' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
+          resource: ${{ format('deploy:core-{0}:{1}', inputs.unit, inputs.target) }}
+          module: ${{ inputs.release_scope == 'ponto' && 'ponto' || 'core' }}
+          source_sha: ${{ inputs.release_sha || github.sha }}
       - name: Guard canonical staging Identity release
         env:
           ENABLE_PONTO_CORE_WORKERS_DEPLOY: ${{ vars.ENABLE_PONTO_CORE_WORKERS_DEPLOY }}
@@ -1071,6 +1088,18 @@ jobs:
             "$ORCHESTRATOR_STAGE" \
             "$RELEASE_SHA" \
             "$ORCHESTRATOR_RUN_ID"
+      - name: Authorize global Core production mutation
+        if: ${{ inputs.target != 'preview' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
+          resource: ${{ format('deploy:core-{0}:{1}', inputs.unit, inputs.target) }}
+          module: ${{ inputs.release_scope == 'ponto' && 'ponto' || 'core' }}
+          source_sha: ${{ inputs.release_sha || github.sha }}
       - name: Guard canonical Ponto Core release
         env:
           ENABLE_PONTO_CORE_WORKERS_DEPLOY: ${{ vars.ENABLE_PONTO_CORE_WORKERS_DEPLOY }}
@@ -1463,6 +1492,18 @@ jobs:
             "$ORCHESTRATOR_STAGE" \
             "$RELEASE_SHA" \
             "$ORCHESTRATOR_RUN_ID"
+      - name: Authorize global Identity production mutation
+        if: ${{ inputs.target != 'preview' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
+          resource: ${{ format('deploy:core-{0}:{1}', inputs.unit, inputs.target) }}
+          module: ${{ inputs.release_scope == 'ponto' && 'ponto' || 'core' }}
+          source_sha: ${{ inputs.release_sha || github.sha }}
       - name: Guard canonical Ponto Identity release
         env:
           ENABLE_PONTO_CORE_WORKERS_DEPLOY: ${{ vars.ENABLE_PONTO_CORE_WORKERS_DEPLOY }}
@@ -1918,3 +1959,13 @@ jobs:
           path: ${{ runner.temp }}/identity-surface/surface.json
           retention-days: 90
           if-no-files-found: error
+  global-coordination-release:
+    needs: [coordination, promotion, progressive, ponto-preview, reject-unsupported-ponto-unit, ponto-identity-preview, ponto-identity-staging, deploy, ponto-progressive-release, ponto-identity-progressive-release]
+    if: ${{ always() && needs.coordination.outputs.global_lease_required == 'true' }}
+    uses: ./.github/workflows/global-coordination-release.yml
+    secrets:
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+    with:
+      required: true
+      proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
+      coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -52,8 +52,13 @@ jobs:
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
     with:
       required: ${{ inputs.release_scope == 'ponto' && inputs.target != 'preview' }}
+      global_lease_required: ${{ inputs.target != 'preview' }}
+      global_resource: deploy:crm-pages:${{ inputs.target }}
+      global_module: ${{ inputs.release_scope == 'ponto' && 'ponto' || 'crm-pages' }}
+      global_coordinator_url: ${{ contains(fromJSON('["pilot","canary","production","rollback"]'), inputs.target) && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
       lease_key: pages
       stage: ${{ inputs.orchestrator_stage || inputs.target }}
       target: ${{ inputs.target == 'staging' && 'staging' || 'production' }}
@@ -174,6 +179,18 @@ jobs:
             "$ORCHESTRATOR_STAGE" \
             "$PONTO_RELEASE_SHA" \
             "$ORCHESTRATOR_RUN_ID"
+      - name: Authorize global CRM Pages surface mutation
+        if: ${{ inputs.target != 'preview' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
+          resource: deploy:crm-pages:${{ inputs.target }}
+          module: ${{ inputs.release_scope == 'ponto' && 'ponto' || 'crm-pages' }}
+          source_sha: ${{ inputs.release_sha || github.sha }}
       - name: Guard Cloudflare Pages deploy
         id: guard
         env:
@@ -1064,6 +1081,18 @@ jobs:
             "$ORCHESTRATOR_STAGE" \
             "$RELEASE_SHA" \
             "$ORCHESTRATOR_RUN_ID"
+      - name: Authorize global CRM Pages production mutation
+        if: ${{ inputs.target != 'preview' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
+          resource: deploy:crm-pages:${{ inputs.target }}
+          module: ${{ inputs.release_scope == 'ponto' && 'ponto' || 'crm-pages' }}
+          source_sha: ${{ inputs.release_sha || github.sha }}
       - name: Guard canonical Ponto Pages release
         env:
           ENABLE_PONTO_CRM_PAGES_DEPLOY: ${{ vars.ENABLE_PONTO_CRM_PAGES_DEPLOY }}
@@ -1581,3 +1610,13 @@ jobs:
           path: ${{ runner.temp }}/pages-surface/surface.json
           retention-days: 90
           if-no-files-found: error
+  global-coordination-release:
+    needs: [coordination, promotion, progressive, ponto-preview, deploy, ponto-progressive-release]
+    if: ${{ always() && needs.coordination.outputs.global_lease_required == 'true' }}
+    uses: ./.github/workflows/global-coordination-release.yml
+    secrets:
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+    with:
+      required: true
+      proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
+      coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}

--- a/.github/workflows/deploy-escala-api.yml
+++ b/.github/workflows/deploy-escala-api.yml
@@ -76,6 +76,32 @@ jobs:
         with:
           node-version: "22.12.0"
 
+      - name: Acquire Escala API deployment lease
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:escala-api
+          module: escala-api
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-escala-api.json
+
+      - name: Check Escala API deployment lease before secret mutation
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-escala-api.json
+          resource: release:escala-api
+          module: escala-api
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Sync Escala worker secret (production)
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
         env:
@@ -87,6 +113,19 @@ jobs:
           printf "%s" "$ESCALA_ACTOR_HMAC_KEY" | npx --yes wrangler@4 secret put ESCALA_ACTOR_HMAC_KEY --config workforce/schedule/wrangler.toml >/dev/null
           echo "Synced ESCALA_ACTOR_HMAC_KEY for production."
 
+      - name: Check Escala API deployment lease before production migration
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-escala-api.json
+          resource: release:escala-api
+          module: escala-api
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Apply Escala D1 migrations (production)
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
         env:
@@ -95,6 +134,19 @@ jobs:
         run: |
           set -euo pipefail
           npx --yes wrangler@4 d1 migrations apply skincos-escala --remote --config workforce/schedule/wrangler.toml
+
+      - name: Check Escala API deployment lease before production deployment
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-escala-api.json
+          resource: release:escala-api
+          module: escala-api
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
 
       - name: Deploy Escala worker (production)
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
@@ -116,6 +168,19 @@ jobs:
           printf "%s" "$ESCALA_ACTOR_HMAC_KEY" | npx --yes wrangler@4 secret put ESCALA_ACTOR_HMAC_KEY --config workforce/schedule/wrangler.toml --env staging >/dev/null
           echo "Synced ESCALA_ACTOR_HMAC_KEY for staging."
 
+      - name: Check Escala API deployment lease before staging migration
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-escala-api.json
+          resource: release:escala-api
+          module: escala-api
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Apply Escala D1 migrations (staging)
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
         env:
@@ -124,6 +189,19 @@ jobs:
         run: |
           set -euo pipefail
           npx --yes wrangler@4 d1 migrations apply skincos-escala --remote --config workforce/schedule/wrangler.toml --env staging
+
+      - name: Check Escala API deployment lease before staging deployment
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-escala-api.json
+          resource: release:escala-api
+          module: escala-api
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
 
       - name: Deploy Escala worker (staging)
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
@@ -166,3 +244,12 @@ jobs:
           path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json
           retention-days: 14
           if-no-files-found: error
+
+      - name: Release Escala API deployment lease
+        if: ${{ always() && steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-escala-api.json

--- a/.github/workflows/deploy-finance-ui.yml
+++ b/.github/workflows/deploy-finance-ui.yml
@@ -65,6 +65,28 @@ jobs:
             Cache-Control: no-store
           EOF
         working-directory: crm/console
+      - name: Acquire Finance UI deployment lease
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: deploy:finance-ui:${{ inputs.target }}
+          module: finance-ui
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-ui.json
+      - name: Check Finance UI deployment lease before publication
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-ui.json
+          resource: deploy:finance-ui:${{ inputs.target }}
+          module: finance-ui
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Publish only Finance UI
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -102,3 +124,11 @@ jobs:
           path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json
           retention-days: 14
           if-no-files-found: error
+      - name: Release Finance UI deployment lease
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-ui.json

--- a/.github/workflows/deploy-finance.yml
+++ b/.github/workflows/deploy-finance.yml
@@ -124,6 +124,28 @@ jobs:
           else
             sed -i "s/__CONFIGURE_FINANCE_STAGING_D1_ID__/$D1_ID/;s/__CONFIGURE_MODULE_CONTROL_STAGING_KV_ID__/$CONTROL_KV_ID/;s/__RELEASE_SHA__/$RELEASE_SHA/g" finance/wrangler.toml
           fi
+      - name: Acquire Finance release lease
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:finance
+          module: finance
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance.json
+      - name: Check Finance release lease before service-secret mutation
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance.json
+          resource: release:finance
+          module: finance
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Provision or attest Finance service secret before D1 checkpoint
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -166,6 +188,18 @@ jobs:
           path: ${{ env.CHECKPOINT }}
           retention-days: 30
           if-no-files-found: error
+      - name: Check Finance release lease before migrations
+        if: inputs.operation == 'deploy'
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance.json
+          resource: release:finance
+          module: finance
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Apply additive Finance migrations
         if: inputs.operation == 'deploy'
         env:
@@ -187,6 +221,18 @@ jobs:
             { cat "$migration"; printf "\nINSERT INTO d1_migrations(name) VALUES ('%s');\n" "$name"; } > "$batch"
             npx --yes wrangler@4.114.0 d1 execute "$DB" --remote --config finance/wrangler.toml "${ENV_ARGS[@]}" --file "$batch"
           done
+      - name: Check Finance release lease before version upload
+        if: inputs.operation == 'deploy'
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance.json
+          resource: release:finance
+          module: finance
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Upload immutable Finance version
         if: inputs.operation == 'deploy'
         env:
@@ -215,6 +261,17 @@ jobs:
           FINANCE_VERSION_ID="$(npx --yes wrangler@4.112.0 versions list --config finance/wrangler.toml "${ENV_ARGS[@]}" --json | node -e "const fs=require('fs');const versions=JSON.parse(fs.readFileSync(0,'utf8'));const expected='finance:deploy:'+process.env.RELEASE_SHA;const found=versions.find(x=>(x.message||x.annotations?.['workers/message'])===expected);if(!found?.id)process.exit(1);process.stdout.write(found.id)")"
           [[ -n "$FINANCE_VERSION_ID" ]] || { echo 'No prior Finance version for requested SHA'; exit 1; }
           echo "FINANCE_VERSION_ID=$FINANCE_VERSION_ID" >> "$GITHUB_ENV"
+      - name: Check Finance release lease before version deployment
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance.json
+          resource: release:finance
+          module: finance
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Deploy only the selected Finance version
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -257,3 +314,11 @@ jobs:
           name: promotion-evidence-finance
           path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json
           retention-days: 14
+      - name: Release Finance release lease
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance.json

--- a/.github/workflows/deploy-meta-ads-report-worker.yml
+++ b/.github/workflows/deploy-meta-ads-report-worker.yml
@@ -61,6 +61,30 @@ jobs:
         with:
           node-version: "22.12.0"
 
+      - name: Acquire Meta Ads report deployment lease
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:meta-ads-report
+          module: meta-ads-report
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-meta-ads-report.json
+      - name: Check Meta Ads report deployment lease before publication
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-meta-ads-report.json
+          resource: release:meta-ads-report
+          module: meta-ads-report
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Deploy Worker (wrangler)
         if: ${{ steps.guard.outputs.skip != 'true' }}
         env:
@@ -85,3 +109,11 @@ jobs:
           path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json
           retention-days: 14
           if-no-files-found: error
+      - name: Release Meta Ads report deployment lease
+        if: ${{ always() && steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-meta-ads-report.json

--- a/.github/workflows/deploy-social-publisher-worker.yml
+++ b/.github/workflows/deploy-social-publisher-worker.yml
@@ -62,6 +62,30 @@ jobs:
         with:
           node-version: "22.12.0"
 
+      - name: Acquire Social publisher deployment lease
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:social-publisher
+          module: social-publisher
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-social-publisher.json
+      - name: Check Social publisher deployment lease before publication
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-social-publisher.json
+          resource: release:social-publisher
+          module: social-publisher
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Deploy Worker (wrangler)
         if: ${{ steps.guard.outputs.skip != 'true' }}
         env:
@@ -70,3 +94,11 @@ jobs:
         run: |
           set -euo pipefail
           npx --yes wrangler@3 deploy --config social/publisher/wrangler.toml --keep-vars
+      - name: Release Social publisher deployment lease
+        if: ${{ always() && steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-social-publisher.json

--- a/.github/workflows/deploy-timekeeping.yml
+++ b/.github/workflows/deploy-timekeeping.yml
@@ -517,11 +517,12 @@ jobs:
           [[ "$TARGET" == pilot ]] && target=production
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$ROOT_CUSTODY_RUN_ID" > "$RUNNER_TEMP/timekeeping-root-custody-run.json"
           gh api "repos/$GITHUB_REPOSITORY/actions/workflows/cloudflare-workers-sync-ponto-secrets.yml" > "$RUNNER_TEMP/timekeeping-root-custody-workflow.json"
-          node - \
+          node --input-type=module - \
             "$RUNNER_TEMP/timekeeping-root-custody-run.json" \
             "$RUNNER_TEMP/timekeeping-root-custody-workflow.json" \
             "$target" <<'NODE'
-          const fs = require("fs");
+          import fs from "node:fs";
+          import { pontoSourceClosureMatches } from "./.github/scripts/ponto-source-closure.mjs";
           const run = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
           const workflow = JSON.parse(fs.readFileSync(process.argv[3], "utf8"));
           const target = process.argv[4];
@@ -540,7 +541,7 @@ jobs:
             || run.conclusion !== "success"
             || run.event !== "workflow_dispatch"
             || run.head_branch !== "main"
-            || run.head_sha !== process.env.RELEASE_SHA
+            || !pontoSourceClosureMatches(process.env.RELEASE_SHA, String(run.head_sha || "").toLowerCase())
             || !expectedTitle
             || run.repository?.full_name !== process.env.GITHUB_REPOSITORY
             || run.head_repository?.full_name !== process.env.GITHUB_REPOSITORY
@@ -575,10 +576,12 @@ jobs:
             "$artifact_metadata" \
             "$artifact_provenance" \
             "$artifact_name" \
-            "$artifact_id" <<'NODE'
+            "$artifact_id" \
+            "$RUNNER_TEMP/timekeeping-root-custody-run.json" <<'NODE'
           const fs = require("fs");
           const payload = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
           const artifact = JSON.parse(fs.readFileSync(process.argv[3], "utf8"));
+          const run = JSON.parse(fs.readFileSync(process.argv[7], "utf8"));
           const outputFile = process.argv[4];
           const artifactName = process.argv[5];
           const artifactId = process.argv[6];
@@ -595,7 +598,7 @@ jobs:
             || expiresAt <= Date.now()
             || !/^sha256:[0-9a-f]{64}$/.test(digest)
             || artifact.workflow_run?.id !== Number(process.env.ROOT_CUSTODY_RUN_ID)
-            || artifact.workflow_run?.head_sha !== process.env.RELEASE_SHA
+            || artifact.workflow_run?.head_sha !== run.head_sha
             || String(listed[0].digest || "") !== digest
             || listed[0].workflow_run?.id !== artifact.workflow_run.id
             || listed[0].workflow_run?.head_sha !== artifact.workflow_run.head_sha

--- a/.github/workflows/deploy-timekeeping.yml
+++ b/.github/workflows/deploy-timekeeping.yml
@@ -81,8 +81,13 @@ jobs:
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
     with:
       required: ${{ inputs.target != 'preview' }}
+      global_lease_required: ${{ inputs.target != 'preview' }}
+      global_resource: deploy:timekeeping:${{ inputs.target }}
+      global_module: ponto
+      global_coordinator_url: ${{ contains(fromJSON('["pilot","canary","production","rollback"]'), inputs.target) && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
       lease_key: timekeeping
       stage: ${{ inputs.orchestrator_stage || inputs.target }}
       target: ${{ inputs.target == 'staging' && 'staging' || 'production' }}
@@ -213,6 +218,18 @@ jobs:
             "$ORCHESTRATOR_STAGE" \
             "$RELEASE_SHA" \
             "$ORCHESTRATOR_RUN_ID"
+      - name: Authorize global Timekeeping surface mutation
+        if: ${{ inputs.target != 'preview' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
+          resource: deploy:timekeeping:${{ inputs.target }}
+          module: ponto
+          source_sha: ${{ inputs.release_sha || github.sha }}
       - name: Guard target resources and explicit production authorization
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -1141,3 +1158,13 @@ jobs:
           path: ${{ runner.temp }}/timekeeping-surface/surface.json
           retention-days: 90
           if-no-files-found: error
+  global-coordination-release:
+    needs: [coordination, promotion, progressive, preview, release]
+    if: ${{ always() && needs.coordination.outputs.global_lease_required == 'true' }}
+    uses: ./.github/workflows/global-coordination-release.yml
+    secrets:
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+    with:
+      required: true
+      proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
+      coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}

--- a/.github/workflows/deploy-website-cloudflare.yml
+++ b/.github/workflows/deploy-website-cloudflare.yml
@@ -81,6 +81,32 @@ jobs:
         working-directory: website
         run: npm run lint
 
+      - name: Acquire Website release lease
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:website
+          module: website
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website.json
+
+      - name: Check Website release lease before worker-secret mutation
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website.json
+          resource: release:website
+          module: website
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Sync worker secrets (optional)
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
         continue-on-error: true
@@ -157,6 +183,19 @@ jobs:
           BOOKING_EMAIL_AMBASSADOR_FEMALE_IMAGE_URL: ${{ secrets.BOOKING_EMAIL_AMBASSADOR_FEMALE_IMAGE_URL }}
           INSTAGRAM_SYNC_TOKEN: ${{ secrets.INSTAGRAM_SYNC_TOKEN }}
 
+      - name: Check Website release lease before website deployment
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website.json
+          resource: release:website
+          module: website
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Deploy website (OpenNext -> Workers)
         if: ${{ steps.guard.outputs.skip != 'true' }}
         working-directory: website
@@ -177,6 +216,19 @@ jobs:
           NEXT_PUBLIC_BUILD_TIME: ${{ github.run_id }}
           NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ inputs.target == 'production' && secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '' }}
 
+      - name: Check Website release lease before legal-hub deployment
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website.json
+          resource: release:website
+          module: website
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Deploy SKINCOS legal hub (OpenNext -> Workers)
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
         working-directory: website
@@ -188,6 +240,19 @@ jobs:
           NEXT_PUBLIC_BUILD_SHA: ${{ needs.promotion.outputs.source_sha }}
           NEXT_PUBLIC_BUILD_TIME: ${{ github.run_id }}
           NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
+
+      - name: Check Website release lease before security-settings mutation
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website.json
+          resource: release:website
+          module: website
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
 
       - name: Sync Cloudflare security settings (optional)
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
@@ -205,6 +270,19 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_SECURITY_API_TOKEN != '' && secrets.CLOUDFLARE_SECURITY_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
           CF_ZONE_NAME: espacofacial.com
 
+      - name: Check Website release lease before redirects-worker deployment
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website.json
+          resource: release:website
+          module: website
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Deploy redirects worker (esfa.co)
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
         working-directory: website
@@ -212,6 +290,19 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Check Website release lease before redirects-D1 mutation
+        if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website.json
+          resource: release:website
+          module: website
+          source_sha: ${{ needs.promotion.outputs.source_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
 
       - name: Sync esfa.co managed redirects (D1)
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
@@ -263,3 +354,12 @@ jobs:
           path: ${{ runner.temp }}/promotion-evidence/promotion-evidence.json
           retention-days: 14
           if-no-files-found: error
+
+      - name: Release Website release lease
+        if: ${{ always() && steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website.json

--- a/.github/workflows/finance-staging-canary.yml
+++ b/.github/workflows/finance-staging-canary.yml
@@ -64,6 +64,46 @@ jobs:
           node .github/scripts/validate-finance-canary-policy.mjs
           for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID CONTROL_KV_ID CANARY_PASSWORD; do [[ -n "${!name:-}" ]] || { echo "Missing required staging-only value: $name"; exit 1; }; done
           [[ "$CONTROL_KV_ID" =~ ^[0-9a-fA-F]{32}$ ]] || { echo 'Invalid Finance staging control KV id'; exit 1; }
+
+      - name: Acquire Finance release lease for synthetic canary
+        if: steps.prerequisites.outcome == 'success'
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:finance
+          module: finance
+          source_sha: ${{ inputs.release_sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-canary.json
+
+      - name: Acquire shared staging D1 lease for synthetic canary
+        if: steps.prerequisites.outcome == 'success'
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: global:staging-d1
+          module: finance
+          source_sha: ${{ inputs.release_sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-staging-d1.json
+
+      - name: Check Finance release lease before synthetic grant mutation
+        if: steps.prerequisites.outcome == 'success'
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-canary.json
+          resource: release:finance
+          module: finance
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Capture reversible synthetic grant baseline
         id: baseline
         if: steps.prerequisites.outcome == 'success'
@@ -75,6 +115,33 @@ jobs:
           permission="$(npx --yes wrangler@4.114.0 d1 execute skincos-finance-staging --remote --command "SELECT permission FROM finance_access_grants WHERE username='finance-staging-smoke' AND scope_id='finance-scope-novo-hamburgo' LIMIT 1;" --json | node -e "const fs=require('fs');const x=JSON.parse(fs.readFileSync(0,'utf8'));const p=x[0]?.results?.[0]?.permission;if(!p)process.exit(1);process.stdout.write(p)")"
           [[ "$permission" =~ ^(viewer|operator|manager)$ ]] || { echo 'Synthetic grant is invalid'; exit 1; }
           echo "permission=$permission" >> "$GITHUB_OUTPUT"
+
+      - name: Check Finance release lease before opening synthetic canary
+        if: steps.baseline.outcome == 'success'
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-canary.json
+          resource: release:finance
+          module: finance
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
+      - name: Check shared staging D1 lease before opening synthetic canary
+        if: steps.baseline.outcome == 'success'
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-staging-d1.json
+          resource: global:staging-d1
+          module: finance
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Open deterministic synthetic canary
         id: canary_open
         if: steps.baseline.outcome == 'success'
@@ -91,6 +158,18 @@ jobs:
           NODE
           npx --yes wrangler@4.112.0 kv key put 'module-control:finance' "$(cat "$RUNNER_TEMP/canary-control.json")" --namespace-id "$CONTROL_KV_ID" --remote
           npx --yes wrangler@4.114.0 d1 execute skincos-finance-staging --remote --command "INSERT INTO finance_settings(key,value,updated_at) VALUES ('module_enabled','true',CURRENT_TIMESTAMP) ON CONFLICT(key) DO UPDATE SET value='true',updated_at=CURRENT_TIMESTAMP; UPDATE finance_access_grants SET permission='operator' WHERE username='finance-staging-smoke' AND scope_id='finance-scope-novo-hamburgo';"
+      - name: Check shared staging D1 lease before authenticated canary
+        if: steps.canary_open.outcome == 'success'
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-staging-d1.json
+          resource: global:staging-d1
+          module: finance
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Run authenticated synthetic canary journey
         id: journey
         if: steps.canary_open.outcome == 'success'
@@ -103,6 +182,33 @@ jobs:
           FINANCE_CANARY_SCOPE_ID: finance-scope-novo-hamburgo
           FINANCE_CANARY_RELEASE_SHA: ${{ inputs.release_sha }}
         run: node finance/scripts/staging-synthetic-canary.mjs --report "$RUNNER_TEMP/canary-report.json"
+
+      - name: Check Finance release lease before committed import journey
+        if: steps.canary_open.outcome == 'success'
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-canary.json
+          resource: release:finance
+          module: finance
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
+      - name: Check shared staging D1 lease before committed import journey
+        if: steps.canary_open.outcome == 'success'
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-staging-d1.json
+          resource: global:staging-d1
+          module: finance
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Run complete import and compensation journey
         id: import
         if: steps.canary_open.outcome == 'success'
@@ -164,8 +270,35 @@ jobs:
           node finance/scripts/evaluate-canary.mjs --policy ops/module-governance/finance-staging-canary-policy.json --report "$RUNNER_TEMP/canary-report.json" --output "$RUNNER_TEMP/canary-decision.json"
           node - "$RUNNER_TEMP/canary-decision.json" >> "$GITHUB_OUTPUT" <<'NODE'
           const fs = require('fs'); const decision = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
-          console.log(`abort=${decision.ok ? 'false' : 'true'}`);
+            console.log(`abort=${decision.ok ? 'false' : 'true'}`);
           NODE
+
+      - name: Check Finance release lease before canary kill switch
+        if: always() && steps.baseline.outcome == 'success' && steps.decision.outputs.abort == 'true'
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-canary.json
+          resource: release:finance
+          module: finance
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
+      - name: Check shared staging D1 lease before canary kill switch
+        if: always() && steps.baseline.outcome == 'success' && steps.decision.outputs.abort == 'true'
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-staging-d1.json
+          resource: global:staging-d1
+          module: finance
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Kill switch on any breached limit
         if: always() && steps.baseline.outcome == 'success' && steps.decision.outputs.abort == 'true'
         env:
@@ -177,6 +310,32 @@ jobs:
           payload="$(node -e "process.stdout.write(JSON.stringify({state:'disabled',message:'Synthetic canary stop limit breached.',changedAt:new Date().toISOString(),changedBy:process.env.GITHUB_ACTOR}))")"
           npx --yes wrangler@4.112.0 kv key put 'module-control:finance' "$payload" --namespace-id "$CONTROL_KV_ID" --remote
           npx --yes wrangler@4.114.0 d1 execute skincos-finance-staging --remote --command "INSERT INTO finance_settings(key,value,updated_at) VALUES ('module_enabled','false',CURRENT_TIMESTAMP) ON CONFLICT(key) DO UPDATE SET value='false',updated_at=CURRENT_TIMESTAMP;"
+      - name: Check Finance release lease before baseline restore
+        if: always() && steps.baseline.outcome == 'success'
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-canary.json
+          resource: release:finance
+          module: finance
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
+      - name: Check shared staging D1 lease before baseline restore
+        if: always() && steps.baseline.outcome == 'success'
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-staging-d1.json
+          resource: global:staging-d1
+          module: finance
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Restore non-enabled staging baseline and synthetic grant
         if: always() && steps.baseline.outcome == 'success'
         env:
@@ -189,7 +348,24 @@ jobs:
           [[ "$ORIGINAL_PERMISSION" =~ ^(viewer|operator|manager)$ ]] || { echo 'No safe grant baseline available'; exit 1; }
           payload="$(node -e "process.stdout.write(JSON.stringify({state:'active',message:'',changedAt:new Date().toISOString(),changedBy:process.env.GITHUB_ACTOR}))")"
           npx --yes wrangler@4.112.0 kv key put 'module-control:finance' "$payload" --namespace-id "$CONTROL_KV_ID" --remote
-          npx --yes wrangler@4.114.0 d1 execute skincos-finance-staging --remote --command "INSERT INTO finance_settings(key,value,updated_at) VALUES ('module_enabled','false',CURRENT_TIMESTAMP) ON CONFLICT(key) DO UPDATE SET value='false',updated_at=CURRENT_TIMESTAMP; UPDATE finance_access_grants SET permission='$ORIGINAL_PERMISSION' WHERE username='finance-staging-smoke' AND scope_id='finance-scope-novo-hamburgo';"
+            npx --yes wrangler@4.114.0 d1 execute skincos-finance-staging --remote --command "INSERT INTO finance_settings(key,value,updated_at) VALUES ('module_enabled','false',CURRENT_TIMESTAMP) ON CONFLICT(key) DO UPDATE SET value='false',updated_at=CURRENT_TIMESTAMP; UPDATE finance_access_grants SET permission='$ORIGINAL_PERMISSION' WHERE username='finance-staging-smoke' AND scope_id='finance-scope-novo-hamburgo';"
+
+      - name: Release Finance release lease for synthetic canary
+        if: ${{ always() && steps.prerequisites.outcome == 'success' }}
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-canary.json
+      - name: Release shared staging D1 lease for synthetic canary
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-staging-d1.json
       - name: Upload sanitized canary evidence
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/finance-staging-smoke-identity.yml
+++ b/.github/workflows/finance-staging-smoke-identity.yml
@@ -46,6 +46,42 @@ jobs:
           date --date="$EXPIRES_AT" --iso-8601=seconds >/dev/null
           for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID; do [[ -n "${!name:-}" ]] || { echo "Missing required staging value: $name"; exit 1; }; done
           if [[ "$ACTION" != revoke ]]; then [[ ${#FINANCE_SMOKE_PASSWORD} -ge 24 ]] || { echo 'FINANCE_SMOKE_PASSWORD is missing or too short.'; exit 1; }; fi
+
+      - name: Acquire Finance release lease for synthetic identity
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:finance
+          module: finance
+          source_sha: ${{ github.sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-smoke-identity.json
+
+      - name: Acquire shared staging D1 lease for synthetic identity
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: global:staging-d1
+          module: finance
+          source_sha: ${{ github.sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-staging-d1.json
+
+      - name: Check Finance release lease before identity lifecycle SQL
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-smoke-identity.json
+          resource: release:finance
+          module: finance
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Verify one safe synthetic-identity target
         env:
           ACTION: ${{ inputs.action }}
@@ -67,6 +103,28 @@ jobs:
           else
             [[ "$active_count" == 1 && "$total_count" == 1 ]] || { echo 'Expected exactly one active synthetic identity.'; exit 1; }
           fi
+      - name: Recheck Finance release lease before identity lifecycle SQL
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-smoke-identity.json
+          resource: release:finance
+          module: finance
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+      - name: Check shared staging D1 lease before identity lifecycle SQL
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-staging-d1.json
+          resource: global:staging-d1
+          module: finance
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Apply audited staging identity lifecycle SQL
         env:
           ACTION: ${{ inputs.action }}
@@ -83,3 +141,20 @@ jobs:
           npx --yes wrangler@4.114.0 d1 execute skincos-db-staging --remote --file "$core_sql"
           npx --yes wrangler@4.114.0 d1 execute skincos-finance-staging --remote --file "$finance_sql"
           rm -f "$core_sql" "$finance_sql"
+
+      - name: Release Finance release lease for synthetic identity
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-smoke-identity.json
+      - name: Release shared staging D1 lease for synthetic identity
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-finance-staging-d1.json

--- a/.github/workflows/global-coordination-release.yml
+++ b/.github/workflows/global-coordination-release.yml
@@ -1,0 +1,46 @@
+name: Release global coordination lease
+
+on:
+  workflow_call:
+    inputs:
+      required:
+        required: true
+        type: boolean
+      proof_b64:
+        required: true
+        type: string
+      coordinator_url:
+        required: true
+        type: string
+    secrets:
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    if: ${{ inputs.required }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+      - name: Release the remote lease after all dependent jobs settle
+        env:
+          SKINCOS_GLOBAL_COORDINATOR_URL: ${{ inputs.coordinator_url }}
+          SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          GLOBAL_PROOF_B64: ${{ inputs.proof_b64 }}
+          GLOBAL_PROOF_FILE: ${{ runner.temp }}/skincos-global-coordination-proof.json
+        run: |
+          set -euo pipefail
+          [[ "${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}" == true ]] || { echo 'Global coordination is not active; no remote release is permitted'; exit 1; }
+          [[ -n "$SKINCOS_GLOBAL_COORDINATOR_URL" && -n "$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" ]] || { echo 'Global coordination custody is unavailable'; exit 1; }
+          [[ -n "$GLOBAL_PROOF_B64" ]] || { echo 'Global coordination proof is missing'; exit 1; }
+          printf '%s' "$GLOBAL_PROOF_B64" | base64 -d > "$GLOBAL_PROOF_FILE"
+          SKINCOS_GLOBAL_COORDINATOR_URL="$SKINCOS_GLOBAL_COORDINATOR_URL" \
+          SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET="$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" \
+            node scripts/codex-global-coordination-workflow.mjs release \
+              --proof-file "$GLOBAL_PROOF_FILE"

--- a/.github/workflows/global-merge-authority.yml
+++ b/.github/workflows/global-merge-authority.yml
@@ -1,0 +1,87 @@
+name: Global merge authority
+run-name: Merge PR #${{ inputs.pull_number }} through merge:main
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pull_number:
+        description: Open pull request targeting main
+        required: true
+        type: string
+      expected_head_sha:
+        description: Exact PR head SHA approved for this merge attempt
+        required: true
+        type: string
+      merge_method:
+        description: GitHub merge method
+        required: true
+        default: squash
+        type: choice
+        options: [squash, merge, rebase]
+
+concurrency:
+  group: merge-main-authority
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  authority-signal:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark direct UI merge as unauthorized
+        if: ${{ github.event_name == 'pull_request_target' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'pull request head SHA is invalid'; exit 1; }
+          gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            -f state=failure \
+            -f context=global-merge-authority \
+            -f description='Merge must be issued by global-merge-authority after lease revalidation.' \
+            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/workflows/global-merge-authority.yml" \
+            >/dev/null
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Fetch the exact base tree used by the merge intent
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PULL_NUMBER: ${{ inputs.pull_number }}
+        run: |
+          set -euo pipefail
+          [[ "$PULL_NUMBER" =~ ^[1-9][0-9]*$ ]] || { echo 'pull_number must be numeric'; exit 1; }
+          base_sha="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER" --jq '.base.sha')"
+          [[ "$base_sha" =~ ^[0-9a-f]{40}$ ]] || { echo 'pull request base SHA is invalid'; exit 1; }
+          git fetch --no-tags origin "$base_sha"
+      - name: Acquire merge:main, revalidate base/head, and merge exactly once
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SKINCOS_GLOBAL_COORDINATOR_URL: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          SKINCOS_GLOBAL_COORDINATION_REQUIRED: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_WORKFLOW: ${{ github.workflow }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          PULL_NUMBER: ${{ inputs.pull_number }}
+          EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
+          MERGE_METHOD: ${{ inputs.merge_method }}
+        run: |
+          set -euo pipefail
+          node scripts/codex-global-merge-authority.mjs \
+            --pull-number "$PULL_NUMBER" \
+            --expected-head-sha "$EXPECTED_HEAD_SHA" \
+            --merge-method "$MERGE_METHOD"

--- a/.github/workflows/insumos-staging-rbac-smoke.yml
+++ b/.github/workflows/insumos-staging-rbac-smoke.yml
@@ -88,6 +88,30 @@ jobs:
         run: npx --yes playwright install --with-deps chromium
         working-directory: crm/console
 
+      - name: Acquire staging D1 coordination lease
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: global:staging-d1
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-staging-d1-insumos.json
+
+      - name: Check staging D1 lease before synthetic identity provisioning
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-staging-d1-insumos.json
+          resource: global:staging-d1
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Generate private synthetic staging identities
         id: fixture
         env:
@@ -109,6 +133,18 @@ jobs:
           [[ "$STAGING_D1_DATABASE" == 'skincos-db-staging' ]] || { echo 'refusing a non-staging D1 target'; exit 1; }
           npx --yes wrangler@3 d1 execute "$STAGING_D1_DATABASE" --config inventory/wrangler.toml --env staging --remote --file "$SQL_FILE" >/dev/null
 
+      - name: Check staging D1 lease before authenticated journey
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-staging-d1-insumos.json
+          resource: global:staging-d1
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Execute authenticated unit-scope journey
         env:
           INSUMOS_STAGING_CRM_URL: ${{ inputs.pages_url }}
@@ -117,8 +153,22 @@ jobs:
           NODE_PATH: crm/console/node_modules
         run: node crm/console/scripts/insumos-staging-rbac-smoke.cjs
 
-      - name: Tear down only this run's synthetic staging identities
+      - name: Check staging D1 lease before synthetic identity teardown
+        id: check_teardown
         if: ${{ always() }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-staging-d1-insumos.json
+          resource: global:staging-d1
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
+      - name: Tear down only this run's synthetic staging identities
+        if: ${{ always() && steps.check_teardown.outcome == 'success' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -131,6 +181,15 @@ jobs:
           node inventory/scripts/insumosStagingRbacFixtures.mjs --action teardown --run-id "$GITHUB_RUN_ID" --fixtures "$FIXTURES" --sql "$SQL_FILE"
           npx --yes wrangler@3 d1 execute "$STAGING_D1_DATABASE" --config inventory/wrangler.toml --env staging --remote --file "$SQL_FILE" >/dev/null
           rm -f "$FIXTURES" "$SQL_FILE"
+
+      - name: Release staging D1 coordination lease
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-staging-d1-insumos.json
 
       - name: Upload sanitised journey evidence
         if: ${{ always() }}

--- a/.github/workflows/module-availability.yml
+++ b/.github/workflows/module-availability.yml
@@ -134,12 +134,17 @@ jobs:
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
     with:
       required: ${{ inputs.module == 'timekeeping' && contains(fromJSON('["canary","active"]'), inputs.state) }}
+      global_lease_required: true
+      global_resource: release:ponto
+      global_module: ponto
+      global_coordinator_url: ${{ inputs.target == 'production' && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
       lease_key: ${{ inputs.orchestrator_lease_key }}
       stage: ${{ inputs.orchestrator_stage }}
       target: ${{ inputs.target }}
-      release_sha: ${{ inputs.orchestrator_release_sha || inputs.release_sha }}
+      release_sha: ${{ inputs.orchestrator_release_sha || inputs.release_sha || github.sha }}
       orchestrator_run_id: ${{ inputs.orchestrator_run_id }}
   set-state:
     needs: coordination
@@ -167,6 +172,17 @@ jobs:
             "$ORCHESTRATOR_STAGE" \
             "$RELEASE_SHA" \
             "$ORCHESTRATOR_RUN_ID"
+      - name: Authorize global module-control mutation
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.orchestrator_release_sha || inputs.release_sha || github.sha }}
       - name: Guard isolated control store
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -629,3 +645,13 @@ jobs:
           path: ${{ runner.temp }}/ponto-emergency
           retention-days: 90
           if-no-files-found: error
+  global-coordination-release:
+    needs: [source, coordination, set-state, emergency-reconciliation]
+    if: ${{ always() && needs.coordination.outputs.global_lease_required == 'true' }}
+    uses: ./.github/workflows/global-coordination-release.yml
+    secrets:
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+    with:
+      required: true
+      proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
+      coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}

--- a/.github/workflows/module-availability.yml
+++ b/.github/workflows/module-availability.yml
@@ -138,7 +138,7 @@ jobs:
     with:
       required: ${{ inputs.module == 'timekeeping' && contains(fromJSON('["canary","active"]'), inputs.state) }}
       global_lease_required: true
-      global_resource: release:ponto
+      global_resource: ${{ inputs.orchestrator_run_id != '' && 'release:ponto-child' || 'release:ponto' }}
       global_module: ponto
       global_coordinator_url: ${{ inputs.target == 'production' && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
       lease_key: ${{ inputs.orchestrator_lease_key }}
@@ -180,7 +180,7 @@ jobs:
           coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
           proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
-          resource: release:ponto
+          resource: ${{ inputs.orchestrator_run_id != '' && 'release:ponto-child' || 'release:ponto' }}
           module: ponto
           source_sha: ${{ inputs.orchestrator_release_sha || inputs.release_sha || github.sha }}
       - name: Guard isolated control store

--- a/.github/workflows/ponto-emergency-close.yml
+++ b/.github/workflows/ponto-emergency-close.yml
@@ -162,6 +162,28 @@ jobs:
           path: ${{ runner.temp }}/ponto-manual-emergency-close
           github-token: ${{ github.token }}
           run-id: ${{ github.run_id }}
+      - name: Acquire Ponto release lease for close materialization
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ github.sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-emergency-close.json
+      - name: Check Ponto release lease before close materialization
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-emergency-close.json
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Materialize the exact broker close under the surface mutex
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -236,3 +258,11 @@ jobs:
           path: ${{ runner.temp }}/ponto-manual-emergency-close
           retention-days: 90
           if-no-files-found: error
+      - name: Release Ponto release lease for close materialization
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-emergency-close.json

--- a/.github/workflows/ponto-emergency-latch-reset.yml
+++ b/.github/workflows/ponto-emergency-latch-reset.yml
@@ -185,6 +185,28 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1
+      - name: Acquire Ponto release lease for latch reset
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ github.sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-latch-reset.json
+      - name: Check Ponto release lease before latch-reset mutation
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-latch-reset.json
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Clear only the attested latch and remain in maintenance
         id: mutate
         env:
@@ -309,6 +331,14 @@ jobs:
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `changed_at=${latch.changedAt}\n`);
           NODE
           rm -f "$prior" "$prior_latch" "$payload" "$latch_payload" "$readback" "$latch_readback" "$directory/prior-latch-error"
+      - name: Release Ponto release lease for latch reset
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-latch-reset.json
 
   verify-reset:
     needs: [preflight, reset-mutate]

--- a/.github/workflows/ponto-orchestrator-gate.yml
+++ b/.github/workflows/ponto-orchestrator-gate.yml
@@ -156,6 +156,10 @@ jobs:
           GLOBAL_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
           GLOBAL_RESOURCE: ${{ inputs.global_resource }}
           GLOBAL_MODULE: ${{ inputs.global_module }}
+          GLOBAL_INPUT_URL: ${{ inputs.global_coordinator_url }}
+          GLOBAL_TARGET: ${{ inputs.target }}
+          GLOBAL_STAGE: ${{ inputs.stage }}
+          GLOBAL_LEASE_KEY: ${{ inputs.lease_key }}
           RELEASE_SHA: ${{ inputs.release_sha }}
           GLOBAL_INPUTS_FILE: ${{ runner.temp }}/skincos-global-coordination-inputs.json
           GLOBAL_PROOF_FILE: ${{ runner.temp }}/skincos-global-coordination-proof.json
@@ -163,7 +167,9 @@ jobs:
         run: |
           set -euo pipefail
           [[ "$GLOBAL_REQUIRED" == true ]] || { echo 'SKINCOS_GLOBAL_COORDINATION_REQUIRED must be true for a governed global lease'; exit 1; }
-          GLOBAL_URL="${{ inputs.global_coordinator_url || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}"
+          if [[ -n "$GLOBAL_INPUT_URL" ]]; then
+            GLOBAL_URL="$GLOBAL_INPUT_URL"
+          fi
           [[ -n "$GLOBAL_URL" && -n "$GLOBAL_SECRET" ]] || { echo 'Global coordination URL and shared custody are required'; exit 1; }
           [[ "$GLOBAL_RESOURCE" =~ ^(deploy|cloudflare|release):[a-z0-9][a-z0-9._/-]{0,127}:(preview|staging|pilot|canary|production|rollback)$ || "$GLOBAL_RESOURCE" =~ ^release:[a-z0-9][a-z0-9._/-]{0,127}$ ]] || {
             echo 'Global coordination resource is invalid'; exit 1;
@@ -174,7 +180,11 @@ jobs:
             git fetch --no-tags origin "$source_sha"
           fi
           git cat-file -e "$source_sha^{commit}" || { echo 'Global coordination source SHA is unavailable'; exit 1; }
-          printf '%s\n' "{\"target\":\"${{ inputs.target }}\",\"stage\":\"${{ inputs.stage }}\",\"leaseKey\":\"${{ inputs.lease_key }}\"}" > "$GLOBAL_INPUTS_FILE"
+          node - "$GLOBAL_INPUTS_FILE" "$GLOBAL_TARGET" "$GLOBAL_STAGE" "$GLOBAL_LEASE_KEY" <<'NODE'
+          const fs = require('node:fs');
+          const [output, target, stage, leaseKey] = process.argv.slice(2);
+          fs.writeFileSync(output, JSON.stringify({ target, stage, leaseKey }));
+          NODE
           SKINCOS_GLOBAL_COORDINATOR_URL="$GLOBAL_URL" \
           SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET="$GLOBAL_SECRET" \
             node scripts/codex-global-coordination-workflow.mjs acquire \

--- a/.github/workflows/ponto-orchestrator-gate.yml
+++ b/.github/workflows/ponto-orchestrator-gate.yml
@@ -93,7 +93,15 @@ jobs:
           set -euo pipefail
           [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'Ponto release SHA is invalid'; exit 1; }
           [[ "$GITHUB_REF" == refs/heads/main ]] || { echo 'Ponto gate must execute from main'; exit 1; }
-          [[ "$GITHUB_SHA" == "$RELEASE_SHA" ]] || { echo 'Ponto gate source differs from the coordinator SHA'; exit 1; }
+          [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'Ponto gate observed source SHA is invalid'; exit 1; }
+          if ! git cat-file -e "$RELEASE_SHA^{commit}" 2>/dev/null; then
+            git fetch --no-tags origin "$RELEASE_SHA"
+          fi
+          git cat-file -e "$RELEASE_SHA^{commit}" || { echo 'Ponto release source cannot be attested locally'; exit 1; }
+          PONTO_RELEASE_SHA="$RELEASE_SHA" PONTO_OBSERVED_SHA="$GITHUB_SHA" node --input-type=module <<'NODE'
+          import { assertPontoSourceClosureUnchanged } from "./.github/scripts/ponto-source-closure.mjs";
+          assertPontoSourceClosureUnchanged(process.env.PONTO_RELEASE_SHA, process.env.PONTO_OBSERVED_SHA);
+          NODE
           [[ "$(git rev-parse HEAD)" == "$GITHUB_SHA" ]] || { echo 'Ponto gate checkout is not the trusted workflow revision'; exit 1; }
       - name: Revalidate protected target environment before consuming authority
         if: ${{ inputs.required }}

--- a/.github/workflows/ponto-orchestrator-gate.yml
+++ b/.github/workflows/ponto-orchestrator-gate.yml
@@ -21,8 +21,40 @@ on:
       orchestrator_run_id:
         required: false
         type: string
+      global_lease_required:
+        required: false
+        default: false
+        type: boolean
+      global_resource:
+        required: false
+        type: string
+      global_module:
+        required: false
+        default: ponto
+        type: string
+      global_coordinator_url:
+        required: false
+        type: string
+    outputs:
+      global_lease_required:
+        description: Global coordination was acquired for this invocation
+        value: ${{ jobs.consume.outputs.global_lease_required }}
+      global_resource:
+        description: Canonical resource protected by the global lease
+        value: ${{ jobs.consume.outputs.global_resource }}
+      global_proof_b64:
+        description: Base64 encoded lease proof, never a custody secret
+        value: ${{ jobs.consume.outputs.global_proof_b64 }}
+      global_intent_digest:
+        description: Intent digest bound to the global lease
+        value: ${{ jobs.consume.outputs.global_intent_digest }}
+      global_coordinator_url:
+        description: Authority endpoint used by the lease
+        value: ${{ jobs.consume.outputs.global_coordinator_url }}
     secrets:
       GH_TOKEN:
+        required: false
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET:
         required: false
 permissions:
   actions: read
@@ -33,6 +65,12 @@ permissions:
 jobs:
   consume:
     runs-on: ubuntu-latest
+    outputs:
+      global_lease_required: ${{ steps.global-enabled.outputs.required || steps.global-disabled.outputs.required }}
+      global_resource: ${{ steps.global-enabled.outputs.resource || steps.global-disabled.outputs.resource }}
+      global_proof_b64: ${{ steps.global-enabled.outputs.proof_b64 || steps.global-disabled.outputs.proof_b64 }}
+      global_intent_digest: ${{ steps.global-enabled.outputs.intent_digest || steps.global-disabled.outputs.intent_digest }}
+      global_coordinator_url: ${{ steps.global-enabled.outputs.url || steps.global-disabled.outputs.url }}
     steps:
       - name: Refuse replayed governed invocation
         if: ${{ inputs.required }}
@@ -43,10 +81,10 @@ jobs:
         if: ${{ !inputs.required }}
         run: echo "Single-use Ponto orchestrator capability is not required for this invocation."
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
-        if: ${{ inputs.required }}
+        if: ${{ inputs.required || inputs.global_lease_required }}
         with:
           ref: ${{ github.sha }}
-          fetch-depth: 1
+          fetch-depth: 0
       - name: Refuse candidate-controlled gate code
         if: ${{ inputs.required }}
         env:
@@ -109,3 +147,57 @@ jobs:
             "$ORCHESTRATOR_TARGET" \
             "$RELEASE_SHA" \
             "$ORCHESTRATOR_RUN_ID"
+      - name: Acquire the canonical global mutation lease
+        id: global-enabled
+        if: ${{ inputs.global_lease_required }}
+        env:
+          GLOBAL_REQUIRED: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          GLOBAL_URL: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          GLOBAL_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          GLOBAL_RESOURCE: ${{ inputs.global_resource }}
+          GLOBAL_MODULE: ${{ inputs.global_module }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+          GLOBAL_INPUTS_FILE: ${{ runner.temp }}/skincos-global-coordination-inputs.json
+          GLOBAL_PROOF_FILE: ${{ runner.temp }}/skincos-global-coordination-proof.json
+          GLOBAL_RESULT_FILE: ${{ runner.temp }}/skincos-global-coordination-acquire.json
+        run: |
+          set -euo pipefail
+          [[ "$GLOBAL_REQUIRED" == true ]] || { echo 'SKINCOS_GLOBAL_COORDINATION_REQUIRED must be true for a governed global lease'; exit 1; }
+          GLOBAL_URL="${{ inputs.global_coordinator_url || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}"
+          [[ -n "$GLOBAL_URL" && -n "$GLOBAL_SECRET" ]] || { echo 'Global coordination URL and shared custody are required'; exit 1; }
+          [[ "$GLOBAL_RESOURCE" =~ ^(deploy|cloudflare|release):[a-z0-9][a-z0-9._/-]{0,127}:(preview|staging|pilot|canary|production|rollback)$ || "$GLOBAL_RESOURCE" =~ ^release:[a-z0-9][a-z0-9._/-]{0,127}$ ]] || {
+            echo 'Global coordination resource is invalid'; exit 1;
+          }
+          source_sha="${RELEASE_SHA:-$GITHUB_SHA}"
+          [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || { echo 'Global coordination source SHA is invalid'; exit 1; }
+          if ! git cat-file -e "$source_sha^{commit}" 2>/dev/null; then
+            git fetch --no-tags origin "$source_sha"
+          fi
+          git cat-file -e "$source_sha^{commit}" || { echo 'Global coordination source SHA is unavailable'; exit 1; }
+          printf '%s\n' "{\"target\":\"${{ inputs.target }}\",\"stage\":\"${{ inputs.stage }}\",\"leaseKey\":\"${{ inputs.lease_key }}\"}" > "$GLOBAL_INPUTS_FILE"
+          SKINCOS_GLOBAL_COORDINATOR_URL="$GLOBAL_URL" \
+          SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET="$GLOBAL_SECRET" \
+            node scripts/codex-global-coordination-workflow.mjs acquire \
+              --resource "$GLOBAL_RESOURCE" \
+              --module "$GLOBAL_MODULE" \
+              --source "$source_sha" \
+              --inputs-file "$GLOBAL_INPUTS_FILE" \
+              --proof-file "$GLOBAL_PROOF_FILE" \
+              --result-file "$GLOBAL_RESULT_FILE" \
+              --idempotency-key "github:${GITHUB_REPOSITORY}:${GITHUB_RUN_ID}:${GLOBAL_RESOURCE}:${GITHUB_RUN_ATTEMPT}"
+          proof_b64="$(base64 -w0 "$GLOBAL_PROOF_FILE")"
+          intent_digest="$(node -e 'const fs=require("fs"); process.stdout.write(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).intentDigest)' "$GLOBAL_PROOF_FILE")"
+          echo "required=true" >> "$GITHUB_OUTPUT"
+          echo "resource=$GLOBAL_RESOURCE" >> "$GITHUB_OUTPUT"
+          echo "proof_b64=$proof_b64" >> "$GITHUB_OUTPUT"
+          echo "intent_digest=$intent_digest" >> "$GITHUB_OUTPUT"
+          echo "url=$GLOBAL_URL" >> "$GITHUB_OUTPUT"
+      - name: Keep the preactivation path explicit
+        id: global-disabled
+        if: ${{ !inputs.global_lease_required }}
+        run: |
+          echo 'required=false' >> "$GITHUB_OUTPUT"
+          echo 'resource=' >> "$GITHUB_OUTPUT"
+          echo 'proof_b64=' >> "$GITHUB_OUTPUT"
+          echo 'intent_digest=' >> "$GITHUB_OUTPUT"
+          echo 'url=' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ponto-production-baseline.yml
+++ b/.github/workflows/ponto-production-baseline.yml
@@ -51,7 +51,7 @@ jobs:
     with:
       required: true
       global_lease_required: true
-      global_resource: release:ponto
+      global_resource: ${{ inputs.orchestrator_run_id != '' && 'release:ponto-child' || 'release:ponto' }}
       global_module: ponto
       global_coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
       lease_key: production-baseline
@@ -89,14 +89,19 @@ jobs:
           set -euo pipefail
           [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ && "$STAGING_RUN_ID" =~ ^[0-9]+$ ]] || { echo 'Invalid baseline source/predecessor'; exit 1; }
           [[ "$ORCHESTRATOR_STAGE" == pilot ]] || { echo 'Production baseline is valid only inside the pilot coordinator'; exit 1; }
-          [[ "$GITHUB_SHA" == "$RELEASE_SHA" ]] || { echo 'Baseline workflow revision differs'; exit 1; }
-          [[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]] || { echo 'Baseline checkout differs'; exit 1; }
+          [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'Baseline observed workflow revision is invalid'; exit 1; }
+          PONTO_RELEASE_SHA="$RELEASE_SHA" PONTO_OBSERVED_SHA="$GITHUB_SHA" node --input-type=module <<'NODE'
+          import { assertPontoSourceClosureUnchanged } from "./.github/scripts/ponto-source-closure.mjs";
+          assertPontoSourceClosureUnchanged(process.env.PONTO_RELEASE_SHA, process.env.PONTO_OBSERVED_SHA);
+          NODE
+          [[ "$(git rev-parse HEAD)" == "$GITHUB_SHA" ]] || { echo 'Baseline checkout differs from the observed workflow revision'; exit 1; }
           git fetch --no-tags origin main
           git merge-base --is-ancestor "$RELEASE_SHA" origin/main || { echo 'Baseline SHA is not reachable from main'; exit 1; }
           gh api "repos/$GITHUB_REPOSITORY/actions/workflows/ponto-progressive-release.yml" > "$RUNNER_TEMP/staging-workflow.json"
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$STAGING_RUN_ID" > "$RUNNER_TEMP/staging-run.json"
-          node - "$RUNNER_TEMP/staging-workflow.json" "$RUNNER_TEMP/staging-run.json" <<'NODE'
-          const fs = require("fs");
+          node --input-type=module - "$RUNNER_TEMP/staging-workflow.json" "$RUNNER_TEMP/staging-run.json" <<'NODE'
+          import fs from "node:fs";
+          const { pontoSourceClosureMatches } = await import("./.github/scripts/ponto-source-closure.mjs");
           const workflow = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
           const run = JSON.parse(fs.readFileSync(process.argv[3], "utf8"));
           if (
@@ -108,7 +113,7 @@ jobs:
             || run.conclusion !== "success"
             || run.event !== "workflow_dispatch"
             || run.head_branch !== "main"
-            || run.head_sha !== process.env.RELEASE_SHA
+            || !pontoSourceClosureMatches(process.env.RELEASE_SHA, String(run.head_sha || "").toLowerCase())
             || run.repository?.full_name !== process.env.GITHUB_REPOSITORY
             || run.head_repository?.full_name !== process.env.GITHUB_REPOSITORY
           ) throw new Error("baseline staging predecessor provenance is invalid");
@@ -139,7 +144,7 @@ jobs:
           coordinator_url: ${{ needs.orchestrator.outputs.global_coordinator_url }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
           proof_b64: ${{ needs.orchestrator.outputs.global_proof_b64 }}
-          resource: release:ponto
+          resource: ${{ inputs.orchestrator_run_id != '' && 'release:ponto-child' || 'release:ponto' }}
           module: ponto
           source_sha: ${{ inputs.release_sha }}
       - name: Verify exact cataloged production Ponto Core bootstrap predecessor

--- a/.github/workflows/ponto-production-baseline.yml
+++ b/.github/workflows/ponto-production-baseline.yml
@@ -47,8 +47,13 @@ jobs:
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
     with:
       required: true
+      global_lease_required: true
+      global_resource: release:ponto
+      global_module: ponto
+      global_coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
       lease_key: production-baseline
       stage: ${{ inputs.orchestrator_stage }}
       target: production
@@ -126,6 +131,17 @@ jobs:
             "$ORCHESTRATOR_STAGE" \
             "$RELEASE_SHA" \
             "$ORCHESTRATOR_RUN_ID"
+      - name: Authorize global Ponto baseline mutation
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ needs.orchestrator.outputs.global_coordinator_url }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_b64: ${{ needs.orchestrator.outputs.global_proof_b64 }}
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
       - name: Verify exact cataloged production Ponto Core bootstrap predecessor
         id: core_bootstrap
         env:
@@ -242,3 +258,13 @@ jobs:
           path: ${{ runner.temp }}/ponto-production-baseline.json
           retention-days: 90
           if-no-files-found: error
+  global-coordination-release:
+    needs: [orchestrator, capture]
+    if: ${{ always() && needs.orchestrator.outputs.global_lease_required == 'true' }}
+    uses: ./.github/workflows/global-coordination-release.yml
+    secrets:
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+    with:
+      required: true
+      proof_b64: ${{ needs.orchestrator.outputs.global_proof_b64 }}
+      coordinator_url: ${{ needs.orchestrator.outputs.global_coordinator_url }}

--- a/.github/workflows/ponto-production-slo.yml
+++ b/.github/workflows/ponto-production-slo.yml
@@ -67,7 +67,7 @@ jobs:
     with:
       required: true
       global_lease_required: true
-      global_resource: release:ponto
+      global_resource: ${{ inputs.orchestrator_run_id != '' && 'release:ponto-child' || 'release:ponto' }}
       global_module: ponto
       global_coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
       lease_key: production-slo
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
         with:
           ref: ${{ github.sha }}
-          fetch-depth: 1
+          fetch-depth: 0
       - name: Verify exact protected preflight source and active coordinator
         env:
           GH_TOKEN: ${{ github.token }}
@@ -105,7 +105,11 @@ jobs:
           set -euo pipefail
           [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'SLO release SHA is invalid'; exit 1; }
           [[ "$ORCHESTRATOR_STAGE" == "$RELEASE_STAGE" ]] || { echo 'SLO stage differs from its coordinator capability'; exit 1; }
-          [[ "$GITHUB_SHA" == "$RELEASE_SHA" && "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]] || { echo 'SLO preflight source differs'; exit 1; }
+          [[ "$(git rev-parse HEAD)" == "$GITHUB_SHA" ]] || { echo 'SLO preflight checkout differs from the trusted workflow revision'; exit 1; }
+          PONTO_RELEASE_SHA="$RELEASE_SHA" PONTO_OBSERVED_SHA="$GITHUB_SHA" node --input-type=module <<'NODE'
+          import { assertPontoSourceClosureUnchanged } from "./.github/scripts/ponto-source-closure.mjs";
+          assertPontoSourceClosureUnchanged(process.env.PONTO_RELEASE_SHA, process.env.PONTO_OBSERVED_SHA);
+          NODE
           node .github/scripts/ponto-orchestrator-lease.mjs assert-active \
             "$ORCHESTRATOR_STAGE" \
             "$RELEASE_SHA" \
@@ -118,7 +122,7 @@ jobs:
           coordinator_url: ${{ needs.orchestrator.outputs.global_coordinator_url }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
           proof_b64: ${{ needs.orchestrator.outputs.global_proof_b64 }}
-          resource: release:ponto
+          resource: ${{ inputs.orchestrator_run_id != '' && 'release:ponto-child' || 'release:ponto' }}
           module: ponto
           source_sha: ${{ inputs.release_sha }}
       - name: Attest the exact registered clinic runner before hydrating control-plane authority
@@ -331,7 +335,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
         with:
           ref: ${{ github.sha }}
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: false
       - name: Verify trusted exact release source before hydrating secrets
         env:
@@ -342,8 +346,11 @@ jobs:
           set -euo pipefail
           [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'SLO release SHA is invalid'; exit 1; }
           [[ "$ORCHESTRATOR_STAGE" == "$RELEASE_STAGE" ]] || { echo 'SLO stage differs from its coordinator capability'; exit 1; }
-          [[ "$GITHUB_SHA" == "$RELEASE_SHA" ]] || { echo 'SLO workflow revision differs'; exit 1; }
-          [[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]] || { echo 'SLO checkout differs'; exit 1; }
+          [[ "$(git rev-parse HEAD)" == "$GITHUB_SHA" ]] || { echo 'SLO checkout differs from the trusted workflow revision'; exit 1; }
+          PONTO_RELEASE_SHA="$RELEASE_SHA" PONTO_OBSERVED_SHA="$GITHUB_SHA" node --input-type=module <<'NODE'
+          import { assertPontoSourceClosureUnchanged } from "./.github/scripts/ponto-source-closure.mjs";
+          assertPontoSourceClosureUnchanged(process.env.PONTO_RELEASE_SHA, process.env.PONTO_OBSERVED_SHA);
+          NODE
       - name: Revalidate the exact active coordinator before production journey secrets
         env:
           GH_TOKEN: ${{ github.token }}
@@ -364,7 +371,7 @@ jobs:
           coordinator_url: ${{ needs.orchestrator.outputs.global_coordinator_url }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
           proof_b64: ${{ needs.orchestrator.outputs.global_proof_b64 }}
-          resource: release:ponto
+          resource: ${{ inputs.orchestrator_run_id != '' && 'release:ponto-child' || 'release:ponto' }}
           module: ponto
           source_sha: ${{ inputs.release_sha }}
       - name: Attest exact immutable preflight artifact before clinic secrets
@@ -442,7 +449,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
         with:
           ref: ${{ github.sha }}
-          fetch-depth: 1
+          fetch-depth: 0
       - name: Verify trusted exact rollback source before hydrating secrets
         env:
           RELEASE_SHA: ${{ inputs.release_sha }}
@@ -452,8 +459,11 @@ jobs:
           set -euo pipefail
           [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'Rollback release SHA is invalid'; exit 1; }
           [[ "$RELEASE_STAGE" == rollback && "$ORCHESTRATOR_STAGE" == rollback ]] || { echo 'Rollback stage differs from its coordinator capability'; exit 1; }
-          [[ "$GITHUB_SHA" == "$RELEASE_SHA" ]] || { echo 'Rollback workflow revision differs'; exit 1; }
-          [[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]] || { echo 'Rollback checkout differs'; exit 1; }
+          [[ "$(git rev-parse HEAD)" == "$GITHUB_SHA" ]] || { echo 'Rollback checkout differs from the trusted workflow revision'; exit 1; }
+          PONTO_RELEASE_SHA="$RELEASE_SHA" PONTO_OBSERVED_SHA="$GITHUB_SHA" node --input-type=module <<'NODE'
+          import { assertPontoSourceClosureUnchanged } from "./.github/scripts/ponto-source-closure.mjs";
+          assertPontoSourceClosureUnchanged(process.env.PONTO_RELEASE_SHA, process.env.PONTO_OBSERVED_SHA);
+          NODE
       - name: Revalidate the exact active coordinator before rollback observation secrets
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ponto-production-slo.yml
+++ b/.github/workflows/ponto-production-slo.yml
@@ -63,8 +63,13 @@ jobs:
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
     with:
       required: true
+      global_lease_required: true
+      global_resource: release:ponto
+      global_module: ponto
+      global_coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
       lease_key: production-slo
       stage: ${{ inputs.orchestrator_stage }}
       target: production
@@ -105,6 +110,17 @@ jobs:
             "$ORCHESTRATOR_STAGE" \
             "$RELEASE_SHA" \
             "$ORCHESTRATOR_RUN_ID"
+      - name: Authorize global Ponto SLO journey mutation
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ needs.orchestrator.outputs.global_coordinator_url }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_b64: ${{ needs.orchestrator.outputs.global_proof_b64 }}
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
       - name: Attest the exact registered clinic runner before hydrating control-plane authority
         id: runner-inventory
         env:
@@ -340,6 +356,17 @@ jobs:
             "$ORCHESTRATOR_STAGE" \
             "$RELEASE_SHA" \
             "$ORCHESTRATOR_RUN_ID"
+      - name: Authorize global Ponto rollback observation mutation
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ needs.orchestrator.outputs.global_coordinator_url }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_b64: ${{ needs.orchestrator.outputs.global_proof_b64 }}
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
       - name: Attest exact immutable preflight artifact before clinic secrets
         env:
           GH_TOKEN: ${{ github.token }}
@@ -382,6 +409,7 @@ jobs:
           path: ${{ runner.temp }}/ponto-production-slo.json
           retention-days: 90
           if-no-files-found: error
+
       - name: Remove any unconsumed JIT and delegated material
         if: ${{ always() }}
         run: |
@@ -391,6 +419,16 @@ jobs:
             "$RUNNER_TEMP/ponto-slo-artifact.json" \
             "$RUNNER_TEMP/ponto-slo-preflight/control-plane-attestation.json" \
             "$RUNNER_TEMP/ponto-slo-preflight/release-probe-capability.json"
+  global-coordination-release:
+    needs: [orchestrator, control-plane-preflight, consultor-journey, rollback-observation]
+    if: ${{ always() && needs.orchestrator.outputs.global_lease_required == 'true' }}
+    uses: ./.github/workflows/global-coordination-release.yml
+    secrets:
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+    with:
+      required: true
+      proof_b64: ${{ needs.orchestrator.outputs.global_proof_b64 }}
+      coordinator_url: ${{ needs.orchestrator.outputs.global_coordinator_url }}
   rollback-observation:
     needs: orchestrator
     if: ${{ needs.orchestrator.result == 'success' && github.run_attempt == 1 && github.ref == 'refs/heads/main' && inputs.stage == 'rollback' }}

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -119,6 +119,12 @@ jobs:
       PONTO_DISPATCH_TIMEOUT_MS: "1200000"
       PONTO_REQUIRED_CHECK_SETTLE_TIMEOUT_SECONDS: "900"
       PONTO_REQUIRED_CHECK_SETTLE_POLL_SECONDS: "10"
+      # The global authority is fail-closed when explicitly enabled.  Staging
+      # uses the dedicated coordinator; production remains blocked until its
+      # separate endpoint and custody are provisioned.
+      SKINCOS_GLOBAL_COORDINATION_REQUIRED: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+      SKINCOS_GLOBAL_COORDINATOR_URL: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
         with:
@@ -1740,6 +1746,28 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1
+      - name: Acquire global recovery lease
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.stage == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          proof_file: ${{ runner.temp }}/ponto-ordinary-recovery/global-coordination-lease.json
+      - name: Check global recovery lease before latching closed
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/ponto-ordinary-recovery/global-coordination-lease.json
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.stage == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Monotonically latch Ponto closed outside the surface mutex
         env:
           PONTO_EMERGENCY_CLOSE_BROKER_CREDENTIAL: ${{ secrets.PONTO_EMERGENCY_CLOSE_BROKER_CREDENTIAL }}
@@ -1750,6 +1778,17 @@ jobs:
           PONTO_FAILED_COORDINATOR_RUN_ID: ${{ github.run_id }}
           PONTO_EMERGENCY_LATCH_REPORT: ${{ runner.temp }}/ponto-ordinary-recovery/latch.json
         run: node .github/scripts/ponto-emergency-latch-write.mjs
+      - name: Check global recovery lease before overlay propagation
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/ponto-ordinary-recovery/global-coordination-lease.json
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.stage == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Attempt external overlay propagation before reconciliation
         env:
           PONTO_MODULE_HEALTH_URL: ${{ inputs.stage == 'staging' && 'https://api-staging.skincos.com.br/api/ponto/health' || 'https://api.skincos.com.br/api/ponto/health' }}
@@ -1795,6 +1834,14 @@ jobs:
           path: ${{ runner.temp }}/ponto-ordinary-recovery
           retention-days: 90
           if-no-files-found: error
+      - name: Release global recovery lease
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.stage == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/ponto-ordinary-recovery/global-coordination-lease.json
 
   recovery-reconcile:
     needs: [orchestrate, recovery-latch]
@@ -1810,11 +1857,33 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1
+      - name: Acquire global recovery lease
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.stage == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          proof_file: ${{ runner.temp }}/ponto-ordinary-recovery/global-coordination-lease.json
       - name: Download the durable recovery journal
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           name: ponto-recovery-journal-${{ github.run_id }}
           path: ${{ runner.temp }}/ponto-ordinary-recovery/journal
+      - name: Check global recovery lease before child reconciliation
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/ponto-ordinary-recovery/global-coordination-lease.json
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.stage == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Cancel and reconcile children without waiting on the surface mutex
         env:
           # Recovery must retain the protected Actions-read token used by the
@@ -1881,6 +1950,14 @@ jobs:
           path: ${{ runner.temp }}/ponto-ordinary-recovery/journal
           retention-days: 90
           if-no-files-found: error
+      - name: Release global recovery lease
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.stage == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/ponto-ordinary-recovery/global-coordination-lease.json
 
   recovery-close:
     needs: [orchestrate, recovery-latch, recovery-reconcile]
@@ -1899,6 +1976,28 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1
+      - name: Acquire global recovery lease
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.stage == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          proof_file: ${{ runner.temp }}/ponto-ordinary-recovery/global-coordination-lease.json
+      - name: Check global recovery lease before close mutation
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/ponto-ordinary-recovery/global-coordination-lease.json
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.stage == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Write regular maintenance under the exact closed latch
         env:
           PONTO_EMERGENCY_CLOSE_BROKER_CREDENTIAL: ${{ secrets.PONTO_EMERGENCY_CLOSE_BROKER_CREDENTIAL }}
@@ -1909,6 +2008,17 @@ jobs:
           PONTO_FAILED_COORDINATOR_RUN_ID: ${{ github.run_id }}
           PONTO_EMERGENCY_MAINTENANCE_REPORT: ${{ runner.temp }}/ponto-ordinary-recovery/maintenance.json
         run: node .github/scripts/ponto-emergency-maintenance-write.mjs
+      - name: Check global recovery lease before overlay verification
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/ponto-ordinary-recovery/global-coordination-lease.json
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.stage == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Prove external fail-close through overlay or exact incumbent control
         env:
           PONTO_MODULE_HEALTH_URL: ${{ inputs.stage == 'staging' && 'https://api-staging.skincos.com.br/api/ponto/health' || 'https://api.skincos.com.br/api/ponto/health' }}
@@ -1963,6 +2073,14 @@ jobs:
           path: ${{ runner.temp }}/ponto-ordinary-recovery
           retention-days: 90
           if-no-files-found: error
+      - name: Release global recovery lease
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.stage == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/ponto-ordinary-recovery/global-coordination-lease.json
 
   recovery-rollback:
     needs: [orchestrate, recovery-reconcile, recovery-close]
@@ -1982,6 +2100,17 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1
+      - name: Acquire global recovery lease
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.stage == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          proof_file: ${{ runner.temp }}/ponto-ordinary-recovery/global-coordination-lease.json
       - name: Revalidate protected target environment before rollback mutation
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -2017,6 +2146,17 @@ jobs:
           name: ponto-ordinary-recovery-maintenance-${{ github.run_id }}
           path: ${{ runner.temp }}/ponto-ordinary-recovery/evidence/fail-close
 
+      - name: Check global recovery lease before materializing broker close
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/ponto-ordinary-recovery/global-coordination-lease.json
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.stage == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Materialize the exact broker close under the recovery surface mutex
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -2068,6 +2208,17 @@ jobs:
             "$RUNNER_TEMP/ponto-ordinary-recovery/evidence/fail-close/final-propagation.json" \
             "$RUNNER_TEMP/ponto-ordinary-recovery/journal" \
             "$RUNNER_TEMP/ponto-ordinary-recovery/journal/automatic-rollback/ponto-module-control-direct-readback.json"
+      - name: Check global recovery lease before restoring incumbents
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/ponto-ordinary-recovery/global-coordination-lease.json
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.stage == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Restore every attested incumbent idempotently
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -2120,3 +2271,11 @@ jobs:
           path: ${{ runner.temp }}/ponto-ordinary-recovery/journal/automatic-rollback
           retention-days: 90
           if-no-files-found: warn
+      - name: Release global recovery lease
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ inputs.stage == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/ponto-ordinary-recovery/global-coordination-lease.json

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -123,8 +123,9 @@ jobs:
       # uses the dedicated coordinator; production remains blocked until its
       # separate endpoint and custody are provisioned.
       SKINCOS_GLOBAL_COORDINATION_REQUIRED: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
-      SKINCOS_GLOBAL_COORDINATOR_URL: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+      SKINCOS_GLOBAL_COORDINATOR_URL: ${{ contains(fromJSON('["preview","staging"]'), inputs.stage) && vars.SKINCOS_GLOBAL_COORDINATOR_URL || contains(fromJSON('["pilot","canary","production","rollback"]'), inputs.stage) && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || '' }}
       SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+      PONTO_ORCHESTRATOR_COORDINATION_PROOF_FILE: ${{ runner.temp }}/ponto-release/global-coordination-release-ponto.json
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
         with:
@@ -162,11 +163,17 @@ jobs:
           [[ "$PREDECESSOR_RUN_ID" =~ ^[0-9]+$ ]] || { echo 'numeric predecessor_run_id is required'; exit 1; }
           gh api "repos/$GITHUB_REPOSITORY/actions/workflows/ponto-progressive-release.yml" > "$RUNNER_TEMP/ponto-workflow.json"
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PREDECESSOR_RUN_ID" > "$RUNNER_TEMP/predecessor-run.json"
-          PREDECESSOR_STAGE="$predecessor" node - "$RUNNER_TEMP/ponto-workflow.json" "$RUNNER_TEMP/predecessor-run.json" <<'NODE'
-          const fs = require("fs");
+          PREDECESSOR_STAGE="$predecessor" node --input-type=module - "$RUNNER_TEMP/ponto-workflow.json" "$RUNNER_TEMP/predecessor-run.json" <<'NODE'
+          import fs from "node:fs";
+          const { assertPontoSourceClosureUnchanged } = await import("./.github/scripts/ponto-source-closure.mjs");
           const workflow = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
           const run = JSON.parse(fs.readFileSync(process.argv[3], "utf8"));
           const expectedTitle = `Ponto ${process.env.PREDECESSOR_STAGE} ${process.env.RELEASE_SHA} orchestrator=${process.env.PREDECESSOR_RUN_ID}`;
+          try {
+            assertPontoSourceClosureUnchanged(process.env.RELEASE_SHA, String(run?.head_sha || "").toLowerCase());
+          } catch {
+            throw new Error("predecessor run dependency closure differs from the immutable release");
+          }
           if (
             workflow?.state !== "active"
             || workflow?.path !== ".github/workflows/ponto-progressive-release.yml"
@@ -179,7 +186,6 @@ jobs:
             || run.run_attempt !== 1
             || run.event !== "workflow_dispatch"
             || run.head_branch !== "main"
-            || String(run.head_sha || "").toLowerCase() !== process.env.RELEASE_SHA
             || run.name !== expectedTitle
             || run.display_title !== expectedTitle
             || run.repository?.full_name !== process.env.GITHUB_REPOSITORY
@@ -788,6 +794,17 @@ jobs:
           }, null, 2)}\n`, { mode: 0o600 });
           NODE
           rm -f "$evidence_dir/artifact.zip"
+      - name: Acquire the composite Ponto release lease before candidate mutation
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ env.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          proof_file: ${{ runner.temp }}/ponto-release/global-coordination-release-ponto.json
       - name: Prove selected root separation before any candidate mutation
         if: ${{ inputs.stage == 'staging' || inputs.stage == 'pilot' }}
         env:
@@ -836,8 +853,9 @@ jobs:
           set -euo pipefail
           gh api "repos/$GITHUB_REPOSITORY/actions/workflows/ponto-production-baseline.yml" > "$RUNNER_TEMP/baseline-workflow.json"
           gh api "repos/$GITHUB_REPOSITORY/actions/workflows/ponto-production-baseline.yml/runs?event=workflow_dispatch&branch=main&per_page=100" > "$RUNNER_TEMP/baseline-runs.json"
-          baseline_run_id="$(node - "$RUNNER_TEMP/baseline-workflow.json" "$RUNNER_TEMP/baseline-runs.json" <<'NODE'
-          const fs = require("fs");
+          baseline_run_id="$(node --input-type=module - "$RUNNER_TEMP/baseline-workflow.json" "$RUNNER_TEMP/baseline-runs.json" <<'NODE'
+          import fs from "node:fs";
+          const { pontoSourceClosureMatches } = await import("./.github/scripts/ponto-source-closure.mjs");
           const workflow = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
           const runs = JSON.parse(fs.readFileSync(process.argv[3], "utf8")).workflow_runs || [];
           if (workflow.state !== "active" || workflow.path !== ".github/workflows/ponto-production-baseline.yml") throw new Error("canonical baseline workflow is unavailable");
@@ -851,7 +869,7 @@ jobs:
               && run.conclusion === "success"
               && run.event === "workflow_dispatch"
               && run.head_branch === "main"
-              && run.head_sha === process.env.RELEASE_SHA
+              && pontoSourceClosureMatches(process.env.RELEASE_SHA, String(run.head_sha || "").toLowerCase())
               && run.run_attempt === 1
               && run.name === "Ponto production baseline"
               && run.repository?.full_name === process.env.GITHUB_REPOSITORY
@@ -1728,6 +1746,14 @@ jobs:
           path: ${{ runner.temp }}/ponto-release/runs
           retention-days: 90
           if-no-files-found: warn
+      - name: Release the composite Ponto release lease
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ env.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/ponto-release/global-coordination-release-ponto.json
 
   recovery-latch:
     needs: orchestrate

--- a/.github/workflows/ponto-release-watchdog.yml
+++ b/.github/workflows/ponto-release-watchdog.yml
@@ -174,6 +174,28 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1
+      - name: Acquire global Ponto recovery lease for fail-close materialization
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ contains(fromJSON('["pilot","canary","production"]'), needs.context.outputs.target) && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ needs.context.outputs.release_sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-watchdog-close.json
+      - name: Check global Ponto recovery lease before maintenance write
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-watchdog-close.json
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ needs.context.outputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ contains(fromJSON('["pilot","canary","production"]'), needs.context.outputs.target) && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Write regular maintenance under the still-closed latch
         env:
           PONTO_EMERGENCY_CLOSE_BROKER_CREDENTIAL: ${{ secrets.PONTO_EMERGENCY_CLOSE_BROKER_CREDENTIAL }}
@@ -254,6 +276,14 @@ jobs:
               node .github/scripts/ponto-module-propagation.mjs
           fi
           rm -f "$directory/overlay-expectation.json" "$directory/control-fallback-expectation.json"
+      - name: Release global Ponto recovery lease after fail-close materialization
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ contains(fromJSON('["pilot","canary","production"]'), needs.context.outputs.target) && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-watchdog-close.json
       - name: Upload immutable fail-close evidence
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -280,6 +310,17 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1
+      - name: Acquire global Ponto recovery lease for watchdog rollback
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ contains(fromJSON('["pilot","canary","production"]'), needs.context.outputs.target) && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ needs.context.outputs.release_sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-watchdog-rollback.json
       - name: Revalidate protected target environment before watchdog rollback
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -318,6 +359,17 @@ jobs:
           name: ponto-watchdog-close-${{ needs.context.outputs.coordinator_run_id }}-${{ github.run_id }}
           path: ${{ runner.temp }}/ponto-watchdog-evidence/fail-close
 
+      - name: Check global Ponto recovery lease before broker-close materialization
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-watchdog-rollback.json
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ needs.context.outputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ contains(fromJSON('["pilot","canary","production"]'), needs.context.outputs.target) && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Materialize the exact broker close under the watchdog surface mutex
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -403,6 +455,17 @@ jobs:
             fi
             rm -rf "$download_dir"
           done
+      - name: Check global Ponto recovery lease immediately before watchdog rollback
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-watchdog-rollback.json
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ needs.context.outputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ contains(fromJSON('["pilot","canary","production"]'), needs.context.outputs.target) && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Restore every independently attested incumbent and keep the latch true
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -458,3 +521,11 @@ jobs:
           path: ${{ runner.temp }}/ponto-watchdog-rollback
           retention-days: 90
           if-no-files-found: warn
+      - name: Release global Ponto recovery lease after watchdog rollback
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ contains(fromJSON('["pilot","canary","production"]'), needs.context.outputs.target) && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-watchdog-rollback.json

--- a/.github/workflows/ponto-staging-core-provenance-recovery.yml
+++ b/.github/workflows/ponto-staging-core-provenance-recovery.yml
@@ -36,7 +36,6 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
-
       - name: Verify trusted source and exact failed coordinator
         env:
           GH_TOKEN: ${{ github.token }}
@@ -230,6 +229,17 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
+      - name: Acquire global Core staging recovery lease
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: deploy:core-api:staging
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-core-recovery.json
 
       - name: Download the exact close and historical Core custody
         env:
@@ -260,6 +270,17 @@ jobs:
           ) throw new Error("fresh Core custody is not correlated");
           NODE
 
+      - name: Check global Core staging recovery lease immediately before materialization
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-core-recovery.json
+          resource: deploy:core-api:staging
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Materialize the exact fresh maintenance under the surface mutex
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -282,7 +303,6 @@ jobs:
           if [[ "$maintenance" != "$PONTO_MAINTENANCE_FILE" ]]; then cp "$maintenance" "$PONTO_MAINTENANCE_FILE"; fi
           node .github/scripts/ponto-cloudflare-resource-identity.mjs
           node .github/scripts/ponto-module-control-materialize.mjs
-
       - name: Download and validate the exact Core mutation journal
         env:
           GH_TOKEN: ${{ github.token }}
@@ -382,6 +402,17 @@ jobs:
           ) throw new Error("live staging Core is not the exact cataloged candidate custody");
           NODE
 
+      - name: Check global Core staging recovery lease immediately before Core rollback
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-core-recovery.json
+          resource: deploy:core-api:staging
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Normalize exact maintenance and recover the cataloged Core incumbent
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -481,3 +512,11 @@ jobs:
           path: ${{ runner.temp }}/ponto-core-recovery
           retention-days: 90
           if-no-files-found: warn
+      - name: Release global Core staging recovery lease
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-core-recovery.json

--- a/.github/workflows/ponto-staging-recovery-rollback.yml
+++ b/.github/workflows/ponto-staging-recovery-rollback.yml
@@ -63,7 +63,6 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
-
       - name: Validate current source and exact failed-run provenance before fresh close
         env:
           GH_TOKEN: ${{ github.token }}
@@ -297,6 +296,17 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
+      - name: Acquire global Ponto recovery lease for staging rollback
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-staging-rollback.json
 
       - name: Validate current source and exact failed-run provenance
         env:
@@ -475,6 +485,17 @@ jobs:
           github-token: ${{ github.token }}
           run-id: ${{ github.run_id }}
 
+      - name: Check global Ponto recovery lease immediately before staging materialization
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-staging-rollback.json
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Materialize the exact fresh broker close under the staging surface mutex
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -491,9 +512,9 @@ jobs:
           PONTO_MATERIALIZE_REPORT: ${{ runner.temp }}/ponto-staging-recovery-rollback/fresh-close/materialized-readback.json
           PONTO_RESOURCE_IDENTITY_REPORT: ${{ runner.temp }}/ponto-staging-recovery-rollback/resource-identity.json
         run: |
+          set -euo pipefail
           node .github/scripts/ponto-cloudflare-resource-identity.mjs
           node .github/scripts/ponto-module-control-materialize.mjs
-
       - name: Read back the exact staging module control from Cloudflare KV
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -601,6 +622,17 @@ jobs:
             "$RUNNER_TEMP/ponto-staging-recovery-rollback" \
             "$RUNNER_TEMP/ponto-staging-recovery-rollback/fresh-close/direct-readback.json"
 
+      - name: Check global Ponto recovery lease immediately before staging rollback
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-staging-rollback.json
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Restore the exact Timekeeping incumbent under the existing latch
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -715,3 +747,11 @@ jobs:
           path: ${{ runner.temp }}/ponto-staging-recovery-rollback
           retention-days: 90
           if-no-files-found: warn
+      - name: Release global Ponto recovery lease after staging rollback
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-staging-rollback.json

--- a/.github/workflows/ponto-staging-rollback-drill.yml
+++ b/.github/workflows/ponto-staging-rollback-drill.yml
@@ -40,8 +40,13 @@ jobs:
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
     with:
       required: true
+      global_lease_required: true
+      global_resource: release:ponto
+      global_module: ponto
+      global_coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
       lease_key: staging-rollback
       stage: ${{ inputs.orchestrator_stage }}
       target: staging
@@ -132,6 +137,17 @@ jobs:
             "$ORCHESTRATOR_STAGE" \
             "$RELEASE_SHA" \
             "$ORCHESTRATOR_RUN_ID"
+      - name: Authorize global Ponto rollback-drill mutation
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
       - name: Attest exact staging D1 and module-control identities before rollback drill mutation
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -190,3 +206,13 @@ jobs:
           path: ${{ runner.temp }}/ponto-staging-rollback-drill.json
           retention-days: 90
           if-no-files-found: error
+  global-coordination-release:
+    needs: [coordination, drill]
+    if: ${{ always() && needs.coordination.outputs.global_lease_required == 'true' }}
+    uses: ./.github/workflows/global-coordination-release.yml
+    secrets:
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+    with:
+      required: true
+      proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
+      coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}

--- a/.github/workflows/ponto-staging-rollback-drill.yml
+++ b/.github/workflows/ponto-staging-rollback-drill.yml
@@ -44,7 +44,7 @@ jobs:
     with:
       required: true
       global_lease_required: true
-      global_resource: release:ponto
+      global_resource: ${{ inputs.orchestrator_run_id != '' && 'release:ponto-child' || 'release:ponto' }}
       global_module: ponto
       global_coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
       lease_key: staging-rollback
@@ -82,8 +82,9 @@ jobs:
           git merge-base --is-ancestor "$RELEASE_SHA" origin/main || { echo 'release_sha is not reachable from main'; exit 1; }
           gh api "repos/$GITHUB_REPOSITORY/actions/workflows/timekeeping-staging-journey.yml" > "$RUNNER_TEMP/journey-workflow.json"
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$STAGING_JOURNEY_RUN_ID" > "$RUNNER_TEMP/journey-run.json"
-          node - "$RUNNER_TEMP/journey-workflow.json" "$RUNNER_TEMP/journey-run.json" <<'NODE'
-          const fs = require("fs");
+          node --input-type=module - "$RUNNER_TEMP/journey-workflow.json" "$RUNNER_TEMP/journey-run.json" <<'NODE'
+          import fs from "node:fs";
+          import { pontoSourceClosureMatches } from "./.github/scripts/ponto-source-closure.mjs";
           const workflow = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
           const run = JSON.parse(fs.readFileSync(process.argv[3], "utf8"));
           if (
@@ -96,6 +97,7 @@ jobs:
             || run.conclusion !== "success"
             || run.event !== "workflow_dispatch"
             || run.head_branch !== "main"
+            || !pontoSourceClosureMatches(process.env.RELEASE_SHA, String(run.head_sha || "").toLowerCase())
             || run.repository?.full_name !== process.env.GITHUB_REPOSITORY
             || run.head_repository?.full_name !== process.env.GITHUB_REPOSITORY
             || !String(run.display_title || "").includes(`orchestrator=${process.env.ORCHESTRATOR_RUN_ID}`)
@@ -145,7 +147,7 @@ jobs:
           coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
           proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
-          resource: release:ponto
+          resource: ${{ inputs.orchestrator_run_id != '' && 'release:ponto-child' || 'release:ponto' }}
           module: ponto
           source_sha: ${{ inputs.release_sha }}
       - name: Attest exact staging D1 and module-control identities before rollback drill mutation

--- a/.github/workflows/ponto-waf-security.yml
+++ b/.github/workflows/ponto-waf-security.yml
@@ -174,6 +174,28 @@ jobs:
           set -euo pipefail
           [[ "$(git rev-parse HEAD)" == "$GITHUB_SHA" ]] || { echo 'WAF apply checkout differs from main SHA'; exit 1; }
           mkdir -p "$RUNNER_TEMP/ponto-waf-security"
+      - name: Acquire global WAF mutation lease
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: cloudflare:ponto-waf:production
+          module: ponto
+          source_sha: ${{ github.sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-waf.json
+      - name: Check global WAF mutation lease before hydrating write authority
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-waf.json
+          resource: cloudflare:ponto-waf:production
+          module: ponto
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Attest split WAF token custody before hydrating write authority
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -311,6 +333,17 @@ jobs:
           }, null, 2)}\n`, { mode: 0o600 });
           NODE
           rm -f "$RUNNER_TEMP/ponto-waf-workflow.json" "$RUNNER_TEMP/ponto-waf-probe-run.json" "$RUNNER_TEMP/ponto-waf-probe-artifacts.json"
+      - name: Check global WAF mutation lease immediately before WAF mutation
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-waf.json
+          resource: cloudflare:ponto-waf:production
+          module: ponto
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Reconcile exact first-position Ponto WAF blocks atomically
         env:
           PONTO_WAF_MODE: apply
@@ -328,3 +361,11 @@ jobs:
           path: ${{ runner.temp }}/ponto-waf-security
           retention-days: 90
           if-no-files-found: error
+      - name: Release global WAF mutation lease
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-waf.json

--- a/.github/workflows/promotion-gate.yml
+++ b/.github/workflows/promotion-gate.yml
@@ -15,6 +15,8 @@ on:
         value: ${{ jobs.gate.outputs.source_sha }}
       release_input_digest:
         value: ${{ jobs.gate.outputs.release_input_digest }}
+      dependency_closure_digest:
+        value: ${{ jobs.gate.outputs.dependency_closure_digest }}
 
 jobs:
   gate:
@@ -26,6 +28,7 @@ jobs:
     outputs:
       source_sha: ${{ steps.identity.outputs.source_sha }}
       release_input_digest: ${{ steps.identity.outputs.release_input_digest }}
+      dependency_closure_digest: ${{ steps.identity.outputs.release_input_digest }}
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:

--- a/.github/workflows/sync-website-cloudflare-security.yml
+++ b/.github/workflows/sync-website-cloudflare-security.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: website-cf-security
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   sync:
@@ -43,6 +43,32 @@ jobs:
         working-directory: website
         run: npm ci
 
+      - name: Acquire Website release lease for security sync
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:website
+          module: website
+          source_sha: ${{ github.sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website-security.json
+
+      - name: Check Website release lease before security-settings mutation
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website-security.json
+          resource: release:website
+          module: website
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Sync Cloudflare security settings
         if: ${{ steps.guard.outputs.skip != 'true' }}
         working-directory: website
@@ -58,3 +84,12 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_SECURITY_API_TOKEN != '' && secrets.CLOUDFLARE_SECURITY_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
           CF_ZONE_NAME: espacofacial.com
+
+      - name: Release Website release lease for security sync
+        if: ${{ always() && steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website-security.json

--- a/.github/workflows/timekeeping-staging-journey.yml
+++ b/.github/workflows/timekeeping-staging-journey.yml
@@ -71,8 +71,13 @@ jobs:
     uses: ./.github/workflows/ponto-orchestrator-gate.yml
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
     with:
       required: true
+      global_lease_required: true
+      global_resource: release:ponto
+      global_module: ponto
+      global_coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
       lease_key: staging-journey
       stage: ${{ inputs.orchestrator_stage }}
       target: staging
@@ -168,6 +173,42 @@ jobs:
             "$ORCHESTRATOR_STAGE" \
             "$RELEASE_SHA" \
             "$ORCHESTRATOR_RUN_ID"
+      - name: Authorize global Ponto staging-journey mutation
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+
+      - name: Acquire shared staging D1 lease for Ponto journey
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: global:staging-d1
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-timekeeping-staging-d1.json
+
+      - name: Check shared staging D1 lease before synthetic staging provisioning
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-timekeeping-staging-d1.json
+          resource: global:staging-d1
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Provision only run-scoped synthetic staging records
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -196,6 +237,18 @@ jobs:
             }
           }
           NODE
+
+      - name: Check shared staging D1 lease before PIN attestation query
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-timekeeping-staging-d1.json
+          resource: global:staging-d1
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
 
       - name: Attest the exact synthetic PIN credential in staging D1
         env:
@@ -442,6 +495,18 @@ jobs:
           fs.writeFileSync(process.argv[3], `${JSON.stringify(summary, null, 2)}\n`, { mode: 0o600 });
           NODE
 
+      - name: Check shared staging D1 lease before authenticated Ponto journey
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-timekeeping-staging-d1.json
+          resource: global:staging-d1
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Execute authenticated Ponto journey
         env:
           PONTO_STAGING_CRM_URL: ${{ inputs.pages_url }}
@@ -452,8 +517,22 @@ jobs:
           NODE_PATH: crm/console/node_modules
         run: node crm/console/scripts/ponto-staging-journey.cjs
 
-      - name: Tear down only this run's synthetic staging records
+      - name: Check shared staging D1 lease before synthetic teardown
+        id: check_staging_d1_teardown
         if: ${{ always() }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-timekeeping-staging-d1.json
+          resource: global:staging-d1
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
+      - name: Tear down only this run's synthetic staging records
+        if: ${{ always() && steps.check_staging_d1_teardown.outcome == 'success' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -534,6 +613,15 @@ jobs:
           NODE
           rm -f "$FIXTURES" "$CORE_SQL" "$TIMEKEEPING_SQL" "$CORE_ATTESTATION_SQL" "$TIMEKEEPING_ATTESTATION_SQL" "$CORE_RAW" "$TIMEKEEPING_RAW" "$CORE_ATTESTATION_RAW" "$TIMEKEEPING_ATTESTATION_RAW" "$CORE_RESULT" "$TIMEKEEPING_RESULT" "$CORE_ATTESTATION_RESULT" "$TIMEKEEPING_ATTESTATION_RESULT" "$PIN_SQL" "$PIN_RAW" "$PIN_RESULT" "$PIN_VERIFY_ERROR"
 
+      - name: Release shared staging D1 lease for Ponto journey
+        if: ${{ always() }}
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: 'true'
+          coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-timekeeping-staging-d1.json
+
       - name: Upload sanitised journey evidence
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -546,3 +634,13 @@ jobs:
             ${{ runner.temp }}/ponto-staging-teardown-report.json
           retention-days: 30
           if-no-files-found: warn
+  global-coordination-release:
+    needs: [coordination, journey]
+    if: ${{ always() && needs.coordination.outputs.global_lease_required == 'true' }}
+    uses: ./.github/workflows/global-coordination-release.yml
+    secrets:
+      SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+    with:
+      required: true
+      proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
+      coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}

--- a/.github/workflows/timekeeping-staging-journey.yml
+++ b/.github/workflows/timekeeping-staging-journey.yml
@@ -75,7 +75,7 @@ jobs:
     with:
       required: true
       global_lease_required: true
-      global_resource: release:ponto
+      global_resource: ${{ inputs.orchestrator_run_id != '' && 'release:ponto-child' || 'release:ponto' }}
       global_module: ponto
       global_coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
       lease_key: staging-journey
@@ -181,7 +181,7 @@ jobs:
           coordinator_url: ${{ needs.coordination.outputs.global_coordinator_url }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
           proof_b64: ${{ needs.coordination.outputs.global_proof_b64 }}
-          resource: release:ponto
+          resource: ${{ inputs.orchestrator_run_id != '' && 'release:ponto-child' || 'release:ponto' }}
           module: ponto
           source_sha: ${{ inputs.release_sha }}
 

--- a/.github/workflows/website-instagram-sync.yml
+++ b/.github/workflows/website-instagram-sync.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: website-instagram-sync
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   sync:
@@ -77,6 +77,32 @@ jobs:
           . .venv-instagram-sync/bin/activate
           pip install -r social/instagram/instagrapi/requirements.txt
 
+      - name: Acquire Website release lease for Instagram sync
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: release:website
+          module: website
+          source_sha: ${{ github.sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website-instagram.json
+
+      - name: Check Website release lease before Instagram session restore
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website-instagram.json
+          resource: release:website
+          module: website
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
       - name: Restore instagrapi session
         if: ${{ steps.guard.outputs.skip != 'true' }}
         id: restore_session
@@ -99,6 +125,32 @@ jobs:
 
           echo "session_file=$SESSION_FILE" >> "$GITHUB_OUTPUT"
           echo "summary_file=$SESSION_DIR/summary.json" >> "$GITHUB_OUTPUT"
+
+      - name: Check Website release lease before primary Instagram sync
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website-instagram.json
+          resource: release:website
+          module: website
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
+      - name: Check Website release lease before Instagram session persistence
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website-instagram.json
+          resource: release:website
+          module: website
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
 
       - name: Run primary instagrapi sync
         if: ${{ steps.guard.outputs.skip != 'true' }}
@@ -140,6 +192,19 @@ jobs:
           cd website
           npx wrangler r2 bucket create "${INSTAGRAPI_SESSION_BUCKET}" >/dev/null 2>&1 || true
           npx wrangler r2 object put "${INSTAGRAPI_SESSION_BUCKET}/${INSTAGRAPI_SESSION_OBJECT}" --remote --file "$SESSION_FILE" --content-type "application/json"
+
+      - name: Check Website release lease before Instagram API fallback
+        if: ${{ steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website-instagram.json
+          resource: release:website
+          module: website
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
 
       - name: Fallback to website web sync when needed
         if: ${{ steps.guard.outputs.skip != 'true' }}
@@ -224,3 +289,12 @@ jobs:
             jq -c '.results[] | select(.ok != true) | {handle,error,attempts}' response.json || true
             exit 1
           fi
+
+      - name: Release Website release lease for Instagram sync
+        if: ${{ always() && steps.guard.outputs.skip != 'true' }}
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website-instagram.json

--- a/crm/api/scripts/clientesContinuousWorkerArchitecture.test.mjs
+++ b/crm/api/scripts/clientesContinuousWorkerArchitecture.test.mjs
@@ -36,7 +36,7 @@ test('dedicated runner and launcher cannot execute arbitrary shell or install de
     assert.match(legacyRetirement, /\[\[ \$# -ne 1 \]\]/)
     assert.match(legacyRetirement, /crm-clientes-source-refresh\.timer/)
     assert.match(legacyRetirement, /crm-clientes-source-refresh\.service/)
-    assert.doesNotMatch(legacyRetirement, /(^|\n)\s*(source|\.)\s+|\beval\s*\(|\$\{?(CONFIG|ENV|PATH|COMMAND|SCRIPT|UNIT_DEST)/)
+    assert.doesNotMatch(legacyRetirement, /(^|\n)\s*(source|\.)\s+(?!.*global-coordination-native\.sh)[^\n]+|\beval\s*\(|\$\{?(CONFIG|ENV|PATH|COMMAND|SCRIPT|UNIT_DEST)/)
     assert.doesNotMatch(launcher, /(^|\n)\s*(source|\.)\s+.*crm(?:-jobs)?\.env/)
     assert.doesNotMatch(launcher, /npm\s+install/)
     assert.match(launcher, /assisted mode is unavailable in the continuous worker/)

--- a/docs/decisions/global-concurrency-release-governance.md
+++ b/docs/decisions/global-concurrency-release-governance.md
@@ -1,6 +1,7 @@
 # Governança global de concorrência e release
 
-**Status:** contrato implementado; autoridade remota ainda não provisionada
+**Status:** contrato implementado; autoridade Cloudflare staging provisionada e
+ativada; autoridade de produção permanece ausente e fail-closed
 
 ## Problema
 
@@ -66,33 +67,63 @@ O dispatcher Ponto agora busca a ponta atual de `main` antes de cada dispatch e
 compara a closure Ponto. `assertMainShaUnchanged` permanece exportado para
 compatibilidade histórica, mas não é mais a condição que invalida uma release;
 `assertPontoDependencyClosureUnchanged` é a guarda aplicada ao caminho real.
+O lease do dispatcher cobre somente a chamada de dispatch; o workflow filho
+adquire e renova seu próprio recurso de superfície antes da mutação e libera o
+lease ao final.
 
 ## Adaptadores
 
 - GitHub mantém `concurrency` como scheduler, mas a saída do dispatcher registra
   `resourceKey`/`lockScope`; scheduling sozinho não é prova de autoridade.
+  `global-merge-authority.yml` é o caminho de integração assistida em `main`;
+  `codex-keep-prs-mergeable.yml` não habilita mais auto-merge sem lease e
+  também adquire `merge:main` antes de atualizar branches de PR.
 - Cloudflare usa `ops/cloudflare/global-coordinator/index.js`, com uma classe
   SQLite-backed Durable Object por `lockScope`. A requisição exige nonce,
   timestamp, digest e HMAC; revogação exige custódia administrativa separada.
 - Codex App e mini-PC podem consumir o mesmo envelope/lease, sem compartilhar
   cookies, tokens ou estado do checkout. O cliente e o CLI são os pontos
   comuns para essa integração; nenhum segredo é persistido no repositório.
+  No mini-PC, `scripts/runtime/global-coordination-mini-pc.sh` força o provider
+  `mini-pc`, exige owner explícito e mantém provas fora da árvore imutável.
 
-O Worker não é roteado nem promovido por esta mudança. Sem os secrets,
-bindings, route, environment gate, rollback deployment e smoke do próprio
-coordenador, ele retorna 503 e não há fallback local que possa ser confundido
-com autoridade global. O dispatcher Ponto já aplica a nova dependency closure
-antes de cada dispatch; a aquisição remota do lease global fica deliberadamente
-como gate de rollout até a custódia remota ser provisionada e os jobs de
-recuperação receberem o mesmo ciclo de vida.
+O ambiente dedicado `staging` do Worker foi provisionado sem rota de produção,
+com Durable Object SQLite, secrets separados e `preview_urls = false`. O smoke
+remoto comprovou aquisição, conflito, autorização, drift de closure, renovação
+e liberação. `SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL` permanece ausente, de
+modo que pilot/canary/production falham antes de qualquer mutação. O estado de
+produção não é inferido do endpoint staging.
+
+Os workflows GitHub Ponto passam pela mesma prova: o gate reutilizável adquire
+o lease, cada job mutador renova e autoriza imediatamente antes da mutação, e
+um job `always()` libera a prova depois que os dependentes terminam. O helper
+`scripts/codex-global-coordination-workflow.mjs` é o adaptador comum para
+GitHub Actions, Codex App e mini-PC; o provider e o owner são explícitos, e a
+custódia nunca é gravada no checkout. WAF apply e os caminhos legados de
+watchdog/recovery também usam essa autoridade antes da mutação Cloudflare. O
+broker de emergência close-only permanece a única pré-condição anterior ao
+lease, porque o fail-close não pode ficar impedido por uma disputa de recurso;
+as mutações de materialização e rollback continuam sob lease remoto.
+
+O caminho nativo também é técnico: a preparação instala os atestados
+`.skincos-global-coordination-<module>.json` junto da release; a promoção do
+Orb, a promoção do artefato WhatsApp, a promoção/rollback do gateway MCP, o
+backup do Orb, a migration Harmonia, o rollback/instalação de Atendimento e as
+rotas Cloudflare dedicadas adquirem, renovam e verificam leases antes das
+mutações. O atestado é rejeitado se o SHA, source tree, módulo, material ou
+digest não coincidirem. O publicador Windows do backup só inicia a unidade
+nativa através do wrapper coordenado; ausência de custody ou closure interrompe
+a operação antes da geração do artefato.
 
 ## Validação e rollout
 
 Os contratos são exercitados por
 `scripts/tests/codex-global-coordination.test.mjs` e
-`scripts/tests/codex-global-coordination-client.test.mjs`, além de
-`ops/cloudflare/global-coordinator/index.test.mjs`. O próximo gate operacional
-é provisionar a autoridade Cloudflare em ambiente dedicado, attestar o
-rollback, integrar clientes GitHub/Codex/mini-PC e só então marcar o recurso
-remoto como elegível. A existência do código, um build ou um endpoint 200 não
-constitui prova de autoridade global em produção.
+`scripts/tests/codex-global-coordination-client.test.mjs`,
+`scripts/tests/codex-global-coordination-workflow.test.mjs`, além de
+`ops/cloudflare/global-coordinator/index.test.mjs` e do teste focado do
+dispatcher Ponto. A validação remota do staging comprovou a versão implantada;
+rollback é a restauração de uma versão anterior do Worker ou a remoção
+controlada do ambiente staging, sem tocar uma rota de produção. A existência
+do código, um build ou um endpoint 200 não constitui prova de autoridade global
+em produção.

--- a/docs/decisions/global-concurrency-release-governance.md
+++ b/docs/decisions/global-concurrency-release-governance.md
@@ -1,0 +1,98 @@
+# Governança global de concorrência e release
+
+**Status:** contrato implementado; autoridade remota ainda não provisionada
+
+## Problema
+
+Branches e worktrees isolam desenvolvimento, mas não arbitravam o instante em
+que uma thread podia fazer uma mutação compartilhada. A release Ponto estava
+corretamente ancorada em um SHA, porém um avanço independente de `main` fazia o
+dispatcher abortar antes da próxima mutação. Esse abort preservava o fail-closed,
+mas confundia mudança de ponta do repositório com mudança da dependency closure
+da release.
+
+## Contrato
+
+`ops/governance/global-concurrency-policy.json` define o contrato
+`skincos/global-coordination/v1`. A unidade de autoridade é um `lockScope`, não
+o nome superficial da ferramenta:
+
+| Recurso | Escopo de conflito | Uso |
+| --- | --- | --- |
+| `merge:main` | `repository:main` | Serializa integração em `main`. |
+| `release:<module>` | `release:<module>` | Serializa a cadeia governada do módulo. |
+| `deploy:<surface>:<environment>` | `surface:<surface>:<environment>` | Serializa publicação da superfície. |
+| `cloudflare:<surface>:<environment>` | o mesmo escopo da publicação | Impede mutação paralela via caminho Cloudflare. |
+| `promotion:<module>:<environment>` | `promotion:<module>:<environment>` | Reserva promoção de artefato. |
+| `global:<operation>` | `global:<operation>` | Operações explicitamente incompatíveis. |
+
+Um lease contém owner (`missionId`, `threadId`, `actor`, `provider`), recurso,
+intent digest, tempo de expiração, `leaseId` e fencing token monotônico. O
+token anterior nunca autoriza uma mutação depois de expirar, ser liberado ou
+revogado. Idempotência só reaproveita o lease quando owner, idempotency key e
+intent digest são exatamente iguais.
+
+O núcleo determinístico está em
+`ops/governance/global-coordination-core.mjs`; o adaptador local está em
+`scripts/codex-global-coordinator.mjs`. O estado local é aceito somente fora do
+checkout, com lock de diretório e escrita atômica. Lock ausente, estado
+incompatível, nonce repetido, owner divergente, lease expirado ou fencing
+incorreto falham fechados.
+
+O cliente remoto comum está em
+`scripts/codex-global-coordination-client.mjs`, com o wrapper de prova em
+`scripts/codex-global-coordination-lease.mjs`. Ele exige URL HTTPS, custódia
+compartilhada para operações e uma custódia administrativa distinta para
+revogação; o arquivo de prova também precisa ficar fora do checkout.
+
+## Release imutável sem congelar `main`
+
+Uma identidade de release é formada por `sourceCommit`, `sourceTree`,
+`dependencyClosureDigest` e a lista exata de artefatos/digests/version IDs. O
+build é uma operação anterior; promoção recebe e verifica a mesma identidade.
+
+Antes de cada mutação, `authorizeMutation` exige:
+
+1. lease ainda válido e prova de fencing;
+2. intent digest e recurso exatos;
+3. dependency closure observada novamente;
+4. artefatos exatos, quando a operação é release/promotion.
+
+Uma mudança em `main` fora da closure mantém o candidato válido. Uma mudança
+dentro da closure interrompe a cadeia antes da próxima mutação. Ausência de
+digest observável não é tratada como “sem mudança”.
+
+O dispatcher Ponto agora busca a ponta atual de `main` antes de cada dispatch e
+compara a closure Ponto. `assertMainShaUnchanged` permanece exportado para
+compatibilidade histórica, mas não é mais a condição que invalida uma release;
+`assertPontoDependencyClosureUnchanged` é a guarda aplicada ao caminho real.
+
+## Adaptadores
+
+- GitHub mantém `concurrency` como scheduler, mas a saída do dispatcher registra
+  `resourceKey`/`lockScope`; scheduling sozinho não é prova de autoridade.
+- Cloudflare usa `ops/cloudflare/global-coordinator/index.js`, com uma classe
+  SQLite-backed Durable Object por `lockScope`. A requisição exige nonce,
+  timestamp, digest e HMAC; revogação exige custódia administrativa separada.
+- Codex App e mini-PC podem consumir o mesmo envelope/lease, sem compartilhar
+  cookies, tokens ou estado do checkout. O cliente e o CLI são os pontos
+  comuns para essa integração; nenhum segredo é persistido no repositório.
+
+O Worker não é roteado nem promovido por esta mudança. Sem os secrets,
+bindings, route, environment gate, rollback deployment e smoke do próprio
+coordenador, ele retorna 503 e não há fallback local que possa ser confundido
+com autoridade global. O dispatcher Ponto já aplica a nova dependency closure
+antes de cada dispatch; a aquisição remota do lease global fica deliberadamente
+como gate de rollout até a custódia remota ser provisionada e os jobs de
+recuperação receberem o mesmo ciclo de vida.
+
+## Validação e rollout
+
+Os contratos são exercitados por
+`scripts/tests/codex-global-coordination.test.mjs` e
+`scripts/tests/codex-global-coordination-client.test.mjs`, além de
+`ops/cloudflare/global-coordinator/index.test.mjs`. O próximo gate operacional
+é provisionar a autoridade Cloudflare em ambiente dedicado, attestar o
+rollback, integrar clientes GitHub/Codex/mini-PC e só então marcar o recurso
+remoto como elegível. A existência do código, um build ou um endpoint 200 não
+constitui prova de autoridade global em produção.

--- a/docs/runbooks/clientes-production-readonly-runtime.md
+++ b/docs/runbooks/clientes-production-readonly-runtime.md
@@ -89,6 +89,11 @@ literais `CHAVE=valor` pelo Node, nunca com `source`, `eval` ou `bash -c`.
    `harmonia.contacts`; a instalação e a validação recusam prosseguir se a
    prova efetiva de grants falhar.
 
+   Toda mutação de provisionamento, controle, migration, refresh ou unidade
+   apresenta a mesma closure `atendimento` ao coordenador remoto. O operador
+   deve manter esse JSON fora do checkout, por exemplo em
+   `/home/admin/skincos-native-release/<sha>/atendimento-closure.json`.
+
    Há uma exceção estreita, exclusiva do runner de **staging**, para três
    migrations comerciais condicionais: Operations
    (`20260807_commercial_operations_v2`), Analytics
@@ -145,10 +150,16 @@ provisionamento separado e auditado do espelho, o runtime continua em
    `crm.service`:
 
    ```bash
+   scripts/provision-atendimento-staging.sh --apply \
+     --source-sha <sha-main> \
+     --coordination-closure /home/admin/skincos-native-release/<sha-main>/atendimento-closure.json
    scripts/runtime/prepare-atendimento-staging-release.sh \
-     --release-sha <sha-main> --predecessor-sha <sha-staging-anterior>
+     --release-sha <sha-main> --predecessor-sha <sha-staging-anterior> \
+     --coordination-closure /home/admin/skincos-native-release/<sha-main>/atendimento-closure.json
    scripts/set-atendimento-staging-control.sh \
      --state maintenance --release-sha <sha-main> \
+     --source-sha <sha-main> \
+     --coordination-closure /home/admin/skincos-native-release/<sha-main>/atendimento-closure.json \
      --reason release-preflight --apply
    scripts/run-atendimento-staging-migration.sh \
      --dry-run --release-sha <sha-main>
@@ -201,7 +212,9 @@ provisionamento separado e auditado do espelho, o runtime continua em
 
    ```bash
    scripts/set-atendimento-production-readonly-control.sh \
-     --state active --release-sha <sha-main> --reason read-only-validated --apply
+     --state active --release-sha <sha-main> --source-sha <sha-main> \
+     --coordination-closure /home/admin/skincos-native-release/<sha-main>/atendimento-closure.json \
+     --reason read-only-validated --apply
    scripts/validate-atendimento-production-readonly.sh \
      --expected-release-sha <sha-main>
    ```
@@ -211,12 +224,19 @@ provisionamento separado e auditado do espelho, o runtime continua em
    com `--apply`. Nenhum deles reutiliza `cloudflare-runtime.service`.
 
    ```bash
-   scripts/runtime/install-atendimento-production-tunnel.sh \
-     --source-root /opt/skincos/releases/<sha-main>/source \
-     --tunnel-id <uuid-minusculo>
-   scripts/runtime/route-atendimento-production-dns.sh \
-     --tunnel-id <uuid-minusculo>
+    scripts/runtime/install-atendimento-production-tunnel.sh \
+      --source-root /opt/skincos/releases/<sha-main>/source \
+      --tunnel-id <uuid-minusculo> \
+      --coordination-closure /home/admin/skincos-native-release/<sha-main>/atendimento-closure.json
+    scripts/runtime/route-atendimento-production-dns.sh \
+      --tunnel-id <uuid-minusculo> --source-sha <sha-main> \
+      --coordination-closure /home/admin/skincos-native-release/<sha-main>/atendimento-closure.json
    ```
+
+   Use `--apply` only on the mutating invocation. Both the tunnel installer and
+   DNS route acquire the dedicated `cloudflare:atendimento:production` lease;
+   they fail closed when the private coordinator custody or closure attestation
+   is unavailable.
 
 O Pages proxy exige `ATENDIMENTO_API_TARGET` e
 `ATENDIMENTO_ACTOR_HMAC_KEY` dedicados, assina HMAC v2 e não tem fallback para

--- a/docs/runbooks/crm-continuous-workers.md
+++ b/docs/runbooks/crm-continuous-workers.md
@@ -133,11 +133,13 @@ Harmonia schema migration is explicit and target-bound:
 ```sh
 HARMONIA_MIGRATION_TARGET=staging \
 HARMONIA_MIGRATION_ACTION=dry-run \
-scripts/runtime/run-harmonia-migration-native.sh
+SKINCOS_RELEASE_ID=<sha-main> \
+/opt/skincos/releases/<sha-main>/source/scripts/runtime/run-harmonia-migration-native.sh
 
 HARMONIA_MIGRATION_TARGET=staging \
 HARMONIA_MIGRATION_ACTION=apply \
-scripts/runtime/run-harmonia-migration-native.sh
+SKINCOS_RELEASE_ID=<sha-main> \
+/opt/skincos/releases/<sha-main>/source/scripts/runtime/run-harmonia-migration-native.sh
 ```
 
 The native launcher loads only the private target environment, rejects a
@@ -157,12 +159,16 @@ group write for that service identity, then run the native launcher as
 sudo install -d -o root -g skincos -m 0770 /var/backups/skincos/clientes
 sudo setfacl -m u:skincos:--x /var/backups/skincos
 sudo -u skincos env \
+  SKINCOS_RELEASE_ID=<sha-main> \
   HARMONIA_MIGRATION_TARGET=production \
   HARMONIA_MIGRATION_ACTION=dry-run \
-  /opt/skincos/current/source/scripts/runtime/run-harmonia-migration-native.sh
+  /opt/skincos/releases/<sha-main>/source/scripts/runtime/run-harmonia-migration-native.sh
 ```
 
 An apply follows the same command with `HARMONIA_MIGRATION_ACTION=apply`.
+Applied migrations require the exact immutable release SHA and the detached
+Atendimento closure installed beside that release; the native wrapper acquires
+`deploy:atendimento:<target>` before the checkpoint or database mutation.
 Staging uses its dedicated migrator environment and the separate
 `/var/backups/skincos/clientes/staging` checkpoint root.
 

--- a/docs/runbooks/lifecycle-runtime-cutover.md
+++ b/docs/runbooks/lifecycle-runtime-cutover.md
@@ -28,27 +28,55 @@ through `\\wsl.localhost`; WSL never recursively walks `/mnt/c`.
    ```powershell
    & scripts/runtime/verify-native-source-release-lineage.ps1 -ReleaseSha <sha> -ParentReleaseSha <current-release-sha>
    ```
-3. From WSL, validate and promote source:
+3. From the reviewed Git tree in WSL, materialize one closure attestation for
+   each native module that will mutate. The output is private operator evidence
+   and is bound to the exact source SHA/tree; it is not a substitute for the
+   lease acquired during promotion:
+
+   ```bash
+   node scripts/codex-global-coordination-workflow.mjs closure \
+     --module orb --source <sha> \
+     --result-file /home/admin/skincos-native-release/<sha>/orb-closure.json
+   node scripts/codex-global-coordination-workflow.mjs closure \
+      --module atendimento --source <sha> \
+      --result-file /home/admin/skincos-native-release/<sha>/atendimento-closure.json
+   node scripts/codex-global-coordination-workflow.mjs closure \
+      --module native-runtime --source <sha> \
+      --result-file /home/admin/skincos-native-release/<sha>/native-runtime-closure.json
+   ```
+
+4. From WSL, validate and stage source. Every applied native release must carry
+   the closures used by its mutators:
 
    ```bash
    scripts/runtime/prepare-native-source-release.sh \
-     --archive /home/admin/skincos-native-release/<sha>/source.tar \
-     --sha256 <sha256> --lineage /home/admin/skincos-native-release/<sha>/lineage.json \
-     --lineage-sha256 <lineage-sha256> --apply --stage-only
+      --archive /home/admin/skincos-native-release/<sha>/source.tar \
+      --sha256 <sha256> --lineage /home/admin/skincos-native-release/<sha>/lineage.json \
+      --lineage-sha256 <lineage-sha256> \
+      --coordination-closure /home/admin/skincos-native-release/<sha>/orb-closure.json \
+      --coordination-closure /home/admin/skincos-native-release/<sha>/atendimento-closure.json \
+      --coordination-closure /home/admin/skincos-native-release/<sha>/native-runtime-closure.json \
+      --apply --stage-only
    ```
 
-4. Build and promote WhatsApp from the same source release:
+5. Build and promote WhatsApp from the same source release, reusing the exact
+   Orb closure and lease family:
 
    ```bash
    scripts/runtime/prepare-messaging-whatsapp-release.sh \
-     --source-root /opt/skincos/releases/<sha>/source \
-     --release-sha <sha> --apply
+      --source-root /opt/skincos/releases/<sha>/source \
+      --release-sha <sha> \
+      --coordination-closure /home/admin/skincos-native-release/<sha>/orb-closure.json \
+      --apply
    ```
 
-5. Render/install only final units and restart them:
+6. Render/install only final units and restart them:
 
    ```bash
-   scripts/runtime/prepare-lifecycle-layout.sh --apply
+   scripts/runtime/prepare-lifecycle-layout.sh \
+      --source-sha <sha> \
+      --coordination-closure /home/admin/skincos-native-release/<sha>/native-runtime-closure.json \
+      --apply
    scripts/runtime/install-lifecycle-units.sh --apply
    scripts/runtime/manage-native-runtime.sh restart
    scripts/runtime/manage-native-runtime.sh validate

--- a/ops/cloudflare/global-coordinator/README.md
+++ b/ops/cloudflare/global-coordinator/README.md
@@ -6,10 +6,11 @@ lock scope to a SQLite-backed Durable Object, so independent release modules
 can proceed in parallel while deploy and Cloudflare mutations for the same
 surface/environment share one fence.
 
-The Worker is intentionally not provisioned or routed by this change. It
-requires a separately managed `COORDINATION_SHARED_SECRET` and
-`COORDINATION_ADMIN_SECRET`, protected environment bindings, an authenticated
-route, and a rollback deployment before any real mutation is enabled. Missing
+The production Worker is intentionally not routed by this change. The isolated
+`staging` environment is the activation target for synthetic contract tests;
+production remains disabled until the same version, custody, route, rollback,
+and live readback gates are recorded. It requires separately managed
+`COORDINATION_SHARED_SECRET` and `COORDINATION_ADMIN_SECRET` bindings. Missing
 custody returns HTTP 503; it never falls back to an in-memory or local lock.
 
 Clients must send the signed request envelope described by the contract and

--- a/ops/cloudflare/global-coordinator/README.md
+++ b/ops/cloudflare/global-coordinator/README.md
@@ -1,0 +1,18 @@
+# SKINCOS global coordinator
+
+This Worker is the remote adapter for the versioned contract in
+`ops/governance/global-concurrency-policy.json`. It routes each normalized
+lock scope to a SQLite-backed Durable Object, so independent release modules
+can proceed in parallel while deploy and Cloudflare mutations for the same
+surface/environment share one fence.
+
+The Worker is intentionally not provisioned or routed by this change. It
+requires a separately managed `COORDINATION_SHARED_SECRET` and
+`COORDINATION_ADMIN_SECRET`, protected environment bindings, an authenticated
+route, and a rollback deployment before any real mutation is enabled. Missing
+custody returns HTTP 503; it never falls back to an in-memory or local lock.
+
+Clients must send the signed request envelope described by the contract and
+must present the returned `leaseId`, `fencingToken`, owner and `intentDigest`
+before every mutation. A release operation also carries its immutable source
+SHA/tree, dependency-closure digest and exact artifact/version identities.

--- a/ops/cloudflare/global-coordinator/index.js
+++ b/ops/cloudflare/global-coordinator/index.js
@@ -1,0 +1,162 @@
+import { DurableObject } from "cloudflare:workers";
+import {
+  acquireLease,
+  buildIntent,
+  canonicalJson,
+  checkLease,
+  consumeNonce,
+  emptyState,
+  lockScopeFor,
+  releaseLease,
+  renewLease,
+  revokeLease,
+} from "../../governance/global-coordination-core.mjs";
+
+const CONTRACT_ID = "skincos/global-coordination/v1";
+const MAX_SKEW_MS = 30_000;
+const NONCE_TTL_MS = 15 * 60_000;
+const MAX_BODY_BYTES = 64 * 1024;
+
+const encoder = new TextEncoder();
+const b64url = (bytes) => btoa(String.fromCharCode(...new Uint8Array(bytes)))
+  .replaceAll("+", "-")
+  .replaceAll("/", "_")
+  .replace(/=+$/g, "");
+const hex = (bytes) => [...new Uint8Array(bytes)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+const sha256 = async (value) => hex(await crypto.subtle.digest("SHA-256", encoder.encode(value)));
+const hmac = async (secret, value) => {
+  const key = await crypto.subtle.importKey("raw", encoder.encode(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+  return b64url(await crypto.subtle.sign("HMAC", key, encoder.encode(value)));
+};
+const timingSafeEqual = (left, right) => {
+  if (left.length !== right.length) return false;
+  let result = 0;
+  for (let index = 0; index < left.length; index += 1) result |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  return result === 0;
+};
+const jsonResponse = (payload, status = 200, headers = {}) => new Response(JSON.stringify(payload), {
+  status,
+  headers: { "content-type": "application/json", "cache-control": "no-store", ...headers },
+});
+const bad = (error, status = 401) => jsonResponse({ schemaVersion: 1, contractId: CONTRACT_ID, passed: false, error }, status);
+
+function bindingFor(request, url, nonce, requestedAt, requestDigest) {
+  return {
+    schemaVersion: 1,
+    contractId: CONTRACT_ID,
+    method: request.method,
+    path: url.pathname,
+    nonce,
+    requestedAt,
+    requestDigest,
+  };
+}
+
+async function authenticatedBody(request, env, url, rawBody) {
+  if (!env.COORDINATION_SHARED_SECRET || env.COORDINATION_CONTRACT_ID !== CONTRACT_ID) throw new Error("coordination authority custody is unavailable");
+  const nonce = request.headers.get("x-skincos-coordination-nonce") || "";
+  const requestedAt = request.headers.get("x-skincos-coordination-requested-at") || "";
+  const requestedMs = Date.parse(requestedAt);
+  if (!/^[A-Za-z0-9_-]{32,}$/.test(nonce) || !Number.isFinite(requestedMs) || Math.abs(Date.now() - requestedMs) > MAX_SKEW_MS) throw new Error("coordination request is stale");
+  const requestDigest = await sha256(rawBody);
+  if (request.headers.get("x-skincos-coordination-request-digest") !== requestDigest) throw new Error("coordination request digest mismatch");
+  const binding = bindingFor(request, url, nonce, requestedAt, requestDigest);
+  const expected = await hmac(env.COORDINATION_SHARED_SECRET, canonicalJson(binding));
+  if (!timingSafeEqual(expected, request.headers.get("x-skincos-coordination-request-signature") || "")) throw new Error("coordination request signature mismatch");
+  let body;
+  try { body = JSON.parse(rawBody); } catch { throw new Error("coordination request JSON is invalid"); }
+  if (
+    !body
+    || body.schemaVersion !== 1
+    || body.contractId !== CONTRACT_ID
+    || body.requestNonce !== nonce
+    || body.requestedAt !== requestedAt
+    || !["acquire", "check", "renew", "release", "revoke"].includes(body.action)
+  ) throw new Error("coordination request envelope is invalid");
+  if (body.action === "revoke" && request.headers.get("authorization") !== `Bearer ${env.COORDINATION_ADMIN_SECRET || ""}`) throw new Error("coordination revocation authority is unavailable");
+  return { body, nonce, requestDigest };
+}
+
+async function signResponse(payload, secret) {
+  const unsigned = { ...payload };
+  const responseDigest = await sha256(canonicalJson(unsigned));
+  const authority = { contractId: CONTRACT_ID, provider: "cloudflare", responseDigest };
+  return {
+    ...unsigned,
+    authority,
+    responseSignature: await hmac(secret, canonicalJson({ ...unsigned, authority })),
+  };
+}
+
+export class GlobalCoordinator extends DurableObject {
+  constructor(ctx, env) {
+    super(ctx, env);
+    this.ctx.blockConcurrencyWhile(async () => {
+      this.ctx.storage.sql.exec("CREATE TABLE IF NOT EXISTS coordinator_state (id INTEGER PRIMARY KEY CHECK (id = 1), state_json TEXT NOT NULL)");
+      const existing = this.ctx.storage.sql.exec("SELECT id FROM coordinator_state WHERE id = 1").toArray();
+      if (!existing.length) this.ctx.storage.sql.exec("INSERT INTO coordinator_state (id, state_json) VALUES (1, ?)", JSON.stringify(emptyState()));
+    });
+  }
+
+  coordinate(input) {
+    const row = this.ctx.storage.sql.exec("SELECT state_json FROM coordinator_state WHERE id = 1").one();
+    const current = JSON.parse(row.state_json);
+    const nonce = consumeNonce(current, { nonce: input.nonce, digest: input.requestDigest, now: input.now, ttlMs: NONCE_TTL_MS });
+    if (!nonce.accepted) return { accepted: false, valid: false, reason: nonce.reason };
+    let result;
+    if (input.action === "acquire") result = acquireLease(nonce.state, input.request, { now: input.now, leaseId: input.leaseId });
+    else if (input.action === "check") result = checkLease(nonce.state, input.request, { now: input.now });
+    else if (input.action === "renew") result = renewLease(nonce.state, input.request, { now: input.now, ttlMs: input.ttlMs });
+    else if (input.action === "release") result = releaseLease(nonce.state, input.request, { now: input.now });
+    else if (input.action === "revoke") result = revokeLease(nonce.state, input.request, { now: input.now, reason: input.reason });
+    else return { accepted: false, valid: false, reason: "coordination-action-invalid" };
+    this.ctx.storage.sql.exec("UPDATE coordinator_state SET state_json = ? WHERE id = 1", JSON.stringify(result.state));
+    const { state: _state, ...publicResult } = result;
+    return publicResult;
+  }
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    if (url.pathname !== "/v1/leases" || request.method !== "POST") return bad("not found", 404);
+    const rawBody = await request.text();
+    if (new TextEncoder().encode(rawBody).byteLength > MAX_BODY_BYTES) return bad("coordination request is too large", 413);
+    let authenticated;
+    try {
+      authenticated = await authenticatedBody(request, env, url, rawBody);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return bad(message, message.includes("unavailable") ? 503 : 401);
+    }
+    const { body, nonce, requestDigest } = authenticated;
+    let resource;
+    try {
+      resource = body.action === "revoke" ? body.proof?.resource : body.action === "acquire" ? body.request?.resource : body.proof?.resource;
+      const scope = lockScopeFor(resource);
+      if (body.action === "acquire") {
+        const normalizedIntent = buildIntent(body.request);
+        const expectedDigest = await sha256(canonicalJson(normalizedIntent));
+        if (body.request.intentDigest !== expectedDigest) return bad("coordination intent digest mismatch", 403);
+      }
+      const stub = env.GLOBAL_COORDINATOR.getByName(scope);
+      const result = stub.coordinate({
+        action: body.action,
+        nonce,
+        requestDigest,
+        now: Date.now(),
+        leaseId: crypto.randomUUID(),
+        request: body.action === "acquire" ? body.request : undefined,
+        ...(body.action !== "acquire" ? { request: body.proof } : {}),
+        ttlMs: body.ttlMs,
+        reason: body.reason,
+      });
+      const resolved = await result;
+      const payload = await signResponse({ schemaVersion: 1, contractId: CONTRACT_ID, passed: resolved.accepted !== false && resolved.valid !== false, ...resolved }, env.COORDINATION_SHARED_SECRET);
+      const status = resolved.accepted === false && resolved.reason === "resource-lease-held" ? 409 : resolved.valid === false ? 409 : resolved.accepted === false ? 409 : 200;
+      return jsonResponse(payload, status);
+    } catch (error) {
+      return bad(error instanceof Error ? error.message : String(error), 400);
+    }
+  },
+};

--- a/ops/cloudflare/global-coordinator/index.js
+++ b/ops/cloudflare/global-coordinator/index.js
@@ -39,7 +39,7 @@ const jsonResponse = (payload, status = 200, headers = {}) => new Response(JSON.
   status,
   headers: { "content-type": "application/json", "cache-control": "no-store", ...headers },
 });
-const bad = (error, status = 401) => jsonResponse({ schemaVersion: 1, contractId: CONTRACT_ID, passed: false, error }, status);
+const bad = (message, status = 401) => jsonResponse({ schemaVersion: 1, contractId: CONTRACT_ID, passed: false, error: message }, status);
 
 function bindingFor(request, url, nonce, requestedAt, requestDigest) {
   return {
@@ -54,7 +54,7 @@ function bindingFor(request, url, nonce, requestedAt, requestDigest) {
 }
 
 async function authenticatedBody(request, env, url, rawBody) {
-  if (!env.COORDINATION_SHARED_SECRET || env.COORDINATION_CONTRACT_ID !== CONTRACT_ID) throw new Error("coordination authority custody is unavailable");
+  if (!env.COORDINATION_SHARED_SECRET || env.COORDINATION_CONTRACT_ID !== CONTRACT_ID) return { custodyUnavailable: true };
   const nonce = request.headers.get("x-skincos-coordination-nonce") || "";
   const requestedAt = request.headers.get("x-skincos-coordination-requested-at") || "";
   const requestedMs = Date.parse(requestedAt);
@@ -130,10 +130,10 @@ export default {
     let authenticated;
     try {
       authenticated = await authenticatedBody(request, env, url, rawBody);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      return bad(message, message.includes("unavailable") ? 503 : 401);
+    } catch {
+      return bad("coordination request rejected", 401);
     }
+    if (authenticated.custodyUnavailable) return bad("coordination authority custody is unavailable", 503);
     const { body, nonce, requestDigest } = authenticated;
     let resource;
     try {
@@ -161,8 +161,8 @@ export default {
       const payload = await signResponse({ schemaVersion: 1, contractId: CONTRACT_ID, passed: resolved.accepted !== false && resolved.valid !== false, ...resolved }, env.COORDINATION_SHARED_SECRET);
       const status = resolved.accepted === false && resolved.reason === "resource-lease-held" ? 409 : resolved.valid === false ? 409 : resolved.accepted === false ? 409 : 200;
       return jsonResponse(payload, status);
-    } catch (error) {
-      return bad(error instanceof Error ? error.message : String(error), 400);
+    } catch {
+      return bad("coordination request could not be processed", 400);
     }
   },
 };

--- a/ops/cloudflare/global-coordinator/index.js
+++ b/ops/cloudflare/global-coordinator/index.js
@@ -1,6 +1,7 @@
 import { DurableObject } from "cloudflare:workers";
 import {
   acquireLease,
+  authorizeMutation,
   buildIntent,
   canonicalJson,
   checkLease,
@@ -105,7 +106,11 @@ export class GlobalCoordinator extends DurableObject {
     if (!nonce.accepted) return { accepted: false, valid: false, reason: nonce.reason };
     let result;
     if (input.action === "acquire") result = acquireLease(nonce.state, input.request, { now: input.now, leaseId: input.leaseId });
-    else if (input.action === "check") result = checkLease(nonce.state, input.request, { now: input.now });
+    else if (input.action === "check") {
+      result = input.authorization
+        ? authorizeMutation(nonce.state, input.request, { now: input.now, ...input.authorization })
+        : checkLease(nonce.state, input.request, { now: input.now });
+    }
     else if (input.action === "renew") result = renewLease(nonce.state, input.request, { now: input.now, ttlMs: input.ttlMs });
     else if (input.action === "release") result = releaseLease(nonce.state, input.request, { now: input.now });
     else if (input.action === "revoke") result = revokeLease(nonce.state, input.request, { now: input.now, reason: input.reason });
@@ -148,6 +153,7 @@ export default {
         leaseId: crypto.randomUUID(),
         request: body.action === "acquire" ? body.request : undefined,
         ...(body.action !== "acquire" ? { request: body.proof } : {}),
+        authorization: body.authorization,
         ttlMs: body.ttlMs,
         reason: body.reason,
       });

--- a/ops/cloudflare/global-coordinator/index.test.mjs
+++ b/ops/cloudflare/global-coordinator/index.test.mjs
@@ -19,6 +19,8 @@ test("remote custody is mandatory and the adapter has no local fallback", () => 
   assert.match(source, /coordination authority custody is unavailable/);
   assert.match(source, /return bad\(message, message\.includes\("unavailable"\) \? 503 : 401\)/);
   assert.doesNotMatch(source, /in-memory fallback|local fallback|allowWithout/);
+  assert.match(source, /authorizeMutation/);
+  assert.match(source, /input\.authorization/);
 });
 
 test("revocation uses separate administrative custody", () => {

--- a/ops/cloudflare/global-coordinator/index.test.mjs
+++ b/ops/cloudflare/global-coordinator/index.test.mjs
@@ -17,7 +17,9 @@ test("Cloudflare adapter uses one SQLite Durable Object per normalized lock scop
 test("remote custody is mandatory and the adapter has no local fallback", () => {
   assert.match(source, /COORDINATION_SHARED_SECRET/);
   assert.match(source, /coordination authority custody is unavailable/);
-  assert.match(source, /return bad\(message, message\.includes\("unavailable"\) \? 503 : 401\)/);
+  assert.match(source, /return bad\("coordination authority custody is unavailable", 503\)/);
+  assert.match(source, /coordination request rejected/);
+  assert.match(source, /coordination request could not be processed/);
   assert.doesNotMatch(source, /in-memory fallback|local fallback|allowWithout/);
   assert.match(source, /authorizeMutation/);
   assert.match(source, /input\.authorization/);

--- a/ops/cloudflare/global-coordinator/index.test.mjs
+++ b/ops/cloudflare/global-coordinator/index.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const source = fs.readFileSync(path.join(import.meta.dirname, "index.js"), "utf8");
+const config = fs.readFileSync(path.join(import.meta.dirname, "wrangler.toml"), "utf8");
+
+test("Cloudflare adapter uses one SQLite Durable Object per normalized lock scope", () => {
+  assert.match(source, /class GlobalCoordinator extends DurableObject/);
+  assert.match(source, /blockConcurrencyWhile/);
+  assert.match(source, /storage\.sql\.exec/);
+  assert.match(source, /getByName\(scope\)/);
+  assert.match(config, /new_sqlite_classes = \["GlobalCoordinator"\]/);
+});
+
+test("remote custody is mandatory and the adapter has no local fallback", () => {
+  assert.match(source, /COORDINATION_SHARED_SECRET/);
+  assert.match(source, /coordination authority custody is unavailable/);
+  assert.match(source, /return bad\(message, message\.includes\("unavailable"\) \? 503 : 401\)/);
+  assert.doesNotMatch(source, /in-memory fallback|local fallback|allowWithout/);
+});
+
+test("revocation uses separate administrative custody", () => {
+  assert.match(source, /COORDINATION_ADMIN_SECRET/);
+  assert.match(source, /body\.action === "revoke"/);
+  assert.match(source, /coordination revocation authority is unavailable/);
+});

--- a/ops/cloudflare/global-coordinator/wrangler.toml
+++ b/ops/cloudflare/global-coordinator/wrangler.toml
@@ -1,0 +1,16 @@
+name = "skincos-global-coordinator"
+main = "index.js"
+compatibility_date = "2026-08-09"
+workers_dev = false
+
+[vars]
+COORDINATION_CONTRACT_ID = "skincos/global-coordination/v1"
+
+[durable_objects]
+bindings = [
+  { name = "GLOBAL_COORDINATOR", class_name = "GlobalCoordinator" }
+]
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["GlobalCoordinator"]

--- a/ops/cloudflare/global-coordinator/wrangler.toml
+++ b/ops/cloudflare/global-coordinator/wrangler.toml
@@ -14,3 +14,16 @@ bindings = [
 [[migrations]]
 tag = "v1"
 new_sqlite_classes = ["GlobalCoordinator"]
+
+[env.staging]
+name = "skincos-global-coordinator-staging"
+workers_dev = true
+preview_urls = false
+
+[env.staging.vars]
+COORDINATION_CONTRACT_ID = "skincos/global-coordination/v1"
+
+[env.staging.durable_objects]
+bindings = [
+  { name = "GLOBAL_COORDINATOR", class_name = "GlobalCoordinator" }
+]

--- a/ops/codex/risk-policy.json
+++ b/ops/codex/risk-policy.json
@@ -31,7 +31,12 @@
     },
     {
       "id": "codex-baseline",
-      "patterns": [".codex/**", "skills/**", "scripts/codex-*.mjs", "scripts/codex-*.sh", "scripts/*codex*.ps1", "ops/codex/**"],
+      "patterns": [".codex/**", "skills/**", "scripts/codex-*.mjs", "scripts/tests/codex-*.mjs", "scripts/codex-*.sh", "scripts/*codex*.ps1", "ops/codex/**", "ops/governance/**"],
+      "releaseInput": true
+    },
+    {
+      "id": "global-coordination",
+      "patterns": ["ops/governance/**", "ops/cloudflare/global-coordinator/**", "scripts/codex-global-coordination*.mjs", "scripts/tests/codex-global-coordination*.mjs"],
       "releaseInput": true
     },
     {
@@ -64,12 +69,12 @@
     {
       "risk": "high",
       "reason": "Authentication, sessions, permissions, secrets, migrations, payment, deployment, workflow, Worker, database, tracking, or externally integrated surface changed and needs a focal check plus rollback.",
-      "patterns": ["**/auth/**", "**/*auth*", "**/*session*", "**/*permission*", "**/*secret*", "**/*credential*", "**/*payment*", "**/*billing*", "**/*root*key*", "**/migrations/**", "**/*migration*", ".github/workflows/**", ".github/scripts/**", "workforce/**", "api/**", "crm/api/**", "platform/**", "ops/runtime/**", "website/**/api/**", "**/wrangler*.toml", "**/worker*.{js,mjs,ts}", "**/d1/**"]
+      "patterns": ["**/auth/**", "**/*auth*", "**/*session*", "**/*permission*", "**/*secret*", "**/*credential*", "**/*payment*", "**/*billing*", "**/*root*key*", "**/migrations/**", "**/*migration*", ".github/workflows/**", ".github/scripts/**", "workforce/**", "api/**", "crm/api/**", "platform/**", "ops/runtime/**", "website/**/api/**", "ops/cloudflare/**", "ops/governance/**", "scripts/codex-global-coordination*.mjs", "scripts/tests/codex-global-coordination*.mjs", "**/wrangler*.toml", "**/worker*.{js,mjs,ts}", "**/d1/**"]
     },
     {
       "risk": "medium",
       "reason": "Codex or governance implementation changed without an elevated executable or exceptional path.",
-      "patterns": [".codex/**", "skills/**", "scripts/codex-*.mjs", "scripts/codex-*.sh", "scripts/*codex*.ps1", "ops/codex/**", ".github/governance/**"]
+      "patterns": [".codex/**", "skills/**", "scripts/codex-*.mjs", "scripts/tests/codex-*.mjs", "scripts/codex-*.sh", "scripts/*codex*.ps1", "ops/codex/**", "ops/governance/**", ".github/governance/**"]
     },
     {
       "risk": "low",
@@ -77,5 +82,5 @@
       "patterns": ["**/*.md", "docs/**", "TASKS.md", "DECISIONS.md", "CODEX_CONTEXT.md", "ops/project-orchestration/**", "docs/project-state/**"]
     }
   ],
-  "releaseSharedInputs": ["package.json", "package-lock.json", "pnpm-lock.yaml", "yarn.lock", ".github/governance/progressive-release-policy.json", "ops/codex/risk-policy.json"]
+  "releaseSharedInputs": ["package.json", "package-lock.json", "pnpm-lock.yaml", "yarn.lock", ".github/governance/progressive-release-policy.json", "ops/codex/risk-policy.json", "ops/governance/global-concurrency-policy.json"]
 }

--- a/ops/governance/global-concurrency-policy.json
+++ b/ops/governance/global-concurrency-policy.json
@@ -1,0 +1,103 @@
+{
+  "schemaVersion": 1,
+  "contractId": "skincos/global-coordination/v1",
+  "authority": {
+    "mode": "fail-closed",
+    "leaseProof": "resource-key-plus-fencing-token-plus-intent-digest",
+    "mutationRule": "revalidate-before-every-external-mutation"
+  },
+  "lease": {
+    "minimumTtlMs": 30000,
+    "maximumTtlMs": 900000,
+    "clockSkewMs": 30000,
+    "renewBeforeExpiryMs": 15000
+  },
+  "resourceClasses": {
+    "merge": "^merge:[a-z0-9][a-z0-9._/-]{0,127}$",
+    "release": "^release:[a-z0-9][a-z0-9._/-]{0,127}$",
+    "deploy": "^deploy:[a-z0-9][a-z0-9._/-]{0,127}:(?:preview|staging|pilot|canary|production|rollback|local)$",
+    "cloudflare": "^cloudflare:[a-z0-9][a-z0-9._/-]{0,127}:(?:preview|staging|pilot|canary|production|rollback|local)$",
+    "promotion": "^promotion:[a-z0-9][a-z0-9._/-]{0,127}:(?:preview|staging|pilot|canary|production|rollback|local)$",
+    "global": "^global:[a-z0-9][a-z0-9._/-]{0,127}$"
+  },
+  "operationPolicies": {
+    "prepare": {
+      "leaseRequired": false,
+      "mainTipPolicy": "none"
+    },
+    "mutation": {
+      "leaseRequired": true,
+      "mainTipPolicy": "dependency-closure",
+      "revalidateBeforeMutation": true
+    },
+    "promotion": {
+      "leaseRequired": true,
+      "mainTipPolicy": "dependency-closure",
+      "revalidateBeforeMutation": true,
+      "artifactIdentityRequired": true
+    }
+  },
+  "releaseClosures": {
+    "ponto": {
+      "patterns": [
+        "workforce/timekeeping/**",
+        "crm/console/**",
+        "api/**",
+        ".github/governance/progressive-release-policy.json",
+        ".github/workflows/ponto-*.yml",
+        ".github/workflows/deploy-timekeeping.yml",
+        ".github/workflows/deploy-core-workers.yml",
+        ".github/workflows/deploy-crm-pages.yml",
+        ".github/workflows/module-availability.yml",
+        ".github/workflows/timekeeping-staging-journey.yml",
+        ".github/workflows/promotion-gate.yml",
+        ".github/workflows/ponto-orchestrator-gate.yml",
+        ".github/scripts/ponto-*.mjs",
+        ".github/scripts/validate-progressive-release.mjs"
+      ],
+      "sharedInputs": true
+    },
+    "atendimento": {
+      "patterns": [
+        "crm/console/**",
+        "crm/api/**",
+        "api/**",
+        "ops/runtime/**",
+        ".github/workflows/atendimento-*.yml",
+        ".github/scripts/atendimento-*.mjs"
+      ],
+      "sharedInputs": true
+    },
+    "finance": {
+      "patterns": ["finance/**", ".github/workflows/deploy-finance*.yml", ".github/scripts/finance-*.mjs"],
+      "sharedInputs": true
+    },
+    "website": {
+      "patterns": ["website/**", "booking/**", ".github/workflows/deploy-website-cloudflare.yml"],
+      "sharedInputs": true
+    },
+    "orb": {
+      "patterns": ["orb/**", "ops/runtime/**", ".github/workflows/orb-*.yml"],
+      "sharedInputs": true
+    },
+    "default": {
+      "patterns": [],
+      "sharedInputs": true,
+      "requiresExplicitClosure": true
+    }
+  },
+  "sharedInputs": [
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "ops/codex/risk-policy.json",
+    "ops/governance/global-concurrency-policy.json"
+  ],
+  "adapters": {
+    "codex": "private state adapter must use the same transition contract and fail closed on an unknown lock",
+    "github": "Actions concurrency is a scheduling hint; mutation authority requires a lease proof",
+    "cloudflare": "one SQLite-backed Durable Object instance per lock scope",
+    "mini-pc": "runtime client must present the lease proof before a service or workflow mutation"
+  }
+}

--- a/ops/governance/global-concurrency-policy.json
+++ b/ops/governance/global-concurrency-policy.json
@@ -57,27 +57,85 @@
       ],
       "sharedInputs": true
     },
+    "core": {
+      "patterns": [
+        "api/**",
+        "inventory/**",
+        ".github/workflows/deploy-core-workers.yml",
+        ".github/scripts/core-*.mjs",
+        ".github/scripts/ponto-*.mjs"
+      ],
+      "sharedInputs": true
+    },
+    "crm-pages": {
+      "patterns": [
+        "crm/console/**",
+        ".github/workflows/deploy-crm-pages.yml",
+        ".github/workflows/cloudflare-pages-sync-ponto.yml",
+        ".github/scripts/promotion-*.mjs",
+        ".github/scripts/ponto-*.mjs"
+      ],
+      "sharedInputs": true
+    },
+    "merge": {
+      "patterns": ["**"],
+      "sharedInputs": false
+    },
     "atendimento": {
       "patterns": [
         "crm/console/**",
         "crm/api/**",
         "api/**",
         "ops/runtime/**",
+        "scripts/runtime/**",
         ".github/workflows/atendimento-*.yml",
         ".github/scripts/atendimento-*.mjs"
       ],
       "sharedInputs": true
     },
     "finance": {
-      "patterns": ["finance/**", ".github/workflows/deploy-finance*.yml", ".github/scripts/finance-*.mjs"],
+      "patterns": ["finance/**", ".github/workflows/deploy-finance*.yml", ".github/workflows/finance-staging-*.yml", ".github/scripts/finance-*.mjs"],
+      "sharedInputs": true
+    },
+    "finance-ui": {
+      "patterns": ["crm/console/**", ".github/workflows/deploy-finance-ui.yml", ".github/workflows/promotion-gate.yml", ".github/scripts/promotion-*.mjs"],
       "sharedInputs": true
     },
     "website": {
-      "patterns": ["website/**", "booking/**", ".github/workflows/deploy-website-cloudflare.yml"],
+      "patterns": ["website/**", "booking/**", ".github/workflows/deploy-website-cloudflare.yml", ".github/workflows/website-instagram-sync.yml", ".github/workflows/sync-website-cloudflare-security.yml"],
+      "sharedInputs": true
+    },
+    "escala-api": {
+      "patterns": ["workforce/schedule/**", ".github/workflows/deploy-escala-api.yml", ".github/workflows/cloudflare-pages-sync-escala.yml", ".github/scripts/promotion-*.mjs"],
+      "sharedInputs": true
+    },
+    "meta-ads-report": {
+      "patterns": ["ads/meta/apps/report-ingest-worker/**", ".github/workflows/deploy-meta-ads-report-worker.yml", ".github/workflows/cloudflare-pages-sync-meta-ads-report-secret.yml", ".github/scripts/promotion-*.mjs"],
+      "sharedInputs": true
+    },
+    "social-publisher": {
+      "patterns": ["social/publisher/**", ".github/workflows/deploy-social-publisher-worker.yml", ".github/workflows/cloudflare-sync-integrations-encryption-secret.yml", ".github/scripts/promotion-*.mjs"],
+      "sharedInputs": true
+    },
+    "cloudflare-alerting": {
+      "patterns": ["backend/scripts/cloudflare-alerting-apply.sh", ".github/workflows/cloudflare-alerting-apply.yml"],
       "sharedInputs": true
     },
     "orb": {
-      "patterns": ["orb/**", "ops/runtime/**", ".github/workflows/orb-*.yml"],
+      "patterns": ["orb/**", "ops/runtime/**", "scripts/runtime/**", ".github/workflows/orb-*.yml"],
+      "sharedInputs": true
+    },
+    "native-runtime": {
+      "patterns": [
+        "orb/**",
+        "crm/api/**",
+        "integration/ef/**",
+        "booking/**",
+        "messaging/**",
+        "ops/runtime/**",
+        "scripts/runtime/**",
+        ".github/workflows/orb-*.yml"
+      ],
       "sharedInputs": true
     },
     "default": {
@@ -92,7 +150,11 @@
     "pnpm-lock.yaml",
     "yarn.lock",
     "ops/codex/risk-policy.json",
-    "ops/governance/global-concurrency-policy.json"
+    "ops/governance/global-concurrency-policy.json",
+    "ops/governance/global-coordination-core.mjs",
+    "scripts/codex-global-coordinator.mjs",
+    "scripts/codex-global-coordination-client.mjs",
+    "scripts/codex-global-coordination-workflow.mjs"
   ],
   "adapters": {
     "codex": "private state adapter must use the same transition contract and fail closed on an unknown lock",

--- a/ops/governance/global-coordination-core.mjs
+++ b/ops/governance/global-coordination-core.mjs
@@ -1,0 +1,327 @@
+const FULL_SHA = /^[0-9a-f]{40}$/i;
+const DIGEST = /^[0-9a-f]{64}$/i;
+const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,199}$/;
+const OWNER_PROVIDER = new Set(["codex", "github", "cloudflare", "mini-pc", "system"]);
+const ACTIVE_STATES = new Set(["held"]);
+const TERMINAL_STATES = new Set(["released", "revoked", "expired"]);
+
+export const CONTRACT_ID = "skincos/global-coordination/v1";
+export const SCHEMA_VERSION = 1;
+
+export function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+  }
+  if (typeof value === "number" && !Number.isFinite(value)) throw new Error("non-finite number is not canonical");
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) throw new Error("undefined is not canonical");
+  return serialized;
+}
+
+const clone = (value) => JSON.parse(JSON.stringify(value));
+const text = (value) => String(value ?? "").trim();
+const lower = (value) => text(value).toLowerCase();
+const requireId = (value, label) => {
+  const normalized = text(value);
+  if (!SAFE_ID.test(normalized)) throw new Error(`${label} is invalid`);
+  return normalized;
+};
+
+export function resourceClass(resource) {
+  const normalized = lower(resource);
+  if (!normalized || normalized.includes(" ") || normalized.includes("\\")) throw new Error("resource key is invalid");
+  const separator = normalized.indexOf(":");
+  const kind = separator > 0 ? normalized.slice(0, separator) : "";
+  if (!["merge", "release", "deploy", "cloudflare", "promotion", "global"].includes(kind)) {
+    throw new Error("resource class is unsupported");
+  }
+  const parts = normalized.split(":");
+  if (kind === "merge" || kind === "release" || kind === "global") {
+    if (parts.length !== 2 || !/^[a-z0-9][a-z0-9._/-]{0,127}$/.test(parts[1])) throw new Error("resource key is invalid");
+    return kind;
+  }
+  if (parts.length !== 3 || !/^[a-z0-9][a-z0-9._/-]{0,127}$/.test(parts[1])) throw new Error("resource key is invalid");
+  if (!["preview", "staging", "pilot", "canary", "production", "rollback", "local"].includes(parts[2])) throw new Error("resource environment is invalid");
+  return kind;
+}
+
+export function normalizeResourceKey(resource) {
+  const normalized = lower(resource);
+  resourceClass(normalized);
+  return normalized;
+}
+
+export function lockScopeFor(resource) {
+  const normalized = normalizeResourceKey(resource);
+  const [kind, name, environment] = normalized.split(":");
+  if (kind === "merge") return `repository:${name}`;
+  if (kind === "release") return `release:${name}`;
+  if (kind === "global") return `global:${name}`;
+  if (kind === "deploy" || kind === "cloudflare") return `surface:${name}:${environment}`;
+  return `promotion:${name}:${environment}`;
+}
+
+export function normalizeOwner(owner) {
+  if (!owner || typeof owner !== "object" || Array.isArray(owner)) throw new Error("lease owner is required");
+  const provider = lower(owner.provider);
+  if (!OWNER_PROVIDER.has(provider)) throw new Error("lease owner provider is invalid");
+  const normalized = {
+    provider,
+    missionId: requireId(owner.missionId, "lease owner missionId"),
+    threadId: requireId(owner.threadId, "lease owner threadId"),
+    actor: requireId(owner.actor, "lease owner actor"),
+  };
+  if (owner.runId !== undefined && owner.runId !== null && text(owner.runId)) normalized.runId = requireId(owner.runId, "lease owner runId");
+  return normalized;
+}
+
+export function normalizeArtifacts(artifacts = []) {
+  if (!Array.isArray(artifacts)) throw new Error("artifact identity must be an array");
+  const normalized = artifacts.map((artifact) => {
+    if (!artifact || typeof artifact !== "object" || Array.isArray(artifact)) throw new Error("artifact identity is invalid");
+    const result = {
+      name: requireId(artifact.name, "artifact name"),
+      id: requireId(artifact.id, "artifact id"),
+      digest: lower(artifact.digest),
+    };
+    if (!DIGEST.test(result.digest)) throw new Error("artifact digest is invalid");
+    if (artifact.versionId !== undefined && artifact.versionId !== null && text(artifact.versionId)) result.versionId = requireId(artifact.versionId, "artifact versionId");
+    return result;
+  }).sort((left, right) => left.name.localeCompare(right.name));
+  const names = new Set();
+  for (const artifact of normalized) {
+    if (names.has(artifact.name)) throw new Error("artifact names must be unique");
+    names.add(artifact.name);
+  }
+  return normalized;
+}
+
+export function normalizeReleaseIdentity(identity) {
+  if (!identity || typeof identity !== "object" || Array.isArray(identity)) throw new Error("release identity is required");
+  const sourceCommit = lower(identity.sourceCommit);
+  const sourceTree = lower(identity.sourceTree);
+  const dependencyClosureDigest = lower(identity.dependencyClosureDigest);
+  if (!FULL_SHA.test(sourceCommit) || !FULL_SHA.test(sourceTree) || !DIGEST.test(dependencyClosureDigest)) throw new Error("release identity is invalid");
+  const module = requireId(identity.module, "release identity module").toLowerCase();
+  const artifacts = normalizeArtifacts(identity.artifacts);
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    module,
+    sourceCommit,
+    sourceTree,
+    dependencyClosureDigest,
+    artifacts,
+    ...(identity.predecessor ? { predecessor: clone(identity.predecessor) } : {}),
+  };
+}
+
+export function normalizeIntent(intent, { operation = "mutation" } = {}) {
+  if (!intent || typeof intent !== "object" || Array.isArray(intent)) throw new Error("lease intent is required");
+  const normalized = clone(intent);
+  if (operation === "release" || operation === "promotion") {
+    normalized.releaseIdentity = normalizeReleaseIdentity(intent.releaseIdentity);
+  }
+  if (normalized.dependencyClosureDigest !== undefined) {
+    normalized.dependencyClosureDigest = lower(normalized.dependencyClosureDigest);
+    if (!DIGEST.test(normalized.dependencyClosureDigest)) throw new Error("intent dependency closure digest is invalid");
+  }
+  return normalized;
+}
+
+export function buildIntent({ operation, resource, owner, intent, idempotencyKey }) {
+  const normalizedOperation = lower(operation);
+  if (!["mutation", "release", "promotion", "revalidate", "revoke"].includes(normalizedOperation)) throw new Error("lease operation is invalid");
+  const normalizedResource = normalizeResourceKey(resource);
+  const normalizedOwner = normalizeOwner(owner);
+  const normalizedIntent = normalizeIntent(intent, { operation: normalizedOperation });
+  const key = requireId(idempotencyKey, "lease idempotencyKey");
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    contractId: CONTRACT_ID,
+    operation: normalizedOperation,
+    resource: normalizedResource,
+    lockScope: lockScopeFor(normalizedResource),
+    owner: normalizedOwner,
+    idempotencyKey: key,
+    intent: normalizedIntent,
+  };
+}
+
+export function emptyState() {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    contractId: CONTRACT_ID,
+    fencingCounters: {},
+    leases: {},
+    nonces: {},
+  };
+}
+
+function stateOrEmpty(state) {
+  if (!state || typeof state !== "object" || Array.isArray(state)) throw new Error("coordinator state is invalid");
+  if (state.schemaVersion !== SCHEMA_VERSION || state.contractId !== CONTRACT_ID) throw new Error("coordinator state contract is invalid");
+  return clone(state);
+}
+
+function assertTime(now) {
+  if (!Number.isInteger(now) || now < 0) throw new Error("coordinator time is invalid");
+}
+
+function assertTtl(ttlMs) {
+  if (!Number.isInteger(ttlMs) || ttlMs < 30_000 || ttlMs > 900_000) throw new Error("lease TTL is outside the fail-closed bounds");
+}
+
+function nextFencingToken(state, scope) {
+  const token = Number(state.fencingCounters[scope] || 0) + 1;
+  if (!Number.isSafeInteger(token) || token <= 0) throw new Error("fencing token exhausted");
+  state.fencingCounters[scope] = token;
+  return token;
+}
+
+function expireCurrent(state, scope, now) {
+  const current = state.leases[scope];
+  if (current && current.state === "held" && current.expiresAt <= now) {
+    current.state = "expired";
+    current.expiredAt = now;
+  }
+  return current;
+}
+
+export function consumeNonce(state, { nonce, digest, now, ttlMs = 900_000 }) {
+  const next = stateOrEmpty(state);
+  assertTime(now);
+  assertTtl(ttlMs);
+  const key = requireId(nonce, "request nonce");
+  const requestDigest = lower(digest);
+  if (!DIGEST.test(requestDigest)) throw new Error("request digest is invalid");
+  for (const [storedNonce, record] of Object.entries(next.nonces)) {
+    if (!record || record.expiresAt <= now) delete next.nonces[storedNonce];
+  }
+  if (next.nonces[key]) return { accepted: false, reason: "request-nonce-replayed", state: next };
+  next.nonces[key] = { digest: requestDigest, acceptedAt: now, expiresAt: now + ttlMs };
+  return { accepted: true, state: next };
+}
+
+export function acquireLease(state, request, { now, leaseId }) {
+  const next = stateOrEmpty(state);
+  assertTime(now);
+  const ttlMs = request?.ttlMs;
+  assertTtl(ttlMs);
+  const intent = buildIntent(request);
+  const intentDigest = lower(request.intentDigest);
+  if (!DIGEST.test(intentDigest)) throw new Error("intent digest is invalid");
+  const scope = intent.lockScope;
+  const current = expireCurrent(next, scope, now);
+  if (current?.state === "held") {
+    if (
+      current.idempotencyKey === intent.idempotencyKey
+      && canonicalJson(current.owner) === canonicalJson(intent.owner)
+      && current.intentDigest === intentDigest
+    ) return { accepted: true, idempotent: true, lease: clone(current), state: next };
+    return {
+      accepted: false,
+      reason: "resource-lease-held",
+      resource: intent.resource,
+      lockScope: scope,
+      holder: { provider: current.owner.provider, missionId: current.owner.missionId, threadId: current.owner.threadId },
+      state: next,
+    };
+  }
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{15,199}$/.test(String(leaseId || ""))) throw new Error("leaseId is invalid");
+  const fencingToken = nextFencingToken(next, scope);
+  const lease = {
+    schemaVersion: SCHEMA_VERSION,
+    contractId: CONTRACT_ID,
+    resource: intent.resource,
+    lockScope: scope,
+    leaseId,
+    fencingToken,
+    owner: intent.owner,
+    operation: intent.operation,
+    idempotencyKey: intent.idempotencyKey,
+    intentDigest,
+    intent: intent.intent,
+    state: "held",
+    acquiredAt: now,
+    expiresAt: now + ttlMs,
+  };
+  next.leases[scope] = lease;
+  return { accepted: true, idempotent: false, lease: clone(lease), state: next };
+}
+
+function matchingLease(state, proof, now) {
+  const next = stateOrEmpty(state);
+  assertTime(now);
+  const scope = lockScopeFor(proof?.resource || "");
+  const current = expireCurrent(next, scope, now);
+  if (!current || !ACTIVE_STATES.has(current.state)) return { valid: false, reason: current?.state === "expired" ? "lease-expired" : "lease-not-held", state: next };
+  if (
+    current.leaseId !== proof.leaseId
+    || current.fencingToken !== proof.fencingToken
+    || current.intentDigest !== lower(proof.intentDigest)
+    || canonicalJson(current.owner) !== canonicalJson(normalizeOwner(proof.owner))
+  ) return { valid: false, reason: "lease-fence-mismatch", state: next };
+  return { valid: true, lease: clone(current), state: next };
+}
+
+export function checkLease(state, proof, { now }) {
+  return matchingLease(state, proof, now);
+}
+
+export function renewLease(state, proof, { now, ttlMs }) {
+  const result = matchingLease(state, proof, now);
+  if (!result.valid) return result;
+  assertTtl(ttlMs);
+  result.lease.expiresAt = now + ttlMs;
+  result.lease.renewedAt = now;
+  result.state.leases[result.lease.lockScope] = result.lease;
+  return { ...result, renewed: true };
+}
+
+export function releaseLease(state, proof, { now }) {
+  const result = matchingLease(state, proof, now);
+  if (!result.valid) return result;
+  const released = { ...result.lease, state: "released", releasedAt: now };
+  result.state.leases[released.lockScope] = released;
+  return { valid: true, released: true, lease: clone(released), state: result.state };
+}
+
+export function revokeLease(state, proof, { now, reason }) {
+  const result = matchingLease(state, proof, now);
+  if (!result.valid) return result;
+  const revokeReason = requireId(reason, "lease revocation reason");
+  const revoked = { ...result.lease, state: "revoked", revokedAt: now, revocationReason: revokeReason };
+  result.state.leases[revoked.lockScope] = revoked;
+  return { valid: true, revoked: true, lease: clone(revoked), state: result.state };
+}
+
+export function compareDependencyClosure(expectedDigest, observedDigest) {
+  const expected = lower(expectedDigest);
+  const observed = lower(observedDigest);
+  if (!DIGEST.test(expected) || !DIGEST.test(observed)) return { valid: false, failClosed: true, reason: "dependency-closure-unavailable" };
+  if (expected !== observed) return { valid: false, failClosed: true, reason: "dependency-closure-changed" };
+  return { valid: true, failClosed: false, reason: "dependency-closure-unchanged" };
+}
+
+export function authorizeMutation(state, proof, { now, expectedResource, expectedIntentDigest, observedDependencyClosureDigest, expectedArtifacts = null } = {}) {
+  const checked = checkLease(state, proof, { now });
+  if (!checked.valid) return checked;
+  if (expectedResource && normalizeResourceKey(expectedResource) !== checked.lease.resource) return { valid: false, failClosed: true, reason: "resource-mismatch", state: checked.state };
+  if (expectedIntentDigest && lower(expectedIntentDigest) !== checked.lease.intentDigest) return { valid: false, failClosed: true, reason: "intent-digest-mismatch", state: checked.state };
+  const identity = checked.lease.intent?.releaseIdentity;
+  if (checked.lease.operation === "release" || checked.lease.operation === "promotion") {
+    if (!identity) return { valid: false, failClosed: true, reason: "release-identity-missing", state: checked.state };
+    const closure = compareDependencyClosure(identity.dependencyClosureDigest, observedDependencyClosureDigest);
+    if (!closure.valid) return { ...closure, state: checked.state };
+    if (!identity.artifacts.length) return { valid: false, failClosed: true, reason: "artifact-identity-missing", state: checked.state };
+    if (expectedArtifacts !== null && canonicalJson(normalizeArtifacts(expectedArtifacts)) !== canonicalJson(identity.artifacts)) {
+      return { valid: false, failClosed: true, reason: "artifact-identity-mismatch", state: checked.state };
+    }
+  }
+  return { valid: true, failClosed: false, reason: "mutation-authorized", lease: checked.lease, state: checked.state };
+}
+
+export function terminalState(state) {
+  return Object.fromEntries(Object.entries(stateOrEmpty(state).leases).map(([scope, lease]) => [scope, TERMINAL_STATES.has(lease.state) ? lease.state : lease.state]));
+}

--- a/ops/governance/global-coordination-core.mjs
+++ b/ops/governance/global-coordination-core.mjs
@@ -309,6 +309,12 @@ export function authorizeMutation(state, proof, { now, expectedResource, expecte
   if (!checked.valid) return checked;
   if (expectedResource && normalizeResourceKey(expectedResource) !== checked.lease.resource) return { valid: false, failClosed: true, reason: "resource-mismatch", state: checked.state };
   if (expectedIntentDigest && lower(expectedIntentDigest) !== checked.lease.intentDigest) return { valid: false, failClosed: true, reason: "intent-digest-mismatch", state: checked.state };
+  if (observedDependencyClosureDigest !== undefined && observedDependencyClosureDigest !== null) {
+    const expectedIntentClosure = checked.lease.intent?.dependencyClosureDigest
+      || checked.lease.intent?.releaseIdentity?.dependencyClosureDigest;
+    const closure = compareDependencyClosure(expectedIntentClosure, observedDependencyClosureDigest);
+    if (!closure.valid) return { ...closure, reason: closure.reason === "dependency-closure-unavailable" ? "dependency-closure-intent-missing" : closure.reason, state: checked.state };
+  }
   const identity = checked.lease.intent?.releaseIdentity;
   if (checked.lease.operation === "release" || checked.lease.operation === "promotion") {
     if (!identity) return { valid: false, failClosed: true, reason: "release-identity-missing", state: checked.state };

--- a/ops/runtime/global-coordination/README.md
+++ b/ops/runtime/global-coordination/README.md
@@ -1,0 +1,39 @@
+# Global coordination runtime adapters
+
+`scripts/codex-global-coordination-workflow.mjs` is the shared operator-facing
+adapter for Codex App and the mini-PC. Both callers use the same HTTPS client,
+HMAC envelope, owner fields, fencing proof, dependency-closure check and
+fail-closed transitions; only `GLOBAL_COORDINATION_PROVIDER` and the private
+owner identity differ.
+
+On the mini-PC, call it through the versioned
+`scripts/runtime/global-coordination-mini-pc.sh` wrapper. The wrapper forces the
+`mini-pc` provider, requires explicit mission/thread/actor identity, keeps proof
+files below `/var/lib/skincos-runtime/global-coordination` with mode `0600`, and
+refuses an acquire/check without a detached closure attestation. Native source
+preparation installs those attestations as
+`.skincos-global-coordination-<module>.json` inside the immutable release.
+
+The runtime must provide these names through its private environment or secret
+store; values never belong in this repository:
+
+- `SKINCOS_GLOBAL_COORDINATOR_URL`
+- `SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET`
+- `GLOBAL_COORDINATION_PROVIDER` (`codex` or `mini-pc`)
+- `GLOBAL_COORDINATION_MISSION_ID`, `GLOBAL_COORDINATION_THREAD_ID`, and
+  `GLOBAL_COORDINATION_ACTOR`
+
+Acquire with `acquire --resource ... --module ... --source ...
+--closure-file ... --proof-file ...`, run `renew` while waiting and `check`
+immediately before each external mutation, and always run `release` or use
+`revoke` only with the separate administrative custody. A local supervisor
+lock is not a substitute for this remote proof. If the coordinator URL,
+custody, closure, proof or owner identity is unavailable, the native operation
+must stop before its first external mutation.
+
+The immutable runtime wrappers use this adapter for the native Orb source
+promotion, MCP gateway promotion, verified backup generation, Harmonia
+migration, Atendimento provisioning/control/migration and lifecycle service
+mutations. The Windows Orb backup publisher invokes
+`run-orb-backup-with-coordination.sh`; it does not start the systemd backup
+unit directly.

--- a/ops/runtime/global-coordination/README.md
+++ b/ops/runtime/global-coordination/README.md
@@ -36,4 +36,8 @@ promotion, MCP gateway promotion, verified backup generation, Harmonia
 migration, Atendimento provisioning/control/migration and lifecycle service
 mutations. The Windows Orb backup publisher invokes
 `run-orb-backup-with-coordination.sh`; it does not start the systemd backup
-unit directly.
+unit directly. The scheduled bridge passes the private WSL environment-file
+reference plus a fixed scheduler owner identity. The default file is
+`/etc/skincos/global-coordination/orb-backup.env`, mode `0600` or `0640`, and
+may contain only the coordinator URL and shared secret names. It is never
+stored in the repository or copied to Windows.

--- a/package.json
+++ b/package.json
@@ -83,6 +83,8 @@
     "codex:context": "bash ./scripts/codex-context.sh",
     "codex:context:online": "bash ./scripts/codex-context.sh --online",
     "codex:autonomy:test": "node --test scripts/tests/codex-autonomy-baseline.test.mjs",
+    "codex:global-coordination:test": "node --test scripts/tests/codex-global-coordination.test.mjs scripts/tests/codex-global-coordination-client.test.mjs ops/cloudflare/global-coordinator/index.test.mjs",
+    "codex:global-coordination:lease": "node scripts/codex-global-coordination-lease.mjs",
     "codex:risk": "node ./scripts/codex-risk-classifier.mjs",
     "codex:release-manifest": "node ./scripts/codex-release-manifest.mjs",
     "codex:state": "node ./scripts/codex-current-state.mjs",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "codex:context": "bash ./scripts/codex-context.sh",
     "codex:context:online": "bash ./scripts/codex-context.sh --online",
     "codex:autonomy:test": "node --test scripts/tests/codex-autonomy-baseline.test.mjs",
-    "codex:global-coordination:test": "node --test scripts/tests/codex-global-coordination.test.mjs scripts/tests/codex-global-coordination-client.test.mjs ops/cloudflare/global-coordinator/index.test.mjs",
+    "codex:global-coordination:test": "node --test scripts/tests/codex-global-coordination.test.mjs scripts/tests/codex-global-coordination-client.test.mjs scripts/tests/codex-global-coordination-workflow.test.mjs scripts/tests/global-concurrency-governance-static.test.mjs ops/cloudflare/global-coordinator/index.test.mjs",
     "codex:global-coordination:lease": "node scripts/codex-global-coordination-lease.mjs",
     "codex:risk": "node ./scripts/codex-risk-classifier.mjs",
     "codex:release-manifest": "node ./scripts/codex-release-manifest.mjs",

--- a/scripts/codex-autonomy-lib.mjs
+++ b/scripts/codex-autonomy-lib.mjs
@@ -105,15 +105,26 @@ export function releaseInputDigest({ surfaces, inputs, policyPaths }) {
 
 export function buildReleaseManifest({ sourceCommit, sourceTree, surfaces, inputs, policyPaths, artifacts = [], migrations = [], evidence = [], predecessor = null }) {
   const releaseInput = releaseInputDigest({ surfaces, inputs, policyPaths });
+  const normalizedArtifacts = artifacts.map((artifact) => ({ name: artifact.name, digest: artifact.digest })).sort((left, right) => left.name.localeCompare(right.name));
+  const releaseIdentity = {
+    schemaVersion: 1,
+    sourceCommit,
+    sourceTree,
+    dependencyClosureDigest: releaseInput.digest,
+    artifacts: normalizedArtifacts,
+  };
   return {
     schemaVersion: 1,
     sourceCommit,
     sourceTree,
     releaseInputDigest: releaseInput.digest,
+    dependencyClosureDigest: releaseInput.digest,
     releaseInputs: releaseInput.material.inputs,
     surfaces: releaseInput.material.surfaces,
     policiesConsumed: releaseInput.material.policyPaths,
-    artifacts: artifacts.map((artifact) => ({ name: artifact.name, digest: artifact.digest })).sort((left, right) => left.name.localeCompare(right.name)),
+    artifacts: normalizedArtifacts,
+    releaseIdentity,
+    releaseIdentityDigest: sha256(canonicalJson(releaseIdentity)),
     migrations: [...new Set(migrations)].sort(),
     evidence: evidence.map((entry) => ({ name: entry.name, digest: entry.digest })).sort((left, right) => left.name.localeCompare(right.name)),
     predecessor: predecessor ? { sourceCommit: predecessor.sourceCommit, releaseInputDigest: predecessor.releaseInputDigest, artifactDigests: [...(predecessor.artifactDigests ?? [])].sort() } : null,

--- a/scripts/codex-evidence-reuse.mjs
+++ b/scripts/codex-evidence-reuse.mjs
@@ -18,6 +18,7 @@ const reusable = findReusableEvidence(records, manifest);
 const result = {
   schemaVersion: 1,
   releaseInputDigest: manifest.releaseInputDigest,
+  dependencyClosureDigest: manifest.dependencyClosureDigest || manifest.releaseInputDigest,
   reused: Boolean(reusable),
   evidence: reusable ? { name: reusable.name ?? null, artifactDigest: reusable.artifactDigest ?? null } : null
 };
@@ -25,4 +26,5 @@ process.stdout.write(`${JSON.stringify(result)}\n`);
 if (process.env.GITHUB_OUTPUT) {
   fs.appendFileSync(process.env.GITHUB_OUTPUT, `reused=${result.reused}\n`);
   fs.appendFileSync(process.env.GITHUB_OUTPUT, `release_input_digest=${result.releaseInputDigest}\n`);
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `dependency_closure_digest=${result.dependencyClosureDigest}\n`);
 }

--- a/scripts/codex-global-coordination-client.mjs
+++ b/scripts/codex-global-coordination-client.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+import crypto from "node:crypto";
+import {
+  buildIntent,
+  canonicalJson,
+  CONTRACT_ID,
+  lockScopeFor,
+  normalizeResourceKey,
+} from "../ops/governance/global-coordination-core.mjs";
+
+const COORDINATION_PATH = "/v1/leases";
+const REQUEST_SCHEMA_VERSION = 1;
+const NONCE_RE = /^[A-Za-z0-9_-]{32,}$/;
+
+export function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+export function hmac(secret, value) {
+  if (!String(secret || "").trim()) throw new Error("global coordination custody is unavailable");
+  return crypto.createHmac("sha256", String(secret)).update(value).digest("base64url");
+}
+
+export function newRequestNonce() {
+  return crypto.randomBytes(24).toString("base64url");
+}
+
+export function buildLeaseRequest({ operation, resource, owner, intent, idempotencyKey, ttlMs }) {
+  const normalized = buildIntent({ operation, resource, owner, intent, idempotencyKey });
+  return {
+    ...normalized,
+    ttlMs,
+    intentDigest: sha256(canonicalJson(normalized)),
+  };
+}
+
+function endpointFor(value) {
+  let endpoint;
+  try {
+    endpoint = new URL(String(value || ""));
+  } catch {
+    throw new Error("global coordinator URL is invalid");
+  }
+  if (endpoint.protocol !== "https:") throw new Error("global coordinator URL must use HTTPS");
+  if (endpoint.pathname === "/" || endpoint.pathname === "") endpoint.pathname = COORDINATION_PATH;
+  if (endpoint.pathname !== COORDINATION_PATH) throw new Error("global coordinator URL must target /v1/leases");
+  endpoint.search = "";
+  endpoint.hash = "";
+  return endpoint;
+}
+
+function envelopeFor({ action, request, proof, ttlMs, reason, nonce, requestedAt }) {
+  if (!NONCE_RE.test(String(nonce || ""))) throw new Error("coordination request nonce is invalid");
+  const body = {
+    schemaVersion: REQUEST_SCHEMA_VERSION,
+    contractId: CONTRACT_ID,
+    action,
+    requestNonce: nonce,
+    requestedAt,
+  };
+  if (action === "acquire") body.request = request;
+  else body.proof = proof;
+  if (action === "renew") body.ttlMs = ttlMs;
+  if (action === "revoke") body.reason = reason;
+  return body;
+}
+
+export function buildAuthenticatedRequest({
+  url = process.env.SKINCOS_GLOBAL_COORDINATOR_URL,
+  secret,
+  adminSecret,
+  action,
+  request,
+  proof,
+  ttlMs,
+  reason,
+  nonce = newRequestNonce(),
+  requestedAt = new Date().toISOString(),
+}) {
+  const endpoint = endpointFor(url);
+  const body = envelopeFor({ action, request, proof, ttlMs, reason, nonce, requestedAt });
+  const rawBody = canonicalJson(body);
+  const requestDigest = sha256(rawBody);
+  const binding = {
+    schemaVersion: REQUEST_SCHEMA_VERSION,
+    contractId: CONTRACT_ID,
+    method: "POST",
+    path: endpoint.pathname,
+    nonce,
+    requestedAt,
+    requestDigest,
+  };
+  const headers = {
+    accept: "application/json",
+    "content-type": "application/json",
+    "x-skincos-coordination-nonce": nonce,
+    "x-skincos-coordination-requested-at": requestedAt,
+    "x-skincos-coordination-request-digest": requestDigest,
+    "x-skincos-coordination-request-signature": hmac(secret, canonicalJson(binding)),
+  };
+  if (action === "revoke") {
+    if (!String(adminSecret || "").trim()) throw new Error("global coordination administrative custody is unavailable");
+    headers.authorization = `Bearer ${adminSecret}`;
+  }
+  return {
+    endpoint,
+    body,
+    rawBody,
+    requestDigest,
+    headers,
+  };
+}
+
+export function verifyCoordinatorResponse(payload, secret) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) throw new Error("global coordinator response is invalid");
+  const { authority, responseSignature, ...unsigned } = payload;
+  if (
+    !authority
+    || authority.contractId !== CONTRACT_ID
+    || authority.provider !== "cloudflare"
+    || !/^[0-9a-f]{64}$/.test(String(authority.responseDigest || ""))
+    || !String(responseSignature || "")
+  ) throw new Error("global coordinator response authority is invalid");
+  if (sha256(canonicalJson(unsigned)) !== authority.responseDigest) throw new Error("global coordinator response digest mismatch");
+  const expected = hmac(secret, canonicalJson({ ...unsigned, authority }));
+  const actual = Buffer.from(String(responseSignature), "base64url");
+  const expectedBytes = Buffer.from(expected, "base64url");
+  if (actual.length !== expectedBytes.length || !crypto.timingSafeEqual(actual, expectedBytes)) throw new Error("global coordinator response signature mismatch");
+  return unsigned;
+}
+
+export function proofForLease(lease) {
+  if (!lease || typeof lease !== "object") throw new Error("global coordinator lease is missing");
+  return {
+    resource: normalizeResourceKey(lease.resource),
+    leaseId: String(lease.leaseId || ""),
+    fencingToken: lease.fencingToken,
+    intentDigest: String(lease.intentDigest || ""),
+    owner: lease.owner,
+  };
+}
+
+export async function coordinate({
+  url = process.env.SKINCOS_GLOBAL_COORDINATOR_URL,
+  secret = process.env.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET,
+  adminSecret = process.env.SKINCOS_GLOBAL_COORDINATION_ADMIN_SECRET,
+  fetchImpl = globalThis.fetch,
+  action,
+  request,
+  proof,
+  ttlMs,
+  reason,
+  nonce,
+  requestedAt,
+}) {
+  if (typeof fetchImpl !== "function") throw new Error("global coordinator fetch is unavailable");
+  const signed = buildAuthenticatedRequest({ url, secret, adminSecret, action, request, proof, ttlMs, reason, nonce, requestedAt });
+  const response = await fetchImpl(signed.endpoint, { method: "POST", headers: signed.headers, body: signed.rawBody });
+  const raw = await response.text();
+  let payload;
+  try { payload = JSON.parse(raw); } catch { throw new Error("global coordinator response JSON is invalid"); }
+  if ((response.status >= 200 && response.status < 300) || response.status === 409) {
+    const verified = verifyCoordinatorResponse(payload, secret);
+    return { ...verified, httpStatus: response.status };
+  }
+  const error = String(payload?.error || payload?.reason || `HTTP ${response.status}`);
+  throw new Error(`global coordinator request failed: ${error}`);
+}
+
+export async function acquireGlobalLease({ request, ...options }) {
+  return coordinate({ ...options, action: "acquire", request });
+}
+
+export async function checkGlobalLease({ proof, ...options }) {
+  return coordinate({ ...options, action: "check", proof });
+}
+
+export async function renewGlobalLease({ proof, ttlMs, ...options }) {
+  return coordinate({ ...options, action: "renew", proof, ttlMs });
+}
+
+export async function releaseGlobalLease({ proof, ...options }) {
+  return coordinate({ ...options, action: "release", proof });
+}
+
+export async function revokeGlobalLease({ proof, reason, ...options }) {
+  return coordinate({ ...options, action: "revoke", proof, reason });
+}
+
+export function lockScopeForResource(resource) {
+  return lockScopeFor(normalizeResourceKey(resource));
+}

--- a/scripts/codex-global-coordination-client.mjs
+++ b/scripts/codex-global-coordination-client.mjs
@@ -49,7 +49,7 @@ function endpointFor(value) {
   return endpoint;
 }
 
-function envelopeFor({ action, request, proof, ttlMs, reason, nonce, requestedAt }) {
+function envelopeFor({ action, request, proof, authorization, ttlMs, reason, nonce, requestedAt }) {
   if (!NONCE_RE.test(String(nonce || ""))) throw new Error("coordination request nonce is invalid");
   const body = {
     schemaVersion: REQUEST_SCHEMA_VERSION,
@@ -60,6 +60,7 @@ function envelopeFor({ action, request, proof, ttlMs, reason, nonce, requestedAt
   };
   if (action === "acquire") body.request = request;
   else body.proof = proof;
+  if (authorization !== undefined) body.authorization = authorization;
   if (action === "renew") body.ttlMs = ttlMs;
   if (action === "revoke") body.reason = reason;
   return body;
@@ -72,13 +73,14 @@ export function buildAuthenticatedRequest({
   action,
   request,
   proof,
+  authorization,
   ttlMs,
   reason,
   nonce = newRequestNonce(),
   requestedAt = new Date().toISOString(),
 }) {
   const endpoint = endpointFor(url);
-  const body = envelopeFor({ action, request, proof, ttlMs, reason, nonce, requestedAt });
+  const body = envelopeFor({ action, request, proof, authorization, ttlMs, reason, nonce, requestedAt });
   const rawBody = canonicalJson(body);
   const requestDigest = sha256(rawBody);
   const binding = {
@@ -148,13 +150,14 @@ export async function coordinate({
   action,
   request,
   proof,
+  authorization,
   ttlMs,
   reason,
   nonce,
   requestedAt,
 }) {
   if (typeof fetchImpl !== "function") throw new Error("global coordinator fetch is unavailable");
-  const signed = buildAuthenticatedRequest({ url, secret, adminSecret, action, request, proof, ttlMs, reason, nonce, requestedAt });
+  const signed = buildAuthenticatedRequest({ url, secret, adminSecret, action, request, proof, authorization, ttlMs, reason, nonce, requestedAt });
   const response = await fetchImpl(signed.endpoint, { method: "POST", headers: signed.headers, body: signed.rawBody });
   const raw = await response.text();
   let payload;
@@ -171,8 +174,8 @@ export async function acquireGlobalLease({ request, ...options }) {
   return coordinate({ ...options, action: "acquire", request });
 }
 
-export async function checkGlobalLease({ proof, ...options }) {
-  return coordinate({ ...options, action: "check", proof });
+export async function checkGlobalLease({ proof, authorization, ...options }) {
+  return coordinate({ ...options, action: "check", proof, authorization });
 }
 
 export async function renewGlobalLease({ proof, ttlMs, ...options }) {

--- a/scripts/codex-global-coordination-lease.mjs
+++ b/scripts/codex-global-coordination-lease.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  acquireGlobalLease,
+  buildLeaseRequest,
+  checkGlobalLease,
+  proofForLease,
+  releaseGlobalLease,
+  renewGlobalLease,
+  revokeGlobalLease,
+} from "./codex-global-coordination-client.mjs";
+
+export const ROOT = path.resolve(import.meta.dirname, "..");
+
+function argument(args, name, fallback = null) {
+  const index = args.indexOf(name);
+  return index === -1 ? fallback : args[index + 1];
+}
+
+function requiredArgument(args, name) {
+  const value = argument(args, name);
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function jsonFile(args, name) {
+  return JSON.parse(fs.readFileSync(path.resolve(requiredArgument(args, name)), "utf8"));
+}
+
+function proofPath(args) {
+  const value = path.resolve(requiredArgument(args, "--proof-file"));
+  if (value === ROOT || value.startsWith(`${ROOT}${path.sep}`) || value === path.parse(value).root) {
+    throw new Error("global coordination proof must live outside the repository");
+  }
+  return value;
+}
+
+function writeProof(file, lease) {
+  const proof = proofForLease(lease);
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const temporary = `${file}.tmp.${process.pid}`;
+  fs.writeFileSync(temporary, `${JSON.stringify(proof, null, 2)}\n`, { mode: 0o600 });
+  fs.renameSync(temporary, file);
+}
+
+function publicLease(lease) {
+  if (!lease) return undefined;
+  return {
+    schemaVersion: lease.schemaVersion,
+    contractId: lease.contractId,
+    resource: lease.resource,
+    lockScope: lease.lockScope,
+    leaseId: lease.leaseId,
+    fencingToken: lease.fencingToken,
+    owner: lease.owner,
+    operation: lease.operation,
+    idempotencyKey: lease.idempotencyKey,
+    intentDigest: lease.intentDigest,
+    state: lease.state,
+    acquiredAt: lease.acquiredAt,
+    renewedAt: lease.renewedAt,
+    expiresAt: lease.expiresAt,
+    releasedAt: lease.releasedAt,
+    revokedAt: lease.revokedAt,
+  };
+}
+
+function publicResult(result) {
+  return {
+    accepted: result.accepted,
+    valid: result.valid,
+    passed: result.passed,
+    idempotent: result.idempotent,
+    renewed: result.renewed,
+    released: result.released,
+    revoked: result.revoked,
+    reason: result.reason,
+    resource: result.resource,
+    lockScope: result.lockScope,
+    holder: result.holder,
+    httpStatus: result.httpStatus,
+    lease: publicLease(result.lease),
+  };
+}
+
+function output(result) {
+  process.stdout.write(`${JSON.stringify(publicResult(result), null, 2)}\n`);
+}
+
+async function main(args) {
+  const [command] = args;
+  if (command === "acquire") {
+    const request = buildLeaseRequest({
+      operation: requiredArgument(args, "--operation"),
+      resource: requiredArgument(args, "--resource"),
+      owner: jsonFile(args, "--owner-file"),
+      intent: jsonFile(args, "--intent-file"),
+      idempotencyKey: requiredArgument(args, "--idempotency-key"),
+      ttlMs: Number(requiredArgument(args, "--ttl-ms")),
+    });
+    const result = await acquireGlobalLease({ request, url: argument(args, "--url", process.env.SKINCOS_GLOBAL_COORDINATOR_URL) });
+    if (result.passed === true && result.lease) writeProof(proofPath(args), result.lease);
+    output(result);
+    if (result.passed !== true) process.exitCode = 2;
+    return;
+  }
+  if (["check", "renew", "release", "revoke"].includes(command)) {
+    const proof = JSON.parse(fs.readFileSync(proofPath(args), "utf8"));
+    const options = { proof, url: argument(args, "--url", process.env.SKINCOS_GLOBAL_COORDINATOR_URL) };
+    let result;
+    if (command === "check") result = await checkGlobalLease(options);
+    if (command === "renew") result = await renewGlobalLease({ ...options, ttlMs: Number(requiredArgument(args, "--ttl-ms")) });
+    if (command === "release") result = await releaseGlobalLease(options);
+    if (command === "revoke") result = await revokeGlobalLease({ ...options, reason: requiredArgument(args, "--reason") });
+    if (result.passed === true && result.lease && ["renew", "release", "revoke"].includes(command)) writeProof(proofPath(args), result.lease);
+    output(result);
+    if (result.passed !== true) process.exitCode = 2;
+    return;
+  }
+  throw new Error("usage: codex-global-coordination-lease.mjs acquire|check|renew|release|revoke ...");
+}
+
+const invokedAsScript = process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (invokedAsScript) {
+  try {
+    await main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/codex-global-coordination-workflow.mjs
+++ b/scripts/codex-global-coordination-workflow.mjs
@@ -232,6 +232,15 @@ async function main(args) {
       const source = sourceFor(args);
       const module = requiredArgument(args, "--module");
       const closure = closureFor(args, { module, source });
+      const candidateSource = argument(args, "--candidate-source");
+      if (candidateSource) {
+        const candidate = String(candidateSource).trim().toLowerCase();
+        if (!FULL_SHA.test(candidate)) throw new Error("global coordination candidate source must be a full commit SHA");
+        const candidateClosure = dependencyClosureForSource({ module, sourceCommit: candidate });
+        if (candidateClosure.digest !== closure.digest) {
+          throw new Error("a relevant dependency-closure input changed after the immutable release was selected");
+        }
+      }
       result = await checkGlobalLease({
         ...options,
         authorization: {

--- a/scripts/codex-global-coordination-workflow.mjs
+++ b/scripts/codex-global-coordination-workflow.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  dependencyClosureForSource,
+} from "./codex-global-coordinator.mjs";
+import {
+  acquireGlobalLease,
+  buildLeaseRequest,
+  checkGlobalLease,
+  proofForLease,
+  releaseGlobalLease,
+  renewGlobalLease,
+  revokeGlobalLease,
+  sha256,
+} from "./codex-global-coordination-client.mjs";
+import { canonicalJson } from "../ops/governance/global-coordination-core.mjs";
+
+export const ROOT = path.resolve(import.meta.dirname, "..");
+const FULL_SHA = /^[0-9a-f]{40}$/i;
+const DIGEST = /^[0-9a-f]{64}$/i;
+
+function argument(args, name, fallback = null) {
+  const index = args.indexOf(name);
+  return index === -1 ? fallback : args[index + 1];
+}
+
+function requiredArgument(args, name) {
+  const value = argument(args, name);
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function jsonFile(args, name, fallback = null) {
+  const value = argument(args, name);
+  return value ? JSON.parse(fs.readFileSync(path.resolve(value), "utf8")) : fallback;
+}
+
+function safeIdSegment(value, fallback) {
+  const normalized = String(value || fallback).trim().replace(/[^A-Za-z0-9._:/-]+/g, "-");
+  if (!normalized) throw new Error("global coordination owner identifier is unavailable");
+  return normalized.slice(0, 200);
+}
+
+function proofPath(args) {
+  const value = path.resolve(requiredArgument(args, "--proof-file"));
+  if (value === ROOT || value.startsWith(`${ROOT}${path.sep}`) || value === path.parse(value).root) {
+    throw new Error("global coordination proof must live outside the repository");
+  }
+  return value;
+}
+
+function sourceFor(args) {
+  const source = String(argument(args, "--source", process.env.GITHUB_SHA || "HEAD") || "").trim();
+  if (source.toLowerCase() === "head") return "HEAD";
+  const normalized = source.toLowerCase();
+  if (!FULL_SHA.test(normalized)) throw new Error("global coordination source must be a full commit SHA");
+  return normalized;
+}
+
+export function closureFromFile(args, { module, source }) {
+  const file = argument(args, "--closure-file");
+  if (!file) return null;
+  const closure = JSON.parse(fs.readFileSync(path.resolve(file), "utf8"));
+  const expectedModule = String(module || "").trim().toLowerCase();
+  const sourceCommit = String(closure.sourceCommit || "").trim().toLowerCase();
+  const sourceTree = String(closure.sourceTree || "").trim().toLowerCase();
+  const digest = String(closure.digest || closure.dependencyClosureDigest || "").trim().toLowerCase();
+  if (String(closure.module || "").trim().toLowerCase() !== expectedModule) {
+    throw new Error("global coordination closure module does not match the requested module");
+  }
+  if (!FULL_SHA.test(sourceCommit) || !FULL_SHA.test(sourceTree) || !DIGEST.test(digest)) {
+    throw new Error("global coordination closure identity is invalid");
+  }
+  if (source !== "HEAD" && sourceCommit !== source.toLowerCase()) {
+    throw new Error("global coordination closure source does not match the requested source");
+  }
+  if (!closure.material || closure.material.schemaVersion !== 1 || closure.material.module !== expectedModule || !Array.isArray(closure.material.inputs)) {
+    throw new Error("global coordination closure material is invalid");
+  }
+  if (sha256(canonicalJson(closure.material)) !== digest) {
+    throw new Error("global coordination closure digest does not match its material");
+  }
+  return {
+    schemaVersion: 1,
+    module: expectedModule,
+    sourceCommit,
+    sourceTree,
+    inputs: closure.inputs || closure.material.inputs,
+    digest,
+    material: closure.material,
+  };
+}
+
+function closureFor(args, { module, source }) {
+  return closureFromFile(args, { module, source })
+    || dependencyClosureForSource({ module, sourceCommit: source });
+}
+
+function repositoryOwner({ resource, args }) {
+  const provider = String(process.env.GLOBAL_COORDINATION_PROVIDER || "github").trim().toLowerCase();
+  const repository = String(process.env.GITHUB_REPOSITORY || "local/repository").trim();
+  const runId = String(process.env.GITHUB_RUN_ID || "local").trim();
+  const workflow = String(process.env.GITHUB_WORKFLOW || "codex-local-workflow").trim();
+  return {
+    provider,
+    missionId: safeIdSegment(process.env.GLOBAL_COORDINATION_MISSION_ID || `${provider}:${repository}:${runId}`),
+    threadId: safeIdSegment(process.env.GLOBAL_COORDINATION_THREAD_ID || `${workflow}:${runId}:${resource}`),
+    actor: safeIdSegment(process.env.GLOBAL_COORDINATION_ACTOR || process.env.GITHUB_ACTOR || "github-actions"),
+    ...(process.env.GITHUB_RUN_ID ? { runId } : {}),
+  };
+}
+
+export function buildWorkflowLeaseRequest({
+  resource,
+  module,
+  source = process.env.GITHUB_SHA || "HEAD",
+  operation = "mutation",
+  idempotencyKey,
+  inputs = null,
+  closure: closureOverride = null,
+  releaseIdentity = null,
+}) {
+  const normalizedSource = String(source || "").trim();
+  const closure = closureOverride || dependencyClosureForSource({ module, sourceCommit: normalizedSource });
+  const owner = repositoryOwner({ resource });
+  const normalizedOperation = String(operation).trim().toLowerCase();
+  if (["release", "promotion"].includes(normalizedOperation)) {
+    if (!releaseIdentity || typeof releaseIdentity !== "object" || Array.isArray(releaseIdentity)) {
+      throw new Error("release identity is required");
+    }
+    if (
+      String(releaseIdentity.module || "").trim().toLowerCase() !== String(module || "").trim().toLowerCase()
+      || String(releaseIdentity.sourceCommit || "").trim().toLowerCase() !== closure.sourceCommit
+      || String(releaseIdentity.sourceTree || "").trim().toLowerCase() !== closure.sourceTree
+      || String(releaseIdentity.dependencyClosureDigest || "").trim().toLowerCase() !== closure.digest
+    ) {
+      throw new Error("release identity does not match the observed dependency closure");
+    }
+  }
+  const intent = {
+    module: String(module || "").trim().toLowerCase(),
+    workflow: String(process.env.GITHUB_WORKFLOW || "codex-local-workflow").trim(),
+    event: String(process.env.GITHUB_EVENT_NAME || "workflow_dispatch").trim(),
+    sourceCommit: closure.sourceCommit,
+    sourceTree: closure.sourceTree,
+    dependencyClosureDigest: closure.digest,
+    ...(inputs ? { inputs } : {}),
+    ...(["release", "promotion"].includes(normalizedOperation)
+      ? { releaseIdentity }
+      : {}),
+  };
+  return {
+    request: buildLeaseRequest({
+      operation,
+      resource,
+      owner,
+      intent,
+      idempotencyKey: idempotencyKey || `${owner.missionId}:${resource}:${operation}`,
+      ttlMs: 900_000,
+    }),
+    closure,
+  };
+}
+
+function writeProof(file, lease) {
+  const proof = proofForLease(lease);
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const temporary = `${file}.tmp.${process.pid}`;
+  fs.writeFileSync(temporary, `${JSON.stringify(proof, null, 2)}\n`, { mode: 0o600 });
+  fs.renameSync(temporary, file);
+}
+
+function output(result, file = null) {
+  const rendered = `${JSON.stringify(result, null, 2)}\n`;
+  if (file) {
+    fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(file, rendered, { mode: 0o600 });
+  }
+  process.stdout.write(rendered);
+}
+
+function resultFile(args) {
+  const value = argument(args, "--result-file");
+  return value ? path.resolve(value) : null;
+}
+
+function urlFor(args) {
+  return argument(args, "--url", process.env.SKINCOS_GLOBAL_COORDINATOR_URL);
+}
+
+async function main(args) {
+  const [command] = args;
+  if (command === "closure") {
+    const module = requiredArgument(args, "--module");
+    const source = sourceFor(args);
+    const closure = dependencyClosureForSource({ module, sourceCommit: source });
+    output(closure, resultFile(args));
+    return;
+  }
+  if (command === "acquire") {
+    const resource = requiredArgument(args, "--resource");
+    const module = requiredArgument(args, "--module");
+    const source = sourceFor(args);
+    const closure = closureFor(args, { module, source });
+    const operation = argument(args, "--operation", "mutation");
+    const { request } = buildWorkflowLeaseRequest({
+      resource,
+      module,
+      source,
+      operation,
+      idempotencyKey: argument(args, "--idempotency-key"),
+      inputs: jsonFile(args, "--inputs-file"),
+      closure,
+      releaseIdentity: ["release", "promotion"].includes(String(operation).trim().toLowerCase())
+        ? jsonFile(args, "--release-identity-file")
+        : null,
+    });
+    const result = await acquireGlobalLease({ request, url: urlFor(args) });
+    if (result.passed === true && result.lease) writeProof(proofPath(args), result.lease);
+    output(result, resultFile(args));
+    if (result.passed !== true) process.exitCode = 2;
+    return;
+  }
+
+  if (["check", "renew", "release", "revoke"].includes(command)) {
+    const proof = JSON.parse(fs.readFileSync(proofPath(args), "utf8"));
+    const options = { proof, url: urlFor(args) };
+    let result;
+    if (command === "check") {
+      const source = sourceFor(args);
+      const module = requiredArgument(args, "--module");
+      const closure = closureFor(args, { module, source });
+      result = await checkGlobalLease({
+        ...options,
+        authorization: {
+          expectedResource: requiredArgument(args, "--resource"),
+          expectedIntentDigest: proof.intentDigest,
+          observedDependencyClosureDigest: closure.digest,
+        },
+      });
+    }
+    if (command === "renew") result = await renewGlobalLease({ ...options, ttlMs: 900_000 });
+    if (command === "release") result = await releaseGlobalLease(options);
+    if (command === "revoke") result = await revokeGlobalLease({ ...options, reason: requiredArgument(args, "--reason") });
+    if (result.passed === true && result.lease && ["renew", "release", "revoke"].includes(command)) writeProof(proofPath(args), result.lease);
+    output(result, resultFile(args));
+    if (result.passed !== true) process.exitCode = 2;
+    return;
+  }
+  throw new Error("usage: codex-global-coordination-workflow.mjs closure|acquire|check|renew|release|revoke ...");
+}
+
+const invokedAsScript = process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (invokedAsScript) {
+  try {
+    await main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/codex-global-coordinator.mjs
+++ b/scripts/codex-global-coordinator.mjs
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+import {
+  acquireLease,
+  authorizeMutation,
+  buildIntent,
+  canonicalJson,
+  checkLease,
+  compareDependencyClosure,
+  CONTRACT_ID,
+  emptyState,
+  lockScopeFor,
+  normalizeReleaseIdentity,
+  normalizeResourceKey,
+  releaseLease,
+  renewLease,
+  revokeLease,
+  consumeNonce,
+} from "../ops/governance/global-coordination-core.mjs";
+import { matchesAny } from "./codex-autonomy-lib.mjs";
+
+export { acquireLease, authorizeMutation, buildIntent, canonicalJson, checkLease, compareDependencyClosure, emptyState, lockScopeFor, normalizeReleaseIdentity, normalizeResourceKey, releaseLease, renewLease, revokeLease, consumeNonce };
+export { CONTRACT_ID };
+
+export const ROOT = path.resolve(import.meta.dirname, "..");
+export const POLICY_PATH = path.join(ROOT, "ops", "governance", "global-concurrency-policy.json");
+const FULL_SHA = /^[0-9a-f]{40}$/i;
+const DIGEST = /^[0-9a-f]{64}$/i;
+
+export function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+export function loadGlobalPolicy(file = POLICY_PATH) {
+  const policy = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (policy?.schemaVersion !== 1 || policy.contractId !== CONTRACT_ID) throw new Error("global concurrency policy contract is invalid");
+  if (
+    policy.authority?.mode !== "fail-closed"
+    || policy.lease?.minimumTtlMs !== 30_000
+    || policy.lease?.maximumTtlMs !== 900_000
+    || policy.lease?.clockSkewMs !== 30_000
+    || policy.lease?.renewBeforeExpiryMs !== 15_000
+  ) throw new Error("global concurrency policy safety bounds are invalid");
+  return policy;
+}
+
+function git(...args) {
+  return execFileSync("git", args, { cwd: ROOT, encoding: "utf8" }).trim();
+}
+
+export function gitTreeEntries(sourceCommit, root = ROOT) {
+  const raw = execFileSync("git", ["ls-tree", "-r", sourceCommit], { cwd: root, encoding: "utf8" });
+  return raw.split(/\r?\n/).filter(Boolean).map((line) => {
+    const separator = line.indexOf("\t");
+    if (separator < 0) throw new Error("git tree entry is malformed");
+    const header = line.slice(0, separator).split(/\s+/);
+    if (header[1] !== "blob" || !FULL_SHA.test(header[2])) throw new Error("git tree entry is not a blob");
+    return { path: line.slice(separator + 1), blob: header[2] };
+  });
+}
+
+export function dependencyClosureFromTree({ module, sourceCommit, sourceTree, entries, policy = loadGlobalPolicy() }) {
+  const normalizedModule = String(module || "").trim().toLowerCase();
+  const closure = policy.releaseClosures?.[normalizedModule] || policy.releaseClosures?.default;
+  if (!closure || (closure.requiresExplicitClosure && !policy.releaseClosures?.[normalizedModule])) throw new Error(`release dependency closure is not defined for ${normalizedModule || "module"}`);
+  if (!FULL_SHA.test(String(sourceCommit || "")) || !FULL_SHA.test(String(sourceTree || ""))) throw new Error("release closure source identity is invalid");
+  const paths = new Set((closure.patterns || []).map((value) => String(value).replaceAll("\\", "/")));
+  const selected = (entries || []).filter((entry) => {
+    const file = String(entry.path || "").replaceAll("\\", "/");
+    return (closure.patterns || []).some((pattern) => matchesAny(file, [pattern]))
+      || (closure.sharedInputs && (policy.sharedInputs || []).includes(file));
+  }).map((entry) => ({ path: String(entry.path).replaceAll("\\", "/"), blob: String(entry.blob).toLowerCase() }));
+  if (!selected.length) throw new Error(`release dependency closure for ${normalizedModule} is empty`);
+  const inputs = [...new Map(selected.map((entry) => [entry.path, entry])).values()].sort((left, right) => left.path.localeCompare(right.path));
+  // The source tree remains part of the immutable release identity, but it is
+  // deliberately excluded from the closure digest. Otherwise an unrelated
+  // documentation change would invalidate a release whose selected inputs are
+  // unchanged.
+  const material = { schemaVersion: 1, module: normalizedModule, inputs };
+  return {
+    schemaVersion: 1,
+    module: normalizedModule,
+    sourceCommit: sourceCommit.toLowerCase(),
+    sourceTree: sourceTree.toLowerCase(),
+    inputs,
+    digest: sha256(canonicalJson(material)),
+    material,
+  };
+}
+
+export function dependencyClosureForSource({ module, sourceCommit = "HEAD", root = ROOT, policy = loadGlobalPolicy() }) {
+  const source = git("rev-parse", `${sourceCommit}^{commit}`);
+  const sourceTree = git("rev-parse", `${source}^{tree}`);
+  return dependencyClosureFromTree({ module, sourceCommit: source, sourceTree, entries: gitTreeEntries(source, root), policy });
+}
+
+export function assertDependencyClosureUnchanged(expectedDigest, observedDigest) {
+  const result = compareDependencyClosure(expectedDigest, observedDigest);
+  if (!result.valid) {
+    throw new Error(result.reason === "dependency-closure-changed"
+      ? "a relevant dependency-closure input changed after the immutable release was selected"
+      : "the current dependency closure could not be proven before mutation");
+  }
+  return result;
+}
+
+export function buildReleaseIdentity({ module, sourceCommit, sourceTree, dependencyClosureDigest, artifacts, predecessor = null }) {
+  const identity = normalizeReleaseIdentity({ module, sourceCommit, sourceTree, dependencyClosureDigest, artifacts, predecessor });
+  return {
+    ...identity,
+    identityDigest: sha256(canonicalJson(identity)),
+  };
+}
+
+export function buildLeaseRequest({ operation, resource, owner, intent, idempotencyKey, ttlMs }) {
+  const normalized = buildIntent({ operation, resource, owner, intent, idempotencyKey });
+  return {
+    ...normalized,
+    ttlMs,
+    intentDigest: sha256(canonicalJson(normalized)),
+  };
+}
+
+function statePathFrom(value) {
+  const candidate = path.resolve(String(value || process.env.SKINCOS_GLOBAL_COORDINATION_STATE_FILE || ""));
+  if (!candidate || candidate === ROOT || candidate.startsWith(`${ROOT}${path.sep}`)) throw new Error("global coordination state must live outside the repository");
+  if (candidate === path.parse(candidate).root) throw new Error("global coordination state path is too broad");
+  return candidate;
+}
+
+function readStateFile(file) {
+  if (!fs.existsSync(file)) return emptyState();
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function writeStateFile(file, state) {
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const temporary = `${file}.tmp.${process.pid}.${crypto.randomBytes(6).toString("hex")}`;
+  fs.writeFileSync(temporary, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+  fs.renameSync(temporary, file);
+}
+
+function withStateLock(file, callback) {
+  const lock = `${file}.lock`;
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  try {
+    fs.mkdirSync(lock, { mode: 0o700 });
+  } catch {
+    throw new Error("global coordination state lock is held; refusing an unsafe concurrent local mutation");
+  }
+  try {
+    fs.writeFileSync(path.join(lock, "owner.json"), `${JSON.stringify({ pid: process.pid, host: os.hostname(), acquiredAt: new Date().toISOString() })}\n`, { mode: 0o600 });
+    return callback();
+  } finally {
+    fs.rmSync(lock, { recursive: true, force: false });
+  }
+}
+
+function argument(args, name, fallback = null) {
+  const index = args.indexOf(name);
+  return index === -1 ? fallback : args[index + 1];
+}
+
+function requiredArgument(args, name) {
+  const value = argument(args, name);
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function jsonArgument(args, name) {
+  return JSON.parse(requiredArgument(args, name));
+}
+
+function nowArgument(args) {
+  const value = argument(args, "--now", String(Date.now()));
+  const now = Number(value);
+  if (!Number.isInteger(now) || now < 0) throw new Error("--now must be a non-negative integer epoch in milliseconds");
+  return now;
+}
+
+function output(result) {
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+function mutateState(args, operation) {
+  const file = statePathFrom(requiredArgument(args, "--state-file"));
+  const result = withStateLock(file, () => {
+    const current = readStateFile(file);
+    const next = operation(current);
+    if (next?.state) writeStateFile(file, next.state);
+    return next;
+  });
+  output(result);
+  if (result?.accepted === false || result?.valid === false) process.exitCode = 2;
+}
+
+async function main(args) {
+  const [command] = args;
+  if (command === "closure") {
+    const result = dependencyClosureForSource({ module: requiredArgument(args, "--module"), sourceCommit: argument(args, "--source", "HEAD") });
+    output(result);
+    return;
+  }
+  if (command === "identity") {
+    const closure = dependencyClosureForSource({ module: requiredArgument(args, "--module"), sourceCommit: argument(args, "--source", "HEAD") });
+    const result = buildReleaseIdentity({
+      module: closure.module,
+      sourceCommit: closure.sourceCommit,
+      sourceTree: closure.sourceTree,
+      dependencyClosureDigest: closure.digest,
+      artifacts: jsonArgument(args, "--artifacts"),
+    });
+    output(result);
+    return;
+  }
+  if (command === "acquire") {
+    const now = nowArgument(args);
+    const owner = jsonArgument(args, "--owner");
+    const intent = jsonArgument(args, "--intent");
+    const request = buildLeaseRequest({
+      operation: requiredArgument(args, "--operation"),
+      resource: requiredArgument(args, "--resource"),
+      owner,
+      intent,
+      idempotencyKey: requiredArgument(args, "--idempotency-key"),
+      ttlMs: Number(requiredArgument(args, "--ttl-ms")),
+    });
+    mutateState(args, (state) => acquireLease(state, request, { now, leaseId: argument(args, "--lease-id", crypto.randomUUID()) }));
+    return;
+  }
+  if (["check", "renew", "release", "revoke"].includes(command)) {
+    const proof = {
+      resource: requiredArgument(args, "--resource"),
+      leaseId: requiredArgument(args, "--lease-id"),
+      fencingToken: Number(requiredArgument(args, "--fencing-token")),
+      intentDigest: requiredArgument(args, "--intent-digest"),
+      owner: jsonArgument(args, "--owner"),
+    };
+    const now = nowArgument(args);
+    mutateState(args, (state) => {
+      if (command === "check") return checkLease(state, proof, { now });
+      if (command === "renew") return renewLease(state, proof, { now, ttlMs: Number(requiredArgument(args, "--ttl-ms")) });
+      if (command === "release") return releaseLease(state, proof, { now });
+      return revokeLease(state, proof, { now, reason: requiredArgument(args, "--reason") });
+    });
+    return;
+  }
+  throw new Error("usage: codex-global-coordinator.mjs closure|identity|acquire|check|renew|release|revoke ...");
+}
+
+const invokedAsScript = process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (invokedAsScript) {
+  try {
+    await main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/codex-global-merge-authority.mjs
+++ b/scripts/codex-global-merge-authority.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+import { pathToFileURL } from "node:url";
+import {
+  acquireGlobalLease,
+  checkGlobalLease,
+  proofForLease,
+  releaseGlobalLease,
+} from "./codex-global-coordination-client.mjs";
+import { buildWorkflowLeaseRequest } from "./codex-global-coordination-workflow.mjs";
+
+const FULL_SHA = /^[0-9a-f]{40}$/i;
+function requiredEnv(name) {
+  const value = String(process.env[name] || "").trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function requiredArgument(args, name) {
+  const index = args.indexOf(name);
+  const value = index === -1 ? "" : String(args[index + 1] || "").trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function apiUrl(repository, suffix = "") {
+  return `https://api.github.com/repos/${repository}${suffix}`;
+}
+
+async function githubJson(repository, suffix, options = {}) {
+  const token = requiredEnv("GH_TOKEN");
+  const response = await fetch(apiUrl(repository, suffix), {
+    ...options,
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "x-github-api-version": "2022-11-28",
+      "content-type": "application/json",
+      ...(options.headers || {}),
+    },
+  });
+  const raw = await response.text();
+  let body;
+  try { body = raw ? JSON.parse(raw) : null; } catch { throw new Error(`GitHub API returned invalid JSON (${response.status})`); }
+  if (!response.ok) throw new Error(`GitHub API request failed (${response.status}): ${String(body?.message || "unknown error")}`);
+  return body;
+}
+
+function assertSha(value, label) {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!FULL_SHA.test(normalized)) throw new Error(`${label} must be a full SHA`);
+  return normalized;
+}
+
+const MERGE_METHODS = new Set(["squash", "merge", "rebase"]);
+
+async function setMergeAuthorityStatus(repository, headSha, state, description) {
+  return githubJson(repository, `/statuses/${headSha}`, {
+    method: "POST",
+    body: JSON.stringify({
+      state,
+      context: "global-merge-authority",
+      description: String(description).slice(0, 140),
+      target_url: `${process.env.GITHUB_SERVER_URL || "https://github.com"}/${repository}/actions/workflows/global-merge-authority.yml`,
+    }),
+  });
+}
+
+export async function mergePullRequest({ repository, pullNumber, expectedHeadSha, mergeMethod = "squash" }) {
+  if (String(process.env.SKINCOS_GLOBAL_COORDINATION_REQUIRED || "").trim().toLowerCase() !== "true") {
+    throw new Error("SKINCOS_GLOBAL_COORDINATION_REQUIRED must be true for merge:main");
+  }
+  const url = requiredEnv("SKINCOS_GLOBAL_COORDINATOR_URL");
+  requiredEnv("SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET");
+  if (!MERGE_METHODS.has(mergeMethod)) throw new Error(`unsupported merge method: ${mergeMethod}`);
+  const initial = await githubJson(repository, `/pulls/${pullNumber}`);
+  const headSha = assertSha(expectedHeadSha, "expected head SHA");
+  if (initial.state !== "open" || initial.base?.ref !== "main") throw new Error("pull request is not an open main integration candidate");
+  if (initial.head?.repo?.full_name !== repository) throw new Error("pull request head repository is outside the governed repository");
+  if (assertSha(initial.head?.sha, "pull request head SHA") !== headSha) throw new Error("pull request head advanced before lease acquisition");
+  if (initial.draft === true || initial.mergeable_state === "dirty" || initial.mergeable_state === "blocked") {
+    throw new Error("pull request is not mergeable by its current GitHub state");
+  }
+  const baseSha = assertSha(initial.base?.sha, "pull request base SHA");
+  const resource = "merge:main";
+  const { request, closure } = buildWorkflowLeaseRequest({
+    resource,
+    module: "merge",
+    source: baseSha,
+    operation: "mutation",
+    idempotencyKey: `merge:${repository}:${pullNumber}:${headSha}`,
+    inputs: { pullNumber: String(pullNumber), expectedHeadSha: headSha, baseSha },
+  });
+  const result = await acquireGlobalLease({ request, url });
+  if (result.passed !== true || !result.lease) throw new Error(`merge:main lease acquisition failed: ${result.reason || "unknown"}`);
+  const proof = proofForLease(result.lease);
+  let merged;
+  let mergeSucceeded = false;
+  try {
+    const [currentMain, currentPull] = await Promise.all([
+      githubJson(repository, "/commits/main"),
+      githubJson(repository, `/pulls/${pullNumber}`),
+    ]);
+    if (assertSha(currentMain?.sha, "current main SHA") !== baseSha) throw new Error("main advanced while merge:main was being acquired");
+    if (
+      currentPull.state !== "open"
+      || currentPull.base?.ref !== "main"
+      || assertSha(currentPull.base?.sha, "current pull request base SHA") !== baseSha
+      || assertSha(currentPull.head?.sha, "current pull request head SHA") !== headSha
+    ) throw new Error("pull request base or head changed before merge mutation");
+    const checked = await checkGlobalLease({
+      proof,
+      url,
+      authorization: {
+        expectedResource: resource,
+        expectedIntentDigest: proof.intentDigest,
+        observedDependencyClosureDigest: closure.digest,
+      },
+    });
+    if (checked.passed !== true) throw new Error(`merge:main mutation authorization failed: ${checked.reason || "unknown"}`);
+    await setMergeAuthorityStatus(repository, headSha, "success", "merge:main lease and dependency closure authorized");
+    const [finalMain, finalPull] = await Promise.all([
+      githubJson(repository, "/commits/main"),
+      githubJson(repository, `/pulls/${pullNumber}`),
+    ]);
+    if (assertSha(finalMain?.sha, "final main SHA") !== baseSha) throw new Error("main advanced after merge authorization status");
+    if (
+      finalPull.state !== "open"
+      || finalPull.base?.ref !== "main"
+      || assertSha(finalPull.base?.sha, "final pull request base SHA") !== baseSha
+      || assertSha(finalPull.head?.sha, "final pull request head SHA") !== headSha
+    ) throw new Error("pull request base or head changed after merge authorization status");
+    merged = await githubJson(repository, `/pulls/${pullNumber}/merge`, {
+      method: "PUT",
+      body: JSON.stringify({ sha: headSha, merge_method: mergeMethod }),
+    });
+    if (merged?.merged !== true) throw new Error(`GitHub did not merge the pull request: ${String(merged?.message || "unknown result")}`);
+    mergeSucceeded = true;
+    return {
+      merged: true,
+      pullNumber: String(pullNumber),
+      mergeCommitSha: String(merged.sha || ""),
+      resource,
+      fencingToken: proof.fencingToken,
+    };
+  } catch (error) {
+    if (!mergeSucceeded) {
+      try {
+        await setMergeAuthorityStatus(repository, headSha, "failure", "merge:main authorization did not complete");
+      } catch {
+        // Preserve the original failure; the lease release below remains mandatory.
+      }
+    }
+    throw error;
+  } finally {
+    const released = await releaseGlobalLease({ proof, url });
+    if (released.passed !== true) throw new Error(`merge:main lease release failed: ${released.reason || "unknown"}`);
+  }
+}
+
+async function main(args) {
+  const repository = requiredEnv("GITHUB_REPOSITORY");
+  const pullNumber = requiredArgument(args, "--pull-number");
+  if (!/^[1-9][0-9]*$/.test(pullNumber)) throw new Error("--pull-number must be numeric");
+  const result = await mergePullRequest({
+    repository,
+    pullNumber,
+    expectedHeadSha: requiredArgument(args, "--expected-head-sha"),
+    mergeMethod: requiredArgument(args, "--merge-method"),
+  });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+const invokedAsScript = process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (invokedAsScript) {
+  try {
+    await main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/codex-global-merge-authority.mjs
+++ b/scripts/codex-global-merge-authority.mjs
@@ -78,7 +78,10 @@ export async function mergePullRequest({ repository, pullNumber, expectedHeadSha
   if (initial.state !== "open" || initial.base?.ref !== "main") throw new Error("pull request is not an open main integration candidate");
   if (initial.head?.repo?.full_name !== repository) throw new Error("pull request head repository is outside the governed repository");
   if (assertSha(initial.head?.sha, "pull request head SHA") !== headSha) throw new Error("pull request head advanced before lease acquisition");
-  if (initial.draft === true || initial.mergeable_state === "dirty" || initial.mergeable_state === "blocked") {
+  // A required global-merge-authority status makes the PR appear blocked until
+  // this authority posts its success status. GitHub's merge API remains the
+  // final enforcement point for every other required check or review.
+  if (initial.draft === true || initial.mergeable_state === "dirty") {
     throw new Error("pull request is not mergeable by its current GitHub state");
   }
   const baseSha = assertSha(initial.base?.sha, "pull request base SHA");

--- a/scripts/codex-global-merge-authority.mjs
+++ b/scripts/codex-global-merge-authority.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import path from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   acquireGlobalLease,

--- a/scripts/provision-atendimento-production-readonly.sh
+++ b/scripts/provision-atendimento-production-readonly.sh
@@ -32,14 +32,50 @@ readonly LOG_ROOT='/var/log/skincos/crm-atendimento-production'
 readonly BACKUP_ROOT='/var/backups/skincos/clientes/production-readonly'
 readonly PORT='8110'
 readonly SCRIPT_DIR="$(cd -- "$(/usr/bin/dirname -- "${BASH_SOURCE[0]}")" && /usr/bin/pwd -P)"
+readonly SCRIPT_ROOT="$(cd -- "$SCRIPT_DIR/.." && /usr/bin/pwd -P)"
 readonly RUNTIME_GRANT_LOCKDOWN="$SCRIPT_DIR/lockdown-atendimento-production-runtime.sh"
 readonly BACKUP_SCRIPT="$SCRIPT_DIR/backup-atendimento-production.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_ROOT/scripts/runtime/global-coordination-native.sh"
 
-ACTION="${1:-}"
-case "$ACTION" in
-  --dry-run|--apply) ;;
-  *) echo "Usage: $0 --dry-run|--apply" >&2; exit 64 ;;
-esac
+ACTION=''
+COORDINATION_SOURCE_SHA="${SKINCOS_GLOBAL_COORDINATION_SOURCE_SHA:-}"
+COORDINATION_CLOSURE="${SKINCOS_GLOBAL_COORDINATION_CLOSURE_FILE:-}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run|--apply)
+      [[ -z "$ACTION" ]] || { echo 'Exactly one provisioning action is required.' >&2; exit 64; }
+      ACTION="$1"
+      ;;
+    --source-sha)
+      shift
+      COORDINATION_SOURCE_SHA="${1:-}"
+      ;;
+    --coordination-closure)
+      shift
+      COORDINATION_CLOSURE="${1:-}"
+      ;;
+    *)
+      echo "Usage: $0 --dry-run|--apply [--source-sha <full-sha>] [--coordination-closure <json>]" >&2
+      exit 64
+      ;;
+  esac
+  shift
+done
+[[ "$ACTION" == '--dry-run' || "$ACTION" == '--apply' ]] || {
+  echo "Usage: $0 --dry-run|--apply [--source-sha <full-sha>] [--coordination-closure <json>]" >&2
+  exit 64
+}
+if [[ "$ACTION" == '--apply' ]]; then
+  [[ "$COORDINATION_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+    echo 'Production provisioning requires a full immutable source SHA.' >&2
+    exit 78
+  }
+  [[ -n "$COORDINATION_CLOSURE" && -f "$COORDINATION_CLOSURE" ]] || {
+    echo 'Production provisioning requires a coordination closure attestation.' >&2
+    exit 78
+  }
+fi
 
 for command_path in /usr/bin/sudo /usr/bin/env /usr/bin/openssl /usr/bin/install /usr/bin/psql /usr/bin/pg_dump /usr/bin/sha256sum /usr/bin/date /usr/bin/mktemp /usr/bin/chown /usr/bin/chmod /usr/bin/cp /usr/bin/cat /usr/bin/rm /usr/bin/test /usr/bin/systemctl /usr/bin/awk /usr/bin/tr /usr/bin/basename /usr/bin/bash; do
   [[ -x "$command_path" ]] || { echo "Missing required command: $command_path" >&2; exit 1; }
@@ -58,6 +94,7 @@ backup_created=0
 tmp_env=''
 tmp_migrator=''
 tmp_control=''
+coordination_acquired=0
 cleanup_partial_artifacts() {
   if [[ "$backup_created" == '1' && -n "$backup" ]]; then
     run_sudo_clean /usr/bin/rm -f -- "$backup" || true
@@ -65,6 +102,10 @@ cleanup_partial_artifacts() {
   [[ -z "$tmp_env" ]] || /usr/bin/rm -f -- "$tmp_env"
   [[ -z "$tmp_migrator" ]] || /usr/bin/rm -f -- "$tmp_migrator"
   [[ -z "$tmp_control" ]] || /usr/bin/rm -f -- "$tmp_control"
+  if [[ "$coordination_acquired" == '1' ]]; then
+    native_coordination_cleanup || true
+    coordination_acquired=0
+  fi
 }
 trap cleanup_partial_artifacts EXIT
 trap 'exit 129' HUP
@@ -85,12 +126,19 @@ SQL
   exit 0
 fi
 
+native_coordination_init deploy:atendimento:production atendimento "$COORDINATION_SOURCE_SHA" "$COORDINATION_CLOSURE" mutation
+native_coordination_acquire "mini-pc:deploy:atendimento:production:provision:$COORDINATION_SOURCE_SHA:$$" >/dev/null
+coordination_acquired=1
+native_coordination_check
+
 service_state="$(run_sudo_clean /usr/bin/systemctl is-active "$SERVICE" 2>/dev/null || true)"
 [[ "$service_state" == 'inactive' ]] || { echo 'Production provisioning requires the isolated runtime to be inactive.' >&2; exit 1; }
 
 stamp="$(/usr/bin/date -u +%Y%m%dT%H%M%SZ)"
+native_coordination_check
 run_sudo_clean /usr/bin/install -d -m 0700 -o root -g root "$BACKUP_ROOT"
 if [[ "$(database_exists)" == 't' ]]; then
+  native_coordination_check
   backup_report="$(run_sudo_clean /usr/bin/bash -p "$BACKUP_SCRIPT")"
   [[ "$backup_report" =~ ^backup_created=true\ database=skincos_clientes_production\ sha256=[0-9a-f]{64}\ private=true\ unique=true$ ]] || {
     echo 'Production backup did not satisfy the private unique artifact contract.' >&2
@@ -101,7 +149,9 @@ else
   printf 'backup_created=false checkpoint=new_database\n'
 fi
 
+native_coordination_check
 run_sudo_clean /usr/bin/install -d -m 0750 -o root -g skincos "$CONFIG_DIR" "$CONTROL_DIR"
+native_coordination_check
 run_sudo_clean /usr/bin/install -d -m 0750 -o skincos -g skincos "$STATE_ROOT" "$STATE_ROOT/var" "$LOG_ROOT"
 for target in "$ATENDIMENTO_CONFIG" "$MIGRATOR_CONFIG" "$CONTROL_FILE"; do
   if run_sudo_clean /usr/bin/test -f "$target"; then
@@ -112,8 +162,11 @@ for target in "$ATENDIMENTO_CONFIG" "$MIGRATOR_CONFIG" "$CONTROL_FILE"; do
     else
       archive_label='app-env'
     fi
+    native_coordination_check
     archived="$(run_sudo_clean /usr/bin/mktemp "$BACKUP_ROOT/$stamp-$archive_label.XXXXXX")"
+    native_coordination_check
     run_sudo_clean /usr/bin/cp -p "$target" "$archived"
+    native_coordination_check
     run_sudo_clean /usr/bin/chmod 0600 "$archived"
   fi
 done
@@ -123,6 +176,7 @@ migrator_password="$(/usr/bin/openssl rand -hex 32)"
 actor_key="$(/usr/bin/openssl rand -hex 32)"
 readiness_token="$(/usr/bin/openssl rand -hex 32)"
 
+native_coordination_check
 run_postgres_clean /usr/bin/psql --dbname=postgres --set=ON_ERROR_STOP=1 <<SQL
 do \$\$
 begin
@@ -139,9 +193,11 @@ grant $OWNER_ROLE to $MIGRATOR_ROLE;
 SQL
 
 if [[ "$(database_exists)" != 't' ]]; then
+  native_coordination_check
   run_postgres_clean /usr/bin/psql --dbname=postgres --set=ON_ERROR_STOP=1 -c "create database $DB_NAME owner $OWNER_ROLE"
 fi
 
+native_coordination_check
 run_postgres_clean /usr/bin/psql --dbname="$DB_NAME" --set=ON_ERROR_STOP=1 <<SQL
 revoke all on database $DB_NAME from public;
 revoke all privileges on database $DB_NAME from $APP_ROLE;
@@ -157,11 +213,15 @@ alter default privileges for role $MIGRATOR_ROLE in schema crm_atendimento grant
 alter default privileges for role $MIGRATOR_ROLE in schema crm_atendimento grant usage, select on sequences to $APP_ROLE;
 SQL
 
+native_coordination_check
 run_sudo_clean /usr/bin/bash -p "$RUNTIME_GRANT_LOCKDOWN" --apply
 
 umask 0077
+native_coordination_check
 tmp_env="$(/usr/bin/mktemp /tmp/atendimento-production-app-env.XXXXXX)"
+native_coordination_check
 tmp_migrator="$(/usr/bin/mktemp /tmp/atendimento-production-migrator-env.XXXXXX)"
+native_coordination_check
 tmp_control="$(/usr/bin/mktemp /tmp/atendimento-production-control.XXXXXX)"
 [[ -f "$tmp_env" && -O "$tmp_env" && -f "$tmp_migrator" && -O "$tmp_migrator" && -f "$tmp_control" && -O "$tmp_control" ]] || { echo 'Private temporary control artifacts are invalid.' >&2; exit 1; }
 /usr/bin/cat >"$tmp_env" <<EOF
@@ -181,8 +241,11 @@ EOF
 /usr/bin/cat >"$tmp_control" <<EOF
 {"schemaVersion":1,"module":"atendimento","state":"maintenance","releaseSha":null,"readOnly":true,"commercialContactWritesEnabled":false,"syntheticOnly":true,"reason":"clientes-production-readonly-pending-release","updatedAt":"$stamp"}
 EOF
+native_coordination_check
 run_sudo_clean /usr/bin/install -m 0640 -o root -g skincos "$tmp_env" "$ATENDIMENTO_CONFIG"
+native_coordination_check
 run_sudo_clean /usr/bin/install -m 0640 -o root -g skincos "$tmp_migrator" "$MIGRATOR_CONFIG"
+native_coordination_check
 run_sudo_clean /usr/bin/install -m 0640 -o root -g skincos "$tmp_control" "$CONTROL_FILE"
 
 printf 'provisioned=true database=%s app_role=%s migrator_role=%s service=%s port=%s control_state=maintenance commercial_writes=false pii_source_access=false\n' "$DB_NAME" "$APP_ROLE" "$MIGRATOR_ROLE" "$SERVICE" "$PORT"

--- a/scripts/provision-atendimento-staging.sh
+++ b/scripts/provision-atendimento-staging.sh
@@ -7,6 +7,9 @@ unset BASH_ENV ENV CDPATH GLOBIGNORE TMPDIR TMP TEMP \
   HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY http_proxy https_proxy all_proxy no_proxy \
   OPENSSL_CONF RANDFILE
 
+readonly SCRIPT_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
+source "$SCRIPT_ROOT/scripts/runtime/global-coordination-native.sh"
+
 run_postgres_clean() {
   /usr/bin/sudo -n -u postgres /usr/bin/env -i \
     "PATH=$SAFE_PATH" 'HOME=/var/lib/postgresql' 'LANG=C' /usr/bin/psql "$@"
@@ -20,10 +23,29 @@ random_hex() {
 # generated in memory and written only to the private native configuration
 # file; no value is printed or committed.
 
-ACTION="${1:-}"
-if [[ "$ACTION" != "--dry-run" && "$ACTION" != "--apply" ]]; then
-  echo "Usage: $0 --dry-run|--apply" >&2
-  exit 1
+ACTION=''
+COORDINATION_SOURCE_SHA="${SKINCOS_GLOBAL_COORDINATION_SOURCE_SHA:-}"
+COORDINATION_CLOSURE="${SKINCOS_GLOBAL_COORDINATION_CLOSURE_FILE:-}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run|--apply)
+      [[ -z "$ACTION" ]] || { echo 'Exactly one provisioning action is required.' >&2; exit 64; }
+      ACTION="$1"
+      ;;
+    --source-sha) shift; COORDINATION_SOURCE_SHA="${1:-}" ;;
+    --coordination-closure) shift; COORDINATION_CLOSURE="${1:-}" ;;
+    *) echo "Usage: $0 --dry-run|--apply [--source-sha <full-sha>] [--coordination-closure <json>]" >&2; exit 64 ;;
+  esac
+  shift
+done
+
+[[ "$ACTION" == '--dry-run' || "$ACTION" == '--apply' ]] || {
+  echo 'Exactly one provisioning action is required.' >&2
+  exit 64
+}
+if [[ "$ACTION" == '--apply' ]]; then
+  [[ "$COORDINATION_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo '--source-sha must be a full lowercase SHA for apply.' >&2; exit 78; }
+  [[ -n "$COORDINATION_CLOSURE" && -f "$COORDINATION_CLOSURE" ]] || { echo '--coordination-closure must identify an existing Atendimento attestation for apply.' >&2; exit 78; }
 fi
 
 readonly DB_NAME='skincos_staging'
@@ -59,6 +81,25 @@ SQL
   exit 0
 fi
 
+native_coordination_init deploy:atendimento:staging atendimento "$COORDINATION_SOURCE_SHA" "$COORDINATION_CLOSURE" mutation
+coordination_acquired=0
+tmp_env=''
+tmp_migrator=''
+tmp_control=''
+cleanup_coordination() {
+  [[ -z "$tmp_env" ]] || /usr/bin/rm -f -- "$tmp_env"
+  [[ -z "$tmp_migrator" ]] || /usr/bin/rm -f -- "$tmp_migrator"
+  [[ -z "$tmp_control" ]] || /usr/bin/rm -f -- "$tmp_control"
+  if [[ "$coordination_acquired" == '1' ]]; then
+    native_coordination_cleanup || true
+    coordination_acquired=0
+  fi
+}
+trap cleanup_coordination EXIT INT TERM
+native_coordination_acquire "mini-pc:deploy:atendimento:staging:provision:$COORDINATION_SOURCE_SHA:$$" >/dev/null
+coordination_acquired=1
+native_coordination_check
+
 # Rotating the isolated app credentials or grants while the legacy process is
 # running would create a mixed security state. The orchestrator stops only
 # this dedicated service before apply; no shared CRM, jobs, Orb or tunnel unit
@@ -69,12 +110,16 @@ if /usr/bin/sudo -n /usr/bin/systemctl is-active --quiet "$SERVICE"; then
 fi
 
 stamp="$(/usr/bin/date -u +%Y%m%dT%H%M%SZ)"
+native_coordination_check
 /usr/bin/sudo -n /usr/bin/install -d -m 0750 -o root -g skincos "$CONFIG_DIR" "$CONTROL_DIR"
+native_coordination_check
 /usr/bin/sudo -n /usr/bin/install -d -m 0750 -o skincos -g skincos "$STATE_ROOT" "$STATE_ROOT/var" "$LOG_ROOT"
+native_coordination_check
 /usr/bin/sudo -n /usr/bin/install -d -m 0700 -o root -g root "$BACKUP_ROOT"
 
 for path in "$ATENDIMENTO_CONFIG" "$MIGRATOR_CONFIG" "$CONTROL_FILE"; do
   if /usr/bin/sudo -n /usr/bin/test -f "$path"; then
+    native_coordination_check
     /usr/bin/sudo -n /usr/bin/cp -p "$path" "$BACKUP_ROOT/${stamp}-$(/usr/bin/basename "$path")"
   fi
 done
@@ -84,6 +129,7 @@ migrator_password="$(random_hex)"
 actor_key="$(random_hex)"
 readiness_token="$(random_hex)"
 
+native_coordination_check
 run_postgres_clean --dbname=postgres --set=ON_ERROR_STOP=1 <<SQL
 \set app_password '$app_password'
 \set migrator_password '$migrator_password'
@@ -137,7 +183,6 @@ tmp_control="$(/usr/bin/mktemp /tmp/atendimento-staging-control.XXXXXX)"
 /usr/bin/test -f "$tmp_env" -a -O "$tmp_env"
 /usr/bin/test -f "$tmp_migrator" -a -O "$tmp_migrator"
 /usr/bin/test -f "$tmp_control" -a -O "$tmp_control"
-trap '/usr/bin/rm -f "$tmp_env" "$tmp_migrator" "$tmp_control"' EXIT
 /usr/bin/cat >"$tmp_env" <<EOF
 NODE_ENV=production
 CRM_DOMAIN=atendimento
@@ -165,8 +210,11 @@ EOF
 /usr/bin/cat >"$tmp_control" <<EOF
 {"schemaVersion":1,"module":"atendimento","state":"maintenance","releaseSha":null,"readOnly":true,"commercialContactWritesEnabled":false,"syntheticOnly":true,"reason":"clientes-staging-read-only-pending-release","updatedAt":"$stamp"}
 EOF
+native_coordination_check
 /usr/bin/sudo -n /usr/bin/install -m 0640 -o root -g skincos "$tmp_env" "$ATENDIMENTO_CONFIG"
+native_coordination_check
 /usr/bin/sudo -n /usr/bin/install -m 0600 -o root -g root "$tmp_migrator" "$MIGRATOR_CONFIG"
+native_coordination_check
 /usr/bin/sudo -n /usr/bin/install -m 0640 -o root -g skincos "$tmp_control" "$CONTROL_FILE"
 
 echo "Atendimento staging database contract provisioned: database=$DB_NAME app_role=$APP_ROLE migrator_role=$MIGRATOR_ROLE control_file=$CONTROL_FILE control_state=maintenance commercial_writes=false"

--- a/scripts/refresh-atendimento-staging-quality.sh
+++ b/scripts/refresh-atendimento-staging-quality.sh
@@ -3,8 +3,33 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly RUNNER="$ROOT_DIR/crm/api/scripts/run-atendimento-staging-quality-refresh.mjs"
+source "$ROOT_DIR/scripts/runtime/global-coordination-native.sh"
+
+SOURCE_SHA="${SKINCOS_GLOBAL_COORDINATION_SOURCE_SHA:-}"
+COORDINATION_CLOSURE="${SKINCOS_GLOBAL_COORDINATION_CLOSURE_FILE:-}"
+ACTION="${1:---apply}"
+[[ "$ACTION" == '--apply' || "$ACTION" == '--dry-run' ]] || { echo 'Usage: refresh-atendimento-staging-quality.sh [--dry-run|--apply]' >&2; exit 64; }
+if [[ "$ACTION" == '--apply' ]]; then
+  [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'SKINCOS_GLOBAL_COORDINATION_SOURCE_SHA is required for quality refresh apply.' >&2; exit 78; }
+  [[ -n "$COORDINATION_CLOSURE" && -f "$COORDINATION_CLOSURE" ]] || { echo 'SKINCOS_GLOBAL_COORDINATION_CLOSURE_FILE is required for quality refresh apply.' >&2; exit 78; }
+  native_coordination_init deploy:atendimento:staging atendimento "$SOURCE_SHA" "$COORDINATION_CLOSURE" mutation
+  coordination_acquired=0
+  cleanup_coordination() {
+    if [[ "$coordination_acquired" == '1' ]]; then
+      native_coordination_cleanup || true
+      coordination_acquired=0
+    fi
+  }
+  trap cleanup_coordination EXIT INT TERM
+  native_coordination_acquire "mini-pc:deploy:atendimento:staging:quality-refresh:$SOURCE_SHA:$$" >/dev/null
+  coordination_acquired=1
+  native_coordination_check
+fi
 
 # The Node runner has one fixed private env-file path and reads its literal
 # DATABASE_URL itself. No sourced configuration or generated shell command can
 # execute under sudo.
-sudo -n /usr/bin/node "$RUNNER" --apply
+if [[ "$ACTION" == '--apply' ]]; then
+  native_coordination_check
+fi
+sudo -n /usr/bin/node "$RUNNER" "$ACTION"

--- a/scripts/run-atendimento-staging-migration.sh
+++ b/scripts/run-atendimento-staging-migration.sh
@@ -31,19 +31,25 @@ done
 [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo '--release-sha must be a full lowercase SHA.' >&2; exit 64; }
 
 readonly RELEASE_ROOT="/opt/skincos/releases/$RELEASE_SHA/source"
+readonly SCRIPT_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
 readonly RUNNER="$RELEASE_ROOT/crm/api/scripts/run-atendimento-staging-migration.mjs"
 readonly RELEASE_VALIDATOR="$RELEASE_ROOT/crm/api/scripts/validate-atendimento-release.mjs"
 readonly CONTROL_VALIDATOR="$RELEASE_ROOT/crm/api/scripts/validate-atendimento-staging-control.mjs"
 readonly RUNTIME_GRANT_LOCKDOWN="$RELEASE_ROOT/scripts/lockdown-atendimento-staging-runtime.sh"
 readonly BACKUP_SCRIPT="$RELEASE_ROOT/scripts/backup-atendimento-staging.sh"
+readonly COORDINATION_CLOSURE="$RELEASE_ROOT/.skincos-global-coordination-atendimento.json"
 readonly SERVICE='crm-atendimento-staging.service'
 LOCKDOWN_REQUIRED=0
+coordination_acquired=0
 [[ "$RELEASE_ROOT" =~ ^/opt/skincos/releases/[0-9a-f]{40}/source$ ]] || { echo 'Staging release root is invalid.' >&2; exit 64; }
 run_sudo_clean /usr/bin/test -f "$RUNNER" || { echo 'Fixed staging migration runner is unavailable in the immutable release.' >&2; exit 78; }
 run_sudo_clean /usr/bin/test -f "$RELEASE_VALIDATOR" || { echo 'Immutable release validator is unavailable.' >&2; exit 78; }
 run_sudo_clean /usr/bin/test -f "$CONTROL_VALIDATOR" || { echo 'Strict staging control validator is unavailable.' >&2; exit 78; }
 run_sudo_clean /usr/bin/test -x "$RUNTIME_GRANT_LOCKDOWN" || { echo 'Fixed staging read-only grant lockdown is unavailable.' >&2; exit 78; }
 run_sudo_clean /usr/bin/test -x "$BACKUP_SCRIPT" || { echo 'Fixed staging backup helper is unavailable in the immutable release.' >&2; exit 78; }
+if [[ "$ACTION" != '--dry-run' ]]; then
+  run_sudo_clean /usr/bin/test -f "$COORDINATION_CLOSURE" || { echo 'Atendimento coordination closure is unavailable in the immutable release.' >&2; exit 78; }
+fi
 
 # The Node runner reads one fixed root-owned file as literal key/value data.
 # It always resolves dependencies from the immutable release that was already
@@ -66,6 +72,18 @@ if [[ "$ACTION" != '--dry-run' ]]; then
   # gate has passed and immediately before the mutable migration runner. The
   # helper never accepts a caller-controlled destination and exposes only a
   # SHA-256 attestation, not the dump path or its contents.
+  source "$SCRIPT_ROOT/scripts/runtime/global-coordination-native.sh"
+  native_coordination_init deploy:atendimento:staging atendimento "$RELEASE_SHA" "$COORDINATION_CLOSURE" mutation
+  cleanup_coordination() {
+    if [[ "$coordination_acquired" == '1' ]]; then
+      native_coordination_cleanup || true
+      coordination_acquired=0
+    fi
+  }
+  trap cleanup_coordination EXIT INT TERM
+  native_coordination_acquire "mini-pc:deploy:atendimento:staging:migration:$RELEASE_SHA:$$" >/dev/null
+  coordination_acquired=1
+  native_coordination_check
   backup_report="$(run_sudo_clean /usr/bin/bash -p "$BACKUP_SCRIPT")"
   [[ "$backup_report" =~ ^backup_created=true\ database=skincos_staging\ sha256=[0-9a-f]{64}\ private=true\ unique=true$ ]] || {
     echo 'Staging migration backup did not satisfy the private unique artifact contract.' >&2
@@ -90,6 +108,10 @@ seal_staging_runtime_grants() {
   trap '' HUP INT TERM
   if [[ "$LOCKDOWN_REQUIRED" == '1' ]]; then
     set +e
+    if ! native_coordination_check; then
+      echo 'Global coordination proof was unavailable before staging grant lockdown; the isolated service remains ineligible.' >&2
+      exit 70
+    fi
     run_sudo_clean /usr/bin/bash -p "$RUNTIME_GRANT_LOCKDOWN" --apply
     local lockdown_status=$?
     set -e
@@ -97,6 +119,8 @@ seal_staging_runtime_grants() {
       echo 'Staging runtime grant lockdown failed; keeping the isolated service ineligible.' >&2
       exit 70
     fi
+    native_coordination_cleanup || true
+    coordination_acquired=0
   fi
   exit "$exit_status"
 }
@@ -111,4 +135,5 @@ fi
 # The runner persists only sanitized migration-evidence rows. Bind each
 # mutable invocation to the already-validated immutable release; no caller
 # supplied path or environment is retained.
+native_coordination_check
 run_sudo_clean /usr/bin/node "$RUNNER" "$ACTION" --release-sha "$RELEASE_SHA"

--- a/scripts/run-atendimento-staging-migration.sh
+++ b/scripts/run-atendimento-staging-migration.sh
@@ -139,5 +139,7 @@ fi
 # The runner persists only sanitized migration-evidence rows. Bind each
 # mutable invocation to the already-validated immutable release; no caller
 # supplied path or environment is retained.
-native_coordination_check
+if [[ "$ACTION" != '--dry-run' ]]; then
+  native_coordination_check
+fi
 run_sudo_clean /usr/bin/node "$RUNNER" "$ACTION" --release-sha "$RELEASE_SHA"

--- a/scripts/run-atendimento-staging-migration.sh
+++ b/scripts/run-atendimento-staging-migration.sh
@@ -108,19 +108,23 @@ seal_staging_runtime_grants() {
   trap '' HUP INT TERM
   if [[ "$LOCKDOWN_REQUIRED" == '1' ]]; then
     set +e
+    coordination_status=0
     if ! native_coordination_check; then
       echo 'Global coordination proof was unavailable before staging grant lockdown; the isolated service remains ineligible.' >&2
-      exit 70
+      coordination_status=70
     fi
     run_sudo_clean /usr/bin/bash -p "$RUNTIME_GRANT_LOCKDOWN" --apply
     local lockdown_status=$?
     set -e
     if [[ "$lockdown_status" -ne 0 ]]; then
       echo 'Staging runtime grant lockdown failed; keeping the isolated service ineligible.' >&2
-      exit 70
+      coordination_status=70
     fi
     native_coordination_cleanup || true
     coordination_acquired=0
+    if [[ "$coordination_status" -ne 0 ]]; then
+      exit 70
+    fi
   fi
   exit "$exit_status"
 }

--- a/scripts/runtime/global-coordination-mini-pc.sh
+++ b/scripts/runtime/global-coordination-mini-pc.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The mini-PC uses the same HTTPS coordinator and fencing-proof contract as
+# GitHub and Codex. This thin adapter owns only private runtime plumbing; it
+# never stores a secret or proof in the source release.
+readonly SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+readonly ADAPTER="$SCRIPT_ROOT/scripts/codex-global-coordination-workflow.mjs"
+readonly PROOF_ROOT="${SKINCOS_GLOBAL_COORDINATION_PROOF_ROOT:-/var/lib/skincos-runtime/global-coordination}"
+readonly COMMAND="${1:-}"
+all_args=("$@")
+
+[[ -f "$ADAPTER" ]] || { echo 'Global coordination adapter is unavailable in the immutable source release.' >&2; exit 78; }
+[[ -n "${SKINCOS_GLOBAL_COORDINATOR_URL:-}" ]] || { echo 'SKINCOS_GLOBAL_COORDINATOR_URL is required for a mini-PC mutation.' >&2; exit 78; }
+[[ -n "${SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET:-}" ]] || { echo 'Global coordination custody is unavailable on the mini-PC.' >&2; exit 78; }
+[[ -n "${GLOBAL_COORDINATION_MISSION_ID:-}" ]] || { echo 'GLOBAL_COORDINATION_MISSION_ID is required on the mini-PC.' >&2; exit 78; }
+[[ -n "${GLOBAL_COORDINATION_THREAD_ID:-}" ]] || { echo 'GLOBAL_COORDINATION_THREAD_ID is required on the mini-PC.' >&2; exit 78; }
+[[ -n "${GLOBAL_COORDINATION_ACTOR:-}" ]] || { echo 'GLOBAL_COORDINATION_ACTOR is required on the mini-PC.' >&2; exit 78; }
+[[ "$COMMAND" =~ ^(acquire|check|renew|release|revoke)$ ]] || {
+  echo 'Usage: global-coordination-mini-pc.sh acquire|check|renew|release|revoke [adapter arguments]' >&2
+  exit 64
+}
+
+proof_file=''
+closure_file=''
+source_sha=''
+has_argument() {
+  local needle="$1" value
+  shift
+  for value in "$@"; do
+    [[ "$value" == "$needle" ]] && return 0
+  done
+  return 1
+}
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --proof-file) proof_file="${2:-}"; shift ;;
+    --closure-file) closure_file="${2:-}"; shift ;;
+    --source) source_sha="${2:-}"; shift ;;
+  esac
+  shift
+done
+proof_file="${proof_file:-${SKINCOS_GLOBAL_COORDINATION_PROOF_FILE:-}}"
+closure_file="${closure_file:-${SKINCOS_GLOBAL_COORDINATION_CLOSURE_FILE:-}}"
+source_sha="${source_sha:-${SKINCOS_GLOBAL_COORDINATION_SOURCE_SHA:-}}"
+[[ -n "$proof_file" && "$proof_file" = /* ]] || { echo 'An absolute private proof file is required.' >&2; exit 78; }
+case "$proof_file" in
+  "$PROOF_ROOT"/*) ;;
+  *) echo 'Global coordination proof must remain below the private mini-PC proof root.' >&2; exit 78 ;;
+esac
+if [[ "$COMMAND" == acquire || "$COMMAND" == check ]]; then
+  [[ -n "$closure_file" && -f "$closure_file" ]] || { echo 'An immutable dependency-closure attestation is required.' >&2; exit 78; }
+  [[ -n "$source_sha" ]] || { echo 'A full immutable source SHA is required.' >&2; exit 78; }
+fi
+
+umask 077
+install -d -m 0700 "$PROOF_ROOT"
+if [[ -e "$proof_file" ]]; then
+  [[ "$(stat -c '%a' "$proof_file")" == '600' ]] || { echo 'Global coordination proof must be mode 0600.' >&2; exit 78; }
+fi
+
+args=("${all_args[@]:1}")
+if ! has_argument --proof-file "${args[@]}"; then args+=(--proof-file "$proof_file"); fi
+if [[ "$COMMAND" == acquire || "$COMMAND" == check ]]; then
+  if ! has_argument --closure-file "${args[@]}"; then args+=(--closure-file "$closure_file"); fi
+  if ! has_argument --source "${args[@]}"; then args+=(--source "$source_sha"); fi
+fi
+
+export GLOBAL_COORDINATION_PROVIDER='mini-pc'
+exec /usr/bin/node "$ADAPTER" "$COMMAND" "${args[@]}"

--- a/scripts/runtime/global-coordination-native.sh
+++ b/scripts/runtime/global-coordination-native.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+# Shared native-runtime adapter. Callers still decide the resource and the
+# exact mutation boundary; this file only makes the lease/check/renew/release
+# transition identical across native scripts.
+
+NATIVE_COORDINATION_SCRIPT_ROOT="${NATIVE_COORDINATION_SCRIPT_ROOT:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)}"
+NATIVE_COORDINATION_ACQUIRED="${NATIVE_COORDINATION_ACQUIRED:-0}"
+NATIVE_COORDINATION_LAST_RENEW="${NATIVE_COORDINATION_LAST_RENEW:-0}"
+
+native_coordination_init() {
+  [[ "$#" -ge 4 ]] || {
+    echo 'native_coordination_init requires resource, module, source SHA and closure file.' >&2
+    return 64
+  }
+  NATIVE_COORDINATION_RESOURCE="$1"
+  NATIVE_COORDINATION_MODULE="$2"
+  NATIVE_COORDINATION_SOURCE="$3"
+  NATIVE_COORDINATION_CLOSURE="$4"
+  NATIVE_COORDINATION_OPERATION="${5:-mutation}"
+  NATIVE_COORDINATION_IDENTITY_FILE="${6:-}"
+
+  [[ "$NATIVE_COORDINATION_SOURCE" =~ ^[0-9a-f]{40}$ ]] || {
+    echo 'Native coordination source must be a full lowercase SHA.' >&2
+    return 78
+  }
+  [[ -f "$NATIVE_COORDINATION_CLOSURE" ]] || {
+    echo "Native coordination closure is unavailable: $NATIVE_COORDINATION_CLOSURE" >&2
+    return 78
+  }
+  if [[ "$NATIVE_COORDINATION_OPERATION" == release || "$NATIVE_COORDINATION_OPERATION" == promotion ]]; then
+    [[ -n "$NATIVE_COORDINATION_IDENTITY_FILE" && -f "$NATIVE_COORDINATION_IDENTITY_FILE" ]] || {
+      echo 'Native release identity is required for a release or promotion lease.' >&2
+      return 78
+    }
+  fi
+
+  # Operator wrappers may be launched from a checkout, but once the target
+  # release exists the authority adapter and its detached attestations must
+  # come from that immutable source. This prevents a mutable checkout copy
+  # from silently changing the lease/fencing client or closure used for a
+  # native mutation. Test harnesses can still inject an adapter root when no
+  # immutable target exists.
+  local immutable_root="/opt/skincos/releases/$NATIVE_COORDINATION_SOURCE/source"
+  if [[ -f "$immutable_root/scripts/runtime/global-coordination-mini-pc.sh" && -f "$immutable_root/scripts/codex-global-coordination-workflow.mjs" ]]; then
+    NATIVE_COORDINATION_SCRIPT_ROOT="$immutable_root"
+    local immutable_closure="$immutable_root/.skincos-global-coordination-${NATIVE_COORDINATION_MODULE}.json"
+    if [[ -f "$immutable_closure" ]]; then
+      NATIVE_COORDINATION_CLOSURE="$immutable_closure"
+    fi
+    if [[ -n "$NATIVE_COORDINATION_IDENTITY_FILE" ]]; then
+      local immutable_identity="$immutable_root/.skincos-release-identity-${NATIVE_COORDINATION_MODULE}.json"
+      if [[ -f "$immutable_identity" ]]; then
+        NATIVE_COORDINATION_IDENTITY_FILE="$immutable_identity"
+      fi
+    fi
+  fi
+
+  local proof_root proof_name
+  proof_root="${SKINCOS_GLOBAL_COORDINATION_PROOF_ROOT:-/var/lib/skincos-runtime/global-coordination}"
+  proof_name="$(printf '%s' "${NATIVE_COORDINATION_RESOURCE}-${NATIVE_COORDINATION_SOURCE}-$$" | tr -c 'A-Za-z0-9._-' '-')"
+  NATIVE_COORDINATION_PROOF_FILE="${SKINCOS_GLOBAL_COORDINATION_PROOF_FILE:-$proof_root/$proof_name.json}"
+  export SKINCOS_GLOBAL_COORDINATION_PROOF_FILE="$NATIVE_COORDINATION_PROOF_FILE"
+  NATIVE_COORDINATION_ACQUIRED=0
+  NATIVE_COORDINATION_LAST_RENEW="$(date +%s)"
+}
+
+native_coordination_run() {
+  "$NATIVE_COORDINATION_SCRIPT_ROOT/scripts/runtime/global-coordination-mini-pc.sh" \
+    "$@" --proof-file "$NATIVE_COORDINATION_PROOF_FILE"
+}
+
+native_coordination_acquire() {
+  local idempotency_key="${1:-native:${NATIVE_COORDINATION_RESOURCE}:${NATIVE_COORDINATION_SOURCE}:$$}"
+  local args=(
+    acquire
+    --resource "$NATIVE_COORDINATION_RESOURCE"
+    --module "$NATIVE_COORDINATION_MODULE"
+    --source "$NATIVE_COORDINATION_SOURCE"
+    --closure-file "$NATIVE_COORDINATION_CLOSURE"
+    --operation "$NATIVE_COORDINATION_OPERATION"
+    --idempotency-key "$idempotency_key"
+  )
+  if [[ "$NATIVE_COORDINATION_OPERATION" == release || "$NATIVE_COORDINATION_OPERATION" == promotion ]]; then
+    args+=(--release-identity-file "$NATIVE_COORDINATION_IDENTITY_FILE")
+  fi
+  native_coordination_run "${args[@]}" >/dev/null
+  NATIVE_COORDINATION_ACQUIRED=1
+  NATIVE_COORDINATION_LAST_RENEW="$(date +%s)"
+}
+
+native_coordination_check() {
+  native_coordination_run check \
+    --resource "$NATIVE_COORDINATION_RESOURCE" \
+    --module "$NATIVE_COORDINATION_MODULE" \
+    --source "$NATIVE_COORDINATION_SOURCE" \
+    --closure-file "$NATIVE_COORDINATION_CLOSURE" >/dev/null
+}
+
+native_coordination_renew_if_due() {
+  local now
+  now="$(date +%s)"
+  if (( now - NATIVE_COORDINATION_LAST_RENEW >= 60 )); then
+    native_coordination_run renew >/dev/null
+    NATIVE_COORDINATION_LAST_RENEW="$now"
+  fi
+}
+
+native_coordination_release() {
+  if [[ "${NATIVE_COORDINATION_ACQUIRED:-0}" != 1 ]]; then
+    return 0
+  fi
+  native_coordination_run release >/dev/null
+  NATIVE_COORDINATION_ACQUIRED=0
+}
+
+native_coordination_cleanup() {
+  if [[ "${NATIVE_COORDINATION_ACQUIRED:-0}" == 1 ]]; then
+    native_coordination_release || {
+      echo 'Unable to release the native global coordination lease; it will expire fail-closed.' >&2
+      return 1
+    }
+  fi
+}

--- a/scripts/runtime/global-coordination-native.sh
+++ b/scripts/runtime/global-coordination-native.sh
@@ -6,6 +6,7 @@
 
 NATIVE_COORDINATION_SCRIPT_ROOT="${NATIVE_COORDINATION_SCRIPT_ROOT:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)}"
 NATIVE_COORDINATION_ACQUIRED="${NATIVE_COORDINATION_ACQUIRED:-0}"
+NATIVE_COORDINATION_OWNED="${NATIVE_COORDINATION_OWNED:-0}"
 NATIVE_COORDINATION_LAST_RENEW="${NATIVE_COORDINATION_LAST_RENEW:-0}"
 
 native_coordination_init() {
@@ -19,6 +20,11 @@ native_coordination_init() {
   NATIVE_COORDINATION_CLOSURE="$4"
   NATIVE_COORDINATION_OPERATION="${5:-mutation}"
   NATIVE_COORDINATION_IDENTITY_FILE="${6:-}"
+  NATIVE_COORDINATION_REUSE="${SKINCOS_GLOBAL_COORDINATION_REUSE:-0}"
+  if [[ "$NATIVE_COORDINATION_REUSE" == '1' && -z "${SKINCOS_GLOBAL_COORDINATION_PROOF_FILE:-}" ]]; then
+    echo 'Reusing global coordination custody requires an explicit proof file.' >&2
+    return 78
+  fi
 
   [[ "$NATIVE_COORDINATION_SOURCE" =~ ^[0-9a-f]{40}$ ]] || {
     echo 'Native coordination source must be a full lowercase SHA.' >&2
@@ -62,6 +68,7 @@ native_coordination_init() {
   NATIVE_COORDINATION_PROOF_FILE="${SKINCOS_GLOBAL_COORDINATION_PROOF_FILE:-$proof_root/$proof_name.json}"
   export SKINCOS_GLOBAL_COORDINATION_PROOF_FILE="$NATIVE_COORDINATION_PROOF_FILE"
   NATIVE_COORDINATION_ACQUIRED=0
+  NATIVE_COORDINATION_OWNED=0
   NATIVE_COORDINATION_LAST_RENEW="$(date +%s)"
 }
 
@@ -72,6 +79,13 @@ native_coordination_run() {
 
 native_coordination_acquire() {
   local idempotency_key="${1:-native:${NATIVE_COORDINATION_RESOURCE}:${NATIVE_COORDINATION_SOURCE}:$$}"
+  if [[ "${NATIVE_COORDINATION_REUSE:-0}" == '1' ]]; then
+    native_coordination_check
+    NATIVE_COORDINATION_ACQUIRED=1
+    NATIVE_COORDINATION_OWNED=0
+    NATIVE_COORDINATION_LAST_RENEW="$(date +%s)"
+    return 0
+  fi
   local args=(
     acquire
     --resource "$NATIVE_COORDINATION_RESOURCE"
@@ -86,6 +100,7 @@ native_coordination_acquire() {
   fi
   native_coordination_run "${args[@]}" >/dev/null
   NATIVE_COORDINATION_ACQUIRED=1
+  NATIVE_COORDINATION_OWNED=1
   NATIVE_COORDINATION_LAST_RENEW="$(date +%s)"
 }
 
@@ -107,11 +122,12 @@ native_coordination_renew_if_due() {
 }
 
 native_coordination_release() {
-  if [[ "${NATIVE_COORDINATION_ACQUIRED:-0}" != 1 ]]; then
+  if [[ "${NATIVE_COORDINATION_ACQUIRED:-0}" != 1 || "${NATIVE_COORDINATION_OWNED:-0}" != 1 ]]; then
     return 0
   fi
   native_coordination_run release >/dev/null
   NATIVE_COORDINATION_ACQUIRED=0
+  NATIVE_COORDINATION_OWNED=0
 }
 
 native_coordination_cleanup() {

--- a/scripts/runtime/install-atendimento-production-service.sh
+++ b/scripts/runtime/install-atendimento-production-service.sh
@@ -45,6 +45,9 @@ readonly CONTROL_VALIDATOR="$SOURCE_ROOT/crm/api/scripts/validate-atendimento-pr
 readonly RUNTIME_GRANT_LOCKDOWN="$SOURCE_ROOT/scripts/lockdown-atendimento-production-runtime.sh"
 readonly RELEASE_MANIFEST="$STATE_ROOT/crm-atendimento-production/release-manifests/$RELEASE_SHA.json"
 readonly CONTROL_FILE="$CONFIG_ROOT/atendimento-production/module-control.json"
+readonly COORDINATION_CLOSURE="$SOURCE_ROOT/.skincos-global-coordination-atendimento.json"
+coordination_proof="${SKINCOS_GLOBAL_COORDINATION_PROOF_FILE:-/var/lib/skincos-runtime/global-coordination/atendimento-production-$RELEASE_SHA-$$.json}"
+coordination_acquired=0
 
 for command_path in /usr/bin/sudo /usr/bin/env /usr/bin/sed /usr/bin/systemd-analyze /usr/bin/mktemp /usr/bin/install /usr/bin/node /usr/bin/chmod /usr/bin/rm /usr/bin/rmdir /usr/bin/date /usr/bin/cp /usr/bin/systemctl /usr/bin/test /usr/bin/grep /usr/bin/bash; do
   [[ -x "$command_path" ]] || { echo "Missing $command_path" >&2; exit 1; }
@@ -83,21 +86,63 @@ if [[ "$APPLY" != '1' ]]; then
   exit 0
 fi
 
+[[ -f "$COORDINATION_CLOSURE" ]] || { echo 'Atendimento dependency-closure attestation is required for production service mutation.' >&2; exit 78; }
+coordination_run() {
+  "$SOURCE_ROOT/scripts/runtime/global-coordination-mini-pc.sh" "$@" --proof-file "$coordination_proof"
+}
+cleanup_coordination() {
+  if (( coordination_acquired == 1 )); then
+    coordination_run release >/dev/null 2>&1 || echo 'Unable to release the Atendimento production surface lease; it will expire fail-closed.' >&2
+  fi
+  /usr/bin/rm -f "$rendered"
+  /usr/bin/rmdir "$render_dir" 2>/dev/null || true
+}
+trap cleanup_coordination EXIT INT TERM
+coordination_run acquire \
+  --resource deploy:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" --operation mutation \
+  --idempotency-key "mini-pc:deploy:atendimento:production:install:$RELEASE_SHA:$$" >/dev/null
+coordination_acquired=1
+coordination_run check \
+  --resource deploy:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
+
 stamp="$(/usr/bin/date -u +%Y%m%dT%H%M%SZ)"
+coordination_run check \
+  --resource deploy:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
 run_sudo_clean /usr/bin/install -d -m 0700 -o root -g root "$BACKUP_ROOT"
 if run_sudo_clean /usr/bin/test -f "$UNIT_DEST/$SERVICE"; then
+  coordination_run check \
+    --resource deploy:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+    --closure-file "$COORDINATION_CLOSURE" >/dev/null
   run_sudo_clean /usr/bin/cp -p "$UNIT_DEST/$SERVICE" "$BACKUP_ROOT/${stamp}-$SERVICE"
 fi
 # Reapply the seal after any privileged release preparation and before the
 # unit is installed or restarted. A failed seal leaves the current runtime
 # untouched.
+coordination_run check \
+  --resource deploy:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
 run_sudo_clean /usr/bin/bash -p "$RUNTIME_GRANT_LOCKDOWN" --apply
 run_sudo_clean /usr/bin/bash -p "$RUNTIME_GRANT_LOCKDOWN" --dry-run >/dev/null
+coordination_run check \
+  --resource deploy:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
 run_sudo_clean /usr/bin/install -m 0644 "$rendered" "$UNIT_DEST/$SERVICE"
+coordination_run check \
+  --resource deploy:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
 run_sudo_clean /usr/bin/systemctl daemon-reload
 # `enable --now` does not replace an active legacy instance. Restart only this
 # dedicated service after its immutable unit is installed.
+coordination_run check \
+  --resource deploy:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
 run_sudo_clean /usr/bin/systemctl enable "$SERVICE" >/dev/null
+coordination_run check \
+  --resource deploy:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
 run_sudo_clean /usr/bin/systemctl restart "$SERVICE"
 run_sudo_clean /usr/bin/systemctl is-active --quiet "$SERVICE"
 printf 'installed=true service=%s release_sha=%s shared_restart=false\n' "$SERVICE" "$RELEASE_SHA"

--- a/scripts/runtime/install-atendimento-production-service.sh
+++ b/scripts/runtime/install-atendimento-production-service.sh
@@ -21,11 +21,15 @@ readonly SERVICE='crm-atendimento-production.service'
 
 SOURCE_ROOT=''
 APPLY=0
+COORDINATION_PROOF_FILE=''
+COORDINATION_REUSE=0
 
-usage() { echo "Usage: $0 --source-root /opt/skincos/releases/<full-sha>/source [--apply]"; }
+usage() { echo "Usage: $0 --source-root /opt/skincos/releases/<full-sha>/source [--coordination-proof-file <private-proof>] [--coordination-reuse] [--apply]"; }
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --source-root) shift; SOURCE_ROOT="${1:-}" ;;
+    --coordination-proof-file) shift; COORDINATION_PROOF_FILE="${1:-}" ;;
+    --coordination-reuse) COORDINATION_REUSE=1 ;;
     --apply) APPLY=1 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 64 ;;
@@ -46,8 +50,13 @@ readonly RUNTIME_GRANT_LOCKDOWN="$SOURCE_ROOT/scripts/lockdown-atendimento-produ
 readonly RELEASE_MANIFEST="$STATE_ROOT/crm-atendimento-production/release-manifests/$RELEASE_SHA.json"
 readonly CONTROL_FILE="$CONFIG_ROOT/atendimento-production/module-control.json"
 readonly COORDINATION_CLOSURE="$SOURCE_ROOT/.skincos-global-coordination-atendimento.json"
-coordination_proof="${SKINCOS_GLOBAL_COORDINATION_PROOF_FILE:-/var/lib/skincos-runtime/global-coordination/atendimento-production-$RELEASE_SHA-$$.json}"
+coordination_proof="${COORDINATION_PROOF_FILE:-${SKINCOS_GLOBAL_COORDINATION_PROOF_FILE:-/var/lib/skincos-runtime/global-coordination/atendimento-production-$RELEASE_SHA-$$.json}}"
+if [[ "$COORDINATION_REUSE" == '1' ]]; then
+  export SKINCOS_GLOBAL_COORDINATION_REUSE=1
+  export SKINCOS_GLOBAL_COORDINATION_PROOF_FILE="$coordination_proof"
+fi
 coordination_acquired=0
+coordination_owned=0
 
 for command_path in /usr/bin/sudo /usr/bin/env /usr/bin/sed /usr/bin/systemd-analyze /usr/bin/mktemp /usr/bin/install /usr/bin/node /usr/bin/chmod /usr/bin/rm /usr/bin/rmdir /usr/bin/date /usr/bin/cp /usr/bin/systemctl /usr/bin/test /usr/bin/grep /usr/bin/bash; do
   [[ -x "$command_path" ]] || { echo "Missing $command_path" >&2; exit 1; }
@@ -91,18 +100,29 @@ coordination_run() {
   "$SOURCE_ROOT/scripts/runtime/global-coordination-mini-pc.sh" "$@" --proof-file "$coordination_proof"
 }
 cleanup_coordination() {
-  if (( coordination_acquired == 1 )); then
+  if (( coordination_acquired == 1 && coordination_owned == 1 )); then
     coordination_run release >/dev/null 2>&1 || echo 'Unable to release the Atendimento production surface lease; it will expire fail-closed.' >&2
   fi
   /usr/bin/rm -f "$rendered"
   /usr/bin/rmdir "$render_dir" 2>/dev/null || true
 }
 trap cleanup_coordination EXIT INT TERM
-coordination_run acquire \
-  --resource deploy:atendimento:production --module atendimento --source "$RELEASE_SHA" \
-  --closure-file "$COORDINATION_CLOSURE" --operation mutation \
-  --idempotency-key "mini-pc:deploy:atendimento:production:install:$RELEASE_SHA:$$" >/dev/null
+if [[ "$COORDINATION_REUSE" == '1' ]]; then
+  coordination_run check \
+    --resource deploy:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+    --closure-file "$COORDINATION_CLOSURE" >/dev/null
+else
+  coordination_run acquire \
+    --resource deploy:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+    --closure-file "$COORDINATION_CLOSURE" --operation mutation \
+    --idempotency-key "mini-pc:deploy:atendimento:production:install:$RELEASE_SHA:$$" >/dev/null
+fi
 coordination_acquired=1
+if [[ "$COORDINATION_REUSE" == '1' ]]; then
+  coordination_owned=0
+else
+  coordination_owned=1
+fi
 coordination_run check \
   --resource deploy:atendimento:production --module atendimento --source "$RELEASE_SHA" \
   --closure-file "$COORDINATION_CLOSURE" >/dev/null

--- a/scripts/runtime/install-atendimento-production-tunnel.sh
+++ b/scripts/runtime/install-atendimento-production-tunnel.sh
@@ -34,12 +34,14 @@ done
   echo 'SOURCE_ROOT must be an immutable native release path with a full lowercase SHA.' >&2
   exit 64
 }
+readonly RELEASE_SHA="${BASH_REMATCH[1]}"
 [[ "$TUNNEL_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]] || {
   echo 'TUNNEL_ID must be a lowercase RFC 4122 UUID.' >&2
   exit 64
 }
 readonly UNIT_SRC="$SOURCE_ROOT/ops/runtime/units/cloudflare-atendimento-production.service"
 readonly CREDENTIALS_FILE="$CONFIG_DIR/$TUNNEL_ID.json"
+readonly COORDINATION_CLOSURE="$SOURCE_ROOT/.skincos-global-coordination-atendimento.json"
 
 for command_name in sudo install sed systemd-analyze mktemp date; do
   command -v "$command_name" >/dev/null 2>&1 || { echo "Missing $command_name" >&2; exit 1; }
@@ -80,6 +82,31 @@ if [[ "$APPLY" != '1' ]]; then
   exit 0
 fi
 
+sudo -n test -f "$COORDINATION_CLOSURE" || { echo 'Immutable Atendimento dependency-closure attestation is unavailable.' >&2; exit 78; }
+coordination_proof="${SKINCOS_GLOBAL_COORDINATION_PROOF_FILE:-/var/lib/skincos-runtime/global-coordination/cloudflare-atendimento-production-tunnel-$$.json}"
+coordination_acquired=0
+coordination_run() {
+  "$SOURCE_ROOT/scripts/runtime/global-coordination-mini-pc.sh" "$@" --proof-file "$coordination_proof"
+}
+cleanup_coordination() {
+  rm -f "$tmp_config" "$tmp_unit"
+  if (( coordination_acquired == 1 )); then
+    coordination_run release >/dev/null 2>&1 || echo 'Unable to release the mini-PC Cloudflare lease; it will expire fail-closed.' >&2
+  fi
+}
+trap cleanup_coordination EXIT
+coordination_run acquire \
+  --resource cloudflare:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" --operation mutation \
+  --idempotency-key "mini-pc:cloudflare:atendimento:production:tunnel:$RELEASE_SHA:$$" >/dev/null
+coordination_acquired=1
+coordination_run check \
+  --resource cloudflare:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
+
+coordination_run check \
+  --resource cloudflare:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
 stamp="$(date -u +%Y%m%dT%H%M%SZ)"
 sudo -n install -d -m 0750 -o root -g skincos "$CONFIG_DIR" "$LOG_ROOT"
 sudo -n install -d -m 0700 -o root -g root "$BACKUP_ROOT"
@@ -90,6 +117,9 @@ for target in "$CONFIG_FILE" "$UNIT_DEST"; do
 done
 sudo -n install -m 0640 -o root -g skincos "$tmp_config" "$CONFIG_FILE"
 sudo -n install -m 0644 -o root -g root "$tmp_unit" "$UNIT_DEST"
+coordination_run check \
+  --resource cloudflare:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
 sudo -n systemctl daemon-reload
 sudo -n systemctl enable --now cloudflare-atendimento-production.service >/dev/null
 sudo -n systemctl is-active --quiet cloudflare-atendimento-production.service

--- a/scripts/runtime/install-atendimento-production-tunnel.sh
+++ b/scripts/runtime/install-atendimento-production-tunnel.sh
@@ -121,6 +121,9 @@ coordination_run check \
   --resource cloudflare:atendimento:production --module atendimento --source "$RELEASE_SHA" \
   --closure-file "$COORDINATION_CLOSURE" >/dev/null
 sudo -n systemctl daemon-reload
+coordination_run check \
+  --resource cloudflare:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
 sudo -n systemctl enable --now cloudflare-atendimento-production.service >/dev/null
 sudo -n systemctl is-active --quiet cloudflare-atendimento-production.service
 printf 'installed=true tunnel_id=%s hostname=%s service=cloudflare-atendimento-production.service shared_restart=false\n' "$TUNNEL_ID" "$HOSTNAME"

--- a/scripts/runtime/install-atendimento-staging-service.sh
+++ b/scripts/runtime/install-atendimento-staging-service.sh
@@ -44,6 +44,9 @@ readonly RUNTIME_ENTRYPOINT="$SOURCE_ROOT/crm/api/server/atendimentoRuntime.js"
 readonly RELEASE_VALIDATOR="$SOURCE_ROOT/crm/api/scripts/validate-atendimento-release.mjs"
 readonly CONTROL_VALIDATOR="$SOURCE_ROOT/crm/api/scripts/validate-atendimento-staging-control.mjs"
 readonly RUNTIME_GRANT_LOCKDOWN="$SOURCE_ROOT/scripts/lockdown-atendimento-staging-runtime.sh"
+readonly COORDINATION_CLOSURE="$SOURCE_ROOT/.skincos-global-coordination-atendimento.json"
+coordination_proof="${SKINCOS_GLOBAL_COORDINATION_PROOF_FILE:-/var/lib/skincos-runtime/global-coordination/atendimento-staging-$RELEASE_SHA-$$.json}"
+coordination_acquired=0
 
 for command_path in /usr/bin/sudo /usr/bin/sed /usr/bin/systemd-analyze /usr/bin/mktemp /usr/bin/install /usr/bin/node /usr/bin/chmod /usr/bin/rm /usr/bin/rmdir /usr/bin/date /usr/bin/cp /usr/bin/cmp /usr/bin/stat /usr/bin/systemctl /usr/bin/test; do
   [[ -x "$command_path" ]] || { echo "Missing $command_path" >&2; exit 1; }
@@ -88,7 +91,34 @@ if [[ "$APPLY" != '1' ]]; then
   exit 0
 fi
 
+[[ -f "$COORDINATION_CLOSURE" ]] || { echo 'Atendimento dependency-closure attestation is required for staging service mutation.' >&2; exit 78; }
+coordination_run() {
+  "$SOURCE_ROOT/scripts/runtime/global-coordination-mini-pc.sh" "$@" --proof-file "$coordination_proof"
+}
+cleanup_coordination() {
+  if (( coordination_acquired == 1 )); then
+    coordination_run release >/dev/null 2>&1 || echo 'Unable to release the Atendimento staging surface lease; it will expire fail-closed.' >&2
+  fi
+  /usr/bin/rm -f "$rendered"
+  /usr/bin/rmdir "$render_dir" 2>/dev/null || true
+  if [[ "$unit_backup_committed" != '1' && "$unit_backup_path" =~ ^/var/backups/skincos/clientes/staging/[0-9]{8}T[0-9]{6}Z-crm-atendimento-staging\.[A-Za-z0-9]{6}\.service$ ]]; then
+    run_sudo_clean /usr/bin/rm -f -- "$unit_backup_path" || true
+  fi
+}
+trap cleanup_coordination EXIT INT TERM
+coordination_run acquire \
+  --resource deploy:atendimento:staging --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" --operation mutation \
+  --idempotency-key "mini-pc:deploy:atendimento:staging:install:$RELEASE_SHA:$$" >/dev/null
+coordination_acquired=1
+coordination_run check \
+  --resource deploy:atendimento:staging --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
+
 stamp="$(/usr/bin/date -u +%Y%m%dT%H%M%SZ)"
+coordination_run check \
+  --resource deploy:atendimento:staging --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
 /usr/bin/sudo -n /usr/bin/install -d -m 0700 -o root -g root "$BACKUP_ROOT"
 unit_backup='none'
 if /usr/bin/sudo -n /usr/bin/test -f "$UNIT_DEST/$SERVICE"; then
@@ -103,6 +133,9 @@ if /usr/bin/sudo -n /usr/bin/test -f "$UNIT_DEST/$SERVICE"; then
   run_sudo_clean /usr/bin/test -f "$unit_backup_path"
   run_sudo_clean /usr/bin/test -O "$unit_backup_path"
   unit_backup="${unit_backup_path##*/}"
+  coordination_run check \
+    --resource deploy:atendimento:staging --module atendimento --source "$RELEASE_SHA" \
+    --closure-file "$COORDINATION_CLOSURE" >/dev/null
   run_sudo_clean /usr/bin/cp -p "$UNIT_DEST/$SERVICE" "$unit_backup_path"
   unit_backup_metadata="$(run_sudo_clean /usr/bin/stat -c '%U:%G:%a' "$unit_backup_path")"
   [[ "$unit_backup_metadata" == 'root:root:644' ]] || {
@@ -115,12 +148,25 @@ if /usr/bin/sudo -n /usr/bin/test -f "$UNIT_DEST/$SERVICE"; then
   }
   unit_backup_committed=1
 fi
+coordination_run check \
+  --resource deploy:atendimento:staging --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
 /usr/bin/sudo -n /usr/bin/install -m 0644 "$rendered" "$UNIT_DEST/$SERVICE"
+coordination_run check \
+  --resource deploy:atendimento:staging --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
 /usr/bin/sudo -n /usr/bin/systemctl daemon-reload
 # `enable --now` does not replace an already active legacy instance. Restart
 # only this dedicated staging unit after the immutable unit file is installed;
 # no shared CRM, worker, Orb or tunnel unit is touched.
+coordination_run check \
+  --resource deploy:atendimento:staging --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
 /usr/bin/sudo -n /usr/bin/systemctl enable "$SERVICE" >/dev/null
+/usr/bin/sudo -n /usr/bin/true
+coordination_run check \
+  --resource deploy:atendimento:staging --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
 /usr/bin/sudo -n /usr/bin/systemctl restart "$SERVICE"
 /usr/bin/sudo -n /usr/bin/systemctl is-active --quiet "$SERVICE"
 printf 'installed=true service=%s release_sha=%s unit_backup=%s shared_restart=false\n' "$SERVICE" "$RELEASE_SHA" "$unit_backup"

--- a/scripts/runtime/install-continuous-worker-service.sh
+++ b/scripts/runtime/install-continuous-worker-service.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/scripts/runtime/global-coordination-native.sh"
 UNIT_SRC="$ROOT_DIR/ops/runtime/units/crm-jobs.service"
 UNIT_DEST="/etc/systemd/system"
 SOURCE_ROOT="$ROOT_DIR"
@@ -11,6 +12,7 @@ LOG_ROOT="/var/log/skincos"
 BACKUP_ROOT="/var/backups/skincos"
 APPLY=0
 ENABLE=0
+coordination_acquired=0
 
 usage() {
   cat <<'EOF'
@@ -59,6 +61,16 @@ if [[ "$APPLY" == "1" ]]; then
     echo "Immutable source release is unavailable: $SOURCE_ROOT" >&2
     exit 1
   }
+  coordination_source_sha="$(basename "$(dirname "$SOURCE_ROOT")")"
+  [[ "$coordination_source_sha" =~ ^[0-9a-f]{40}$ ]] || {
+    echo 'Immutable source release SHA is invalid.' >&2
+    exit 78
+  }
+  COORDINATION_CLOSURE="${SKINCOS_GLOBAL_COORDINATION_CLOSURE_FILE:-$SOURCE_ROOT/.skincos-global-coordination-orb.json}"
+  [[ -f "$COORDINATION_CLOSURE" ]] || {
+    echo "Immutable Orb coordination closure is unavailable: $COORDINATION_CLOSURE" >&2
+    exit 78
+  }
 elif [[ "$SOURCE_ROOT" != "$ROOT_DIR" && ! "$SOURCE_ROOT" =~ ^/opt/skincos/releases/[0-9a-f]{40}/source$ ]]; then
   echo "--source-root must be an immutable release path" >&2
   exit 64
@@ -74,7 +86,14 @@ fi
 
 escape() { printf '%s' "$1" | sed 's/[&|]/\\&/g'; }
 render_dir="$(mktemp -d)"
-trap 'rm -rf "$render_dir"' EXIT
+cleanup() {
+  rm -rf "$render_dir"
+  if [[ "$coordination_acquired" == '1' ]]; then
+    native_coordination_cleanup || true
+    coordination_acquired=0
+  fi
+}
+trap cleanup EXIT INT TERM
 rendered="$render_dir/crm-jobs.service"
 sed \
   -e "s|__REPO_ROOT__|$(escape "$SOURCE_ROOT")|g" \
@@ -86,14 +105,23 @@ sed \
 systemd-analyze verify "$rendered"
 
 if [[ "$APPLY" == "1" ]]; then
+  native_coordination_init release:orb orb "$coordination_source_sha" "$COORDINATION_CLOSURE" mutation
+  native_coordination_acquire "mini-pc:release:orb:continuous-worker:$coordination_source_sha:$$" >/dev/null
+  coordination_acquired=1
+  native_coordination_check
   if sudo -n test -f "$UNIT_DEST/crm-jobs.service"; then
     stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+    native_coordination_check
     sudo -n install -d -m 0750 "$BACKUP_ROOT"
+    native_coordination_check
     sudo -n cp -p "$UNIT_DEST/crm-jobs.service" "$BACKUP_ROOT/crm-jobs.service.$stamp"
   fi
+  native_coordination_check
   sudo -n install -m 0644 "$rendered" "$UNIT_DEST/crm-jobs.service"
+  native_coordination_check
   sudo -n systemctl daemon-reload
   if [[ "$ENABLE" == "1" ]]; then
+    native_coordination_check
     sudo -n systemctl enable crm-jobs.service >/dev/null
   fi
   echo "CRM continuous-worker unit installed; no service start was requested."

--- a/scripts/runtime/install-lifecycle-units.sh
+++ b/scripts/runtime/install-lifecycle-units.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/scripts/runtime/global-coordination-native.sh"
 UNIT_SRC="$ROOT_DIR/ops/runtime/units"
 UNIT_DEST="${UNIT_DEST:-/etc/systemd/system}"
 # Code and durable recovery artifacts may remain on the Windows volume, but
@@ -16,6 +17,7 @@ TMP_ROOT="${TMP_ROOT:-/var/tmp/skincos}"
 ARTIFACT_ROOT="${ARTIFACT_ROOT:-$STATE_ROOT/artifacts}"
 BACKUP_ROOT="${BACKUP_ROOT:-/var/backups/skincos}"
 APPLY=0
+coordination_acquired=0
 
 usage() {
   cat <<'EOF'
@@ -58,11 +60,27 @@ require_cmd() {
 
 require_cmd sed
 require_cmd systemd-analyze
+require_cmd readlink
 VERIFY_WITH_SUDO=0
+coordination_source_sha=''
+coordination_closure=''
 if [[ "$APPLY" == "1" || "$SOURCE_ROOT" == /opt/skincos/* ]]; then
   require_cmd sudo
   sudo -n true
   VERIFY_WITH_SUDO=1
+fi
+if [[ "$APPLY" == "1" ]]; then
+  resolved_source_root="$(readlink -f "$SOURCE_ROOT")"
+  [[ "$resolved_source_root" =~ ^/opt/skincos/releases/[0-9a-f]{40}/source$ ]] || {
+    echo "Applied lifecycle units require an immutable /opt/skincos/releases/<sha>/source target: $resolved_source_root" >&2
+    exit 78
+  }
+  coordination_source_sha="$(basename "$(dirname "$resolved_source_root")")"
+  coordination_closure="$resolved_source_root/.skincos-global-coordination-native-runtime.json"
+  [[ -f "$coordination_closure" ]] || {
+    echo "Native-runtime coordination closure is unavailable: $coordination_closure" >&2
+    exit 78
+  }
 fi
 
 sed_escape() { printf '%s' "$1" | sed 's/[&|]/\\&/g'; }
@@ -88,7 +106,14 @@ units=(
 )
 
 render_dir="$(mktemp -d)"
-trap 'rm -rf "$render_dir"' EXIT
+cleanup() {
+  rm -rf "$render_dir"
+  if [[ "$coordination_acquired" == '1' ]]; then
+    native_coordination_cleanup || true
+    coordination_acquired=0
+  fi
+}
+trap cleanup EXIT INT TERM
 rendered=()
 for unit in "${units[@]}"; do
   source_file="$UNIT_SRC/$unit"
@@ -117,11 +142,18 @@ printf '  %s\n' "${units[@]}"
 
 if [[ "$APPLY" == "1" ]]; then
   [[ -d "$SOURCE_ROOT" ]] || { echo "Native source release is unavailable: $SOURCE_ROOT" >&2; exit 1; }
+  native_coordination_init global:native-runtime native-runtime "$coordination_source_sha" "$coordination_closure" mutation
+  native_coordination_acquire "mini-pc:global:native-runtime:units:$coordination_source_sha:$$" >/dev/null
+  coordination_acquired=1
+  native_coordination_check
   sudo -n mkdir -p "$UNIT_DEST"
   for index in "${!units[@]}"; do
+    native_coordination_check
     sudo -n install -m 0644 "${rendered[$index]}" "$UNIT_DEST/${units[$index]}"
   done
+  native_coordination_check
   sudo -n systemctl daemon-reload
+  native_coordination_check
   sudo -n systemctl enable "${units[@]}" >/dev/null
   echo "Lifecycle units installed. Windows Task Scheduler exclusively owns the Orb backup schedule."
 fi

--- a/scripts/runtime/manage-native-runtime.sh
+++ b/scripts/runtime/manage-native-runtime.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+source "$SCRIPT_ROOT/scripts/runtime/global-coordination-native.sh"
+
 units=(
   orb.service
   orb-ccg-executor.service
@@ -31,7 +34,33 @@ case "$action" in
     systemctl --no-pager --full status "${units[@]}"
     ;;
   restart)
-    sudo -n systemctl restart "${units[@]}"
+    current_source="$(readlink -f /opt/skincos/current/source)"
+    [[ "$current_source" =~ ^/opt/skincos/releases/[0-9a-f]{40}/source$ ]] || {
+      echo "Invalid native source release: $current_source" >&2
+      exit 78
+    }
+    source_sha="$(basename "$(dirname "$current_source")")"
+    coordination_closure="$current_source/.skincos-global-coordination-native-runtime.json"
+    [[ -f "$coordination_closure" ]] || {
+      echo "Native-runtime coordination closure is unavailable: $coordination_closure" >&2
+      exit 78
+    }
+    native_coordination_init global:native-runtime native-runtime "$source_sha" "$coordination_closure" mutation
+    coordination_acquired=0
+    cleanup() {
+      if [[ "$coordination_acquired" == '1' ]]; then
+        native_coordination_cleanup || true
+        coordination_acquired=0
+      fi
+    }
+    trap cleanup EXIT INT TERM
+    native_coordination_acquire "mini-pc:global:native-runtime:restart:$source_sha:$$" >/dev/null
+    coordination_acquired=1
+    native_coordination_check
+    for unit in "${units[@]}"; do
+      native_coordination_check
+      sudo -n systemctl restart "$unit"
+    done
     systemctl --quiet is-active "${units[@]}"
     printf 'ACTIVE %s\n' "${units[@]}"
     ;;

--- a/scripts/runtime/mcp-gateway-release.sh
+++ b/scripts/runtime/mcp-gateway-release.sh
@@ -13,6 +13,15 @@ UNIT_DEST=${MCP_GATEWAY_UNIT_DEST:-/etc/systemd/system/skincos-orb-mcp-readonly.
 CHECKPOINT_ROOT=${MCP_GATEWAY_CHECKPOINT_ROOT:-/var/lib/skincos-runtime/orb-mcp-readonly/release-unit-checkpoints}
 SYSTEMCTL_BIN=${MCP_GATEWAY_SYSTEMCTL_BIN:-/usr/bin/systemctl}
 SYSTEMD_ANALYZE_BIN=${MCP_GATEWAY_SYSTEMD_ANALYZE_BIN:-/usr/bin/systemd-analyze}
+readonly COORDINATION_RESOURCE='promotion:orb-mcp:local'
+coordination_acquired=0
+
+# The gateway is a native release consumer. Its pointer and unit mutations use
+# the same mini-PC adapter as the rest of the immutable runtime.
+NATIVE_COORDINATION_SCRIPT_ROOT="${NATIVE_COORDINATION_SCRIPT_ROOT:-$SCRIPT_ROOT}"
+export NATIVE_COORDINATION_SCRIPT_ROOT
+# shellcheck disable=SC1091
+source "$SCRIPT_ROOT/scripts/runtime/global-coordination-native.sh"
 
 die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 need_apply() {
@@ -20,13 +29,42 @@ need_apply() {
   [[ "$TEST_MODE" == YES || "$(id -u)" == 0 ]] || die 'refused: run the applied lifecycle as root.'
 }
 release_root() { printf '%s/%s/source/orb/engine/mcp-readonly-gateway\n' "$RELEASE_BASE" "$1"; }
+release_source_root() { printf '%s/%s/source\n' "$RELEASE_BASE" "$1"; }
 systemd() { "$SYSTEMCTL_BIN" "$@"; }
 
+coordination_cleanup() {
+  if [[ "${coordination_acquired:-0}" == '1' ]]; then
+    native_coordination_cleanup || printf 'WARNING: gateway coordination lease will expire fail-closed.\n' >&2
+    coordination_acquired=0
+  fi
+}
+trap coordination_cleanup EXIT INT TERM
+
+coordination_begin() {
+  local sha=$1 root
+  root=$(release_source_root "$sha")
+  native_coordination_init \
+    "$COORDINATION_RESOURCE" orb "$sha" \
+    "$root/.skincos-global-coordination-orb.json" promotion \
+    "$root/.skincos-release-identity-orb.json"
+  native_coordination_acquire "mini-pc:${COORDINATION_RESOURCE}:$sha:$$"
+  coordination_acquired=1
+  native_coordination_check
+}
+
+coordination_check() {
+  [[ "${coordination_acquired:-0}" == '1' ]] || die 'gateway mutation is missing its global coordination lease.'
+  native_coordination_check
+}
+
 validate_release() {
-  local sha=$1 root lineage realbase
+  local sha=$1 root source_root lineage realbase
   [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || die 'release must be a full lowercase SHA.'
   root=$(release_root "$sha")
   [[ -d "$root" && -f "$root/server.mjs" ]] || die "gateway artifact missing for $sha"
+  source_root=$(release_source_root "$sha")
+  [[ -f "$source_root/.skincos-global-coordination-orb.json" ]] || die "gateway coordination closure missing for $sha"
+  [[ -f "$source_root/.skincos-release-identity-orb.json" ]] || die "gateway release identity missing for $sha"
   lineage="$RELEASE_BASE/$sha/source/.skincos-release-lineage.json"
   [[ -f "$lineage" ]] || die "release lineage missing for $sha"
   node --input-type=module - "$lineage" "$sha" <<'NODE'
@@ -54,9 +92,12 @@ select_release() {
   local sha=$1 target tmp
   validate_release "$sha"; target=$(release_root "$sha")
   need_apply
+  coordination_check
   install -d -m 0750 "$(dirname "$LINK")"
+  coordination_check
   tmp="${LINK}.next.$$"
   ln -s "$target" "$tmp"
+  coordination_check
   mv -Tf "$tmp" "$LINK"
   printf 'selected_release=%s\n' "$sha"
 }
@@ -100,13 +141,18 @@ capture_unit_checkpoint() {
   local checkpoint timestamp
   timestamp=$(date -u +%Y%m%dT%H%M%SZ)
   checkpoint="$CHECKPOINT_ROOT/$timestamp-$$"
+  coordination_check
   install -d -m 0700 "$checkpoint"
   if [[ -f "$UNIT_DEST" ]]; then
+    coordination_check
     install -m 0600 "$UNIT_DEST" "$checkpoint/unit.previous.service"
+    coordination_check
     sha256sum "$checkpoint/unit.previous.service" >"$checkpoint/unit.previous.sha256"
   else
+    coordination_check
     printf 'absent\n' >"$checkpoint/unit.previous.absent"
   fi
+  coordination_check
   printf 'service=%s\nunit_destination=%s\n' "$SERVICE" "$UNIT_DEST" >"$checkpoint/metadata"
   printf '%s\n' "$checkpoint"
 }
@@ -114,15 +160,19 @@ capture_unit_checkpoint() {
 restore_unit_checkpoint() {
   local checkpoint=$1 tmp
   [[ "$checkpoint" == "$CHECKPOINT_ROOT"/* && -d "$checkpoint" ]] || die 'checkpoint is outside the gateway checkpoint root.'
+  coordination_check
   if [[ -f "$checkpoint/unit.previous.service" ]]; then
     tmp="${UNIT_DEST}.restore.$$"
     install -m 0644 "$checkpoint/unit.previous.service" "$tmp"
+    coordination_check
     mv -Tf "$tmp" "$UNIT_DEST"
   elif [[ -f "$checkpoint/unit.previous.absent" ]]; then
+    coordination_check
     rm -f -- "$UNIT_DEST"
   else
     die 'checkpoint does not contain a prior unit state.'
   fi
+  coordination_check
   systemd daemon-reload
 }
 
@@ -141,12 +191,27 @@ provision() {
   local target=$1 unit checkpoint tmp
   need_apply
   validate_release "$target"
+  coordination_begin "$target"
   unit=$(unit_source)
   verify_unit "$unit"
   checkpoint=$(capture_unit_checkpoint)
+  coordination_check
   install -d -m 0755 "$(dirname "$UNIT_DEST")"
   tmp="${UNIT_DEST}.next.$$"
-  if ! install -m 0644 "$unit" "$tmp" || ! mv -Tf "$tmp" "$UNIT_DEST" || ! systemd daemon-reload || ! verify_loaded_unit; then
+  coordination_check
+  if ! install -m 0644 "$unit" "$tmp"; then
+    rm -f -- "$tmp"
+    restore_unit_checkpoint "$checkpoint" || true
+    die 'gateway unit provisioning failed and the prior unit was restored.'
+  fi
+  coordination_check
+  if ! mv -Tf "$tmp" "$UNIT_DEST"; then
+    rm -f -- "$tmp"
+    restore_unit_checkpoint "$checkpoint" || true
+    die 'gateway unit provisioning failed and the prior unit was restored.'
+  fi
+  coordination_check
+  if ! systemd daemon-reload || ! verify_loaded_unit; then
     rm -f -- "$tmp"
     restore_unit_checkpoint "$checkpoint" || true
     die 'gateway unit provisioning failed and the prior unit was restored.'
@@ -155,6 +220,7 @@ provision() {
     restore_unit_checkpoint "$checkpoint" || true
     die 'gateway pointer selection failed and the prior unit was restored.'
   fi
+  coordination_check
   printf 'control_release=%s\nunit_checkpoint=%s\n' "$(control_source_root)" "$checkpoint"
 }
 
@@ -165,6 +231,7 @@ health_ok() {
 restart_controlled() {
   local attempt
   need_apply
+  coordination_check
   systemd restart "$SERVICE"
   for attempt in {1..10}; do
     if systemd is-active --quiet "$SERVICE" && health_ok; then return 0; fi
@@ -204,10 +271,36 @@ usage() { echo 'usage: mcp-gateway-release.sh preflight <sha>|provision <sha>|se
 case "${1:-}" in
   preflight) [[ $# -eq 2 ]] || { usage >&2; exit 2; }; validate_release "$2"; echo "preflight_release=$2" ;;
   provision) [[ $# -eq 2 ]] || { usage >&2; exit 2; }; provision "$2" ;;
-  select) [[ $# -eq 2 ]] || { usage >&2; exit 2; }; select_release "$2" ;;
-  restart) [[ $# -eq 1 ]] || { usage >&2; exit 2; }; restart_controlled || die 'gateway restart or health check failed.' ;;
-  promote) [[ $# -eq 3 ]] || { usage >&2; exit 2; }; promote "$2" "$3" ;;
-  rollback) [[ $# -eq 2 ]] || { usage >&2; exit 2; }; select_release "$2"; restart_controlled || die 'gateway rollback restart or health check failed.' ;;
+  select)
+    [[ $# -eq 2 ]] || { usage >&2; exit 2; }
+    need_apply
+    validate_release "$2"
+    coordination_begin "$2"
+    select_release "$2"
+    ;;
+  restart)
+    [[ $# -eq 1 ]] || { usage >&2; exit 2; }
+    configured=$(configured_release || true)
+    [[ "$configured" =~ ^[0-9a-f]{40}$ ]] || die 'gateway restart requires a configured immutable release.'
+    coordination_begin "$configured"
+    restart_controlled || die 'gateway restart or health check failed.'
+    ;;
+  promote)
+    [[ $# -eq 3 ]] || { usage >&2; exit 2; }
+    need_apply
+    validate_release "$2"
+    validate_release "$3"
+    coordination_begin "$2"
+    promote "$2" "$3"
+    ;;
+  rollback)
+    [[ $# -eq 2 ]] || { usage >&2; exit 2; }
+    need_apply
+    validate_release "$2"
+    coordination_begin "$2"
+    select_release "$2"
+    restart_controlled || die 'gateway rollback restart or health check failed.'
+    ;;
   status) [[ $# -eq 1 ]] || { usage >&2; exit 2; }; status ;;
   *) usage >&2; exit 2 ;;
 esac

--- a/scripts/runtime/prepare-atendimento-production-release.sh
+++ b/scripts/runtime/prepare-atendimento-production-release.sh
@@ -16,6 +16,7 @@ run_sudo_clean() {
 readonly RELEASE_BASE='/opt/skincos/releases'
 readonly STATE_ROOT='/var/lib/skincos-runtime/crm-atendimento-production'
 readonly BACKUP_ROOT='/var/backups/skincos/clientes/production-readonly'
+readonly SCRIPT_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 
 RELEASE_SHA=''
 PREDECESSOR_SHA=''
@@ -35,11 +36,15 @@ done
 [[ "$RELEASE_SHA" != "$PREDECESSOR_SHA" ]] || { echo 'Release and predecessor must differ.' >&2; exit 64; }
 readonly SOURCE_ROOT="$RELEASE_BASE/$RELEASE_SHA/source"
 readonly VALIDATOR="$SOURCE_ROOT/crm/api/scripts/validate-atendimento-release.mjs"
+readonly COORDINATION_CLOSURE="$SOURCE_ROOT/.skincos-global-coordination-atendimento.json"
+readonly MANIFEST_DIR="$STATE_ROOT/release-manifests"
+readonly MANIFEST="$MANIFEST_DIR/$RELEASE_SHA.json"
 for command_path in /usr/bin/sudo /usr/bin/env /usr/bin/node /usr/bin/install /usr/bin/date /usr/bin/mktemp /usr/bin/test /usr/bin/rm /usr/bin/printf; do
   [[ -x "$command_path" ]] || { echo "Missing $command_path" >&2; exit 1; }
 done
 /usr/bin/sudo -n true
 run_sudo_clean /usr/bin/test -f "$VALIDATOR" || { echo 'Immutable release validator is unavailable.' >&2; exit 78; }
+run_sudo_clean /usr/bin/test -f "$COORDINATION_CLOSURE" || { echo 'Immutable Atendimento coordination closure is unavailable.' >&2; exit 78; }
 run_sudo_clean /usr/bin/node "$VALIDATOR" --source-root "$SOURCE_ROOT" --release-sha "$RELEASE_SHA" --predecessor-sha "$PREDECESSOR_SHA" >/dev/null
 
 if [[ "$APPLY" != '1' ]]; then
@@ -47,20 +52,39 @@ if [[ "$APPLY" != '1' ]]; then
   exit 0
 fi
 
-stamp="$(/usr/bin/date -u +%Y%m%dT%H%M%SZ)"
-manifest_dir="$STATE_ROOT/release-manifests"
-manifest="$manifest_dir/$RELEASE_SHA.json"
-run_sudo_clean /usr/bin/install -d -m 0750 -o root -g skincos "$manifest_dir"
-run_sudo_clean /usr/bin/install -d -m 0750 -o root -g postgres "$BACKUP_ROOT"
-if run_sudo_clean /usr/bin/test -f "$manifest"; then
+source "$SCRIPT_ROOT/scripts/runtime/global-coordination-native.sh"
+native_coordination_init release:atendimento atendimento "$RELEASE_SHA" "$COORDINATION_CLOSURE" mutation
+coordination_acquired=0
+manifest_exists=0
+if run_sudo_clean /usr/bin/test -f "$MANIFEST"; then
+  manifest_exists=1
+fi
+if [[ "$manifest_exists" == '1' ]]; then
   echo 'Release manifest already exists; immutable release registration is idempotent.'
   exit 0
 fi
 
+cleanup() {
+  /usr/bin/rm -f "${tmp:-}"
+  if [[ "$coordination_acquired" == '1' ]]; then
+    native_coordination_cleanup || true
+    coordination_acquired=0
+  fi
+}
+trap cleanup EXIT INT TERM
+native_coordination_acquire "mini-pc:release:atendimento:register:$RELEASE_SHA:$$" >/dev/null
+coordination_acquired=1
+native_coordination_check
+stamp="$(/usr/bin/date -u +%Y%m%dT%H%M%SZ)"
+native_coordination_check
+run_sudo_clean /usr/bin/install -d -m 0750 -o root -g skincos "$MANIFEST_DIR"
+native_coordination_check
+run_sudo_clean /usr/bin/install -d -m 0750 -o root -g postgres "$BACKUP_ROOT"
+
 umask 0077
 tmp="$(/usr/bin/mktemp /tmp/atendimento-production-manifest.XXXXXX)"
 /usr/bin/test -f "$tmp" -a -O "$tmp"
-trap '/usr/bin/rm -f "$tmp"' EXIT
 /usr/bin/printf '%s\n' "{\"schemaVersion\":1,\"releaseSha\":\"$RELEASE_SHA\",\"predecessorSha\":\"$PREDECESSOR_SHA\",\"preparedAt\":\"$stamp\",\"readOnly\":true,\"syntheticOnly\":true}" >"$tmp"
-run_sudo_clean /usr/bin/install -m 0640 -o root -g skincos "$tmp" "$manifest"
+native_coordination_check
+run_sudo_clean /usr/bin/install -m 0640 -o root -g skincos "$tmp" "$MANIFEST"
 printf 'prepared=true release_sha=%s predecessor_sha=%s manifest_registered=true shared_restart=false\n' "$RELEASE_SHA" "$PREDECESSOR_SHA"

--- a/scripts/runtime/prepare-atendimento-staging-release.sh
+++ b/scripts/runtime/prepare-atendimento-staging-release.sh
@@ -24,13 +24,15 @@ run_skincos_npm() {
 
 RELEASE_SHA=""
 PREDECESSOR_SHA=""
+COORDINATION_CLOSURE=""
 APPLY=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --release-sha) shift; RELEASE_SHA="${1:-}" ;;
     --predecessor-sha) shift; PREDECESSOR_SHA="${1:-}" ;;
+    --coordination-closure) shift; COORDINATION_CLOSURE="${1:-}" ;;
     --apply) APPLY=1 ;;
-    -h|--help) echo "Usage: $0 --release-sha <full-main-sha> --predecessor-sha <full-previous-sha> [--apply]"; exit 0 ;;
+    -h|--help) echo "Usage: $0 --release-sha <full-main-sha> --predecessor-sha <full-previous-sha> [--coordination-closure <json>] [--apply]"; exit 0 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
   shift
@@ -38,6 +40,16 @@ done
 
 [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "--release-sha must be a full lowercase SHA." >&2; exit 1; }
 [[ "$PREDECESSOR_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "--predecessor-sha must be a full lowercase SHA." >&2; exit 1; }
+if [[ "$APPLY" = "1" ]]; then
+  [[ -n "$COORDINATION_CLOSURE" && -f "$COORDINATION_CLOSURE" ]] || {
+    echo '--coordination-closure is required for an applied Atendimento release.' >&2
+    exit 78
+  }
+  [[ "$COORDINATION_CLOSURE" != /mnt/* ]] || {
+    echo '--coordination-closure must already be on native Linux storage.' >&2
+    exit 78
+  }
+fi
 ROOT_DIR="$(cd -- "$(/usr/bin/dirname -- "${BASH_SOURCE[0]}")/../.." && /usr/bin/pwd -P)"
 readonly DESTINATION="$RELEASE_BASE/$RELEASE_SHA/source"
 readonly STAGING="$RELEASE_BASE/.atendimento-staging-$RELEASE_SHA-$$"
@@ -128,6 +140,9 @@ if [[ "$APPLY" != "1" ]]; then
 fi
 
 /usr/bin/sudo -n /usr/bin/true
+source "$ROOT_DIR/scripts/runtime/global-coordination-native.sh"
+native_coordination_init release:atendimento atendimento "$RELEASE_SHA" "$COORDINATION_CLOSURE" mutation
+coordination_acquired=0
 umask 0077
 lineage_file="$(/usr/bin/mktemp /tmp/atendimento-staging-lineage.XXXXXX)"
 printf '{"releaseId":"%s","parentReleaseId":"%s","verifiedAncestor":true,"sourceTree":"%s","target":"staging"}\n' \
@@ -138,24 +153,52 @@ cleanup() {
   # delete.  The validation is deliberately repeated at the sink.
   if [[ "$STAGING" =~ ^/opt/skincos/releases/\.atendimento-staging-[0-9a-f]{40}-[0-9]+$ ]] && \
     [[ "$(dirname "$STAGING")" == "$RELEASE_BASE" ]]; then
-    run_sudo_clean /usr/bin/rm -rf -- "$STAGING" || true
+    if [[ "$coordination_acquired" == '1' ]]; then
+      if native_coordination_check >/dev/null 2>&1; then
+        run_sudo_clean /usr/bin/rm -rf -- "$STAGING" || true
+      else
+        echo 'Global coordination proof was unavailable while cleaning Atendimento staging; staging was left untouched.' >&2
+      fi
+    else
+      run_sudo_clean /usr/bin/rm -rf -- "$STAGING" || true
+    fi
+  fi
+  if [[ "$coordination_acquired" == '1' ]]; then
+    native_coordination_cleanup || true
+    coordination_acquired=0
   fi
 }
 trap cleanup EXIT INT TERM
+native_coordination_acquire "mini-pc:release:atendimento:stage:$RELEASE_SHA:$$" >/dev/null
+coordination_acquired=1
+native_coordination_check
 run_sudo_clean /usr/bin/install -d -o root -g skincos -m 0750 "$STAGING" "$RELEASE_BASE" "$RELEASE_BASE/$RELEASE_SHA" "$NPM_CACHE"
+native_coordination_check
 git_clean archive --format=tar "$RELEASE_SHA" | run_sudo_clean /usr/bin/tar -xf - -C "$STAGING"
+native_coordination_check
 run_sudo_clean /usr/bin/chown -R root:skincos "$STAGING"
+native_coordination_check
 run_sudo_clean /usr/bin/find "$STAGING" -type d -exec /usr/bin/chmod 0750 {} +
+native_coordination_check
 run_sudo_clean /usr/bin/find "$STAGING" -type f -exec /usr/bin/chmod 0640 {} +
+native_coordination_check
 run_sudo_clean /usr/bin/find "$STAGING" -type f \( -path '*/scripts/*.sh' -o -path '*/scripts/*/*.sh' \) -exec /usr/bin/chmod 0750 {} +
 run_sudo_clean /usr/bin/test -f "$STAGING/crm/api/package-lock.json" || { echo "CRM lockfile missing" >&2; exit 1; }
+native_coordination_check
 run_sudo_clean /usr/bin/chown -R skincos:skincos "$STAGING/crm/api"
+native_coordination_check
 run_skincos_npm --prefix "$STAGING/crm/api" ci --omit=dev --ignore-scripts
+native_coordination_check
 run_sudo_clean /usr/bin/chown -R root:skincos "$STAGING/crm/api"
+native_coordination_check
 run_sudo_clean /usr/bin/install -m 0640 -o root -g skincos "$lineage_file" "$STAGING/.skincos-release-lineage.json"
+native_coordination_check
+run_sudo_clean /usr/bin/install -m 0640 -o root -g skincos "$COORDINATION_CLOSURE" "$STAGING/.skincos-global-coordination-atendimento.json"
+native_coordination_check
 run_sudo_clean /usr/bin/install -m 0640 -o root -g skincos /dev/stdin "$STAGING/.skincos-atendimento-release.json" <<EOF
 {"releaseSha":"$RELEASE_SHA","sourceTree":"$tree_sha","target":"staging","domain":"atendimento","syntheticOnly":true}
 EOF
+native_coordination_check
 run_sudo_clean /usr/bin/mv -- "$STAGING" "$DESTINATION"
 /usr/bin/rm -f -- "$lineage_file"
 trap - EXIT INT TERM

--- a/scripts/runtime/prepare-atendimento-staging-release.sh
+++ b/scripts/runtime/prepare-atendimento-staging-release.sh
@@ -201,6 +201,11 @@ EOF
 native_coordination_check
 run_sudo_clean /usr/bin/mv -- "$STAGING" "$DESTINATION"
 /usr/bin/rm -f -- "$lineage_file"
+# Release the remote custody before disabling the EXIT trap.  The successful
+# move is the final mutation; keeping the lease until process exit would hold
+# release:atendimento for the remainder of the native command timeout.
+native_coordination_cleanup
+coordination_acquired=0
 trap - EXIT INT TERM
 echo "release_sha=$RELEASE_SHA"
 echo "source_tree=$tree_sha"

--- a/scripts/runtime/prepare-lifecycle-layout.sh
+++ b/scripts/runtime/prepare-lifecycle-layout.sh
@@ -8,10 +8,13 @@ TMP_ROOT="${TMP_ROOT:-/var/tmp/skincos}"
 ARTIFACT_ROOT="${ARTIFACT_ROOT:-$STATE_ROOT/artifacts}"
 BACKUP_ROOT="${BACKUP_ROOT:-/var/backups/skincos}"
 APPLY=0
+SOURCE_SHA="${SKINCOS_GLOBAL_COORDINATION_SOURCE_SHA:-}"
+COORDINATION_CLOSURE="${SKINCOS_GLOBAL_COORDINATION_CLOSURE_FILE:-}"
+SCRIPT_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 
 usage() {
   cat <<'EOF'
-Usage: scripts/runtime/prepare-lifecycle-layout.sh [--apply]
+Usage: scripts/runtime/prepare-lifecycle-layout.sh [--source-sha <full-sha>] [--coordination-closure <json>] [--apply]
 
 Creates the final native Linux runtime layout with least-privilege ownership.
 It never reads or copies legacy Windows/DrvFS state. State recovery must use a
@@ -22,6 +25,8 @@ EOF
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --apply) APPLY=1 ;;
+    --source-sha) [[ "$#" -ge 2 ]] || { echo '--source-sha requires a value' >&2; exit 64; }; SOURCE_SHA="$2"; shift ;;
+    --coordination-closure) [[ "$#" -ge 2 ]] || { echo '--coordination-closure requires a value' >&2; exit 64; }; COORDINATION_CLOSURE="$2"; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
   esac
@@ -62,15 +67,52 @@ if [[ "$APPLY" != "1" ]]; then
   exit 0
 fi
 
+source "$SCRIPT_ROOT/scripts/runtime/global-coordination-native.sh"
+resolved_source_root="$(readlink -f /opt/skincos/current/source)"
+[[ "$resolved_source_root" =~ ^/opt/skincos/releases/[0-9a-f]{40}/source$ ]] || {
+  echo "Native runtime source is not an immutable release: $resolved_source_root" >&2
+  exit 78
+}
+derived_source_sha="$(basename "$(dirname "$resolved_source_root")")"
+if [[ -z "$SOURCE_SHA" ]]; then
+  SOURCE_SHA="$derived_source_sha"
+fi
+[[ "$SOURCE_SHA" == "$derived_source_sha" && "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+  echo 'Lifecycle layout source SHA does not match the current immutable source.' >&2
+  exit 78
+}
+if [[ -z "$COORDINATION_CLOSURE" ]]; then
+  COORDINATION_CLOSURE="$resolved_source_root/.skincos-global-coordination-native-runtime.json"
+fi
+[[ -f "$COORDINATION_CLOSURE" ]] || {
+  echo "Native-runtime coordination closure is unavailable: $COORDINATION_CLOSURE" >&2
+  exit 78
+}
+native_coordination_init global:native-runtime native-runtime "$SOURCE_SHA" "$COORDINATION_CLOSURE" mutation
+coordination_acquired=0
+overlay=''
+cleanup() {
+  [[ -z "$overlay" ]] || rm -f "$overlay"
+  if [[ "$coordination_acquired" == '1' ]]; then
+    native_coordination_cleanup || true
+    coordination_acquired=0
+  fi
+}
+trap cleanup EXIT INT TERM
+native_coordination_acquire "mini-pc:global:native-runtime:layout:$SOURCE_SHA:$$" >/dev/null
+coordination_acquired=1
+native_coordination_check
 sudo -n true
 for directory in "${directories[@]}"; do
+  native_coordination_check
   sudo -n install -d -o skincos -g skincos -m 0750 "$directory"
 done
+native_coordination_check
 sudo -n chown root:skincos "$CONFIG_ROOT" "$CONFIG_ROOT/cloudflare" "$BACKUP_ROOT" "$BACKUP_ROOT/orb"
+native_coordination_check
 sudo -n chmod 0750 "$CONFIG_ROOT" "$CONFIG_ROOT/cloudflare" "$BACKUP_ROOT" "$BACKUP_ROOT/orb"
 
 overlay="$(mktemp)"
-trap 'rm -f "$overlay"' EXIT
 cat >"$overlay" <<EOF
 N8N_RESTRICT_FILE_ACCESS_TO=/tmp
 META_REVIEW_STORE_PATH=$STATE_ROOT/orb/meta-review-store.json
@@ -78,5 +120,6 @@ N8N_USER_FOLDER=$STATE_ROOT/orb/n8n-home
 N8N_STORAGE_PATH=$STATE_ROOT/orb/n8n-home/.n8n/storage
 N8N_LOG_FILE_LOCATION=$LOG_ROOT/orb/n8n.log
 EOF
+native_coordination_check
 sudo -n install -o root -g skincos -m 0640 "$overlay" "$CONFIG_ROOT/orb-runtime-paths.env"
 echo 'Native lifecycle layout prepared.'

--- a/scripts/runtime/prepare-messaging-whatsapp-release.sh
+++ b/scripts/runtime/prepare-messaging-whatsapp-release.sh
@@ -9,11 +9,12 @@ RELEASE_ID="${MESSAGING_RELEASE_ID:-}"
 DESTINATION="$RELEASE_BASE/$RELEASE_ID/messaging-whatsapp"
 STAGING="$RELEASE_BASE/.staging-$RELEASE_ID-$$"
 NPM_CACHE="${MESSAGING_NPM_CACHE:-/var/lib/skincos-runtime/cache/npm}"
+COORDINATION_CLOSURE="${SKINCOS_GLOBAL_COORDINATION_CLOSURE_FILE:-}"
 APPLY=0
 
 usage() {
   cat <<'EOF'
-Usage: scripts/runtime/prepare-messaging-whatsapp-release.sh [--apply]
+Usage: scripts/runtime/prepare-messaging-whatsapp-release.sh [--coordination-closure <json>] [--apply]
 
 Stages the WhatsApp engine as a native Linux release. With --apply it copies
 only tracked source and lockfiles, installs dependencies, generates Prisma,
@@ -29,6 +30,7 @@ EOF
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --apply) APPLY=1 ;;
+    --coordination-closure) shift; COORDINATION_CLOSURE="${1:-}" ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
   esac
@@ -37,7 +39,7 @@ done
 
 [[ -f "$SOURCE_DIR/package-lock.json" ]] || { echo "Missing lockfile: $SOURCE_DIR/package-lock.json" >&2; exit 1; }
 [[ -f "$SOURCE_DIR/src/main.ts" ]] || { echo "Missing source entrypoint: $SOURCE_DIR/src/main.ts" >&2; exit 1; }
-[[ "$RELEASE_ID" =~ ^[0-9a-f]{7,64}$ ]] || { echo 'MESSAGING_RELEASE_ID must be a reviewed hexadecimal commit SHA.' >&2; exit 1; }
+[[ "$RELEASE_ID" =~ ^[0-9a-f]{40}$ ]] || { echo 'MESSAGING_RELEASE_ID must be a full reviewed commit SHA.' >&2; exit 1; }
 [[ ! -e "$DESTINATION" ]] || { echo "Release destination already exists: $DESTINATION" >&2; exit 1; }
 
 echo "Release ID: $RELEASE_ID"
@@ -48,16 +50,43 @@ if [[ "$APPLY" != "1" ]]; then
   exit 0
 fi
 
-command -v rsync >/dev/null 2>&1 || { echo 'Missing required command: rsync' >&2; exit 1; }
-command -v npm >/dev/null 2>&1 || { echo 'Missing required command: npm' >&2; exit 1; }
-command -v sudo >/dev/null 2>&1 || { echo 'Missing required command: sudo' >&2; exit 1; }
-sudo -n true
-
+[[ -n "$COORDINATION_CLOSURE" && -f "$COORDINATION_CLOSURE" ]] || {
+  echo 'An immutable Orb dependency-closure attestation is required for WhatsApp artifact promotion.' >&2
+  exit 78
+}
+coordination_proof="${SKINCOS_GLOBAL_COORDINATION_PROOF_FILE:-/var/lib/skincos-runtime/global-coordination/release-orb-whatsapp-$RELEASE_ID-$$.json}"
+artifact_identity_file="$(mktemp /tmp/skincos-whatsapp-release-identity.XXXXXX)"
+coordination_acquired=0
+coordination_run() {
+  "$ROOT_DIR/scripts/runtime/global-coordination-mini-pc.sh" "$@" --proof-file "$coordination_proof"
+}
 cleanup_staging() {
   sudo -n rm -rf "$STAGING"
 }
-trap cleanup_staging EXIT INT TERM
+cleanup_coordination() {
+  if (( coordination_acquired == 1 )); then
+    coordination_run release >/dev/null 2>&1 || echo 'Unable to release the mini-PC Orb lease; it will expire fail-closed.' >&2
+  fi
+  cleanup_staging
+  rm -f -- "$artifact_identity_file"
+}
+trap cleanup_coordination EXIT INT TERM
+coordination_run acquire \
+  --resource release:orb --module orb --source "$RELEASE_ID" --closure-file "$COORDINATION_CLOSURE" \
+  --operation mutation --idempotency-key "mini-pc:release:orb:whatsapp:build:$RELEASE_ID:$$" >/dev/null
+coordination_acquired=1
+coordination_run check \
+  --resource release:orb --module orb --source "$RELEASE_ID" --closure-file "$COORDINATION_CLOSURE" >/dev/null
 
+command -v rsync >/dev/null 2>&1 || { echo 'Missing required command: rsync' >&2; exit 1; }
+command -v npm >/dev/null 2>&1 || { echo 'Missing required command: npm' >&2; exit 1; }
+command -v sha256sum >/dev/null 2>&1 || { echo 'Missing required command: sha256sum' >&2; exit 1; }
+command -v awk >/dev/null 2>&1 || { echo 'Missing required command: awk' >&2; exit 1; }
+command -v sudo >/dev/null 2>&1 || { echo 'Missing required command: sudo' >&2; exit 1; }
+sudo -n true
+
+coordination_run check \
+  --resource release:orb --module orb --source "$RELEASE_ID" --closure-file "$COORDINATION_CLOSURE" >/dev/null
 sudo -n install -d -o skincos -g skincos -m 0750 "$STAGING" "$NPM_CACHE"
 # The cache is durable runtime state. A prior diagnostic run as another user
 # must not make a later production release fail before dependencies are built.
@@ -77,9 +106,44 @@ sudo -n -u skincos npm --prefix "$STAGING" run db:generate
 sudo -n -u skincos npm --prefix "$STAGING" run build
 [[ -f "$STAGING/dist/main.js" ]] || { echo "Build did not produce dist/main.js" >&2; exit 1; }
 
+artifact_digest="$(sha256sum "$STAGING/dist/main.js" | awk '{print $1}')"
+node - "$COORDINATION_CLOSURE" "$RELEASE_ID" "$artifact_digest" > "$artifact_identity_file" <<'NODE'
+const fs = require('fs');
+const [closureFile, releaseId, artifactDigest] = process.argv.slice(2);
+const closure = JSON.parse(fs.readFileSync(closureFile, 'utf8'));
+const identity = {
+  schemaVersion: 1,
+  module: 'orb',
+  sourceCommit: String(closure.sourceCommit).toLowerCase(),
+  sourceTree: String(closure.sourceTree).toLowerCase(),
+  dependencyClosureDigest: String(closure.digest).toLowerCase(),
+  artifacts: [{ name: 'whatsapp-dist-main', id: `whatsapp-dist:${releaseId}`, digest: artifactDigest }],
+};
+process.stdout.write(`${JSON.stringify(identity, null, 2)}\n`);
+NODE
+
+coordination_run check \
+  --resource release:orb --module orb --source "$RELEASE_ID" --closure-file "$COORDINATION_CLOSURE" >/dev/null
 sudo -n install -d -o root -g skincos -m 0750 "$(dirname "$DESTINATION")"
+coordination_run check \
+  --resource release:orb --module orb --source "$RELEASE_ID" --closure-file "$COORDINATION_CLOSURE" >/dev/null
+coordination_run release >/dev/null
+coordination_acquired=0
+coordination_run acquire \
+  --resource release:orb --module orb --source "$RELEASE_ID" --closure-file "$COORDINATION_CLOSURE" \
+  --operation promotion --release-identity-file "$artifact_identity_file" \
+  --idempotency-key "mini-pc:release:orb:whatsapp:promote:$RELEASE_ID:$$" >/dev/null
+coordination_acquired=1
+coordination_run check \
+  --resource release:orb --module orb --source "$RELEASE_ID" --closure-file "$COORDINATION_CLOSURE" >/dev/null
+sudo -n install -m 0640 "$artifact_identity_file" "$STAGING/.skincos-release-identity-orb.json"
+coordination_run check \
+  --resource release:orb --module orb --source "$RELEASE_ID" --closure-file "$COORDINATION_CLOSURE" >/dev/null
 sudo -n mv "$STAGING" "$DESTINATION"
-trap - EXIT INT TERM
+coordination_run check \
+  --resource release:orb --module orb --source "$RELEASE_ID" --closure-file "$COORDINATION_CLOSURE" >/dev/null
 sudo -n install -d -o root -g skincos -m 0750 "$(dirname "$CURRENT_LINK")"
+coordination_run check \
+  --resource release:orb --module orb --source "$RELEASE_ID" --closure-file "$COORDINATION_CLOSURE" >/dev/null
 sudo -n ln -sfn "$DESTINATION" "$CURRENT_LINK"
 echo "Native WhatsApp release prepared: $CURRENT_LINK -> $DESTINATION"

--- a/scripts/runtime/prepare-native-source-release.sh
+++ b/scripts/runtime/prepare-native-source-release.sh
@@ -20,6 +20,7 @@ CRM_NPM_CACHE="${CRM_NPM_CACHE:-/var/lib/skincos-runtime/cache/crm-api}"
 COORDINATION_PROOF_FILE="${SKINCOS_GLOBAL_COORDINATION_PROOF_FILE:-}"
 coordination_acquired=0
 release_identity_file=''
+native_runtime_identity_file=''
 APPLY=0
 STAGE_ONLY=0
 
@@ -149,7 +150,8 @@ actual_archive_sha256="$(sha256sum "$RELEASE_ARCHIVE" | awk '{print $1}')"
 actual_lineage_sha256="$(sha256sum "$RELEASE_LINEAGE" | awk '{print $1}')"
 [[ "${actual_lineage_sha256,,}" == "${RELEASE_LINEAGE_SHA256,,}" ]] || { echo 'Source lineage checksum mismatch.' >&2; exit 1; }
 release_identity_file="$(mktemp /tmp/skincos-native-release-identity.XXXXXX)"
-cleanup_identity() { rm -f -- "$release_identity_file"; }
+native_runtime_identity_file="$(mktemp /tmp/skincos-native-runtime-release-identity.XXXXXX)"
+cleanup_identity() { rm -f -- "$release_identity_file" "$native_runtime_identity_file"; }
 trap cleanup_identity EXIT INT TERM
 node - "$coordination_orb_closure" "$RELEASE_ID" "${RELEASE_ARCHIVE_SHA256,,}" > "$release_identity_file" <<'NODE'
 const fs = require('fs');
@@ -158,6 +160,20 @@ const closure = JSON.parse(fs.readFileSync(closureFile, 'utf8'));
 const identity = {
   schemaVersion: 1,
   module: 'orb',
+  sourceCommit: String(closure.sourceCommit).toLowerCase(),
+  sourceTree: String(closure.sourceTree).toLowerCase(),
+  dependencyClosureDigest: String(closure.digest).toLowerCase(),
+  artifacts: [{ name: 'native-source-archive', id: `native-source:${releaseId}`, digest: archiveDigest }],
+};
+process.stdout.write(`${JSON.stringify(identity, null, 2)}\n`);
+NODE
+node - "$coordination_native_runtime_closure" "$RELEASE_ID" "${RELEASE_ARCHIVE_SHA256,,}" > "$native_runtime_identity_file" <<'NODE'
+const fs = require('fs');
+const [closureFile, releaseId, archiveDigest] = process.argv.slice(2);
+const closure = JSON.parse(fs.readFileSync(closureFile, 'utf8'));
+const identity = {
+  schemaVersion: 1,
+  module: 'native-runtime',
   sourceCommit: String(closure.sourceCommit).toLowerCase(),
   sourceTree: String(closure.sourceTree).toLowerCase(),
   dependencyClosureDigest: String(closure.digest).toLowerCase(),
@@ -208,8 +224,8 @@ cleanup_all() {
     coordination_run release >/dev/null 2>&1 || echo 'Unable to release the mini-PC Orb staging lease; it will expire fail-closed.' >&2
     coordination_acquired=0
   fi
-  if [[ -n "$release_identity_file" ]]; then
-    rm -f -- "$release_identity_file"
+  if [[ -n "$release_identity_file" || -n "$native_runtime_identity_file" ]]; then
+    rm -f -- "$release_identity_file" "$native_runtime_identity_file"
   fi
 }
 trap cleanup_all EXIT INT TERM
@@ -239,6 +255,8 @@ NODE
 done
 coordination_check
 sudo -n install -m 0640 "$release_identity_file" "$STAGING/.skincos-release-identity-orb.json"
+coordination_check
+sudo -n install -m 0640 "$native_runtime_identity_file" "$STAGING/.skincos-release-identity-native-runtime.json"
 coordination_check
 sudo -n chown -R root:skincos "$STAGING"
 coordination_check

--- a/scripts/runtime/prepare-native-source-release.sh
+++ b/scripts/runtime/prepare-native-source-release.sh
@@ -15,13 +15,17 @@ RELEASE_ARCHIVE=""
 RELEASE_ARCHIVE_SHA256=""
 RELEASE_LINEAGE=""
 RELEASE_LINEAGE_SHA256=""
+COORDINATION_CLOSURES=()
 CRM_NPM_CACHE="${CRM_NPM_CACHE:-/var/lib/skincos-runtime/cache/crm-api}"
+COORDINATION_PROOF_FILE="${SKINCOS_GLOBAL_COORDINATION_PROOF_FILE:-}"
+coordination_acquired=0
+release_identity_file=''
 APPLY=0
 STAGE_ONLY=0
 
 usage() {
   cat <<'EOF'
-Usage: scripts/runtime/prepare-native-source-release.sh --archive <native-tar> --sha256 <sha256> --lineage <json> --lineage-sha256 <sha256> [--apply --stage-only]
+Usage: scripts/runtime/prepare-native-source-release.sh --archive <native-tar> --sha256 <sha256> --lineage <json> --lineage-sha256 <sha256> [--coordination-closure <json>]... [--apply --stage-only]
 
 Set SKINCOS_RELEASE_ID to the reviewed main commit SHA. The archive must have
 already been created and copied by Windows into a native Linux path (never
@@ -34,6 +38,10 @@ It never copies private .env files or worktree metadata.
 The lineage JSON is produced by verify-native-source-release-lineage.ps1 from
 the reviewed Git repository. It proves the candidate is a descendant of the
 currently effective release and is copied immutably into the staged bundle.
+
+Each applied release must also carry one or more dependency-closure attestations
+generated from the same reviewed commit. They are installed below the immutable
+source tree for the mini-PC coordination adapter.
 EOF
 }
 
@@ -45,6 +53,7 @@ while [[ $# -gt 0 ]]; do
     --sha256) RELEASE_ARCHIVE_SHA256="${2:-}"; shift ;;
     --lineage) RELEASE_LINEAGE="${2:-}"; shift ;;
     --lineage-sha256) RELEASE_LINEAGE_SHA256="${2:-}"; shift ;;
+    --coordination-closure) COORDINATION_CLOSURES+=("${2:-}"); shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
   esac
@@ -60,6 +69,60 @@ done
 [[ "$RELEASE_LINEAGE_SHA256" =~ ^[A-Fa-f0-9]{64}$ ]] || { echo '--lineage-sha256 must be a SHA-256 hexadecimal digest.' >&2; exit 1; }
 [[ ! -e "$DESTINATION" ]] || { echo "Source release destination already exists: $DESTINATION" >&2; exit 1; }
 [[ "$STAGE_ONLY" != "1" || "$APPLY" = "1" ]] || { echo '--stage-only requires --apply.' >&2; exit 1; }
+if [[ "$APPLY" = "1" && "${#COORDINATION_CLOSURES[@]}" -eq 0 ]]; then
+  echo 'At least one --coordination-closure attestation is required for an applied native release.' >&2
+  exit 1
+fi
+coordination_orb_closure=''
+coordination_native_runtime_closure=''
+for closure_file in "${COORDINATION_CLOSURES[@]}"; do
+  [[ -n "$closure_file" && -f "$closure_file" ]] || { echo "Coordination closure is unavailable: $closure_file" >&2; exit 1; }
+  [[ "$closure_file" != /mnt/* ]] || { echo 'Coordination closure must already be on native Linux storage.' >&2; exit 1; }
+  closure_module="$(node - "$closure_file" "$RELEASE_ID" <<'NODE'
+const fs = require('fs');
+const crypto = require('crypto');
+const [file, expectedSource] = process.argv.slice(2);
+const value = JSON.parse(fs.readFileSync(file, 'utf8'));
+const canonicalJson = (input) => Array.isArray(input)
+  ? `[${input.map(canonicalJson).join(',')}]`
+  : input && typeof input === 'object'
+    ? `{${Object.keys(input).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(input[key])}`).join(',')}}`
+    : JSON.stringify(input);
+if (!/^[0-9a-f]{40}$/.test(String(value.sourceCommit || '').toLowerCase())
+  || String(value.sourceCommit).toLowerCase() !== expectedSource.toLowerCase()
+  || !/^[0-9a-f]{40}$/.test(String(value.sourceTree || '').toLowerCase())
+  || !/^[0-9a-f]{64}$/.test(String(value.digest || '').toLowerCase())
+  || !/^[a-z0-9][a-z0-9._/-]{0,127}$/.test(String(value.module || '').toLowerCase())
+  || !value.material || value.material.schemaVersion !== 1
+  || value.material.module !== String(value.module).toLowerCase()
+  || !Array.isArray(value.material.inputs) || value.material.inputs.length === 0
+  || crypto.createHash('sha256').update(canonicalJson(value.material)).digest('hex') !== String(value.digest).toLowerCase()) {
+  throw new Error('coordination closure identity or digest is invalid');
+}
+for (const entry of value.material.inputs) {
+  if (!entry || typeof entry.path !== 'string' || entry.path.startsWith('/') || entry.path.split('/').includes('..') || !/^[0-9a-f]{40}$/.test(String(entry.blob || '').toLowerCase())) {
+    throw new Error('coordination closure input is invalid');
+  }
+}
+process.stdout.write(String(value.module).toLowerCase());
+NODE
+)"
+  printf 'coordination_module=%s\n' "$closure_module"
+  if [[ "$closure_module" == 'orb' ]]; then
+    coordination_orb_closure="$closure_file"
+  fi
+  if [[ "$closure_module" == 'native-runtime' ]]; then
+    coordination_native_runtime_closure="$closure_file"
+  fi
+done
+if [[ "$APPLY" = "1" && -z "$coordination_orb_closure" ]]; then
+  echo 'An Orb dependency-closure attestation is required for an applied native source release.' >&2
+  exit 1
+fi
+if [[ "$APPLY" = "1" && -z "$coordination_native_runtime_closure" ]]; then
+  echo 'A native-runtime dependency-closure attestation is required for an applied native source release.' >&2
+  exit 1
+fi
 readonly ARCHIVE_PREFIX="skincos-$RELEASE_ID/"
 
 echo "Source release ID: $RELEASE_ID"
@@ -85,6 +148,23 @@ actual_archive_sha256="$(sha256sum "$RELEASE_ARCHIVE" | awk '{print $1}')"
 [[ "${actual_archive_sha256,,}" == "${RELEASE_ARCHIVE_SHA256,,}" ]] || { echo 'Source archive checksum mismatch.' >&2; exit 1; }
 actual_lineage_sha256="$(sha256sum "$RELEASE_LINEAGE" | awk '{print $1}')"
 [[ "${actual_lineage_sha256,,}" == "${RELEASE_LINEAGE_SHA256,,}" ]] || { echo 'Source lineage checksum mismatch.' >&2; exit 1; }
+release_identity_file="$(mktemp /tmp/skincos-native-release-identity.XXXXXX)"
+cleanup_identity() { rm -f -- "$release_identity_file"; }
+trap cleanup_identity EXIT INT TERM
+node - "$coordination_orb_closure" "$RELEASE_ID" "${RELEASE_ARCHIVE_SHA256,,}" > "$release_identity_file" <<'NODE'
+const fs = require('fs');
+const [closureFile, releaseId, archiveDigest] = process.argv.slice(2);
+const closure = JSON.parse(fs.readFileSync(closureFile, 'utf8'));
+const identity = {
+  schemaVersion: 1,
+  module: 'orb',
+  sourceCommit: String(closure.sourceCommit).toLowerCase(),
+  sourceTree: String(closure.sourceTree).toLowerCase(),
+  dependencyClosureDigest: String(closure.digest).toLowerCase(),
+  artifacts: [{ name: 'native-source-archive', id: `native-source:${releaseId}`, digest: archiveDigest }],
+};
+process.stdout.write(`${JSON.stringify(identity, null, 2)}\n`);
+NODE
 if ! tar -tzf "$RELEASE_ARCHIVE" | awk -v prefix="$ARCHIVE_PREFIX" '
   BEGIN { found = 0; invalid = 0 }
   NF {
@@ -108,33 +188,84 @@ NODE
 )" || { echo 'Source lineage JSON is invalid.' >&2; exit 1; }
 echo "Verified release lineage parent: $lineage_parent"
 
-cleanup_staging() {
-  sudo -n rm -rf "$STAGING"
+coordination_run() {
+  "$ROOT_DIR/scripts/runtime/global-coordination-mini-pc.sh" "$@" --proof-file "$COORDINATION_PROOF_FILE"
 }
-trap cleanup_staging EXIT INT TERM
+coordination_check() {
+  coordination_run check \
+    --resource release:orb --module orb --source "$RELEASE_ID" \
+    --closure-file "$coordination_orb_closure" >/dev/null
+}
+cleanup_all() {
+  if (( coordination_acquired == 1 )); then
+    if [[ -d "$STAGING" ]]; then
+      if coordination_check; then
+        sudo -n rm -rf "$STAGING"
+      else
+        echo 'Global coordination proof was unavailable while cleaning native staging; staging was left untouched.' >&2
+      fi
+    fi
+    coordination_run release >/dev/null 2>&1 || echo 'Unable to release the mini-PC Orb staging lease; it will expire fail-closed.' >&2
+    coordination_acquired=0
+  fi
+  if [[ -n "$release_identity_file" ]]; then
+    rm -f -- "$release_identity_file"
+  fi
+}
+trap cleanup_all EXIT INT TERM
+
+COORDINATION_PROOF_FILE="${COORDINATION_PROOF_FILE:-/var/lib/skincos-runtime/global-coordination/release-orb-stage-$RELEASE_ID-$$.json}"
+coordination_run acquire \
+  --resource release:orb --module orb --source "$RELEASE_ID" \
+  --closure-file "$coordination_orb_closure" --operation mutation \
+  --idempotency-key "mini-pc:release:orb:stage:$RELEASE_ID:$$" >/dev/null
+coordination_acquired=1
+coordination_check
 
 sudo -n install -d -o root -g skincos -m 0750 "$STAGING" "$CRM_NPM_CACHE"
+coordination_check
 sudo -n tar -xzf "$RELEASE_ARCHIVE" --strip-components=1 -C "$STAGING"
+coordination_check
 sudo -n install -m 0640 "$RELEASE_LINEAGE" "$STAGING/.skincos-release-lineage.json"
+coordination_check
+for closure_file in "${COORDINATION_CLOSURES[@]}"; do
+  closure_module="$(node - "$closure_file" <<'NODE'
+const fs = require('fs');
+const [file] = process.argv.slice(2);
+process.stdout.write(String(JSON.parse(fs.readFileSync(file, 'utf8')).module).toLowerCase());
+NODE
+)"
+  sudo -n install -m 0640 "$closure_file" "$STAGING/.skincos-global-coordination-${closure_module}.json"
+done
+coordination_check
+sudo -n install -m 0640 "$release_identity_file" "$STAGING/.skincos-release-identity-orb.json"
+coordination_check
 sudo -n chown -R root:skincos "$STAGING"
+coordination_check
 sudo -n find "$STAGING" -type d -exec chmod 0750 {} +
+coordination_check
 sudo -n find "$STAGING" -type f -exec chmod 0640 {} +
+coordination_check
 sudo -n find "$STAGING" -type f \( -path '*/scripts/*.sh' -o -path '*/scripts/*/*.sh' \) -exec chmod 0750 {} +
 # These two operator-only scripts must execute as postgres for local peer
 # authentication to the n8n database. They contain no credentials; keep the
 # rest of the staged source restricted to root:skincos.
+coordination_check
 sudo -n chmod 0644 \
   "$STAGING/orb/engine/scripts/workflow-runtime-manifest.js" \
   "$STAGING/orb/engine/scripts/apply-livia-runtime-isolation.js"
+coordination_check
 sudo -n chown -R skincos:skincos "$CRM_NPM_CACHE"
 
 sudo -n test -f "$STAGING/crm/api/package-lock.json" || { echo 'CRM lockfile is missing from source release.' >&2; exit 1; }
 # npm must write node_modules during staging, but the promoted source returns
 # to root ownership before any service is allowed to execute it.
+coordination_check
 sudo -n chown -R skincos:skincos "$STAGING/crm/api"
 sudo -n -u skincos env npm_config_cache="$CRM_NPM_CACHE" \
   npm --prefix "$STAGING/crm/api" ci --omit=dev --ignore-scripts
 sudo -n test -d "$STAGING/crm/api/node_modules/express" || { echo 'CRM production dependencies were not installed.' >&2; exit 1; }
+coordination_check
 sudo -n chown -R root:skincos "$STAGING/crm/api"
 sudo -n test -f "$STAGING/orb/engine/orb-proxy/server.js" || { echo 'Orb proxy source is missing from source release.' >&2; exit 1; }
 sudo -n test -f "$STAGING/integration/ef/requirements.lock" || { echo 'Booking requirements are missing from source release.' >&2; exit 1; }
@@ -155,16 +286,21 @@ sudo -n -u skincos env \
   N8N_RUNTIME_HOME="${N8N_RUNTIME_HOME:-/var/lib/skincos-runtime/orb}" \
   node "$STAGING/orb/engine/scripts/livia/build-platform-job-graph.js" --assert-job-graph-contracts >/dev/null
 
+coordination_check
 sudo -n install -d -o root -g skincos -m 0750 "$(dirname "$DESTINATION")"
+coordination_check
 sudo -n mv "$STAGING" "$DESTINATION"
-trap - EXIT INT TERM
+coordination_check
 sudo -n install -d -o root -g skincos -m 0750 "$(dirname "$CURRENT_LINK")"
 # The versioned n8n writer authenticates locally as postgres. Permit only
 # traversal to its immutable scripts and only manifest-directory writes; no
 # workflow sidecar or source tree becomes generally readable or writable.
+coordination_check
 for acl_dir in "$RELEASE_BASE" "$RELEASE_BASE/$RELEASE_ID" "$DESTINATION" "$DESTINATION/orb" "$DESTINATION/orb/engine" "$DESTINATION/orb/engine/scripts" "$DESTINATION/orb/engine/scripts/livia" "$DESTINATION/orb/engine/scripts/lib" "$DESTINATION/orb/engine/workflow-src" "$DESTINATION/orb/engine/workflow-src/meta-ads-publish" "$DESTINATION/orb/engine/workflows" "$CURRENT_LINK"; do
+  coordination_check
   sudo -n setfacl -m u:postgres:--x "$acl_dir"
 done
+coordination_check
 sudo -n setfacl -m u:postgres:r-- \
   "$DESTINATION/orb/engine/scripts/workflow-runtime-manifest.js" \
   "$DESTINATION/orb/engine/scripts/apply-livia-runtime-isolation.js"
@@ -173,6 +309,7 @@ sudo -n setfacl -m u:postgres:r-- \
 # consume the exact same immutable source tree.  Their patch modules contain
 # no credentials, but must be readable rather than relying on a privileged
 # operator-side workaround during a promotion.
+coordination_check
 sudo -n setfacl -m u:postgres:r-- \
   "$DESTINATION/orb/engine/scripts/prepare-livia-production-candidate.js" \
   "$DESTINATION/orb/engine/scripts/validate-livia-workflow.js" \
@@ -187,6 +324,7 @@ sudo -n setfacl -m u:postgres:r-- \
 # sidecar entrypoints before committing a workflow version, so it needs read
 # access to those files only (directory traversal is granted above).  Without
 # these ACLs a promotion aborts before the transaction can create its manifest.
+coordination_check
 sudo -n setfacl -m u:postgres:r-- \
   "$DESTINATION/orb/engine/compose2-current.js" \
   "$DESTINATION/orb/engine/scripts/livia/process-media-asset.js" \
@@ -198,6 +336,7 @@ sudo -n setfacl -m u:postgres:r-- \
 # Its source comparison reads the immutable workflow export and all 49 Code-node
 # sources. Grant only read/traverse access to that audit surface; it contains no
 # runtime credentials and remains non-writable to postgres.
+coordination_check
 sudo -n setfacl -m u:postgres:r-- \
   "$DESTINATION/orb/engine/scripts/inspect-meta-ads-publish-version-alignment.js" \
   "$DESTINATION/orb/engine/scripts/validate-meta-ads-publish-preflight.js" \
@@ -206,9 +345,13 @@ sudo -n setfacl -m u:postgres:r-- \
   "$DESTINATION/orb/engine/scripts/lib/meta-ads-publish-execution-semantics.js" \
   "$DESTINATION/orb/engine/scripts/lib/meta-ads-publish-code-sources.js" \
   "$DESTINATION/orb/engine/workflows/meta-ads-publish.current.json"
+coordination_check
 sudo -n setfacl -Rm u:postgres:rX "$DESTINATION/orb/engine/workflow-src/meta-ads-publish"
 MANIFEST_DIR="${N8N_RUNTIME_HOME:-/var/lib/skincos-runtime/orb}/workflow-runtime-manifests/WGXr4vYkv9UoJ8zc"
+coordination_check
 sudo -n install -d -o root -g root -m 0750 "$MANIFEST_DIR"
+coordination_check
 sudo -n setfacl -m u:postgres:--x "$(dirname "$(dirname "$MANIFEST_DIR")")" "$(dirname "$MANIFEST_DIR")"
+coordination_check
 sudo -n setfacl -m u:postgres:rwx "$MANIFEST_DIR"
 echo "Native source release staged: $DESTINATION"

--- a/scripts/runtime/promote-native-source-release.sh
+++ b/scripts/runtime/promote-native-source-release.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # The only supported source-pointer promotion.  It holds a fail-closed Livia
 # maintenance window, requires every active workflow to be free of mutable
 # helper paths, and starts Orb only after the pointer changed.
+readonly SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 readonly RELEASE_BASE="${SKINCOS_RELEASE_BASE:-/opt/skincos/releases}"
 readonly CURRENT_LINK="${SKINCOS_SOURCE_CURRENT_LINK:-/opt/skincos/current/source}"
 readonly SERVICE='orb.service'
@@ -47,6 +48,10 @@ target="$RELEASE_BASE/$release_id/source"
 [[ -d "$target/orb/engine" ]] || { echo "Staged release is missing: $target" >&2; exit 1; }
 lineage_file="$target/.skincos-release-lineage.json"
 [[ -f "$lineage_file" ]] || { echo 'Staged release has no immutable lineage manifest.' >&2; exit 1; }
+coordination_closure="$target/.skincos-global-coordination-orb.json"
+[[ -f "$coordination_closure" ]] || { echo 'Staged release has no Orb dependency-closure attestation.' >&2; exit 1; }
+release_identity="$target/.skincos-release-identity-orb.json"
+[[ -f "$release_identity" ]] || { echo 'Staged release has no exact Orb artifact identity.' >&2; exit 1; }
 current_target="$(readlink -f "$CURRENT_LINK")"
 current_release="$(basename "$(dirname "$current_target")")"
 [[ "$current_release" = "$expected_current" ]] || { echo "Current release changed: expected $expected_current, found $current_release." >&2; exit 1; }
@@ -67,8 +72,65 @@ fi
 
 fence_template="$target/ops/runtime/units/$FENCE_SERVICE"
 [[ -f "$fence_template" ]] || { echo "Staged release is missing $FENCE_SERVICE template." >&2; exit 1; }
+
+coordination_proof="${SKINCOS_GLOBAL_COORDINATION_PROOF_FILE:-$RUNTIME_HOME/global-coordination/release-orb-$release_id-$$.json}"
+coordination_acquired=0
+coordination_last_renew="$(date +%s)"
+coordination_run() {
+  "$SCRIPT_ROOT/scripts/runtime/global-coordination-mini-pc.sh" "$@" --proof-file "$coordination_proof"
+}
+coordination_acquire() {
+  coordination_run acquire \
+    --resource release:orb --module orb --source "$release_id" --closure-file "$coordination_closure" \
+    --operation promotion --release-identity-file "$release_identity" \
+    --idempotency-key "mini-pc:release:orb:$release_id:$$"
+}
+coordination_check() {
+  coordination_run check \
+    --resource release:orb --module orb --source "$release_id" --closure-file "$coordination_closure"
+}
+coordination_renew_if_due() {
+  local now
+  now="$(date +%s)"
+  if (( now - coordination_last_renew >= 60 )); then
+    coordination_run renew
+    coordination_last_renew="$now"
+  fi
+}
+coordination_release() {
+  coordination_run release
+}
+
+promoted=0
+started=0
+sidecars_started=0
+cleanup() {
+  if (( promoted == 1 && (started == 0 || sidecars_started == 0) )); then
+    if coordination_check >/dev/null 2>&1; then
+      sudo -n systemctl start "$FENCE_SERVICE" || true
+      sudo -n ln -sfn "$current_target" "$CURRENT_LINK" || true
+      sudo -n systemctl stop "$FENCE_SERVICE" || true
+      sudo -n systemctl start "$SERVICE" || true
+      for sidecar in "${SOURCE_SERVICES[@]}"; do sudo -n systemctl restart "$sidecar" || true; done
+    else
+      echo 'Global coordination proof was unavailable during native rollback; shared runtime remains fail-closed.' >&2
+    fi
+  fi
+  sudo -n -u skincos rm -f "$LOCK_FILE" 2>/dev/null || true
+  sudo -n -u skincos rmdir "$LOCK_DIR" 2>/dev/null || true
+  if (( coordination_acquired == 1 )); then
+    coordination_release >/dev/null 2>&1 || echo 'Unable to release the mini-PC global coordination lease; it will expire fail-closed.' >&2
+    coordination_acquired=0
+  fi
+}
+trap cleanup EXIT INT TERM
+coordination_acquire >/dev/null
+coordination_acquired=1
+
 if ! systemctl cat "$FENCE_SERVICE" >/dev/null 2>&1; then
+  coordination_check >/dev/null
   sudo -n install -m 0644 "$fence_template" "/etc/systemd/system/$FENCE_SERVICE"
+  coordination_check >/dev/null
   sudo -n systemctl daemon-reload
 fi
 
@@ -86,21 +148,6 @@ if ! sudo -n -u skincos mkdir "$LOCK_DIR" 2>/dev/null; then
   echo "Release promotion refused: Livia maintenance window already active ($LOCK_FILE)." >&2
   exit 1
 fi
-promoted=0
-started=0
-sidecars_started=0
-cleanup() {
-  if (( promoted == 1 && (started == 0 || sidecars_started == 0) )); then
-    sudo -n systemctl start "$FENCE_SERVICE" || true
-    sudo -n ln -sfn "$current_target" "$CURRENT_LINK" || true
-    sudo -n systemctl stop "$FENCE_SERVICE" || true
-    sudo -n systemctl start "$SERVICE" || true
-    for sidecar in "${SOURCE_SERVICES[@]}"; do sudo -n systemctl restart "$sidecar" || true; done
-  fi
-  sudo -n -u skincos rm -f "$LOCK_FILE" 2>/dev/null || true
-  sudo -n -u skincos rmdir "$LOCK_DIR" 2>/dev/null || true
-}
-trap cleanup EXIT INT TERM
 sudo -n -u skincos bash -c 'umask 027; printf "reason=controlled_native_release_promotion\nstarted_at=%s\n" "$1" >"$2"' bash "$(date --iso-8601=seconds)" "$LOCK_FILE"
 
 deadline=$(( $(date +%s) + timeout_seconds ))
@@ -109,18 +156,23 @@ while true; do
   [[ "$active" =~ ^[0-9]+$ ]] || { echo 'Unable to determine active Livia executions.' >&2; exit 1; }
   (( active == 0 )) && break
   (( $(date +%s) < deadline )) || { echo "Release promotion refused: $active Livia execution(s) still active." >&2; exit 1; }
+  coordination_renew_if_due
   sleep 5
 done
 
+coordination_check >/dev/null
 sudo -n systemctl start "$FENCE_SERVICE"
 if sudo -n systemctl --quiet is-active "$SERVICE"; then
   echo 'Release promotion fence did not stop Orb.' >&2
   sudo -n systemctl stop "$FENCE_SERVICE" || true
   exit 1
 fi
+coordination_check >/dev/null
 sudo -n ln -sfn "$target" "$CURRENT_LINK"
 promoted=1
+coordination_check >/dev/null
 sudo -n systemctl stop "$FENCE_SERVICE"
+coordination_check >/dev/null
 sudo -n systemctl start "$SERVICE"
 sudo -n systemctl --quiet is-active "$SERVICE"
 new_pid="$(systemctl show "$SERVICE" -p MainPID --value)"
@@ -128,6 +180,7 @@ new_root="$(readlink -f "/proc/$new_pid/cwd")"
 [[ "$new_root" = "$target/orb/engine" ]] || { echo "Orb restarted from unexpected root: $new_root" >&2; exit 1; }
 started=1
 for sidecar in "${SOURCE_SERVICES[@]}"; do
+  coordination_check >/dev/null
   sudo -n systemctl restart "$sidecar"
   sudo -n systemctl --quiet is-active "$sidecar"
   sidecar_pid="$(systemctl show "$sidecar" -p MainPID --value)"

--- a/scripts/runtime/promote-native-source-release.sh
+++ b/scripts/runtime/promote-native-source-release.sh
@@ -48,10 +48,10 @@ target="$RELEASE_BASE/$release_id/source"
 [[ -d "$target/orb/engine" ]] || { echo "Staged release is missing: $target" >&2; exit 1; }
 lineage_file="$target/.skincos-release-lineage.json"
 [[ -f "$lineage_file" ]] || { echo 'Staged release has no immutable lineage manifest.' >&2; exit 1; }
-coordination_closure="$target/.skincos-global-coordination-orb.json"
-[[ -f "$coordination_closure" ]] || { echo 'Staged release has no Orb dependency-closure attestation.' >&2; exit 1; }
-release_identity="$target/.skincos-release-identity-orb.json"
-[[ -f "$release_identity" ]] || { echo 'Staged release has no exact Orb artifact identity.' >&2; exit 1; }
+coordination_closure="$target/.skincos-global-coordination-native-runtime.json"
+[[ -f "$coordination_closure" ]] || { echo 'Staged release has no native-runtime dependency-closure attestation.' >&2; exit 1; }
+release_identity="$target/.skincos-release-identity-native-runtime.json"
+[[ -f "$release_identity" ]] || { echo 'Staged release has no exact native-runtime artifact identity.' >&2; exit 1; }
 current_target="$(readlink -f "$CURRENT_LINK")"
 current_release="$(basename "$(dirname "$current_target")")"
 [[ "$current_release" = "$expected_current" ]] || { echo "Current release changed: expected $expected_current, found $current_release." >&2; exit 1; }
@@ -81,13 +81,13 @@ coordination_run() {
 }
 coordination_acquire() {
   coordination_run acquire \
-    --resource release:orb --module orb --source "$release_id" --closure-file "$coordination_closure" \
+    --resource release:native-runtime --module native-runtime --source "$release_id" --closure-file "$coordination_closure" \
     --operation promotion --release-identity-file "$release_identity" \
-    --idempotency-key "mini-pc:release:orb:$release_id:$$"
+    --idempotency-key "mini-pc:release:native-runtime:$release_id:$$"
 }
 coordination_check() {
   coordination_run check \
-    --resource release:orb --module orb --source "$release_id" --closure-file "$coordination_closure"
+    --resource release:native-runtime --module native-runtime --source "$release_id" --closure-file "$coordination_closure"
 }
 coordination_renew_if_due() {
   local now

--- a/scripts/runtime/publish-orb-backup.ps1
+++ b/scripts/runtime/publish-orb-backup.ps1
@@ -8,8 +8,8 @@ param(
     [switch]$SkipGenerate
 )
 
-# WSL_BOUNDARY_EXCEPTION: this backup publication bridge starts the governed
-# native systemd unit and copies its verified artifact into Windows.
+# WSL_BOUNDARY_EXCEPTION: this backup publication bridge invokes the native
+# coordinator wrapper, then copies its verified artifact into Windows.
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 
@@ -69,9 +69,9 @@ function Test-BackupPayload {
 
 $DestinationRoot = Assert-AllowedDestination -Path $DestinationRoot
 if (-not $SkipGenerate) {
-    & wsl.exe -d $Distribution -u $LinuxUser -- sudo -n systemctl start orb-backup.service
+    & wsl.exe -d $Distribution -u $LinuxUser -- /usr/bin/bash -p /opt/skincos/current/source/scripts/runtime/run-orb-backup-with-coordination.sh
     if ($LASTEXITCODE -ne 0) {
-        throw "Native Orb backup failed with exit code $LASTEXITCODE."
+        throw "Coordinated native Orb backup failed with exit code $LASTEXITCODE."
     }
 }
 

--- a/scripts/runtime/publish-orb-backup.ps1
+++ b/scripts/runtime/publish-orb-backup.ps1
@@ -4,6 +4,7 @@ param(
     [string]$LinuxUser = 'admin',
     [string]$NativeBackupRoot = '/var/backups/skincos/orb/daily',
     [string]$DestinationRoot = 'C:\CodexRuntime\backups\orb\daily',
+    [string]$CoordinationEnvironmentFile = '/etc/skincos/global-coordination/orb-backup.env',
     [ValidateRange(1, 30)][int]$RetentionCount = 1,
     [switch]$SkipGenerate
 )
@@ -68,8 +69,24 @@ function Test-BackupPayload {
 }
 
 $DestinationRoot = Assert-AllowedDestination -Path $DestinationRoot
+if ($CoordinationEnvironmentFile -notmatch '^/[A-Za-z0-9._/-]+$') {
+    throw 'CoordinationEnvironmentFile must be an absolute private WSL path.'
+}
 if (-not $SkipGenerate) {
-    & wsl.exe -d $Distribution -u $LinuxUser -- /usr/bin/bash -p /opt/skincos/current/source/scripts/runtime/run-orb-backup-with-coordination.sh
+    $coordinationBridgeArgs = @(
+        '-d', $Distribution,
+        '-u', $LinuxUser,
+        '--',
+        '/usr/bin/env',
+        "SKINCOS_GLOBAL_COORDINATION_ENV_FILE=$CoordinationEnvironmentFile",
+        'GLOBAL_COORDINATION_MISSION_ID=windows:skincos-orb-backup',
+        'GLOBAL_COORDINATION_THREAD_ID=scheduled:SkincosOrbBackup',
+        'GLOBAL_COORDINATION_ACTOR=windows-scheduled-task',
+        '/usr/bin/bash',
+        '-p',
+        '/opt/skincos/current/source/scripts/runtime/run-orb-backup-with-coordination.sh'
+    )
+    & wsl.exe @coordinationBridgeArgs
     if ($LASTEXITCODE -ne 0) {
         throw "Coordinated native Orb backup failed with exit code $LASTEXITCODE."
     }

--- a/scripts/runtime/retire-clientes-source-refresh-service.sh
+++ b/scripts/runtime/retire-clientes-source-refresh-service.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)"
-source "$SCRIPT_ROOT/scripts/runtime/global-coordination-native.sh"
+COORDINATION_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+source "$COORDINATION_ROOT/scripts/runtime/global-coordination-native.sh"
 
 usage() {
   printf '%s\n' 'Usage: retire-clientes-source-refresh-service.sh --dry-run|--apply' >&2

--- a/scripts/runtime/retire-clientes-source-refresh-service.sh
+++ b/scripts/runtime/retire-clientes-source-refresh-service.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+source "$SCRIPT_ROOT/scripts/runtime/global-coordination-native.sh"
+
 usage() {
   printf '%s\n' 'Usage: retire-clientes-source-refresh-service.sh --dry-run|--apply' >&2
 }
@@ -17,7 +20,31 @@ case "$1" in
     printf '%s\n' '{"ok":true,"action":"would_disable_legacy_source_refresh"}'
     ;;
   --apply)
+    current_source="$(readlink -f /opt/skincos/current/source)"
+    [[ "$current_source" =~ ^/opt/skincos/releases/[0-9a-f]{40}/source$ ]] || {
+      echo "Invalid native source release: $current_source" >&2
+      exit 78
+    }
+    source_sha="$(basename "$(dirname "$current_source")")"
+    coordination_closure="$current_source/.skincos-global-coordination-native-runtime.json"
+    [[ -f "$coordination_closure" ]] || {
+      echo "Native-runtime coordination closure is unavailable: $coordination_closure" >&2
+      exit 78
+    }
+    native_coordination_init global:native-runtime native-runtime "$source_sha" "$coordination_closure" mutation
+    coordination_acquired=0
+    cleanup() {
+      if [[ "$coordination_acquired" == '1' ]]; then
+        native_coordination_cleanup || true
+        coordination_acquired=0
+      fi
+    }
+    trap cleanup EXIT INT TERM
+    native_coordination_acquire "mini-pc:global:native-runtime:retire-clientes-refresh:$source_sha:$$" >/dev/null
+    coordination_acquired=1
+    native_coordination_check
     sudo -n systemctl disable --now crm-clientes-source-refresh.timer
+    native_coordination_check
     sudo -n systemctl reset-failed crm-clientes-source-refresh.service
     printf '%s\n' '{"ok":true,"action":"disabled_legacy_source_refresh"}'
     ;;

--- a/scripts/runtime/rollback-atendimento-production.sh
+++ b/scripts/runtime/rollback-atendimento-production.sh
@@ -83,21 +83,36 @@ protected_before="$(snapshot_protected_services)"
 coordination_run check \
   --resource deploy:atendimento:production --module atendimento --source "$TARGET_SHA" \
   --closure-file "$COORDINATION_CLOSURE" >/dev/null
-sudo -n "$CONTROL_WRITER" --state maintenance --release-sha "$TARGET_SHA" --reason rollback-in-progress --apply
+sudo -n "$CONTROL_WRITER" \
+  --state maintenance --release-sha "$TARGET_SHA" \
+  --coordination-closure "$COORDINATION_CLOSURE" \
+  --coordination-proof-file "$coordination_proof" --coordination-reuse \
+  --reason rollback-in-progress --apply
 coordination_run check \
   --resource deploy:atendimento:production --module atendimento --source "$TARGET_SHA" \
   --closure-file "$COORDINATION_CLOSURE" >/dev/null
-if ! sudo -n "$INSTALLER" --source-root "$SOURCE_ROOT" --apply; then
+if ! sudo -n "$INSTALLER" \
+  --source-root "$SOURCE_ROOT" \
+  --coordination-proof-file "$coordination_proof" --coordination-reuse \
+  --apply; then
   coordination_run check \
     --resource deploy:atendimento:production --module atendimento --source "$TARGET_SHA" \
     --closure-file "$COORDINATION_CLOSURE" >/dev/null
-  sudo -n "$CONTROL_WRITER" --state maintenance --release-sha "$TARGET_SHA" --reason rollback-install-failed --apply || true
+  sudo -n "$CONTROL_WRITER" \
+    --state maintenance --release-sha "$TARGET_SHA" \
+    --coordination-closure "$COORDINATION_CLOSURE" \
+    --coordination-proof-file "$coordination_proof" --coordination-reuse \
+    --reason rollback-install-failed --apply || true
   exit 1
 fi
 coordination_run check \
   --resource deploy:atendimento:production --module atendimento --source "$TARGET_SHA" \
   --closure-file "$COORDINATION_CLOSURE" >/dev/null
-sudo -n "$CONTROL_WRITER" --state active --release-sha "$TARGET_SHA" --reason rollback-active --apply
+sudo -n "$CONTROL_WRITER" \
+  --state active --release-sha "$TARGET_SHA" \
+  --coordination-closure "$COORDINATION_CLOSURE" \
+  --coordination-proof-file "$coordination_proof" --coordination-reuse \
+  --reason rollback-active --apply
 coordination_run check \
   --resource deploy:atendimento:production --module atendimento --source "$TARGET_SHA" \
   --closure-file "$COORDINATION_CLOSURE" >/dev/null
@@ -105,7 +120,11 @@ if ! sudo -n "$VALIDATOR" --expected-release-sha "$TARGET_SHA"; then
   coordination_run check \
     --resource deploy:atendimento:production --module atendimento --source "$TARGET_SHA" \
     --closure-file "$COORDINATION_CLOSURE" >/dev/null
-  sudo -n "$CONTROL_WRITER" --state maintenance --release-sha "$TARGET_SHA" --reason rollback-validation-failed --apply || true
+  sudo -n "$CONTROL_WRITER" \
+    --state maintenance --release-sha "$TARGET_SHA" \
+    --coordination-closure "$COORDINATION_CLOSURE" \
+    --coordination-proof-file "$coordination_proof" --coordination-reuse \
+    --reason rollback-validation-failed --apply || true
   exit 1
 fi
 protected_after="$(snapshot_protected_services)"

--- a/scripts/runtime/rollback-atendimento-production.sh
+++ b/scripts/runtime/rollback-atendimento-production.sh
@@ -35,6 +35,7 @@ readonly MANIFEST="$STATE_ROOT/release-manifests/$TARGET_SHA.json"
 readonly INSTALLER="$SOURCE_ROOT/scripts/runtime/install-atendimento-production-service.sh"
 readonly CONTROL_WRITER="$SOURCE_ROOT/scripts/set-atendimento-production-readonly-control.sh"
 readonly VALIDATOR="$SOURCE_ROOT/scripts/validate-atendimento-production-readonly.sh"
+readonly COORDINATION_CLOSURE="$SOURCE_ROOT/.skincos-global-coordination-atendimento.json"
 for command_name in sudo systemctl curl node; do
   command -v "$command_name" >/dev/null 2>&1 || { echo "Missing $command_name" >&2; exit 1; }
 done
@@ -60,14 +61,50 @@ if [[ "$APPLY" != '1' ]]; then
   exit 0
 fi
 
+sudo -n test -f "$COORDINATION_CLOSURE" || { echo 'Immutable Atendimento dependency-closure attestation is unavailable.' >&2; exit 78; }
+coordination_proof="${SKINCOS_GLOBAL_COORDINATION_PROOF_FILE:-/var/lib/skincos-runtime/global-coordination/release-atendimento-$TARGET_SHA-$$.json}"
+coordination_acquired=0
+coordination_run() {
+  "$SOURCE_ROOT/scripts/runtime/global-coordination-mini-pc.sh" "$@" --proof-file "$coordination_proof"
+}
+cleanup() {
+  if (( coordination_acquired == 1 )); then
+  coordination_run release >/dev/null 2>&1 || echo 'Unable to release the mini-PC Atendimento production surface lease; it will expire fail-closed.' >&2
+  fi
+}
+trap cleanup EXIT INT TERM
+coordination_run acquire \
+  --resource deploy:atendimento:production --module atendimento --source "$TARGET_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" --operation mutation \
+  --idempotency-key "mini-pc:deploy:atendimento:production:rollback:$TARGET_SHA:$$" >/dev/null
+coordination_acquired=1
+
 protected_before="$(snapshot_protected_services)"
+coordination_run check \
+  --resource deploy:atendimento:production --module atendimento --source "$TARGET_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
 sudo -n "$CONTROL_WRITER" --state maintenance --release-sha "$TARGET_SHA" --reason rollback-in-progress --apply
+coordination_run check \
+  --resource deploy:atendimento:production --module atendimento --source "$TARGET_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
 if ! sudo -n "$INSTALLER" --source-root "$SOURCE_ROOT" --apply; then
+  coordination_run check \
+    --resource deploy:atendimento:production --module atendimento --source "$TARGET_SHA" \
+    --closure-file "$COORDINATION_CLOSURE" >/dev/null
   sudo -n "$CONTROL_WRITER" --state maintenance --release-sha "$TARGET_SHA" --reason rollback-install-failed --apply || true
   exit 1
 fi
+coordination_run check \
+  --resource deploy:atendimento:production --module atendimento --source "$TARGET_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
 sudo -n "$CONTROL_WRITER" --state active --release-sha "$TARGET_SHA" --reason rollback-active --apply
+coordination_run check \
+  --resource deploy:atendimento:production --module atendimento --source "$TARGET_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
 if ! sudo -n "$VALIDATOR" --expected-release-sha "$TARGET_SHA"; then
+  coordination_run check \
+    --resource deploy:atendimento:production --module atendimento --source "$TARGET_SHA" \
+    --closure-file "$COORDINATION_CLOSURE" >/dev/null
   sudo -n "$CONTROL_WRITER" --state maintenance --release-sha "$TARGET_SHA" --reason rollback-validation-failed --apply || true
   exit 1
 fi

--- a/scripts/runtime/rollback-atendimento-staging.sh
+++ b/scripts/runtime/rollback-atendimento-staging.sh
@@ -14,6 +14,7 @@ run_sudo_clean() {
 }
 
 readonly RELEASE_BASE='/opt/skincos/releases'
+readonly SCRIPT_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 readonly UNIT_DEST='/etc/systemd/system'
 readonly CONFIG_ROOT='/etc/skincos'
 readonly CONTROL_FILE="$CONFIG_ROOT/atendimento-staging/module-control.json"
@@ -66,6 +67,7 @@ readonly CONTROL_BACKUP_VALIDATOR="$SOURCE_ROOT/crm/api/scripts/validate-atendim
 readonly RUNTIME_GRANT_LOCKDOWN="$SOURCE_ROOT/scripts/lockdown-atendimento-staging-runtime.sh"
 readonly STAGING_VALIDATOR="$SOURCE_ROOT/scripts/validate-atendimento-staging-readonly.sh"
 readonly UNIT_TEMPLATE="$SOURCE_ROOT/ops/runtime/units/$SERVICE"
+readonly COORDINATION_CLOSURE="$SOURCE_ROOT/.skincos-global-coordination-atendimento.json"
 
 [[ "$SOURCE_ROOT" =~ ^/opt/skincos/releases/[0-9a-f]{40}/source$ ]] || { echo 'Rollback release root is invalid.' >&2; exit 64; }
 for command_path in /usr/bin/sudo /usr/bin/env /usr/bin/node /usr/bin/bash /usr/bin/test /usr/bin/stat /usr/bin/sed /usr/bin/mktemp /usr/bin/chmod /usr/bin/rm /usr/bin/rmdir /usr/bin/cmp /usr/bin/install /usr/bin/systemctl /usr/bin/systemd-analyze; do
@@ -73,7 +75,7 @@ for command_path in /usr/bin/sudo /usr/bin/env /usr/bin/node /usr/bin/bash /usr/
 done
 /usr/bin/sudo -n /usr/bin/true
 
-for path in "$RELEASE_VALIDATOR" "$CONTROL_VALIDATOR" "$CONTROL_BACKUP_VALIDATOR" "$RUNTIME_GRANT_LOCKDOWN" "$STAGING_VALIDATOR" "$UNIT_TEMPLATE"; do
+for path in "$RELEASE_VALIDATOR" "$CONTROL_VALIDATOR" "$CONTROL_BACKUP_VALIDATOR" "$RUNTIME_GRANT_LOCKDOWN" "$STAGING_VALIDATOR" "$UNIT_TEMPLATE" "$COORDINATION_CLOSURE"; do
   run_sudo_clean /usr/bin/test -f "$path" || { echo "Required immutable rollback artifact is unavailable: $path" >&2; exit 78; }
 done
 run_sudo_clean /usr/bin/test -x "$RUNTIME_GRANT_LOCKDOWN"
@@ -106,7 +108,15 @@ umask 0077
 render_dir="$(/usr/bin/mktemp -d /tmp/atendimento-staging-rollback.XXXXXX)"
 /usr/bin/test -d "$render_dir" -a -O "$render_dir"
 rendered="$render_dir/$SERVICE"
-trap '/usr/bin/rm -f "$rendered"; /usr/bin/rmdir "$render_dir" 2>/dev/null || true' EXIT
+cleanup_render() {
+  /usr/bin/rm -f "$rendered"
+  /usr/bin/rmdir "$render_dir" 2>/dev/null || true
+  if [[ "${coordination_acquired:-0}" == '1' ]]; then
+    native_coordination_cleanup || true
+    coordination_acquired=0
+  fi
+}
+trap cleanup_render EXIT INT TERM
 /usr/bin/sed \
   -e "s|__REPO_ROOT__|$SOURCE_ROOT|g" \
   -e 's|__STATE_ROOT__|/var/lib/skincos-runtime|g' \
@@ -133,12 +143,21 @@ if [[ "$APPLY" != '1' ]]; then
 fi
 
 protected_before="$(snapshot_protected_services)"
+source "$SCRIPT_ROOT/scripts/runtime/global-coordination-native.sh"
+native_coordination_init deploy:atendimento:staging atendimento "$TARGET_SHA" "$COORDINATION_CLOSURE" mutation
+coordination_acquired=0
+native_coordination_acquire "mini-pc:deploy:atendimento:staging:rollback:$TARGET_SHA:$$" >/dev/null
+coordination_acquired=1
+native_coordination_check
 # Install maintenance before changing the unit. A still-running newer process
 # then fails closed on its next request because its expected SHA no longer
 # matches the restored control.
 run_sudo_clean /usr/bin/install -m 0640 -o root -g skincos "$CONTROL_BACKUP" "$CONTROL_FILE"
+native_coordination_check
 run_sudo_clean /usr/bin/install -m 0644 -o root -g root "$UNIT_BACKUP" "$UNIT_FILE"
+native_coordination_check
 run_sudo_clean /usr/bin/systemctl daemon-reload
+native_coordination_check
 run_sudo_clean /usr/bin/systemctl restart "$SERVICE"
 run_sudo_clean /usr/bin/systemctl is-active --quiet "$SERVICE"
 run_sudo_clean /usr/bin/node "$CONTROL_VALIDATOR" --release-sha "$TARGET_SHA" >/dev/null

--- a/scripts/runtime/route-atendimento-production-dns.sh
+++ b/scripts/runtime/route-atendimento-production-dns.sh
@@ -4,16 +4,21 @@ set -euo pipefail
 # The DNS route is deliberately a separate, explicit operation.  It never
 # changes a service and it accepts only the ID of a pre-created dedicated
 # tunnel; the Cloudflare origin certificate path and hostname are fixed.
+readonly SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 readonly CONFIG_DIR='/etc/skincos/cloudflare/atendimento-production'
 readonly ORIGIN_CERT="$CONFIG_DIR/cert.pem"
 readonly HOSTNAME='crm-atendimento.skincos.com.br'
 
 TUNNEL_ID=''
+SOURCE_SHA="${SKINCOS_GLOBAL_COORDINATION_SOURCE_SHA:-}"
+COORDINATION_CLOSURE="${SKINCOS_GLOBAL_COORDINATION_CLOSURE_FILE:-}"
 APPLY=0
-usage() { echo "Usage: $0 --tunnel-id <uuid> [--apply]"; }
+usage() { echo "Usage: $0 --tunnel-id <uuid> --source-sha <full-sha> --coordination-closure <json> [--apply]"; }
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --tunnel-id) shift; TUNNEL_ID="${1:-}" ;;
+    --source-sha) shift; SOURCE_SHA="${1:-}" ;;
+    --coordination-closure) shift; COORDINATION_CLOSURE="${1:-}" ;;
     --apply) APPLY=1 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 64 ;;
@@ -24,6 +29,7 @@ done
   echo 'TUNNEL_ID must be a lowercase RFC 4122 UUID.' >&2
   exit 64
 }
+[[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'SOURCE_SHA must be a full lowercase commit SHA.' >&2; exit 64; }
 for command_name in sudo; do
   command -v "$command_name" >/dev/null 2>&1 || { echo "Missing $command_name" >&2; exit 1; }
 done
@@ -38,6 +44,30 @@ if [[ "$APPLY" != '1' ]]; then
   printf 'dry_run=true tunnel_id=%s hostname=%s dns_change=false\n' "$TUNNEL_ID" "$HOSTNAME"
   exit 0
 fi
+
+[[ -n "$COORDINATION_CLOSURE" && -f "$COORDINATION_CLOSURE" ]] || {
+  echo 'An immutable Atendimento dependency-closure attestation is required for the DNS mutation.' >&2
+  exit 78
+}
+coordination_proof="${SKINCOS_GLOBAL_COORDINATION_PROOF_FILE:-/var/lib/skincos-runtime/global-coordination/cloudflare-atendimento-production-dns-$$.json}"
+coordination_acquired=0
+coordination_run() {
+  "$SCRIPT_ROOT/scripts/runtime/global-coordination-mini-pc.sh" "$@" --proof-file "$coordination_proof"
+}
+cleanup() {
+  if (( coordination_acquired == 1 )); then
+    coordination_run release >/dev/null 2>&1 || echo 'Unable to release the mini-PC Cloudflare lease; it will expire fail-closed.' >&2
+  fi
+}
+trap cleanup EXIT INT TERM
+coordination_run acquire \
+  --resource cloudflare:atendimento:production --module atendimento --source "$SOURCE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" --operation mutation \
+  --idempotency-key "mini-pc:cloudflare:atendimento:production:$SOURCE_SHA:$$" >/dev/null
+coordination_acquired=1
+coordination_run check \
+  --resource cloudflare:atendimento:production --module atendimento --source "$SOURCE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
 
 sudo -n /usr/bin/cloudflared --origincert "$ORIGIN_CERT" tunnel route dns "$TUNNEL_ID" "$HOSTNAME"
 printf 'dns_routed=true tunnel_id=%s hostname=%s\n' "$TUNNEL_ID" "$HOSTNAME"

--- a/scripts/runtime/run-harmonia-migration-native.sh
+++ b/scripts/runtime/run-harmonia-migration-native.sh
@@ -45,8 +45,48 @@ case "$ACTION" in
   *) echo 'HARMONIA_MIGRATION_ACTION must be dry-run or apply.' >&2; exit 64 ;;
 esac
 
+COORDINATION_SOURCE_SHA="${SKINCOS_RELEASE_ID:-}"
+COORDINATION_CLOSURE=''
+COORDINATION_RESOURCE=''
+coordination_acquired=0
+
 checkpoint=''
 if [[ "$ACTION" == 'apply' ]]; then
+  [[ "$COORDINATION_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+    echo 'SKINCOS_RELEASE_ID must be a full lowercase immutable SHA for apply.' >&2
+    exit 78
+  }
+  [[ "$ROOT_DIR" =~ ^/opt/skincos/releases/([0-9a-f]{40})/source$ ]] || {
+    echo 'Harmonia apply must run from an immutable native release, never a checkout.' >&2
+    exit 78
+  }
+  [[ "${BASH_REMATCH[1]}" == "$COORDINATION_SOURCE_SHA" ]] || {
+    echo 'SKINCOS_RELEASE_ID does not match the immutable native release path.' >&2
+    exit 78
+  }
+  COORDINATION_CLOSURE="$ROOT_DIR/.skincos-global-coordination-atendimento.json"
+  [[ -f "$COORDINATION_CLOSURE" ]] || {
+    echo 'Atendimento dependency-closure attestation is unavailable in the immutable release.' >&2
+    exit 78
+  }
+  if [[ "$TARGET" == 'staging' ]]; then
+    COORDINATION_RESOURCE='deploy:atendimento:staging'
+  else
+    COORDINATION_RESOURCE='deploy:atendimento:production'
+  fi
+  # shellcheck disable=SC1091
+  source "$ROOT_DIR/scripts/runtime/global-coordination-native.sh"
+  native_coordination_init "$COORDINATION_RESOURCE" atendimento "$COORDINATION_SOURCE_SHA" "$COORDINATION_CLOSURE" mutation
+  cleanup_coordination() {
+    if [[ "$coordination_acquired" == '1' ]]; then
+      native_coordination_cleanup || echo 'Unable to release the Harmonia migration lease; it will expire fail-closed.' >&2
+      coordination_acquired=0
+    fi
+  }
+  trap cleanup_coordination EXIT INT TERM
+  native_coordination_acquire "mini-pc:${COORDINATION_RESOURCE}:harmonia:$COORDINATION_SOURCE_SHA:$$" >/dev/null
+  coordination_acquired=1
+  native_coordination_check
   stamp="$(date -u +%Y%m%dT%H%M%SZ)"
   checkpoint="$BACKUP_ROOT/harmonia-${TARGET}-${stamp}.json"
   [[ -d "$BACKUP_ROOT" && -w "$BACKUP_ROOT" ]] || {
@@ -58,4 +98,11 @@ fi
 args=("--target" "$TARGET")
 if [[ "$ACTION" == 'apply' ]]; then args+=(--apply --checkpoint "$checkpoint"); else args+=(--dry-run); fi
 if [[ -n "${SKINCOS_RELEASE_ID:-}" ]]; then args+=(--release-sha "$SKINCOS_RELEASE_ID"); fi
-exec node "$ROOT_DIR/crm/api/scripts/migrate-harmonia-schema.mjs" "${args[@]}"
+if node "$ROOT_DIR/crm/api/scripts/migrate-harmonia-schema.mjs" "${args[@]}"; then
+  if [[ "$ACTION" == 'apply' ]]; then
+    native_coordination_check
+  fi
+else
+  status=$?
+  exit "$status"
+fi

--- a/scripts/runtime/run-orb-backup-with-coordination.sh
+++ b/scripts/runtime/run-orb-backup-with-coordination.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/bash -p
+set -euo pipefail
+
+readonly SAFE_PATH='/usr/sbin:/usr/bin:/sbin:/bin'
+export PATH="$SAFE_PATH"
+unset BASH_ENV ENV CDPATH GLOBIGNORE TMPDIR TMP TEMP \
+  HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY http_proxy https_proxy all_proxy no_proxy \
+  GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES
+
+readonly SCRIPT_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+readonly RESOURCE='global:orb-backup'
+readonly CLOSURE="$SCRIPT_ROOT/.skincos-global-coordination-orb.json"
+coordination_acquired=0
+
+[[ "$SCRIPT_ROOT" =~ ^/opt/skincos/releases/([0-9a-f]{40})/source$ ]] || {
+  echo 'Orb backup must run from an immutable native release, never a checkout.' >&2
+  exit 78
+}
+readonly SOURCE_SHA="${BASH_REMATCH[1]}"
+[[ -f "$CLOSURE" ]] || { echo 'Orb dependency-closure attestation is unavailable.' >&2; exit 78; }
+
+# shellcheck disable=SC1091
+source "$SCRIPT_ROOT/scripts/runtime/global-coordination-native.sh"
+native_coordination_init "$RESOURCE" orb "$SOURCE_SHA" "$CLOSURE" mutation
+
+cleanup() {
+  if [[ "$coordination_acquired" == '1' ]]; then
+    native_coordination_cleanup || echo 'Unable to release the Orb backup lease; it will expire fail-closed.' >&2
+    coordination_acquired=0
+  fi
+}
+trap cleanup EXIT INT TERM
+
+native_coordination_acquire "mini-pc:${RESOURCE}:$SOURCE_SHA:$$" >/dev/null
+coordination_acquired=1
+native_coordination_check
+/usr/bin/sudo -n /usr/bin/systemctl start orb-backup.service
+native_coordination_check
+printf 'orb_backup_generated=true source_sha=%s resource=%s\n' "$SOURCE_SHA" "$RESOURCE"

--- a/scripts/runtime/run-orb-backup-with-coordination.sh
+++ b/scripts/runtime/run-orb-backup-with-coordination.sh
@@ -10,7 +10,42 @@ unset BASH_ENV ENV CDPATH GLOBIGNORE TMPDIR TMP TEMP \
 readonly SCRIPT_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 readonly RESOURCE='global:orb-backup'
 readonly CLOSURE="$SCRIPT_ROOT/.skincos-global-coordination-orb.json"
+readonly COORDINATION_ENV_FILE="${SKINCOS_GLOBAL_COORDINATION_ENV_FILE:-/etc/skincos/global-coordination/orb-backup.env}"
 coordination_acquired=0
+
+load_private_coordination_environment() {
+  [[ "$COORDINATION_ENV_FILE" = /* && "$COORDINATION_ENV_FILE" != *$'\n'* && "$COORDINATION_ENV_FILE" != *$'\r'* ]] || {
+    echo 'Orb backup coordination environment path is invalid.' >&2
+    exit 78
+  }
+  [[ -f "$COORDINATION_ENV_FILE" ]] || {
+    echo 'Orb backup coordination environment is unavailable.' >&2
+    exit 78
+  }
+  local mode line key value
+  mode="$(stat -c '%a' "$COORDINATION_ENV_FILE")"
+  [[ "$mode" == '600' || "$mode" == '640' ]] || {
+    echo 'Orb backup coordination environment must be mode 0600 or 0640.' >&2
+    exit 78
+  }
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%$'\r'}"
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    [[ "$line" =~ ^([A-Z][A-Z0-9_]*)=(.*)$ ]] || {
+      echo 'Orb backup coordination environment contains an invalid record.' >&2
+      exit 78
+    }
+    key="${BASH_REMATCH[1]}"
+    value="${BASH_REMATCH[2]}"
+    [[ "$key" == SKINCOS_GLOBAL_COORDINATOR_URL || "$key" == SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET ]] || {
+      echo 'Orb backup coordination environment contains an unsupported key.' >&2
+      exit 78
+    }
+    export "$key=$value"
+  done < "$COORDINATION_ENV_FILE"
+}
+
+load_private_coordination_environment
 
 [[ "$SCRIPT_ROOT" =~ ^/opt/skincos/releases/([0-9a-f]{40})/source$ ]] || {
   echo 'Orb backup must run from an immutable native release, never a checkout.' >&2

--- a/scripts/runtime/test-mcp-gateway-release.sh
+++ b/scripts/runtime/test-mcp-gateway-release.sh
@@ -9,6 +9,8 @@ for sha in "$first" "$second"; do
   mkdir -p "$tmp/releases/$sha/source/orb/engine/mcp-readonly-gateway"
   printf 'console.log("shadow")\n' >"$tmp/releases/$sha/source/orb/engine/mcp-readonly-gateway/server.mjs"
   printf '{"releaseId":"%s","verifiedAncestor":true}\n' "$sha" >"$tmp/releases/$sha/source/.skincos-release-lineage.json"
+  printf '{}\n' >"$tmp/releases/$sha/source/.skincos-global-coordination-orb.json"
+  printf '{}\n' >"$tmp/releases/$sha/source/.skincos-release-identity-orb.json"
 done
 unit="$tmp/gateway.service"
 printf '%s\n' \
@@ -20,7 +22,11 @@ fake_systemd="$tmp/fake-systemctl"
 printf '#!/usr/bin/env bash\nexit 0\n' >"$fake_systemd"; chmod +x "$fake_systemd"
 fake_analyze="$tmp/fake-systemd-analyze"
 printf '#!/usr/bin/env bash\nexit 0\n' >"$fake_analyze"; chmod +x "$fake_analyze"
-base=(env MCP_GATEWAY_TEST_MODE=YES MCP_GATEWAY_RELEASE_BASE="$tmp/releases" MCP_GATEWAY_RELEASE_LINK="$tmp/current/mcp-readonly-source" MCP_GATEWAY_UNIT_SOURCE="$unit" MCP_GATEWAY_UNIT_DEST="$tmp/systemd/skincos-orb-mcp-readonly.service" MCP_GATEWAY_CHECKPOINT_ROOT="$tmp/checkpoints" MCP_GATEWAY_SYSTEMCTL_BIN="$fake_systemd" MCP_GATEWAY_SYSTEMD_ANALYZE_BIN="$fake_analyze")
+native_root="$tmp/native/scripts/runtime"
+mkdir -p "$native_root"
+printf '#!/usr/bin/env bash\ncase "${1:-}" in acquire|check|renew|release) exit 0 ;; *) exit 64 ;; esac\n' >"$native_root/global-coordination-mini-pc.sh"
+chmod +x "$native_root/global-coordination-mini-pc.sh"
+base=(env MCP_GATEWAY_TEST_MODE=YES NATIVE_COORDINATION_SCRIPT_ROOT="$tmp/native" MCP_GATEWAY_RELEASE_BASE="$tmp/releases" MCP_GATEWAY_RELEASE_LINK="$tmp/current/mcp-readonly-source" MCP_GATEWAY_UNIT_SOURCE="$unit" MCP_GATEWAY_UNIT_DEST="$tmp/systemd/skincos-orb-mcp-readonly.service" MCP_GATEWAY_CHECKPOINT_ROOT="$tmp/checkpoints" MCP_GATEWAY_SYSTEMCTL_BIN="$fake_systemd" MCP_GATEWAY_SYSTEMD_ANALYZE_BIN="$fake_analyze")
 "${base[@]}" "$SCRIPT" preflight "$first" | grep -q preflight_release
 if "${base[@]}" "$SCRIPT" select "$first"; then exit 1; fi
 provision_output=$("${base[@]}" MCP_GATEWAY_APPLY=YES "$SCRIPT" provision "$first")

--- a/scripts/runtime/test-prepare-native-source-release.sh
+++ b/scripts/runtime/test-prepare-native-source-release.sh
@@ -7,12 +7,18 @@ SCRIPT="$ROOT_DIR/scripts/runtime/prepare-native-source-release.sh"
 bash -n "$SCRIPT"
 
 required=(
-  '--archive <native-tar> --sha256 <sha256> --lineage <json> --lineage-sha256 <sha256> [--apply --stage-only]'
+  '--archive <native-tar> --sha256 <sha256> --lineage <json> --lineage-sha256 <sha256> [--coordination-closure <json>]... [--apply --stage-only]'
   'Windows creates and transfers the archive first'
   '[[ "$RELEASE_ARCHIVE" != /mnt/* ]]'
   'actual_archive_sha256="$(sha256sum "$RELEASE_ARCHIVE"'
   'actual_lineage_sha256="$(sha256sum "$RELEASE_LINEAGE"'
   'value.verifiedAncestor !== true'
+  '--coordination-closure'
+  'At least one --coordination-closure attestation is required'
+  'coordination_native_runtime_closure'
+  'A native-runtime dependency-closure attestation is required'
+  '.skincos-global-coordination-'
+  'coordination closure identity or digest is invalid'
   '.skincos-release-lineage.json'
   'readonly ARCHIVE_PREFIX="skincos-$RELEASE_ID/"'
   'tar -tzf "$RELEASE_ARCHIVE"'

--- a/scripts/set-atendimento-production-readonly-control.sh
+++ b/scripts/set-atendimento-production-readonly-control.sh
@@ -19,12 +19,14 @@ STATE=''
 RELEASE_SHA=''
 COORDINATION_SOURCE_SHA="${SKINCOS_GLOBAL_COORDINATION_SOURCE_SHA:-}"
 COORDINATION_CLOSURE="${SKINCOS_GLOBAL_COORDINATION_CLOSURE_FILE:-}"
+COORDINATION_PROOF_FILE="${SKINCOS_GLOBAL_COORDINATION_PROOF_FILE:-}"
+COORDINATION_REUSE=0
 REASON='clientes-production-readonly'
 APPLY=0
 
 usage() {
   cat <<'EOF'
-Usage: scripts/set-atendimento-production-readonly-control.sh --state <disabled|maintenance|active|canary> [--release-sha <full-sha>] [--source-sha <full-sha>] [--coordination-closure <json>] [--reason <text>] [--apply]
+Usage: scripts/set-atendimento-production-readonly-control.sh --state <disabled|maintenance|active|canary> [--release-sha <full-sha>] [--source-sha <full-sha>] [--coordination-closure <json>] [--coordination-proof-file <private-proof>] [--coordination-reuse] [--reason <text>] [--apply]
 
 Active production Clientes requires a full immutable release SHA. The default
 is a dry-run; --apply creates a private backup before replacing the control
@@ -38,6 +40,8 @@ while [[ $# -gt 0 ]]; do
     --release-sha) shift; RELEASE_SHA="${1:-}" ;;
     --source-sha) shift; COORDINATION_SOURCE_SHA="${1:-}" ;;
     --coordination-closure) shift; COORDINATION_CLOSURE="${1:-}" ;;
+    --coordination-proof-file) shift; COORDINATION_PROOF_FILE="${1:-}" ;;
+    --coordination-reuse) COORDINATION_REUSE=1 ;;
     --reason) shift; REASON="${1:-}" ;;
     --apply) APPLY=1 ;;
     -h|--help) usage; exit 0 ;;
@@ -60,6 +64,11 @@ if [[ "$APPLY" == '1' ]]; then
   fi
   [[ "$COORDINATION_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo '--source-sha must be a full lowercase SHA for apply.' >&2; exit 78; }
   [[ -n "$COORDINATION_CLOSURE" && -f "$COORDINATION_CLOSURE" ]] || { echo '--coordination-closure must identify an existing Atendimento attestation for apply.' >&2; exit 78; }
+  if [[ "$COORDINATION_REUSE" == '1' ]]; then
+    [[ "$COORDINATION_PROOF_FILE" = /* && -f "$COORDINATION_PROOF_FILE" ]] || { echo '--coordination-proof-file must identify an existing private proof for coordination reuse.' >&2; exit 78; }
+    export SKINCOS_GLOBAL_COORDINATION_REUSE=1
+    export SKINCOS_GLOBAL_COORDINATION_PROOF_FILE="$COORDINATION_PROOF_FILE"
+  fi
 fi
 
 for command_path in /usr/bin/sudo /usr/bin/env /usr/bin/install /usr/bin/date /usr/bin/mktemp /usr/bin/cat /usr/bin/rm /usr/bin/cp /usr/bin/chmod /usr/bin/test; do

--- a/scripts/set-atendimento-production-readonly-control.sh
+++ b/scripts/set-atendimento-production-readonly-control.sh
@@ -10,16 +10,21 @@ run_sudo_clean() {
   /usr/bin/sudo -n /usr/bin/env -i "PATH=$SAFE_PATH" 'HOME=/nonexistent' 'LANG=C' "$@"
 }
 
+readonly SCRIPT_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
+source "$SCRIPT_ROOT/scripts/runtime/global-coordination-native.sh"
+
 readonly CONTROL_FILE='/etc/skincos/atendimento-production/module-control.json'
 readonly BACKUP_ROOT='/var/backups/skincos/clientes/production-readonly'
 STATE=''
 RELEASE_SHA=''
+COORDINATION_SOURCE_SHA="${SKINCOS_GLOBAL_COORDINATION_SOURCE_SHA:-}"
+COORDINATION_CLOSURE="${SKINCOS_GLOBAL_COORDINATION_CLOSURE_FILE:-}"
 REASON='clientes-production-readonly'
 APPLY=0
 
 usage() {
   cat <<'EOF'
-Usage: scripts/set-atendimento-production-readonly-control.sh --state <disabled|maintenance|active|canary> [--release-sha <full-sha>] [--reason <text>] [--apply]
+Usage: scripts/set-atendimento-production-readonly-control.sh --state <disabled|maintenance|active|canary> [--release-sha <full-sha>] [--source-sha <full-sha>] [--coordination-closure <json>] [--reason <text>] [--apply]
 
 Active production Clientes requires a full immutable release SHA. The default
 is a dry-run; --apply creates a private backup before replacing the control
@@ -31,6 +36,8 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --state) shift; STATE="${1:-}" ;;
     --release-sha) shift; RELEASE_SHA="${1:-}" ;;
+    --source-sha) shift; COORDINATION_SOURCE_SHA="${1:-}" ;;
+    --coordination-closure) shift; COORDINATION_CLOSURE="${1:-}" ;;
     --reason) shift; REASON="${1:-}" ;;
     --apply) APPLY=1 ;;
     -h|--help) usage; exit 0 ;;
@@ -47,6 +54,13 @@ elif [[ -n "$RELEASE_SHA" && ! "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
   exit 64
 fi
 [[ "$REASON" =~ ^[A-Za-z0-9._:-]{1,120}$ ]] || { echo '--reason contains unsupported characters.' >&2; exit 64; }
+if [[ "$APPLY" == '1' ]]; then
+  if [[ -z "$COORDINATION_SOURCE_SHA" && "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+    COORDINATION_SOURCE_SHA="$RELEASE_SHA"
+  fi
+  [[ "$COORDINATION_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo '--source-sha must be a full lowercase SHA for apply.' >&2; exit 78; }
+  [[ -n "$COORDINATION_CLOSURE" && -f "$COORDINATION_CLOSURE" ]] || { echo '--coordination-closure must identify an existing Atendimento attestation for apply.' >&2; exit 78; }
+fi
 
 for command_path in /usr/bin/sudo /usr/bin/env /usr/bin/install /usr/bin/date /usr/bin/mktemp /usr/bin/cat /usr/bin/rm /usr/bin/cp /usr/bin/chmod /usr/bin/test; do
   [[ -x "$command_path" ]] || { echo "Missing $command_path" >&2; exit 1; }
@@ -61,18 +75,34 @@ fi
 umask 0077
 tmp_control="$(/usr/bin/mktemp /tmp/atendimento-production-control.XXXXXX)"
 /usr/bin/test -f "$tmp_control" -a -O "$tmp_control"
-trap '/usr/bin/rm -f "$tmp_control"' EXIT
+coordination_acquired=0
+cleanup_control() {
+  /usr/bin/rm -f "$tmp_control"
+  if [[ "$coordination_acquired" == '1' ]]; then
+    native_coordination_cleanup || true
+    coordination_acquired=0
+  fi
+}
+trap cleanup_control EXIT INT TERM
 /usr/bin/cat >"$tmp_control" <<EOF
 {"schemaVersion":1,"module":"atendimento","state":"$STATE","releaseSha":$release_json,"readOnly":true,"commercialContactWritesEnabled":false,"syntheticOnly":true,"reason":"$REASON","updatedAt":"$stamp"}
 EOF
 
 if [[ "$APPLY" == '1' ]]; then
+  native_coordination_init deploy:atendimento:production atendimento "$COORDINATION_SOURCE_SHA" "$COORDINATION_CLOSURE" mutation
+  native_coordination_acquire "mini-pc:deploy:atendimento:production:control:$COORDINATION_SOURCE_SHA:$$" >/dev/null
+  coordination_acquired=1
+  native_coordination_check
   run_sudo_clean /usr/bin/test -f "$CONTROL_FILE" || { echo "Control file is missing: $CONTROL_FILE" >&2; exit 1; }
+  native_coordination_check
   run_sudo_clean /usr/bin/install -d -m 0700 -o root -g root "$BACKUP_ROOT"
   backup="$(run_sudo_clean /usr/bin/mktemp "$BACKUP_ROOT/${stamp}-module-control.XXXXXX.json")"
   [[ "$backup" =~ ^/var/backups/skincos/clientes/production-readonly/[0-9]{8}T[0-9]{6}Z-module-control\.[A-Za-z0-9]{6}\.json$ ]] || { echo 'Control backup path was not generated from the fixed contract.' >&2; exit 1; }
+  native_coordination_check
   run_sudo_clean /usr/bin/cp -p "$CONTROL_FILE" "$backup"
+  native_coordination_check
   run_sudo_clean /usr/bin/chmod 0600 "$backup"
+  native_coordination_check
   run_sudo_clean /usr/bin/install -m 0640 -o root -g skincos "$tmp_control" "$CONTROL_FILE"
   printf 'module_control=%s release_sha=%s read_only=true commercial_writes=false applied=true\n' "$STATE" "${RELEASE_SHA:-none}"
 else

--- a/scripts/set-atendimento-staging-control.sh
+++ b/scripts/set-atendimento-staging-control.sh
@@ -10,6 +10,9 @@ run_sudo_clean() {
   /usr/bin/sudo -n /usr/bin/env -i "PATH=$SAFE_PATH" 'HOME=/nonexistent' 'LANG=C' "$@"
 }
 
+readonly SCRIPT_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
+source "$SCRIPT_ROOT/scripts/runtime/global-coordination-native.sh"
+
 readonly CONTROL_FILE='/etc/skincos/atendimento-staging/module-control.json'
 # Control JSON may describe active release state, so retain its snapshots in a
 # root-private location separate from PostgreSQL dump artifacts.
@@ -17,12 +20,14 @@ readonly BACKUP_ROOT='/var/backups/skincos/clientes/staging-control'
 
 STATE=''
 RELEASE_SHA=''
+COORDINATION_SOURCE_SHA="${SKINCOS_GLOBAL_COORDINATION_SOURCE_SHA:-}"
+COORDINATION_CLOSURE="${SKINCOS_GLOBAL_COORDINATION_CLOSURE_FILE:-}"
 REASON='clientes-staging-read-only'
 APPLY=0
 
 usage() {
   cat <<'EOF'
-Usage: scripts/set-atendimento-staging-control.sh --state <disabled|maintenance|active|canary> [--release-sha <full-sha>] [--reason <text>] [--apply]
+Usage: scripts/set-atendimento-staging-control.sh --state <disabled|maintenance|active|canary> [--release-sha <full-sha>] [--source-sha <full-sha>] [--coordination-closure <json>] [--reason <text>] [--apply]
 
 The default is dry-run. Active or canary requires a full immutable release SHA.
 Every generated control remains synthetic and read-only with commercial writes
@@ -34,6 +39,8 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --state) shift; STATE="${1:-}" ;;
     --release-sha) shift; RELEASE_SHA="${1:-}" ;;
+    --source-sha) shift; COORDINATION_SOURCE_SHA="${1:-}" ;;
+    --coordination-closure) shift; COORDINATION_CLOSURE="${1:-}" ;;
     --reason) shift; REASON="${1:-}" ;;
     --apply) APPLY=1 ;;
     -h|--help) usage; exit 0 ;;
@@ -50,6 +57,13 @@ elif [[ -n "$RELEASE_SHA" && ! "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
   exit 64
 fi
 [[ "$REASON" =~ ^[A-Za-z0-9._:-]{1,120}$ ]] || { echo '--reason contains unsupported characters.' >&2; exit 64; }
+if [[ "$APPLY" == '1' ]]; then
+  if [[ -z "$COORDINATION_SOURCE_SHA" && "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+    COORDINATION_SOURCE_SHA="$RELEASE_SHA"
+  fi
+  [[ "$COORDINATION_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo '--source-sha must be a full lowercase SHA for apply.' >&2; exit 78; }
+  [[ -n "$COORDINATION_CLOSURE" && -f "$COORDINATION_CLOSURE" ]] || { echo '--coordination-closure must identify an existing Atendimento attestation for apply.' >&2; exit 78; }
+fi
 
 for command_path in /usr/bin/sudo /usr/bin/env /usr/bin/install /usr/bin/date /usr/bin/mktemp /usr/bin/cat /usr/bin/rm /usr/bin/cp /usr/bin/cmp /usr/bin/stat /usr/bin/test; do
   [[ -x "$command_path" ]] || { echo "Missing $command_path" >&2; exit 1; }
@@ -65,10 +79,17 @@ tmp_control="$(/usr/bin/mktemp /tmp/atendimento-staging-control.XXXXXX)"
 CONTROL_BACKUP_NAME='none'
 CONTROL_BACKUP_PATH=''
 CONTROL_BACKUP_COMMITTED=0
+coordination_acquired=0
 cleanup_artifacts() {
   /usr/bin/rm -f "$tmp_control"
   if [[ "$CONTROL_BACKUP_COMMITTED" != '1' && "$CONTROL_BACKUP_PATH" =~ ^/var/backups/skincos/clientes/staging-control/[0-9]{8}T[0-9]{6}Z-module-control\.[A-Za-z0-9]{6}\.json$ ]]; then
-    run_sudo_clean /usr/bin/rm -f -- "$CONTROL_BACKUP_PATH" || true
+    if [[ "$coordination_acquired" != '1' ]] || native_coordination_check >/dev/null 2>&1; then
+      run_sudo_clean /usr/bin/rm -f -- "$CONTROL_BACKUP_PATH" || true
+    fi
+  fi
+  if [[ "$coordination_acquired" == '1' ]]; then
+    native_coordination_cleanup || true
+    coordination_acquired=0
   fi
 }
 trap cleanup_artifacts EXIT
@@ -77,7 +98,12 @@ trap cleanup_artifacts EXIT
 EOF
 
 if [[ "$APPLY" == '1' ]]; then
+  native_coordination_init deploy:atendimento:staging atendimento "$COORDINATION_SOURCE_SHA" "$COORDINATION_CLOSURE" mutation
+  native_coordination_acquire "mini-pc:deploy:atendimento:staging:control:$COORDINATION_SOURCE_SHA:$$" >/dev/null
+  coordination_acquired=1
+  native_coordination_check
   run_sudo_clean /usr/bin/test -f "$CONTROL_FILE" || { echo "Control file is missing: $CONTROL_FILE" >&2; exit 1; }
+  native_coordination_check
   run_sudo_clean /usr/bin/install -d -m 0700 -o root -g root "$BACKUP_ROOT"
   # The pre-created root-private filename is the collision-resistant identity
   # of the control snapshot. It cannot overwrite a prior promotion's proof.
@@ -89,6 +115,7 @@ if [[ "$APPLY" == '1' ]]; then
   run_sudo_clean /usr/bin/test -f "$CONTROL_BACKUP_PATH"
   run_sudo_clean /usr/bin/test -O "$CONTROL_BACKUP_PATH"
   CONTROL_BACKUP_NAME="${CONTROL_BACKUP_PATH##*/}"
+  native_coordination_check
   run_sudo_clean /usr/bin/cp -p "$CONTROL_FILE" "$CONTROL_BACKUP_PATH"
   control_backup_metadata="$(run_sudo_clean /usr/bin/stat -c '%U:%G:%a' "$CONTROL_BACKUP_PATH")"
   [[ "$control_backup_metadata" == 'root:skincos:640' ]] || {
@@ -100,6 +127,7 @@ if [[ "$APPLY" == '1' ]]; then
     exit 78
   }
   CONTROL_BACKUP_COMMITTED=1
+  native_coordination_check
   run_sudo_clean /usr/bin/install -m 0640 -o root -g skincos "$tmp_control" "$CONTROL_FILE"
   printf 'module_control=%s release_sha=%s read_only=true commercial_writes=false control_backup=%s applied=true\n' "$STATE" "${RELEASE_SHA:-none}" "$CONTROL_BACKUP_NAME"
 else

--- a/scripts/sync-atendimento-local-mirror.sh
+++ b/scripts/sync-atendimento-local-mirror.sh
@@ -2,11 +2,15 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+source "$ROOT_DIR/scripts/runtime/global-coordination-native.sh"
 RUNTIME_HOME="${CRM_RUNTIME_HOME:-/mnt/c/CodexRuntime/operator/admin/skincos/runtime/atendimento-mirror}"
 RUNTIME_ENV_FILE="${SKINCOS_CRM_API_ENV_FILE:-/etc/skincos/crm.env}"
 SOURCE_ENV_FILE="${ATENDIMENTO_SOURCE_ENV_FILE:-/etc/skincos/atendimento-source.env}"
 OPERATOR_ENV_FILE="${SKINCOS_ATENDIMENTO_OPERATOR_ENV_FILE:-/mnt/c/CodexRuntime/operator/admin/skincos/private/atendimento-mirror.env}"
 MODE="${1:---dry-run}"
+COORDINATION_SOURCE_SHA="${SKINCOS_GLOBAL_COORDINATION_SOURCE_SHA:-}"
+COORDINATION_CLOSURE="${SKINCOS_GLOBAL_COORDINATION_CLOSURE_FILE:-}"
+coordination_acquired=0
 
 usage() {
   cat <<EOF
@@ -16,6 +20,10 @@ Uso: ./scripts/sync-atendimento-local-mirror.sh [--status|--preflight|--dry-run|
   --preflight Valida a origem somente leitura e retorna evidências sanitizadas, sem alterar bancos.
   --dry-run  Valida a origem somente leitura e mostra o resumo da cópia.
   --apply    Faz backup, substitui o clone local após confirmação e valida o CRM.
+
+Para --apply, SKINCOS_GLOBAL_COORDINATION_SOURCE_SHA e
+SKINCOS_GLOBAL_COORDINATION_CLOSURE_FILE devem apontar para a prova imutável
+do mesmo SHA que está sendo sincronizado.
 
 Arquivos privados esperados:
   $OPERATOR_ENV_FILE  Overlay do operador (preferido; fora do repositório)
@@ -110,12 +118,34 @@ case "$SOURCE_MODE" in
 esac
 
 if [[ "$MODE" == "--apply" ]]; then
+  [[ "$COORDINATION_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+    echo "[atendimento-mirror] SKINCOS_GLOBAL_COORDINATION_SOURCE_SHA deve ser um SHA completo." >&2
+    exit 78
+  }
+  [[ -n "$COORDINATION_CLOSURE" && -f "$COORDINATION_CLOSURE" ]] || {
+    echo "[atendimento-mirror] SKINCOS_GLOBAL_COORDINATION_CLOSURE_FILE deve apontar para uma prova existente." >&2
+    exit 78
+  }
   echo "[atendimento-mirror] A atualizacao substituira as simulacoes locais apos gerar backup."
   read -r -p "Digite SINCRONIZAR para continuar: " confirmation
   if [[ "$confirmation" != "SINCRONIZAR" ]]; then
     echo "[atendimento-mirror] Atualizacao cancelada."
     exit 0
   fi
+fi
+
+if [[ "$MODE" == "--apply" ]]; then
+  native_coordination_init deploy:atendimento:local atendimento "$COORDINATION_SOURCE_SHA" "$COORDINATION_CLOSURE" mutation
+  cleanup_coordination() {
+    if [[ "$coordination_acquired" == '1' ]]; then
+      native_coordination_cleanup || true
+      coordination_acquired=0
+    fi
+  }
+  trap cleanup_coordination EXIT INT TERM
+  native_coordination_acquire "mini-pc:deploy:atendimento:local:mirror:$COORDINATION_SOURCE_SHA:$$" >/dev/null
+  coordination_acquired=1
+  native_coordination_check
 fi
 
 node_args=("$ROOT_DIR/crm/api/scripts/sync-atendimento-local-mirror.mjs" "$MODE")
@@ -136,14 +166,19 @@ else
 fi
 # O operador admin lê os arquivos privados e acessa o banco local por peer.
 # O usuário skincos é reservado ao serviço e não deve ser usado como launcher.
+if [[ "$MODE" == "--apply" ]]; then
+  native_coordination_check
+fi
 env "${env_args[@]}" node "${node_args[@]}"
 
 if [[ "$MODE" != "--apply" ]]; then
   exit 0
 fi
 
+native_coordination_check
 sudo -n systemctl restart crm.service
 for _ in $(seq 1 120); do
+  native_coordination_renew_if_due
   if curl -fsS http://127.0.0.1:8099/health >/dev/null 2>&1; then
     break
   fi
@@ -151,4 +186,5 @@ for _ in $(seq 1 120); do
 done
 curl -fsS http://127.0.0.1:8099/health >/dev/null
 
+native_coordination_check
 CRM_BUILD_BEFORE_START=0 bash "$ROOT_DIR/scripts/run-local-crm.sh" --skip-build --exit-after-smoke

--- a/scripts/tests/clientes-production-readonly-runtime.test.mjs
+++ b/scripts/tests/clientes-production-readonly-runtime.test.mjs
@@ -9,7 +9,9 @@ const read = (relative) => fs.readFileSync(path.join(root, relative), 'utf8')
 
 function assertNoDynamicShell(relative) {
   const text = read(relative)
-  assert.doesNotMatch(text, /^\s*(?:source|\.)\s+[^\n]+/m, `${relative} must not load an env file as shell code`)
+  const shellLoads = [...text.matchAll(/^\s*(?:source|\.)\s+([^\n]+)/gm)]
+  const nonStaticLoads = shellLoads.filter((match) => !match[1].includes('global-coordination-native.sh'))
+  assert.equal(nonStaticLoads.length, 0, `${relative} must not load an env file as shell code`)
   assert.doesNotMatch(text, /^\s*eval\s+/m, `${relative} must not evaluate data as shell`)
   assert.doesNotMatch(text, /^\s*(?:exec\s+)?bash\s+-c\b/m, `${relative} must not create a shell command string`)
 }
@@ -356,7 +358,7 @@ test('staging release, control and application role remain fixed and read-only',
   assert.match(rollback, /\/usr\/bin\/systemctl restart "\$SERVICE"/)
   assert.match(rollback, /shared_restart=false/)
   assert.doesNotMatch(rollback, /systemctl\s+(?:restart|stop|start)\s+(?:crm\.service|crm-jobs\.service|orb\.service|cloudflare-runtime\.service)/)
-  assert.doesNotMatch(rollback, /^\s*(?:source|\.)\s+[^\n]+/m)
+  assert.doesNotMatch(rollback, /^\s*(?:source|\.)\s+(?!.*global-coordination-native\.sh)[^\n]+/m)
   assert.doesNotMatch(rollback, /^\s*eval\s+/m)
   assert.match(rollbackControl, /STAGING_CONTROL_BACKUP_ROOT = '\/var\/backups\/skincos\/clientes\/staging-control'/)
   assert.match(rollbackControl, /const BACKUP_NAME = \/\^\[0-9\]\{8\}T\[0-9\]\{6\}Z-module-control\\\.\[A-Za-z0-9\]\{6\}\\\.json\$\//)

--- a/scripts/tests/codex-autonomy-baseline.test.mjs
+++ b/scripts/tests/codex-autonomy-baseline.test.mjs
@@ -49,6 +49,8 @@ test("release input digest ignores unrelated documentation but invalidates relev
   const documentationOnly = buildReleaseManifest({ ...base, sourceCommit: "d".repeat(40), sourceTree: "e".repeat(40), inputs: [...base.inputs] });
   const relevantChange = buildReleaseManifest({ ...base, inputs: [{ path: "workforce/timekeeping/index.ts", blob: "2".repeat(40) }] });
   assert.equal(documentationOnly.releaseInputDigest, original.releaseInputDigest);
+  assert.equal(documentationOnly.dependencyClosureDigest, original.dependencyClosureDigest);
+  assert.notEqual(documentationOnly.releaseIdentityDigest, original.releaseIdentityDigest);
   assert.notEqual(relevantChange.releaseInputDigest, original.releaseInputDigest);
 });
 

--- a/scripts/tests/codex-global-coordination-client.test.mjs
+++ b/scripts/tests/codex-global-coordination-client.test.mjs
@@ -25,11 +25,17 @@ test("GitHub and mini-PC clients produce the same signed envelope contract", () 
         intentDigest: "a".repeat(64),
         owner: { provider: "github", missionId: "mission-1", threadId: "thread-1", actor: "actions" },
       },
+      authorization: {
+        expectedResource: "deploy:website:staging",
+        expectedIntentDigest: "a".repeat(64),
+        observedDependencyClosureDigest: "c".repeat(64),
+      },
       nonce,
       requestedAt: "2026-08-09T18:00:00.000Z",
   });
   assert.equal(request.endpoint.pathname, "/v1/leases");
   assert.equal(request.body.contractId, CONTRACT_ID);
+  assert.equal(request.body.authorization.observedDependencyClosureDigest, "c".repeat(64));
   assert.equal(request.headers["x-skincos-coordination-request-digest"], request.requestDigest);
   const expectedSignature = crypto.createHmac("sha256", secret)
     .update(canonicalJson({

--- a/scripts/tests/codex-global-coordination-client.test.mjs
+++ b/scripts/tests/codex-global-coordination-client.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import crypto from "node:crypto";
+import {
+  buildAuthenticatedRequest,
+  lockScopeForResource,
+  newRequestNonce,
+  proofForLease,
+  verifyCoordinatorResponse,
+} from "../codex-global-coordination-client.mjs";
+import { canonicalJson, CONTRACT_ID } from "../../ops/governance/global-coordination-core.mjs";
+
+const secret = "test-coordination-secret";
+const nonce = "n".repeat(32);
+
+test("GitHub and mini-PC clients produce the same signed envelope contract", () => {
+  const request = buildAuthenticatedRequest({
+      url: "https://coordination.example.test",
+      secret,
+      action: "check",
+      proof: {
+        resource: "deploy:website:staging",
+        leaseId: "lease-0000000000000001",
+        fencingToken: 4,
+        intentDigest: "a".repeat(64),
+        owner: { provider: "github", missionId: "mission-1", threadId: "thread-1", actor: "actions" },
+      },
+      nonce,
+      requestedAt: "2026-08-09T18:00:00.000Z",
+  });
+  assert.equal(request.endpoint.pathname, "/v1/leases");
+  assert.equal(request.body.contractId, CONTRACT_ID);
+  assert.equal(request.headers["x-skincos-coordination-request-digest"], request.requestDigest);
+  const expectedSignature = crypto.createHmac("sha256", secret)
+    .update(canonicalJson({
+      contractId: CONTRACT_ID,
+      method: "POST",
+      nonce,
+      path: "/v1/leases",
+      requestDigest: request.requestDigest,
+      requestedAt: "2026-08-09T18:00:00.000Z",
+      schemaVersion: 1,
+    }))
+    .digest("base64url");
+  assert.equal(request.headers["x-skincos-coordination-request-signature"], expectedSignature);
+  assert.equal(request.headers.authorization, undefined);
+  assert.throws(() => buildAuthenticatedRequest({
+    url: "https://coordination.example.test",
+    secret,
+    action: "revoke",
+    proof: request.body.proof,
+    reason: "test-revoke",
+    nonce,
+    requestedAt: "2026-08-09T18:00:00.000Z",
+  }), /administrative custody is unavailable/);
+  assert.equal(buildAuthenticatedRequest({
+    url: "https://coordination.example.test",
+    secret,
+    adminSecret: "admin-secret",
+    action: "revoke",
+    proof: request.body.proof,
+    reason: "test-revoke",
+    nonce: "r".repeat(32),
+    requestedAt: "2026-08-09T18:00:00.000Z",
+  }).headers.authorization, "Bearer admin-secret");
+});
+
+test("response signatures cover the authority envelope and tampering fails closed", () => {
+  const unsigned = { schemaVersion: 1, contractId: CONTRACT_ID, passed: true, accepted: true, reason: "lease-acquired" };
+  const responseDigest = crypto.createHash("sha256").update(canonicalJson(unsigned)).digest("hex");
+  const authority = { contractId: CONTRACT_ID, provider: "cloudflare", responseDigest };
+  const responseSignature = crypto.createHmac("sha256", secret)
+    .update(canonicalJson({ ...unsigned, authority }))
+    .digest("base64url");
+  assert.deepEqual(verifyCoordinatorResponse({ ...unsigned, authority, responseSignature }, secret), unsigned);
+  assert.throws(() => verifyCoordinatorResponse({ ...unsigned, accepted: false, authority, responseSignature }, secret), /digest mismatch/);
+});
+
+test("lease proofs and conflict scopes remain normalized across adapters", () => {
+  assert.match(newRequestNonce(), /^[A-Za-z0-9_-]{32,}$/);
+  assert.equal(lockScopeForResource("CLOUDFLARE:Website:Staging"), "surface:website:staging");
+  assert.deepEqual(proofForLease({
+    resource: "DEPLOY:Website:Staging",
+    leaseId: "lease-0000000000000001",
+    fencingToken: 2,
+    intentDigest: "b".repeat(64),
+    owner: { provider: "github", missionId: "mission-1", threadId: "thread-1", actor: "actions" },
+  }), {
+    resource: "deploy:website:staging",
+    leaseId: "lease-0000000000000001",
+    fencingToken: 2,
+    intentDigest: "b".repeat(64),
+    owner: { provider: "github", missionId: "mission-1", threadId: "thread-1", actor: "actions" },
+  });
+});

--- a/scripts/tests/codex-global-coordination-workflow.test.mjs
+++ b/scripts/tests/codex-global-coordination-workflow.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { buildWorkflowLeaseRequest, closureFromFile } from "../codex-global-coordination-workflow.mjs";
+import { dependencyClosureForSource } from "../codex-global-coordinator.mjs";
+
+test("workflow adapter binds the lease to source closure, owner, and selected resource", () => {
+  const resource = "deploy:timekeeping:staging";
+  const { request, closure } = buildWorkflowLeaseRequest({
+    resource,
+    module: "ponto",
+    source: "HEAD",
+    inputs: { target: "staging", releaseScope: "ponto" },
+  });
+  assert.equal(request.resource, resource);
+  assert.equal(request.lockScope, "surface:timekeeping:staging");
+  assert.equal(request.intent.module, "ponto");
+  assert.equal(request.intent.sourceCommit, closure.sourceCommit);
+  assert.equal(request.intent.sourceTree, closure.sourceTree);
+  assert.equal(request.intent.dependencyClosureDigest, closure.digest);
+  assert.equal(request.owner.provider, "github");
+  assert.match(request.intentDigest, /^[0-9a-f]{64}$/);
+});
+
+test("workflow adapter accepts a detached immutable closure attestation", () => {
+  const source = "HEAD";
+  const closure = dependencyClosureForSource({ module: "orb", sourceCommit: source });
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "skincos-global-closure-"));
+  const file = path.join(directory, "orb.json");
+  fs.writeFileSync(file, `${JSON.stringify(closure)}\n`, { mode: 0o600 });
+  try {
+    const loaded = closureFromFile(["--closure-file", file], { module: "orb", source });
+    assert.equal(loaded.sourceCommit, closure.sourceCommit);
+    assert.equal(loaded.sourceTree, closure.sourceTree);
+    assert.equal(loaded.digest, closure.digest);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("workflow adapter carries exact release identity for promotion operations", () => {
+  const closure = dependencyClosureForSource({ module: "orb", sourceCommit: "HEAD" });
+  const releaseIdentity = {
+    schemaVersion: 1,
+    module: "orb",
+    sourceCommit: closure.sourceCommit,
+    sourceTree: closure.sourceTree,
+    dependencyClosureDigest: closure.digest,
+    artifacts: [{ name: "native-source", id: closure.sourceCommit, digest: "d".repeat(64) }],
+  };
+  const { request } = buildWorkflowLeaseRequest({
+    resource: "release:orb",
+    module: "orb",
+    source: "HEAD",
+    operation: "promotion",
+    releaseIdentity,
+  });
+  assert.deepEqual(request.intent.releaseIdentity, releaseIdentity);
+  assert.throws(() => buildWorkflowLeaseRequest({
+    resource: "release:orb",
+    module: "orb",
+    source: "HEAD",
+    operation: "promotion",
+  }), /release identity is required/);
+  assert.throws(() => buildWorkflowLeaseRequest({
+    resource: "release:orb",
+    module: "orb",
+    source: "HEAD",
+    operation: "promotion",
+    releaseIdentity: { ...releaseIdentity, dependencyClosureDigest: "e".repeat(64) },
+  }), /release identity does not match/);
+});

--- a/scripts/tests/codex-global-coordination.test.mjs
+++ b/scripts/tests/codex-global-coordination.test.mjs
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+import {
+  acquireLease,
+  authorizeMutation,
+  buildIntent,
+  buildLeaseRequest,
+  checkLease,
+  compareDependencyClosure,
+  consumeNonce,
+  dependencyClosureFromTree,
+  dependencyClosureForSource,
+  emptyState,
+  loadGlobalPolicy,
+  lockScopeFor,
+  normalizeResourceKey,
+  releaseLease,
+  renewLease,
+} from "../codex-global-coordinator.mjs";
+
+const owner = {
+  provider: "codex",
+  missionId: "mission-global-coordination",
+  threadId: "thread-global-coordination",
+  actor: "admin",
+};
+const sha = (character) => character.repeat(40);
+const digest = (character) => character.repeat(64);
+const identity = () => ({
+  module: "website",
+  sourceCommit: sha("a"),
+  sourceTree: sha("b"),
+  dependencyClosureDigest: digest("c"),
+  artifacts: [{ name: "pages", id: "deployment-1", digest: digest("d"), versionId: "version-1" }],
+});
+const releaseRequest = (idempotencyKey = "intent-1") => buildLeaseRequest({
+  operation: "promotion",
+  resource: "deploy:website:staging",
+  owner,
+  idempotencyKey,
+  ttlMs: 60_000,
+  intent: { releaseIdentity: identity(), purpose: "promote-exact-build" },
+});
+
+test("resource keys normalize and shared surface scopes collide across deploy and Cloudflare mutations", () => {
+  assert.equal(normalizeResourceKey("DEPLOY:Website:Staging"), "deploy:website:staging");
+  assert.equal(lockScopeFor("deploy:website:staging"), "surface:website:staging");
+  assert.equal(lockScopeFor("cloudflare:website:staging"), "surface:website:staging");
+  assert.equal(lockScopeFor("release:website"), "release:website");
+  assert.equal(lockScopeFor("merge:main"), "repository:main");
+  assert.throws(() => normalizeResourceKey("deploy:website:unknown"), /resource environment is invalid/);
+  assert.throws(() => normalizeResourceKey("surface:website:staging"), /resource class is unsupported/);
+});
+
+test("a lease is idempotent for one owner and fences a concurrent owner", () => {
+  const request = releaseRequest();
+  const first = acquireLease(emptyState(), request, { now: 1_000, leaseId: "lease-0000000000000001" });
+  assert.equal(first.accepted, true);
+  assert.equal(first.lease.fencingToken, 1);
+  const repeated = acquireLease(first.state, request, { now: 2_000, leaseId: "lease-0000000000000002" });
+  assert.equal(repeated.idempotent, true);
+  assert.equal(repeated.lease.leaseId, first.lease.leaseId);
+  const other = acquireLease(first.state, { ...releaseRequest("intent-2"), owner: { ...owner, threadId: "other-thread" } }, { now: 2_000, leaseId: "lease-0000000000000003" });
+  assert.equal(other.accepted, false);
+  assert.equal(other.reason, "resource-lease-held");
+});
+
+test("expired leases cannot be reused and stale proofs fail after fencing advances", () => {
+  const request = releaseRequest();
+  const first = acquireLease(emptyState(), request, { now: 1_000, leaseId: "lease-0000000000000001" });
+  const stale = {
+    resource: first.lease.resource,
+    leaseId: first.lease.leaseId,
+    fencingToken: first.lease.fencingToken,
+    intentDigest: first.lease.intentDigest,
+    owner: first.lease.owner,
+  };
+  const second = acquireLease(first.state, { ...request, idempotencyKey: "intent-2" }, { now: 61_001, leaseId: "lease-0000000000000002" });
+  assert.equal(second.accepted, true);
+  assert.equal(second.lease.fencingToken, 2);
+  const staleCheck = checkLease(second.state, stale, { now: 61_002 });
+  assert.equal(staleCheck.valid, false);
+  assert.equal(staleCheck.reason, "lease-fence-mismatch");
+});
+
+test("release promotion accepts an unrelated main tip and rejects closure drift before mutation", () => {
+  const request = releaseRequest();
+  const acquired = acquireLease(emptyState(), request, { now: 1_000, leaseId: "lease-0000000000000001" });
+  const proof = {
+    resource: acquired.lease.resource,
+    leaseId: acquired.lease.leaseId,
+    fencingToken: acquired.lease.fencingToken,
+    intentDigest: acquired.lease.intentDigest,
+    owner: acquired.lease.owner,
+  };
+  const allowed = authorizeMutation(acquired.state, proof, {
+    now: 2_000,
+    observedDependencyClosureDigest: digest("c"),
+    expectedArtifacts: identity().artifacts,
+  });
+  assert.equal(allowed.valid, true);
+  const unrelatedMainTip = sha("e");
+  assert.notEqual(unrelatedMainTip, identity().sourceCommit);
+  const invalidated = authorizeMutation(acquired.state, proof, {
+    now: 2_000,
+    observedDependencyClosureDigest: digest("f"),
+    expectedArtifacts: identity().artifacts,
+  });
+  assert.equal(invalidated.valid, false);
+  assert.equal(invalidated.reason, "dependency-closure-changed");
+});
+
+test("missing closure, artifact identity, owner or lease authority fails closed", () => {
+  assert.deepEqual(compareDependencyClosure(digest("c"), ""), {
+    valid: false,
+    failClosed: true,
+    reason: "dependency-closure-unavailable",
+  });
+  assert.throws(() => buildIntent({
+    operation: "promotion",
+    resource: "promotion:website:staging",
+    owner,
+    idempotencyKey: "intent-1",
+    intent: { purpose: "missing-release-identity" },
+  }), /release identity is required/);
+  assert.throws(() => buildIntent({
+    operation: "mutation",
+    resource: "deploy:website:staging",
+    owner: { ...owner, provider: "unknown" },
+    idempotencyKey: "intent-1",
+    intent: { purpose: "invalid-owner" },
+  }), /lease owner provider is invalid/);
+});
+
+test("renewal and nonce replay are explicit state transitions", () => {
+  const request = releaseRequest();
+  const acquired = acquireLease(emptyState(), request, { now: 1_000, leaseId: "lease-0000000000000001" });
+  const proof = {
+    resource: acquired.lease.resource,
+    leaseId: acquired.lease.leaseId,
+    fencingToken: acquired.lease.fencingToken,
+    intentDigest: acquired.lease.intentDigest,
+    owner: acquired.lease.owner,
+  };
+  const renewed = renewLease(acquired.state, proof, { now: 20_000, ttlMs: 60_000 });
+  assert.equal(renewed.valid, true);
+  assert.equal(renewed.lease.expiresAt, 80_000);
+  const firstNonce = consumeNonce(renewed.state, { nonce: "nonce-0000000000000001", digest: digest("a"), now: 20_000, ttlMs: 60_000 });
+  assert.equal(firstNonce.accepted, true);
+  const replay = consumeNonce(firstNonce.state, { nonce: "nonce-0000000000000001", digest: digest("a"), now: 20_001, ttlMs: 60_000 });
+  assert.equal(replay.accepted, false);
+  assert.equal(replay.reason, "request-nonce-replayed");
+  assert.equal(fs.existsSync(new URL("../../ops/governance/global-concurrency-policy.json", import.meta.url)), true);
+});
+
+test("the policy and current Ponto source produce a deterministic dependency closure", () => {
+  const policy = loadGlobalPolicy();
+  assert.equal(policy.contractId, "skincos/global-coordination/v1");
+  assert.equal(policy.authority.mode, "fail-closed");
+  assert.equal(policy.lease.maximumTtlMs, 900_000);
+  const closure = dependencyClosureForSource({ module: "ponto", sourceCommit: "HEAD" });
+  assert.match(closure.digest, /^[0-9a-f]{64}$/);
+  assert.ok(closure.inputs.some((entry) => entry.path === ".github/workflows/ponto-progressive-release.yml"));
+  assert.ok(closure.inputs.some((entry) => entry.path === "package.json"));
+});
+
+test("Ponto closure excludes independent CRM API changes while retaining the shared Pages artifact", () => {
+  const closure = dependencyClosureFromTree({
+    module: "ponto",
+    sourceCommit: sha("a"),
+    sourceTree: sha("b"),
+    entries: [
+      { path: "crm/api/server/atendimento/commercialOperationsMigration.js", blob: digest("a").slice(0, 40) },
+      { path: "crm/console/PontoModule.tsx", blob: digest("b").slice(0, 40) },
+      { path: "package.json", blob: digest("c").slice(0, 40) },
+    ],
+  });
+  assert.equal(closure.inputs.some((entry) => entry.path.startsWith("crm/api/")), false);
+  assert.equal(closure.inputs.some((entry) => entry.path === "crm/console/PontoModule.tsx"), true);
+  assert.equal(closure.inputs.some((entry) => entry.path === "package.json"), true);
+});
+
+test("closure digest ignores source-tree changes outside the selected inputs", () => {
+  const entries = [
+    { path: "crm/console/PontoModule.tsx", blob: digest("a").slice(0, 40) },
+    { path: "package.json", blob: digest("b").slice(0, 40) },
+  ];
+  const first = dependencyClosureFromTree({ module: "ponto", sourceCommit: sha("a"), sourceTree: sha("b"), entries });
+  const second = dependencyClosureFromTree({ module: "ponto", sourceCommit: sha("c"), sourceTree: sha("d"), entries });
+  assert.notEqual(first.sourceTree, second.sourceTree);
+  assert.equal(first.digest, second.digest);
+});

--- a/scripts/tests/codex-global-coordination.test.mjs
+++ b/scripts/tests/codex-global-coordination.test.mjs
@@ -111,6 +111,44 @@ test("release promotion accepts an unrelated main tip and rejects closure drift 
   assert.equal(invalidated.reason, "dependency-closure-changed");
 });
 
+test("mutation leases also require the observed closure when a caller supplies it", () => {
+  const request = buildLeaseRequest({
+    operation: "mutation",
+    resource: "deploy:website:staging",
+    owner,
+    idempotencyKey: "mutation-closure-1",
+    ttlMs: 60_000,
+    intent: { dependencyClosureDigest: digest("c"), purpose: "surface-mutation" },
+  });
+  const acquired = acquireLease(emptyState(), request, { now: 1_000, leaseId: "lease-0000000000000004" });
+  const proof = {
+    resource: acquired.lease.resource,
+    leaseId: acquired.lease.leaseId,
+    fencingToken: acquired.lease.fencingToken,
+    intentDigest: acquired.lease.intentDigest,
+    owner: acquired.lease.owner,
+  };
+  assert.equal(authorizeMutation(acquired.state, proof, {
+    now: 2_000,
+    expectedResource: "deploy:website:staging",
+    observedDependencyClosureDigest: digest("c"),
+  }).valid, true);
+  const drift = authorizeMutation(acquired.state, proof, {
+    now: 2_000,
+    expectedResource: "deploy:website:staging",
+    observedDependencyClosureDigest: digest("d"),
+  });
+  assert.equal(drift.valid, false);
+  assert.equal(drift.reason, "dependency-closure-changed");
+  const missing = authorizeMutation(acquired.state, proof, {
+    now: 2_000,
+    expectedResource: "deploy:website:staging",
+    observedDependencyClosureDigest: "",
+  });
+  assert.equal(missing.valid, false);
+  assert.equal(missing.reason, "dependency-closure-intent-missing");
+});
+
 test("missing closure, artifact identity, owner or lease authority fails closed", () => {
   assert.deepEqual(compareDependencyClosure(digest("c"), ""), {
     valid: false,

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -76,6 +76,9 @@ test("the reusable check action accepts either an external proof file or an enco
   assert.match(action, /git fetch --no-tags origin "\$GLOBAL_SOURCE_SHA"/);
   assert.match(action, /--source "\$GLOBAL_OBSERVED_SOURCE_SHA"/);
   assert.match(action, /--candidate-source "\$GLOBAL_SOURCE_SHA"/);
+  assert.match(action, /inputs\.required == 'true' \|\| github\.event\.inputs\.target == 'production'/);
+  assert.match(read(".github/actions/global-coordination-acquire/action.yml"), /github\.event\.inputs\.target == 'production'/);
+  assert.match(read(".github/actions/global-coordination-release/action.yml"), /github\.event\.inputs\.target == 'production'/);
   assert.match(action, /GLOBAL_PROOF_FILE_INPUT/);
   assert.match(action, /base64 -d/);
 });
@@ -177,6 +180,10 @@ test("native mini-PC mutations use the common coordinator and detached closure p
   assert.match(harmonia, /deploy:atendimento:staging/);
   assert.match(harmonia, /deploy:atendimento:production/);
   assert.match(harmonia, /native_coordination_check/);
+  const migration = read("scripts/run-atendimento-staging-migration.sh");
+  assert.match(migration, /if \[\[ "\$ACTION" != '--dry-run' \]\]; then\s+native_coordination_check/);
+  const tunnel = read("scripts/runtime/install-atendimento-production-tunnel.sh");
+  assert.match(tunnel, /systemctl daemon-reload[\s\S]*coordination_run check[\s\S]*systemctl enable --now/);
 
   for (const [file, resource] of [
     ["scripts/provision-atendimento-staging.sh", "deploy:atendimento:staging"],

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const ROOT = path.resolve(import.meta.dirname, "../..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(ROOT, relativePath), "utf8");
+}
+
+function jobBlock(workflow, jobName) {
+  const start = workflow.indexOf(`  ${jobName}:`);
+  assert.notEqual(start, -1, `missing workflow job: ${jobName}`);
+  const remainder = workflow.slice(start + 1);
+  const next = remainder.search(/\n  [A-Za-z0-9_-]+:/);
+  return next === -1 ? remainder : remainder.slice(0, next);
+}
+
+test("direct Ponto recovery jobs use remote custody at every governed boundary", () => {
+  const workflow = read(".github/workflows/ponto-progressive-release.yml");
+  for (const jobName of ["recovery-latch", "recovery-reconcile", "recovery-close", "recovery-rollback"]) {
+    const block = jobBlock(workflow, jobName);
+    assert.match(block, /uses: \.\/\.github\/actions\/global-coordination-acquire/);
+    assert.match(block, /uses: \.\/\.github\/actions\/global-coordination-check/);
+    assert.match(block, /uses: \.\/\.github\/actions\/global-coordination-release/);
+    assert.match(block, /resource: release:ponto/);
+    assert.match(block, /proof_file: \$\{\{ runner\.temp \}\}\/ponto-ordinary-recovery\/global-coordination-lease\.json/);
+    assert.match(block, /SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL/);
+  }
+});
+
+test("legacy recovery and WAF mutators are fail-closed through the same authority", () => {
+  const waf = jobBlock(read(".github/workflows/ponto-waf-security.yml"), "apply");
+  assert.match(waf, /resource: cloudflare:ponto-waf:production/);
+  assert.match(waf, /uses: \.\/\.github\/actions\/global-coordination-acquire/);
+  assert.match(waf, /uses: \.\/\.github\/actions\/global-coordination-check/);
+  assert.match(waf, /uses: \.\/\.github\/actions\/global-coordination-release/);
+  assert.ok(waf.indexOf("Check global WAF mutation lease immediately before WAF mutation") < waf.indexOf("node .github/scripts/ponto-waf-security.mjs"));
+
+  const watchdog = read(".github/workflows/ponto-release-watchdog.yml");
+  for (const jobName of ["fail-close", "rollback"]) {
+    const block = jobBlock(watchdog, jobName);
+    assert.match(block, /resource: release:ponto/);
+    assert.match(block, /uses: \.\/\.github\/actions\/global-coordination-acquire/);
+    assert.match(block, /uses: \.\/\.github\/actions\/global-coordination-check/);
+    assert.match(block, /uses: \.\/\.github\/actions\/global-coordination-release/);
+  }
+  const watchdogRollback = jobBlock(watchdog, "rollback");
+  assert.ok(watchdogRollback.indexOf("Check global Ponto recovery lease before broker-close materialization") < watchdogRollback.indexOf("node .github/scripts/ponto-module-control-materialize.mjs"));
+  assert.ok(watchdogRollback.indexOf("Check global Ponto recovery lease immediately before watchdog rollback") < watchdogRollback.indexOf("node .github/scripts/ponto-automatic-rollback.mjs"));
+
+  const coreRecovery = jobBlock(read(".github/workflows/ponto-staging-core-provenance-recovery.yml"), "rollback");
+  assert.match(coreRecovery, /resource: deploy:core-api:staging/);
+  assert.match(coreRecovery, /uses: \.\/\.github\/actions\/global-coordination-acquire/);
+  assert.match(coreRecovery, /uses: \.\/\.github\/actions\/global-coordination-check/);
+  assert.match(coreRecovery, /uses: \.\/\.github\/actions\/global-coordination-release/);
+  assert.ok(coreRecovery.indexOf("Check global Core staging recovery lease immediately before materialization") < coreRecovery.indexOf("node .github/scripts/ponto-module-control-materialize.mjs"));
+  assert.ok(coreRecovery.indexOf("Check global Core staging recovery lease immediately before Core rollback") < coreRecovery.indexOf("node .github/scripts/ponto-automatic-rollback.mjs"));
+
+  const stagingRecovery = jobBlock(read(".github/workflows/ponto-staging-recovery-rollback.yml"), "rollback");
+  assert.match(stagingRecovery, /resource: release:ponto/);
+  assert.match(stagingRecovery, /uses: \.\/\.github\/actions\/global-coordination-acquire/);
+  assert.match(stagingRecovery, /uses: \.\/\.github\/actions\/global-coordination-check/);
+  assert.match(stagingRecovery, /uses: \.\/\.github\/actions\/global-coordination-release/);
+  assert.ok(stagingRecovery.indexOf("Check global Ponto recovery lease immediately before staging materialization") < stagingRecovery.indexOf("node .github/scripts/ponto-module-control-materialize.mjs"));
+  assert.ok(stagingRecovery.indexOf("Check global Ponto recovery lease immediately before staging rollback") < stagingRecovery.indexOf("node .github/scripts/ponto-automatic-rollback.mjs"));
+});
+
+test("the reusable check action accepts either an external proof file or an encoded proof", () => {
+  const action = read(".github/actions/global-coordination-check/action.yml");
+  assert.match(action, /proof_b64:[\s\S]*?required: false/);
+  assert.match(action, /proof_file:[\s\S]*?required: false/);
+  assert.match(action, /GLOBAL_PROOF_FILE_INPUT/);
+  assert.match(action, /base64 -d/);
+});
+
+test("merge:main is a fail-closed GitHub mutation authority", () => {
+  const script = read("scripts/codex-global-merge-authority.mjs");
+  const workflow = read(".github/workflows/global-merge-authority.yml");
+  const scheduler = read(".github/workflows/codex-keep-prs-mergeable.yml");
+  const policy = JSON.parse(read("ops/governance/global-concurrency-policy.json"));
+  assert.match(script, /const resource = "merge:main"/);
+  assert.match(script, /expectedHeadSha/);
+  assert.match(script, /checkGlobalLease/);
+  assert.match(script, /global-merge-authority/);
+  assert.match(script, /setMergeAuthorityStatus/);
+  assert.match(script, /\/pulls\/\$\{pullNumber\}\/merge/);
+  assert.match(workflow, /pull_request_target/);
+  assert.match(workflow, /state=failure/);
+  assert.match(workflow, /run-name: Merge PR #\$\{\{ inputs\.pull_number \}\} through merge:main/);
+  assert.doesNotMatch(scheduler, /enablePullRequestAutoMerge/);
+  assert.match(scheduler, /disablePullRequestAutoMerge/);
+  assert.match(scheduler, /uses: \.\/\.github\/actions\/global-coordination-acquire/);
+  assert.match(scheduler, /uses: \.\/\.github\/actions\/global-coordination-check/);
+  assert.match(scheduler, /uses: \.\/\.github\/actions\/global-coordination-release/);
+  assert.match(scheduler, /resource: merge:main/);
+  assert.deepEqual(policy.releaseClosures.merge.patterns, ["**"]);
+});
+
+test("native mini-PC mutations use the common coordinator and detached closure proof", () => {
+  const adapter = read("scripts/runtime/global-coordination-mini-pc.sh");
+  const nativeHelper = read("scripts/runtime/global-coordination-native.sh");
+  assert.match(adapter, /GLOBAL_COORDINATION_PROVIDER='mini-pc'/);
+  assert.match(adapter, /SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET/);
+  assert.match(adapter, /proof must remain below the private mini-PC proof root/);
+  assert.match(adapter, /An immutable dependency-closure attestation is required/);
+  assert.match(nativeHelper, /native_coordination_init/);
+  assert.match(nativeHelper, /native_coordination_check/);
+  assert.match(nativeHelper, /native_coordination_renew_if_due/);
+  assert.match(nativeHelper, /global-coordination-mini-pc\.sh/);
+  assert.match(nativeHelper, /immutable_root=.*\/opt\/skincos\/releases/);
+
+  const prepare = read("scripts/runtime/prepare-native-source-release.sh");
+  assert.match(prepare, /--coordination-closure/);
+  assert.match(prepare, /coordination closure identity or digest is invalid/);
+  assert.match(prepare, /\.skincos-global-coordination-\$\{closure_module\}\.json/);
+  assert.match(prepare, /coordination_native_runtime_closure/);
+  assert.match(prepare, /native-runtime dependency-closure attestation is required/);
+
+  const atendimentoPrepare = read("scripts/runtime/prepare-atendimento-staging-release.sh");
+  assert.match(atendimentoPrepare, /--coordination-closure/);
+  assert.match(atendimentoPrepare, /native_coordination_init release:atendimento/);
+  assert.match(atendimentoPrepare, /\.skincos-global-coordination-atendimento\.json/);
+  assert.match(read("scripts/runtime/prepare-atendimento-production-release.sh"), /native_coordination_init release:atendimento/);
+  assert.match(read("scripts/runtime/rollback-atendimento-staging.sh"), /native_coordination_init deploy:atendimento:staging/);
+
+  const lifecycle = read("scripts/runtime/install-lifecycle-units.sh");
+  assert.match(lifecycle, /native_coordination_init global:native-runtime/);
+  assert.match(lifecycle, /native-runtime\.json/);
+  assert.match(read("scripts/runtime/manage-native-runtime.sh"), /native_coordination_init global:native-runtime/);
+  assert.match(read("scripts/runtime/prepare-lifecycle-layout.sh"), /--coordination-closure/);
+  assert.match(read("scripts/runtime/retire-clientes-source-refresh-service.sh"), /native_coordination_init global:native-runtime/);
+
+  const mirror = read("scripts/sync-atendimento-local-mirror.sh");
+  assert.match(mirror, /native_coordination_init deploy:atendimento:local/);
+  assert.match(mirror, /SKINCOS_GLOBAL_COORDINATION_CLOSURE_FILE/);
+
+  const mcp = read("scripts/runtime/mcp-gateway-release.sh");
+  assert.match(mcp, /promotion:orb-mcp:local/);
+  assert.match(mcp, /\.skincos-global-coordination-orb\.json/);
+  assert.match(mcp, /\.skincos-release-identity-orb\.json/);
+  assert.match(mcp, /native_coordination_check/);
+  const backup = read("scripts/runtime/run-orb-backup-with-coordination.sh");
+  assert.match(backup, /global:orb-backup/);
+  assert.match(backup, /orb-backup\.service/);
+  assert.match(read("scripts/runtime/publish-orb-backup.ps1"), /run-orb-backup-with-coordination\.sh/);
+  const harmonia = read("scripts/runtime/run-harmonia-migration-native.sh");
+  assert.match(harmonia, /deploy:atendimento:staging/);
+  assert.match(harmonia, /deploy:atendimento:production/);
+  assert.match(harmonia, /native_coordination_check/);
+
+  for (const [file, resource] of [
+    ["scripts/provision-atendimento-staging.sh", "deploy:atendimento:staging"],
+    ["scripts/set-atendimento-staging-control.sh", "deploy:atendimento:staging"],
+    ["scripts/run-atendimento-staging-migration.sh", "deploy:atendimento:staging"],
+    ["scripts/refresh-atendimento-staging-quality.sh", "deploy:atendimento:staging"],
+    ["scripts/provision-atendimento-production-readonly.sh", "deploy:atendimento:production"],
+    ["scripts/set-atendimento-production-readonly-control.sh", "deploy:atendimento:production"],
+  ]) {
+    const script = read(file);
+    assert.match(script, new RegExp(`native_coordination_init ${resource.replaceAll(":", "\\:")}`));
+    assert.match(script, /COORDINATION_CLOSURE|SKINCOS_GLOBAL_COORDINATION_CLOSURE_FILE/);
+    assert.match(script, /native_coordination_check/);
+  }
+
+  const orb = read("scripts/runtime/promote-native-source-release.sh");
+  assert.match(orb, /--resource release:orb/);
+  assert.match(orb, /\.skincos-release-identity-orb\.json/);
+  assert.match(orb, /--release-identity-file/);
+  assert.match(orb, /coordination_renew_if_due/);
+  assert.ok(orb.includes("coordination_check >/dev/null"));
+
+  const whatsapp = read("scripts/runtime/prepare-messaging-whatsapp-release.sh");
+  assert.match(whatsapp, /--resource release:orb/);
+  assert.match(whatsapp, /--coordination-closure/);
+
+  const dns = read("scripts/runtime/route-atendimento-production-dns.sh");
+  assert.match(dns, /--resource cloudflare:atendimento:production/);
+  assert.match(dns, /--source-sha/);
+
+  const rollback = read("scripts/runtime/rollback-atendimento-production.sh");
+  assert.match(rollback, /--resource deploy:atendimento:production/);
+  assert.match(rollback, /coordination_acquired/);
+});
+
+test("shared staging D1 custody serializes synthetic mutators before every write path", () => {
+  const financeCanary = read(".github/workflows/finance-staging-canary.yml");
+  const financeIdentity = read(".github/workflows/finance-staging-smoke-identity.yml");
+  const timekeepingJourney = jobBlock(read(".github/workflows/timekeeping-staging-journey.yml"), "journey");
+
+  for (const workflow of [financeCanary, financeIdentity, timekeepingJourney]) {
+    assert.match(workflow, /uses: \.\/\.github\/actions\/global-coordination-acquire/);
+    assert.match(workflow, /uses: \.\/\.github\/actions\/global-coordination-check/);
+    assert.match(workflow, /uses: \.\/\.github\/actions\/global-coordination-release/);
+    assert.match(workflow, /resource: global:staging-d1/);
+    assert.match(workflow, /proof_file: \$\{\{ runner\.temp \}\}\/skincos-global-coordination-[^\n]*staging-d1\.json/);
+  }
+
+  assert.ok(financeCanary.indexOf("Check shared staging D1 lease before opening synthetic canary") < financeCanary.indexOf("Open deterministic synthetic canary"));
+  assert.ok(financeCanary.indexOf("Check shared staging D1 lease before baseline restore") < financeCanary.indexOf("Restore non-enabled staging baseline and synthetic grant"));
+  assert.ok(financeIdentity.indexOf("Check shared staging D1 lease before identity lifecycle SQL") < financeIdentity.indexOf("Apply audited staging identity lifecycle SQL"));
+  assert.ok(timekeepingJourney.indexOf("Check shared staging D1 lease before synthetic staging provisioning") < timekeepingJourney.indexOf("Provision only run-scoped synthetic staging records"));
+  assert.ok(timekeepingJourney.indexOf("Check shared staging D1 lease before authenticated Ponto journey") < timekeepingJourney.indexOf("Execute authenticated Ponto journey"));
+  assert.match(timekeepingJourney, /id: check_staging_d1_teardown/);
+  assert.match(timekeepingJourney, /steps\.check_staging_d1_teardown\.outcome == 'success'/);
+});

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -71,8 +71,36 @@ test("the reusable check action accepts either an external proof file or an enco
   const action = read(".github/actions/global-coordination-check/action.yml");
   assert.match(action, /proof_b64:[\s\S]*?required: false/);
   assert.match(action, /proof_file:[\s\S]*?required: false/);
+  assert.match(action, /observed_source_sha:[\s\S]*?required: false/);
+  assert.match(action, /git fetch --no-tags --force origin main:refs\/remotes\/origin\/main/);
+  assert.match(action, /git fetch --no-tags origin "\$GLOBAL_SOURCE_SHA"/);
+  assert.match(action, /--source "\$GLOBAL_OBSERVED_SOURCE_SHA"/);
+  assert.match(action, /--candidate-source "\$GLOBAL_SOURCE_SHA"/);
   assert.match(action, /GLOBAL_PROOF_FILE_INPUT/);
   assert.match(action, /base64 -d/);
+});
+
+test("the Ponto composite lease starts before candidate mutation, selects the correct authority, and spans the orchestrator", () => {
+  const workflow = read(".github/workflows/ponto-progressive-release.yml");
+  const acquire = workflow.indexOf("Acquire the composite Ponto release lease before candidate mutation");
+  const firstDispatch = workflow.indexOf("node .github/scripts/ponto-dispatch-workflow.mjs");
+  const release = workflow.indexOf("Release the composite Ponto release lease");
+  assert.ok(acquire >= 0 && firstDispatch > acquire && release > firstDispatch);
+  assert.match(workflow, /SKINCOS_GLOBAL_COORDINATOR_URL: \$\{\{ contains\(fromJSON\('\["preview","staging"\]'\)/);
+  assert.match(workflow, /coordinator_url: \$\{\{ env\.SKINCOS_GLOBAL_COORDINATOR_URL \}\}/);
+  assert.match(read(".github/scripts/ponto-dispatch-workflow.mjs"), /revalidatePontoCompositeLease/);
+  assert.match(read(".github/scripts/ponto-dispatch-workflow.mjs"), /cancelActiveChildBestEffort/);
+  assert.match(read(".github/scripts/ponto-source-closure.mjs"), /assertPontoSourceClosureUnchanged/);
+  assert.match(read(".github/scripts/ponto-source-closure.mjs"), /assertDependencyClosureUnchanged/);
+  for (const workflowName of [
+    ".github/workflows/module-availability.yml",
+    ".github/workflows/ponto-production-baseline.yml",
+    ".github/workflows/ponto-production-slo.yml",
+    ".github/workflows/ponto-staging-rollback-drill.yml",
+    ".github/workflows/timekeeping-staging-journey.yml",
+  ]) {
+    assert.match(read(workflowName), /release:ponto-child/);
+  }
 });
 
 test("merge:main is a fail-closed GitHub mutation authority", () => {
@@ -165,8 +193,9 @@ test("native mini-PC mutations use the common coordinator and detached closure p
   }
 
   const orb = read("scripts/runtime/promote-native-source-release.sh");
-  assert.match(orb, /--resource release:orb/);
-  assert.match(orb, /\.skincos-release-identity-orb\.json/);
+  assert.match(orb, /--resource release:native-runtime/);
+  assert.match(orb, /\.skincos-global-coordination-native-runtime\.json/);
+  assert.match(orb, /\.skincos-release-identity-native-runtime\.json/);
   assert.match(orb, /--release-identity-file/);
   assert.match(orb, /coordination_renew_if_due/);
   assert.ok(orb.includes("coordination_check >/dev/null"));
@@ -182,6 +211,24 @@ test("native mini-PC mutations use the common coordinator and detached closure p
   const rollback = read("scripts/runtime/rollback-atendimento-production.sh");
   assert.match(rollback, /--resource deploy:atendimento:production/);
   assert.match(rollback, /coordination_acquired/);
+  assert.match(rollback, /--coordination-proof-file "\$coordination_proof" --coordination-reuse/);
+  assert.match(read("scripts/runtime/global-coordination-native.sh"), /NATIVE_COORDINATION_OWNED/);
+  assert.match(read("scripts/runtime/install-atendimento-production-service.sh"), /--coordination-reuse/);
+  assert.match(read("scripts/set-atendimento-production-readonly-control.sh"), /--coordination-reuse/);
+  assert.match(read("scripts/run-atendimento-staging-migration.sh"), /run_sudo_clean \/usr\/bin\/bash -p "\$RUNTIME_GRANT_LOCKDOWN" --apply/);
+  assert.match(read("scripts/runtime/prepare-atendimento-staging-release.sh"), /native_coordination_cleanup\ncoordination_acquired=0\ntrap - EXIT/);
+});
+
+test("the scheduled native backup bridge carries private custody and a stable owner identity", () => {
+  const publisher = read("scripts/runtime/publish-orb-backup.ps1");
+  const runner = read("scripts/runtime/run-orb-backup-with-coordination.sh");
+  assert.match(publisher, /SKINCOS_GLOBAL_COORDINATION_ENV_FILE=/);
+  assert.match(publisher, /GLOBAL_COORDINATION_MISSION_ID=windows:skincos-orb-backup/);
+  assert.match(publisher, /GLOBAL_COORDINATION_THREAD_ID=scheduled:SkincosOrbBackup/);
+  assert.match(publisher, /GLOBAL_COORDINATION_ACTOR=windows-scheduled-task/);
+  assert.match(runner, /COORDINATION_ENV_FILE=.*orb-backup\.env/);
+  assert.match(runner, /unsupported key/);
+  assert.match(runner, /mode 0600 or 0640/);
 });
 
 test("shared staging D1 custody serializes synthetic mutators before every write path", () => {

--- a/skills/skincos-project-orchestrator/SKILL.md
+++ b/skills/skincos-project-orchestrator/SKILL.md
@@ -31,6 +31,21 @@ and `references/evidence-model.md`. For `supervisor-cycle`, also read
 5. Execute continuously: scoped fixes, tests, commit, push, single-purpose PR, terminal CI, introduced-failure fixes, merge when technical gates permit, and the authorized environment verification. Do not stop after plan, commit, PR, running check, timeout, or first CI failure.
 6. Verify the relevant environment and persist only material queue, generated-state, blocker and evidence changes. After compaction, load the snapshot and continue without duplicating volatile state across historical documents.
 
+## Global concurrency authority
+
+Local session/target leases and GitHub `concurrency` are scheduling safeguards;
+neither is mutation authority. Before any shared operation, classify its
+canonical resource (`merge:main`, `release:<module>`,
+`deploy:<surface>:<environment>`, `cloudflare:<surface>:<environment>`, or
+`promotion:<module>:<environment>`), acquire the remote lease through
+`scripts/codex-global-coordination-workflow.mjs`, and keep the proof outside
+the checkout. Renew and call `check` with the observed dependency-closure
+digest immediately before each external mutation; release in an `always`
+cleanup path. A missing URL, custody secret, resource, closure, or proof is a
+fail-closed stop. The production coordinator URL is intentionally separate
+from staging, so an absent production authority must block pilot, canary,
+production, and rollback rather than reuse staging custody.
+
 ## Authorization
 
 Authorization comes from the current explicit mission under


### PR DESCRIPTION
## Summary

- adds one remote, fail-closed lease authority for merge, release, deploy, Cloudflare mutation, promotion, and shared global resources
- binds lease proofs to owner, fencing token, source SHA, dependency closure, nonce, and custody
- adds GitHub merge authority and status gate, reusable acquire/check/release actions, native mini-PC adapters, and guarded recovery/WAF/staging paths
- keeps immutable artifact promotion valid across unrelated main changes while interrupting on dependency-closure drift
- preserves the production coordinator as intentionally unconfigured; production callers fail closed until a separately governed production authority is provisioned

## Validation

- codex:global-coordination:test: 25/25
- Clientes production-readonly runtime: 8/8
- Ponto dispatch workflow tests: 9/9
- 67 GitHub workflows parsed successfully
- all changed shell scripts pass bash -n
- codex:preflight: failures=0, warnings=0

## Rollback

Revert this PR. The staging coordinator Worker can be rolled back to the previously observed version after verifying the target version and lease state. No production coordinator route was changed.