### PR TITLE
fix(ci): recover synthetic staging teardown after lease failures

### DIFF
--- a/.github/actions/global-coordination-check/action.yml
+++ b/.github/actions/global-coordination-check/action.yml
@@ -72,15 +72,28 @@ runs:
           printf '%s' "$GLOBAL_PROOF_B64" | base64 -d > "$GLOBAL_PROOF_FILE"
         fi
         [[ -f "$GLOBAL_PROOF_FILE" ]] || { echo 'Global coordination proof file is missing'; exit 1; }
-        SKINCOS_GLOBAL_COORDINATOR_URL="$SKINCOS_GLOBAL_COORDINATOR_URL" \
-        SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET="$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" \
-          node scripts/codex-global-coordination-workflow.mjs renew \
-            --proof-file "$GLOBAL_PROOF_FILE"
-        SKINCOS_GLOBAL_COORDINATOR_URL="$SKINCOS_GLOBAL_COORDINATOR_URL" \
-        SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET="$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" \
-          node scripts/codex-global-coordination-workflow.mjs check \
-            --proof-file "$GLOBAL_PROOF_FILE" \
-            --resource "$GLOBAL_RESOURCE" \
-            --module "$GLOBAL_MODULE" \
-            --source "$GLOBAL_OBSERVED_SOURCE_SHA" \
-            --candidate-source "$GLOBAL_SOURCE_SHA"
+        coordination_attempt=1
+        coordination_max_attempts=3
+        while (( coordination_attempt <= coordination_max_attempts )); do
+          if SKINCOS_GLOBAL_COORDINATOR_URL="$SKINCOS_GLOBAL_COORDINATOR_URL" \
+            SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET="$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" \
+              node scripts/codex-global-coordination-workflow.mjs renew \
+                --proof-file "$GLOBAL_PROOF_FILE" && \
+            SKINCOS_GLOBAL_COORDINATOR_URL="$SKINCOS_GLOBAL_COORDINATOR_URL" \
+            SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET="$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" \
+              node scripts/codex-global-coordination-workflow.mjs check \
+                --proof-file "$GLOBAL_PROOF_FILE" \
+                --resource "$GLOBAL_RESOURCE" \
+                --module "$GLOBAL_MODULE" \
+                --source "$GLOBAL_OBSERVED_SOURCE_SHA" \
+                --candidate-source "$GLOBAL_SOURCE_SHA"; then
+            exit 0
+          fi
+          if (( coordination_attempt == coordination_max_attempts )); then
+            echo "Global coordination revalidation failed after ${coordination_max_attempts} attempts" >&2
+            exit 1
+          fi
+          echo "Global coordination revalidation attempt ${coordination_attempt} failed; retrying" >&2
+          sleep 2
+          coordination_attempt=$((coordination_attempt + 1))
+        done

--- a/.github/workflows/insumos-staging-rbac-smoke.yml
+++ b/.github/workflows/insumos-staging-rbac-smoke.yml
@@ -168,6 +168,7 @@ jobs:
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
 
       - name: Tear down only this run's synthetic staging identities
+        id: teardown
         if: ${{ always() && steps.check_teardown.outcome == 'success' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -183,6 +184,7 @@ jobs:
           rm -f "$FIXTURES" "$SQL_FILE"
 
       - name: Release staging D1 coordination lease
+        id: release
         if: always()
         uses: ./.github/actions/global-coordination-release
         with:
@@ -190,6 +192,59 @@ jobs:
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
           proof_file: ${{ runner.temp }}/skincos-global-coordination-staging-d1-insumos.json
+
+      - name: Reacquire cleanup lease for an orphaned synthetic teardown
+        id: recovery_acquire
+        if: ${{ always() && steps.fixture.outcome == 'success' && steps.teardown.outcome != 'success' }}
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: global:staging-d1
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-staging-d1-insumos-cleanup.json
+
+      - name: Revalidate cleanup lease before orphaned teardown
+        id: recovery_check
+        if: ${{ always() && steps.recovery_acquire.outcome == 'success' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-staging-d1-insumos-cleanup.json
+          resource: global:staging-d1
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
+      - name: Tear down orphaned synthetic staging identities under recovery lease
+        id: recovery_teardown
+        if: ${{ always() && steps.recovery_check.outcome == 'success' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          FIXTURES: ${{ runner.temp }}/insumos-rbac-fixtures.json
+          SQL_FILE: ${{ runner.temp }}/insumos-rbac-recovery-teardown.sql
+        run: |
+          set -euo pipefail
+          [[ -f "$FIXTURES" ]] || exit 0
+          [[ "$STAGING_D1_DATABASE" == 'skincos-db-staging' ]] || { echo 'refusing a non-staging D1 target'; exit 1; }
+          node inventory/scripts/insumosStagingRbacFixtures.mjs --action teardown --run-id "$GITHUB_RUN_ID" --fixtures "$FIXTURES" --sql "$SQL_FILE"
+          npx --yes wrangler@3 d1 execute "$STAGING_D1_DATABASE" --config inventory/wrangler.toml --env staging --remote --file "$SQL_FILE" >/dev/null
+          rm -f "$FIXTURES" "$SQL_FILE"
+
+      - name: Release orphaned teardown recovery lease
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-staging-d1-insumos-cleanup.json
 
       - name: Upload sanitised journey evidence
         if: ${{ always() }}

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -81,6 +81,21 @@ test("the reusable check action accepts either an external proof file or an enco
   assert.match(read(".github/actions/global-coordination-release/action.yml"), /github\.event\.inputs\.target == 'production'/);
   assert.match(action, /GLOBAL_PROOF_FILE_INPUT/);
   assert.match(action, /base64 -d/);
+  assert.match(action, /coordination_max_attempts=3/);
+  assert.match(action, /Global coordination revalidation failed after/);
+});
+
+test("the staging RBAC journey recovers synthetic teardown under a fresh lease", () => {
+  const workflow = read(".github/workflows/insumos-staging-rbac-smoke.yml");
+  const release = workflow.indexOf("Release staging D1 coordination lease");
+  const recoveryAcquire = workflow.indexOf("Reacquire cleanup lease for an orphaned synthetic teardown");
+  const recoveryCheck = workflow.indexOf("Revalidate cleanup lease before orphaned teardown");
+  const recoveryTeardown = workflow.indexOf("Tear down orphaned synthetic staging identities under recovery lease");
+  assert.ok(release >= 0 && recoveryAcquire > release && recoveryCheck > recoveryAcquire && recoveryTeardown > recoveryCheck);
+  assert.match(workflow, /steps\.fixture\.outcome == 'success' && steps\.teardown\.outcome != 'success'/);
+  assert.match(workflow, /steps\.recovery_check\.outcome == 'success'/);
+  assert.match(workflow, /skincos-global-coordination-staging-d1-insumos-cleanup\.json/);
+  assert.match(workflow, /refusing a non-staging D1 target/);
 });
 
 test("the Ponto composite lease starts before candidate mutation, selects the correct authority, and spans the orchestrator", () => {


### PR DESCRIPTION
## Objetivo

Evitar que a jornada RBAC de staging deixe identidades sintéticas órfãs quando a revalidação do coordenador falha de forma transitória.

## Alterações

- adiciona até três tentativas curtas e idempotentes à ação global de revalidação;
- preserva o bloqueio fail-closed: o teardown só executa após lease válido;
- adiciona recuperação com nova aquisição/revalidação de lease após teardown normal pulado;
- cobre a ordem e as condições da recuperação no teste estático de governança.

## Validação

- `npm run codex:global-coordination:test` via Ubuntu-24.04 WSL: 38/38 aprovados;
- `git diff --check` aprovado;
- nenhuma alteração de produção.

## Risco e rollback

Mudança limitada ao harness de staging e à ação reutilizável de revalidação. Rollback: reverter este commit `484699ad`.