### PR TITLE
fix(governance): retry coordinator readiness after propagation

### DIFF
--- a/.github/workflows/deploy-global-coordinator.yml
+++ b/.github/workflows/deploy-global-coordinator.yml
@@ -263,16 +263,29 @@ jobs:
             idempotencyKey: `global-coordinator-readiness:${runId}:${targetId}`,
             ttlMs: 30_000,
           });
-          const result = await evaluateGlobalGate({
-            request,
-            url: process.env.COORDINATOR_URL,
-            secret: process.env.COORDINATION_SHARED_SECRET,
-            keyId: process.env.COORDINATION_ACTIVE_KEY_ID,
-            previousKeyId: process.env.COORDINATION_PREVIOUS_KEY_ID,
-            previousSecret: process.env.COORDINATION_PREVIOUS_KEY,
-            previousKeyExpiresAt: process.env.COORDINATION_PREVIOUS_KEY_EXPIRES_AT,
-          });
-          if (result.passed !== true) throw new Error(`signed coordination gate denied: ${result.reason || 'unknown'}`);
+          let result;
+          let gateAttempts = 0;
+          for (gateAttempts = 1; gateAttempts <= 6; gateAttempts += 1) {
+            try {
+              result = await evaluateGlobalGate({
+                request,
+                url: process.env.COORDINATOR_URL,
+                secret: process.env.COORDINATION_SHARED_SECRET,
+                keyId: process.env.COORDINATION_ACTIVE_KEY_ID,
+                previousKeyId: process.env.COORDINATION_PREVIOUS_KEY_ID,
+                previousSecret: process.env.COORDINATION_PREVIOUS_KEY,
+                previousKeyExpiresAt: process.env.COORDINATION_PREVIOUS_KEY_EXPIRES_AT,
+              });
+              if (result.passed !== true) throw new Error(`signed coordination gate denied: ${result.reason || 'unknown'}`);
+              break;
+            } catch (error) {
+              // A policy denial is final. Transport/custody rejection may be
+              // eventual immediately after a Worker version or secret update.
+              if (String(error?.message || '').startsWith('signed coordination gate denied:') || gateAttempts === 6) throw error;
+              console.log(`signed coordination gate retry ${gateAttempts}/5 after bounded propagation delay`);
+              await new Promise((resolve) => setTimeout(resolve, 5_000));
+            }
+          }
           fs.writeFileSync(process.env.EVIDENCE_DIR + '/summary.json', `${JSON.stringify({
             schemaVersion: 1,
             target: process.env.TARGET,
@@ -283,7 +296,7 @@ jobs:
             bootstrap: process.env.ALLOW_PRODUCTION_BOOTSTRAP === 'true',
             previousVersionId: process.env.PREVIOUS_VERSION_ID || null,
             currentVersionId: process.env.CURRENT_VERSION_ID,
-            signedGate: { passed: result.passed, reason: result.reason, httpStatus: result.httpStatus },
+            signedGate: { passed: result.passed, reason: result.reason, httpStatus: result.httpStatus, attempts: gateAttempts },
             workflow: process.env.GITHUB_WORKFLOW,
             runId: process.env.GITHUB_RUN_ID,
           }, null, 2)}\n`, { mode: 0o600 });

--- a/ops/cloudflare/global-coordinator/index.js
+++ b/ops/cloudflare/global-coordinator/index.js
@@ -46,7 +46,7 @@ const jsonResponse = (payload, status = 200, headers = {}) => new Response(JSON.
   status,
   headers: { "content-type": "application/json", "cache-control": "no-store", ...headers },
 });
-const bad = (message, status = 401) => jsonResponse({ schemaVersion: 1, contractId: CONTRACT_ID, passed: false, error: message }, status);
+const bad = (message, status = 401, extra = {}) => jsonResponse({ schemaVersion: 1, contractId: CONTRACT_ID, passed: false, ...extra, error: message }, status);
 const OBSERVABILITY_FIELDS = new Set([
   "route",
   "action",
@@ -65,6 +65,15 @@ function logEvent(event, fields = {}) {
     if (OBSERVABILITY_FIELDS.has(name) && (typeof value === "string" || typeof value === "number" || typeof value === "boolean")) record[name] = value;
   }
   try { console.log(JSON.stringify(record)); } catch { /* logging must never change the mutation decision */ }
+}
+
+function processingErrorCode(error) {
+  const message = String(error?.message || "");
+  if (message.includes("coordinator state")) return "coordinator-state-invalid";
+  if (message.includes("request nonce")) return "coordination-nonce-invalid";
+  if (message.includes("lease")) return "coordination-lease-invalid";
+  if (message.includes("intent")) return "coordination-intent-invalid";
+  return "coordination-processing-error";
 }
 
 function bindingFor(request, url, nonce, requestedAt, requestDigest, keyId) {
@@ -363,9 +372,10 @@ export default {
         resourceClass: lockScope || "global",
       });
       return jsonResponse(payload, status);
-    } catch {
-      emit("coordination.request_failed", { action: body?.action || "unknown", status: 400, result: "processing_error" });
-      return bad("coordination request could not be processed", 400);
+    } catch (error) {
+      const errorCode = processingErrorCode(error);
+      emit("coordination.request_failed", { action: body?.action || "unknown", status: 400, result: errorCode });
+      return bad("coordination request could not be processed", 400, { errorCode });
     }
   },
 };

--- a/scripts/codex-global-coordination-client.mjs
+++ b/scripts/codex-global-coordination-client.mjs
@@ -326,7 +326,7 @@ export async function coordinate({
   const error = String(payload?.error || payload?.reason || `HTTP ${response.status}`);
   const errorCode = String(payload?.errorCode || "").trim();
   const suffix = errorCode ? ` [${errorCode}]` : "";
-  throw new Error(`global coordinator request failed: ${error}${suffix}`);
+  throw new Error(`global coordinator ${action} request failed: ${error}${suffix}`);
 }
 
 export async function acquireGlobalLease({ request, ...options }) {

--- a/scripts/codex-global-coordination-client.mjs
+++ b/scripts/codex-global-coordination-client.mjs
@@ -2,6 +2,7 @@
 import crypto from "node:crypto";
 import {
   buildIntent,
+  buildLegacyIntentV1,
   canonicalJson,
   CONTRACT_ID,
   lockScopeFor,
@@ -38,6 +39,19 @@ export function buildLeaseRequest({ operation, resource, owner, intent, idempote
   };
 }
 
+// Transitional adapter for a coordinator Worker that predates the explicit
+// owner.sessionId digest field. It changes only the request canonicalization;
+// the remote coordinator still owns the lease, fencing token, and mutation
+// decision. Remove this adapter after every governed plane reports epoch-fence-v1.
+export function buildLegacyLeaseRequest({ operation, resource, owner, intent, idempotencyKey, ttlMs }) {
+  const normalized = buildLegacyIntentV1({ operation, resource, owner, intent, idempotencyKey });
+  return {
+    ...normalized,
+    ttlMs,
+    intentDigest: sha256(canonicalJson(normalized)),
+  };
+}
+
 function endpointFor(value) {
   let endpoint;
   try {
@@ -51,6 +65,47 @@ function endpointFor(value) {
   endpoint.search = "";
   endpoint.hash = "";
   return endpoint;
+}
+
+function readinessEndpointFor(value) {
+  let endpoint;
+  try {
+    endpoint = new URL(String(value || ""));
+  } catch {
+    throw new Error("global coordinator URL is invalid");
+  }
+  if (endpoint.protocol !== "https:") throw new Error("global coordinator URL must use HTTPS");
+  endpoint.pathname = "/v1/readyz";
+  endpoint.search = "";
+  endpoint.hash = "";
+  return endpoint;
+}
+
+export async function probeCoordinatorProtocol({ url = process.env.SKINCOS_GLOBAL_COORDINATOR_URL, fetchImpl = globalThis.fetch } = {}) {
+  if (typeof fetchImpl !== "function") throw new Error("global coordinator readiness probe is unavailable");
+  const endpoint = readinessEndpointFor(url);
+  const response = await fetchImpl(endpoint, { method: "GET", headers: { accept: "application/json" } });
+  if (response.status === 404) {
+    return { protocol: "legacy-v1", readiness: "not-supported", httpStatus: 404 };
+  }
+  const raw = await response.text();
+  let payload;
+  try { payload = JSON.parse(raw); } catch { throw new Error("global coordinator readiness response JSON is invalid"); }
+  if (!response.ok) throw new Error(`global coordinator readiness probe failed closed: HTTP ${response.status}`);
+  if (
+    payload?.contractId !== CONTRACT_ID
+    || payload?.protocol !== COORDINATION_PROTOCOL
+    || payload?.ready !== true
+    || payload?.coordinationPlane !== "global"
+    || !Number.isSafeInteger(payload?.authorityEpoch)
+    || payload.authorityEpoch < 1
+  ) throw new Error("global coordinator readiness contract is invalid");
+  return {
+    protocol: COORDINATION_PROTOCOL,
+    readiness: "ready",
+    authorityEpoch: payload.authorityEpoch,
+    httpStatus: response.status,
+  };
 }
 
 function envelopeFor({ action, request, proof, authorization, ttlMs, reason, nonce, requestedAt }) {
@@ -269,7 +324,9 @@ export async function coordinate({
     return { ...verified, httpStatus: response.status };
   }
   const error = String(payload?.error || payload?.reason || `HTTP ${response.status}`);
-  throw new Error(`global coordinator request failed: ${error}`);
+  const errorCode = String(payload?.errorCode || "").trim();
+  const suffix = errorCode ? ` [${errorCode}]` : "";
+  throw new Error(`global coordinator request failed: ${error}${suffix}`);
 }
 
 export async function acquireGlobalLease({ request, ...options }) {

--- a/scripts/codex-global-merge-authority.mjs
+++ b/scripts/codex-global-merge-authority.mjs
@@ -3,7 +3,9 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   acquireGlobalLease,
+  buildLegacyLeaseRequest,
   checkGlobalLease,
+  probeCoordinatorProtocol,
   proofForLease,
   releaseGlobalLease,
 } from "./codex-global-coordination-client.mjs";
@@ -97,6 +99,12 @@ async function mergePullRequestOnce({ repository, pullNumber, expectedHeadSha, m
   const candidate = await loadMergeCandidate({ repository, pullNumber, expectedHeadSha });
   const initial = candidate.pull;
   const { headSha, baseSha, request, closure } = candidate;
+  const coordinatorProtocol = await probeCoordinatorProtocol({ url });
+  // A 404 is the explicit compatibility signal from the pre-readiness Worker;
+  // any other unavailable or malformed response fails closed in the probe.
+  const coordinationRequest = coordinatorProtocol.protocol === "legacy-v1"
+    ? buildLegacyLeaseRequest(request)
+    : request;
   // A required global-merge-authority status makes the PR appear blocked until
   // this authority posts its success status. GitHub's merge API remains the
   // final enforcement point for every other required check or review.
@@ -104,7 +112,7 @@ async function mergePullRequestOnce({ repository, pullNumber, expectedHeadSha, m
     throw new Error("pull request is not mergeable by its current GitHub state");
   }
   const resource = "merge:main";
-  const result = await acquireMergeLease({ request, url });
+  const result = await acquireMergeLease({ request: coordinationRequest, url });
   if (result.passed !== true || !result.lease) throw new Error(`merge:main lease acquisition failed: ${result.reason || "unknown"}`);
   const proof = proofForLease(result.lease);
   let merged;

--- a/scripts/tests/codex-global-coordination-client.test.mjs
+++ b/scripts/tests/codex-global-coordination-client.test.mjs
@@ -3,9 +3,12 @@ import test from "node:test";
 import crypto from "node:crypto";
 import {
   buildAuthenticatedRequest,
+  buildLegacyLeaseRequest,
   buildRecoveryFenceRequest,
+  buildLeaseRequest,
   lockScopeForResource,
   newRequestNonce,
+  probeCoordinatorProtocol,
   proofForLease,
   verifyCoordinatorResponse,
 } from "../codex-global-coordination-client.mjs";
@@ -13,6 +16,47 @@ import { canonicalJson, CONTRACT_ID } from "../../ops/governance/global-coordina
 
 const secret = "test-coordination-secret";
 const nonce = "n".repeat(32);
+
+test("legacy lease adapter is explicit and preserves the same resource identity", () => {
+  const args = {
+    operation: "mutation",
+    resource: "merge:main",
+    owner: { provider: "github", missionId: "mission-1", threadId: "thread-1", actor: "actions" },
+    intent: { module: "merge", dependencyClosureDigest: "a".repeat(64), inputs: { changedPaths: ["docs/readme.md"] } },
+    idempotencyKey: "legacy-lease-compatibility",
+    ttlMs: 60_000,
+  };
+  const modern = buildLeaseRequest(args);
+  const legacy = buildLegacyLeaseRequest(args);
+  assert.equal(legacy.resource, modern.resource);
+  assert.equal(legacy.lockScope, modern.lockScope);
+  assert.equal(legacy.owner.sessionId, undefined);
+  assert.notEqual(legacy.intentDigest, modern.intentDigest);
+});
+
+test("readiness probe selects only the explicit legacy 404 path and fails closed otherwise", async () => {
+  const legacy = await probeCoordinatorProtocol({
+    url: "https://coordination.example.test",
+    fetchImpl: async () => new Response(JSON.stringify({ error: "not found" }), { status: 404 }),
+  });
+  assert.deepEqual(legacy, { protocol: "legacy-v1", readiness: "not-supported", httpStatus: 404 });
+  const modern = await probeCoordinatorProtocol({
+    url: "https://coordination.example.test",
+    fetchImpl: async () => new Response(JSON.stringify({
+      contractId: CONTRACT_ID,
+      protocol: "epoch-fence-v1",
+      ready: true,
+      coordinationPlane: "global",
+      authorityEpoch: 3,
+    }), { status: 200 }),
+  });
+  assert.equal(modern.protocol, "epoch-fence-v1");
+  assert.equal(modern.authorityEpoch, 3);
+  await assert.rejects(() => probeCoordinatorProtocol({
+    url: "https://coordination.example.test",
+    fetchImpl: async () => new Response(JSON.stringify({ error: "unavailable" }), { status: 503 }),
+  }), /failed closed/);
+});
 
 test("GitHub and mini-PC clients produce the same signed envelope contract", () => {
   const request = buildAuthenticatedRequest({

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -42,6 +42,8 @@ test("Cloudflare mutators have one fail-closed writer group and no unclassified 
   assert.match(coordinator, /environment: \$\{\{ inputs\.target \}\}/);
   assert.equal((coordinator.match(/^\s+COORDINATION_PREVIOUS_KEY_ID:/gm) || []).length, 1);
   assert.equal((coordinator.match(/^\s+COORDINATION_PREVIOUS_KEY_EXPIRES_AT:/gm) || []).length, 1);
+  assert.match(coordinator, /signed coordination gate retry/);
+  assert.match(coordinator, /gateAttempts <= 6/);
   const coordinatorSurface = policy.surfaces.find((surface) => surface.id === "global-coordination-plane");
   assert.equal(coordinatorSurface.canonicalDeployWorkflow, ".github/workflows/deploy-global-coordinator.yml");
   assert.equal(coordinatorSurface.coordinationGroup, "global-coordinator-writer");


### PR DESCRIPTION
## Summary\n- retry the signed staging readiness gate for a bounded propagation window after Worker/secret publication\n- fail immediately on an explicit policy denial and retain fail-closed rollback on exhausted retries\n- record the attempt count in non-sensitive evidence and protect the bound with static coverage\n\n## Validation\n- npm run codex:global-coordination:test (164 passed)\n\nThe previous staging attempt published and automatically rolled back after an immediate custody rejection; this change addresses only bounded post-publish propagation.