### PR TITLE
fix(governance): remove unsupported vars from composite actions

### DIFF
--- a/.github/actions/global-coordination-acquire/action.yml
+++ b/.github/actions/global-coordination-acquire/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: Shared custody secret passed only in process environment
     required: true
   key_id:
-    description: Optional active coordination key identifier; defaults to the repository variable
+    description: Optional active coordination key identifier; overrides the job environment when provided
     required: false
     default: ''
   resource:
@@ -44,7 +44,7 @@ runs:
       env:
         SKINCOS_GLOBAL_COORDINATOR_URL: ${{ inputs.coordinator_url }}
         SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ inputs.shared_secret }}
-        SKINCOS_GLOBAL_COORDINATION_KEY_ID: ${{ inputs.key_id || vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+        GLOBAL_KEY_ID_INPUT: ${{ inputs.key_id }}
         GLOBAL_ENABLED: ${{ inputs.enabled }}
         GLOBAL_RESOURCE: ${{ inputs.resource }}
         GLOBAL_MODULE: ${{ inputs.module }}
@@ -56,6 +56,11 @@ runs:
         set -euo pipefail
         [[ "$GLOBAL_ENABLED" == true ]] || { echo 'Global coordination is not active'; exit 1; }
         [[ -n "$SKINCOS_GLOBAL_COORDINATOR_URL" && -n "$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" ]] || { echo 'Global coordination custody is unavailable'; exit 1; }
+        coordination_key_id="${GLOBAL_KEY_ID_INPUT:-${SKINCOS_GLOBAL_COORDINATION_KEY_ID:-}}"
+        if [[ -n "$coordination_key_id" && ! "$coordination_key_id" =~ ^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$ ]]; then
+          echo 'Global coordination key identifier is invalid'
+          exit 1
+        fi
         [[ "$GLOBAL_SOURCE_SHA" =~ ^[0-9a-fA-F]{40}$ ]] || { echo 'Global coordination source SHA is invalid'; exit 1; }
         [[ "$GLOBAL_PROOF_FILE" != "$GITHUB_WORKSPACE"/* ]] || { echo 'Global coordination proof must live outside the repository'; exit 1; }
         mkdir -p "$(dirname "$GLOBAL_PROOF_FILE")"
@@ -68,7 +73,7 @@ runs:
         git cat-file -e "${GLOBAL_SOURCE_SHA}^{commit}"
         SKINCOS_GLOBAL_COORDINATOR_URL="$SKINCOS_GLOBAL_COORDINATOR_URL" \
         SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET="$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" \
-        SKINCOS_GLOBAL_COORDINATION_KEY_ID="${SKINCOS_GLOBAL_COORDINATION_KEY_ID:-}" \
+        SKINCOS_GLOBAL_COORDINATION_KEY_ID="$coordination_key_id" \
           node scripts/codex-global-coordination-workflow.mjs acquire \
             --resource "$GLOBAL_RESOURCE" \
             --module "$GLOBAL_MODULE" \

--- a/.github/actions/global-coordination-check/action.yml
+++ b/.github/actions/global-coordination-check/action.yml
@@ -32,7 +32,7 @@ inputs:
     description: Shared custody secret passed only in process environment
     required: true
   key_id:
-    description: Optional active coordination key identifier; defaults to the repository variable
+    description: Optional active coordination key identifier; overrides the job environment when provided
     required: false
     default: ''
 runs:
@@ -46,7 +46,7 @@ runs:
       env:
         SKINCOS_GLOBAL_COORDINATOR_URL: ${{ inputs.coordinator_url }}
         SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ inputs.shared_secret }}
-        SKINCOS_GLOBAL_COORDINATION_KEY_ID: ${{ inputs.key_id || vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+        GLOBAL_KEY_ID_INPUT: ${{ inputs.key_id }}
         GLOBAL_PROOF_B64: ${{ inputs.proof_b64 }}
         GLOBAL_PROOF_FILE_INPUT: ${{ inputs.proof_file }}
         GLOBAL_RESOURCE: ${{ inputs.resource }}
@@ -59,6 +59,11 @@ runs:
         set -euo pipefail
         [[ "$GLOBAL_ENABLED" == true ]] || { echo 'Global coordination is not active'; exit 1; }
         [[ -n "$SKINCOS_GLOBAL_COORDINATOR_URL" && -n "$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" ]] || { echo 'Global coordination custody is unavailable'; exit 1; }
+        coordination_key_id="${GLOBAL_KEY_ID_INPUT:-${SKINCOS_GLOBAL_COORDINATION_KEY_ID:-}}"
+        if [[ -n "$coordination_key_id" && ! "$coordination_key_id" =~ ^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$ ]]; then
+          echo 'Global coordination key identifier is invalid'
+          exit 1
+        fi
         [[ "$GLOBAL_SOURCE_SHA" =~ ^[0-9a-fA-F]{40}$ ]] || { echo 'Global coordination source SHA is invalid'; exit 1; }
         if [[ -z "$GLOBAL_OBSERVED_SOURCE_SHA" ]]; then
           git fetch --no-tags --force origin main:refs/remotes/origin/main
@@ -82,12 +87,12 @@ runs:
         while (( coordination_attempt <= coordination_max_attempts )); do
           if SKINCOS_GLOBAL_COORDINATOR_URL="$SKINCOS_GLOBAL_COORDINATOR_URL" \
             SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET="$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" \
-            SKINCOS_GLOBAL_COORDINATION_KEY_ID="${SKINCOS_GLOBAL_COORDINATION_KEY_ID:-}" \
+            SKINCOS_GLOBAL_COORDINATION_KEY_ID="$coordination_key_id" \
               node scripts/codex-global-coordination-workflow.mjs renew \
                 --proof-file "$GLOBAL_PROOF_FILE" && \
             SKINCOS_GLOBAL_COORDINATOR_URL="$SKINCOS_GLOBAL_COORDINATOR_URL" \
             SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET="$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" \
-            SKINCOS_GLOBAL_COORDINATION_KEY_ID="${SKINCOS_GLOBAL_COORDINATION_KEY_ID:-}" \
+            SKINCOS_GLOBAL_COORDINATION_KEY_ID="$coordination_key_id" \
               node scripts/codex-global-coordination-workflow.mjs check \
                 --proof-file "$GLOBAL_PROOF_FILE" \
                 --resource "$GLOBAL_RESOURCE" \

--- a/.github/actions/global-coordination-release/action.yml
+++ b/.github/actions/global-coordination-release/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: Shared custody secret passed only in process environment
     required: true
   key_id:
-    description: Optional active coordination key identifier; defaults to the repository variable
+    description: Optional active coordination key identifier; overrides the job environment when provided
     required: false
     default: ''
   proof_file:
@@ -28,11 +28,16 @@ runs:
       env:
         SKINCOS_GLOBAL_COORDINATOR_URL: ${{ inputs.coordinator_url }}
         SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ inputs.shared_secret }}
-        SKINCOS_GLOBAL_COORDINATION_KEY_ID: ${{ inputs.key_id || vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+        GLOBAL_KEY_ID_INPUT: ${{ inputs.key_id }}
         GLOBAL_PROOF_FILE: ${{ inputs.proof_file }}
       run: |
         set -euo pipefail
         [[ -n "$SKINCOS_GLOBAL_COORDINATOR_URL" && -n "$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" ]] || { echo 'Global coordination custody is unavailable'; exit 1; }
+        coordination_key_id="${GLOBAL_KEY_ID_INPUT:-${SKINCOS_GLOBAL_COORDINATION_KEY_ID:-}}"
+        if [[ -n "$coordination_key_id" && ! "$coordination_key_id" =~ ^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$ ]]; then
+          echo 'Global coordination key identifier is invalid'
+          exit 1
+        fi
         if [[ ! -f "$GLOBAL_PROOF_FILE" ]]; then
           echo 'No global coordination proof was acquired; nothing to release'
           exit 0
@@ -42,7 +47,7 @@ runs:
         while true; do
           if SKINCOS_GLOBAL_COORDINATOR_URL="$SKINCOS_GLOBAL_COORDINATOR_URL" \
           SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET="$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" \
-          SKINCOS_GLOBAL_COORDINATION_KEY_ID="${SKINCOS_GLOBAL_COORDINATION_KEY_ID:-}" \
+          SKINCOS_GLOBAL_COORDINATION_KEY_ID="$coordination_key_id" \
             node scripts/codex-global-coordination-workflow.mjs release \
               --proof-file "$GLOBAL_PROOF_FILE"; then
             exit 0

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -99,7 +99,7 @@ test("the reusable check action accepts either an external proof file or an enco
   const action = read(".github/actions/global-coordination-check/action.yml");
   assert.match(action, /proof_b64:[\s\S]*?required: false/);
   assert.match(action, /proof_file:[\s\S]*?required: false/);
-  assert.match(action, /key_id:[\s\S]*?defaults to the repository variable/);
+  assert.match(action, /key_id:[\s\S]*?overrides the job environment when provided/);
   assert.match(action, /observed_source_sha:[\s\S]*?required: false/);
   assert.match(action, /git fetch --no-tags --force origin main:refs\/remotes\/origin\/main/);
   assert.match(action, /git fetch --no-tags origin "\$GLOBAL_SOURCE_SHA"/);
@@ -114,6 +114,17 @@ test("the reusable check action accepts either an external proof file or an enco
   assert.match(action, /Global coordination revalidation failed after/);
   assert.match(read(".github/actions/global-coordination-acquire/action.yml"), /SKINCOS_GLOBAL_COORDINATION_KEY_ID/);
   assert.match(read(".github/actions/global-coordination-release/action.yml"), /SKINCOS_GLOBAL_COORDINATION_KEY_ID/);
+  for (const actionPath of [
+    ".github/actions/global-coordination-acquire/action.yml",
+    ".github/actions/global-coordination-check/action.yml",
+    ".github/actions/global-coordination-release/action.yml",
+  ]) {
+    const source = read(actionPath);
+    assert.doesNotMatch(source, /\$\{\{[^\n}]*\bvars\./, `${actionPath} must not use the workflow-only vars context`);
+    assert.match(source, /GLOBAL_KEY_ID_INPUT: \$\{\{ inputs\.key_id \}\}/);
+    assert.match(source, /coordination_key_id="\$\{GLOBAL_KEY_ID_INPUT:-\$\{SKINCOS_GLOBAL_COORDINATION_KEY_ID:-\}\}"/);
+    assert.match(source, /Global coordination key identifier is invalid/);
+  }
 });
 
 test("the staging RBAC journey recovers synthetic teardown under a fresh lease", () => {


### PR DESCRIPTION
## Context\nThe governance rollout introduced ars expressions inside composite action metadata. GitHub rejects that context before any job step runs, blocking the CRM Pages staging deployment.\n\n## Change\n- remove the unsupported workflow-only ars context from the three composite coordination actions;\n- accept an explicit key_id input or inherited job environment;\n- validate the identifier and preserve the existing legacy-v1 behavior when no rotation is configured;\n- add a static regression guard.\n\n## Validation\n- codex:global-coordination:test — 158 passed\n- git diff --check — passed\n\nNo Cloudflare, database, staging, or production mutation is included in this PR.