### PR TITLE
feat(governance): add global integration admission gate

### DIFF
--- a/.github/governance/rulesets/main-enterprise-baseline.json
+++ b/.github/governance/rulesets/main-enterprise-baseline.json
@@ -29,7 +29,9 @@
         "strict_required_status_checks_policy": true,
         "do_not_enforce_on_create": false,
         "required_status_checks": [
-          { "context": "codex-autonomy-gate" }
+          { "context": "codex-autonomy-gate" },
+          { "context": "global-merge-authority" },
+          { "context": "skincos-integration-gate" }
         ]
       }
     }

--- a/.github/governance/rulesets/main-enterprise-baseline.json
+++ b/.github/governance/rulesets/main-enterprise-baseline.json
@@ -29,9 +29,9 @@
         "strict_required_status_checks_policy": true,
         "do_not_enforce_on_create": false,
         "required_status_checks": [
-          { "context": "codex-autonomy-gate" },
-          { "context": "global-merge-authority" },
-          { "context": "skincos-integration-gate" }
+          { "context": "codex-autonomy-gate", "integration_id": 15368 },
+          { "context": "global-merge-authority", "integration_id": 15368 },
+          { "context": "skincos-integration-gate", "integration_id": 15368 }
         ]
       }
     }

--- a/.github/workflows/global-merge-authority.yml
+++ b/.github/workflows/global-merge-authority.yml
@@ -67,7 +67,10 @@ jobs:
       - name: Acquire merge:main, revalidate base/head, and merge exactly once
         if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Use repository GitHub App/PAT custody for the merge mutation so
+          # GitHub emits the normal post-merge workflow events. GITHUB_TOKEN
+          # events are intentionally suppressed by GitHub.
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           SKINCOS_GLOBAL_COORDINATOR_URL: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
           SKINCOS_GLOBAL_COORDINATION_REQUIRED: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
           SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}

--- a/.github/workflows/ponto-orchestrator-gate.yml
+++ b/.github/workflows/ponto-orchestrator-gate.yml
@@ -179,7 +179,7 @@ jobs:
             GLOBAL_URL="$GLOBAL_INPUT_URL"
           fi
           [[ -n "$GLOBAL_URL" && -n "$GLOBAL_SECRET" ]] || { echo 'Global coordination URL and shared custody are required'; exit 1; }
-          [[ "$GLOBAL_RESOURCE" =~ ^(deploy|cloudflare|release):[a-z0-9][a-z0-9._/-]{0,127}:(preview|staging|pilot|canary|production|rollback)$ || "$GLOBAL_RESOURCE" =~ ^release:[a-z0-9][a-z0-9._/-]{0,127}$ ]] || {
+          [[ "$GLOBAL_RESOURCE" =~ ^(deploy|mutate|cloudflare|release):[a-z0-9][a-z0-9._/-]{0,127}:(preview|staging|pilot|canary|production|rollback)$ || "$GLOBAL_RESOURCE" =~ ^release:[a-z0-9][a-z0-9._/-]{0,127}$ ]] || {
             echo 'Global coordination resource is invalid'; exit 1;
           }
           source_sha="${RELEASE_SHA:-$GITHUB_SHA}"

--- a/.github/workflows/skincos-integration-gate-recheck.yml
+++ b/.github/workflows/skincos-integration-gate-recheck.yml
@@ -1,0 +1,48 @@
+name: SKINCOS integration gate recheck
+run-name: Recheck pending global integration gates
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: skincos-integration-gate-recheck
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  recheck:
+    if: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Recheck every open main PR from trusted main
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          SKINCOS_GLOBAL_COORDINATION_REQUIRED: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          SKINCOS_GLOBAL_COORDINATOR_URL: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+        run: |
+          set -euo pipefail
+          failures=0
+          while IFS=$'\t' read -r pull_number head_sha; do
+            [[ -n "$pull_number" && -n "$head_sha" ]] || continue
+            if ! node scripts/codex-global-integration-gate.mjs \
+              --pull-number "$pull_number" \
+              --expected-head-sha "$head_sha" \
+              --max-wait-ms 15000 \
+              --poll-ms 5000; then
+              failures=1
+            fi
+          done < <(gh pr list --repo "$GITHUB_REPOSITORY" --state open --base main --limit 50 --json number,headRefOid --jq '.[] | [.number, .headRefOid] | @tsv')
+          exit "$failures"

--- a/.github/workflows/skincos-integration-gate-recheck.yml
+++ b/.github/workflows/skincos-integration-gate-recheck.yml
@@ -44,5 +44,5 @@ jobs:
               --poll-ms 5000; then
               failures=1
             fi
-          done < <(gh pr list --repo "$GITHUB_REPOSITORY" --state open --base main --limit 50 --json number,headRefOid --jq '.[] | [.number, .headRefOid] | @tsv')
+          done < <(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls?state=open&base=main&per_page=100" --jq '.[] | [.number, .head.sha] | @tsv')
           exit "$failures"

--- a/.github/workflows/skincos-integration-gate-recheck.yml
+++ b/.github/workflows/skincos-integration-gate-recheck.yml
@@ -37,6 +37,8 @@ jobs:
           failures=0
           while IFS=$'\t' read -r pull_number head_sha; do
             [[ -n "$pull_number" && -n "$head_sha" ]] || continue
+            gate_state="$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/statuses?per_page=100" --jq '[.[] | select(.context == "skincos-integration-gate")][0].state // "")"
+            [[ "$gate_state" == "pending" ]] || continue
             if ! node scripts/codex-global-integration-gate.mjs \
               --pull-number "$pull_number" \
               --expected-head-sha "$head_sha" \

--- a/.github/workflows/skincos-integration-gate.yml
+++ b/.github/workflows/skincos-integration-gate.yml
@@ -22,7 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          # Never execute or checkout the incoming PR from pull_request_target.
+          # The exact base SHA is fetched/attested by the read-only GitHub API
+          # adapter while this runner stays on the trusted main tree.
+          ref: main
           fetch-depth: 0
       - name: Evaluate global integration admission
         env:

--- a/.github/workflows/skincos-integration-gate.yml
+++ b/.github/workflows/skincos-integration-gate.yml
@@ -1,0 +1,38 @@
+name: SKINCOS integration gate
+run-name: Integration gate PR #${{ github.event.pull_request.number }}
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: skincos-integration-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  gate:
+    if: ${{ github.event.pull_request.base.ref == 'main' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+      - name: Evaluate global integration admission
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          SKINCOS_GLOBAL_COORDINATION_REQUIRED: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          SKINCOS_GLOBAL_COORDINATOR_URL: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+        run: |
+          set -euo pipefail
+          node scripts/codex-global-integration-gate.mjs \
+            --pull-number "${{ github.event.pull_request.number }}" \
+            --expected-head-sha "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/skincos-integration-gate.yml
+++ b/.github/workflows/skincos-integration-gate.yml
@@ -27,6 +27,16 @@ jobs:
           # adapter while this runner stays on the trusted main tree.
           ref: main
           fetch-depth: 0
+      - name: Fetch the exact PR base tree used for closure admission
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PULL_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          base_sha="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER" --jq '.base.sha')"
+          [[ "$base_sha" =~ ^[0-9a-f]{40}$ ]] || { echo 'pull request base SHA is invalid'; exit 1; }
+          git fetch --no-tags origin "$base_sha"
+          git cat-file -e "${base_sha}^{commit}"
       - name: Evaluate global integration admission
         env:
           GH_TOKEN: ${{ github.token }}

--- a/docs/decisions/global-concurrency-release-governance.md
+++ b/docs/decisions/global-concurrency-release-governance.md
@@ -66,6 +66,11 @@ superfície. A análise de admission cruza merge com release por caminhos: uma
 mudança disjunta é compatível, uma interseção aguarda, e closure ausente ou
 ambígua falha fechada.
 
+A transição para esse nome único não pode abandonar objetos antigos: a primeira
+versão usa `COORDINATION_PLANE_MODE=legacy-drain`, recusa aquisição/admission/
+renovação e roteia check/release/revoke para o scope legado. Depois do TTL
+máximo, a mesma versão é promovida com `COORDINATION_PLANE_MODE=global`.
+
 ## Autoridade única de integração
 
 Threads podem criar worktrees, testar, commitar, fazer push e deixar uma PR

--- a/docs/decisions/global-concurrency-release-governance.md
+++ b/docs/decisions/global-concurrency-release-governance.md
@@ -1,7 +1,8 @@
 # Governança global de concorrência e release
 
-**Status:** contrato implementado; autoridade Cloudflare staging provisionada e
-ativada; autoridade de produção permanece ausente e fail-closed
+**Status:** Fase 1 implementada em PR de follow-up; autoridade Cloudflare
+staging provisionada e ativada; autoridade de produção permanece ausente e
+fail-closed
 
 ## Problema
 
@@ -11,6 +12,13 @@ corretamente ancorada em um SHA, porém um avanço independente de `main` fazia 
 dispatcher abortar antes da próxima mutação. Esse abort preservava o fail-closed,
 mas confundia mudança de ponta do repositório com mudança da dependency closure
 da release.
+
+O contrato agora separa cinco decisões: a missão pode estar autorizada; a
+operação precisa ser tecnicamente elegível; o recurso global precisa ter
+ownership temporário; a integração em `main` pertence à autoridade única; e a
+release promove uma identidade/artefato imutável. Autorização não concede
+ownership instantâneo. A falta temporária do lease é um estado de espera ou
+blocker técnico, não uma solicitação de nova autorização.
 
 ## Contrato
 
@@ -23,15 +31,19 @@ o nome superficial da ferramenta:
 | `merge:main` | `repository:main` | Serializa integração em `main`. |
 | `release:<module>` | `release:<module>` | Serializa a cadeia governada do módulo. |
 | `deploy:<surface>:<environment>` | `surface:<surface>:<environment>` | Serializa publicação da superfície. |
-| `cloudflare:<surface>:<environment>` | o mesmo escopo da publicação | Impede mutação paralela via caminho Cloudflare. |
+| `mutate:<surface>:<environment>` | `surface:<surface>:<environment>` | Nome canônico para qualquer mutação da superfície. |
+| `cloudflare:<surface>:<environment>` | o mesmo escopo da publicação | Alias de compatibilidade para mutação Cloudflare. |
 | `promotion:<module>:<environment>` | `promotion:<module>:<environment>` | Reserva promoção de artefato. |
 | `global:<operation>` | `global:<operation>` | Operações explicitamente incompatíveis. |
 
-Um lease contém owner (`missionId`, `threadId`, `actor`, `provider`), recurso,
-intent digest, tempo de expiração, `leaseId` e fencing token monotônico. O
-token anterior nunca autoriza uma mutação depois de expirar, ser liberado ou
-revogado. Idempotência só reaproveita o lease quando owner, idempotency key e
-intent digest são exatamente iguais.
+Um lease contém `resource`, `missionId`, `holder/session`, `run/workflow`,
+`acquiredAt`, `updatedAt`, `heartbeatAt`, `ttlMs`, estado, `leaseId`, intent
+digest e fencing token monotônico. O token anterior nunca autoriza uma mutação
+depois de expirar, ser liberado ou revogado. Idempotência só reaproveita o lease
+quando owner, idempotency key e intent digest são exatamente iguais; liberação e
+revogação repetidas da mesma prova também são idempotentes. Expiração é
+observada pelo coordenador antes de uma nova aquisição, permitindo recuperação
+segura de lease órfão com nova geração.
 
 O núcleo determinístico está em
 `ops/governance/global-coordination-core.mjs`; o adaptador local está em
@@ -46,11 +58,36 @@ O cliente remoto comum está em
 compartilhada para operações e uma custódia administrativa distinta para
 revogação; o arquivo de prova também precisa ficar fora do checkout.
 
+O Durable Object Cloudflare é uma única coordination plane nomeada (`global`),
+com SQLite serializado e lock scopes lógicos dentro do mesmo estado. Isso é
+necessário para arbitrar conflitos entre `merge:main` e `release:<module>`;
+`deploy`, `mutate` e o alias `cloudflare` compartilham o mesmo scope de
+superfície. A análise de admission cruza merge com release por caminhos: uma
+mudança disjunta é compatível, uma interseção aguarda, e closure ausente ou
+ambígua falha fechada.
+
+## Autoridade única de integração
+
+Threads podem criar worktrees, testar, commitar, fazer push e deixar uma PR
+`READY_TO_MERGE`. A integração passa pelo `skincos-integration-gate` e pela
+workflow `global-merge-authority`: o primeiro consulta a admission global e
+permanece pending em conflito compatível com espera; a segunda adquire
+`merge:main`, revalida base/head/lease e chama a API de merge uma única vez.
+Actions `concurrency` é apenas scheduler. A prova remota, o status obrigatório e
+a revalidação imediatamente antes da mutação são a autoridade técnica.
+
 ## Release imutável sem congelar `main`
 
 Uma identidade de release é formada por `sourceCommit`, `sourceTree`,
 `dependencyClosureDigest` e a lista exata de artefatos/digests/version IDs. O
 build é uma operação anterior; promoção recebe e verifica a mesma identidade.
+
+Durante a migração, o dispatcher Ponto ainda conserva compatibilidade com
+`assertMainShaUnchanged`, mas a decisão operacional usa closure. Mudança
+independente em `main` não cancela a release; uma mudança relevante na closure
+é detectada antes do próximo dispatch ou mutação e interrompe a cadeia. A
+próxima fase consolidará a identidade em manifest/ref imutável consumido por
+todos os child workflows, incluindo IDs de artefato, versão e rollback.
 
 Antes de cada mutação, `authorizeMutation` exige:
 
@@ -79,7 +116,8 @@ lease ao final.
   `codex-keep-prs-mergeable.yml` não habilita mais auto-merge sem lease e
   também adquire `merge:main` antes de atualizar branches de PR.
 - Cloudflare usa `ops/cloudflare/global-coordinator/index.js`, com uma classe
-  SQLite-backed Durable Object por `lockScope`. A requisição exige nonce,
+  SQLite-backed Durable Object global nomeada `global`; os `lockScope` ficam no
+  estado para fencing e admission. A requisição exige nonce,
   timestamp, digest e HMAC; revogação exige custódia administrativa separada.
 - Codex App e mini-PC podem consumir o mesmo envelope/lease, sem compartilhar
   cookies, tokens ou estado do checkout. O cliente e o CLI são os pontos
@@ -122,7 +160,11 @@ Os contratos são exercitados por
 `scripts/tests/codex-global-coordination-client.test.mjs`,
 `scripts/tests/codex-global-coordination-workflow.test.mjs`, além de
 `ops/cloudflare/global-coordinator/index.test.mjs` e do teste focado do
-dispatcher Ponto. A validação remota do staging comprovou a versão implantada;
+dispatcher Ponto. A Fase 1 inclui propriedades de exclusividade, fencing após
+expiração, admission por closure, retries idempotentes, alias de superfície e
+indisponibilidade ambígua fail-closed; o teste de caos/concorrência completo e
+a aceitação multi-thread permanecem nas fases seguintes. A validação remota do
+staging comprovou a versão implantada;
 rollback é a restauração de uma versão anterior do Worker ou a remoção
 controlada do ambiente staging, sem tocar uma rota de produção. A existência
 do código, um build ou um endpoint 200 não constitui prova de autoridade global

--- a/ops/cloudflare/global-coordinator/README.md
+++ b/ops/cloudflare/global-coordinator/README.md
@@ -22,3 +22,14 @@ The `gate` action is read-only admission: it returns success only when the
 candidate is compatible with all active leases. The merge authority acquires
 `merge:main` and revalidates immediately before the GitHub merge, so a status
 check can never substitute for ownership.
+
+## Coordination-plane migration
+
+The first deployment that changes from the historical per-`lockScope` Durable
+Objects to the single `global` object must use
+`COORDINATION_PLANE_MODE = "legacy-drain"`. In that mode new acquisitions,
+admission checks and renewals fail closed; check, release and revoke requests
+are routed to the old logical scope so active proofs can finish without being
+silently discarded. After the maximum lease TTL has elapsed, deploy the same
+code with `COORDINATION_PLANE_MODE = "global"`. A direct cutover is not safe:
+it could strand an active legacy lease outside the new fencing domain.

--- a/ops/cloudflare/global-coordinator/README.md
+++ b/ops/cloudflare/global-coordinator/README.md
@@ -1,10 +1,11 @@
 # SKINCOS global coordinator
 
 This Worker is the remote adapter for the versioned contract in
-`ops/governance/global-concurrency-policy.json`. It routes each normalized
-lock scope to a SQLite-backed Durable Object, so independent release modules
-can proceed in parallel while deploy and Cloudflare mutations for the same
-surface/environment share one fence.
+`ops/governance/global-concurrency-policy.json`. It uses one globally named,
+SQLite-backed Durable Object coordination plane. Logical lock scopes remain
+fenced independently, so unrelated modules proceed in parallel while the
+authority can also arbitrate cross-scope conflicts such as `merge:main` versus
+an active `release:<module>` lease.
 
 The production Worker is intentionally not routed by this change. The isolated
 `staging` environment is the activation target for synthetic contract tests;
@@ -17,3 +18,7 @@ Clients must send the signed request envelope described by the contract and
 must present the returned `leaseId`, `fencingToken`, owner and `intentDigest`
 before every mutation. A release operation also carries its immutable source
 SHA/tree, dependency-closure digest and exact artifact/version identities.
+The `gate` action is read-only admission: it returns success only when the
+candidate is compatible with all active leases. The merge authority acquires
+`merge:main` and revalidates immediately before the GitHub merge, so a status
+check can never substitute for ownership.

--- a/ops/cloudflare/global-coordinator/index.js
+++ b/ops/cloudflare/global-coordinator/index.js
@@ -7,6 +7,7 @@ import {
   checkLease,
   consumeNonce,
   emptyState,
+  evaluateLeaseAdmission,
   lockScopeFor,
   releaseLease,
   renewLease,
@@ -72,7 +73,7 @@ async function authenticatedBody(request, env, url, rawBody) {
     || body.contractId !== CONTRACT_ID
     || body.requestNonce !== nonce
     || body.requestedAt !== requestedAt
-    || !["acquire", "check", "renew", "release", "revoke"].includes(body.action)
+    || !["acquire", "gate", "check", "renew", "release", "revoke"].includes(body.action)
   ) throw new Error("coordination request envelope is invalid");
   if (body.action === "revoke" && request.headers.get("authorization") !== `Bearer ${env.COORDINATION_ADMIN_SECRET || ""}`) throw new Error("coordination revocation authority is unavailable");
   return { body, nonce, requestDigest };
@@ -106,6 +107,7 @@ export class GlobalCoordinator extends DurableObject {
     if (!nonce.accepted) return { accepted: false, valid: false, reason: nonce.reason };
     let result;
     if (input.action === "acquire") result = acquireLease(nonce.state, input.request, { now: input.now, leaseId: input.leaseId });
+    else if (input.action === "gate") result = evaluateLeaseAdmission(nonce.state, input.request, { now: input.now });
     else if (input.action === "check") {
       result = input.authorization
         ? authorizeMutation(nonce.state, input.request, { now: input.now, ...input.authorization })
@@ -137,29 +139,35 @@ export default {
     const { body, nonce, requestDigest } = authenticated;
     let resource;
     try {
-      resource = body.action === "revoke" ? body.proof?.resource : body.action === "acquire" ? body.request?.resource : body.proof?.resource;
-      const scope = lockScopeFor(resource);
-      if (body.action === "acquire") {
+      resource = ["acquire", "gate"].includes(body.action) ? body.request?.resource : body.proof?.resource;
+      lockScopeFor(resource);
+      if (["acquire", "gate"].includes(body.action)) {
         const normalizedIntent = buildIntent(body.request);
         const expectedDigest = await sha256(canonicalJson(normalizedIntent));
         if (body.request.intentDigest !== expectedDigest) return bad("coordination intent digest mismatch", 403);
       }
-      const stub = env.GLOBAL_COORDINATOR.getByName(scope);
+      // One globally named Durable Object is the coordination plane. The
+      // logical lockScope remains part of the lease and fencing proof, while
+      // one serialized state machine can arbitrate cross-resource conflicts
+      // such as merge:main versus release:<module>.
+      const stub = env.GLOBAL_COORDINATOR.getByName(env.COORDINATION_PLANE_NAME || "global");
       const result = stub.coordinate({
         action: body.action,
         nonce,
         requestDigest,
         now: Date.now(),
         leaseId: crypto.randomUUID(),
-        request: body.action === "acquire" ? body.request : undefined,
-        ...(body.action !== "acquire" ? { request: body.proof } : {}),
+         request: ["acquire", "gate"].includes(body.action) ? body.request : body.proof,
         authorization: body.authorization,
         ttlMs: body.ttlMs,
         reason: body.reason,
       });
       const resolved = await result;
-      const payload = await signResponse({ schemaVersion: 1, contractId: CONTRACT_ID, passed: resolved.accepted !== false && resolved.valid !== false, ...resolved }, env.COORDINATION_SHARED_SECRET);
-      const status = resolved.accepted === false && resolved.reason === "resource-lease-held" ? 409 : resolved.valid === false ? 409 : resolved.accepted === false ? 409 : 200;
+      const passed = body.action === "gate"
+        ? resolved.allowed === true
+        : resolved.accepted !== false && resolved.valid !== false;
+      const payload = await signResponse({ schemaVersion: 1, contractId: CONTRACT_ID, passed, ...resolved }, env.COORDINATION_SHARED_SECRET);
+      const status = resolved.allowed === false || resolved.accepted === false || resolved.valid === false ? 409 : 200;
       return jsonResponse(payload, status);
     } catch {
       return bad("coordination request could not be processed", 400);

--- a/ops/cloudflare/global-coordinator/index.js
+++ b/ops/cloudflare/global-coordinator/index.js
@@ -18,6 +18,7 @@ const CONTRACT_ID = "skincos/global-coordination/v1";
 const MAX_SKEW_MS = 30_000;
 const NONCE_TTL_MS = 15 * 60_000;
 const MAX_BODY_BYTES = 64 * 1024;
+const COORDINATION_MODES = new Set(["legacy-drain", "global"]);
 
 const encoder = new TextEncoder();
 const b64url = (bytes) => btoa(String.fromCharCode(...new Uint8Array(bytes)))
@@ -140,17 +141,25 @@ export default {
     let resource;
     try {
       resource = ["acquire", "gate"].includes(body.action) ? body.request?.resource : body.proof?.resource;
-      lockScopeFor(resource);
+      const lockScope = lockScopeFor(resource);
       if (["acquire", "gate"].includes(body.action)) {
         const normalizedIntent = buildIntent(body.request);
         const expectedDigest = await sha256(canonicalJson(normalizedIntent));
         if (body.request.intentDigest !== expectedDigest) return bad("coordination intent digest mismatch", 403);
       }
+      const coordinationMode = String(env.COORDINATION_PLANE_MODE || "global").trim().toLowerCase();
+      if (!COORDINATION_MODES.has(coordinationMode)) return bad("coordination plane mode is invalid", 503);
+      if (coordinationMode === "legacy-drain" && ["acquire", "gate", "renew"].includes(body.action)) {
+        return bad("coordination plane is draining legacy lock scopes", 503);
+      }
       // One globally named Durable Object is the coordination plane. The
       // logical lockScope remains part of the lease and fencing proof, while
       // one serialized state machine can arbitrate cross-resource conflicts
       // such as merge:main versus release:<module>.
-      const stub = env.GLOBAL_COORDINATOR.getByName(env.COORDINATION_PLANE_NAME || "global");
+      const planeName = coordinationMode === "legacy-drain"
+        ? lockScope
+        : (env.COORDINATION_PLANE_NAME || "global");
+      const stub = env.GLOBAL_COORDINATOR.getByName(planeName);
       const result = stub.coordinate({
         action: body.action,
         nonce,

--- a/ops/cloudflare/global-coordinator/index.js
+++ b/ops/cloudflare/global-coordinator/index.js
@@ -3,6 +3,7 @@ import {
   acquireLease,
   authorizeMutation,
   buildIntent,
+  buildLegacyIntentV1,
   canonicalJson,
   checkLease,
   consumeNonce,
@@ -145,7 +146,17 @@ export default {
       if (["acquire", "gate"].includes(body.action)) {
         const normalizedIntent = buildIntent(body.request);
         const expectedDigest = await sha256(canonicalJson(normalizedIntent));
-        if (body.request.intentDigest !== expectedDigest) return bad("coordination intent digest mismatch", 403);
+        let intentDigestValid = body.request.intentDigest === expectedDigest;
+        // During the distributed rollout, already-running v1 clients may not
+        // include the newly explicit owner.sessionId field. Accept that exact
+        // legacy canonicalization only when the field is absent; a request that
+        // includes sessionId must use the new digest.
+        if (!intentDigestValid && !body.request.owner?.sessionId) {
+          const legacyIntent = buildLegacyIntentV1(body.request);
+          const legacyDigest = await sha256(canonicalJson(legacyIntent));
+          intentDigestValid = body.request.intentDigest === legacyDigest;
+        }
+        if (!intentDigestValid) return bad("coordination intent digest mismatch", 403);
       }
       const coordinationMode = String(env.COORDINATION_PLANE_MODE || "global").trim().toLowerCase();
       if (!COORDINATION_MODES.has(coordinationMode)) return bad("coordination plane mode is invalid", 503);

--- a/ops/cloudflare/global-coordinator/index.test.mjs
+++ b/ops/cloudflare/global-coordinator/index.test.mjs
@@ -10,10 +10,14 @@ test("Cloudflare adapter uses one globally serialized SQLite Durable Object coor
   assert.match(source, /class GlobalCoordinator extends DurableObject/);
   assert.match(source, /blockConcurrencyWhile/);
   assert.match(source, /storage\.sql\.exec/);
-  assert.match(source, /getByName\(env\.COORDINATION_PLANE_NAME \|\| "global"\)/);
+  assert.match(source, /env\.COORDINATION_PLANE_NAME \|\| "global"/);
+  assert.match(source, /COORDINATION_PLANE_MODE/);
+  assert.match(source, /coordinationMode === "legacy-drain"/);
+  assert.match(source, /getByName\(planeName\)/);
   assert.match(source, /evaluateLeaseAdmission/);
   assert.match(config, /new_sqlite_classes = \["GlobalCoordinator"\]/);
   assert.match(config, /COORDINATION_PLANE_NAME = "global"/);
+  assert.match(config, /COORDINATION_PLANE_MODE = "legacy-drain"/);
 });
 
 test("remote custody is mandatory and the adapter has no local fallback", () => {

--- a/ops/cloudflare/global-coordinator/index.test.mjs
+++ b/ops/cloudflare/global-coordinator/index.test.mjs
@@ -6,12 +6,14 @@ import test from "node:test";
 const source = fs.readFileSync(path.join(import.meta.dirname, "index.js"), "utf8");
 const config = fs.readFileSync(path.join(import.meta.dirname, "wrangler.toml"), "utf8");
 
-test("Cloudflare adapter uses one SQLite Durable Object per normalized lock scope", () => {
+test("Cloudflare adapter uses one globally serialized SQLite Durable Object coordination plane", () => {
   assert.match(source, /class GlobalCoordinator extends DurableObject/);
   assert.match(source, /blockConcurrencyWhile/);
   assert.match(source, /storage\.sql\.exec/);
-  assert.match(source, /getByName\(scope\)/);
+  assert.match(source, /getByName\(env\.COORDINATION_PLANE_NAME \|\| "global"\)/);
+  assert.match(source, /evaluateLeaseAdmission/);
   assert.match(config, /new_sqlite_classes = \["GlobalCoordinator"\]/);
+  assert.match(config, /COORDINATION_PLANE_NAME = "global"/);
 });
 
 test("remote custody is mandatory and the adapter has no local fallback", () => {

--- a/ops/cloudflare/global-coordinator/wrangler.toml
+++ b/ops/cloudflare/global-coordinator/wrangler.toml
@@ -6,6 +6,7 @@ workers_dev = false
 [vars]
 COORDINATION_CONTRACT_ID = "skincos/global-coordination/v1"
 COORDINATION_PLANE_NAME = "global"
+COORDINATION_PLANE_MODE = "global"
 
 [durable_objects]
 bindings = [
@@ -24,6 +25,7 @@ preview_urls = false
 [env.staging.vars]
 COORDINATION_CONTRACT_ID = "skincos/global-coordination/v1"
 COORDINATION_PLANE_NAME = "global"
+COORDINATION_PLANE_MODE = "legacy-drain"
 
 [env.staging.durable_objects]
 bindings = [

--- a/ops/cloudflare/global-coordinator/wrangler.toml
+++ b/ops/cloudflare/global-coordinator/wrangler.toml
@@ -5,6 +5,7 @@ workers_dev = false
 
 [vars]
 COORDINATION_CONTRACT_ID = "skincos/global-coordination/v1"
+COORDINATION_PLANE_NAME = "global"
 
 [durable_objects]
 bindings = [
@@ -22,6 +23,7 @@ preview_urls = false
 
 [env.staging.vars]
 COORDINATION_CONTRACT_ID = "skincos/global-coordination/v1"
+COORDINATION_PLANE_NAME = "global"
 
 [env.staging.durable_objects]
 bindings = [

--- a/ops/governance/global-concurrency-policy.json
+++ b/ops/governance/global-concurrency-policy.json
@@ -16,6 +16,7 @@
     "merge": "^merge:[a-z0-9][a-z0-9._/-]{0,127}$",
     "release": "^release:[a-z0-9][a-z0-9._/-]{0,127}$",
     "deploy": "^deploy:[a-z0-9][a-z0-9._/-]{0,127}:(?:preview|staging|pilot|canary|production|rollback|local)$",
+    "mutate": "^mutate:[a-z0-9][a-z0-9._/-]{0,127}:(?:preview|staging|pilot|canary|production|rollback|local)$",
     "cloudflare": "^cloudflare:[a-z0-9][a-z0-9._/-]{0,127}:(?:preview|staging|pilot|canary|production|rollback|local)$",
     "promotion": "^promotion:[a-z0-9][a-z0-9._/-]{0,127}:(?:preview|staging|pilot|canary|production|rollback|local)$",
     "global": "^global:[a-z0-9][a-z0-9._/-]{0,127}$"
@@ -159,7 +160,13 @@
   "adapters": {
     "codex": "private state adapter must use the same transition contract and fail closed on an unknown lock",
     "github": "Actions concurrency is a scheduling hint; mutation authority requires a lease proof",
-    "cloudflare": "one SQLite-backed Durable Object instance per lock scope",
+    "cloudflare": "one globally named SQLite-backed Durable Object coordination plane; logical lock scopes remain fenced in state",
     "mini-pc": "runtime client must present the lease proof before a service or workflow mutation"
+  },
+  "admission": {
+    "crossScope": "merge:main conflicts with an active release lease only when changed paths intersect the release dependency closure",
+    "unknownClosure": "missing merge paths or release closure patterns fail closed",
+    "surfaceAliases": ["deploy", "mutate", "cloudflare"],
+    "coordinationPlane": "global"
   }
 }

--- a/ops/governance/global-coordination-core.mjs
+++ b/ops/governance/global-coordination-core.mjs
@@ -4,6 +4,11 @@ const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,199}$/;
 const OWNER_PROVIDER = new Set(["codex", "github", "cloudflare", "mini-pc", "system"]);
 const ACTIVE_STATES = new Set(["held"]);
 const TERMINAL_STATES = new Set(["released", "revoked", "expired"]);
+const RESOURCE_KINDS = new Set(["merge", "release", "deploy", "mutate", "cloudflare", "promotion", "global"]);
+const ENVIRONMENTS = new Set(["preview", "staging", "pilot", "canary", "production", "rollback", "local"]);
+// Release closures can legitimately contain several hundred tracked inputs.
+// Keep the admission payload bounded without truncating a verified closure.
+const MAX_RESOURCE_LIST_ITEMS = 4096;
 
 export const CONTRACT_ID = "skincos/global-coordination/v1";
 export const SCHEMA_VERSION = 1;
@@ -33,7 +38,7 @@ export function resourceClass(resource) {
   if (!normalized || normalized.includes(" ") || normalized.includes("\\")) throw new Error("resource key is invalid");
   const separator = normalized.indexOf(":");
   const kind = separator > 0 ? normalized.slice(0, separator) : "";
-  if (!["merge", "release", "deploy", "cloudflare", "promotion", "global"].includes(kind)) {
+  if (!RESOURCE_KINDS.has(kind)) {
     throw new Error("resource class is unsupported");
   }
   const parts = normalized.split(":");
@@ -42,7 +47,7 @@ export function resourceClass(resource) {
     return kind;
   }
   if (parts.length !== 3 || !/^[a-z0-9][a-z0-9._/-]{0,127}$/.test(parts[1])) throw new Error("resource key is invalid");
-  if (!["preview", "staging", "pilot", "canary", "production", "rollback", "local"].includes(parts[2])) throw new Error("resource environment is invalid");
+  if (!ENVIRONMENTS.has(parts[2])) throw new Error("resource environment is invalid");
   return kind;
 }
 
@@ -58,7 +63,7 @@ export function lockScopeFor(resource) {
   if (kind === "merge") return `repository:${name}`;
   if (kind === "release") return `release:${name}`;
   if (kind === "global") return `global:${name}`;
-  if (kind === "deploy" || kind === "cloudflare") return `surface:${name}:${environment}`;
+  if (kind === "deploy" || kind === "mutate" || kind === "cloudflare") return `surface:${name}:${environment}`;
   return `promotion:${name}:${environment}`;
 }
 
@@ -70,10 +75,22 @@ export function normalizeOwner(owner) {
     provider,
     missionId: requireId(owner.missionId, "lease owner missionId"),
     threadId: requireId(owner.threadId, "lease owner threadId"),
+    sessionId: requireId(owner.sessionId || owner.threadId, "lease owner sessionId"),
     actor: requireId(owner.actor, "lease owner actor"),
   };
   if (owner.runId !== undefined && owner.runId !== null && text(owner.runId)) normalized.runId = requireId(owner.runId, "lease owner runId");
+  if (owner.workflow !== undefined && owner.workflow !== null && text(owner.workflow)) normalized.workflow = requireId(owner.workflow, "lease owner workflow");
   return normalized;
+}
+
+function normalizeStringList(value, label) {
+  if (!Array.isArray(value) || value.length > MAX_RESOURCE_LIST_ITEMS) throw new Error(`${label} must be a bounded array`);
+  const normalized = value.map((entry) => {
+    const item = text(entry).replaceAll("\\", "/");
+    if (!item || item.length > 512) throw new Error(`${label} contains an invalid item`);
+    return item;
+  });
+  return [...new Set(normalized)].sort();
 }
 
 export function normalizeArtifacts(artifacts = []) {
@@ -125,6 +142,12 @@ export function normalizeIntent(intent, { operation = "mutation" } = {}) {
   if (normalized.dependencyClosureDigest !== undefined) {
     normalized.dependencyClosureDigest = lower(normalized.dependencyClosureDigest);
     if (!DIGEST.test(normalized.dependencyClosureDigest)) throw new Error("intent dependency closure digest is invalid");
+  }
+  if (normalized.dependencyClosurePaths !== undefined) {
+    normalized.dependencyClosurePaths = normalizeStringList(normalized.dependencyClosurePaths, "intent dependency closure paths");
+  }
+  if (normalized.dependencyClosurePatterns !== undefined) {
+    normalized.dependencyClosurePatterns = normalizeStringList(normalized.dependencyClosurePatterns, "intent dependency closure patterns");
   }
   return normalized;
 }
@@ -184,8 +207,162 @@ function expireCurrent(state, scope, now) {
   if (current && current.state === "held" && current.expiresAt <= now) {
     current.state = "expired";
     current.expiredAt = now;
+    current.updatedAt = now;
   }
   return current;
+}
+
+function expireLeases(state, now) {
+  for (const scope of Object.keys(state.leases)) expireCurrent(state, scope, now);
+  return state;
+}
+
+function globMatch(value, pattern) {
+  const memo = new Map();
+  function match(valueIndex, patternIndex) {
+    const key = `${valueIndex}:${patternIndex}`;
+    if (memo.has(key)) return memo.get(key);
+    let result;
+    if (patternIndex === pattern.length) {
+      result = valueIndex === value.length;
+    } else if (pattern[patternIndex] === "*" && pattern[patternIndex + 1] === "*") {
+      const afterGlob = patternIndex + 2 + (pattern[patternIndex + 2] === "/" ? 1 : 0);
+      result = match(valueIndex, afterGlob)
+        || (valueIndex < value.length && match(valueIndex + 1, patternIndex));
+    } else if (pattern[patternIndex] === "*") {
+      result = match(valueIndex, patternIndex + 1)
+        || (valueIndex < value.length && value[valueIndex] !== "/" && match(valueIndex + 1, patternIndex));
+    } else if (pattern[patternIndex] === "?") {
+      result = valueIndex < value.length && value[valueIndex] !== "/" && match(valueIndex + 1, patternIndex + 1);
+    } else {
+      result = valueIndex < value.length
+        && value[valueIndex] === pattern[patternIndex]
+        && match(valueIndex + 1, patternIndex + 1);
+    }
+    memo.set(key, result);
+    return result;
+  }
+  return match(0, 0);
+}
+
+function changedPathsFor(intent) {
+  const value = intent?.inputs?.changedPaths ?? intent?.changedPaths;
+  if (!Array.isArray(value)) return null;
+  return normalizeStringList(value, "merge changed paths");
+}
+
+function releaseClosureFor(lease) {
+  const patterns = lease?.intent?.dependencyClosurePatterns;
+  if (Array.isArray(patterns) && patterns.length) return normalizeStringList(patterns, "lease dependency closure patterns");
+  const paths = lease?.intent?.dependencyClosurePaths;
+  if (Array.isArray(paths) && paths.length) return normalizeStringList(paths, "lease dependency closure paths");
+  return null;
+}
+
+function pathsOverlap(changedPaths, closurePatterns) {
+  if (!Array.isArray(changedPaths) || !changedPaths.length || !Array.isArray(closurePatterns) || !closurePatterns.length) return null;
+  return changedPaths.some((changedPath) => closurePatterns.some((pattern) => globMatch(changedPath, pattern)));
+}
+
+function holderSummary(lease) {
+  return {
+    provider: lease.owner.provider,
+    missionId: lease.owner.missionId,
+    threadId: lease.owner.threadId,
+    sessionId: lease.owner.sessionId,
+    actor: lease.owner.actor,
+    ...(lease.owner.runId ? { runId: lease.owner.runId } : {}),
+    ...(lease.owner.workflow ? { workflow: lease.owner.workflow } : {}),
+  };
+}
+
+function leaseProofMatches(lease, proof) {
+  return Boolean(
+    lease
+      && proof
+      && lease.leaseId === proof.leaseId
+      && lease.fencingToken === proof.fencingToken
+      && lease.intentDigest === lower(proof.intentDigest)
+      && canonicalJson(normalizeOwner(lease.owner)) === canonicalJson(normalizeOwner(proof.owner)),
+  );
+}
+
+function intentResourceKind(intent) {
+  return resourceClass(intent.resource);
+}
+
+function conflictForIntent(state, candidateIntent, { now, ignoreScope = null } = {}) {
+  const next = stateOrEmpty(state);
+  assertTime(now);
+  expireLeases(next, now);
+  const candidateKind = intentResourceKind(candidateIntent);
+  const candidateScope = candidateIntent.lockScope;
+  const candidateChangedPaths = changedPathsFor(candidateIntent.intent);
+  for (const lease of Object.values(next.leases)) {
+    if (!lease || lease.state !== "held" || lease.lockScope === ignoreScope) continue;
+    if (lease.lockScope === candidateScope) {
+      return {
+        conflict: true,
+        failClosed: false,
+        reason: "resource-lease-held",
+        resource: candidateIntent.resource,
+        lockScope: candidateScope,
+        holder: holderSummary(lease),
+        state: next,
+      };
+    }
+    const leaseKind = intentResourceKind(lease);
+    const mergeReleasePair = (candidateKind === "merge" && leaseKind === "release")
+      || (candidateKind === "release" && leaseKind === "merge");
+    if (!mergeReleasePair) continue;
+    const mergeLease = candidateKind === "merge" ? candidateIntent : lease;
+    const changedPaths = candidateKind === "merge" ? candidateChangedPaths : changedPathsFor(mergeLease.intent);
+    const closurePatterns = candidateKind === "release"
+      ? releaseClosureFor(candidateIntent)
+      : releaseClosureFor(lease);
+    const overlap = pathsOverlap(changedPaths, closurePatterns);
+    if (overlap === null) {
+      return {
+        conflict: true,
+        failClosed: true,
+        reason: "coordination-dependency-closure-ambiguous",
+        resource: candidateIntent.resource,
+        lockScope: candidateScope,
+        holder: holderSummary(lease),
+        state: next,
+      };
+    }
+    if (overlap) {
+      return {
+        conflict: true,
+        failClosed: false,
+        reason: "incompatible-release-lease",
+        resource: candidateIntent.resource,
+        lockScope: candidateScope,
+        conflictingResource: lease.resource,
+        holder: holderSummary(lease),
+        state: next,
+      };
+    }
+    // A documented disjoint closure is compatible with this release. Keep
+    // checking other active leases before admitting the candidate.
+  }
+  return { conflict: false, failClosed: false, reason: "coordination-admission-allowed", state: next };
+}
+
+export function evaluateLeaseAdmission(state, request, { now } = {}) {
+  const intent = buildIntent(request);
+  const result = conflictForIntent(state, intent, { now });
+  return {
+    allowed: !result.conflict,
+    failClosed: result.failClosed,
+    reason: result.reason,
+    ...(result.resource ? { resource: result.resource } : {}),
+    ...(result.lockScope ? { lockScope: result.lockScope } : {}),
+    ...(result.conflictingResource ? { conflictingResource: result.conflictingResource } : {}),
+    ...(result.holder ? { holder: result.holder } : {}),
+    state: result.state,
+  };
 }
 
 export function consumeNonce(state, { nonce, digest, now, ttlMs = 900_000 }) {
@@ -216,7 +393,7 @@ export function acquireLease(state, request, { now, leaseId }) {
   if (current?.state === "held") {
     if (
       current.idempotencyKey === intent.idempotencyKey
-      && canonicalJson(current.owner) === canonicalJson(intent.owner)
+      && canonicalJson(normalizeOwner(current.owner)) === canonicalJson(normalizeOwner(intent.owner))
       && current.intentDigest === intentDigest
     ) return { accepted: true, idempotent: true, lease: clone(current), state: next };
     return {
@@ -224,8 +401,21 @@ export function acquireLease(state, request, { now, leaseId }) {
       reason: "resource-lease-held",
       resource: intent.resource,
       lockScope: scope,
-      holder: { provider: current.owner.provider, missionId: current.owner.missionId, threadId: current.owner.threadId },
+      holder: holderSummary(current),
       state: next,
+    };
+  }
+  const admission = conflictForIntent(next, intent, { now, ignoreScope: scope });
+  if (admission.conflict) {
+    return {
+      accepted: false,
+      reason: admission.reason,
+      failClosed: admission.failClosed,
+      resource: intent.resource,
+      lockScope: scope,
+      ...(admission.conflictingResource ? { conflictingResource: admission.conflictingResource } : {}),
+      ...(admission.holder ? { holder: admission.holder } : {}),
+      state: admission.state,
     };
   }
   if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{15,199}$/.test(String(leaseId || ""))) throw new Error("leaseId is invalid");
@@ -243,7 +433,11 @@ export function acquireLease(state, request, { now, leaseId }) {
     intentDigest,
     intent: intent.intent,
     state: "held",
+    holder: holderSummary({ owner: intent.owner }),
     acquiredAt: now,
+    updatedAt: now,
+    heartbeatAt: now,
+    ttlMs,
     expiresAt: now + ttlMs,
   };
   next.leases[scope] = lease;
@@ -260,7 +454,7 @@ function matchingLease(state, proof, now) {
     current.leaseId !== proof.leaseId
     || current.fencingToken !== proof.fencingToken
     || current.intentDigest !== lower(proof.intentDigest)
-    || canonicalJson(current.owner) !== canonicalJson(normalizeOwner(proof.owner))
+    || canonicalJson(normalizeOwner(current.owner)) !== canonicalJson(normalizeOwner(proof.owner))
   ) return { valid: false, reason: "lease-fence-mismatch", state: next };
   return { valid: true, lease: clone(current), state: next };
 }
@@ -275,23 +469,40 @@ export function renewLease(state, proof, { now, ttlMs }) {
   assertTtl(ttlMs);
   result.lease.expiresAt = now + ttlMs;
   result.lease.renewedAt = now;
+  result.lease.updatedAt = now;
+  result.lease.heartbeatAt = now;
+  result.lease.ttlMs = ttlMs;
   result.state.leases[result.lease.lockScope] = result.lease;
   return { ...result, renewed: true };
 }
 
 export function releaseLease(state, proof, { now }) {
+  const next = stateOrEmpty(state);
+  assertTime(now);
+  const scope = lockScopeFor(proof?.resource || "");
+  const current = expireCurrent(next, scope, now);
+  if (current?.state === "released" && leaseProofMatches(current, proof)) {
+    return { valid: true, released: true, idempotent: true, lease: clone(current), state: next };
+  }
   const result = matchingLease(state, proof, now);
   if (!result.valid) return result;
-  const released = { ...result.lease, state: "released", releasedAt: now };
+  const released = { ...result.lease, state: "released", releasedAt: now, updatedAt: now };
   result.state.leases[released.lockScope] = released;
   return { valid: true, released: true, lease: clone(released), state: result.state };
 }
 
 export function revokeLease(state, proof, { now, reason }) {
+  const next = stateOrEmpty(state);
+  assertTime(now);
+  const scope = lockScopeFor(proof?.resource || "");
+  const current = expireCurrent(next, scope, now);
+  if (current?.state === "revoked" && leaseProofMatches(current, proof)) {
+    return { valid: true, revoked: true, idempotent: true, lease: clone(current), state: next };
+  }
   const result = matchingLease(state, proof, now);
   if (!result.valid) return result;
   const revokeReason = requireId(reason, "lease revocation reason");
-  const revoked = { ...result.lease, state: "revoked", revokedAt: now, revocationReason: revokeReason };
+  const revoked = { ...result.lease, state: "revoked", revokedAt: now, updatedAt: now, revocationReason: revokeReason };
   result.state.leases[revoked.lockScope] = revoked;
   return { valid: true, revoked: true, lease: clone(revoked), state: result.state };
 }

--- a/ops/governance/global-coordination-core.mjs
+++ b/ops/governance/global-coordination-core.mjs
@@ -67,7 +67,7 @@ export function lockScopeFor(resource) {
   return `promotion:${name}:${environment}`;
 }
 
-export function normalizeOwner(owner) {
+export function normalizeOwner(owner, { includeSessionId = true } = {}) {
   if (!owner || typeof owner !== "object" || Array.isArray(owner)) throw new Error("lease owner is required");
   const provider = lower(owner.provider);
   if (!OWNER_PROVIDER.has(provider)) throw new Error("lease owner provider is invalid");
@@ -75,9 +75,9 @@ export function normalizeOwner(owner) {
     provider,
     missionId: requireId(owner.missionId, "lease owner missionId"),
     threadId: requireId(owner.threadId, "lease owner threadId"),
-    sessionId: requireId(owner.sessionId || owner.threadId, "lease owner sessionId"),
     actor: requireId(owner.actor, "lease owner actor"),
   };
+  if (includeSessionId) normalized.sessionId = requireId(owner.sessionId || owner.threadId, "lease owner sessionId");
   if (owner.runId !== undefined && owner.runId !== null && text(owner.runId)) normalized.runId = requireId(owner.runId, "lease owner runId");
   if (owner.workflow !== undefined && owner.workflow !== null && text(owner.workflow)) normalized.workflow = requireId(owner.workflow, "lease owner workflow");
   return normalized;
@@ -152,11 +152,11 @@ export function normalizeIntent(intent, { operation = "mutation" } = {}) {
   return normalized;
 }
 
-export function buildIntent({ operation, resource, owner, intent, idempotencyKey }) {
+function buildIntentWithOwnerMode({ operation, resource, owner, intent, idempotencyKey }, { includeSessionId }) {
   const normalizedOperation = lower(operation);
   if (!["mutation", "release", "promotion", "revalidate", "revoke"].includes(normalizedOperation)) throw new Error("lease operation is invalid");
   const normalizedResource = normalizeResourceKey(resource);
-  const normalizedOwner = normalizeOwner(owner);
+  const normalizedOwner = normalizeOwner(owner, { includeSessionId });
   const normalizedIntent = normalizeIntent(intent, { operation: normalizedOperation });
   const key = requireId(idempotencyKey, "lease idempotencyKey");
   return {
@@ -169,6 +169,16 @@ export function buildIntent({ operation, resource, owner, intent, idempotencyKey
     idempotencyKey: key,
     intent: normalizedIntent,
   };
+}
+
+export function buildIntent(request) {
+  return buildIntentWithOwnerMode(request, { includeSessionId: true });
+}
+
+// Compatibility adapter for v1 clients deployed before sessionId became an
+// explicit owner field. It is used only to validate an old request digest.
+export function buildLegacyIntentV1(request) {
+  return buildIntentWithOwnerMode(request, { includeSessionId: false });
 }
 
 export function emptyState() {

--- a/ops/governance/global-coordination-core.mjs
+++ b/ops/governance/global-coordination-core.mjs
@@ -253,10 +253,15 @@ function changedPathsFor(intent) {
 
 function releaseClosureFor(lease) {
   const patterns = lease?.intent?.dependencyClosurePatterns;
-  if (Array.isArray(patterns) && patterns.length) return normalizeStringList(patterns, "lease dependency closure patterns");
   const paths = lease?.intent?.dependencyClosurePaths;
-  if (Array.isArray(paths) && paths.length) return normalizeStringList(paths, "lease dependency closure paths");
-  return null;
+  const normalizedPatterns = Array.isArray(patterns)
+    ? normalizeStringList(patterns, "lease dependency closure patterns")
+    : [];
+  const normalizedPaths = Array.isArray(paths)
+    ? normalizeStringList(paths, "lease dependency closure paths")
+    : [];
+  const combined = [...new Set([...normalizedPatterns, ...normalizedPaths])].sort();
+  return combined.length ? combined : null;
 }
 
 function pathsOverlap(changedPaths, closurePatterns) {

--- a/scripts/codex-github-integration-candidate.mjs
+++ b/scripts/codex-github-integration-candidate.mjs
@@ -49,7 +49,9 @@ export async function pullRequestFiles({ repository, pullNumber, token = process
     if (batch.length < 100) break;
     if (files.length >= 2_000) throw new Error("pull request changed-file set is too large to attest safely");
   }
-  const changedPaths = [...new Set(files.map((entry) => String(entry?.filename || "").trim().replaceAll("\\", "/")).filter(Boolean))].sort();
+  const changedPaths = [...new Set(files.flatMap((entry) => [entry?.filename, entry?.previous_filename]
+    .map((value) => String(value || "").trim().replaceAll("\\", "/"))
+    .filter(Boolean)))].sort();
   if (!changedPaths.length) throw new Error("pull request changed-file set is unavailable");
   return changedPaths;
 }

--- a/scripts/codex-github-integration-candidate.mjs
+++ b/scripts/codex-github-integration-candidate.mjs
@@ -65,7 +65,7 @@ export function assertCoordinationPayloadSize(request) {
   return bytes;
 }
 
-export async function loadMergeCandidate({ repository, pullNumber, expectedHeadSha = null, token = process.env.GH_TOKEN }) {
+export async function loadMergeCandidateIdentity({ repository, pullNumber, expectedHeadSha = null, token = process.env.GH_TOKEN }) {
   if (!repository || !/^[^/]+\/[^/]+$/.test(repository)) throw new Error("repository is invalid");
   if (!/^[1-9][0-9]*$/.test(String(pullNumber))) throw new Error("pull number is invalid");
   const pull = await githubJson(repository, `/pulls/${pullNumber}`, {}, token);
@@ -77,6 +77,18 @@ export async function loadMergeCandidate({ repository, pullNumber, expectedHeadS
     || pull.head?.repo?.full_name !== repository
     || (expectedHeadSha && headSha !== assertSha(expectedHeadSha, "expected head SHA"))
   ) throw new Error("pull request is not an open same-repository main integration candidate");
+  return { pull, headSha, baseSha };
+}
+
+export async function loadMergeCandidate({
+  repository,
+  pullNumber,
+  expectedHeadSha = null,
+  token = process.env.GH_TOKEN,
+  identity = null,
+}) {
+  const candidateIdentity = identity || await loadMergeCandidateIdentity({ repository, pullNumber, expectedHeadSha, token });
+  const { pull, headSha, baseSha } = candidateIdentity;
   const changedPaths = await pullRequestFiles({ repository, pullNumber, token });
   const { request, closure } = buildWorkflowLeaseRequest({
     resource: "merge:main",

--- a/scripts/codex-github-integration-candidate.mjs
+++ b/scripts/codex-github-integration-candidate.mjs
@@ -1,0 +1,79 @@
+import { buildWorkflowLeaseRequest } from "./codex-global-coordination-workflow.mjs";
+
+const FULL_SHA = /^[0-9a-f]{40}$/i;
+
+function requiredToken(token = process.env.GH_TOKEN) {
+  const value = String(token || "").trim();
+  if (!value) throw new Error("GH_TOKEN is required");
+  return value;
+}
+
+function apiUrl(repository, suffix = "") {
+  return `https://api.github.com/repos/${repository}${suffix}`;
+}
+
+export async function githubJson(repository, suffix, options = {}, token = process.env.GH_TOKEN) {
+  const response = await fetch(apiUrl(repository, suffix), {
+    ...options,
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${requiredToken(token)}`,
+      "x-github-api-version": "2022-11-28",
+      "content-type": "application/json",
+      ...(options.headers || {}),
+    },
+  });
+  const raw = await response.text();
+  let body;
+  try {
+    body = raw ? JSON.parse(raw) : null;
+  } catch {
+    throw new Error(`GitHub API returned invalid JSON (${response.status})`);
+  }
+  if (!response.ok) throw new Error(`GitHub API request failed (${response.status}): ${String(body?.message || "unknown error")}`);
+  return body;
+}
+
+function assertSha(value, label) {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!FULL_SHA.test(normalized)) throw new Error(`${label} must be a full SHA`);
+  return normalized;
+}
+
+export async function pullRequestFiles({ repository, pullNumber, token = process.env.GH_TOKEN }) {
+  const files = [];
+  for (let page = 1; page <= 20; page += 1) {
+    const batch = await githubJson(repository, `/pulls/${pullNumber}/files?per_page=100&page=${page}`, {}, token);
+    if (!Array.isArray(batch)) throw new Error("GitHub pull request file response is invalid");
+    files.push(...batch);
+    if (batch.length < 100) break;
+    if (files.length >= 2_000) throw new Error("pull request changed-file set is too large to attest safely");
+  }
+  const changedPaths = [...new Set(files.map((entry) => String(entry?.filename || "").trim().replaceAll("\\", "/")).filter(Boolean))].sort();
+  if (!changedPaths.length) throw new Error("pull request changed-file set is unavailable");
+  return changedPaths;
+}
+
+export async function loadMergeCandidate({ repository, pullNumber, expectedHeadSha = null, token = process.env.GH_TOKEN }) {
+  if (!repository || !/^[^/]+\/[^/]+$/.test(repository)) throw new Error("repository is invalid");
+  if (!/^[1-9][0-9]*$/.test(String(pullNumber))) throw new Error("pull number is invalid");
+  const pull = await githubJson(repository, `/pulls/${pullNumber}`, {}, token);
+  const headSha = assertSha(pull?.head?.sha, "pull request head SHA");
+  const baseSha = assertSha(pull?.base?.sha, "pull request base SHA");
+  if (
+    pull.state !== "open"
+    || pull.base?.ref !== "main"
+    || pull.head?.repo?.full_name !== repository
+    || (expectedHeadSha && headSha !== assertSha(expectedHeadSha, "expected head SHA"))
+  ) throw new Error("pull request is not an open same-repository main integration candidate");
+  const changedPaths = await pullRequestFiles({ repository, pullNumber, token });
+  const { request, closure } = buildWorkflowLeaseRequest({
+    resource: "merge:main",
+    module: "merge",
+    source: baseSha,
+    operation: "mutation",
+    idempotencyKey: `merge:${repository}:${pullNumber}:${headSha}`,
+    inputs: { pullNumber: String(pullNumber), expectedHeadSha: headSha, baseSha, changedPaths },
+  });
+  return { pull, headSha, baseSha, changedPaths, request, closure };
+}

--- a/scripts/codex-github-integration-candidate.mjs
+++ b/scripts/codex-github-integration-candidate.mjs
@@ -1,6 +1,7 @@
 import { buildWorkflowLeaseRequest } from "./codex-global-coordination-workflow.mjs";
 
 const FULL_SHA = /^[0-9a-f]{40}$/i;
+const MAX_COORDINATION_REQUEST_BYTES = 48 * 1024;
 
 function requiredToken(token = process.env.GH_TOKEN) {
   const value = String(token || "").trim();
@@ -56,6 +57,14 @@ export async function pullRequestFiles({ repository, pullNumber, token = process
   return changedPaths;
 }
 
+export function assertCoordinationPayloadSize(request) {
+  const bytes = Buffer.byteLength(JSON.stringify(request), "utf8");
+  if (bytes > MAX_COORDINATION_REQUEST_BYTES) {
+    throw new Error(`pull request coordination attestation exceeds the ${MAX_COORDINATION_REQUEST_BYTES}-byte payload budget`);
+  }
+  return bytes;
+}
+
 export async function loadMergeCandidate({ repository, pullNumber, expectedHeadSha = null, token = process.env.GH_TOKEN }) {
   if (!repository || !/^[^/]+\/[^/]+$/.test(repository)) throw new Error("repository is invalid");
   if (!/^[1-9][0-9]*$/.test(String(pullNumber))) throw new Error("pull number is invalid");
@@ -77,5 +86,6 @@ export async function loadMergeCandidate({ repository, pullNumber, expectedHeadS
     idempotencyKey: `merge:${repository}:${pullNumber}:${headSha}`,
     inputs: { pullNumber: String(pullNumber), expectedHeadSha: headSha, baseSha, changedPaths },
   });
+  assertCoordinationPayloadSize(request);
   return { pull, headSha, baseSha, changedPaths, request, closure };
 }

--- a/scripts/codex-global-coordination-client.mjs
+++ b/scripts/codex-global-coordination-client.mjs
@@ -58,7 +58,7 @@ function envelopeFor({ action, request, proof, authorization, ttlMs, reason, non
     requestNonce: nonce,
     requestedAt,
   };
-  if (action === "acquire") body.request = request;
+  if (["acquire", "gate"].includes(action)) body.request = request;
   else body.proof = proof;
   if (authorization !== undefined) body.authorization = authorization;
   if (action === "renew") body.ttlMs = ttlMs;
@@ -139,6 +139,7 @@ export function proofForLease(lease) {
     fencingToken: lease.fencingToken,
     intentDigest: String(lease.intentDigest || ""),
     owner: lease.owner,
+    ...(lease.holder ? { holder: lease.holder } : {}),
   };
 }
 
@@ -172,6 +173,10 @@ export async function coordinate({
 
 export async function acquireGlobalLease({ request, ...options }) {
   return coordinate({ ...options, action: "acquire", request });
+}
+
+export async function evaluateGlobalGate({ request, ...options }) {
+  return coordinate({ ...options, action: "gate", request });
 }
 
 export async function checkGlobalLease({ proof, authorization, ...options }) {

--- a/scripts/codex-global-coordination-workflow.mjs
+++ b/scripts/codex-global-coordination-workflow.mjs
@@ -146,6 +146,9 @@ export function buildWorkflowLeaseRequest({
     sourceCommit: closure.sourceCommit,
     sourceTree: closure.sourceTree,
     dependencyClosureDigest: closure.digest,
+    dependencyClosurePaths: closure.dependencyClosurePaths || closure.inputs.map((entry) => entry.path),
+    dependencyClosurePatterns: closure.dependencyClosurePatterns || [],
+    dependencyClosureSharedInputs: closure.dependencyClosureSharedInputs === true,
     ...(inputs ? { inputs } : {}),
     ...(["release", "promotion"].includes(normalizedOperation)
       ? { releaseIdentity }

--- a/scripts/codex-global-coordination-workflow.mjs
+++ b/scripts/codex-global-coordination-workflow.mjs
@@ -82,16 +82,38 @@ export function closureFromFile(args, { module, source }) {
   if (sha256(canonicalJson(closure.material)) !== digest) {
     throw new Error("global coordination closure digest does not match its material");
   }
+  const materialInputs = closure.material.inputs
+    .map((entry) => ({
+      path: String(entry?.path || "").trim().replaceAll("\\", "/"),
+      blob: String(entry?.blob || "").trim().toLowerCase(),
+    }))
+    .sort((left, right) => left.path.localeCompare(right.path));
+  if (materialInputs.some((entry) => !entry.path || !FULL_SHA.test(entry.blob))) {
+    throw new Error("global coordination closure material inputs are invalid");
+  }
+  const materialPaths = materialInputs.map((entry) => entry.path);
+  const declaredPaths = Array.isArray(closure.dependencyClosurePaths)
+    ? [...new Set(closure.dependencyClosurePaths.map((entry) => String(entry || "").trim().replaceAll("\\", "/")))].sort()
+    : materialPaths;
+  if (canonicalJson([...new Set(declaredPaths)].sort()) !== canonicalJson([...new Set(materialPaths)].sort())) {
+    throw new Error("global coordination closure admission paths are not bound to the verified material");
+  }
+  const verifiedPatterns = Array.isArray(closure.material.dependencyClosurePatterns)
+    ? closure.material.dependencyClosurePatterns
+    : [];
+  const verifiedSharedInputPaths = Array.isArray(closure.material.dependencyClosureSharedInputPaths)
+    ? closure.material.dependencyClosureSharedInputPaths
+    : [];
   return {
     schemaVersion: 1,
     module: expectedModule,
     sourceCommit,
     sourceTree,
-    inputs: closure.inputs || closure.material.inputs,
-    ...(Array.isArray(closure.dependencyClosurePaths) ? { dependencyClosurePaths: closure.dependencyClosurePaths } : {}),
-    ...(Array.isArray(closure.dependencyClosurePatterns) ? { dependencyClosurePatterns: closure.dependencyClosurePatterns } : {}),
-    ...(Array.isArray(closure.dependencyClosureSharedInputPaths) ? { dependencyClosureSharedInputPaths: closure.dependencyClosureSharedInputPaths } : {}),
-    dependencyClosureSharedInputs: closure.dependencyClosureSharedInputs === true,
+    inputs: materialInputs,
+    dependencyClosurePaths: materialPaths,
+    dependencyClosurePatterns: verifiedPatterns,
+    dependencyClosureSharedInputPaths: verifiedSharedInputPaths,
+    dependencyClosureSharedInputs: closure.material.dependencyClosureSharedInputs === true,
     digest,
     material: closure.material,
   };

--- a/scripts/codex-global-coordination-workflow.mjs
+++ b/scripts/codex-global-coordination-workflow.mjs
@@ -88,6 +88,10 @@ export function closureFromFile(args, { module, source }) {
     sourceCommit,
     sourceTree,
     inputs: closure.inputs || closure.material.inputs,
+    ...(Array.isArray(closure.dependencyClosurePaths) ? { dependencyClosurePaths: closure.dependencyClosurePaths } : {}),
+    ...(Array.isArray(closure.dependencyClosurePatterns) ? { dependencyClosurePatterns: closure.dependencyClosurePatterns } : {}),
+    ...(Array.isArray(closure.dependencyClosureSharedInputPaths) ? { dependencyClosureSharedInputPaths: closure.dependencyClosureSharedInputPaths } : {}),
+    dependencyClosureSharedInputs: closure.dependencyClosureSharedInputs === true,
     digest,
     material: closure.material,
   };
@@ -139,6 +143,11 @@ export function buildWorkflowLeaseRequest({
       throw new Error("release identity does not match the observed dependency closure");
     }
   }
+  const exactClosurePaths = closure.dependencyClosurePaths || closure.inputs.map((entry) => entry.path);
+  const closurePatterns = [...new Set([
+    ...(closure.dependencyClosurePatterns || []),
+    ...(closure.dependencyClosureSharedInputPaths || []),
+  ])].sort();
   const intent = {
     module: String(module || "").trim().toLowerCase(),
     workflow: String(process.env.GITHUB_WORKFLOW || "codex-local-workflow").trim(),
@@ -146,8 +155,10 @@ export function buildWorkflowLeaseRequest({
     sourceCommit: closure.sourceCommit,
     sourceTree: closure.sourceTree,
     dependencyClosureDigest: closure.digest,
-    dependencyClosurePaths: closure.dependencyClosurePaths || closure.inputs.map((entry) => entry.path),
-    dependencyClosurePatterns: closure.dependencyClosurePatterns || [],
+    ...(String(module || "").trim().toLowerCase() !== "merge" && exactClosurePaths.length <= 1024
+      ? { dependencyClosurePaths: exactClosurePaths }
+      : {}),
+    dependencyClosurePatterns: closurePatterns,
     dependencyClosureSharedInputs: closure.dependencyClosureSharedInputs === true,
     ...(inputs ? { inputs } : {}),
     ...(["release", "promotion"].includes(normalizedOperation)

--- a/scripts/codex-global-coordinator.mjs
+++ b/scripts/codex-global-coordinator.mjs
@@ -14,6 +14,7 @@ import {
   compareDependencyClosure,
   CONTRACT_ID,
   emptyState,
+  evaluateLeaseAdmission,
   lockScopeFor,
   normalizeReleaseIdentity,
   normalizeResourceKey,
@@ -24,7 +25,7 @@ import {
 } from "../ops/governance/global-coordination-core.mjs";
 import { matchesAny } from "./codex-autonomy-lib.mjs";
 
-export { acquireLease, authorizeMutation, buildIntent, canonicalJson, checkLease, compareDependencyClosure, emptyState, lockScopeFor, normalizeReleaseIdentity, normalizeResourceKey, releaseLease, renewLease, revokeLease, consumeNonce };
+export { acquireLease, authorizeMutation, buildIntent, canonicalJson, checkLease, compareDependencyClosure, emptyState, evaluateLeaseAdmission, lockScopeFor, normalizeReleaseIdentity, normalizeResourceKey, releaseLease, renewLease, revokeLease, consumeNonce };
 export { CONTRACT_ID };
 
 export const ROOT = path.resolve(import.meta.dirname, "..");
@@ -88,6 +89,9 @@ export function dependencyClosureFromTree({ module, sourceCommit, sourceTree, en
     sourceCommit: sourceCommit.toLowerCase(),
     sourceTree: sourceTree.toLowerCase(),
     inputs,
+    dependencyClosurePaths: inputs.map((entry) => entry.path),
+    dependencyClosurePatterns: [...(closure.patterns || [])],
+    dependencyClosureSharedInputs: closure.sharedInputs === true,
     digest: sha256(canonicalJson(material)),
     material,
   };

--- a/scripts/codex-global-coordinator.mjs
+++ b/scripts/codex-global-coordinator.mjs
@@ -71,6 +71,9 @@ export function dependencyClosureFromTree({ module, sourceCommit, sourceTree, en
   if (!closure || (closure.requiresExplicitClosure && !policy.releaseClosures?.[normalizedModule])) throw new Error(`release dependency closure is not defined for ${normalizedModule || "module"}`);
   if (!FULL_SHA.test(String(sourceCommit || "")) || !FULL_SHA.test(String(sourceTree || ""))) throw new Error("release closure source identity is invalid");
   const paths = new Set((closure.patterns || []).map((value) => String(value).replaceAll("\\", "/")));
+  const sharedInputPaths = closure.sharedInputs
+    ? [...(policy.sharedInputs || [])].map((value) => String(value).replaceAll("\\", "/"))
+    : [];
   const selected = (entries || []).filter((entry) => {
     const file = String(entry.path || "").replaceAll("\\", "/");
     return (closure.patterns || []).some((pattern) => matchesAny(file, [pattern]))
@@ -91,6 +94,7 @@ export function dependencyClosureFromTree({ module, sourceCommit, sourceTree, en
     inputs,
     dependencyClosurePaths: inputs.map((entry) => entry.path),
     dependencyClosurePatterns: [...(closure.patterns || [])],
+    dependencyClosureSharedInputPaths: sharedInputPaths,
     dependencyClosureSharedInputs: closure.sharedInputs === true,
     digest: sha256(canonicalJson(material)),
     material,

--- a/scripts/codex-global-coordinator.mjs
+++ b/scripts/codex-global-coordinator.mjs
@@ -9,6 +9,7 @@ import {
   acquireLease,
   authorizeMutation,
   buildIntent,
+  buildLegacyIntentV1,
   canonicalJson,
   checkLease,
   compareDependencyClosure,
@@ -25,7 +26,7 @@ import {
 } from "../ops/governance/global-coordination-core.mjs";
 import { matchesAny } from "./codex-autonomy-lib.mjs";
 
-export { acquireLease, authorizeMutation, buildIntent, canonicalJson, checkLease, compareDependencyClosure, emptyState, evaluateLeaseAdmission, lockScopeFor, normalizeReleaseIdentity, normalizeResourceKey, releaseLease, renewLease, revokeLease, consumeNonce };
+export { acquireLease, authorizeMutation, buildIntent, buildLegacyIntentV1, canonicalJson, checkLease, compareDependencyClosure, emptyState, evaluateLeaseAdmission, lockScopeFor, normalizeReleaseIdentity, normalizeResourceKey, releaseLease, renewLease, revokeLease, consumeNonce };
 export { CONTRACT_ID };
 
 export const ROOT = path.resolve(import.meta.dirname, "..");
@@ -85,7 +86,14 @@ export function dependencyClosureFromTree({ module, sourceCommit, sourceTree, en
   // deliberately excluded from the closure digest. Otherwise an unrelated
   // documentation change would invalidate a release whose selected inputs are
   // unchanged.
-  const material = { schemaVersion: 1, module: normalizedModule, inputs };
+  const material = {
+    schemaVersion: 1,
+    module: normalizedModule,
+    inputs,
+    dependencyClosurePatterns: [...(closure.patterns || [])],
+    dependencyClosureSharedInputPaths: sharedInputPaths,
+    dependencyClosureSharedInputs: closure.sharedInputs === true,
+  };
   return {
     schemaVersion: 1,
     module: normalizedModule,

--- a/scripts/codex-global-integration-gate.mjs
+++ b/scripts/codex-global-integration-gate.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+import { loadMergeCandidate, githubJson } from "./codex-github-integration-candidate.mjs";
+import { evaluateGlobalGate } from "./codex-global-coordination-client.mjs";
+
+function requiredEnv(name) {
+  const value = String(process.env[name] || "").trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function argument(args, name, fallback = null) {
+  const index = args.indexOf(name);
+  return index === -1 ? fallback : args[index + 1];
+}
+
+async function setStatus(repository, sha, state, description) {
+  return githubJson(repository, `/statuses/${sha}`, {
+    method: "POST",
+    body: JSON.stringify({
+      state,
+      context: "skincos-integration-gate",
+      description: String(description).slice(0, 140),
+      target_url: `${process.env.GITHUB_SERVER_URL || "https://github.com"}/${repository}/actions/workflows/skincos-integration-gate.yml`,
+    }),
+  });
+}
+
+function isWaitable(result) {
+  return ["resource-lease-held", "incompatible-release-lease"].includes(String(result?.reason || ""));
+}
+
+export async function runIntegrationGate({ repository, pullNumber, expectedHeadSha, maxWaitMs = 15 * 60_000, pollMs = 15_000 }) {
+  if (String(process.env.SKINCOS_GLOBAL_COORDINATION_REQUIRED || "").trim().toLowerCase() !== "true") {
+    throw new Error("SKINCOS_GLOBAL_COORDINATION_REQUIRED must be true for the integration gate");
+  }
+  const candidate = await loadMergeCandidate({ repository, pullNumber, expectedHeadSha });
+  await setStatus(repository, candidate.headSha, "pending", "Waiting for compatible global resource ownership before main integration.");
+  const deadline = Date.now() + maxWaitMs;
+  let lastReason = "";
+  while (Date.now() <= deadline) {
+    const result = await evaluateGlobalGate({
+      request: candidate.request,
+      url: requiredEnv("SKINCOS_GLOBAL_COORDINATOR_URL"),
+    });
+    lastReason = String(result.reason || "unknown");
+    if (result.passed === true) {
+      await setStatus(repository, candidate.headSha, "success", "No incompatible global release or merge lease is active.");
+      return { passed: true, reason: lastReason, changedPaths: candidate.changedPaths };
+    }
+    if (!isWaitable(result)) {
+      throw new Error(`global integration gate failed closed: ${lastReason}`);
+    }
+    if (Date.now() + pollMs > deadline) break;
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  throw new Error(`global integration gate remained pending on ${lastReason || "an active global lease"}`);
+}
+
+async function main(args) {
+  const repository = requiredEnv("GITHUB_REPOSITORY");
+  const pullNumber = argument(args, "--pull-number");
+  const expectedHeadSha = argument(args, "--expected-head-sha");
+  const maxWaitMs = Number(argument(args, "--max-wait-ms", "900000"));
+  const pollMs = Number(argument(args, "--poll-ms", "15000"));
+  if (!Number.isInteger(maxWaitMs) || maxWaitMs < 15_000 || maxWaitMs > 30 * 60_000) throw new Error("--max-wait-ms is outside the safe bounds");
+  if (!Number.isInteger(pollMs) || pollMs < 5_000 || pollMs > 60_000) throw new Error("--poll-ms is outside the safe bounds");
+  try {
+    const result = await runIntegrationGate({ repository, pullNumber, expectedHeadSha, maxWaitMs, pollMs });
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    try {
+      const candidate = await loadMergeCandidate({ repository, pullNumber, expectedHeadSha });
+      await setStatus(repository, candidate.headSha, "failure", message);
+    } catch {
+      // Preserve the original fail-closed error when the PR itself advanced or
+      // GitHub status custody is unavailable.
+    }
+    throw error;
+  }
+}
+
+if (process.argv[1] && new URL(`file://${process.argv[1]}`).href === import.meta.url) {
+  try {
+    await main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/codex-global-integration-gate.mjs
+++ b/scripts/codex-global-integration-gate.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
-import { loadMergeCandidate, githubJson } from "./codex-github-integration-candidate.mjs";
+import { loadMergeCandidate, loadMergeCandidateIdentity, githubJson } from "./codex-github-integration-candidate.mjs";
 import { evaluateGlobalGate } from "./codex-global-coordination-client.mjs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 function requiredEnv(name) {
   const value = String(process.env[name] || "").trim();
@@ -33,7 +35,14 @@ export async function runIntegrationGate({ repository, pullNumber, expectedHeadS
   if (String(process.env.SKINCOS_GLOBAL_COORDINATION_REQUIRED || "").trim().toLowerCase() !== "true") {
     throw new Error("SKINCOS_GLOBAL_COORDINATION_REQUIRED must be true for the integration gate");
   }
-  const candidate = await loadMergeCandidate({ repository, pullNumber, expectedHeadSha });
+  const identity = await loadMergeCandidateIdentity({ repository, pullNumber, expectedHeadSha });
+  let candidate;
+  try {
+    candidate = await loadMergeCandidate({ repository, pullNumber, expectedHeadSha, identity });
+  } catch (error) {
+    await setStatus(repository, identity.headSha, "failure", error instanceof Error ? error.message : String(error));
+    throw error;
+  }
   await setStatus(repository, candidate.headSha, "pending", "Waiting for compatible global resource ownership before main integration.");
   const deadline = Date.now() + maxWaitMs;
   let lastReason = "";
@@ -89,7 +98,9 @@ async function main(args) {
   }
 }
 
-if (process.argv[1] && new URL(`file://${process.argv[1]}`).href === import.meta.url) {
+const invokedAsScript = process.argv[1]
+  && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (invokedAsScript) {
   try {
     await main(process.argv.slice(2));
   } catch (error) {

--- a/scripts/codex-global-integration-gate.mjs
+++ b/scripts/codex-global-integration-gate.mjs
@@ -53,7 +53,16 @@ export async function runIntegrationGate({ repository, pullNumber, expectedHeadS
     if (Date.now() + pollMs > deadline) break;
     await new Promise((resolve) => setTimeout(resolve, pollMs));
   }
-  throw new Error(`global integration gate remained pending on ${lastReason || "an active global lease"}`);
+  // Keep the commit status pending. A scheduled recheck workflow will call
+  // this same trusted-main script again after the competing lease can expire
+  // or be released; turning this ordinary wait into failure would strand the
+  // PR until a new pull_request event occurs.
+  return {
+    passed: false,
+    pending: true,
+    reason: lastReason || "active-global-lease",
+    changedPaths: candidate.changedPaths,
+  };
 }
 
 async function main(args) {

--- a/scripts/codex-global-merge-authority.mjs
+++ b/scripts/codex-global-merge-authority.mjs
@@ -66,6 +66,26 @@ async function setMergeAuthorityStatus(repository, headSha, state, description) 
   });
 }
 
+function waitableLeaseReason(reason) {
+  return ["resource-lease-held", "incompatible-release-lease"].includes(String(reason || ""));
+}
+
+export async function acquireMergeLease({ request, url, maxWaitMs = 15 * 60_000, pollMs = 15_000, acquireImpl = acquireGlobalLease }) {
+  const deadline = Date.now() + maxWaitMs;
+  let lastReason = "";
+  while (Date.now() <= deadline) {
+    const result = await acquireImpl({ request, url });
+    if (result.passed === true && result.lease) return result;
+    lastReason = String(result.reason || "unknown");
+    if (!waitableLeaseReason(lastReason)) {
+      throw new Error(`merge:main lease acquisition failed closed: ${lastReason}`);
+    }
+    if (Date.now() + pollMs > deadline) break;
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  throw new Error(`merge:main lease remained unavailable: ${lastReason || "unknown"}`);
+}
+
 export async function mergePullRequest({ repository, pullNumber, expectedHeadSha, mergeMethod = "squash" }) {
   if (String(process.env.SKINCOS_GLOBAL_COORDINATION_REQUIRED || "").trim().toLowerCase() !== "true") {
     throw new Error("SKINCOS_GLOBAL_COORDINATION_REQUIRED must be true for merge:main");
@@ -83,7 +103,7 @@ export async function mergePullRequest({ repository, pullNumber, expectedHeadSha
     throw new Error("pull request is not mergeable by its current GitHub state");
   }
   const resource = "merge:main";
-  const result = await acquireGlobalLease({ request, url });
+  const result = await acquireMergeLease({ request, url });
   if (result.passed !== true || !result.lease) throw new Error(`merge:main lease acquisition failed: ${result.reason || "unknown"}`);
   const proof = proofForLease(result.lease);
   let merged;

--- a/scripts/codex-global-merge-authority.mjs
+++ b/scripts/codex-global-merge-authority.mjs
@@ -7,7 +7,7 @@ import {
   proofForLease,
   releaseGlobalLease,
 } from "./codex-global-coordination-client.mjs";
-import { buildWorkflowLeaseRequest } from "./codex-global-coordination-workflow.mjs";
+import { loadMergeCandidate } from "./codex-github-integration-candidate.mjs";
 
 const FULL_SHA = /^[0-9a-f]{40}$/i;
 function requiredEnv(name) {
@@ -73,27 +73,16 @@ export async function mergePullRequest({ repository, pullNumber, expectedHeadSha
   const url = requiredEnv("SKINCOS_GLOBAL_COORDINATOR_URL");
   requiredEnv("SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET");
   if (!MERGE_METHODS.has(mergeMethod)) throw new Error(`unsupported merge method: ${mergeMethod}`);
-  const initial = await githubJson(repository, `/pulls/${pullNumber}`);
-  const headSha = assertSha(expectedHeadSha, "expected head SHA");
-  if (initial.state !== "open" || initial.base?.ref !== "main") throw new Error("pull request is not an open main integration candidate");
-  if (initial.head?.repo?.full_name !== repository) throw new Error("pull request head repository is outside the governed repository");
-  if (assertSha(initial.head?.sha, "pull request head SHA") !== headSha) throw new Error("pull request head advanced before lease acquisition");
+  const candidate = await loadMergeCandidate({ repository, pullNumber, expectedHeadSha });
+  const initial = candidate.pull;
+  const { headSha, baseSha, request, closure } = candidate;
   // A required global-merge-authority status makes the PR appear blocked until
   // this authority posts its success status. GitHub's merge API remains the
   // final enforcement point for every other required check or review.
   if (initial.draft === true || initial.mergeable_state === "dirty") {
     throw new Error("pull request is not mergeable by its current GitHub state");
   }
-  const baseSha = assertSha(initial.base?.sha, "pull request base SHA");
   const resource = "merge:main";
-  const { request, closure } = buildWorkflowLeaseRequest({
-    resource,
-    module: "merge",
-    source: baseSha,
-    operation: "mutation",
-    idempotencyKey: `merge:${repository}:${pullNumber}:${headSha}`,
-    inputs: { pullNumber: String(pullNumber), expectedHeadSha: headSha, baseSha },
-  });
   const result = await acquireGlobalLease({ request, url });
   if (result.passed !== true || !result.lease) throw new Error(`merge:main lease acquisition failed: ${result.reason || "unknown"}`);
   const proof = proofForLease(result.lease);

--- a/scripts/tests/codex-global-coordination-workflow.test.mjs
+++ b/scripts/tests/codex-global-coordination-workflow.test.mjs
@@ -73,3 +73,15 @@ test("workflow adapter carries exact release identity for promotion operations",
     releaseIdentity: { ...releaseIdentity, dependencyClosureDigest: "e".repeat(64) },
   }), /release identity does not match/);
 });
+
+test("merge admission carries only changed paths, not the full repository closure", () => {
+  const { request } = buildWorkflowLeaseRequest({
+    resource: "merge:main",
+    module: "merge",
+    source: "HEAD",
+    inputs: { changedPaths: ["docs/readme.md"] },
+  });
+  assert.equal(request.intent.dependencyClosurePaths, undefined);
+  assert.deepEqual(request.intent.dependencyClosurePatterns, ["**"]);
+  assert.ok(Buffer.byteLength(JSON.stringify(request), "utf8") < 64 * 1024);
+});

--- a/scripts/tests/codex-global-coordination-workflow.test.mjs
+++ b/scripts/tests/codex-global-coordination-workflow.test.mjs
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { assertCoordinationPayloadSize } from "../codex-github-integration-candidate.mjs";
 import { buildWorkflowLeaseRequest, closureFromFile } from "../codex-global-coordination-workflow.mjs";
 import { dependencyClosureForSource } from "../codex-global-coordinator.mjs";
 
@@ -84,4 +85,10 @@ test("merge admission carries only changed paths, not the full repository closur
   assert.equal(request.intent.dependencyClosurePaths, undefined);
   assert.deepEqual(request.intent.dependencyClosurePatterns, ["**"]);
   assert.ok(Buffer.byteLength(JSON.stringify(request), "utf8") < 64 * 1024);
+});
+
+test("merge admission rejects a changed-file payload before remote coordination", () => {
+  assert.throws(() => assertCoordinationPayloadSize({
+    inputs: { changedPaths: Array.from({ length: 2_000 }, (_, index) => `website/${"x".repeat(48)}/${index}.tsx`) },
+  }), /payload budget/);
 });

--- a/scripts/tests/codex-global-coordination-workflow.test.mjs
+++ b/scripts/tests/codex-global-coordination-workflow.test.mjs
@@ -20,6 +20,7 @@ test("workflow adapter binds the lease to source closure, owner, and selected re
   assert.equal(request.intent.sourceCommit, closure.sourceCommit);
   assert.equal(request.intent.sourceTree, closure.sourceTree);
   assert.equal(request.intent.dependencyClosureDigest, closure.digest);
+  assert.ok(request.intent.dependencyClosurePatterns.length > 0);
   assert.equal(request.owner.provider, "github");
   assert.match(request.intentDigest, /^[0-9a-f]{64}$/);
 });

--- a/scripts/tests/codex-global-coordination.test.mjs
+++ b/scripts/tests/codex-global-coordination.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import test from "node:test";
 import { acquireMergeLease } from "../codex-global-merge-authority.mjs";
@@ -6,6 +7,7 @@ import {
   acquireLease,
   authorizeMutation,
   buildIntent,
+  buildLegacyIntentV1,
   buildLeaseRequest,
   checkLease,
   compareDependencyClosure,
@@ -19,6 +21,7 @@ import {
   normalizeResourceKey,
   releaseLease,
   renewLease,
+  canonicalJson,
 } from "../codex-global-coordinator.mjs";
 
 const owner = {
@@ -35,6 +38,22 @@ const identity = () => ({
   sourceTree: sha("b"),
   dependencyClosureDigest: digest("c"),
   artifacts: [{ name: "pages", id: "deployment-1", digest: digest("d"), versionId: "version-1" }],
+});
+
+test("v1 owner expansion keeps an exact legacy digest compatibility path", () => {
+  const request = {
+    operation: "mutation",
+    resource: "merge:main",
+    owner,
+    intent: { module: "merge", dependencyClosureDigest: digest("a") },
+    idempotencyKey: "legacy-owner-compatibility",
+  };
+  const modern = buildIntent(request);
+  const legacy = buildLegacyIntentV1(request);
+  const digestFor = (value) => crypto.createHash("sha256").update(canonicalJson(value)).digest("hex");
+  assert.equal(modern.owner.sessionId, owner.threadId);
+  assert.equal(legacy.owner.sessionId, undefined);
+  assert.notEqual(digestFor(modern), digestFor(legacy));
 });
 const releaseRequest = (idempotencyKey = "intent-1") => buildLeaseRequest({
   operation: "promotion",

--- a/scripts/tests/codex-global-coordination.test.mjs
+++ b/scripts/tests/codex-global-coordination.test.mjs
@@ -12,6 +12,7 @@ import {
   dependencyClosureFromTree,
   dependencyClosureForSource,
   emptyState,
+  evaluateLeaseAdmission,
   loadGlobalPolicy,
   lockScopeFor,
   normalizeResourceKey,
@@ -49,6 +50,8 @@ test("resource keys normalize and shared surface scopes collide across deploy an
   assert.equal(lockScopeFor("cloudflare:website:staging"), "surface:website:staging");
   assert.equal(lockScopeFor("release:website"), "release:website");
   assert.equal(lockScopeFor("merge:main"), "repository:main");
+  assert.equal(normalizeResourceKey("MUTATE:Website:Staging"), "mutate:website:staging");
+  assert.equal(lockScopeFor("mutate:website:staging"), "surface:website:staging");
   assert.throws(() => normalizeResourceKey("deploy:website:unknown"), /resource environment is invalid/);
   assert.throws(() => normalizeResourceKey("surface:website:staging"), /resource class is unsupported/);
 });
@@ -189,7 +192,85 @@ test("renewal and nonce replay are explicit state transitions", () => {
   const replay = consumeNonce(firstNonce.state, { nonce: "nonce-0000000000000001", digest: digest("a"), now: 20_001, ttlMs: 60_000 });
   assert.equal(replay.accepted, false);
   assert.equal(replay.reason, "request-nonce-replayed");
+  assert.equal(renewed.lease.updatedAt, 20_000);
+  assert.equal(renewed.lease.heartbeatAt, 20_000);
   assert.equal(fs.existsSync(new URL("../../ops/governance/global-concurrency-policy.json", import.meta.url)), true);
+});
+
+test("global admission allows an unrelated merge while fencing a closure-overlapping merge", () => {
+  const releaseRequest = buildLeaseRequest({
+    operation: "mutation",
+    resource: "release:website",
+    owner,
+    idempotencyKey: "release-website-1",
+    ttlMs: 60_000,
+    intent: {
+      module: "website",
+      dependencyClosureDigest: digest("c"),
+      dependencyClosurePatterns: ["website/**", "package.json"],
+      dependencyClosurePaths: ["website/src/index.ts", "package.json"],
+    },
+  });
+  const held = acquireLease(emptyState(), releaseRequest, { now: 1_000, leaseId: "lease-0000000000000011" });
+  assert.equal(held.accepted, true);
+
+  const unrelated = buildLeaseRequest({
+    operation: "mutation",
+    resource: "merge:main",
+    owner: { ...owner, threadId: "merge-thread" },
+    idempotencyKey: "merge-unrelated-1",
+    ttlMs: 60_000,
+    intent: { module: "merge", dependencyClosureDigest: digest("d"), inputs: { changedPaths: ["docs/readme.md"] } },
+  });
+  const allowed = evaluateLeaseAdmission(held.state, unrelated, { now: 2_000 });
+  assert.equal(allowed.allowed, true);
+  const acquired = acquireLease(held.state, unrelated, { now: 2_000, leaseId: "lease-0000000000000012" });
+  assert.equal(acquired.accepted, true);
+
+  const relevant = buildLeaseRequest({
+    ...unrelated,
+    idempotencyKey: "merge-relevant-1",
+    intent: { module: "merge", dependencyClosureDigest: digest("d"), inputs: { changedPaths: ["website/src/index.ts"] } },
+  });
+  const blocked = evaluateLeaseAdmission(held.state, relevant, { now: 2_000 });
+  assert.equal(blocked.allowed, false);
+  assert.equal(blocked.reason, "incompatible-release-lease");
+});
+
+test("ambiguous cross-scope admission fails closed and release retries are idempotent", () => {
+  const held = acquireLease(emptyState(), buildLeaseRequest({
+    operation: "mutation",
+    resource: "release:website",
+    owner,
+    idempotencyKey: "release-retry",
+    ttlMs: 60_000,
+    intent: { module: "website", dependencyClosureDigest: digest("c") },
+  }), { now: 1_000, leaseId: "lease-0000000000000013" });
+  const merge = buildLeaseRequest({
+    operation: "mutation",
+    resource: "merge:main",
+    owner: { ...owner, threadId: "merge-ambiguous" },
+    idempotencyKey: "merge-ambiguous-1",
+    ttlMs: 60_000,
+    intent: { module: "merge", dependencyClosureDigest: digest("d") },
+  });
+  const ambiguous = evaluateLeaseAdmission(held.state, merge, { now: 2_000 });
+  assert.equal(ambiguous.allowed, false);
+  assert.equal(ambiguous.failClosed, true);
+  assert.equal(ambiguous.reason, "coordination-dependency-closure-ambiguous");
+
+  const proof = {
+    resource: held.lease.resource,
+    leaseId: held.lease.leaseId,
+    fencingToken: held.lease.fencingToken,
+    intentDigest: held.lease.intentDigest,
+    owner: held.lease.owner,
+  };
+  const first = releaseLease(held.state, proof, { now: 3_000 });
+  const retry = releaseLease(first.state, proof, { now: 3_001 });
+  assert.equal(first.released, true);
+  assert.equal(retry.released, true);
+  assert.equal(retry.idempotent, true);
 });
 
 test("the policy and current Ponto source produce a deterministic dependency closure", () => {

--- a/scripts/tests/codex-global-coordination.test.mjs
+++ b/scripts/tests/codex-global-coordination.test.mjs
@@ -273,6 +273,33 @@ test("ambiguous cross-scope admission fails closed and release retries are idemp
   assert.equal(retry.idempotent, true);
 });
 
+test("shared exact closure inputs still fence a merge when module patterns do not match", () => {
+  const held = acquireLease(emptyState(), buildLeaseRequest({
+    operation: "mutation",
+    resource: "release:website",
+    owner,
+    idempotencyKey: "release-shared-input",
+    ttlMs: 60_000,
+    intent: {
+      module: "website",
+      dependencyClosureDigest: digest("c"),
+      dependencyClosurePatterns: ["website/**"],
+      dependencyClosurePaths: ["package.json"],
+    },
+  }), { now: 1_000, leaseId: "lease-0000000000000014" });
+  const merge = buildLeaseRequest({
+    operation: "mutation",
+    resource: "merge:main",
+    owner: { ...owner, threadId: "merge-shared-input" },
+    idempotencyKey: "merge-shared-input",
+    ttlMs: 60_000,
+    intent: { module: "merge", dependencyClosureDigest: digest("d"), inputs: { changedPaths: ["package.json"] } },
+  });
+  const admission = evaluateLeaseAdmission(held.state, merge, { now: 2_000 });
+  assert.equal(admission.allowed, false);
+  assert.equal(admission.reason, "incompatible-release-lease");
+});
+
 test("the policy and current Ponto source produce a deterministic dependency closure", () => {
   const policy = loadGlobalPolicy();
   assert.equal(policy.contractId, "skincos/global-coordination/v1");

--- a/scripts/tests/codex-global-coordination.test.mjs
+++ b/scripts/tests/codex-global-coordination.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import test from "node:test";
+import { acquireMergeLease } from "../codex-global-merge-authority.mjs";
 import {
   acquireLease,
   authorizeMutation,
@@ -298,6 +299,31 @@ test("shared exact closure inputs still fence a merge when module patterns do no
   const admission = evaluateLeaseAdmission(held.state, merge, { now: 2_000 });
   assert.equal(admission.allowed, false);
   assert.equal(admission.reason, "incompatible-release-lease");
+});
+
+test("merge authority retries only known transient lease conflicts", async () => {
+  let calls = 0;
+  const result = await acquireMergeLease({
+    request: {},
+    url: "https://coordination.example.test",
+    maxWaitMs: 100,
+    pollMs: 0,
+    acquireImpl: async () => {
+      calls += 1;
+      return calls < 3
+        ? { passed: false, reason: "resource-lease-held" }
+        : { passed: true, lease: { leaseId: "lease-1" } };
+    },
+  });
+  assert.equal(calls, 3);
+  assert.equal(result.lease.leaseId, "lease-1");
+  await assert.rejects(() => acquireMergeLease({
+    request: {},
+    url: "https://coordination.example.test",
+    maxWaitMs: 100,
+    pollMs: 0,
+    acquireImpl: async () => ({ passed: false, reason: "coordination-dependency-closure-ambiguous" }),
+  }), /failed closed/);
 });
 
 test("the policy and current Ponto source produce a deterministic dependency closure", () => {

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -116,6 +116,10 @@ test("merge:main is a fail-closed GitHub mutation authority", () => {
   assert.match(script, /checkGlobalLease/);
   assert.match(script, /global-merge-authority/);
   assert.match(script, /setMergeAuthorityStatus/);
+  assert.match(script, /loadMergeCandidate/);
+  assert.match(read("scripts/codex-github-integration-candidate.mjs"), /changedPaths/);
+  assert.match(read("scripts/codex-global-integration-gate.mjs"), /skincos-integration-gate/);
+  assert.match(read(".github/workflows/skincos-integration-gate.yml"), /pull_request_target/);
   assert.match(script, /\/pulls\/\$\{pullNumber\}\/merge/);
   assert.match(workflow, /pull_request_target/);
   assert.match(workflow, /state=failure/);
@@ -127,6 +131,8 @@ test("merge:main is a fail-closed GitHub mutation authority", () => {
   assert.match(scheduler, /uses: \.\/\.github\/actions\/global-coordination-release/);
   assert.match(scheduler, /resource: merge:main/);
   assert.deepEqual(policy.releaseClosures.merge.patterns, ["**"]);
+  assert.match(policy.resourceClasses.mutate, /^\^mutate:/);
+  assert.equal(policy.admission.coordinationPlane, "global");
 });
 
 test("native mini-PC mutations use the common coordinator and detached closure proof", () => {

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -119,7 +119,10 @@ test("merge:main is a fail-closed GitHub mutation authority", () => {
   assert.match(script, /loadMergeCandidate/);
   assert.match(read("scripts/codex-github-integration-candidate.mjs"), /changedPaths/);
   assert.match(read("scripts/codex-global-integration-gate.mjs"), /skincos-integration-gate/);
-  assert.match(read(".github/workflows/skincos-integration-gate.yml"), /pull_request_target/);
+  const integrationGate = read(".github/workflows/skincos-integration-gate.yml");
+  assert.match(integrationGate, /pull_request_target/);
+  assert.match(integrationGate, /ref: main/);
+  assert.doesNotMatch(integrationGate, /ref: \$\{\{ github\.event\.pull_request\./);
   assert.match(script, /\/pulls\/\$\{pullNumber\}\/merge/);
   assert.match(workflow, /pull_request_target/);
   assert.match(workflow, /state=failure/);

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -128,11 +128,13 @@ test("merge:main is a fail-closed GitHub mutation authority", () => {
   const integrationGate = read(".github/workflows/skincos-integration-gate.yml");
   assert.match(integrationGate, /pull_request_target/);
   assert.match(integrationGate, /ref: main/);
+  assert.match(integrationGate, /Fetch the exact PR base tree used for closure admission/);
   assert.doesNotMatch(integrationGate, /ref: \$\{\{ github\.event\.pull_request\./);
   const integrationRecheck = read(".github/workflows/skincos-integration-gate-recheck.yml");
   assert.match(integrationRecheck, /schedule:/);
   assert.match(integrationRecheck, /--max-wait-ms 15000/);
   assert.match(integrationRecheck, /gh api --paginate/);
+  assert.match(integrationRecheck, /gate_state/);
   assert.match(read("ops/cloudflare/global-coordinator/index.js"), /buildLegacyIntentV1/);
   assert.match(read("scripts/codex-global-coordination-workflow.mjs"), /admission paths are not bound/);
   assert.match(script, /\/pulls\/\$\{pullNumber\}\/merge/);
@@ -152,6 +154,7 @@ test("merge:main is a fail-closed GitHub mutation authority", () => {
   const ruleset = JSON.parse(read(".github/governance/rulesets/main-enterprise-baseline.json"));
   const requiredContexts = ruleset.rules.find((rule) => rule.type === "required_status_checks").parameters.required_status_checks.map((entry) => entry.context);
   assert.deepEqual(requiredContexts, ["codex-autonomy-gate", "global-merge-authority", "skincos-integration-gate"]);
+  assert.ok(ruleset.rules.find((rule) => rule.type === "required_status_checks").parameters.required_status_checks.every((entry) => entry.integration_id === 15368));
 });
 
 test("native mini-PC mutations use the common coordinator and detached closure proof", () => {

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -114,6 +114,9 @@ test("merge:main is a fail-closed GitHub mutation authority", () => {
   assert.match(script, /const resource = "merge:main"/);
   assert.match(script, /expectedHeadSha/);
   assert.match(script, /checkGlobalLease/);
+  assert.match(script, /acquireMergeLease/);
+  assert.match(script, /incompatible-release-lease/);
+  assert.match(script, /merge:main lease remained unavailable/);
   assert.match(script, /global-merge-authority/);
   assert.match(script, /setMergeAuthorityStatus/);
   assert.match(script, /loadMergeCandidate/);

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -123,6 +123,8 @@ test("merge:main is a fail-closed GitHub mutation authority", () => {
   assert.match(read("scripts/codex-github-integration-candidate.mjs"), /changedPaths/);
   assert.match(read("scripts/codex-github-integration-candidate.mjs"), /previous_filename/);
   assert.match(read("scripts/codex-global-integration-gate.mjs"), /skincos-integration-gate/);
+  assert.match(read("scripts/codex-global-integration-gate.mjs"), /loadMergeCandidateIdentity/);
+  assert.match(read("scripts/codex-global-integration-gate.mjs"), /pathToFileURL/);
   const integrationGate = read(".github/workflows/skincos-integration-gate.yml");
   assert.match(integrationGate, /pull_request_target/);
   assert.match(integrationGate, /ref: main/);
@@ -130,6 +132,9 @@ test("merge:main is a fail-closed GitHub mutation authority", () => {
   const integrationRecheck = read(".github/workflows/skincos-integration-gate-recheck.yml");
   assert.match(integrationRecheck, /schedule:/);
   assert.match(integrationRecheck, /--max-wait-ms 15000/);
+  assert.match(integrationRecheck, /gh api --paginate/);
+  assert.match(read("ops/cloudflare/global-coordinator/index.js"), /buildLegacyIntentV1/);
+  assert.match(read("scripts/codex-global-coordination-workflow.mjs"), /admission paths are not bound/);
   assert.match(script, /\/pulls\/\$\{pullNumber\}\/merge/);
   assert.match(workflow, /pull_request_target/);
   assert.match(workflow, /state=failure/);

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -127,10 +127,14 @@ test("merge:main is a fail-closed GitHub mutation authority", () => {
   assert.match(integrationGate, /pull_request_target/);
   assert.match(integrationGate, /ref: main/);
   assert.doesNotMatch(integrationGate, /ref: \$\{\{ github\.event\.pull_request\./);
+  const integrationRecheck = read(".github/workflows/skincos-integration-gate-recheck.yml");
+  assert.match(integrationRecheck, /schedule:/);
+  assert.match(integrationRecheck, /--max-wait-ms 15000/);
   assert.match(script, /\/pulls\/\$\{pullNumber\}\/merge/);
   assert.match(workflow, /pull_request_target/);
   assert.match(workflow, /state=failure/);
   assert.match(workflow, /run-name: Merge PR #\$\{\{ inputs\.pull_number \}\} through merge:main/);
+  assert.match(workflow, /GH_TOKEN: \$\{\{ secrets\.GH_TOKEN \}\}/);
   assert.doesNotMatch(scheduler, /enablePullRequestAutoMerge/);
   assert.match(scheduler, /disablePullRequestAutoMerge/);
   assert.match(scheduler, /uses: \.\/\.github\/actions\/global-coordination-acquire/);

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -118,6 +118,7 @@ test("merge:main is a fail-closed GitHub mutation authority", () => {
   assert.match(script, /setMergeAuthorityStatus/);
   assert.match(script, /loadMergeCandidate/);
   assert.match(read("scripts/codex-github-integration-candidate.mjs"), /changedPaths/);
+  assert.match(read("scripts/codex-github-integration-candidate.mjs"), /previous_filename/);
   assert.match(read("scripts/codex-global-integration-gate.mjs"), /skincos-integration-gate/);
   const integrationGate = read(".github/workflows/skincos-integration-gate.yml");
   assert.match(integrationGate, /pull_request_target/);
@@ -136,6 +137,9 @@ test("merge:main is a fail-closed GitHub mutation authority", () => {
   assert.deepEqual(policy.releaseClosures.merge.patterns, ["**"]);
   assert.match(policy.resourceClasses.mutate, /^\^mutate:/);
   assert.equal(policy.admission.coordinationPlane, "global");
+  const ruleset = JSON.parse(read(".github/governance/rulesets/main-enterprise-baseline.json"));
+  const requiredContexts = ruleset.rules.find((rule) => rule.type === "required_status_checks").parameters.required_status_checks.map((entry) => entry.context);
+  assert.deepEqual(requiredContexts, ["codex-autonomy-gate", "global-merge-authority", "skincos-integration-gate"]);
 });
 
 test("native mini-PC mutations use the common coordinator and detached closure proof", () => {


### PR DESCRIPTION
## O que mudou

- adiciona `mutate:<surface>:<environment>` e aliases de superfície no contrato canônico;
- transforma o Durable Object em uma coordination plane global, com admission cruzado entre `merge:main` e `release:<module>` por dependency closure;
- adiciona `holder/session`, `workflow`, heartbeat, TTL, updated-at, fencing e retries idempotentes;
- adiciona `skincos-integration-gate` em `pull_request_target` e reutiliza a mesma candidatura de PR na autoridade final de merge;
- permite merge disjunto durante release e bloqueia merge que intersecciona a closure, sempre fail-closed quando a prova é ambígua;
- atualiza o contrato de governança e a documentação do comportamento de main drift.

## Por que

A release deve ser protegida contra mudanças relevantes da sua dependency closure, sem transformar qualquer avanço independente de `main` em abort obrigatório. O merge continua sendo uma mutação única, revalidada e custodiada por `merge:main`.

## Validação

- `codex:global-coordination:test` via Ubuntu-24.04 WSL: 29/29 testes;
- `node --check` via wrapper WSL para os módulos alterados;
- `git diff --check`.

As fases de identidade de release/manifest, supervisor multi-thread, build-once/promotion e auditoria single-writer Cloudflare permanecem como PRs ordenadas posteriores.