### PR TITLE
fix(ci): expose coordination outputs to Pages deploy

### DIFF
--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -145,7 +145,10 @@ jobs:
           retention-days: 90
           if-no-files-found: error
   deploy:
-    needs: promotion
+    # The deploy job reads lease outputs from the reusable coordination job.
+    # `promotion` depends on it transitively, but GitHub only exposes `needs`
+    # outputs from direct dependencies.
+    needs: [coordination, promotion]
     if: ${{ inputs.target != 'preview' && (inputs.release_scope != 'ponto' || github.run_attempt == 1) && (inputs.release_scope != 'ponto' || inputs.target == 'staging') }}
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -280,3 +280,9 @@ test("the reusable orchestrator gate exposes global lease outputs to callers", (
   assert.match(workflow, /id: global_disabled/);
   assert.doesNotMatch(workflow, /steps\.global-(?:enabled|disabled)\.outputs/);
 });
+
+test("CRM Pages deploy declares coordination as a direct dependency for lease outputs", () => {
+  const workflow = read(".github/workflows/deploy-crm-pages.yml");
+
+  assert.match(workflow, /\n  deploy:\n    # The deploy job reads lease outputs from the reusable coordination job\.[\s\S]*?\n    needs: \[coordination, promotion\]/);
+});


### PR DESCRIPTION
## Summary
- make the CRM Pages deploy job depend directly on the reusable coordination job
- prevent empty needs.coordination.outputs.* in the surface authorization gate
- add a static regression test for the dependency contract

## Validation
- node --test scripts/tests/global-concurrency-governance-static.test.mjs via invoke-skincos-wsl.ps1

Observed in staging run 31348761158: coordination acquired the lease, but the deploy job received empty URL/proof because coordination was only a transitive dependency through promotion.