### PR TITLE
feat(crm): paginate unified team management safely

### DIFF
--- a/crm/api/server.js
+++ b/crm/api/server.js
@@ -1632,7 +1632,11 @@ if (DEV_AUTH_ENABLED) {
         }
         const requestedStatus = String(req.query?.status || 'active').trim().toUpperCase()
         const query = String(req.query?.q || '').trim().toLowerCase()
-        const data = store.team
+        const pageRaw = Number.parseInt(String(req.query?.page || ''), 10)
+        const limitRaw = Number.parseInt(String(req.query?.limit || ''), 10)
+        const page = Number.isInteger(pageRaw) && pageRaw > 0 ? Math.min(pageRaw, 10000) : 1
+        const limit = Number.isInteger(limitRaw) && limitRaw > 0 ? Math.min(limitRaw, 100) : 50
+        const filtered = store.team
           .filter((member) => requestedStatus === 'ALL'
               ? true
               : requestedStatus === 'ACTIVE'
@@ -1641,21 +1645,25 @@ if (DEV_AUTH_ENABLED) {
           .filter((member) => !query || [member.fullName, member.username, member.corporateEmail, member.department, member.jobTitle, ...member.units]
               .some((value) => String(value || '').toLowerCase().includes(query)))
           .filter((member) => role === 'ADMIN' || localTeamUnitsVisible(session, member))
+        const total = filtered.length
+        const pages = Math.max(1, Math.ceil(total / limit))
+        const data = filtered.slice((page - 1) * limit, page * limit).map(localPublicTeamMember)
         const pendingItems = localPendingItems(data)
         // The Pages Function already authenticates and scopes this loopback
-      // response. Applying the unit filter again here would make the local
-      // preview dependent on a second process' session serialization.
-      .map(localPublicTeamMember)
+        // response. Applying the unit filter again here would make the local
+        // preview dependent on a second process' session serialization.
         return res.status(200).set('cache-control', 'no-store').json({
             success: true,
             data,
             activeOnly: requestedStatus !== 'ALL',
             status: requestedStatus,
+            pagination: { page, limit, total, pages, hasMore: page < pages },
             summary: {
-                members: data.length,
-                pendingInvites: data.filter((member) => member.accountStatus === 'INVITED').length,
-                pendingLinks: data.reduce((total, member) => total + (member.identityLinks || []).filter((link) => link.reviewStatus === 'PENDING_REVIEW').length, 0),
-                pendingProvisioning: data.filter((member) => ['PROVISIONING', 'WORKFORCE_SYNCED', 'INVITE_PENDING', 'FAILED'].includes(String(member.provisioningState || '').toUpperCase())).length,
+                members: total,
+                pendingInvites: filtered.filter((member) => member.accountStatus === 'INVITED').length,
+                pendingLinks: filtered.reduce((sum, member) => sum + (member.identityLinks || []).filter((link) => link.reviewStatus === 'PENDING_REVIEW').length, 0),
+                pendingProvisioning: filtered.filter((member) => ['PROVISIONING', 'WORKFORCE_SYNCED', 'INVITE_PENDING', 'FAILED'].includes(String(member.provisioningState || '').toUpperCase())).length,
+                pendingAccountLinks: filtered.filter((member) => !member.crmAccountLinked && ['ACTIVE', 'SUSPENDED', 'TERMINATED'].includes(String(member.accountStatus || '').toUpperCase())).length,
             },
             pendingItems,
         })

--- a/crm/console/UsersModule.tsx
+++ b/crm/console/UsersModule.tsx
@@ -9,7 +9,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { getCsrfToken } from '@/csrf'
 import { Input } from '@/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/select'
-import { buildCorporateEmail, suggestUsername, type UnifiedTeamConfig, type UnifiedTeamMember } from '@/teamApi'
+import { buildCorporateEmail, suggestUsername, type UnifiedTeamConfig, type UnifiedTeamMember, type UnifiedTeamPagination } from '@/teamApi'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/tabs'
 import { TooltipButton } from '@/tooltip'
 
@@ -112,6 +112,8 @@ const initialForm = {
   scheduleInstagram: '',
   scheduleColor: '',
 }
+
+const TEAM_PAGE_SIZE = 50
 
 async function api<T>(path: string, opts: RequestOptions = {}): Promise<T> {
   const headers: Record<string, string> = { Accept: 'application/json', ...(opts.headers || {}) }
@@ -286,7 +288,9 @@ export function UsersModule() {
   const [statusFilter, setStatusFilter] = React.useState('ACTIVE')
   const [searchQuery, setSearchQuery] = React.useState('')
   const [searchInput, setSearchInput] = React.useState('')
+  const [page, setPage] = React.useState(1)
   const [summary, setSummary] = React.useState<TeamSummary>({})
+  const [pagination, setPagination] = React.useState<UnifiedTeamPagination | null>(null)
   const [selectedIds, setSelectedIds] = React.useState<string[]>([])
   const [bulkSaving, setBulkSaving] = React.useState(false)
   const [formTab, setFormTab] = React.useState('identity')
@@ -314,6 +318,9 @@ export function UsersModule() {
   const editingRow = editingId ? teamRows.find((row) => row.id === editingId) || null : null
   const editingIsSuspended = editingRow?.accountStatus === 'SUSPENDED'
   const unitCount = new Set(teamRows.flatMap((row) => row.units)).size
+  const pageTotal = pagination?.total ?? summary.members ?? teamRows.length
+  const pageStart = pageTotal > 0 ? ((pagination?.page || page) - 1) * (pagination?.limit || TEAM_PAGE_SIZE) + 1 : 0
+  const pageEnd = pageTotal > 0 ? Math.min(pageTotal, pageStart + teamRows.length - 1) : 0
   const canRead = ['ADMIN', 'GESTOR', 'GERENTE', 'SUPERVISOR'].includes(role)
   const formReadOnly = !canManage
   const editTitles = Array.from(new Set([editingRow?.jobTitle, ...selectableTitles].filter((value): value is string => Boolean(value))))
@@ -335,12 +342,15 @@ export function UsersModule() {
         const params = new URLSearchParams()
         if (statusFilter) params.set('status', statusFilter)
         if (searchQuery.trim()) params.set('q', searchQuery.trim())
-        const result = await api<{ success?: boolean; data?: UnifiedTeamMember[]; summary?: TeamSummary; pendingItems?: TeamPendingItem[] }>(`/admin/team?${params.toString()}`, { csrf: auth.csrfToken })
+        params.set('page', String(page))
+        params.set('limit', String(TEAM_PAGE_SIZE))
+        const result = await api<{ success?: boolean; data?: UnifiedTeamMember[]; summary?: TeamSummary; pendingItems?: TeamPendingItem[]; pagination?: UnifiedTeamPagination }>(`/admin/team?${params.toString()}`, { csrf: auth.csrfToken })
         if (sequence !== loadSequence.current) return
         const members = Array.isArray(result?.data) ? result!.data! : []
         setTeamRows(members)
         setSelectedIds((current) => current.filter((id) => members.some((member) => member.id === id)))
         setSummary({ ...(result?.summary || { members: members.length }), pendingItems: result?.pendingItems || result?.summary?.pendingItems || [] })
+        setPagination(result?.pagination || { page, limit: TEAM_PAGE_SIZE, total: members.length, pages: 1, hasMore: false })
       } else {
         const params = new URLSearchParams({ status: statusFilter || 'ALL' })
         if (searchQuery.trim()) params.set('q', searchQuery.trim())
@@ -350,6 +360,7 @@ export function UsersModule() {
         setTeamRows(legacyRows.map((row) => ({ ...row, schedule: undefined, identityLinks: [] })))
         setSelectedIds([])
         setSummary(result?.summary || { members: legacyRows.length })
+        setPagination(null)
       }
       if (sequence === loadSequence.current) setLoadError('')
     } catch (error: any) {
@@ -357,12 +368,12 @@ export function UsersModule() {
     } finally {
       if (sequence === loadSequence.current) setLoading(false)
     }
-  }, [searchQuery, statusFilter])
+  }, [page, searchQuery, statusFilter])
 
   React.useEffect(() => { void load() }, [load])
 
   React.useEffect(() => {
-    const timer = window.setTimeout(() => setSearchQuery(searchInput), 250)
+    const timer = window.setTimeout(() => { setSearchQuery(searchInput); setPage(1) }, 250)
     return () => window.clearTimeout(timer)
   }, [searchInput])
 
@@ -776,7 +787,7 @@ export function UsersModule() {
                 </div>
               </div>
               <div className="flex items-center gap-2 text-xs text-blue-100/60">
-                <span>{loading ? 'Atualizando' : `${teamRows.length} ${teamRows.length === 1 ? 'membro' : 'membros'}`}</span>
+                <span>{loading ? 'Atualizando' : `${pageTotal} ${pageTotal === 1 ? 'membro' : 'membros'}`}</span>
                 <span className="size-1 rounded-full bg-white/25" aria-hidden="true" />
                 <span>{unitCount} {unitCount === 1 ? 'unidade' : 'unidades'}</span>
               </div>
@@ -801,7 +812,7 @@ export function UsersModule() {
                     <Input value={searchInput} onChange={(event) => setSearchInput(event.target.value)} placeholder="Buscar por nome, usuário, cargo ou unidade" className="pl-9" aria-label="Buscar equipe" />
                   </label>
                   <div className="flex flex-wrap items-center gap-2">
-                    <Select value={statusFilter} onValueChange={setStatusFilter}>
+                    <Select value={statusFilter} onValueChange={(value) => { setStatusFilter(value); setPage(1) }}>
                       <SelectTrigger className="w-full min-w-[170px] sm:w-[190px]" aria-label="Filtrar status"><SelectValue /></SelectTrigger>
                       <SelectContent>
                         <SelectItem value="ACTIVE">Ativos e convites</SelectItem>
@@ -812,11 +823,11 @@ export function UsersModule() {
                         <SelectItem value="ALL">Todos os estados</SelectItem>
                       </SelectContent>
                     </Select>
-                    {(searchInput || searchQuery || statusFilter !== 'ACTIVE') && <Button type="button" variant="ghost" size="sm" onClick={() => { setSearchInput(''); setSearchQuery(''); setStatusFilter('ACTIVE') }}>Limpar</Button>}
+                    {(searchInput || searchQuery || statusFilter !== 'ACTIVE') && <Button type="button" variant="ghost" size="sm" onClick={() => { setSearchInput(''); setSearchQuery(''); setStatusFilter('ACTIVE'); setPage(1) }}>Limpar</Button>}
                   </div>
                 </div>
                 <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
-                  <div className="rounded-xl border border-white/10 bg-white/[0.025] px-3 py-2"><p className="text-[10px] uppercase tracking-[0.12em] text-blue-100/45">Exibidos</p><p className="mt-1 text-lg font-semibold text-white">{teamRows.length}</p></div>
+                  <div className="rounded-xl border border-white/10 bg-white/[0.025] px-3 py-2"><p className="text-[10px] uppercase tracking-[0.12em] text-blue-100/45">Total</p><p className="mt-1 text-lg font-semibold text-white">{pageTotal}</p></div>
                   <div className="rounded-xl border border-amber-300/15 bg-amber-400/[0.06] px-3 py-2"><p className="text-[10px] uppercase tracking-[0.12em] text-amber-100/55">Convites</p><p className="mt-1 text-lg font-semibold text-amber-50">{summary.pendingInvites || 0}</p></div>
                   <div className="rounded-xl border border-sky-300/15 bg-sky-400/[0.06] px-3 py-2"><p className="text-[10px] uppercase tracking-[0.12em] text-sky-100/55">Vínculos pendentes</p><p className="mt-1 text-lg font-semibold text-sky-50">{summary.pendingLinks || 0}</p></div>
                   <div className="rounded-xl border border-rose-300/15 bg-rose-400/[0.06] px-3 py-2"><p className="text-[10px] uppercase tracking-[0.12em] text-rose-100/55">Contas sem vínculo</p><p className="mt-1 text-lg font-semibold text-rose-50">{summary.pendingAccountLinks || 0}</p></div>
@@ -957,6 +968,16 @@ export function UsersModule() {
               ))}
               {!teamRows.length && <div className="rounded-2xl border border-dashed border-white/15 p-5 text-sm text-blue-100/70">{loading ? 'Carregando…' : teamConfig.enabled ? (searchQuery || statusFilter !== 'ACTIVE' ? 'Nenhum membro corresponde aos filtros.' : 'Nenhum integrante ativo.') : 'A lista aparecerá após a liberação da centralização.'}</div>}
             </div>
+            {teamConfig.enabled && pagination && (
+              <nav className="mt-4 flex flex-col gap-3 rounded-2xl border border-white/10 bg-black/10 px-3 py-3 text-xs text-blue-100/65 sm:flex-row sm:items-center sm:justify-between" aria-label="Paginação da equipe">
+                <span>{pageTotal > 0 ? `Exibindo ${pageStart}–${pageEnd} de ${pageTotal}` : 'Nenhum membro encontrado'}</span>
+                <div className="flex items-center gap-2">
+                  <Button type="button" size="sm" variant="outline" disabled={loading || page <= 1} aria-label="Página anterior" onClick={() => setPage((current) => Math.max(1, current - 1))}>Anterior</Button>
+                  <span aria-live="polite" className="min-w-[5.5rem] text-center">Página {pagination.page} de {pagination.pages}</span>
+                  <Button type="button" size="sm" variant="outline" disabled={loading || !pagination.hasMore} aria-label="Próxima página" onClick={() => setPage((current) => current + 1)}>Próxima</Button>
+                </div>
+              </nav>
+            )}
           </CardContent>
         </Card>
       </div>

--- a/crm/console/e2e/users-module-fixtures.ts
+++ b/crm/console/e2e/users-module-fixtures.ts
@@ -43,10 +43,23 @@ function cloneRows() {
   return syntheticTeam.map((row) => ({ ...row, units: [...row.units], schedule: { ...row.schedule, units: [...row.schedule.units] }, scheduleSync: row.scheduleSync ? { ...row.scheduleSync } : undefined, identityLinks: row.identityLinks.map((link) => ({ ...link })) }))
 }
 
-type MockUsersOptions = { failedActivationFor?: string }
+type MockUsersOptions = { failedActivationFor?: string; paginated?: boolean }
 
 export async function mockUsersApi(page: Page, role = 'GESTOR', options: MockUsersOptions = {}) {
   const rows = cloneRows()
+  if (options.paginated) {
+    for (let index = 0; index < 52; index += 1) {
+      rows.push({
+        ...rows[0],
+        id: `e2e-extra-${index}`,
+        fullName: `Membro Extra ${index + 1}`,
+        username: `membroextra${index + 1}`,
+        corporateEmail: `membroextra${index + 1}@espacofacial.com`,
+        workforceEmployeeId: `e2e-wf-extra-${index}`,
+        identityLinks: [],
+      })
+    }
+  }
   const failedActivationRow = rows.find((row) => row.id === options.failedActivationFor)
   if (failedActivationRow) {
     failedActivationRow.accountStatus = 'INVITED'
@@ -65,13 +78,16 @@ export async function mockUsersApi(page: Page, role = 'GESTOR', options: MockUse
     if (path.endsWith('/api/crm/admin/team') && request.method() === 'GET') {
       const status = (url.searchParams.get('status') || 'ACTIVE').toUpperCase()
       const query = (url.searchParams.get('q') || '').toLowerCase()
-      const data = rows.filter((row) => status === 'ALL' ? true : status === 'ACTIVE' ? ['ACTIVE', 'INVITED'].includes(row.accountStatus) : row.accountStatus === status).filter((row) => !query || [row.fullName, row.username, row.corporateEmail, row.department, row.jobTitle, ...row.units].some((value) => value.toLowerCase().includes(query)))
+      const filtered = rows.filter((row) => status === 'ALL' ? true : status === 'ACTIVE' ? ['ACTIVE', 'INVITED'].includes(row.accountStatus) : row.accountStatus === status).filter((row) => !query || [row.fullName, row.username, row.corporateEmail, row.department, row.jobTitle, ...row.units].some((value) => value.toLowerCase().includes(query)))
+      const page = Number(url.searchParams.get('page') || '1')
+      const limit = Number(url.searchParams.get('limit') || '50')
+      const data = options.paginated ? filtered.slice((page - 1) * limit, page * limit) : filtered
       const pendingItems = data.flatMap((row) => [
         ...(!row.crmAccountLinked && ['ACTIVE', 'SUSPENDED', 'TERMINATED'].includes(row.accountStatus) ? [{ memberId: row.id, kind: 'CRM_ACCOUNT_LINK', status: row.crmAccountReviewStatus || 'PENDING' }] : []),
         ...row.identityLinks.filter((link) => link.reviewStatus === 'PENDING_REVIEW').map((link) => ({ memberId: row.id, kind: 'IDENTITY_LINK', source: link.source, status: link.reviewStatus })),
         ...(row.scheduleSync && ['PENDING', 'FAILED', 'BLOCKED'].includes(row.scheduleSync.state) ? [{ memberId: row.id, kind: 'ESCALA_SYNC', status: row.scheduleSync.state }] : []),
       ])
-      return send({ success: true, data, pendingItems, summary: { members: data.length, pendingInvites: data.filter((row) => row.accountStatus === 'INVITED').length, pendingLinks: pendingItems.length, pendingProvisioning: 0, pendingAccountLinks: data.filter((row) => !row.crmAccountLinked && ['ACTIVE', 'SUSPENDED', 'TERMINATED'].includes(row.accountStatus)).length } })
+      return send({ success: true, data, pendingItems, summary: { members: filtered.length, pendingInvites: filtered.filter((row) => row.accountStatus === 'INVITED').length, pendingLinks: filtered.reduce((total, row) => total + row.identityLinks.filter((link) => link.reviewStatus === 'PENDING_REVIEW').length, 0), pendingProvisioning: 0, pendingAccountLinks: filtered.filter((row) => !row.crmAccountLinked && ['ACTIVE', 'SUSPENDED', 'TERMINATED'].includes(row.accountStatus)).length }, ...(options.paginated ? { pagination: { page, limit, total: filtered.length, pages: Math.max(1, Math.ceil(filtered.length / limit)), hasMore: page < Math.max(1, Math.ceil(filtered.length / limit)) } } : {}) })
     }
     if (path.endsWith('/api/crm/admin/team/bulk-status') && request.method() === 'POST') {
       const body = await json()

--- a/crm/console/e2e/users-module.spec.ts
+++ b/crm/console/e2e/users-module.spec.ts
@@ -21,6 +21,17 @@ test.describe('Usuários e Equipe', () => {
     await expect(page.getByRole('table').getByText('Ana Ribeiro', { exact: true })).toHaveCount(0)
   })
 
+  test('navigates a server-paginated roster without losing the total count', async ({ page }) => {
+    await mockUsersApi(page, 'GESTOR', { paginated: true })
+    await page.goto('/?module=users')
+    await expect(page.getByRole('navigation', { name: 'Paginação da equipe' })).toBeVisible()
+    await expect(page.getByText('Página 1 de 2', { exact: true })).toBeVisible()
+    await expect(page.getByText('Exibindo 1–50 de 54', { exact: true })).toBeVisible()
+    await page.getByRole('button', { name: 'Próxima página' }).click()
+    await expect(page.getByText('Página 2 de 2', { exact: true })).toBeVisible()
+    await expect(page.getByText('Exibindo 51–54 de 54', { exact: true })).toBeVisible()
+  })
+
   test('keeps identity, operation, invite and read-only editing in one auditable flow', async ({ page }) => {
     await mockUsersApi(page)
     await page.goto('/?module=users')

--- a/crm/console/teamApi.ts
+++ b/crm/console/teamApi.ts
@@ -9,6 +9,14 @@ export type UnifiedTeamConfig = {
   }
 }
 
+export type UnifiedTeamPagination = {
+  page: number
+  limit: number
+  total: number
+  pages: number
+  hasMore: boolean
+}
+
 export type UnifiedTeamMember = {
   id: string
   fullName: string

--- a/inventory/migrations/0028_unified_team_query_indexes.sql
+++ b/inventory/migrations/0028_unified_team_query_indexes.sql
@@ -1,0 +1,8 @@
+-- Keep the unified team list bounded and deterministic as the roster grows.
+-- The route still applies the unit scope in SQL and in application code; these
+-- indexes only accelerate the status/order path and do not change any data.
+CREATE INDEX IF NOT EXISTS idx_crm_employee_onboarding_status_created
+  ON crm_employee_onboarding(account_status, created_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_crm_employee_onboarding_created
+  ON crm_employee_onboarding(created_at DESC, id DESC);

--- a/inventory/src/routes/admin.js
+++ b/inventory/src/routes/admin.js
@@ -247,6 +247,60 @@ function teamUnitsVisible(auth, units) {
   return actorUnits.length > 0 && targetUnits.length > 0 && targetUnits.every((unit) => actorUnits.includes(unit));
 }
 
+function parseTeamPage(value, fallback = 1) {
+  const parsed = Number.parseInt(String(value || ''), 10);
+  if (!Number.isInteger(parsed) || parsed < 1) return fallback;
+  return Math.min(parsed, 10000);
+}
+
+function parseTeamPageSize(value, fallback = 50) {
+  const parsed = Number.parseInt(String(value || ''), 10);
+  if (!Number.isInteger(parsed) || parsed < 1) return fallback;
+  return Math.min(parsed, 100);
+}
+
+function teamListSqlFilters(auth, requestedStatus, query) {
+  const clauses = [];
+  const params = [];
+  if (requestedStatus === 'ACTIVE') {
+    clauses.push(`AND o.account_status IN ('INVITED', 'ACTIVE')`);
+  } else if (requestedStatus !== 'ALL') {
+    clauses.push('AND o.account_status = ?');
+    params.push(requestedStatus);
+  }
+
+  if (normalizeRole(auth?.user?.role) !== 'ADMIN') {
+    const actorUnits = normalizeAllowedUnits(auth?.user?.allowedUnits);
+    if (!actorUnits.length) {
+      clauses.push('AND 0=1');
+    } else {
+      clauses.push(`AND json_valid(o.units_json)=1
+        AND json_array_length(o.units_json)>0
+        AND NOT EXISTS (
+          SELECT 1 FROM json_each(o.units_json) AS target_unit
+          WHERE lower(CAST(target_unit.value AS TEXT)) NOT IN (${actorUnits.map(() => '?').join(', ')})
+        )`);
+      params.push(...actorUnits);
+    }
+  }
+
+  const normalizedQuery = String(query || '').trim().toLowerCase();
+  if (normalizedQuery) {
+    const like = `%${normalizedQuery}%`;
+    clauses.push(`AND (
+      lower(COALESCE(o.full_name, '')) LIKE ?
+      OR lower(COALESCE(o.requested_username, '')) LIKE ?
+      OR lower(COALESCE(o.corporate_email, '')) LIKE ?
+      OR lower(COALESCE(o.department_name, '')) LIKE ?
+      OR lower(COALESCE(o.job_title, '')) LIKE ?
+      OR lower(COALESCE(t.schedule_role, '')) LIKE ?
+      OR lower(COALESCE(o.units_json, '')) LIKE ?
+    )`);
+    params.push(like, like, like, like, like, like, like);
+  }
+  return { clauses, params };
+}
+
 function teamPendingItems(rows) {
   const items = [];
   for (const row of rows || []) {
@@ -1787,16 +1841,29 @@ export async function handleAdminRoutes({
     try {
       const requestedStatus = String(url.searchParams.get('status') || 'active').trim().toUpperCase();
       const query = String(url.searchParams.get('q') || '').trim().toLowerCase();
-      const statusClause = requestedStatus === 'ALL'
-        ? ''
-        : requestedStatus === 'ACTIVE'
-          ? `AND o.account_status IN ('INVITED', 'ACTIVE')`
-          : `AND o.account_status = ?`;
-      const params = requestedStatus === 'ALL' || requestedStatus === 'ACTIVE' ? [] : [requestedStatus];
-      const rows = await env.DB.prepare(`SELECT o.*, t.schedule_professional_id, t.schedule_status, t.schedule_role, t.schedule_shift, t.schedule_nickname, t.schedule_instagram, t.units_json AS schedule_units_json, a.id AS crm_account_link_id, a.crm_username AS crm_account_username, a.review_status AS crm_account_review_status
-        FROM crm_employee_onboarding o LEFT JOIN crm_employee_team t ON t.onboarding_id=o.id
+      const page = parseTeamPage(url.searchParams.get('page'));
+      const limit = parseTeamPageSize(url.searchParams.get('limit'));
+      const filters = teamListSqlFilters(auth, requestedStatus, query);
+      const fromSql = `FROM crm_employee_onboarding o
+        LEFT JOIN crm_employee_team t ON t.onboarding_id=o.id
         LEFT JOIN crm_employee_account_links a ON a.onboarding_id=o.id
-        WHERE 1=1 ${statusClause} ORDER BY o.created_at DESC LIMIT 500`).bind(...params).all();
+        WHERE 1=1 ${filters.clauses.join(' ')}`;
+      const summaryRow = await env.DB.prepare(`SELECT
+        COUNT(*) AS total,
+        COALESCE(SUM(CASE WHEN o.account_status='INVITED' THEN 1 ELSE 0 END), 0) AS pending_invites,
+        COALESCE(SUM(CASE WHEN o.provisioning_state IN ('PROVISIONING', 'WORKFORCE_SYNCED', 'INVITE_PENDING', 'FAILED') THEN 1 ELSE 0 END), 0) AS pending_provisioning,
+        COALESCE(SUM(CASE WHEN o.account_status IN ('ACTIVE', 'SUSPENDED', 'TERMINATED')
+          AND NOT (UPPER(COALESCE(a.review_status, ''))='CONFIRMED' AND TRIM(COALESCE(a.crm_username, '')) <> '')
+          THEN 1 ELSE 0 END), 0) AS pending_account_links,
+        COALESCE(SUM((SELECT COUNT(*) FROM crm_employee_identity_links l
+          WHERE l.workforce_employee_id=o.workforce_employee_id AND l.review_status='PENDING_REVIEW')), 0) AS pending_links
+        ${fromSql}`).bind(...filters.params).first();
+      const total = Number(summaryRow?.total || 0);
+      const pages = Math.max(1, Math.ceil(total / limit));
+      const effectivePage = Math.min(page, pages);
+      const offset = (effectivePage - 1) * limit;
+      const rows = await env.DB.prepare(`SELECT o.*, t.schedule_professional_id, t.schedule_status, t.schedule_role, t.schedule_shift, t.schedule_nickname, t.schedule_instagram, t.schedule_color, t.units_json AS schedule_units_json, a.id AS crm_account_link_id, a.crm_username AS crm_account_username, a.review_status AS crm_account_review_status
+        ${fromSql} ORDER BY o.created_at DESC, o.id DESC LIMIT ? OFFSET ?`).bind(...filters.params, limit, offset).all();
       const visible = (rows?.results || [])
         .filter((row) => teamUnitsVisible(auth, row.units_json))
         .filter((row) => !query || [row.full_name, row.requested_username, row.corporate_email, row.department_name, row.job_title, ...normalizeAllowedUnits(row.units_json)]
@@ -1812,10 +1879,18 @@ export async function handleAdminRoutes({
         list.push(publicIdentityLink(link));
         linksByEmployee.set(key, list);
       }
-      const operations = await env.DB.prepare(`SELECT operation_key, operation_type, member_ids_json, result_json, created_at
-        FROM crm_team_operations
-        WHERE operation_type='ESCALA_SYNC'
-        ORDER BY created_at DESC LIMIT 2000`).all();
+      const onboardingIds = visible.map((row) => String(row.id || '').trim()).filter(Boolean);
+      const operations = onboardingIds.length
+        ? await env.DB.prepare(`SELECT operation_key, operation_type, member_ids_json, result_json, created_at
+          FROM crm_team_operations
+          WHERE operation_type='ESCALA_SYNC'
+            AND json_valid(member_ids_json)=1
+            AND EXISTS (
+              SELECT 1 FROM json_each(member_ids_json) AS member_id
+              WHERE member_id.value IN (${onboardingIds.map(() => '?').join(', ')})
+            )
+          ORDER BY created_at DESC LIMIT ?`).bind(...onboardingIds, Math.min(onboardingIds.length * 10, 1000)).all()
+        : { results: [] };
       const latestScheduleSync = latestScheduleSyncByMember(operations?.results || []);
       const data = visible.map((row) => publicTeamMember(
         row,
@@ -1831,7 +1906,18 @@ export async function handleAdminRoutes({
         data,
         activeOnly: requestedStatus !== 'ALL',
         status: requestedStatus,
-        summary: { members: data.length, pendingLinks, pendingProvisioning, pendingInvites, pendingAccountLinks },
+        pagination: { page: effectivePage, limit, total, pages, hasMore: effectivePage < pages },
+        summary: {
+          members: total,
+          pendingLinks: Number(summaryRow?.pending_links || 0),
+          pendingProvisioning: Number(summaryRow?.pending_provisioning || 0),
+          pendingInvites: Number(summaryRow?.pending_invites || 0),
+          pendingAccountLinks: Number(summaryRow?.pending_account_links || 0),
+          pagePendingLinks: pendingLinks,
+          pagePendingProvisioning: pendingProvisioning,
+          pagePendingInvites: pendingInvites,
+          pagePendingAccountLinks: pendingAccountLinks,
+        },
         pendingItems: teamPendingItems(data),
       }), { status: 200 }, appOrigin);
     } catch {

--- a/inventory/tests/teamPagination.test.mjs
+++ b/inventory/tests/teamPagination.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFile } from 'node:fs/promises';
+
+test('unified team listing is paginated and scoped before the database limit', async () => {
+  const admin = await readFile(new URL('../src/routes/admin.js', import.meta.url), 'utf8');
+  const localApi = await readFile(new URL('../../crm/api/server.js', import.meta.url), 'utf8');
+  const migration = await readFile(new URL('../migrations/0028_unified_team_query_indexes.sql', import.meta.url), 'utf8');
+
+  assert.match(admin, /parseTeamPage\(/);
+  assert.match(admin, /parseTeamPageSize\(/);
+  assert.match(admin, /function teamListSqlFilters\(/);
+  assert.match(admin, /json_each\(o\.units_json\)/);
+  assert.match(admin, /NOT EXISTS/);
+  assert.match(admin, /COUNT\(\*\) AS total/);
+  assert.match(admin, /ORDER BY o\.created_at DESC, o\.id DESC LIMIT \? OFFSET \?/);
+  assert.match(admin, /pagination: \{ page: effectivePage, limit, total, pages, hasMore: effectivePage < pages \}/);
+  assert.match(admin, /json_valid\(member_ids_json\)=1/);
+  assert.match(admin, /FROM json_each\(member_ids_json\)/);
+  assert.match(admin, /member_id\.value IN \(/);
+  assert.match(admin, /const onboardingIds = visible\.map\(\(row\) => String\(row\.id/);
+  assert.match(admin, /\.bind\(\.\.\.onboardingIds, Math\.min\(onboardingIds\.length \* 10, 1000\)\)/);
+  assert.match(admin, /const effectivePage = Math\.min\(page, pages\)/);
+  assert.doesNotMatch(admin, /ORDER BY o\.created_at DESC LIMIT 500/);
+
+  assert.match(localApi, /const filtered = store\.team/);
+  assert.match(localApi, /const data = filtered\.slice\([^\n]+\.map\(localPublicTeamMember\)/);
+  assert.match(localApi, /pagination: \{ page, limit, total, pages, hasMore: page < pages \}/);
+
+  assert.match(migration, /CREATE INDEX IF NOT EXISTS idx_crm_employee_onboarding_status_created/);
+  assert.match(migration, /CREATE INDEX IF NOT EXISTS idx_crm_employee_onboarding_created/);
+  assert.doesNotMatch(migration, /ALTER TABLE|DROP TABLE|DELETE FROM|UPDATE /i);
+});
+
+test('users UI carries the page boundary and exposes accessible navigation', async () => {
+  const users = await readFile(new URL('../../crm/console/UsersModule.tsx', import.meta.url), 'utf8');
+  assert.match(users, /params\.set\('page', String\(page\)\)/);
+  assert.match(users, /params\.set\('limit', String\(TEAM_PAGE_SIZE\)\)/);
+  assert.match(users, /aria-label="Paginação da equipe"/);
+  assert.match(users, /aria-label="Página anterior"/);
+  assert.match(users, /aria-label="Próxima página"/);
+  assert.match(users, /setPage\(1\)/);
+});


### PR DESCRIPTION
# Summary

Centraliza a consulta paginada de Usuários/Equipe com escopo por unidade aplicado no SQL, ordenação determinística e resumo global, preservando a defesa em profundidade na aplicação. A prévia local passa a respeitar o mesmo contrato público sem devolver campos pessoais brutos, e a interface exibe navegação acessível para listas maiores.

## Type of change
- [x] Feature
- [x] Fix
- [ ] Refactor
- [ ] Docs
- [x] Performance
- [x] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (README, API refs, diagrams)
- [ ] Security review (CodeQL, gitleaks)
- [x] Performance impact measured
- [ ] Remote migration applied

## Links
- Issue: —
- Design/ADR: —
- Migration steps: apply `0028_unified_team_query_indexes.sql` only through the governed staging/production workflow after schema and pre-production gates are green.

## Screenshots / Evidence

- Local runtime `gestor/users` ready at commit `fdfb01d4`; smoke gate `ok: true`, zero API/console/page errors and no request storms.
- Inventory suite: 77/77.
- Unified-team pagination contract test: 2/2.
- Console E2E users module: 10/10; accessibility: 2/2.
- Console focused unit tests: 14/14.
- Browser response verified `page=1&limit=50`, no `personalEmail` or `mobilePhone` in the public payload, and pending items remain identifier-only.
- No staging/production database or deployment mutation was performed in this PR.