### PR TITLE
fix(governance): activate global staging coordinator plane

### DIFF
--- a/ops/cloudflare/global-coordinator/index.test.mjs
+++ b/ops/cloudflare/global-coordinator/index.test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 
 const source = fs.readFileSync(path.join(import.meta.dirname, "index.js"), "utf8");
 const config = fs.readFileSync(path.join(import.meta.dirname, "wrangler.toml"), "utf8");
+const stagingConfig = config.match(/\[env\.staging\.vars\][\s\S]*?(?=\n\[|$)/)?.[0] ?? "";
 
 test("Cloudflare adapter uses one globally serialized SQLite Durable Object coordination plane", () => {
   assert.match(source, /class GlobalCoordinator extends DurableObject/);
@@ -17,7 +18,7 @@ test("Cloudflare adapter uses one globally serialized SQLite Durable Object coor
   assert.match(source, /evaluateLeaseAdmission/);
   assert.match(config, /new_sqlite_classes = \["GlobalCoordinator"\]/);
   assert.match(config, /COORDINATION_PLANE_NAME = "global"/);
-  assert.match(config, /COORDINATION_PLANE_MODE = "global"/);
+  assert.match(stagingConfig, /COORDINATION_PLANE_MODE = "global"/);
 });
 
 test("remote custody is mandatory and the adapter has no local fallback", () => {

--- a/ops/cloudflare/global-coordinator/index.test.mjs
+++ b/ops/cloudflare/global-coordinator/index.test.mjs
@@ -17,7 +17,7 @@ test("Cloudflare adapter uses one globally serialized SQLite Durable Object coor
   assert.match(source, /evaluateLeaseAdmission/);
   assert.match(config, /new_sqlite_classes = \["GlobalCoordinator"\]/);
   assert.match(config, /COORDINATION_PLANE_NAME = "global"/);
-  assert.match(config, /COORDINATION_PLANE_MODE = "legacy-drain"/);
+  assert.match(config, /COORDINATION_PLANE_MODE = "global"/);
 });
 
 test("remote custody is mandatory and the adapter has no local fallback", () => {

--- a/ops/cloudflare/global-coordinator/wrangler.toml
+++ b/ops/cloudflare/global-coordinator/wrangler.toml
@@ -25,7 +25,7 @@ preview_urls = false
 [env.staging.vars]
 COORDINATION_CONTRACT_ID = "skincos/global-coordination/v1"
 COORDINATION_PLANE_NAME = "global"
-COORDINATION_PLANE_MODE = "legacy-drain"
+COORDINATION_PLANE_MODE = "global"
 
 [env.staging.durable_objects]
 bindings = [


### PR DESCRIPTION
## Summary\n- switch only the staging global coordinator plane from legacy-drain to global after the documented drain window\n- update the static contract test to prevent regression\n\n## Validation\n- git diff --check\n- node --test ops/cloudflare/global-coordinator/index.test.mjs scripts/tests/codex-global-coordination.test.mjs scripts/tests/codex-global-coordination-client.test.mjs scripts/tests/codex-global-coordination-workflow.test.mjs\n\nProduction configuration and routing are unchanged.