### PR TITLE
fix(governance): migrate legacy coordinator nonce state

### DIFF
--- a/ops/cloudflare/global-coordinator/index.js
+++ b/ops/cloudflare/global-coordinator/index.js
@@ -10,6 +10,7 @@ import {
   emptyState,
   evaluateLeaseAdmission,
   lockScopeFor,
+  migratePersistedState,
   releaseLease,
   renewLease,
   revokeLease,
@@ -104,7 +105,7 @@ export class GlobalCoordinator extends DurableObject {
 
   coordinate(input) {
     const row = this.ctx.storage.sql.exec("SELECT state_json FROM coordinator_state WHERE id = 1").one();
-    const current = JSON.parse(row.state_json);
+    const current = migratePersistedState(JSON.parse(row.state_json));
     const nonce = consumeNonce(current, { nonce: input.nonce, digest: input.requestDigest, now: input.now, ttlMs: NONCE_TTL_MS });
     if (!nonce.accepted) return { accepted: false, valid: false, reason: nonce.reason };
     let result;

--- a/ops/governance/global-coordination-core.mjs
+++ b/ops/governance/global-coordination-core.mjs
@@ -197,6 +197,26 @@ function stateOrEmpty(state) {
   return clone(state);
 }
 
+// The first global coordinator rollout persisted the v1 state before request
+// nonces were introduced. Migrate only that additive field; any other malformed
+// state remains fail-closed instead of being silently repaired.
+export function migratePersistedState(state) {
+  const next = stateOrEmpty(state);
+  for (const [key, value] of Object.entries({
+    fencingCounters: next.fencingCounters,
+    leases: next.leases,
+  })) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error(`coordinator state ${key} is invalid`);
+    }
+  }
+  if (next.nonces === undefined) next.nonces = {};
+  if (!next.nonces || typeof next.nonces !== "object" || Array.isArray(next.nonces)) {
+    throw new Error("coordinator state nonces are invalid");
+  }
+  return next;
+}
+
 function assertTime(now) {
   if (!Number.isInteger(now) || now < 0) throw new Error("coordinator time is invalid");
 }
@@ -381,7 +401,7 @@ export function evaluateLeaseAdmission(state, request, { now } = {}) {
 }
 
 export function consumeNonce(state, { nonce, digest, now, ttlMs = 900_000 }) {
-  const next = stateOrEmpty(state);
+  const next = migratePersistedState(state);
   assertTime(now);
   assertTtl(ttlMs);
   const key = requireId(nonce, "request nonce");

--- a/scripts/codex-global-coordinator.mjs
+++ b/scripts/codex-global-coordinator.mjs
@@ -17,6 +17,7 @@ import {
   emptyState,
   evaluateLeaseAdmission,
   lockScopeFor,
+  migratePersistedState,
   normalizeReleaseIdentity,
   normalizeResourceKey,
   releaseLease,
@@ -26,7 +27,7 @@ import {
 } from "../ops/governance/global-coordination-core.mjs";
 import { matchesAny } from "./codex-autonomy-lib.mjs";
 
-export { acquireLease, authorizeMutation, buildIntent, buildLegacyIntentV1, canonicalJson, checkLease, compareDependencyClosure, emptyState, evaluateLeaseAdmission, lockScopeFor, normalizeReleaseIdentity, normalizeResourceKey, releaseLease, renewLease, revokeLease, consumeNonce };
+export { acquireLease, authorizeMutation, buildIntent, buildLegacyIntentV1, canonicalJson, checkLease, compareDependencyClosure, emptyState, evaluateLeaseAdmission, lockScopeFor, migratePersistedState, normalizeReleaseIdentity, normalizeResourceKey, releaseLease, renewLease, revokeLease, consumeNonce };
 export { CONTRACT_ID };
 
 export const ROOT = path.resolve(import.meta.dirname, "..");

--- a/scripts/tests/codex-global-coordination.test.mjs
+++ b/scripts/tests/codex-global-coordination.test.mjs
@@ -18,6 +18,7 @@ import {
   evaluateLeaseAdmission,
   loadGlobalPolicy,
   lockScopeFor,
+  migratePersistedState,
   normalizeResourceKey,
   releaseLease,
   renewLease,
@@ -215,6 +216,22 @@ test("renewal and nonce replay are explicit state transitions", () => {
   assert.equal(renewed.lease.updatedAt, 20_000);
   assert.equal(renewed.lease.heartbeatAt, 20_000);
   assert.equal(fs.existsSync(new URL("../../ops/governance/global-concurrency-policy.json", import.meta.url)), true);
+});
+
+test("legacy persisted coordinator state receives only the additive nonce map", () => {
+  const legacy = {
+    schemaVersion: 1,
+    contractId: "skincos/global-coordination/v1",
+    fencingCounters: { "repository:skincos": 4 },
+    leases: {},
+  };
+  const migrated = migratePersistedState(legacy);
+  assert.deepEqual(migrated.nonces, {});
+  assert.deepEqual(migrated.fencingCounters, legacy.fencingCounters);
+  assert.deepEqual(migrated.leases, legacy.leases);
+  assert.equal(legacy.nonces, undefined);
+  assert.throws(() => migratePersistedState({ ...legacy, leases: null }), /coordinator state leases is invalid/);
+  assert.throws(() => migratePersistedState({ ...legacy, nonces: [] }), /coordinator state nonces are invalid/);
 });
 
 test("global admission allows an unrelated merge while fencing a closure-overlapping merge", () => {


### PR DESCRIPTION
## Objetivo\nRestaurar a coordenação global quando o Durable Object existente foi criado antes da introdução de request nonces.\n\n## Escopo\n- migra somente o campo aditivo 
onces ausente;\n- preserva leases e contadores;\n- falha fechada para estado inválido;\n- adiciona teste de compatibilidade e rejeição.\n\n## Evidência\n- suíte codex:global-coordination:test: 144/144;\n- staging authority run 31405556085 reproduziu coordination request could not be processed;\n- sem reset, exclusão ou reinterpretação de estado.\n\n## Rollback\nReverter o commit/PR e restaurar a versão anterior do Worker somente se o smoke assinado pós-deploy falhar; o estado do Durable Object permanece preservado.