### PR TITLE
feat(crm): gate unified team production rollout

### DIFF
--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -22,7 +22,12 @@ on:
         default: false
         type: boolean
       unified_team_enabled:
-        description: "Enable unified team routes for isolated staging validation only"
+        description: "Enable unified team routes for the selected governed release"
+        required: true
+        default: false
+        type: boolean
+      production_unified_team_authorized:
+        description: "Explicit production authorization for unified team routes; requires the production environment gate"
         required: true
         default: false
         type: boolean
@@ -758,6 +763,8 @@ jobs:
           TARGET: ${{ inputs.target }}
           UNIT: ${{ inputs.unit }}
           UNIFIED_TEAM_ENABLED: ${{ inputs.unified_team_enabled }}
+          PRODUCTION_UNIFIED_TEAM_AUTHORIZED: ${{ inputs.production_unified_team_authorized }}
+          UNIFIED_TEAM_PRODUCTION_GATE: ${{ vars.ENABLE_UNIFIED_TEAM_PRODUCTION }}
           BOOTSTRAP_FINANCE_CONTEXT: ${{ inputs.bootstrap_finance_context }}
           RELEASE_SCOPE: ${{ inputs.release_scope }}
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
@@ -774,8 +781,16 @@ jobs:
             inventory_d1_name=skincos-db
           fi
           if [[ "$UNIFIED_TEAM_ENABLED" == "true" ]]; then
-            [[ "$TARGET" == "staging" ]] || { echo 'Unified team routes can only be enabled in staging.'; exit 1; }
             [[ "$UNIT" == "inventory" || "$UNIT" == "all" ]] || { echo 'Unified team routes require the inventory unit.'; exit 1; }
+            if [[ "$TARGET" == "production" ]]; then
+              [[ "$UNIT" == "inventory" ]] || { echo 'Production unified team rollout is inventory-only.'; exit 1; }
+              [[ "$RELEASE_SCOPE" == "general" ]] || { echo 'Production unified team rollout is limited to the general CRM surface.'; exit 1; }
+              [[ "$PRODUCTION_UNIFIED_TEAM_AUTHORIZED" == "true" ]] || { echo 'Production unified team rollout requires explicit dispatch authorization.'; exit 1; }
+              [[ "$UNIFIED_TEAM_PRODUCTION_GATE" == "true" ]] || { echo 'Production unified team rollout requires ENABLE_UNIFIED_TEAM_PRODUCTION=true.'; exit 1; }
+            elif [[ "$TARGET" != "staging" ]]; then
+              echo 'Unified team routes can only be enabled in staging or an explicitly authorized production rollout.'
+              exit 1
+            fi
           fi
           if [[ "$UNIT" == "inventory" || "$UNIT" == "all" ]]; then
             # D1 migrations must precede the Worker that requires them. They

--- a/docs/decisions/adr-unified-workforce-identity.md
+++ b/docs/decisions/adr-unified-workforce-identity.md
@@ -1,6 +1,6 @@
 # ADR: identidade canônica da equipe por workforce_employee_id
 
-- Status: proposta para validação em staging
+- Status: aprovada para rollout controlado após validação em staging
 - Escopo: CRM, onboarding/convites, Escala, Atendimento e Ponto
 - Flag de rollout: UNIFIED_TEAM_ENABLED
 
@@ -52,7 +52,22 @@ pendência/conflito; nenhum deles gera vínculo confirmado automaticamente.
              └── explicit source link ──> Atendimento professional      └── units/hierarchy/audit
 
     read-only snapshots -> sanitized inventory -> human review
-                              -> dry-run links -> staging flag -> controlled rollout
+                             -> dry-run links -> staging flag -> controlled rollout
+
+## Gate de rollout controlado
+
+A flag continua desligada por padrão. A ativação em produção só é elegível
+quando o release exato tiver evidência de staging, migrations e dependências
+prontas, smoke autenticado de configuração/listagem e rollback identificado.
+Além disso, o workflow exige simultaneamente:
+
+1. `production_unified_team_authorized=true` no dispatch do release; e
+2. `ENABLE_UNIFIED_TEAM_PRODUCTION=true` no ambiente `production`.
+
+O segundo item é uma autorização temporária do pipeline, não substitui a flag
+de runtime e deve voltar a `false` depois da promoção. O runtime permanece
+`UNIFIED_TEAM_ENABLED=true` somente no release de produção explicitamente
+promovido; o rollback desliga essa flag através do fluxo governado.
 
 ## Contrato do inventário
 
@@ -69,7 +84,8 @@ retorna nomes, e-mails, telefones, IDs brutos ou conteúdo operacional privado.
 ## Rollback e operação
 
 Antes de qualquer apply, manter backup verificável, registrar o fingerprint e
-manter a flag desligada fora do ambiente autorizado. O rollback desliga a flag e
+manter a flag desligada fora do ambiente autorizado. Em produção, o ambiente
+autorizado é criado apenas pelo gate de rollout controlado acima. O rollback desliga a flag e
 restaura apenas vínculos novos identificados pelo fingerprint, sem apagar agenda,
 ponto, nomes históricos ou auditoria. Falha de backup, conflito, divergência de
 unidade ou revisão incompleta interrompe a operação.

--- a/docs/runbooks/unified-team-migration.md
+++ b/docs/runbooks/unified-team-migration.md
@@ -37,15 +37,19 @@ confirmação automática.
    deve ser convertido em `CONFIRMED`.
 4. Antes de qualquer aplicação controlada, obter backup verificável dos bancos
    envolvidos, registrar o fingerprint aprovado e confirmar que a flag
-   `UNIFIED_TEAM_ENABLED` permanece desligada fora do ambiente de validação.
+   `UNIFIED_TEAM_ENABLED` permanece desligada fora do ambiente autorizado. A
+   produção só pode ser autorizada pelo gate temporário
+   `ENABLE_UNIFIED_TEAM_PRODUCTION=true` combinado ao input explícito
+   `production_unified_team_authorized=true` do workflow.
 5. Aplicar apenas os statements gerados para os itens `ready`, em uma sessão
    com rollback operacional documentado. O SQL usa `INSERT OR IGNORE`, portanto
    a reaplicação do mesmo plano não cria duplicidade; conflitos existentes não
    são sobrescritos.
 6. Reexecutar o plano depois da aplicação. O resultado esperado é `noop` para
    os vínculos aplicados, sem aumento de `conflicts` ou `pending`.
-7. Somente depois da validação de staging, ativar a flag no preview/ambiente
-   autorizado e então coletar os dados faltantes para convites. Convites devem
+7. Somente depois da validação de staging, ativar a flag no preview ou ambiente
+   de produção autorizado pelo gate, e então coletar os dados faltantes para
+   convites. Convites devem
    ser enviados apenas pelo fluxo de onboarding hospedado e após confirmação
    explícita do relatório.
 
@@ -167,3 +171,18 @@ Qualquer ausência de binding, release, destinatário de teste ou evidência de
 backup mantém a flag desligada e a Escala em contingência. O relatório deve
 separar claramente `local`, `staging` e `produção`; sucesso de um ambiente não
 é evidência de publicação ou convite nos demais.
+
+## Ativação controlada em produção
+
+Para o rollout do módulo Usuários/Equipe, o release governado deve publicar
+somente o Worker `inventory` com `UNIFIED_TEAM_ENABLED=true`, referenciar o
+`staging_run_id` exato e informar `production_unified_team_authorized=true`.
+Antes do dispatch, `ENABLE_UNIFIED_TEAM_PRODUCTION` precisa estar explicitamente
+`true` no ambiente `production`; depois da promoção, essa autorização do
+pipeline volta a `false`, sem alterar a flag de runtime publicada.
+
+O smoke pós-promoção confirma `/health` pronto, configuração autenticada com
+`enabled=true` e `readiness.ready=true`, listagem paginada HTTP 200 e a jornada
+do console em `?module=users`. Se qualquer uma dessas condições falhar, o
+rollback governado retorna ao Worker/deployment incumbente identificado no
+checkpoint e repete o smoke sem dados reais adicionais.

--- a/inventory/tests/onboardingConsistency.test.mjs
+++ b/inventory/tests/onboardingConsistency.test.mjs
@@ -261,7 +261,7 @@ test('team readiness is authenticated, read-only and reports safe dependency cod
   assert.doesNotMatch(readiness, /console\.log|process\.env|personalEmail|mobilePhone/i);
 });
 
-test('unified team rollout is explicit, staging-only and fail-closed by default', async () => {
+test('unified team rollout is explicit, fail-closed by default, and production requires two gates', async () => {
   const workflow = await readFile(
     new URL('../../.github/workflows/deploy-core-workers.yml', import.meta.url),
     'utf8',
@@ -269,7 +269,12 @@ test('unified team rollout is explicit, staging-only and fail-closed by default'
   assert.match(workflow, /unified_team_enabled:/);
   assert.match(workflow, /default: false/);
   assert.match(workflow, /UNIFIED_TEAM_ENABLED: \$\{\{ inputs\.unified_team_enabled \}\}/);
-  assert.match(workflow, /Unified team routes can only be enabled in staging/);
+  assert.match(workflow, /production_unified_team_authorized:/);
+  assert.match(workflow, /PRODUCTION_UNIFIED_TEAM_AUTHORIZED: \$\{\{ inputs\.production_unified_team_authorized \}\}/);
+  assert.match(workflow, /UNIFIED_TEAM_PRODUCTION_GATE: \$\{\{ vars\.ENABLE_UNIFIED_TEAM_PRODUCTION \}\}/);
+  assert.match(workflow, /Production unified team rollout requires explicit dispatch authorization/);
+  assert.match(workflow, /Production unified team rollout requires ENABLE_UNIFIED_TEAM_PRODUCTION=true/);
+  assert.match(workflow, /Unified team routes can only be enabled in staging or an explicitly authorized production rollout/);
   assert.match(workflow, /Unified team routes require the inventory unit/);
   assert.match(workflow, /unified_team_var=false/);
   assert.match(workflow, /--var "APP_VERSION:\$RELEASE_SHA"/);


### PR DESCRIPTION
## Objetivo

Permitir o rollout governado do módulo Usuários/Equipe em produção depois da validação do release imutável em staging.

## O que mudou

- Mantém `UNIFIED_TEAM_ENABLED=false` como default.
- Permite `true` em produção somente para o Worker `inventory`, no escopo `general`.
- Exige simultaneamente:
  - input `production_unified_team_authorized=true`;
  - variável temporária `ENABLE_UNIFIED_TEAM_PRODUCTION=true` no ambiente `production`.
- Atualiza o ADR e o runbook para registrar o gate, o smoke e o rollback.
- Atualiza a suíte de consistência do Inventory.

## Causa

O workflow de produção recusava explicitamente qualquer `UNIFIED_TEAM_ENABLED=true` fora de staging, embora a promoção autorizada do módulo exija habilitar o backend após staging verde.

## Validação

- `npm --prefix inventory test` via WSL: 77/77.
- `git diff --check`.
- Staging do release de runtime `1734614b2cb67f4117568ac5b98f992edd0a59f1` e smoke RBAC oficial já verdes nos runs `31419556525`, `31419761684` e `31420040827`.

## Rollback

- O gate temporário volta a `false` após a promoção.
- O runtime pode ser revertido pelo fluxo governado para o incumbent de produção `89ce7ac6c3e1b8ae0637044e89f3d3abdab658a0`.
- A alteração não executa migration nem deploy por si só.