### PR TITLE
docs(governance): distinguish live ruleset from target

### DIFF
--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -15,13 +15,32 @@ autoridade global de integração.
   - `skincos-integration-gate`
 - Require branches to be up to date before merging: `true`
 - Ruleset: `.github/governance/rulesets/main-enterprise-baseline.json`
-  - update rule denies uncoordinated ref updates;
+  - the versioned target includes an `update` rule that denies uncoordinated ref
+    updates;
   - only the GitHub Actions integration used by `global-merge-authority` is the
-    versioned bypass actor for the update rule;
+    versioned bypass actor for that rule;
   - squash is the only allowed merge method;
   - no human or administrator bypass is part of the contract.
 - Allow force pushes: `false`
 - Allow deletions: `false`
+
+## Estado live verificado
+
+Em 2026-08-10, o ruleset ativo `main-enterprise-baseline` (ID `19631459`)
+foi lido no GitHub e contém `deletion`, `non_fast_forward`, `pull_request`
+com somente `squash` e os três checks obrigatórios. Ele não contém ainda a
+regra live `update` nem bypass actors. A tentativa de aplicar a configuração
+versionada foi recusada pelo GitHub porque este repositório pessoal não pode
+usar a integração GitHub Actions como actor de bypass de ruleset.
+
+Assim, o arquivo versionado é o estado-alvo, não uma afirmação de que a regra
+`update` já está ativa. Até a transferência para uma organização ou instalação
+de uma GitHub App/integração que o GitHub aceite como owner do ruleset, a única
+autoridade suportada para integrar `main` continua sendo
+`global-merge-authority.yml`, protegida pelos checks obrigatórios e pela
+revalidação do lease. Não adicionar bypass humano para compensar a limitação.
+Depois de provisionar a autoridade compatível, reaplicar o ruleset completo e
+confirmar o readback antes de remover este blocker.
 
 ## Observações
 

--- a/docs/decisions/global-concurrency-release-governance.md
+++ b/docs/decisions/global-concurrency-release-governance.md
@@ -2,9 +2,10 @@
 
 **Status:** Fundação das Fases 1–5 implementada; esta hardening final adiciona
 fencing de autoridade, recovery fail-closed, gate de merge com rechecagem final,
-closure automática e rastreamento transitive de writers. O rollout remoto da
-versão desta branch ainda exige CI, staging e a promoção normal protegida; a
-existência do código não é confundida com o estado live.
+closure automática e rastreamento transitive de writers. O coordination plane
+foi validado em staging no SHA `64993934c371dba5a06381a98056c5f5eabc419d` em
+2026-08-10; produção permanece sem promoção. A existência do código não é
+confundida com o estado live.
 
 ## Problema
 
@@ -94,10 +95,20 @@ a revalidação imediatamente antes da mutação são a autoridade técnica.
 O ruleset versionado acrescenta a regra `update`, limita o merge a `squash` e
 declara o GitHub Actions integration actor como único bypass técnico do update
 rule. O validador rejeita qualquer workflow adicional que contenha uma mutação
-de merge ou atualização direta de `main`. A janela residual entre a última
-leitura REST e o `PUT /merge` é fechada pelo update rule da plataforma, pela
-concurrency do workflow e pelo `sha` esperado enviado à API; se a plataforma
-não comprovar o actor dedicado, o rollout permanece fail-closed.
+de merge ou atualização direta de `main`.
+
+O readback live de 2026-08-10 mostrou o ruleset ativo `main-enterprise-baseline`
+(ID `19631459`) com `deletion`, `non_fast_forward`, `pull_request` somente com
+`squash` e os checks obrigatórios, mas sem a regra `update` e sem bypass actors.
+A aplicação do estado-alvo foi recusada pelo GitHub porque este repositório
+pessoal não pode usar a integração GitHub Actions como actor de bypass de
+ruleset. Portanto, o estado-alvo versionado não deve ser descrito como estado
+live: a integração suportada permanece `global-merge-authority.yml`, com
+revalidação de base/head/lease e checks obrigatórios. A janela residual entre a
+última leitura REST e o `PUT /merge` só poderá ser considerada fechada pela
+plataforma depois que uma organização ou GitHub App/integração compatível for
+provisionada e o ruleset completo for reaplicado e lido de volta. O fail-closed
+continua sendo a regra; não se adiciona bypass humano.
 
 ## Release imutável sem congelar `main`
 


### PR DESCRIPTION
## Summary
- document the versioned ruleset as a target state rather than live state
- record the verified live ruleset contents and the GitHub personal-repository limitation
- keep the single integration workflow and fail-closed blocker explicit

## Validation
- git diff --check
- node --test scripts/tests/codex-global-coordination-client.test.mjs scripts/tests/codex-global-concurrency-chaos.test.mjs scripts/tests/codex-global-coordination.test.mjs scripts/tests/global-concurrency-governance-static.test.mjs ops/cloudflare/global-coordinator/index.test.mjs (47/47)
- live GitHub ruleset readback: ruleset 19631459
- live staging readyz: epoch-fence-v1 / ready=true / authorityEpoch=1