### PR TITLE
fix(governance): accept canonical global lease resources

### DIFF
--- a/.github/workflows/ponto-orchestrator-gate.yml
+++ b/.github/workflows/ponto-orchestrator-gate.yml
@@ -187,7 +187,10 @@ jobs:
             GLOBAL_URL="$GLOBAL_INPUT_URL"
           fi
           [[ -n "$GLOBAL_URL" && -n "$GLOBAL_SECRET" ]] || { echo 'Global coordination URL and shared custody are required'; exit 1; }
-          [[ "$GLOBAL_RESOURCE" =~ ^(deploy|mutate|cloudflare|release):[a-z0-9][a-z0-9._/-]{0,127}:(preview|staging|pilot|canary|production|rollback)$ || "$GLOBAL_RESOURCE" =~ ^release:[a-z0-9][a-z0-9._/-]{0,127}$ ]] || {
+          # `global:*` is the reviewed cross-surface resource namespace used by
+          # the single-writer policy. Keep it compatible with the coordinator
+          # core, which already normalizes and scopes this resource class.
+          [[ "$GLOBAL_RESOURCE" =~ ^global:[a-z0-9][a-z0-9._/-]{0,127}$ || "$GLOBAL_RESOURCE" =~ ^(deploy|mutate|cloudflare|release):[a-z0-9][a-z0-9._/-]{0,127}:(preview|staging|pilot|canary|production|rollback)$ || "$GLOBAL_RESOURCE" =~ ^release:[a-z0-9][a-z0-9._/-]{0,127}$ ]] || {
             echo 'Global coordination resource is invalid'; exit 1;
           }
           source_sha="${RELEASE_SHA:-$GITHUB_SHA}"

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -379,6 +379,7 @@ test("general CRM Pages checks out trusted local coordination actions before usi
 test("the reusable orchestrator gate exposes global lease outputs to callers", () => {
   const workflow = read(".github/workflows/ponto-orchestrator-gate.yml");
 
+  assert.match(workflow, /GLOBAL_RESOURCE.*\^global:\[a-z0-9\]/s);
   assert.match(workflow, /steps\.global_enabled\.outputs\.proof_b64/);
   assert.match(workflow, /steps\.global_enabled\.outputs\.url/);
   assert.match(workflow, /id: global_enabled/);


### PR DESCRIPTION
Corrige a divergência entre os recursos globais global:* catalogados na política single-writer e o regex do reusable ponto-orchestrator-gate. Mantém o lease/coordenador obrigatório e o bloqueio fail-closed para recursos inválidos. Inclui cobertura estática. Nenhum dado, segredo ou binding foi alterado. Validação: npm run codex:global-coordination:test via Ubuntu-24.04, 139/139. Rollback: reverter este PR.