### PR TITLE
fix(governance): make coordinator recovery incumbent verifiable

### DIFF
--- a/.github/scripts/global-coordinator-recovery-guard.mjs
+++ b/.github/scripts/global-coordinator-recovery-guard.mjs
@@ -5,7 +5,10 @@ import { fileURLToPath } from "node:url";
 export const RECOVERY_PROTOCOL = "epoch-fence-v1";
 export const RECOVERY_CONFIRMATION = "RECOVER-KNOWN-COORDINATOR-VERSION";
 const FULL_SHA = /^[0-9a-f]{40}$/i;
+const TREE_SHA = /^[0-9a-f]{40}$/i;
+const DIGEST = /^[0-9a-f]{64}$/i;
 const VERSION_ID = /^[0-9a-f-]{16,128}$/i;
+const WORKFLOW_RUN_ID = /^[1-9][0-9]{5,}$/;
 
 function text(value) {
   return String(value ?? "").trim();
@@ -17,13 +20,37 @@ function requireText(value, label) {
   return normalized;
 }
 
-export function loadRecoveryRegistry(registryPath = path.resolve(import.meta.dirname, "../../ops/cloudflare/global-coordinator/recovery-incumbents.json")) {
-  const registry = JSON.parse(fs.readFileSync(registryPath, "utf8"));
+export function validateRecoveryRegistry(registry) {
   if (registry.schemaVersion !== 1 || registry.workerName !== "skincos-global-coordinator") {
     throw new Error("global coordinator recovery registry contract is invalid");
   }
   if (!Array.isArray(registry.knownVersions)) throw new Error("global coordinator recovery registry must declare knownVersions");
+  const seen = new Set();
+  for (const entry of registry.knownVersions) {
+    const id = text(entry?.versionId);
+    if (!VERSION_ID.test(id)) throw new Error("global coordinator recovery registry contains an invalid version id");
+    if (seen.has(id)) throw new Error(`global coordinator recovery registry contains duplicate version ${id}`);
+    seen.add(id);
+    if (text(entry?.environment) !== "production") throw new Error(`global coordinator recovery registry version ${id} is not production`);
+    if (!FULL_SHA.test(text(entry?.sourceSha))) throw new Error(`global coordinator recovery registry version ${id} has an invalid source SHA`);
+    if (entry.sourceTree !== undefined && !TREE_SHA.test(text(entry.sourceTree))) {
+      throw new Error(`global coordinator recovery registry version ${id} has an invalid source tree`);
+    }
+    if (entry.dependencyClosureDigest !== undefined && !DIGEST.test(text(entry.dependencyClosureDigest))) {
+      throw new Error(`global coordinator recovery registry version ${id} has an invalid dependency closure digest`);
+    }
+    if (entry.recoveryEligible === true) {
+      if (text(entry.protocol) !== RECOVERY_PROTOCOL) throw new Error(`global coordinator recovery registry version ${id} is eligible without epoch fencing`);
+      if (!WORKFLOW_RUN_ID.test(text(entry.registeredFromWorkflowRun))) {
+        throw new Error(`global coordinator recovery registry version ${id} has no successful deployment run identity`);
+      }
+    }
+  }
   return registry;
+}
+
+export function loadRecoveryRegistry(registryPath = path.resolve(import.meta.dirname, "../../ops/cloudflare/global-coordinator/recovery-incumbents.json")) {
+  return validateRecoveryRegistry(JSON.parse(fs.readFileSync(registryPath, "utf8")));
 }
 
 export function classifyRecoveryProbe({ status, body, error } = {}) {

--- a/.github/scripts/global-coordinator-recovery-guard.test.mjs
+++ b/.github/scripts/global-coordinator-recovery-guard.test.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
 import test from "node:test";
-import { RECOVERY_CONFIRMATION, RECOVERY_PROTOCOL, classifyRecoveryProbe, evaluateRecoveryIntent } from "./global-coordinator-recovery-guard.mjs";
+import { RECOVERY_CONFIRMATION, RECOVERY_PROTOCOL, classifyRecoveryProbe, evaluateRecoveryIntent, loadRecoveryRegistry, validateRecoveryRegistry } from "./global-coordinator-recovery-guard.mjs";
 
 const candidate = {
   versionId: "11111111-2222-3333-4444-555555555555",
@@ -48,4 +50,30 @@ test("the probe classifier distinguishes healthy readiness from degraded transpo
   assert.equal(classifyRecoveryProbe({ error: "timeout" }), "timeout");
   assert.equal(classifyRecoveryProbe({ status: 404, body: {} }), "ambiguous");
   assert.equal(classifyRecoveryProbe({ status: 200, body: { ready: true } }), "malformed");
+});
+
+test("the versioned production registry contains a modern recovery incumbent with deployment provenance", () => {
+  const registry = loadRecoveryRegistry();
+  const eligible = registry.knownVersions.filter((entry) => entry.recoveryEligible === true);
+  assert.ok(eligible.length >= 1);
+  assert.ok(eligible.every((entry) => entry.protocol === RECOVERY_PROTOCOL));
+  assert.ok(eligible.every((entry) => /^[0-9a-f]{40}$/i.test(entry.sourceSha)));
+  assert.ok(eligible.every((entry) => /^[1-9][0-9]{5,}$/.test(String(entry.registeredFromWorkflowRun))));
+});
+
+test("the registry rejects duplicate or malformed eligible incumbents before recovery", () => {
+  assert.throws(() => validateRecoveryRegistry({
+    schemaVersion: 1,
+    workerName: "skincos-global-coordinator",
+    knownVersions: [{ ...candidate, registeredFromWorkflowRun: "31427360586" }, { ...candidate, registeredFromWorkflowRun: "31427360587" }],
+  }), /duplicate version/);
+});
+
+test("the recovery workflow keeps production custody and restore scope narrow", () => {
+  const workflow = fs.readFileSync(path.resolve(import.meta.dirname, "../workflows/recover-global-coordinator.yml"), "utf8");
+  assert.match(workflow, /environment: production/);
+  assert.match(workflow, /SKINCOS_GLOBAL_COORDINATION_RECOVERY_SECRET/);
+  assert.match(workflow, /versions deploy \"\$\{VERSION_ID\}@100%\"/);
+  assert.match(workflow, /recovery-incumbents\.json/);
+  assert.doesNotMatch(workflow, /global-coordination-acquire/);
 });

--- a/ops/cloudflare/global-coordinator/README.md
+++ b/ops/cloudflare/global-coordinator/README.md
@@ -19,6 +19,17 @@ post-deploy validation fails. It requires separately managed
 `COORDINATION_SHARED_SECRET` and `COORDINATION_ADMIN_SECRET` bindings. Missing
 custody returns HTTP 503; it never falls back to an in-memory or local lock.
 
+Break-glass recovery is a separate, production-only path in
+`.github/workflows/recover-global-coordinator.yml`. It can restore only an
+exact `versionId` recorded in `recovery-incumbents.json`, after the normal
+readiness probe proves a degraded (not healthy or ambiguous) plane. The
+workflow then reads back modern readiness and advances `authorityEpoch` through
+the separate `COORDINATION_RECOVERY_SECRET`; it does not acquire normal leases,
+upload source, or accept a staging target. A successful normal production
+deployment must add its exact version, source SHA/tree, closure digest and run
+ID to the registry before that version is considered recovery eligible. The
+registry validator rejects duplicate or malformed incumbents.
+
 Clients must send the signed request envelope described by the contract and
 must present the returned `leaseId`, `fencingToken`, owner and `intentDigest`
 before every mutation. A release operation also carries its immutable source

--- a/ops/cloudflare/global-coordinator/recovery-incumbents.json
+++ b/ops/cloudflare/global-coordinator/recovery-incumbents.json
@@ -5,6 +5,18 @@
   "authority": "github-actions-normal-deployment-plus-cloudflare-version-restore",
   "knownVersions": [
     {
+      "versionId": "cc747d37-f7c3-487a-8301-12e72558e60d",
+      "environment": "production",
+      "sourceSha": "4b870ea953d5e3703bc8a874dc20e84cfe2d98a7",
+      "sourceTree": "2d335e0ff8b18b011d3db76e41dd05d8f7534e5b",
+      "dependencyClosureDigest": "de9f482a88d997b96685aeb4e4892246f334ab1dfa5dc6f5d66d16c7417af0b8",
+      "protocol": "epoch-fence-v1",
+      "recoveryEligible": true,
+      "registeredFromWorkflowRun": "31427360586",
+      "registeredAt": "2026-08-10T20:06:05Z",
+      "reason": "successful normal production deployment with modern readiness, signed gate, and sanitized readback"
+    },
+    {
       "versionId": "7e7575c7-6094-4695-a588-c25921b053d6",
       "environment": "production",
       "sourceSha": "7ab35c2fd090b7d367ec4c66e969871f8e826f36",


### PR DESCRIPTION
## Objetivo

Fechar a prontidão P0 do break-glass do coordenador global sem criar uma segunda autoridade de operação.

## Alterações

- registra o incumbente moderno de produção `cc747d37-f7c3-487a-8301-12e72558e60d` apenas após o deploy canônico 31427360586, signed gate e readback saudável;
- valida duplicidade, SHA/tree, closure digest, protocolo epoch-fence e identidade do workflow de registro;
- adiciona testes para recuperação exata, estado saudável/ambíguo, alvo/ref/replay, registry malformed e escopo estreito do workflow;
- documenta que recovery usa custódia separada, produção somente, restore de versão exata e fencing de `authorityEpoch`.

A custódia separada foi provisionada sem expor o valor; a publicação canônica sincronizou-a no Worker. Nenhuma versão arbitrária, lease normal ou fonte foi usado pelo caminho de recovery.

## Validação

- `node --test .github/scripts/global-coordinator-recovery-guard.test.mjs` via wrapper WSL: 7/7;
- deploy canônico de produção 31427360586: sucesso;
- readback: versão `cc747d37-f7c3-487a-8301-12e72558e60d`, signed gate aprovado, rollback incumbent `1f88d803-8e28-4185-8b15-80cc5206c23a` registrado no artefato privado.

Não foi provocado incidente real para testar restore; a matriz de guardas e a recuperação por versão exata permanecem fail-closed.