### PR TITLE
fix(governance): pass coordination key through composite actions

### DIFF
--- a/.github/actions/global-coordination-acquire/action.yml
+++ b/.github/actions/global-coordination-acquire/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: Shared custody secret passed only in process environment
     required: true
   key_id:
-    description: Optional active coordination key identifier; defaults to the repository variable
+    description: Optional active coordination key identifier supplied by the caller; empty preserves legacy coordination compatibility
     required: false
     default: ''
   resource:
@@ -44,7 +44,7 @@ runs:
       env:
         SKINCOS_GLOBAL_COORDINATOR_URL: ${{ inputs.coordinator_url }}
         SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ inputs.shared_secret }}
-        SKINCOS_GLOBAL_COORDINATION_KEY_ID: ${{ inputs.key_id || vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+        SKINCOS_GLOBAL_COORDINATION_KEY_ID: ${{ inputs.key_id }}
         GLOBAL_ENABLED: ${{ inputs.enabled }}
         GLOBAL_RESOURCE: ${{ inputs.resource }}
         GLOBAL_MODULE: ${{ inputs.module }}

--- a/.github/actions/global-coordination-check/action.yml
+++ b/.github/actions/global-coordination-check/action.yml
@@ -32,7 +32,7 @@ inputs:
     description: Shared custody secret passed only in process environment
     required: true
   key_id:
-    description: Optional active coordination key identifier; defaults to the repository variable
+    description: Optional active coordination key identifier supplied by the caller; empty preserves legacy coordination compatibility
     required: false
     default: ''
 runs:
@@ -46,7 +46,7 @@ runs:
       env:
         SKINCOS_GLOBAL_COORDINATOR_URL: ${{ inputs.coordinator_url }}
         SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ inputs.shared_secret }}
-        SKINCOS_GLOBAL_COORDINATION_KEY_ID: ${{ inputs.key_id || vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+        SKINCOS_GLOBAL_COORDINATION_KEY_ID: ${{ inputs.key_id }}
         GLOBAL_PROOF_B64: ${{ inputs.proof_b64 }}
         GLOBAL_PROOF_FILE_INPUT: ${{ inputs.proof_file }}
         GLOBAL_RESOURCE: ${{ inputs.resource }}

--- a/.github/actions/global-coordination-release/action.yml
+++ b/.github/actions/global-coordination-release/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: Shared custody secret passed only in process environment
     required: true
   key_id:
-    description: Optional active coordination key identifier; defaults to the repository variable
+    description: Optional active coordination key identifier supplied by the caller; empty preserves legacy coordination compatibility
     required: false
     default: ''
   proof_file:
@@ -28,7 +28,7 @@ runs:
       env:
         SKINCOS_GLOBAL_COORDINATOR_URL: ${{ inputs.coordinator_url }}
         SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ inputs.shared_secret }}
-        SKINCOS_GLOBAL_COORDINATION_KEY_ID: ${{ inputs.key_id || vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+        SKINCOS_GLOBAL_COORDINATION_KEY_ID: ${{ inputs.key_id }}
         GLOBAL_PROOF_FILE: ${{ inputs.proof_file }}
       run: |
         set -euo pipefail

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -99,7 +99,7 @@ test("the reusable check action accepts either an external proof file or an enco
   const action = read(".github/actions/global-coordination-check/action.yml");
   assert.match(action, /proof_b64:[\s\S]*?required: false/);
   assert.match(action, /proof_file:[\s\S]*?required: false/);
-  assert.match(action, /key_id:[\s\S]*?defaults to the repository variable/);
+  assert.match(action, /key_id:[\s\S]*?supplied by the caller/);
   assert.match(action, /observed_source_sha:[\s\S]*?required: false/);
   assert.match(action, /git fetch --no-tags --force origin main:refs\/remotes\/origin\/main/);
   assert.match(action, /git fetch --no-tags origin "\$GLOBAL_SOURCE_SHA"/);
@@ -112,8 +112,15 @@ test("the reusable check action accepts either an external proof file or an enco
   assert.match(action, /base64 -d/);
   assert.match(action, /coordination_max_attempts=3/);
   assert.match(action, /Global coordination revalidation failed after/);
-  assert.match(read(".github/actions/global-coordination-acquire/action.yml"), /SKINCOS_GLOBAL_COORDINATION_KEY_ID/);
-  assert.match(read(".github/actions/global-coordination-release/action.yml"), /SKINCOS_GLOBAL_COORDINATION_KEY_ID/);
+  for (const file of [
+    ".github/actions/global-coordination-acquire/action.yml",
+    ".github/actions/global-coordination-check/action.yml",
+    ".github/actions/global-coordination-release/action.yml",
+  ]) {
+    const reusableAction = read(file);
+    assert.match(reusableAction, /SKINCOS_GLOBAL_COORDINATION_KEY_ID:\s+\$\{\{\s*inputs\.key_id\s*\}\}/);
+    assert.doesNotMatch(reusableAction, /\bvars\./);
+  }
 });
 
 test("the staging RBAC journey recovers synthetic teardown under a fresh lease", () => {


### PR DESCRIPTION
## Objetivo
Corrigir o carregamento das composite actions de coordenação global. A referência de variável de repositório não é válida no contexto de uma action composta e impedia as gates de staging antes de qualquer mutação Cloudflare.

## Alteração
- recebe o key_id pelo input do chamador nas actions acquire, check e release;
- mantém vazio o input por compatibilidade com o contrato legado atual;
- amplia o teste estático para impedir regressão do contexto inválido.

## Validação
- node --test scripts/tests/global-concurrency-governance-static.test.mjs via wrapper WSL;
- npm run codex:global-coordination:test via wrapper WSL (158 testes);
- git diff --check.

## Risco e rollback
Mudança somente em governança de workflow, sem alteração de runtime CRM, flag, banco ou Cloudflare. Rollback pelo revert do commit 5da940a4.