### PR TITLE
fix(api): allow unified team binding latency

### DIFF
--- a/api/src/gateway.js
+++ b/api/src/gateway.js
@@ -9,10 +9,11 @@ const FINANCE_PROBE_TIMEOUT_MS = 3_000;
 const FINANCE_READ_TIMEOUT_MS = 3_000;
 const FINANCE_WRITE_TIMEOUT_MS = 5_000;
 // Inventory's authenticated routes traverse the service's rate-limiter
-// Durable Object before reaching D1. Keep this bounded, but above the public
-// probe budget so normal cold-start latency is not turned into a fabricated
-// 503 by the Core gateway.
+// Durable Object before reaching D1. Keep the normal budget bounded, but give
+// the unified team route a separate budget because its readiness/config read
+// intentionally checks several D1 tables before returning.
 const INVENTORY_READ_TIMEOUT_MS = 3_000;
+const INVENTORY_TEAM_TIMEOUT_MS = 8_000;
 const CLOUDFLARE_VERSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const NETWORK_CONTEXT_RE = /^v1:[A-Za-z0-9_-]{43}$/;
 const B64URL_SHA256_RE = /^[A-Za-z0-9_-]{43}$/;
@@ -80,6 +81,13 @@ function financeServiceTimeout(request) {
     return ['GET', 'HEAD'].includes(request.method) ? FINANCE_READ_TIMEOUT_MS : FINANCE_WRITE_TIMEOUT_MS;
 }
 
+function inventoryServiceTimeout(request) {
+    const pathname = new URL(request.url).pathname;
+    return pathname === '/admin/team' || pathname.startsWith('/admin/team/')
+        ? INVENTORY_TEAM_TIMEOUT_MS
+        : INVENTORY_READ_TIMEOUT_MS;
+}
+
 export async function forwardFinanceProbe(request, env) {
     // This route is read-only and is itself evaluated by the external monitor's
     // latency budget. Keep the service-binding deadline above that budget so a
@@ -139,7 +147,7 @@ export function createApiGateway({ inventoryHandler, timekeepingHandler, finance
 export { createGatewayHandler } from './router.js';
 
 export const handleGatewayRequest = createApiGateway({
-    inventoryHandler: (request, env) => fetchBoundService(request, env, 'INVENTORY', { timeoutMs: INVENTORY_READ_TIMEOUT_MS }),
+    inventoryHandler: (request, env) => fetchBoundService(request, env, 'INVENTORY', { timeoutMs: inventoryServiceTimeout(request) }),
     timekeepingHandler: (request, env) => fetchBoundService(request, env, 'TIMEKEEPING', { timeoutMs: 800 }),
     financeDomainHandler: forwardFinanceToService,
 });

--- a/api/test/gateway.test.mjs
+++ b/api/test/gateway.test.mjs
@@ -249,6 +249,26 @@ test('default gateway tolerates stateful Inventory binding latency beyond the pu
     assert.equal(response.headers.get('x-skincos-dependency-status'), 'live');
 });
 
+test('default gateway gives unified team reads a bounded readiness budget', async () => {
+    resetBoundServiceResilienceForTest();
+    const response = await handleGatewayRequest(
+        new Request('https://api.skincos.com.br/inventory/admin/team?mode=config'),
+        {
+            INVENTORY: {
+                fetch: async (request) => {
+                    assert.equal(new URL(request.url).pathname, '/admin/team');
+                    await new Promise((resolve) => setTimeout(resolve, 3_200));
+                    return new Response('team-config-result');
+                },
+            },
+        },
+        {},
+    );
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), 'team-config-result');
+    assert.equal(response.headers.get('x-skincos-dependency-status'), 'live');
+});
+
 test('an unavailable optional Inventory binding degrades only its route and leaves gateway health operational', async () => {
     resetBoundServiceResilienceForTest();
     const inventory = await handleGatewayRequest(new Request('https://api.skincos.com.br/inventory/insumos'), {}, {});


### PR DESCRIPTION
## Context
The current staged Users/Equipe journey reaches the Inventory service, but the Core API gateway aborted `GET /inventory/admin/team?mode=config` after 3 seconds. The direct staging service completed the same read in about 4.1 seconds, so the gateway returned a false `503 domain_service_degraded`.

## Change
- keep the normal Inventory binding timeout at 3 seconds;
- give `/admin/team` and its subroutes a separate bounded 8-second timeout;
- add a regression test proving a 3.2-second unified-team response remains live.

This keeps the fail-closed service-binding behavior and circuit breaker intact without widening every Inventory route.

## Validation
- `npm run api:test` — 31/31 passing;
- `git diff --check` — passing;
- staging diagnostic fixture `31412070763` was removed and remote counts for `crm_users`, onboarding, team and links are all zero;
- no production data or deployment was changed.