### PR TITLE
fix(ci): propagate global coordination outputs

### DIFF
--- a/.github/workflows/ponto-orchestrator-gate.yml
+++ b/.github/workflows/ponto-orchestrator-gate.yml
@@ -66,11 +66,11 @@ jobs:
   consume:
     runs-on: ubuntu-latest
     outputs:
-      global_lease_required: ${{ steps.global-enabled.outputs.required || steps.global-disabled.outputs.required }}
-      global_resource: ${{ steps.global-enabled.outputs.resource || steps.global-disabled.outputs.resource }}
-      global_proof_b64: ${{ steps.global-enabled.outputs.proof_b64 || steps.global-disabled.outputs.proof_b64 }}
-      global_intent_digest: ${{ steps.global-enabled.outputs.intent_digest || steps.global-disabled.outputs.intent_digest }}
-      global_coordinator_url: ${{ steps.global-enabled.outputs.url || steps.global-disabled.outputs.url }}
+      global_lease_required: ${{ steps.global_enabled.outputs.required || steps.global_disabled.outputs.required }}
+      global_resource: ${{ steps.global_enabled.outputs.resource || steps.global_disabled.outputs.resource }}
+      global_proof_b64: ${{ steps.global_enabled.outputs.proof_b64 || steps.global_disabled.outputs.proof_b64 }}
+      global_intent_digest: ${{ steps.global_enabled.outputs.intent_digest || steps.global_disabled.outputs.intent_digest }}
+      global_coordinator_url: ${{ steps.global_enabled.outputs.url || steps.global_disabled.outputs.url }}
     steps:
       - name: Refuse replayed governed invocation
         if: ${{ inputs.required }}
@@ -156,7 +156,7 @@ jobs:
             "$RELEASE_SHA" \
             "$ORCHESTRATOR_RUN_ID"
       - name: Acquire the canonical global mutation lease
-        id: global-enabled
+        id: global_enabled
         if: ${{ inputs.global_lease_required }}
         env:
           GLOBAL_REQUIRED: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
@@ -211,7 +211,7 @@ jobs:
           echo "intent_digest=$intent_digest" >> "$GITHUB_OUTPUT"
           echo "url=$GLOBAL_URL" >> "$GITHUB_OUTPUT"
       - name: Keep the preactivation path explicit
-        id: global-disabled
+        id: global_disabled
         if: ${{ !inputs.global_lease_required }}
         run: |
           echo 'required=false' >> "$GITHUB_OUTPUT"

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -270,3 +270,13 @@ test("general CRM Pages checks out trusted local coordination actions before usi
   assert.match(workflow.slice(checkout, authorization), /ref: \$\{\{ github\.sha \}\}/);
   assert.match(workflow.slice(checkout, authorization), /inputs\.release_scope == 'general'/);
 });
+
+test("the reusable orchestrator gate exposes global lease outputs to callers", () => {
+  const workflow = read(".github/workflows/ponto-orchestrator-gate.yml");
+
+  assert.match(workflow, /steps\.global_enabled\.outputs\.proof_b64/);
+  assert.match(workflow, /steps\.global_enabled\.outputs\.url/);
+  assert.match(workflow, /id: global_enabled/);
+  assert.match(workflow, /id: global_disabled/);
+  assert.doesNotMatch(workflow, /steps\.global-(?:enabled|disabled)\.outputs/);
+});


### PR DESCRIPTION
## Objetivo
Corrigir a propagação do lease global no workflow reutilizável `ponto-orchestrator-gate`.

## Evidência
O deploy CRM Pages staging `31347921274` adquiriu o lease e liberou-o corretamente, mas o job consumidor recebeu `global_coordinator_url` e `global_proof_b64` vazios e parou antes da mutação. A causa é a referência a step IDs com hífen (`global-enabled`/`global-disabled`) nos outputs do job.

## Mudança
- normaliza os IDs para `global_enabled`/`global_disabled`;
- atualiza todos os outputs expostos pelo workflow reutilizável;
- adiciona regressão estática para impedir a volta da referência inválida.

## Validação
- `node --test scripts/tests/global-concurrency-governance-static.test.mjs`
- rollback automático/lease release do run que falhou: concluído com sucesso.

A correção não altera flags, bancos ou superfícies produtivas.