### PR TITLE
feat(governance): coordinate supervisor resources and branch maintenance

### DIFF
--- a/.codex/hooks/skincos-supervisor-gate.py
+++ b/.codex/hooks/skincos-supervisor-gate.py
@@ -67,6 +67,7 @@ SNAPSHOT_INPUT_FIELDS = {
     "blocker_fingerprint",
     "valid_evidence_refs",
     "resource_declaration",
+    "task_slug",
 }
 SNAPSHOT_TOP_LEVEL_FIELDS = SNAPSHOT_INPUT_FIELDS - {"schema_version"}
 SNAPSHOT_STRING_FIELDS = (
@@ -74,6 +75,7 @@ SNAPSHOT_STRING_FIELDS = (
     "checkpoint",
     "remote_fingerprint",
     "blocker_fingerprint",
+    "task_slug",
 )
 RESOURCE_DECLARATION_SCHEMA_VERSION = 1
 RESOURCE_DECLARATION_FIELDS = {
@@ -259,7 +261,10 @@ def validate_contract(contract: dict[str, Any], event_session: str) -> str | Non
     evidence = contract.get("evidence_refs")
     if not isinstance(evidence, list) or any(not isinstance(item, str) for item in evidence):
         return "supervisor state evidence_refs must be a list of strings"
-    _, declaration_error = normalize_resource_declaration(contract.get("resource_declaration"))
+    raw_declaration, extraction_error = contract_resource_declaration(contract)
+    if extraction_error:
+        return extraction_error
+    declaration, declaration_error = normalize_resource_declaration(raw_declaration)
     if declaration_error:
         return declaration_error
     next_item = contract.get("next_item")
@@ -277,8 +282,19 @@ def validate_contract(contract: dict[str, Any], event_session: str) -> str | Non
             return "continue cannot carry a human or credential blocker"
         if contract.get("production_authorization_required"):
             return "continue cannot require production authorization"
-        if next_item_is_global and contract.get("resource_declaration") is None:
+        if next_item_is_global and raw_declaration is None:
             return "global next_item requires reads/writes/requires/leases resource_declaration"
+        if next_item_is_global:
+            resource_value = next_item.get("resource")
+            if not isinstance(resource_value, str) or not resource_value.strip():
+                return "global next_item requires a concrete resource"
+            resource = resource_value.strip()
+            if is_global_resource_name(resource):
+                resource = resource.lower()
+            if resource not in declaration["writes"]:
+                return f"global next_item resource {resource} must be declared in resource_declaration.writes"
+            if resource not in declaration["leases"]:
+                return f"global next_item resource {resource} must be declared in resource_declaration.leases"
     elif status == "complete":
         if contract.get("objective_status") != "complete":
             return "complete requires objective_status=complete"
@@ -342,6 +358,8 @@ def normalize_resource_declaration(
                 return None, f"resource_declaration {field} contains an oversized item"
             if "\n" in candidate or "\r" in candidate:
                 return None, f"resource_declaration {field} cannot contain line breaks"
+            if field in ("writes", "leases") and is_global_resource_name(candidate):
+                candidate = candidate.lower()
             items.add(candidate)
         normalized[field] = sorted(items)
 
@@ -421,6 +439,24 @@ def extract_snapshot_declaration(contract: dict[str, Any]) -> tuple[dict[str, An
     return declared, None
 
 
+def contract_resource_declaration(contract: dict[str, Any]) -> tuple[Any, str | None]:
+    declared, error = extract_snapshot_declaration(contract)
+    if error or declared is None:
+        return None, error
+    return declared.get("resource_declaration"), None
+
+
+def derive_task_slug(branch_worktree: dict[str, str | None]) -> str | None:
+    for field in ("branch", "worktree"):
+        value = branch_worktree.get(field)
+        if not isinstance(value, str) or not value.strip():
+            continue
+        segments = [segment for segment in re.split(r"[\\/]+", value.strip()) if segment]
+        if segments:
+            return segments[-1]
+    return None
+
+
 def normalize_branch_worktree(
     declared: dict[str, Any],
     existing: dict[str, Any],
@@ -477,6 +513,7 @@ def build_session_snapshot(
         "authorization_source": None,
         "issue": None,
         "branch_worktree": {"branch": None, "worktree": None},
+        "task_slug": None,
         "checkpoint": None,
         "remote_fingerprint": None,
         "blocker_fingerprint": None,
@@ -488,15 +525,15 @@ def build_session_snapshot(
             "authorization_source",
             "issue",
             "branch_worktree",
+            "task_slug",
             "checkpoint",
             "remote_fingerprint",
             "blocker_fingerprint",
             "valid_evidence_refs",
-            "resource_declaration",
         ):
             context[field] = previous.get(field)
 
-    raw_declaration = contract.get("resource_declaration")
+    raw_declaration = declared.get("resource_declaration")
     if raw_declaration is not None:
         declaration, declaration_error = normalize_resource_declaration(raw_declaration)
         if declaration_error or declaration is None:
@@ -526,6 +563,9 @@ def build_session_snapshot(
         return None, field_error
     context["branch_worktree"] = branch_worktree
 
+    if context["task_slug"] is None:
+        context["task_slug"] = derive_task_slug(branch_worktree)
+
     if "valid_evidence_refs" in declared:
         references, field_error = normalize_snapshot_refs(declared["valid_evidence_refs"], "valid_evidence_refs")
         if field_error or references is None:
@@ -552,6 +592,7 @@ def build_session_snapshot(
         "checkpoint": context["checkpoint"],
         "remote_fingerprint": context["remote_fingerprint"],
         "valid_evidence_refs": context["valid_evidence_refs"],
+        "task_slug": context["task_slug"],
         "resource_declaration": context["resource_declaration"],
     }
     serialized, field_error = canonical_json(progress_material)
@@ -567,6 +608,7 @@ def build_session_snapshot(
         "authorization_source": context["authorization_source"],
         "issue": context["issue"],
         "branch_worktree": context["branch_worktree"],
+        "task_slug": context["task_slug"],
         "checkpoint": context["checkpoint"],
         "remote_fingerprint": context["remote_fingerprint"],
         "blocker_fingerprint": context["blocker_fingerprint"],
@@ -883,6 +925,7 @@ def continuation_prompt(
             "remote_fingerprint": snapshot["remote_fingerprint"],
             "blocker_fingerprint": snapshot["blocker_fingerprint"],
             "valid_evidence_refs": snapshot["valid_evidence_refs"],
+            "task_slug": snapshot["task_slug"],
             "resource_declaration": snapshot["resource_declaration"],
         },
     }
@@ -1100,6 +1143,7 @@ def process(
 
         mission["resource_declaration"] = snapshot["resource_declaration"]
         mission["branch_worktree"] = snapshot["branch_worktree"]
+        mission["task_slug"] = snapshot["task_slug"]
 
         status = str(contract["orchestration_status"])
         if status != "continue":

--- a/.codex/hooks/skincos-supervisor-gate.py
+++ b/.codex/hooks/skincos-supervisor-gate.py
@@ -66,6 +66,7 @@ SNAPSHOT_INPUT_FIELDS = {
     "remote_fingerprint",
     "blocker_fingerprint",
     "valid_evidence_refs",
+    "resource_declaration",
 }
 SNAPSHOT_TOP_LEVEL_FIELDS = SNAPSHOT_INPUT_FIELDS - {"schema_version"}
 SNAPSHOT_STRING_FIELDS = (
@@ -73,6 +74,26 @@ SNAPSHOT_STRING_FIELDS = (
     "checkpoint",
     "remote_fingerprint",
     "blocker_fingerprint",
+)
+RESOURCE_DECLARATION_SCHEMA_VERSION = 1
+RESOURCE_DECLARATION_FIELDS = {
+    "schema_version",
+    "reads",
+    "writes",
+    "requires",
+    "leases",
+}
+RESOURCE_DECLARATION_LIST_FIELDS = ("reads", "writes", "requires", "leases")
+MAX_RESOURCE_DECLARATION_ITEMS = 64
+MAX_RESOURCE_DECLARATION_ITEM_LENGTH = 256
+GLOBAL_RESOURCE_PREFIXES = (
+    "merge:",
+    "release:",
+    "deploy:",
+    "mutate:",
+    "cloudflare:",
+    "promotion:",
+    "global:",
 )
 MAX_SNAPSHOT_STRING_LENGTH = 512
 MAX_EVIDENCE_REFS = 32
@@ -238,6 +259,14 @@ def validate_contract(contract: dict[str, Any], event_session: str) -> str | Non
     evidence = contract.get("evidence_refs")
     if not isinstance(evidence, list) or any(not isinstance(item, str) for item in evidence):
         return "supervisor state evidence_refs must be a list of strings"
+    _, declaration_error = normalize_resource_declaration(contract.get("resource_declaration"))
+    if declaration_error:
+        return declaration_error
+    next_item = contract.get("next_item")
+    next_item_is_global = isinstance(next_item, dict) and (
+        next_item.get("mutates_global") is True
+        or is_global_resource_name(next_item.get("resource"))
+    )
 
     if status == "continue":
         if contract.get("objective_status") != "in_progress":
@@ -248,6 +277,8 @@ def validate_contract(contract: dict[str, Any], event_session: str) -> str | Non
             return "continue cannot carry a human or credential blocker"
         if contract.get("production_authorization_required"):
             return "continue cannot require production authorization"
+        if next_item_is_global and contract.get("resource_declaration") is None:
+            return "global next_item requires reads/writes/requires/leases resource_declaration"
     elif status == "complete":
         if contract.get("objective_status") != "complete":
             return "complete requires objective_status=complete"
@@ -262,6 +293,67 @@ def validate_contract(contract: dict[str, Any], event_session: str) -> str | Non
     ):
         return "production_authorization_required requires its boolean gate"
     return None
+
+
+def is_global_resource_name(value: Any) -> bool:
+    return isinstance(value, str) and value.strip().lower().startswith(GLOBAL_RESOURCE_PREFIXES)
+
+
+def default_resource_declaration() -> dict[str, Any]:
+    return {
+        "schema_version": RESOURCE_DECLARATION_SCHEMA_VERSION,
+        "reads": [],
+        "writes": [],
+        "requires": [],
+        "leases": [],
+    }
+
+
+def normalize_resource_declaration(
+    value: Any,
+    *,
+    required: bool = False,
+) -> tuple[dict[str, Any] | None, str | None]:
+    if value is None:
+        if required:
+            return None, "resource_declaration is required for a global mutation"
+        return default_resource_declaration(), None
+    if not isinstance(value, dict):
+        return None, "resource_declaration must be a JSON object"
+    unknown = sorted(set(value) - RESOURCE_DECLARATION_FIELDS)
+    if unknown:
+        return None, f"resource_declaration contains unsupported fields: {', '.join(unknown)}"
+    if value.get("schema_version", RESOURCE_DECLARATION_SCHEMA_VERSION) != RESOURCE_DECLARATION_SCHEMA_VERSION:
+        return None, "resource_declaration schema_version is unsupported"
+
+    normalized: dict[str, Any] = {"schema_version": RESOURCE_DECLARATION_SCHEMA_VERSION}
+    for field in RESOURCE_DECLARATION_LIST_FIELDS:
+        raw = value.get(field, [])
+        if not isinstance(raw, list) or any(not isinstance(item, str) for item in raw):
+            return None, f"resource_declaration {field} must be a list of strings"
+        if len(raw) > MAX_RESOURCE_DECLARATION_ITEMS:
+            return None, f"resource_declaration {field} exceeds the item limit"
+        items: set[str] = set()
+        for item in raw:
+            candidate = item.strip()
+            if not candidate:
+                return None, f"resource_declaration {field} cannot contain empty items"
+            if len(candidate) > MAX_RESOURCE_DECLARATION_ITEM_LENGTH:
+                return None, f"resource_declaration {field} contains an oversized item"
+            if "\n" in candidate or "\r" in candidate:
+                return None, f"resource_declaration {field} cannot contain line breaks"
+            items.add(candidate)
+        normalized[field] = sorted(items)
+
+    global_writes = [item for item in normalized["writes"] if is_global_resource_name(item)]
+    if global_writes and not normalized["leases"]:
+        return None, "global writes require an explicit lease declaration"
+    if "merge:main" in global_writes:
+        if "merge:main" not in normalized["leases"]:
+            return None, "merge:main writes require the merge:main lease"
+        if "skincos-integration-gate" not in normalized["requires"]:
+            return None, "merge:main writes require skincos-integration-gate"
+    return normalized, None
 
 
 def canonical_json(value: Any) -> tuple[str | None, str | None]:
@@ -389,6 +481,7 @@ def build_session_snapshot(
         "remote_fingerprint": None,
         "blocker_fingerprint": None,
         "valid_evidence_refs": [],
+        "resource_declaration": default_resource_declaration(),
     }
     if previous and not is_root:
         for field in (
@@ -399,8 +492,18 @@ def build_session_snapshot(
             "remote_fingerprint",
             "blocker_fingerprint",
             "valid_evidence_refs",
+            "resource_declaration",
         ):
             context[field] = previous.get(field)
+
+    raw_declaration = contract.get("resource_declaration")
+    if raw_declaration is not None:
+        declaration, declaration_error = normalize_resource_declaration(raw_declaration)
+        if declaration_error or declaration is None:
+            return None, declaration_error
+        context["resource_declaration"] = declaration
+    elif not isinstance(context.get("resource_declaration"), dict):
+        context["resource_declaration"] = default_resource_declaration()
 
     for field in SNAPSHOT_STRING_FIELDS:
         if field not in declared:
@@ -449,6 +552,7 @@ def build_session_snapshot(
         "checkpoint": context["checkpoint"],
         "remote_fingerprint": context["remote_fingerprint"],
         "valid_evidence_refs": context["valid_evidence_refs"],
+        "resource_declaration": context["resource_declaration"],
     }
     serialized, field_error = canonical_json(progress_material)
     if field_error or serialized is None:
@@ -467,6 +571,7 @@ def build_session_snapshot(
         "remote_fingerprint": context["remote_fingerprint"],
         "blocker_fingerprint": context["blocker_fingerprint"],
         "valid_evidence_refs": context["valid_evidence_refs"],
+        "resource_declaration": context["resource_declaration"],
         "completed_item": contract.get("completed_item"),
         "next_item": contract.get("next_item"),
         "progress_fingerprint": digest(serialized),
@@ -501,6 +606,10 @@ def validate_stored_snapshot(
     _, error = normalize_snapshot_refs(snapshot.get("valid_evidence_refs"), "valid_evidence_refs")
     if error:
         return error
+    if "resource_declaration" in snapshot:
+        _, error = normalize_resource_declaration(snapshot.get("resource_declaration"))
+        if error:
+            return error
     for field in ("completed_item", "next_item"):
         error = validate_snapshot_item(snapshot.get(field), field)
         if error:
@@ -774,6 +883,7 @@ def continuation_prompt(
             "remote_fingerprint": snapshot["remote_fingerprint"],
             "blocker_fingerprint": snapshot["blocker_fingerprint"],
             "valid_evidence_refs": snapshot["valid_evidence_refs"],
+            "resource_declaration": snapshot["resource_declaration"],
         },
     }
     return (
@@ -987,6 +1097,9 @@ def process(
                 {**event_record, "result": "invalid_session_snapshot", "mission_id": mission_id},
             )
             return safe_allow(f"SKINCOS supervisor safety stop: {snapshot_error}")
+
+        mission["resource_declaration"] = snapshot["resource_declaration"]
+        mission["branch_worktree"] = snapshot["branch_worktree"]
 
         status = str(contract["orchestration_status"])
         if status != "continue":

--- a/.codex/hooks/skincos-supervisor-gate.py
+++ b/.codex/hooks/skincos-supervisor-gate.py
@@ -289,6 +289,8 @@ def validate_contract(contract: dict[str, Any], event_session: str) -> str | Non
             if not isinstance(resource_value, str) or not resource_value.strip():
                 return "global next_item requires a concrete resource"
             resource = resource_value.strip()
+            if next_item.get("mutates_global") is True and not is_global_resource_name(resource):
+                return "global next_item requires a canonical resource name"
             if is_global_resource_name(resource):
                 resource = resource.lower()
             if resource not in declaration["writes"]:
@@ -364,8 +366,9 @@ def normalize_resource_declaration(
         normalized[field] = sorted(items)
 
     global_writes = [item for item in normalized["writes"] if is_global_resource_name(item)]
-    if global_writes and not normalized["leases"]:
-        return None, "global writes require an explicit lease declaration"
+    missing_leases = [item for item in global_writes if item not in normalized["leases"]]
+    if missing_leases:
+        return None, f"global writes require an explicit lease declaration for each resource: {', '.join(missing_leases)}"
     if "merge:main" in global_writes:
         if "merge:main" not in normalized["leases"]:
             return None, "merge:main writes require the merge:main lease"
@@ -446,15 +449,30 @@ def contract_resource_declaration(contract: dict[str, Any]) -> tuple[Any, str | 
     return declared.get("resource_declaration"), None
 
 
-def derive_task_slug(branch_worktree: dict[str, str | None]) -> str | None:
-    for field in ("branch", "worktree"):
-        value = branch_worktree.get(field)
-        if not isinstance(value, str) or not value.strip():
-            continue
-        segments = [segment for segment in re.split(r"[\\/]+", value.strip()) if segment]
-        if segments:
-            return segments[-1]
-    return None
+def task_identity_component(value: Any) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    segments = [segment for segment in re.split(r"[\\/]+", value.strip()) if segment]
+    return segments[-1] if segments else None
+
+
+def normalize_task_identity(
+    branch_worktree: dict[str, str | None],
+    task_slug: str | None,
+) -> tuple[str | None, str | None]:
+    components = {
+        component
+        for component in (
+            task_identity_component(branch_worktree.get("branch")),
+            task_identity_component(branch_worktree.get("worktree")),
+        )
+        if component is not None
+    }
+    if len(components) > 1:
+        return None, "branch, worktree, and task_slug must identify the same task"
+    if task_slug is not None and components and task_slug not in components:
+        return None, "task_slug does not match the branch/worktree task identity"
+    return task_slug or next(iter(components), None), None
 
 
 def normalize_branch_worktree(
@@ -563,8 +581,10 @@ def build_session_snapshot(
         return None, field_error
     context["branch_worktree"] = branch_worktree
 
-    if context["task_slug"] is None:
-        context["task_slug"] = derive_task_slug(branch_worktree)
+    task_slug, identity_error = normalize_task_identity(branch_worktree, context["task_slug"])
+    if identity_error:
+        return None, identity_error
+    context["task_slug"] = task_slug
 
     if "valid_evidence_refs" in declared:
         references, field_error = normalize_snapshot_refs(declared["valid_evidence_refs"], "valid_evidence_refs")
@@ -636,6 +656,9 @@ def validate_stored_snapshot(
         _, error = normalize_snapshot_string(snapshot.get(field), field)
         if error:
             return error
+    task_slug, error = normalize_snapshot_string(snapshot.get("task_slug"), "task_slug")
+    if error:
+        return error
     _, error = normalize_snapshot_string(snapshot.get("issue"), "issue", allow_integer=True)
     if error:
         return error
@@ -643,6 +666,9 @@ def validate_stored_snapshot(
     if not isinstance(branch_worktree, dict) or set(branch_worktree) != {"branch", "worktree"}:
         return "session snapshot branch_worktree is invalid"
     _, error = normalize_branch_worktree({}, branch_worktree)
+    if error:
+        return error
+    _, error = normalize_task_identity(branch_worktree, task_slug)
     if error:
         return error
     _, error = normalize_snapshot_refs(snapshot.get("valid_evidence_refs"), "valid_evidence_refs")

--- a/.codex/hooks/tests/test_skincos_supervisor_gate.py
+++ b/.codex/hooks/tests/test_skincos_supervisor_gate.py
@@ -172,6 +172,67 @@ class GateFixture(unittest.TestCase):
         self.assertEqual(snapshot["resource_declaration"]["leases"], ["merge:main"])
         self.assertIn('"resource_declaration"', result["reason"])
 
+    def test_nested_resource_declaration_is_accepted_and_persisted(self) -> None:
+        result = self.run_gate(
+            self.payload(
+                self.contract(
+                    next_item={"resource": "deploy:site:staging", "operation": "deploy"},
+                    session_snapshot={
+                        "resource_declaration": {
+                            "writes": ["deploy:site:staging"],
+                            "leases": ["deploy:site:staging"],
+                        }
+                    },
+                )
+            )
+        )
+        self.assertEqual(result["decision"], "block")
+        snapshot = self.read_snapshot()
+        self.assertEqual(snapshot["resource_declaration"]["writes"], ["deploy:site:staging"])
+        self.assertEqual(snapshot["resource_declaration"]["leases"], ["deploy:site:staging"])
+
+    def test_global_next_item_must_bind_to_the_declared_write_and_lease(self) -> None:
+        result = self.run_gate(
+            self.payload(
+                self.contract(
+                    next_item={"resource": "deploy:site:staging", "operation": "deploy"},
+                    resource_declaration={
+                        "writes": ["deploy:other:staging"],
+                        "leases": ["deploy:other:staging"],
+                    },
+                )
+            )
+        )
+        self.assertTrue(result["continue"])
+        self.assertIn("must be declared in resource_declaration.writes", result["stopReason"])
+
+        missing_resource = self.run_gate(
+            self.payload(
+                self.contract(
+                    next_item={"mutates_global": True, "operation": "deploy"},
+                    resource_declaration={},
+                ),
+                turn_id="turn-missing-resource",
+            )
+        )
+        self.assertTrue(missing_resource["continue"])
+        self.assertIn("concrete resource", missing_resource["stopReason"])
+
+    def test_merge_main_resource_names_are_case_insensitive_but_still_require_the_gate(self) -> None:
+        result = self.run_gate(
+            self.payload(
+                self.contract(
+                    next_item={"resource": "Merge:Main", "operation": "merge"},
+                    resource_declaration={
+                        "writes": ["Merge:Main"],
+                        "leases": ["MERGE:MAIN"],
+                    },
+                )
+            )
+        )
+        self.assertTrue(result["continue"])
+        self.assertIn("skincos-integration-gate", result["stopReason"])
+
     def test_merge_main_declaration_requires_gate_and_lease(self) -> None:
         result = self.run_gate(
             self.payload(
@@ -225,6 +286,7 @@ class GateFixture(unittest.TestCase):
                 "worktree": "C:/CodexShared/Worktrees/skincos/admin/codex-autonomy-baseline",
             },
         )
+        self.assertEqual(snapshot["task_slug"], "codex-autonomy-baseline")
         self.assertEqual(snapshot["checkpoint"], "checkpoint:before-supervisor-change")
         self.assertEqual(snapshot["remote_fingerprint"], "remote:main-16cace3")
         self.assertEqual(snapshot["valid_evidence_refs"], ["artifact:baseline", "ci:baseline-green"])
@@ -262,6 +324,33 @@ class GateFixture(unittest.TestCase):
         self.assertEqual(snapshot["checkpoint"], "checkpoint:before-change")
         self.assertEqual(snapshot["remote_fingerprint"], "remote:main-before")
         self.assertEqual(snapshot["valid_evidence_refs"], ["artifact:before"])
+
+    def test_omitted_local_milestone_does_not_inherit_a_global_resource_declaration(self) -> None:
+        self.write_config(cooldown_seconds=0)
+        initial = self.contract(
+            next_item={"resource": "deploy:site:staging", "operation": "deploy"},
+            resource_declaration={
+                "writes": ["deploy:site:staging"],
+                "leases": ["deploy:site:staging"],
+            },
+        )
+        first = self.run_gate(self.payload(initial, turn_id="root-global"))
+        self.assertEqual(first["decision"], "block")
+
+        local = self.contract(
+            completed_item="deploy:site:staging",
+            next_item={"operation": "inspect-local-artifact"},
+            evidence_refs=["local:artifact-inspected"],
+        )
+        second = self.run_gate(
+            self.payload(local, turn_id="auto-local", stop_hook_active=True),
+            now=self.now + 10,
+        )
+        self.assertEqual(second["decision"], "block")
+        self.assertEqual(
+            self.read_snapshot()["resource_declaration"],
+            gate.default_resource_declaration(),
+        )
 
     def test_claimed_progress_without_changed_fingerprint_does_not_repeat_work(self) -> None:
         self.write_config(cooldown_seconds=0)

--- a/.codex/hooks/tests/test_skincos_supervisor_gate.py
+++ b/.codex/hooks/tests/test_skincos_supervisor_gate.py
@@ -218,6 +218,33 @@ class GateFixture(unittest.TestCase):
         self.assertTrue(missing_resource["continue"])
         self.assertIn("concrete resource", missing_resource["stopReason"])
 
+        noncanonical = self.run_gate(
+            self.payload(
+                self.contract(
+                    next_item={"resource": "website", "mutates_global": True},
+                    resource_declaration={"writes": ["website"], "leases": ["website"]},
+                ),
+                turn_id="turn-noncanonical-resource",
+            )
+        )
+        self.assertTrue(noncanonical["continue"])
+        self.assertIn("canonical resource name", noncanonical["stopReason"])
+
+        missing_one_of_two = self.run_gate(
+            self.payload(
+                self.contract(
+                    next_item={"resource": "deploy:site:staging", "operation": "deploy"},
+                    resource_declaration={
+                        "writes": ["deploy:site:staging", "deploy:crm:production"],
+                        "leases": ["deploy:site:staging"],
+                    },
+                ),
+                turn_id="turn-missing-second-lease",
+            )
+        )
+        self.assertTrue(missing_one_of_two["continue"])
+        self.assertIn("deploy:crm:production", missing_one_of_two["stopReason"])
+
     def test_merge_main_resource_names_are_case_insensitive_but_still_require_the_gate(self) -> None:
         result = self.run_gate(
             self.payload(
@@ -292,6 +319,36 @@ class GateFixture(unittest.TestCase):
         self.assertEqual(snapshot["valid_evidence_refs"], ["artifact:baseline", "ci:baseline-green"])
         self.assertIn("issue:942-user-mission", result["reason"])
         self.assertIn("remote:main-16cace3", result["reason"])
+
+    def test_task_identity_rejects_mismatched_branch_worktree_or_slug(self) -> None:
+        mismatch = self.run_gate(
+            self.payload(
+                self.contract(
+                    branch_worktree={
+                        "branch": "codex/admin/task-one",
+                        "worktree": "C:/CodexShared/Worktrees/skincos/admin/task-two",
+                    }
+                ),
+                turn_id="turn-mismatched-worktree",
+            )
+        )
+        self.assertTrue(mismatch["continue"])
+        self.assertIn("same task", mismatch["stopReason"])
+
+        mismatch_slug = self.run_gate(
+            self.payload(
+                self.contract(
+                    branch_worktree={
+                        "branch": "codex/admin/task-one",
+                        "worktree": "C:/CodexShared/Worktrees/skincos/admin/task-one",
+                    },
+                    task_slug="task-two",
+                ),
+                turn_id="turn-mismatched-slug",
+            )
+        )
+        self.assertTrue(mismatch_slug["continue"])
+        self.assertIn("task_slug", mismatch_slug["stopReason"])
 
     def test_continued_snapshot_preserves_omitted_context_after_measurable_progress(self) -> None:
         self.write_config(cooldown_seconds=0)

--- a/.codex/hooks/tests/test_skincos_supervisor_gate.py
+++ b/.codex/hooks/tests/test_skincos_supervisor_gate.py
@@ -141,6 +141,49 @@ class GateFixture(unittest.TestCase):
         self.assertIn("$skincos-project-orchestrator supervisor-cycle", result["reason"])
         self.assertIn('"cycle": 1', result["reason"])
 
+    def test_global_next_item_requires_a_resource_declaration(self) -> None:
+        result = self.run_gate(
+            self.payload(
+                self.contract(next_item={"resource": "merge:main", "operation": "merge"})
+            )
+        )
+        self.assertTrue(result["continue"])
+        self.assertIn("resource_declaration", result["stopReason"])
+
+    def test_resource_declaration_is_normalized_and_persisted(self) -> None:
+        declaration = {
+            "schema_version": 1,
+            "reads": ["main", "main"],
+            "writes": ["merge:main"],
+            "requires": ["skincos-integration-gate"],
+            "leases": ["merge:main"],
+        }
+        result = self.run_gate(
+            self.payload(
+                self.contract(
+                    next_item={"resource": "merge:main", "operation": "merge"},
+                    resource_declaration=declaration,
+                )
+            )
+        )
+        self.assertEqual(result["decision"], "block")
+        snapshot = self.read_snapshot()
+        self.assertEqual(snapshot["resource_declaration"]["reads"], ["main"])
+        self.assertEqual(snapshot["resource_declaration"]["leases"], ["merge:main"])
+        self.assertIn('"resource_declaration"', result["reason"])
+
+    def test_merge_main_declaration_requires_gate_and_lease(self) -> None:
+        result = self.run_gate(
+            self.payload(
+                self.contract(
+                    next_item={"resource": "merge:main", "operation": "merge"},
+                    resource_declaration={"writes": ["merge:main"]},
+                )
+            )
+        )
+        self.assertTrue(result["continue"])
+        self.assertIn("explicit lease declaration", result["stopReason"])
+
     def test_active_mission_rejects_an_unstructured_normal_stop(self) -> None:
         initial = self.run_gate(self.payload())
         self.assertEqual(initial["decision"], "block")

--- a/.github/actions/global-coordination-release/action.yml
+++ b/.github/actions/global-coordination-release/action.yml
@@ -32,7 +32,21 @@ runs:
           echo 'No global coordination proof was acquired; nothing to release'
           exit 0
         fi
-        SKINCOS_GLOBAL_COORDINATOR_URL="$SKINCOS_GLOBAL_COORDINATOR_URL" \
-        SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET="$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" \
-          node scripts/codex-global-coordination-workflow.mjs release \
-            --proof-file "$GLOBAL_PROOF_FILE"
+        attempt=1
+        max_attempts=5
+        while true; do
+          if SKINCOS_GLOBAL_COORDINATOR_URL="$SKINCOS_GLOBAL_COORDINATOR_URL" \
+          SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET="$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" \
+            node scripts/codex-global-coordination-workflow.mjs release \
+              --proof-file "$GLOBAL_PROOF_FILE"; then
+            exit 0
+          fi
+          if (( attempt >= max_attempts )); then
+            echo "Global coordination release failed after ${max_attempts} idempotent attempts" >&2
+            exit 1
+          fi
+          sleep_seconds=$((attempt * 2))
+          echo "Global coordination release retry ${attempt}/${max_attempts} after ${sleep_seconds}s" >&2
+          sleep "$sleep_seconds"
+          attempt=$((attempt + 1))
+        done

--- a/.github/workflows/codex-keep-prs-mergeable.yml
+++ b/.github/workflows/codex-keep-prs-mergeable.yml
@@ -73,6 +73,7 @@ jobs:
           source_sha: ${{ github.sha }}
           proof_file: ${{ runner.temp }}/skincos-global-coordination-merge-maintenance.json
       - name: Check merge:main before PR branch maintenance
+        id: check_branch_maintenance
         if: ${{ steps.acquire_branch_maintenance.outcome == 'success' }}
         uses: ./.github/actions/global-coordination-check
         with:
@@ -85,13 +86,16 @@ jobs:
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Keep codex PRs up-to-date (update-branch) + label conflicts
-        if: ${{ steps.acquire_branch_maintenance.outcome == 'success' }}
+        if: ${{ always() }}
+        env:
+          ALLOW_BRANCH_UPDATES: ${{ steps.check_branch_maintenance.outcome == 'success' && 'true' || 'false' }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GH_TOKEN != '' && secrets.GH_TOKEN || github.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const allowBranchUpdates = process.env.ALLOW_BRANCH_UPDATES === "true";
 
             const LABELS = {
               updated: {
@@ -244,6 +248,11 @@ jobs:
               }
 
               if (mergeableState === "behind") {
+                if (!allowBranchUpdates) {
+                  await addLabel(prNumber, LABELS.pending.name);
+                  core.warning(`PR #${prNumber} is behind but branch maintenance lease is not held; leaving it unchanged.`);
+                  continue;
+                }
                 // Keep strict up-to-date requirement satisfied.
                 try {
                   await github.rest.pulls.updateBranch({

--- a/.github/workflows/codex-keep-prs-mergeable.yml
+++ b/.github/workflows/codex-keep-prs-mergeable.yml
@@ -23,7 +23,45 @@ jobs:
         with:
           ref: main
           fetch-depth: 1
+      - name: Detect whether branch maintenance needs merge:main
+        id: maintenance_scan
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          github-token: ${{ secrets.GH_TOKEN != '' && secrets.GH_TOKEN || github.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "open",
+              base: "main",
+              sort: "updated",
+              direction: "desc",
+              per_page: 100,
+            });
+            const candidates = pulls.filter((pr) => {
+              if (pr.head?.repo?.full_name !== `${owner}/${repo}`) return false;
+              if (!String(pr.head?.ref || "").startsWith("codex/")) return false;
+              return String(pr.user?.login || "") === "jubenitogarcia";
+            });
+            let needsMaintenance = false;
+            for (const pr of candidates) {
+              const response = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pr.number,
+              });
+              if (response.data.mergeable_state === "behind") {
+                needsMaintenance = true;
+                break;
+              }
+            }
+            core.setOutput("needs_maintenance", String(needsMaintenance));
+            core.info(`Branch maintenance lease needed: ${needsMaintenance}`);
       - name: Acquire merge:main for branch maintenance
+        id: acquire_branch_maintenance
+        if: ${{ steps.maintenance_scan.outputs.needs_maintenance == 'true' }}
         uses: ./.github/actions/global-coordination-acquire
         with:
           required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
@@ -35,6 +73,7 @@ jobs:
           source_sha: ${{ github.sha }}
           proof_file: ${{ runner.temp }}/skincos-global-coordination-merge-maintenance.json
       - name: Check merge:main before PR branch maintenance
+        if: ${{ steps.acquire_branch_maintenance.outcome == 'success' }}
         uses: ./.github/actions/global-coordination-check
         with:
           required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
@@ -46,6 +85,7 @@ jobs:
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
       - name: Keep codex PRs up-to-date (update-branch) + label conflicts
+        if: ${{ steps.acquire_branch_maintenance.outcome == 'success' }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GH_TOKEN != '' && secrets.GH_TOKEN || github.token }}

--- a/.github/workflows/global-merge-authority.yml
+++ b/.github/workflows/global-merge-authority.yml
@@ -71,6 +71,10 @@ jobs:
           # GitHub emits the normal post-merge workflow events. GITHUB_TOKEN
           # events are intentionally suppressed by GitHub.
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          # Required status checks are bound to the GitHub Actions integration;
+          # keep status publication on that token while GH_TOKEN performs the
+          # merge mutation and preserves post-merge workflow events.
+          SKINCOS_STATUS_TOKEN: ${{ github.token }}
           SKINCOS_GLOBAL_COORDINATOR_URL: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
           SKINCOS_GLOBAL_COORDINATION_REQUIRED: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
           SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}

--- a/.github/workflows/global-merge-authority.yml
+++ b/.github/workflows/global-merge-authority.yml
@@ -51,7 +51,11 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
-          ref: main
+          # Execute the authority implementation from the explicitly selected
+          # dispatch ref. Normal production dispatches use main; this also
+          # makes the first governed migration run the candidate's corrected
+          # status-publication code before that correction is merged.
+          ref: ${{ github.ref }}
           fetch-depth: 0
       - name: Fetch the exact base tree used by the merge intent
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,15 @@
   e `DECISIONS.md` como contexto durável/histórico, não como cópias
   obrigatórias de estado volátil.
 - Use branches in the format `codex/admin/<task-slug>`.
-- Prefer worktrees under `C:\CodexShared\Worktrees\skincos\admin\<task-slug>`
-  when more than one Codex task may work in parallel.
+- For every non-trivial or potentially concurrent mission, a dedicated
+  worktree under `C:\CodexShared\Worktrees\skincos\admin\<task-slug>` is
+  mandatory. The shared checkout is a read-only context/source-of-truth
+  surface for agents, not a normal editing surface. The task identity is the
+  tuple `mission_id`, `task_slug`, `codex/admin/<task-slug>` branch and the
+  dedicated worktree path; persist that tuple in the supervisor snapshot.
+- A worktree may not be edited by another task. Pushes must use the task branch
+  and PR flow; direct pushes or merges to `main` are unsupported and are
+  rejected by the protected ruleset and integration authority.
 - Keep Codex authentication, browser profiles, temporary files and PID state in
   `%LOCALAPPDATA%\Codex\skincos\`. Keep durable operator artifacts (logs,
   reports, checkpoints, evidence and local backups) in the private runtime at

--- a/docs/codex-shared-workspace.md
+++ b/docs/codex-shared-workspace.md
@@ -16,10 +16,14 @@ Tarefas simultâneas do Codex continuam usando worktrees para evitar conflitos.
   versiona os botões do topo do Codex App para o clone compartilhado e para os
   worktrees. Nenhum outro arquivo de `.codex` deve ser salvo aqui.
 - Usar branch no formato `codex/admin/<task-slug>`.
-- Se houver chance de trabalho concorrente, usar worktree dedicado em
-  `C:\CodexShared\Worktrees\skincos\<ator>\<task-slug>`.
-- O clone compartilhado deve ficar reservado para contexto, revisão, bootstrap
-  e tarefas curtas; mudanças longas ou paralelas devem migrar para worktree.
+- Para toda tarefa não trivial, usar obrigatoriamente worktree dedicado em
+  `C:\CodexShared\Worktrees\skincos\<ator>\<task-slug>`. O clone compartilhado
+  permanece reservado para contexto, revisão e bootstrap; não é superfície de
+  edição normal de agentes.
+- A identidade persistida da tarefa é `mission_id`, `task_slug`, branch e
+  caminho do worktree. Uma tarefa não altera o worktree de outra. Push direto
+  para `main` não faz parte do fluxo suportado: a proteção remota e a
+  autoridade de integração rejeitam essa operação.
 - Autenticação, perfis de browser, envs privados, PID e temporários do Codex
   ficam fora do repositório compartilhado, em `%LOCALAPPDATA%\Codex\skincos\`.
   Logs, relatórios, checkpoints, evidências e backups locais ficam no runtime
@@ -294,7 +298,8 @@ Exemplo de saída esperada:
 1. Rodar bootstrap, validação e instalação dos atalhos uma vez por usuário.
 2. Abrir `C:\CodexShared\Projetos\skincos` no Codex App para entender o contexto.
 3. Usar `Codex Context` ou rodar `bash ./scripts/codex-context.sh` via WSL.
-4. Para qualquer tarefa paralela ou mais longa, criar um worktree por usuário/tarefa.
+4. Para qualquer tarefa não trivial, criar um worktree por usuário/tarefa antes
+   de editar.
 5. Abrir o worktree no Codex App e trabalhar só nele.
 6. Rodar apps locais com perfil, autenticação, temporários e overrides em
    `%LOCALAPPDATA%\Codex\skincos\`; os artefatos duráveis vão para o runtime

--- a/scripts/codex-global-merge-authority.mjs
+++ b/scripts/codex-global-merge-authority.mjs
@@ -27,8 +27,9 @@ function apiUrl(repository, suffix = "") {
   return `https://api.github.com/repos/${repository}${suffix}`;
 }
 
-async function githubJson(repository, suffix, options = {}) {
-  const token = requiredEnv("GH_TOKEN");
+async function githubJson(repository, suffix, options = {}, tokenName = "GH_TOKEN") {
+  const token = String(process.env[tokenName] || process.env.GH_TOKEN || "").trim();
+  if (!token) throw new Error(`${tokenName} is required`);
   const response = await fetch(apiUrl(repository, suffix), {
     ...options,
     headers: {
@@ -63,7 +64,7 @@ async function setMergeAuthorityStatus(repository, headSha, state, description) 
       description: String(description).slice(0, 140),
       target_url: `${process.env.GITHUB_SERVER_URL || "https://github.com"}/${repository}/actions/workflows/global-merge-authority.yml`,
     }),
-  });
+  }, "SKINCOS_STATUS_TOKEN");
 }
 
 function waitableLeaseReason(reason) {

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -153,6 +153,9 @@ test("merge:main is a fail-closed GitHub mutation authority", () => {
   assert.match(scheduler, /Detect whether branch maintenance needs merge:main/);
   assert.match(scheduler, /steps\.maintenance_scan\.outputs\.needs_maintenance == 'true'/);
   assert.match(scheduler, /steps\.acquire_branch_maintenance\.outcome == 'success'/);
+  assert.match(scheduler, /ALLOW_BRANCH_UPDATES/);
+  assert.match(scheduler, /always\(\)/);
+  assert.match(scheduler, /allowBranchUpdates/);
   assert.match(read(".github/actions/global-coordination-release/action.yml"), /max_attempts=5/);
   assert.match(read(".codex/hooks/skincos-supervisor-gate.py"), /resource_declaration/);
   assert.match(read("skills/skincos-project-orchestrator/references/supervisor-cycle.md"), /technical wait\/blocker/);

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -139,6 +139,7 @@ test("merge:main is a fail-closed GitHub mutation authority", () => {
   assert.match(read("scripts/codex-global-coordination-workflow.mjs"), /admission paths are not bound/);
   assert.match(script, /\/pulls\/\$\{pullNumber\}\/merge/);
   assert.match(workflow, /pull_request_target/);
+  assert.match(workflow, /ref: \$\{\{ github\.ref \}\}/);
   assert.match(workflow, /state=failure/);
   assert.match(workflow, /run-name: Merge PR #\$\{\{ inputs\.pull_number \}\} through merge:main/);
   assert.match(workflow, /GH_TOKEN: \$\{\{ secrets\.GH_TOKEN \}\}/);

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -142,6 +142,8 @@ test("merge:main is a fail-closed GitHub mutation authority", () => {
   assert.match(workflow, /state=failure/);
   assert.match(workflow, /run-name: Merge PR #\$\{\{ inputs\.pull_number \}\} through merge:main/);
   assert.match(workflow, /GH_TOKEN: \$\{\{ secrets\.GH_TOKEN \}\}/);
+  assert.match(workflow, /SKINCOS_STATUS_TOKEN: \$\{\{ github\.token \}\}/);
+  assert.match(script, /SKINCOS_STATUS_TOKEN/);
   assert.doesNotMatch(scheduler, /enablePullRequestAutoMerge/);
   assert.match(scheduler, /disablePullRequestAutoMerge/);
   assert.match(scheduler, /uses: \.\/\.github\/actions\/global-coordination-acquire/);

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -148,6 +148,12 @@ test("merge:main is a fail-closed GitHub mutation authority", () => {
   assert.match(scheduler, /uses: \.\/\.github\/actions\/global-coordination-check/);
   assert.match(scheduler, /uses: \.\/\.github\/actions\/global-coordination-release/);
   assert.match(scheduler, /resource: merge:main/);
+  assert.match(scheduler, /Detect whether branch maintenance needs merge:main/);
+  assert.match(scheduler, /steps\.maintenance_scan\.outputs\.needs_maintenance == 'true'/);
+  assert.match(scheduler, /steps\.acquire_branch_maintenance\.outcome == 'success'/);
+  assert.match(read(".github/actions/global-coordination-release/action.yml"), /max_attempts=5/);
+  assert.match(read(".codex/hooks/skincos-supervisor-gate.py"), /resource_declaration/);
+  assert.match(read("skills/skincos-project-orchestrator/references/supervisor-cycle.md"), /technical wait\/blocker/);
   assert.deepEqual(policy.releaseClosures.merge.patterns, ["**"]);
   assert.match(policy.resourceClasses.mutate, /^\^mutate:/);
   assert.equal(policy.admission.coordinationPlane, "global");

--- a/skills/skincos-project-orchestrator/SKILL.md
+++ b/skills/skincos-project-orchestrator/SKILL.md
@@ -46,6 +46,15 @@ fail-closed stop. The production coordinator URL is intentionally separate
 from staging, so an absent production authority must block pilot, canary,
 production, and rollback rather than reuse staging custody.
 
+Each mission milestone also carries a compact `resource_declaration` with
+`reads`, `writes`, `requires` and `leases`. Derive it from the actual next
+operation and persist it with the supervisor snapshot. For a global mutation,
+the orchestrator must acquire the listed remote lease and own a current fencing
+proof before executing; authorization remains valid while waiting for that
+ownership. The Stop hook only validates this shape and persistence. It is not a
+second coordination authority and must not contain dependency or business
+compatibility decisions.
+
 ## Authorization
 
 Authorization comes from the current explicit mission under

--- a/skills/skincos-project-orchestrator/references/supervisor-cycle.md
+++ b/skills/skincos-project-orchestrator/references/supervisor-cycle.md
@@ -33,7 +33,16 @@ evidence judgment remains here.
    another session.
 6. Persist durable queue, blocker and evidence changes when facts materially
    changed. Keep transient hook state outside Git.
-7. Choose exactly one terminal or continuing orchestration status. Automatic
+7. Before selecting a `next_item`, emit its compact `resource_declaration`.
+   Use `reads` for source observations, `writes` for intended mutations,
+   `requires` for technical gates, and `leases` for canonical global resources.
+   A global mutation is not eligible merely because the mission is authorized:
+   the orchestrator must present the current remote proof and run the shared
+   `check` immediately before the mutation. A missing or temporarily held lease
+   is a technical wait/blocker and never a request for duplicate authorization.
+   The Stop hook validates and persists this declaration; it does not decide
+   business compatibility or call the coordination plane.
+8. Choose exactly one terminal or continuing orchestration status. Automatic
    continuation is allowed only when real progress occurred and a concrete,
    technically safe next item remains within the active mission. Production may
    continue when the mission covers it and every applicable technical gate is
@@ -58,6 +67,13 @@ SKINCOS_SUPERVISOR_STATE_BEGIN
   "human_blocker": null,
   "credential_blocker": null,
   "production_authorization_required": false,
+  "resource_declaration": {
+    "schema_version": 1,
+    "reads": ["origin/main", "pr:1261"],
+    "writes": ["merge:main"],
+    "requires": ["skincos-integration-gate"],
+    "leases": ["merge:main"]
+  },
   "evidence_refs": []
 }
 SKINCOS_SUPERVISOR_STATE_END
@@ -65,6 +81,13 @@ SKINCOS_SUPERVISOR_STATE_END
 
 The minimum fields shown above are mandatory; `mission_id` is optional on the
 first root turn and must be preserved when the gate supplies it.
+
+`resource_declaration` is optional for local-only milestones and mandatory when
+`next_item` declares a global resource or `mutates_global=true`. Its four lists
+are bounded, normalized and persisted with the mission snapshot. The hook does
+not treat a declaration as ownership: the orchestrator must acquire the remote
+lease, retain the fencing proof outside the checkout and re-check it before
+each protected mutation.
 
 Allowed `orchestration_status` values:
 


### PR DESCRIPTION
## Fase 2 — supervisor multi-thread e branch maintenance

Este PR fecha a camada local de coordenação sem criar uma segunda autoridade:

- persiste `resource_declaration` (`reads`, `writes`, `requires`, `leases`) no snapshot/mission;
- faz o Stop hook validar somente shape, limites e invariantes determinísticas;
- deixa ownership remoto, dependency compatibility e `check` no orquestrador/coordination plane;
- evita que o `codex-keep-prs-mergeable` adquira `merge:main` quando não há branch atrasada;
- torna a liberação de lease idempotente com retries limitados;
- torna worktree dedicada obrigatória para tarefas não triviais e explicita identidade mission/task/branch/worktree.

Validação WSL:
- `codex:supervisor:test` — 37 testes, OK;
- `codex:global-coordination:test` — 37 testes, OK;
- `git diff --check` — OK.

Não há deploy ou mutação de produção neste PR.