### PR TITLE
fix(governance): repair integration gate recheck shell

### DIFF
--- a/.github/workflows/skincos-integration-gate-recheck.yml
+++ b/.github/workflows/skincos-integration-gate-recheck.yml
@@ -37,7 +37,7 @@ jobs:
           failures=0
           while IFS=$'\t' read -r pull_number head_sha; do
             [[ -n "$pull_number" && -n "$head_sha" ]] || continue
-            gate_state="$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/statuses?per_page=100" --jq '[.[] | select(.context == "skincos-integration-gate")][0].state // "")"
+            gate_state="$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/statuses?per_page=100" --jq '[.[] | select(.context == "skincos-integration-gate")][0].state // ""')"
             [[ "$gate_state" == "pending" ]] || continue
             if ! node scripts/codex-global-integration-gate.mjs \
               --pull-number "$pull_number" \

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -198,6 +198,8 @@ test("merge:main is a fail-closed GitHub mutation authority", () => {
   assert.match(integrationRecheck, /--max-wait-ms 15000/);
   assert.match(integrationRecheck, /gh api --paginate/);
   assert.match(integrationRecheck, /gate_state/);
+  assert.match(integrationRecheck, /--jq '\[\.\[\] \| select\(\.context == "skincos-integration-gate"\)\]\[0\]\.state \/\/ ""'/);
+  assert.doesNotMatch(integrationRecheck, /--jq '[^\n]*\/\/ ""\)"/);
   assert.match(read("ops/cloudflare/global-coordinator/index.js"), /buildLegacyIntentV1/);
   assert.match(read("scripts/codex-global-coordination-workflow.mjs"), /admission paths are not bound/);
   assert.match(script, /\/pulls\/\$\{pullNumber\}\/merge/);


### PR DESCRIPTION
## Summary\n- repair the pending integration gate recheck jq shell quoting\n- add a static regression assertion for the executable command\n\n## Validation\n- codex:global-coordination:test (139 passing)\n- actionlint .github/workflows/skincos-integration-gate-recheck.yml\n\nThis is a fail-closed reliability fix; it does not bypass coordination or merge authority.