### PR TITLE
fix(ci): checkout trusted pages coordination action

### DIFF
--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -179,6 +179,15 @@ jobs:
             "$ORCHESTRATOR_STAGE" \
             "$PONTO_RELEASE_SHA" \
             "$ORCHESTRATOR_RUN_ID"
+      - name: Checkout trusted general coordination actions
+        if: ${{ inputs.release_scope == 'general' && inputs.target != 'preview' }}
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        with:
+          # The local coordination action runs before the candidate checkout.
+          # Keep this gate on the immutable workflow dispatch revision so a
+          # candidate cannot replace the action that authorizes the mutation.
+          ref: ${{ github.sha }}
+          fetch-depth: 1
       - name: Authorize global CRM Pages surface mutation
         if: ${{ inputs.target != 'preview' }}
         uses: ./.github/actions/global-coordination-check

--- a/crm/api/localTeamIdentity.js
+++ b/crm/api/localTeamIdentity.js
@@ -1,0 +1,20 @@
+/**
+ * Keep the local preview aligned with the hosted identity invariant:
+ * a CRM account is linked only when the review is confirmed and an explicit
+ * CRM username is present. Legacy preview rows may contain only one side of
+ * that state; they must fail closed and remain repairable by an explicit link
+ * proposal.
+ */
+export function normalizeLocalCrmAccountLink(member = {}) {
+    const username = String(member.crmAccountUsername || '').trim() || null
+    const reviewStatus = String(
+        member.crmAccountReviewStatus || (member.crmAccountLinked === false ? '' : 'CONFIRMED'),
+    ).trim().toUpperCase() || null
+
+    return {
+        username,
+        reviewStatus,
+        linked: reviewStatus === 'CONFIRMED' && Boolean(username),
+        inconsistent: reviewStatus === 'CONFIRMED' && !username,
+    }
+}

--- a/crm/api/server.js
+++ b/crm/api/server.js
@@ -36,6 +36,7 @@ import { createCaixaRouter } from './server/caixa/routes.js'
 import { configuredCorsOrigins, isAllowedCrmCorsOrigin } from './server/corsPolicy.js'
 import { effectiveAllowedModules, normalizeCrmRole as normalizeRole } from './server/crmRolePolicy.js'
 import { resolveEvolutionMediaUrl } from './server/whatsappMediaUrl.js'
+import { normalizeLocalCrmAccountLink } from './localTeamIdentity.js'
 
 // Axios for facade requests to Unified System
 import axios from 'axios'
@@ -1310,6 +1311,7 @@ if (DEV_AUTH_ENABLED) {
         if (!member || typeof member !== 'object') return null
         const profile = String(member.profile || localProfileForTitle(member.jobTitle) || 'CONSULTOR').toUpperCase()
         const units = localNormalizeUnits(member.units)
+        const crmAccount = normalizeLocalCrmAccountLink(member)
         return {
             ...member,
             id: String(member.id || `local-team-${randomUUID()}`),
@@ -1324,9 +1326,9 @@ if (DEV_AUTH_ENABLED) {
             department: String(member.department || '').trim(),
             units,
             accountStatus: String(member.accountStatus || 'INVITED').trim().toUpperCase(),
-            crmAccountLinked: member.crmAccountLinked === undefined ? true : Boolean(member.crmAccountLinked),
-            crmAccountUsername: String(member.crmAccountUsername || '').trim() || null,
-            crmAccountReviewStatus: String(member.crmAccountReviewStatus || (member.crmAccountLinked === false ? '' : 'CONFIRMED')).trim().toUpperCase() || null,
+            crmAccountLinked: crmAccount.linked,
+            crmAccountUsername: crmAccount.username,
+            crmAccountReviewStatus: crmAccount.reviewStatus,
             crmAccountLinkId: String(member.crmAccountLinkId || '').trim() || null,
             inviteId: String(member.inviteId || '').trim() || null,
             provisioningState: String(member.provisioningState || 'COMPLETED').trim(),
@@ -2101,7 +2103,10 @@ if (DEV_AUTH_ENABLED) {
         const currentStatus = String(member.crmAccountReviewStatus || '').toUpperCase()
         if (currentStatus === 'CONFIRMED') {
             if (localNormalizeUsername(member.crmAccountUsername) === crmUsername) return res.status(200).json({ success: true, data: localPublicAccountLink(member), replayed: true })
-            return res.status(409).json({ success: false, error: 'O vínculo confirmado não pode ser substituído neste fluxo', code: 'CRM_ACCOUNT_LINK_CONFIRMED_IMMUTABLE' })
+            // A legacy preview row can retain CONFIRMED without the explicit
+            // username required by the invariant. Keep the state fail-closed,
+            // but allow a new exact proposal so an operator can repair it.
+            if (member.crmAccountUsername) return res.status(409).json({ success: false, error: 'O vínculo confirmado não pode ser substituído neste fluxo', code: 'CRM_ACCOUNT_LINK_CONFIRMED_IMMUTABLE' })
         }
         if (currentStatus === 'PENDING_REVIEW') {
             if (localNormalizeUsername(member.crmAccountUsername) === crmUsername) return res.status(200).json({ success: true, data: localPublicAccountLink(member), replayed: true })

--- a/crm/api/server/__tests__/localTeamIdentity.test.js
+++ b/crm/api/server/__tests__/localTeamIdentity.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { normalizeLocalCrmAccountLink } from '../../localTeamIdentity.js'
+
+test('requires confirmed status and explicit username before exposing a CRM link', () => {
+    assert.deepEqual(normalizeLocalCrmAccountLink({ crmAccountLinked: true }), {
+        username: null,
+        reviewStatus: 'CONFIRMED',
+        linked: false,
+        inconsistent: true,
+    })
+    assert.deepEqual(normalizeLocalCrmAccountLink({ crmAccountUsername: 'ana', crmAccountReviewStatus: 'CONFIRMED' }), {
+        username: 'ana',
+        reviewStatus: 'CONFIRMED',
+        linked: true,
+        inconsistent: false,
+    })
+})
+
+test('keeps pending and rejected proposals explicit without granting access', () => {
+    assert.equal(normalizeLocalCrmAccountLink({ crmAccountUsername: 'legacy', crmAccountReviewStatus: 'PENDING_REVIEW' }).linked, false)
+    assert.equal(normalizeLocalCrmAccountLink({ crmAccountUsername: 'legacy', crmAccountReviewStatus: 'REJECTED' }).linked, false)
+})

--- a/crm/console/App.tsx
+++ b/crm/console/App.tsx
@@ -1534,7 +1534,10 @@ export default function AppFunctionalNeatlab() {
 					                                                    value={selectedUnit}
 			                                                    onValueChange={(v) => setSelectedUnit(v)}
 			                                                >
-                                                    <SelectTrigger className="h-8 w-44 bg-white/[0.06] border-white/20 text-white">
+                                                    <SelectTrigger
+                                                        className="h-8 w-44 bg-white/[0.06] border-white/20 text-white"
+                                                        aria-label="Unidade do módulo Insumos"
+                                                    >
 				                                                        <SelectValue placeholder="Unidade" />
 				                                                    </SelectTrigger>
 				                                                    <SelectContent>
@@ -2421,7 +2424,10 @@ export default function AppFunctionalNeatlab() {
 		                                    <div className="flex items-center gap-2">
 		                                        <div className="flex-1">
 		                                            <Select value={selectedUnit} onValueChange={(v) => setSelectedUnit(v)}>
-		                                                <SelectTrigger className="h-10 w-full bg-white/[0.06] border-white/20 text-white">
+                                                    <SelectTrigger
+                                                        className="h-10 w-full bg-white/[0.06] border-white/20 text-white"
+                                                        aria-label="Unidade do módulo Insumos"
+                                                    >
 		                                                    <SelectValue placeholder="Selecione a unidade" />
 		                                                </SelectTrigger>
 		                                                <SelectContent>

--- a/crm/console/UsersModule.tsx
+++ b/crm/console/UsersModule.tsx
@@ -65,6 +65,28 @@ function requestErrorMessage(error: any, fallback: string) {
   return message || fallback
 }
 
+const readinessLabels: Record<string, string> = {
+  UNIFIED_TEAM_ENABLED: 'liberação da centralização',
+  TEAM_SCHEMA: 'estrutura do cadastro unificado',
+  ONBOARDING_USERNAME: 'coluna de usuário do onboarding',
+  ONBOARDING_REQUEST_FINGERPRINT: 'fingerprint de idempotência',
+  INVITE_USERNAME: 'usuário do convite',
+  INVITE_CORPORATE_EMAIL: 'identidade corporativa do convite',
+  ONBOARDING_SAGA: 'estado transacional do onboarding',
+  TEAM_LINK_LEDGER: 'ledger de vínculos da equipe',
+  WORKFORCE_BINDING: 'vínculo com Workforce',
+  IDENTITY_PII_KEY: 'chave privada de identidade',
+  INVITE_MAILER: 'mailer de convites',
+}
+
+function readinessMessage(readiness?: UnifiedTeamConfig['readiness']) {
+  if (!readiness || readiness.ready) return ''
+  const missing = (readiness.missing || []).map((item) => readinessLabels[item] || item).join(', ')
+  if (readiness.state === 'MIGRATION_REQUIRED') return `A centralização está bloqueada até concluir ${missing || 'as migrações do cadastro unificado'}.`
+  if (readiness.state === 'DEPENDENCY_DEGRADED') return `A centralização está em modo protegido porque falta configurar ${missing || 'uma dependência operacional'}.`
+  return 'A centralização da equipe está desligada neste ambiente.'
+}
+
 const unitLabels: Record<string, string> = { 'novo-hamburgo': 'Novo Hamburgo', 'barra-shopping-sul': 'Barra Shopping Sul' }
 const titleOptions = ['Gestor', 'Gerente', 'Coordenador', 'Responsável Técnico', 'Injetor', 'Consultor']
 const creatableTitlesByRole: Record<string, string[]> = {
@@ -760,6 +782,11 @@ export function UsersModule() {
               <CircleAlert className="mt-0.5 size-4 shrink-0 text-rose-200" aria-hidden="true" />
               <div className="min-w-0 flex-1"><p>{loadError}</p><p className="mt-1 text-xs text-rose-100/65">Os dados exibidos podem estar desatualizados.</p></div>
               <TooltipButton label="Tentar carregar novamente"><Button type="button" size="icon" variant="ghost" className="h-8 w-8 shrink-0 rounded-full text-rose-100 hover:bg-rose-200/10" aria-label="Tentar carregar novamente" onClick={() => void load()}><RefreshCw className={`size-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" /></Button></TooltipButton>
+            </div>}
+            {teamConfig.enabled && teamConfig.readiness && !teamConfig.readiness.ready && <div className="mb-4 flex items-start gap-3 rounded-2xl border border-amber-200/20 bg-amber-300/[0.06] px-3 py-3 text-sm text-amber-50" role="status">
+              <CircleAlert className="mt-0.5 size-4 shrink-0 text-amber-200" aria-hidden="true" />
+              <div className="min-w-0 flex-1"><p>{readinessMessage(teamConfig.readiness)}</p><p className="mt-1 text-xs text-amber-100/60">As ações de escrita continuam protegidas até o ambiente ficar pronto.</p></div>
+              <TooltipButton label="Atualizar prontidão"><Button type="button" size="icon" variant="ghost" className="h-8 w-8 shrink-0 rounded-full text-amber-100 hover:bg-amber-200/10" aria-label="Atualizar prontidão" onClick={() => void load()}><RefreshCw className={`size-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" /></Button></TooltipButton>
             </div>}
             {canRead && (
               <div className="mb-4 space-y-3">

--- a/crm/console/UsersModule.tsx
+++ b/crm/console/UsersModule.tsx
@@ -136,6 +136,20 @@ function statusLabel(status: string) {
   return ({ INVITED: 'Convite enviado', ACTIVE: 'Ativo', SUSPENDED: 'Suspenso', TERMINATED: 'Desativado', PENDING_ACCESS: 'Aguardando acesso' } as Record<string, string>)[status] || status
 }
 
+function crmAccountLabel(row: Pick<UnifiedTeamMember, 'crmAccountLinked' | 'crmAccountUsername' | 'crmAccountReviewStatus'>) {
+  if (row.crmAccountLinked) return 'CRM vinculado'
+  if (row.crmAccountReviewStatus === 'CONFIRMED' && !row.crmAccountUsername) return 'CRM inconsistente'
+  if (row.crmAccountReviewStatus === 'REJECTED') return 'CRM rejeitado'
+  return 'CRM pendente'
+}
+
+function crmAccountBadgeVariant(row: Pick<UnifiedTeamMember, 'crmAccountLinked' | 'crmAccountUsername' | 'crmAccountReviewStatus'>): BadgeVariant {
+  if (row.crmAccountLinked) return 'success'
+  if (row.crmAccountReviewStatus === 'CONFIRMED' && !row.crmAccountUsername) return 'destructive'
+  if (row.crmAccountReviewStatus === 'REJECTED') return 'destructive'
+  return 'warning'
+}
+
 type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline' | 'success' | 'warning' | 'premium'
 
 function statusBadgeVariant(status: string): BadgeVariant {
@@ -864,7 +878,7 @@ export function UsersModule() {
                           )) : <Badge variant="outline" className="px-2 py-1 text-[11px]">Sem unidade</Badge>}
                         </div>
                       </td>
-                      <td className="p-3 align-middle"><div className="flex flex-wrap gap-1"><Badge variant={statusBadgeVariant(row.accountStatus)} className="px-2 py-1 text-[11px]">{statusLabel(row.accountStatus)}</Badge><Badge variant={row.crmAccountLinked ? 'success' : row.crmAccountReviewStatus === 'REJECTED' ? 'destructive' : 'warning'} className="px-2 py-1 text-[11px]" title={row.crmAccountUsername ? `Conta ${row.crmAccountUsername}` : 'Conta ainda sem vínculo explícito'}>{row.crmAccountLinked ? 'CRM vinculado' : row.crmAccountReviewStatus === 'REJECTED' ? 'CRM rejeitado' : 'CRM pendente'}</Badge></div></td>
+                      <td className="p-3 align-middle"><div className="flex flex-wrap gap-1"><Badge variant={statusBadgeVariant(row.accountStatus)} className="px-2 py-1 text-[11px]">{statusLabel(row.accountStatus)}</Badge><Badge variant={crmAccountBadgeVariant(row)} className="px-2 py-1 text-[11px]" title={row.crmAccountUsername ? `Conta ${row.crmAccountUsername}` : 'Conta ainda sem vínculo explícito'}>{crmAccountLabel(row)}</Badge></div></td>
                       <td className="p-3 align-middle"><Badge variant={scheduleSyncBadgeVariant(row.scheduleSync?.state)} className="px-2 py-1 text-[11px]">{scheduleSyncLabel(row.scheduleSync?.state)}</Badge></td>
                       <td className="p-3 text-right align-middle">
                         <TooltipButton label={`Editar ${row.fullName}`}>
@@ -904,7 +918,7 @@ export function UsersModule() {
                     <div><p className="mb-1 text-[10px] uppercase tracking-[0.12em] text-blue-100/45">Cargo</p><Badge variant={titleBadgeVariant(row.jobTitle)} className="px-2 py-1 text-[11px]">{row.jobTitle}</Badge></div>
                     <div><p className="mb-1 text-[10px] uppercase tracking-[0.12em] text-blue-100/45">Departamento</p><p className="text-blue-100/80">{row.department || '—'}</p></div>
                     <div className="col-span-2"><p className="mb-1 text-[10px] uppercase tracking-[0.12em] text-blue-100/45">Unidades</p><div className="flex flex-wrap gap-1">{row.units.length ? row.units.map((unit) => <Badge key={unit} variant="outline" className="px-2 py-1 text-[11px]">{unitLabels[unit] || unit}</Badge>) : <Badge variant="outline" className="px-2 py-1 text-[11px]">Sem unidade</Badge>}</div></div>
-                    <div><p className="mb-1 text-[10px] uppercase tracking-[0.12em] text-blue-100/45">Conta</p><div className="flex flex-wrap gap-1"><Badge variant={statusBadgeVariant(row.accountStatus)} className="px-2 py-1 text-[11px]">{statusLabel(row.accountStatus)}</Badge><Badge variant={row.crmAccountLinked ? 'success' : row.crmAccountReviewStatus === 'REJECTED' ? 'destructive' : 'warning'} className="px-2 py-1 text-[11px]">{row.crmAccountLinked ? 'CRM vinculado' : row.crmAccountReviewStatus === 'REJECTED' ? 'CRM rejeitado' : 'CRM pendente'}</Badge></div></div>
+                    <div><p className="mb-1 text-[10px] uppercase tracking-[0.12em] text-blue-100/45">Conta</p><div className="flex flex-wrap gap-1"><Badge variant={statusBadgeVariant(row.accountStatus)} className="px-2 py-1 text-[11px]">{statusLabel(row.accountStatus)}</Badge><Badge variant={crmAccountBadgeVariant(row)} className="px-2 py-1 text-[11px]">{crmAccountLabel(row)}</Badge></div></div>
                     <div><p className="mb-1 text-[10px] uppercase tracking-[0.12em] text-blue-100/45">Escala</p><Badge variant={scheduleSyncBadgeVariant(row.scheduleSync?.state)} className="px-2 py-1 text-[11px]">{scheduleSyncLabel(row.scheduleSync?.state)}</Badge></div>
                   </div>
                 </article>
@@ -1001,11 +1015,12 @@ export function UsersModule() {
                       <div><h3 id="team-account-link-title" className="text-sm font-semibold text-white">Conta CRM vinculada</h3><p className="mt-1 text-xs text-blue-100/55">O vínculo usa somente o nome de usuário exato; nunca é resolvido por nome, e-mail ou semelhança.</p></div>
                     </div>
                     {editingRow && <div className="flex flex-wrap items-center gap-2">
-                      <Badge variant={editingRow.crmAccountLinked ? 'success' : editingRow.crmAccountReviewStatus === 'REJECTED' ? 'destructive' : 'warning'} className="px-2 py-1 text-[10px]">{editingRow.crmAccountLinked ? 'Confirmada' : editingRow.crmAccountReviewStatus === 'REJECTED' ? 'Rejeitada' : editingRow.crmAccountReviewStatus === 'PENDING_REVIEW' ? 'Em revisão' : 'Sem vínculo'}</Badge>
+                      <Badge variant={crmAccountBadgeVariant(editingRow)} className="px-2 py-1 text-[10px]">{editingRow.crmAccountLinked ? 'Confirmada' : editingRow.crmAccountReviewStatus === 'CONFIRMED' && !editingRow.crmAccountUsername ? 'Inconsistente' : editingRow.crmAccountReviewStatus === 'REJECTED' ? 'Rejeitada' : editingRow.crmAccountReviewStatus === 'PENDING_REVIEW' ? 'Em revisão' : 'Sem vínculo'}</Badge>
                       {editingRow.crmAccountUsername && <span className="font-mono text-[11px] text-blue-100/65">{editingRow.crmAccountUsername}</span>}
                     </div>}
                   </div>
                   {editingRow?.crmAccountReviewStatus === 'PENDING_REVIEW' && canManage && <div className="mb-3 flex flex-wrap items-center justify-between gap-2 rounded-xl border border-amber-200/10 bg-amber-200/[0.04] px-3 py-2 text-xs text-amber-50/80"><span>Esta proposta aguarda confirmação humana antes de qualquer alteração de acesso.</span><div className="flex items-center gap-1"><TooltipButton label="Confirmar conta CRM"><Button type="button" size="icon" variant="ghost" className="h-7 w-7 rounded-full text-emerald-100 hover:bg-emerald-200/10" aria-label={`Confirmar conta CRM ${editingRow.crmAccountUsername || ''}`} disabled={crmLinkReviewing} onClick={() => void reviewCrmAccountLink('CONFIRMED')}><Check className="size-3.5" aria-hidden="true" /></Button></TooltipButton><TooltipButton label="Rejeitar conta CRM"><Button type="button" size="icon" variant="ghost" className="h-7 w-7 rounded-full text-rose-100 hover:bg-rose-200/10" aria-label={`Rejeitar conta CRM ${editingRow.crmAccountUsername || ''}`} disabled={crmLinkReviewing} onClick={() => void reviewCrmAccountLink('REJECTED')}><X className="size-3.5" aria-hidden="true" /></Button></TooltipButton></div></div>}
+                  {editingRow?.crmAccountReviewStatus === 'CONFIRMED' && !editingRow.crmAccountUsername && <div className="mb-3 rounded-xl border border-rose-200/15 bg-rose-300/[0.06] px-3 py-2 text-xs text-rose-50" role="alert">O vínculo CRM confirmado não possui um usuário explícito. O acesso permanece protegido; proponha novamente o nome exato da conta para corrigir este cadastro.</div>}
                   {canManage && editingId && !editingRow?.crmAccountLinked && <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end"><label className="space-y-1 text-xs text-blue-100/75">Nome de usuário da conta CRM<Input value={crmUsernameInput} onChange={(event) => setCrmUsernameInput(event.target.value)} placeholder="exato, por exemplo anareibeiro" autoComplete="off" /></label><Button type="button" disabled={crmLinkSaving || !crmUsernameInput.trim() || editingRow?.crmAccountReviewStatus === 'PENDING_REVIEW'} onClick={() => void proposeCrmAccountLink()}><Link2 className="mr-2 size-4" aria-hidden="true" />{crmLinkSaving ? 'Registrando…' : 'Propor vínculo'}</Button></div>}
                   {!editingRow?.crmAccountUsername && <p className="text-xs text-blue-100/55">Nenhuma conta foi associada a este cadastro. Resolva a pendência antes de reativar ou desligar uma conta já operacional.</p>}
                 </section>

--- a/crm/console/UsersModule.tsx
+++ b/crm/console/UsersModule.tsx
@@ -49,6 +49,22 @@ class RequestError extends Error {
   }
 }
 
+function requestErrorMessage(error: any, fallback: string) {
+  const code = String(error?.code || '').trim().toUpperCase()
+  const message = String(error?.message || '').trim()
+  const normalized = `${code} ${message.toUpperCase()}`
+  if (['DOMAIN_SERVICE_DEGRADED', 'SERVICE_DEGRADED', 'WORKFORCE_SERVICE_DEGRADED', 'MODULE_MAINTENANCE'].some((value) => normalized.includes(value))) {
+    return 'A integração operacional está temporariamente em manutenção. Nenhum acesso foi liberado; tente novamente após a normalização do serviço.'
+  }
+  if (['TEAM_LOCAL_PERSISTENCE_PENDING', 'LOCAL_TEAM_CREATE_PENDING'].some((value) => code === value || message.toUpperCase().includes(value))) {
+    return 'A identidade foi sincronizada, mas a projeção da equipe ficou pendente de compensação. Atualize a lista e tente novamente.'
+  }
+  if (['TEAM_MIGRATION_REQUIRED', 'ONBOARDING_MIGRATION_REQUIRED'].includes(code)) {
+    return 'A estrutura do cadastro unificado ainda não foi aplicada neste ambiente.'
+  }
+  return message || fallback
+}
+
 const unitLabels: Record<string, string> = { 'novo-hamburgo': 'Novo Hamburgo', 'barra-shopping-sul': 'Barra Shopping Sul' }
 const titleOptions = ['Gestor', 'Gerente', 'Coordenador', 'Responsável Técnico', 'Injetor', 'Consultor']
 const creatableTitlesByRole: Record<string, string[]> = {
@@ -385,7 +401,7 @@ export function UsersModule() {
       })
       return true
     } catch (error: any) {
-      toast.warning(`Cadastro salvo, mas o vínculo com a Escala ficou pendente: ${error?.message || 'tente novamente'}.`)
+      toast.warning(`Cadastro salvo, mas o vínculo com a Escala ficou pendente: ${requestErrorMessage(error, 'tente novamente')}.`)
       return false
     }
   }
@@ -401,7 +417,7 @@ export function UsersModule() {
       })
       return true
     } catch (error: any) {
-      toast.warning(`A Escala foi processada, mas o estado não pôde ser registrado: ${error?.message || 'tente atualizar a lista'}.`)
+      toast.warning(`A Escala foi processada, mas o estado não pôde ser registrado: ${requestErrorMessage(error, 'tente atualizar a lista')}.`)
       return false
     }
   }
@@ -425,7 +441,7 @@ export function UsersModule() {
       toast.success('Vínculo registrado para revisão.')
       await load()
     } catch (error: any) {
-      toast.error(error?.message || 'Não foi possível registrar o vínculo.')
+      toast.error(requestErrorMessage(error, 'Não foi possível registrar o vínculo.'))
     } finally {
       setLinkSaving(false)
     }
@@ -451,7 +467,7 @@ export function UsersModule() {
       toast.success(reviewStatus === 'CONFIRMED' ? 'Vínculo confirmado.' : 'Vínculo rejeitado.')
       await load()
     } catch (error: any) {
-      toast.error(error?.message || 'Não foi possível atualizar a revisão do vínculo.')
+      toast.error(requestErrorMessage(error, 'Não foi possível atualizar a revisão do vínculo.'))
     } finally {
       setLinkReviewingId(null)
     }
@@ -470,7 +486,7 @@ export function UsersModule() {
       toast.success('Conta CRM registrada para revisão explícita.')
       await load()
     } catch (error: any) {
-      toast.error(error?.message || 'Não foi possível registrar o vínculo da conta CRM.')
+      toast.error(requestErrorMessage(error, 'Não foi possível registrar o vínculo da conta CRM.'))
     } finally {
       setCrmLinkSaving(false)
     }
@@ -496,7 +512,7 @@ export function UsersModule() {
       toast.success(reviewStatus === 'CONFIRMED' ? 'Conta CRM confirmada.' : 'Vínculo da conta CRM rejeitado.')
       await load()
     } catch (error: any) {
-      toast.error(error?.message || 'Não foi possível atualizar a revisão da conta CRM.')
+      toast.error(requestErrorMessage(error, 'Não foi possível atualizar a revisão da conta CRM.'))
     } finally {
       setCrmLinkReviewing(false)
     }
@@ -607,7 +623,7 @@ export function UsersModule() {
       } else if (error instanceof RequestError && error.code === 'USERNAME_TAKEN') {
         toast.error('Esse nome de usuário já está reservado. Escolha outro.')
       } else {
-        toast.error(error?.message || 'Não foi possível concluir o cadastro.')
+        toast.error(requestErrorMessage(error, 'Não foi possível concluir o cadastro.'))
       }
     } finally {
       setSaving(false)
@@ -632,7 +648,7 @@ export function UsersModule() {
       setEditingId(null)
       await load()
     } catch (error: any) {
-      toast.error(error?.message || `Não foi possível ${activating ? 'ativar' : 'desativar'} o membro.`)
+      toast.error(requestErrorMessage(error, `Não foi possível ${activating ? 'ativar' : 'desativar'} o membro.`))
     }
   }
 
@@ -647,7 +663,7 @@ export function UsersModule() {
       setEditingId(null)
       await load()
     } catch (error: any) {
-      toast.error(error?.message || `Não foi possível ${action === 'resend' ? 'reenviar' : 'revogar'} o convite.`)
+      toast.error(requestErrorMessage(error, `Não foi possível ${action === 'resend' ? 'reenviar' : 'revogar'} o convite.`))
     }
   }
 
@@ -660,7 +676,7 @@ export function UsersModule() {
       toast.success('Acesso ativado e Workforce reconciliado.')
       await load()
     } catch (error: any) {
-      toast.error(error?.code === 'INVITE_REGISTRATION_REQUIRED' ? 'O funcionário ainda não criou a senha pelo convite.' : error?.message || 'Não foi possível concluir a ativação.')
+      toast.error(error?.code === 'INVITE_REGISTRATION_REQUIRED' ? 'O funcionário ainda não criou a senha pelo convite.' : requestErrorMessage(error, 'Não foi possível concluir a ativação.'))
     } finally {
       setActivationRetryingId(null)
     }
@@ -688,7 +704,7 @@ export function UsersModule() {
       toast.success(`${ids.length} membro${ids.length === 1 ? '' : 's'} ${nextStatus === 'ACTIVE' ? 'ativado' : 'suspenso'}${ids.length === 1 ? '' : 's'}.`)
       await load()
     } catch (error: any) {
-      toast.error(error?.message || 'A ação em lote ficou pendente de sincronização.')
+      toast.error(requestErrorMessage(error, 'A ação em lote ficou pendente de sincronização.'))
       await load()
     } finally {
       setBulkSaving(false)

--- a/crm/console/teamApi.ts
+++ b/crm/console/teamApi.ts
@@ -1,6 +1,12 @@
 export type UnifiedTeamConfig = {
   enabled: boolean
   legacyEscalaEditor: boolean
+  readiness?: {
+    ready: boolean
+    state: 'DISABLED' | 'MIGRATION_REQUIRED' | 'DEPENDENCY_DEGRADED' | 'READY' | string
+    checks?: Record<string, boolean>
+    missing?: string[]
+  }
 }
 
 export type UnifiedTeamMember = {

--- a/docs/runbooks/unified-team-migration.md
+++ b/docs/runbooks/unified-team-migration.md
@@ -58,6 +58,16 @@ resolvem a identidade. Falhas são persistidas somente como códigos operacionai
 sem PII e podem ser repetidas pela rota autenticada
 `POST /admin/team/:id/schedule-sync`, sempre com `Idempotency-Key` único.
 
+### Prontidão do módulo
+
+Gestores autorizados podem consultar `GET /admin/team?mode=readiness`. A
+resposta é somente leitura e PII-free; ela informa `DISABLED`,
+`MIGRATION_REQUIRED`, `DEPENDENCY_DEGRADED` ou `READY`, além de códigos
+sanitizados para cada requisito ausente. O endpoint não testa por tentativa,
+não envia convite, não altera flag e não revela valores de segredos. O painel
+de Usuários usa o mesmo contrato para orientar a correção sem transformar uma
+falha de binding ou migração em uma tentativa de escrita.
+
 Vínculos novos entram como `PENDING_REVIEW` quando não vieram de uma resposta
 confirmada da origem. A decisão humana usa
 `POST /admin/team/:id/links/:linkId/review` com `CONFIRMED` ou `REJECTED`;

--- a/inventory/src/routes/admin.js
+++ b/inventory/src/routes/admin.js
@@ -37,7 +37,9 @@ function isOnboardingDependencyError(value) {
   const code = String(value || '').trim().toUpperCase();
   return code === 'IDENTITY_PII_KEY_NOT_CONFIGURED'
     || code === 'AUTH_EMAIL_NOT_CONFIGURED'
-    || /^(WORKFORCE_|IDENTITY_WORKFORCE_|SMTP_|EMAIL_|MODULE_|TIMEKEEPING_|RELEASE_AFFINITY_|RUNTIME_BINDINGS_|SERVICE_|DATABASE_UNAVAILABLE|ONBOARDING_MIGRATION_REQUIRED)/.test(code);
+    || /^(WORKFORCE_|IDENTITY_WORKFORCE_|SMTP_|EMAIL_|MODULE_|TIMEKEEPING_|RELEASE_AFFINITY_|RUNTIME_BINDINGS_|SERVICE_|DATABASE_UNAVAILABLE|ONBOARDING_MIGRATION_REQUIRED)/.test(code)
+    || code === 'DOMAIN_SERVICE_DEGRADED'
+    || code === 'SERVICE_DEGRADED';
 }
 
 function unifiedTeamEnabled(env) {
@@ -610,6 +612,10 @@ export async function handleAdminRoutes({
   // The client supplies employment facts only. Profile, scopes and invite state
   // are derived here so no browser can grant modules or a wider unit scope.
   if ((url.pathname === '/admin/onboarding' || url.pathname === '/admin/team') && request.method === 'POST') {
+    let onboardingId = '';
+    let requestId = '';
+    let workforceSynchronized = false;
+    let localPersistenceStage = 'PREPARATION';
     try {
       const body = await request.json().catch(() => ({}));
       const input = validateOnboardingInput(body, {
@@ -656,6 +662,7 @@ export async function handleAdminRoutes({
         if (existing?.provisioning_state === 'COMPLETED') return withCORS(JSON.stringify({ success: true, data: publicOnboarding(existing), replayed: true }), { status: 200 }, appOrigin);
       }
       const id = await sha256Hex(`employee-onboarding:v1:${input.corporateEmail}`);
+      onboardingId = id;
       const existingOnboarding = await env.DB.prepare('SELECT * FROM crm_employee_onboarding WHERE id=? OR LOWER(corporate_email)=LOWER(?) LIMIT 1').bind(id, input.corporateEmail).first();
       if (existingOnboarding && String(existingOnboarding.id || '').trim() !== id) {
         throw new Error('ONBOARDING_IDEMPOTENCY_CONFLICT');
@@ -696,7 +703,7 @@ export async function handleAdminRoutes({
         }
       }
       const at = new Date().toISOString();
-      const requestId = String(request.headers.get('x-request-id') || `identity-onboarding-${id}`).slice(0, 180);
+      requestId = String(request.headers.get('x-request-id') || `identity-onboarding-${id}`).slice(0, 180);
       let repairMissingTeam = false;
       if (existingOnboarding?.provisioning_state === 'COMPLETED') {
         if (url.pathname !== '/admin/team') {
@@ -748,8 +755,10 @@ export async function handleAdminRoutes({
 
       let current = await env.DB.prepare('SELECT * FROM crm_employee_onboarding WHERE id=?').bind(id).first();
       let workforce = current?.workforce_employee_id ? { employeeId: current.workforce_employee_id } : null;
+      workforceSynchronized = Boolean(workforce?.employeeId);
       if (!workforce) {
         try {
+          localPersistenceStage = 'WORKFORCE_SYNC';
           workforce = await syncIdentityWorkforceOnboarding(env, {
             onboardingId: id,
             fullName: input.fullName,
@@ -763,6 +772,8 @@ export async function handleAdminRoutes({
             createdBy: String(auth?.user?.username || ''),
           }, requestId);
           await env.DB.prepare('UPDATE crm_employee_onboarding SET workforce_employee_id=?, provisioning_state=?, updated_at=?, last_error_code=NULL WHERE id=?').bind(workforce?.employeeId || null, 'WORKFORCE_SYNCED', new Date().toISOString(), id).run();
+          workforceSynchronized = Boolean(workforce?.employeeId);
+          localPersistenceStage = 'WORKFORCE_SYNCED';
         } catch (error) {
           await env.DB.prepare('UPDATE crm_employee_onboarding SET provisioning_state=?, last_error_code=?, updated_at=? WHERE id=?').bind('FAILED', String(error?.message || 'WORKFORCE_SYNC_FAILED').slice(0, 120), new Date().toISOString(), id).run().catch(() => {});
           await Promise.resolve(appendAuditLog?.({ env, actor: auth.user.username, role: auth.user.role, ip, userAgent, idempotencyKey: idempotency, action: 'EMPLOYEE_ONBOARDING_FAILED', entity: 'EMPLOYEE_ONBOARDING', entityId: id, unidade: input.units.join(','), after: { stage: 'WORKFORCE_SYNC', compensated: false, requestId } })).catch(() => {});
@@ -773,6 +784,7 @@ export async function handleAdminRoutes({
       let inviteId = current?.invite_id || null;
       let token = '';
       let expiresAt = '';
+      localPersistenceStage = 'INVITE_PROVISIONING';
       if (shouldIssueInvite(input.accountStatus)) {
         if (inviteId) {
           const invite = await env.DB.prepare(`SELECT id, expires_at, revoked FROM ${invitesTable} WHERE id=? LIMIT 1`).bind(inviteId).first();
@@ -807,6 +819,7 @@ export async function handleAdminRoutes({
         const reuseExistingInvite = repairMissingTeam && existingOnboarding?.invite_id && inviteId === existingOnboarding.invite_id;
         if (!reuseExistingInvite) {
           try {
+            localPersistenceStage = 'INVITE_DELIVERY';
             await sendAccountInviteEmail({ env, to: input.personalEmail, token, expiresAt, appUrl: String(env?.AUTH_INVITE_APP_URL || appOrigin) });
           } catch (error) {
             await env.DB.prepare(`UPDATE ${invitesTable} SET revoked=1 WHERE id=?`).bind(inviteId).run().catch(() => {});
@@ -817,9 +830,11 @@ export async function handleAdminRoutes({
           }
         }
       }
+      localPersistenceStage = 'ONBOARDING_COMPLETE';
       await env.DB.prepare('UPDATE crm_employee_onboarding SET invite_id=?, workforce_employee_id=?, provisioning_state=?, updated_at=?, last_error_code=NULL WHERE id=?').bind(inviteId, workforce?.employeeId || null, 'COMPLETED', new Date().toISOString(), id).run();
       let scheduleSync = null;
       if (url.pathname === '/admin/team') {
+        localPersistenceStage = 'TEAM_CREATE';
         const workforceEmployeeId = String(workforce?.employeeId || '').trim();
         if (!workforceEmployeeId) throw new Error('WORKFORCE_EMPLOYEE_ID_REQUIRED');
         const teamAt = new Date().toISOString();
@@ -854,6 +869,28 @@ export async function handleAdminRoutes({
       return withCORS(JSON.stringify({ success: true, data: publicOnboarding(created), team: url.pathname === '/admin/team' ? { ...normalizeTeamData(teamData, input.units), scheduleSync: publicScheduleSync(scheduleSync?.scheduleSync || { state: hasScheduleIntent(teamData) ? 'PENDING' : 'NOT_CONFIGURED' }, '') } : undefined }), { status: existingOnboarding ? 200 : 201 }, appOrigin);
     } catch (error) {
       const message = String(error?.message || 'ONBOARDING_FAILED');
+      if (url.pathname === '/admin/team' && workforceSynchronized && onboardingId && ['ONBOARDING_COMPLETE', 'TEAM_CREATE'].includes(localPersistenceStage)) {
+        const safeErrorCode = message.slice(0, 120);
+        await env.DB.prepare("UPDATE crm_employee_onboarding SET compensation_state='LOCAL_TEAM_CREATE_PENDING', last_error_code=?, updated_at=? WHERE id=?")
+          .bind(safeErrorCode, new Date().toISOString(), onboardingId)
+          .run()
+          .catch(() => {});
+        await Promise.resolve(appendAuditLog?.({
+          env,
+          actor: auth.user.username,
+          role: auth.user.role,
+          ip,
+          userAgent,
+          idempotencyKey: String(request.headers.get('idempotency-key') || '').trim().slice(0, 180),
+          action: 'EMPLOYEE_TEAM_COMPENSATION_PENDING',
+          entity: 'EMPLOYEE_ONBOARDING',
+          entityId: onboardingId,
+          unidade: '',
+          after: { stage: localPersistenceStage, workforceSynchronized: true, requestId, failClosed: true },
+        })).catch(() => {});
+        await recordTeamTelemetry({ env, eventName: 'EMPLOYEE_TEAM_CREATED', actorRole: auth.user.role, outcome: 'PENDING', itemCount: 1 });
+        return withCORS(JSON.stringify({ success: false, error: 'Projeção local da equipe pendente de compensação', code: 'TEAM_LOCAL_PERSISTENCE_PENDING' }), { status: 503 }, appOrigin);
+      }
       const status = ['ONBOARDING_IDEMPOTENCY_CONFLICT', 'ONBOARDING_IDEMPOTENCY_FINGERPRINT_REQUIRED'].includes(message)
         ? 409
         : isOnboardingDependencyError(message) ? 503 : 500;
@@ -1619,6 +1656,22 @@ export async function handleAdminRoutes({
       const nextPersonalEmailHash = nextPersonalEmail ? await sha256Hex(nextPersonalEmail) : '';
       const nextPhoneEncrypted = nextPhone ? await encryptOnboardingPii(env, nextPhone) : '';
       const nextPhoneHash = nextPhone ? await sha256Hex(nextPhone) : '';
+      const teamData = normalizeTeamData(body.team, nextUnits, {
+        professionalId: current.schedule_professional_id,
+        status: current.schedule_status,
+        role: current.schedule_role,
+        shift: current.schedule_shift,
+        nickname: current.schedule_nickname,
+        instagram: current.schedule_instagram,
+        color: current.schedule_color,
+        units: nextUnits,
+      });
+      if (body?.team?.units !== undefined && unknownUnitScopes(body.team.units).length) {
+        return withCORS(JSON.stringify({ success: false, error: 'Unidades operacionais inválidas', code: 'TEAM_UNITS_INVALID' }), { status: 400 }, appOrigin);
+      }
+      if (teamData.units.some((unit) => !nextUnits.includes(unit))) {
+        return withCORS(JSON.stringify({ success: false, error: 'As unidades operacionais devem estar dentro do escopo do cadastro', code: 'TEAM_UNITS_DENIED' }), { status: 403 }, appOrigin);
+      }
 
       const requestId = String(request.headers.get('x-request-id') || `identity-team-update-${onboardingId}`).slice(0, 180);
       await syncIdentityWorkforceOnboarding(env, {
@@ -1651,22 +1704,6 @@ export async function handleAdminRoutes({
       if (Number(onboardingUpdate?.meta?.changes ?? 0) !== 1) throw new Error('TEAM_ONBOARDING_LOCAL_UPDATE_NOT_APPLIED');
 
       localPersistenceStage = 'TEAM_UPDATE';
-      const teamData = normalizeTeamData(body.team, nextUnits, {
-        professionalId: current.schedule_professional_id,
-        status: current.schedule_status,
-        role: current.schedule_role,
-        shift: current.schedule_shift,
-        nickname: current.schedule_nickname,
-        instagram: current.schedule_instagram,
-        color: current.schedule_color,
-        units: nextUnits,
-      });
-      if (body?.team?.units !== undefined && unknownUnitScopes(body.team.units).length) {
-        return withCORS(JSON.stringify({ success: false, error: 'Unidades operacionais inválidas', code: 'TEAM_UNITS_INVALID' }), { status: 400 }, appOrigin);
-      }
-      if (teamData.units.some((unit) => !nextUnits.includes(unit))) {
-        return withCORS(JSON.stringify({ success: false, error: 'As unidades operacionais devem estar dentro do escopo do cadastro', code: 'TEAM_UNITS_DENIED' }), { status: 403 }, appOrigin);
-      }
       const nextScheduleProfessionalId = teamData.professionalId || current.schedule_professional_id || null;
       const teamUpdate = await env.DB.prepare(`UPDATE crm_employee_team SET schedule_professional_id=?, schedule_status=?, schedule_role=?, schedule_shift=?, schedule_nickname=?, schedule_instagram=?, schedule_color=?, units_json=?, updated_at=? WHERE onboarding_id=?`).bind(
         nextScheduleProfessionalId, teamData.status || null, teamData.role || null, teamData.shift || null,

--- a/inventory/src/routes/admin.js
+++ b/inventory/src/routes/admin.js
@@ -8,13 +8,14 @@ import {
 } from '../services/backup.js';
 import { isAuthorizedDevSeedRequest } from '../lib/devSeed.js';
 import { resolveCrmTables } from '../d1Store.js';
-import { sendAccountInviteEmail } from '../smtpMailer.js';
+import { hasAuthMailerConfig, sendAccountInviteEmail } from '../smtpMailer.js';
 import { normalizeInviteEmail, normalizeInviteScope, validateInviteDelegation } from '../invitePolicy.js';
 import { normalizeAllowedUnits as normalizeCanonicalAllowedUnits, unknownUnitScopes } from '../../../shared/identity-contract/index.js';
 import { buildEmployeeOnboardingFingerprintPayload, canCreateEmployee, displayJobTitle, publicOnboarding, resolveEmployeeProfile, suggestEmployeeUsername, validateOnboardingInput } from '../../../shared/identity-runtime/inventory-compat.js';
 import { syncIdentityWorkforceOnboarding, syncIdentityWorkforceStatus } from '../../../shared/identity-runtime/workforce-onboarding.js';
 import { isValidAccountTransition, normalizeAccountState, shouldIssueInvite } from '../../../shared/identity-runtime/onboarding-state.js';
 import { recordTeamTelemetry } from '../services/teamTelemetry.js';
+import { buildTeamReadiness } from '../services/teamReadiness.js';
 import {
   SCHEDULE_SYNC_STATES,
   buildScheduleSyncRecord,
@@ -581,14 +582,6 @@ export async function handleAdminRoutes({
     return withCORS(JSON.stringify({ success: false, error: 'DB_NOT_CONFIGURED' }), { status: 500 }, appOrigin);
   }
 
-  if (isTeamRoute && url.pathname === '/admin/team' && request.method === 'GET' && url.searchParams.get('mode') === 'config') {
-    return withCORS(JSON.stringify({ success: true, data: { enabled: unifiedTeamEnabled(env), legacyEscalaEditor: !unifiedTeamEnabled(env) } }), { status: 200 }, appOrigin);
-  }
-
-  if (isTeamRoute && !unifiedTeamEnabled(env)) {
-    return withCORS(JSON.stringify({ success: false, error: 'Gestão centralizada da equipe ainda não está liberada', code: 'TEAM_UNIFIED_DISABLED' }), { status: 404 }, appOrigin);
-  }
-
   const { usersTable, invitesTable } = await resolveCrmTables(env);
   const usersHasModules = await tableHasColumn(env, usersTable, 'allowed_modules_json');
   const invitesHasModules = await tableHasColumn(env, invitesTable, 'allowed_modules_json');
@@ -603,6 +596,42 @@ export async function handleAdminRoutes({
     && await tableExists(env, 'crm_employee_account_links')
     && await tableExists(env, 'crm_team_operations')
     && await tableExists(env, 'crm_team_telemetry');
+
+  const teamSchemaMissing = [
+    !onboardingHasUsername && 'ONBOARDING_USERNAME',
+    !onboardingHasRequestFingerprint && 'ONBOARDING_REQUEST_FINGERPRINT',
+    !invitesHasUsername && 'INVITE_USERNAME',
+    !invitesHasCorporateEmail && 'INVITE_CORPORATE_EMAIL',
+    !onboardingHasSaga && 'ONBOARDING_SAGA',
+    !teamTablesReady && 'TEAM_LINK_LEDGER',
+  ].filter(Boolean);
+  const teamReadiness = buildTeamReadiness({
+    enabled: unifiedTeamEnabled(env),
+    schemaReady: teamSchemaMissing.length === 0,
+    schemaMissing: teamSchemaMissing,
+    workforceBinding: Boolean(env?.WORKFORCE?.fetch),
+    piiKey: Boolean(String(env?.IDENTITY_PII_KEY || '').trim()),
+    inviteMailer: Boolean(hasAuthMailerConfig(env)),
+  });
+
+  if (isTeamRoute && url.pathname === '/admin/team' && request.method === 'GET' && ['config', 'readiness'].includes(url.searchParams.get('mode'))) {
+    const mode = url.searchParams.get('mode');
+    if (mode === 'readiness') {
+      return withCORS(JSON.stringify({ success: true, data: teamReadiness }), { status: 200 }, appOrigin);
+    }
+    return withCORS(JSON.stringify({
+      success: true,
+      data: {
+        enabled: unifiedTeamEnabled(env),
+        legacyEscalaEditor: !unifiedTeamEnabled(env),
+        readiness: teamReadiness,
+      },
+    }), { status: 200 }, appOrigin);
+  }
+
+  if (isTeamRoute && !unifiedTeamEnabled(env)) {
+    return withCORS(JSON.stringify({ success: false, error: 'Gestão centralizada da equipe ainda não está liberada', code: 'TEAM_UNIFIED_DISABLED' }), { status: 404 }, appOrigin);
+  }
 
   if (isTeamRoute && (!onboardingHasUsername || !onboardingHasRequestFingerprint || !invitesHasUsername || !invitesHasCorporateEmail || !onboardingHasSaga || !teamTablesReady)) {
     return withCORS(JSON.stringify({ success: false, error: 'Migração da equipe unificada pendente', code: 'TEAM_MIGRATION_REQUIRED' }), { status: 503 }, appOrigin);

--- a/inventory/src/services/teamReadiness.js
+++ b/inventory/src/services/teamReadiness.js
@@ -1,0 +1,65 @@
+const READINESS_STATES = Object.freeze([
+  'DISABLED',
+  'MIGRATION_REQUIRED',
+  'DEPENDENCY_DEGRADED',
+  'READY',
+]);
+
+const CHECK_LABELS = Object.freeze({
+  featureFlag: 'UNIFIED_TEAM_ENABLED',
+  schema: 'TEAM_SCHEMA',
+  workforceBinding: 'WORKFORCE_BINDING',
+  piiKey: 'IDENTITY_PII_KEY',
+  inviteMailer: 'INVITE_MAILER',
+});
+
+function bool(value) {
+  return value === true;
+}
+
+/**
+ * Build a PII-free readiness contract for the authenticated Users/Equipe
+ * surface. This reports configuration shape only; it never returns secret
+ * material and never probes or mutates an external service.
+ */
+export function buildTeamReadiness({
+  enabled = false,
+  schemaReady = false,
+  schemaMissing = [],
+  workforceBinding = false,
+  piiKey = false,
+  inviteMailer = false,
+} = {}) {
+  const checks = {
+    featureFlag: bool(enabled),
+    schema: bool(schemaReady),
+    workforceBinding: bool(workforceBinding),
+    piiKey: bool(piiKey),
+    inviteMailer: bool(inviteMailer),
+  };
+  const missing = [];
+  if (!checks.featureFlag) missing.push(CHECK_LABELS.featureFlag);
+  if (!checks.schema) {
+    const normalizedSchemaMissing = Array.from(new Set((Array.isArray(schemaMissing) ? schemaMissing : [])
+      .map((value) => String(value || '').trim().toUpperCase())
+      .filter(Boolean)));
+    missing.push(...(normalizedSchemaMissing.length ? normalizedSchemaMissing : [CHECK_LABELS.schema]));
+  }
+  if (!checks.workforceBinding) missing.push(CHECK_LABELS.workforceBinding);
+  if (!checks.piiKey) missing.push(CHECK_LABELS.piiKey);
+  if (!checks.inviteMailer) missing.push(CHECK_LABELS.inviteMailer);
+
+  let state = 'READY';
+  if (!checks.featureFlag) state = 'DISABLED';
+  else if (!checks.schema) state = 'MIGRATION_REQUIRED';
+  else if (missing.length) state = 'DEPENDENCY_DEGRADED';
+
+  return {
+    ready: state === 'READY',
+    state: READINESS_STATES.includes(state) ? state : 'DEPENDENCY_DEGRADED',
+    checks,
+    missing: Array.from(new Set(missing)),
+  };
+}
+
+export { READINESS_STATES };

--- a/inventory/tests/onboardingConsistency.test.mjs
+++ b/inventory/tests/onboardingConsistency.test.mjs
@@ -250,6 +250,17 @@ test('team telemetry accepts only aggregate fields and cannot persist identity P
   assert.doesNotMatch(implementation, /email|phone|fullName|entityId|memberId/i);
 });
 
+test('team readiness is authenticated, read-only and reports safe dependency codes', async () => {
+  const admin = await readFile(new URL('../src/routes/admin.js', import.meta.url), 'utf8');
+  const readiness = await readFile(new URL('../src/services/teamReadiness.js', import.meta.url), 'utf8');
+  assert.match(admin, /mode === 'readiness'/);
+  assert.match(admin, /buildTeamReadiness\(/);
+  assert.match(admin, /hasAuthMailerConfig\(env\)/);
+  assert.match(admin, /Boolean\(env\?\.WORKFORCE\?\.fetch\)/);
+  assert.match(readiness, /never returns secret/);
+  assert.doesNotMatch(readiness, /console\.log|process\.env|personalEmail|mobilePhone/i);
+});
+
 test('unified team rollout is explicit, staging-only and fail-closed by default', async () => {
   const workflow = await readFile(
     new URL('../../.github/workflows/deploy-core-workers.yml', import.meta.url),

--- a/inventory/tests/onboardingConsistency.test.mjs
+++ b/inventory/tests/onboardingConsistency.test.mjs
@@ -203,6 +203,9 @@ test('unified team management is explicit about RBAC, scope, idempotency and agg
 test('team edits expose a fail-closed local persistence compensation boundary', async () => {
   const admin = await readFile(new URL('../src/routes/admin.js', import.meta.url), 'utf8');
   const updateBlock = admin.slice(admin.indexOf('const teamMemberMatch'), admin.indexOf("if (url.pathname === '/admin/team' && request.method === 'GET')"));
+  const teamValidationIndex = updateBlock.indexOf('const teamData = normalizeTeamData');
+  const workforceSyncIndex = updateBlock.indexOf('await syncIdentityWorkforceOnboarding');
+  assert.ok(teamValidationIndex >= 0 && teamValidationIndex < workforceSyncIndex, 'team input must be validated before Workforce synchronization');
   assert.match(updateBlock, /let workforceSynchronized = false/);
   assert.match(updateBlock, /localPersistenceStage = 'ONBOARDING_UPDATE'/);
   assert.match(updateBlock, /localPersistenceStage = 'TEAM_UPDATE'/);
@@ -211,6 +214,8 @@ test('team edits expose a fail-closed local persistence compensation boundary', 
   assert.match(updateBlock, /TEAM_LOCAL_PERSISTENCE_PENDING/);
   assert.match(updateBlock, /failClosed: true/);
   assert.match(updateBlock, /outcome: 'PENDING'/);
+  assert.match(admin, /LOCAL_TEAM_CREATE_PENDING/);
+  assert.match(admin, /Projeção local da equipe pendente de compensação/);
 });
 
 test('team usernames remain reserved across lifecycle history', async () => {
@@ -272,6 +277,7 @@ test('unified team maps dependency outages to retryable 503 responses', async ()
   const admin = await readFile(new URL('../src/routes/admin.js', import.meta.url), 'utf8');
   assert.match(admin, /function isOnboardingDependencyError\(value\)/);
   assert.match(admin, /IDENTITY_WORKFORCE_\|SMTP_\|EMAIL_\|MODULE_\|TIMEKEEPING_\|RELEASE_AFFINITY_\|RUNTIME_BINDINGS_\|SERVICE_\|DATABASE_UNAVAILABLE/);
+  assert.match(admin, /DOMAIN_SERVICE_DEGRADED/);
   assert.match(admin, /isOnboardingDependencyError\(message\) \? 503 : 500/);
   assert.doesNotMatch(admin, /message === 'IDENTITY_PII_KEY_NOT_CONFIGURED'.*\^WORKFORCE_\|\^SMTP_\|\^EMAIL_/s);
 });

--- a/inventory/tests/teamReadiness.test.mjs
+++ b/inventory/tests/teamReadiness.test.mjs
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildTeamReadiness } from '../src/services/teamReadiness.js';
+
+test('team readiness is disabled by default and exposes only safe requirement codes', () => {
+  const result = buildTeamReadiness();
+
+  assert.deepEqual(result, {
+    ready: false,
+    state: 'DISABLED',
+    checks: {
+      featureFlag: false,
+      schema: false,
+      workforceBinding: false,
+      piiKey: false,
+      inviteMailer: false,
+    },
+    missing: [
+      'UNIFIED_TEAM_ENABLED',
+      'TEAM_SCHEMA',
+      'WORKFORCE_BINDING',
+      'IDENTITY_PII_KEY',
+      'INVITE_MAILER',
+    ],
+  });
+});
+
+test('schema failures take precedence over dependency failures', () => {
+  const result = buildTeamReadiness({
+    enabled: true,
+    schemaReady: false,
+    schemaMissing: ['ONBOARDING_USERNAME', 'ONBOARDING_USERNAME', 'TEAM_LINK_LEDGER'],
+    workforceBinding: true,
+    piiKey: true,
+    inviteMailer: true,
+  });
+
+  assert.equal(result.ready, false);
+  assert.equal(result.state, 'MIGRATION_REQUIRED');
+  assert.deepEqual(result.missing, ['ONBOARDING_USERNAME', 'TEAM_LINK_LEDGER']);
+});
+
+test('fully configured team readiness is ready without returning secret values', () => {
+  const result = buildTeamReadiness({
+    enabled: true,
+    schemaReady: true,
+    schemaMissing: [],
+    workforceBinding: true,
+    piiKey: true,
+    inviteMailer: true,
+  });
+
+  assert.deepEqual(result, {
+    ready: true,
+    state: 'READY',
+    checks: {
+      featureFlag: true,
+      schema: true,
+      workforceBinding: true,
+      piiKey: true,
+      inviteMailer: true,
+    },
+    missing: [],
+  });
+  assert.doesNotMatch(JSON.stringify(result), /secret|password|token|key_value/i);
+});

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -259,3 +259,14 @@ test("shared staging D1 custody serializes synthetic mutators before every write
   assert.match(timekeepingJourney, /id: check_staging_d1_teardown/);
   assert.match(timekeepingJourney, /steps\.check_staging_d1_teardown\.outcome == 'success'/);
 });
+
+test("general CRM Pages checks out trusted local coordination actions before using them", () => {
+  const workflow = read(".github/workflows/deploy-crm-pages.yml");
+  const checkout = workflow.indexOf("Checkout trusted general coordination actions");
+  const authorization = workflow.indexOf("uses: ./.github/actions/global-coordination-check", checkout);
+
+  assert.ok(checkout >= 0, "general Pages deploy must prepare the local coordination action");
+  assert.ok(authorization > checkout, "the coordination action must be available before authorization");
+  assert.match(workflow.slice(checkout, authorization), /ref: \$\{\{ github\.sha \}\}/);
+  assert.match(workflow.slice(checkout, authorization), /inputs\.release_scope == 'general'/);
+});


### PR DESCRIPTION
## Objetivo
Corrigir o caminho geral de CRM Pages em staging/produção: a action local de coordenação era chamada antes do checkout e o job falhava com `Can't find action.yml`.

## Mudança
- faz checkout do SHA de despacho antes da autorização de mutação, somente no escopo `general` e fora da prévia;
- mantém o checkout posterior do SHA promovido para build/deploy;
- adiciona teste estático que protege a ordem e a origem confiável da action.

## Validação
- `node --test scripts/tests/global-concurrency-governance-static.test.mjs`
- o primeiro deploy de CRM Pages staging reproduziu a falha; nenhum passo de mutação Cloudflare foi alcançado.

Rollback: reverter este commit; o fluxo volta a falhar fechado antes da mutação.