### PR TITLE
fix(crm): route local users proxy to adapter

### DIFF
--- a/crm/console/functions/api/crm/[[path]].ts
+++ b/crm/console/functions/api/crm/[[path]].ts
@@ -20,7 +20,11 @@ function isLoopbackTarget(value: string): boolean {
 export function buildCrmTargetUrl(targetOrigin: string, rest: string, search: string): string {
   const targetUrl = new URL(targetOrigin)
   const basePath = targetUrl.pathname.replace(/\/$/, '')
-  targetUrl.pathname = `${basePath}/inventory${rest.startsWith('/') ? '' : '/'}${rest}`
+  // Hosted Core owns the /inventory mount. The local CRM adapter exposes its
+  // admin routes directly, so adding that prefix to a loopback target would
+  // turn a valid /admin/team request into a guaranteed 404.
+  const mountPath = isLoopbackTarget(targetOrigin) ? '' : '/inventory'
+  targetUrl.pathname = `${basePath}${mountPath}${rest.startsWith('/') ? '' : '/'}${rest}`
   targetUrl.search = search
   return targetUrl.toString()
 }
@@ -39,7 +43,9 @@ export async function onRequest(context: any): Promise<Response> {
   const prefix = '/api/crm'
   const rest = url.pathname.startsWith(prefix) ? url.pathname.slice(prefix.length) || '/' : url.pathname
 
-  const targetOrigin = (context.env?.INSUMOS_API_TARGET as string | undefined) || 'https://api.skincos.com.br'
+  const targetOrigin = (context.env?.CRM_API_TARGET as string | undefined)
+    || (context.env?.INSUMOS_API_TARGET as string | undefined)
+    || 'https://api.skincos.com.br'
   const targetUrl = new URL(buildCrmTargetUrl(targetOrigin, rest, url.search))
 
   const headers = sanitizeProxyRequestHeaders(request.headers)

--- a/crm/console/scripts/dev_pages.sh
+++ b/crm/console/scripts/dev_pages.sh
@@ -99,7 +99,14 @@ add_binding "LOCAL_AUTH_ALLOWED_UNITS" "$local_auth_allowed_units"
 add_optional_binding "LOCAL_AUTH_ALLOWED_HOSTS" "$local_auth_allowed_hosts"
 add_optional_binding "AUTH_API_TARGET" "${AUTH_API_TARGET:-}"
 add_binding "AUTH_PATH_PREFIX" "$auth_path_prefix"
-add_optional_binding "CRM_API_TARGET" "${CRM_API_TARGET:-}"
+if [[ -n "${LOCAL_WA_ORCHESTRATOR_API_TARGET:-}" ]]; then
+  # The local adapter owns CRM identity/team routes directly. Keep this
+  # binding separate from the hosted Inventory mount so the Pages proxy can
+  # select the loopback contract without changing hosted routing.
+  add_binding "CRM_API_TARGET" "$LOCAL_WA_ORCHESTRATOR_API_TARGET"
+else
+  add_optional_binding "CRM_API_TARGET" "${CRM_API_TARGET:-}"
+fi
 add_optional_binding "CAIXA_API_TARGET" "${CAIXA_API_TARGET:-}"
 add_optional_binding "TRACKING_API_TARGET" "${TRACKING_API_TARGET:-}"
 add_optional_binding "UNIT_MONITOR_API_TARGET" "${UNIT_MONITOR_API_TARGET:-}"

--- a/crm/console/tests/crmProxyRoute.test.ts
+++ b/crm/console/tests/crmProxyRoute.test.ts
@@ -23,6 +23,13 @@ describe('CRM API proxy mount', () => {
       .toBe('https://api.example.test/base/inventory/auth/me?status=active')
   })
 
+  it('keeps the local adapter route unmounted while preserving its base path', () => {
+    expect(buildCrmTargetUrl('http://127.0.0.1:25054', '/admin/team', '?mode=config'))
+      .toBe('http://127.0.0.1:25054/admin/team?mode=config')
+    expect(buildCrmTargetUrl('http://localhost:25054/base/', '/auth/me', '?status=active'))
+      .toBe('http://localhost:25054/base/auth/me?status=active')
+  })
+
   it('uses the canonical mount when the Pages handler proxies a request', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response('{"success":true}', {
       status: 200,
@@ -39,5 +46,27 @@ describe('CRM API proxy mount', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect((fetchMock.mock.calls[0][0] as Request).url)
       .toBe('https://api-staging.skincos.com.br/inventory/admin/team?mode=config')
+  })
+
+  it('uses the explicit local CRM target before the hosted inventory fallback', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{"success":true}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const response = await onRequest(createContext(
+      'http://localhost:25050/api/crm/admin/team?mode=config',
+      {
+        CRM_API_TARGET: 'http://127.0.0.1:25054',
+        INSUMOS_API_TARGET: 'https://api-staging.skincos.com.br',
+        LOCAL_AUTH_BYPASS: 'true',
+      },
+    ))
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect((fetchMock.mock.calls[0][0] as Request).url)
+      .toBe('http://127.0.0.1:25054/admin/team?mode=config')
   })
 })


### PR DESCRIPTION
## Summary\n- preserve the hosted /inventory mount for CRM API proxy requests\n- route loopback Users/Equipe requests directly to the local CRM adapter\n- bind CRM_API_TARGET in the modular local Pages runner and cover both contracts\n\n## Validation\n- crm/console/tests/crmProxyRoute.test.ts: 5 passed\n- crm/console TypeScript noCheck: passed\n- no production or staging data writes