### PR TITLE
fix(escala): use staging D1 binding in deploy

### DIFF
--- a/.github/workflows/deploy-escala-api.yml
+++ b/.github/workflows/deploy-escala-api.yml
@@ -188,7 +188,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail
-          npx --yes wrangler@4 d1 migrations apply skincos-escala --remote --config workforce/schedule/wrangler.toml --env staging
+          npx --yes wrangler@4 d1 migrations apply skincos-escala-staging --remote --config workforce/schedule/wrangler.toml --env staging
 
       - name: Check Escala API deployment lease before staging deployment
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}


### PR DESCRIPTION
## Objetivo
Corrigir o nome do D1 usado pelo passo de migration da Escala em staging.

## Evidência
O binding em workforce/schedule/wrangler.toml é skincos-escala-staging. O run 31404626292 passou pelo guard, lease e secret sync, mas parou antes de escrever D1 porque o workflow chamava skincos-escala --env staging.

## Risco e rollout
- Escopo: somente o workflow de staging da Escala.
- Dados: nenhuma migration foi aplicada pelo run com falha.
- Rollback: reverter o commit/PR ou desabilitar ENABLE_ESCALA_API_DEPLOY_STAGING.
- Produção: o comando de produção permanece inalterado.

## Validação planejada
Reexecutar preview/staging no SHA deste PR, confirmar migrations 0003-0005, deploy e smoke da API staging.