### PR TITLE
feat(crm): gate unified team production rollout explicitly

### DIFF
--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -22,7 +22,7 @@ on:
         default: false
         type: boolean
       unified_team_enabled:
-        description: "Enable unified team routes for isolated staging validation only"
+        description: "Enable unified team routes for staging validation or an explicitly enabled production rollout"
         required: true
         default: false
         type: boolean
@@ -758,6 +758,7 @@ jobs:
           TARGET: ${{ inputs.target }}
           UNIT: ${{ inputs.unit }}
           UNIFIED_TEAM_ENABLED: ${{ inputs.unified_team_enabled }}
+          UNIFIED_TEAM_PRODUCTION_ENABLED: ${{ vars.ENABLE_CRM_UNIFIED_TEAM_PRODUCTION }}
           BOOTSTRAP_FINANCE_CONTEXT: ${{ inputs.bootstrap_finance_context }}
           RELEASE_SCOPE: ${{ inputs.release_scope }}
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
@@ -774,8 +775,23 @@ jobs:
             inventory_d1_name=skincos-db
           fi
           if [[ "$UNIFIED_TEAM_ENABLED" == "true" ]]; then
-            [[ "$TARGET" == "staging" ]] || { echo 'Unified team routes can only be enabled in staging.'; exit 1; }
             [[ "$UNIT" == "inventory" || "$UNIT" == "all" ]] || { echo 'Unified team routes require the inventory unit.'; exit 1; }
+            case "$TARGET" in
+              staging) ;;
+              production)
+                # Production activation is a separately auditable, reversible
+                # control. A missing environment flag remains fail-closed even
+                # when a caller supplies unified_team_enabled=true.
+                [[ "${UNIFIED_TEAM_PRODUCTION_ENABLED:-false}" == "true" ]] || {
+                  echo 'Production unified team routes require ENABLE_CRM_UNIFIED_TEAM_PRODUCTION=true.'
+                  exit 1
+                }
+                ;;
+              *)
+                echo 'Unified team routes are disabled for pilot, canary, and rollback.'
+                exit 1
+                ;;
+            esac
           fi
           if [[ "$UNIT" == "inventory" || "$UNIT" == "all" ]]; then
             # D1 migrations must precede the Worker that requires them. They

--- a/inventory/tests/onboardingConsistency.test.mjs
+++ b/inventory/tests/onboardingConsistency.test.mjs
@@ -261,7 +261,7 @@ test('team readiness is authenticated, read-only and reports safe dependency cod
   assert.doesNotMatch(readiness, /console\.log|process\.env|personalEmail|mobilePhone/i);
 });
 
-test('unified team rollout is explicit, staging-only and fail-closed by default', async () => {
+test('unified team rollout is explicit, reversibly gated in production and fail-closed by default', async () => {
   const workflow = await readFile(
     new URL('../../.github/workflows/deploy-core-workers.yml', import.meta.url),
     'utf8',
@@ -269,8 +269,11 @@ test('unified team rollout is explicit, staging-only and fail-closed by default'
   assert.match(workflow, /unified_team_enabled:/);
   assert.match(workflow, /default: false/);
   assert.match(workflow, /UNIFIED_TEAM_ENABLED: \$\{\{ inputs\.unified_team_enabled \}\}/);
-  assert.match(workflow, /Unified team routes can only be enabled in staging/);
   assert.match(workflow, /Unified team routes require the inventory unit/);
+  assert.match(workflow, /UNIFIED_TEAM_PRODUCTION_ENABLED: \$\{\{ vars\.ENABLE_CRM_UNIFIED_TEAM_PRODUCTION \}\}/);
+  assert.match(workflow, /Production unified team routes require ENABLE_CRM_UNIFIED_TEAM_PRODUCTION=true/);
+  assert.match(workflow, /Unified team routes are disabled for pilot, canary, and rollback/);
+  assert.match(workflow, /\$\{UNIFIED_TEAM_PRODUCTION_ENABLED:-false\}/);
   assert.match(workflow, /unified_team_var=false/);
   assert.match(workflow, /--var "APP_VERSION:\$RELEASE_SHA"/);
   assert.match(workflow, /--var "UNIFIED_TEAM_ENABLED:\$unified_team_var"/);


### PR DESCRIPTION
- Objetivo: permitir o rollout produtivo de Usuários/Equipe somente por controle explícito e reversível.
- Alterações: remove o bloqueio artificial staging-only; exige `ENABLE_CRM_UNIFIED_TEAM_PRODUCTION=true` no environment `production`; mantém default false, unidade `inventory` obrigatória e bloqueia pilot/canary/rollback.
- Validação: `inventory/tests/onboardingConsistency.test.mjs` (18/18).
- Rollback: manter a flag de ambiente ausente/false e executar o deploy Core com `unified_team_enabled=false`.
- Sem migrations, dados, secrets ou produção alterados neste PR.