### PR TITLE
fix(governance): bootstrap merge authority when only signal blocks

### DIFF
--- a/.github/workflows/codex-keep-prs-mergeable.yml
+++ b/.github/workflows/codex-keep-prs-mergeable.yml
@@ -182,9 +182,40 @@ jobs:
               });
             }
 
+            async function authoritySignalIsOnlyBlock(pr) {
+              const headSha = String(pr.head?.sha || '').trim().toLowerCase();
+              if (!/^[0-9a-f]{40}$/.test(headSha)) return false;
+              try {
+                const [combined, checkRuns] = await Promise.all([
+                  github.rest.repos.getCombinedStatusForRef({ owner, repo, ref: headSha }),
+                  github.paginate(github.rest.checks.listForRef, {
+                    owner,
+                    repo,
+                    ref: headSha,
+                    per_page: 100,
+                  }),
+                ]);
+                const statuses = combined.data.statuses || [];
+                const authorityStatuses = statuses
+                  .filter((status) => String(status.context || '') === 'global-merge-authority')
+                  .sort((left, right) => Date.parse(String(left.created_at || '')) - Date.parse(String(right.created_at || '')));
+                const latestAuthority = authorityStatuses.at(-1);
+                if (String(latestAuthority?.state || '') !== 'failure') return false;
+                if (statuses.some((status) => String(status.context || '') !== 'global-merge-authority' && String(status.state || '') !== 'success')) return false;
+                const allowedConclusions = new Set(['success', 'skipped', 'neutral']);
+                if (checkRuns.some((run) => String(run.status || '') !== 'completed' || !allowedConclusions.has(String(run.conclusion || '')))) return false;
+                core.info(`PR #${pr.number} is blocked only by the deliberate global-merge-authority status; bootstrapping the official dispatch.`);
+                return true;
+              } catch (err) {
+                core.warning(`Could not verify the authority-only block for #${pr.number}: ${err?.message || err}`);
+                return false;
+              }
+            }
+
             async function dispatchMergeAuthorityIfEligible(pr) {
               const labels = new Set((pr.labels || []).map((label) => String(label?.name || '')));
-              if (pr.draft === true || pr.mergeable_state !== 'clean' || !labels.has(LABELS.enabled.name)) return;
+              const authorityOnlyBlock = pr.mergeable_state === 'blocked' && await authoritySignalIsOnlyBlock(pr);
+              if (pr.draft === true || !['clean', 'blocked'].includes(String(pr.mergeable_state || '')) || (pr.mergeable_state === 'blocked' && !authorityOnlyBlock) || !labels.has(LABELS.enabled.name)) return;
               const activeStatuses = new Set(['queued', 'in_progress', 'waiting', 'requested']);
               let runs = [];
               try {
@@ -333,6 +364,8 @@ jobs:
               // Keep conflict label unless it is clearly clean.
               if (mergeableState === "clean") {
                 await removeLabel(prNumber, LABELS.conflict.name);
+                await dispatchMergeAuthorityIfEligible(full);
+              } else if (mergeableState === "blocked") {
                 await dispatchMergeAuthorityIfEligible(full);
               }
             }

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -252,6 +252,10 @@ test("merge:main is a fail-closed GitHub mutation authority", () => {
   assert.match(scheduler, /ALLOW_BRANCH_UPDATES/);
   assert.match(scheduler, /always\(\)/);
   assert.match(scheduler, /allowBranchUpdates/);
+  assert.match(scheduler, /getCombinedStatusForRef/);
+  assert.match(scheduler, /checks\.listForRef/);
+  assert.match(scheduler, /authoritySignalIsOnlyBlock/);
+  assert.match(scheduler, /mergeableState === "blocked"/);
   assert.match(read(".github/actions/global-coordination-release/action.yml"), /max_attempts=5/);
   assert.match(read(".codex/hooks/skincos-supervisor-gate.py"), /resource_declaration/);
   assert.match(read("skills/skincos-project-orchestrator/references/supervisor-cycle.md"), /technical wait\/blocker/);


### PR DESCRIPTION
## Objetivo

Permitir que a manutenção periódica inicie a autoridade oficial quando o próprio marcador `global-merge-authority` deliberadamente bloqueia o PR após o evento `pull_request_target`.

## Guarda fail-closed

- aceita o estado `blocked` somente quando o último status `global-merge-authority` é `failure`;
- exige que todos os demais status do SHA estejam `success`;
- exige que todos os check runs do SHA estejam concluídos com `success`, `skipped` ou `neutral`;
- mantém a mutação exclusivamente no workflow oficial `global-merge-authority.yml`, que revalida lease, base e head.

## Validação

- `git diff --check`
- assertions estáticas de governança incluídas no PR

Sem auto-merge fora da autoridade global.