### PR TITLE
fix(governance): close native stdin and post-merge release gaps

### DIFF
--- a/.github/scripts/validate-progressive-release.mjs
+++ b/.github/scripts/validate-progressive-release.mjs
@@ -64,6 +64,9 @@ const candidate = read(".github/workflows/prepare-release-candidate.yml");
 for (const required of ["branches: [main]", "git merge-base --is-ancestor", "git archive --format=tar.gz", "sourceArchiveSha256", "release-source-${{ steps.release.outputs.source_sha }}"]) {
   if (!candidate.includes(required)) fail(`release candidate workflow is missing ${required}`);
 }
+for (const required of ["workflow_run:", "workflows: [Global merge authority]", "github.event.workflow_run.conclusion == 'success'", "gh api \"repos/$REPOSITORY/commits/main\""]) {
+  if (!candidate.includes(required)) fail(`release candidate workflow is missing automatic post-merge custody: ${required}`);
+}
 const gate = read(".github/workflows/promotion-gate.yml");
 if (!gate.includes("fetch-depth: 0")) fail("promotion gate must fetch complete main history before validating an immutable rollback SHA");
 for (const required of ["release_sha", "Verify predecessor evidence", "promotion-evidence.mjs verify", "source_sha"]) if (!gate.includes(required)) fail(`immutable promotion gate is missing ${required}`);

--- a/.github/workflows/prepare-release-candidate.yml
+++ b/.github/workflows/prepare-release-candidate.yml
@@ -3,6 +3,9 @@ name: Prepare immutable release candidate
 on:
   push:
     branches: [main]
+  workflow_run:
+    workflows: [Global merge authority]
+    types: [completed]
   workflow_dispatch:
     inputs:
       release_sha:
@@ -14,25 +17,41 @@ permissions:
   contents: read
 
 concurrency:
-  group: prepare-release-candidate-${{ inputs.release_sha || github.sha }}
+  group: prepare-release-candidate-${{ inputs.release_sha || github.event.workflow_run.id || github.sha }}
   cancel-in-progress: false
 
 jobs:
   archive:
     name: Archive immutable source and release identity
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'workflow_dispatch' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      )
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
+          ref: main
           fetch-depth: 0
       - name: Resolve a commit already promoted to main
         id: release
         env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPOSITORY: ${{ github.repository }}
           REQUESTED_SHA: ${{ inputs.release_sha }}
           EVENT_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          release_sha="${REQUESTED_SHA:-$EVENT_SHA}"
+          if [[ "$EVENT_NAME" == 'workflow_run' ]]; then
+            release_sha="$(gh api "repos/$REPOSITORY/commits/main" --jq .sha)"
+          else
+            release_sha="${REQUESTED_SHA:-$EVENT_SHA}"
+          fi
           [[ "$release_sha" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::release_sha must be a full commit SHA"; exit 1; }
           git fetch --no-tags origin main
           git cat-file -e "$release_sha^{commit}"

--- a/scripts/invoke-skincos-wsl.ps1
+++ b/scripts/invoke-skincos-wsl.ps1
@@ -30,6 +30,12 @@ param(
     [AllowEmptyCollection()]
     [string[]]$Argument = @(),
 
+    # Optional in-memory stdin for one-shot native bootstrap flows. The value
+    # is written to the child process only; it is never put in WSL argv, the
+    # rendered bash program, a file, or command output.
+    [AllowEmptyString()]
+    [string]$StandardInputText,
+
     [string]$ProjectRoot = "C:\CodexShared\Projetos\skincos",
 
     # The typed wrapper supplies this for process-control helpers.  Keep it
@@ -470,9 +476,11 @@ function New-SkincosWslProcessArgumentList {
     # (for example require('./package.json') becomes require(./package.json)).
     # Carry the rendered script as inert base64 and decode it inside the fixed
     # Ubuntu/admin boundary instead of relying on cross-platform quote rules.
+    # Process substitution keeps the child's stdin available for one-shot
+    # bootstrap tokens; a decode pipeline directly into bash would consume it.
     $bashBytes = [Text.Encoding]::UTF8.GetBytes($BashCommand)
     $bashBase64 = [Convert]::ToBase64String($bashBytes)
-    $bootstrapCommand = "printf %s $bashBase64 | base64 --decode | bash"
+    $bootstrapCommand = "bash <(printf %s $bashBase64 | base64 --decode)"
 
     return [string[]]@(
         "--distribution",
@@ -484,6 +492,76 @@ function New-SkincosWslProcessArgumentList {
         "-lc",
         $bootstrapCommand
     )
+}
+
+function Convert-ToWindowsProcessArguments {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Values
+    )
+
+    # New-SkincosWslProcessArgumentList emits a fixed argv shape and the only
+    # free-form value is base64. Quote every entry for ProcessStartInfo so the
+    # standard-input path cannot fall back to a shell or command-line parsing.
+    $quoted = foreach ($value in $Values) {
+        if ($value -notmatch '[\s"]') {
+            $value
+            continue
+        }
+        '"' + $value.Replace('\', '\\').Replace('"', '\"') + '"'
+    }
+    return ($quoted -join ' ')
+}
+
+function Invoke-SkincosWslWithStandardInput {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FileName,
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$InputText,
+        [Parameter(Mandatory = $true)]
+        [ref]$ExitCode
+    )
+
+    $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+    $startInfo.FileName = $FileName
+    $startInfo.Arguments = Convert-ToWindowsProcessArguments -Values $Arguments
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardInput = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+
+    $process = New-Object System.Diagnostics.Process
+    $process.StartInfo = $startInfo
+    try {
+        if (-not $process.Start()) {
+            throw "WSL process could not be started."
+        }
+
+        $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+        $stderrTask = $process.StandardError.ReadToEndAsync()
+        try {
+            $process.StandardInput.Write($InputText)
+        } finally {
+            $process.StandardInput.Close()
+        }
+        $process.WaitForExit()
+        $stdout = $stdoutTask.Result
+        $stderr = $stderrTask.Result
+        if (-not [string]::IsNullOrEmpty($stdout)) {
+            Write-Output $stdout.TrimEnd("`r", "`n")
+        }
+        if (-not [string]::IsNullOrEmpty($stderr)) {
+            [Console]::Error.Write($stderr)
+        }
+        $ExitCode.Value = $process.ExitCode
+    } finally {
+        $process.Dispose()
+    }
 }
 
 # Dot-sourcing is used only by the Windows-native unit test to exercise the
@@ -530,8 +608,20 @@ if (-not $wsl) {
 $wslArguments = New-SkincosWslProcessArgumentList -BashCommand $invocation.BashCommand
 
 Write-Host "Running as $script:SkincosWslOperator in $script:SkincosWslDistribution repo: $($invocation.RepoMountPath)"
-& $wsl.Source @wslArguments
-$wslExitCode = $LASTEXITCODE
+if ($PSBoundParameters.ContainsKey("StandardInputText")) {
+    if ($null -eq $StandardInputText -or $StandardInputText.Contains([char]0)) {
+        throw "StandardInputText must not contain NUL bytes."
+    }
+    $wslExitCode = 0
+    Invoke-SkincosWslWithStandardInput `
+        -FileName $wsl.Source `
+        -Arguments $wslArguments `
+        -InputText $StandardInputText `
+        -ExitCode ([ref]$wslExitCode)
+} else {
+    & $wsl.Source @wslArguments
+    $wslExitCode = $LASTEXITCODE
+}
 if ($wslExitCode -ne 0) {
     exit $wslExitCode
 }

--- a/scripts/tests/invoke-skincos-wsl.test.ps1
+++ b/scripts/tests/invoke-skincos-wsl.test.ps1
@@ -83,7 +83,7 @@ Assert-True -Condition ($processArguments[3] -eq "admin") -Message "the admin op
 Assert-True -Condition ($processArguments[4] -eq "--") -Message "WSL options must end before bash argv"
 $encodedMatch = [regex]::Match(
     $processArguments[7],
-    '^printf %s (?<payload>[A-Za-z0-9+/=]+) \| base64 --decode \| bash$'
+    '^bash <\(printf %s (?<payload>[A-Za-z0-9+/=]+) \| base64 --decode\)$'
 )
 Assert-True -Condition $encodedMatch.Success -Message "bash program must use the quote-safe base64 transport"
 $decodedProgram = [Text.Encoding]::UTF8.GetString(
@@ -96,10 +96,25 @@ Assert-Contains `
     -Expected ("node -e " + (Convert-ToBashLiteral -Value $npmProbeSource)) `
     -Message "the effective npm preflight must preserve JavaScript string quotes"
 
+$stdinGateway = & $gatewayPath `
+    -ProjectRoot "C:\CodexShared\Projetos\skincos" `
+    -Executable /usr/bin/bash `
+    -ArgumentList @("-c", 'IFS= read -r line; printf ''received=%s\n'' "$line"') `
+    -StandardInputText "stdin-round-trip" `
+    -SkipBootstrapCheck `
+    -SkipRepoCheck `
+    -SkipNodeCheck `
+    -SkipNpmCheck
+Assert-True `
+    -Condition ([string]($stdinGateway | Select-Object -Last 1) -eq "received=stdin-round-trip") `
+    -Message "explicit standard input must reach WSL without becoming an argv value"
+
+# Use an intentionally unregistered path; a real shared worktree is approved
+# by the gateway and must not be treated as an unsafe fixture.
 $governedWorktree = New-SkincosWslInvocation `
     -Mode Executable `
     -Target "node" `
-    -ProjectRoot "C:\CodexShared\Worktrees\skincos\admin\ponto-progressive-release" `
+    -ProjectRoot "C:\Users\admin\Desktop\skincos-unregistered-gateway-test" `
     -Argument @("--version")
 Assert-Contains `
     -Value $governedWorktree.BashCommand `


### PR DESCRIPTION
﻿This is the up-to-date replacement for #1293, rebased from current main after #1291 advanced the base.

Changes:
- add explicit in-memory stdin forwarding to the typed WSL gateway, preserving one-shot bootstrap tokens out of argv, files, and logs;
- keep the quote-safe base64 transport while preserving child stdin;
- trigger immutable release-candidate archiving after a successful workflow_dispatch run of Global merge authority, resolving the actual current main SHA;
- add static governance coverage for the post-merge trigger and use a truly unregistered WSL gateway fixture.

Validation:
- Windows native WSL gateway contract and live stdin round-trip pass;
- progressive release policy validation passes;
- native custody, Livia rollout, and policy tests pass.
