### PR TITLE
fix(clientes): align tunnel log namespace

### DIFF
--- a/ops/runtime/units/cloudflare-atendimento-production.service
+++ b/ops/runtime/units/cloudflare-atendimento-production.service
@@ -26,7 +26,7 @@ ProtectKernelModules=true
 ProtectControlGroups=true
 LockPersonality=true
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
-ReadWritePaths=__LOG_ROOT__/cloudflare-atendimento-production
+ReadWritePaths=__LOG_ROOT__
 UMask=0027
 SyslogIdentifier=cloudflare-atendimento-production
 

--- a/scripts/tests/clientes-production-readonly-runtime.test.mjs
+++ b/scripts/tests/clientes-production-readonly-runtime.test.mjs
@@ -475,6 +475,7 @@ test('release, rollback and tunnel paths are immutable, fixed and isolated', () 
   assert.match(tunnel, /mktemp \/tmp\/atendimento-production-tunnel-unit\.XXXXXX\.service/)
   assert.match(dns, /dns_change=false/)
   assert.match(read('ops/runtime/units/cloudflare-atendimento-production.service'), /ExecStart=\/usr\/bin\/cloudflared/)
+  assert.match(read('ops/runtime/units/cloudflare-atendimento-production.service'), /ReadWritePaths=__LOG_ROOT__\n/)
 })
 
 test('production validation invokes only loopback health plus the fixed signed smoke', () => {


### PR DESCRIPTION
Aligns the dedicated Cloudflare tunnel unit ReadWritePaths with the fixed log directory created by the installer. This prevents systemd mount-namespace failure before cloudflared starts, with a focused regression. No host/service mutation is part of this PR.