### PR TITLE
feat(governance): validate observed dependency closure graph

### DIFF
--- a/.github/governance/cloudflare-single-writer-policy.json
+++ b/.github/governance/cloudflare-single-writer-policy.json
@@ -12,6 +12,16 @@
   "retiredWorkflows": [
     ".github/workflows/ponto-core-baseline-publisher.yml"
   ],
+  "nonPublishingWorkflows": [
+    {
+      "workflow": ".github/workflows/timekeeping-ci.yml",
+      "reason": "CI exercises local D1 and Wrangler dry-runs only; it has no publishing authority.",
+      "requiredMarkers": [
+        "--local",
+        "--dry-run"
+      ]
+    }
+  ],
   "coordinationGroups": [
     {
       "id": "crm-cloudflare-writer",
@@ -22,6 +32,11 @@
       "id": "ponto-workers-writer",
       "resource": "global:ponto-workers-writer",
       "purpose": "Serializes Ponto timekeeping, identity and core Worker publication/custody workflows."
+    },
+    {
+      "id": "ponto-release-writer",
+      "resource": "release:ponto",
+      "purpose": "Serializes Ponto release-control, module-control, rollback and emergency Cloudflare mutations under the composite release authority."
     },
     {
       "id": "website-writer",
@@ -192,6 +207,21 @@
       "mutationWorkflows": [
         ".github/workflows/insumos-staging-rbac-smoke.yml",
         ".github/workflows/timekeeping-staging-journey.yml"
+      ]
+    },
+    {
+      "id": "ponto-release-control-plane",
+      "platform": "cloudflare-ponto-release-control",
+      "canonicalDeployWorkflow": ".github/workflows/ponto-progressive-release.yml",
+      "coordinationGroup": "ponto-release-writer",
+      "mutationWorkflows": [
+        ".github/workflows/ponto-progressive-release.yml",
+        ".github/workflows/ponto-release-watchdog.yml",
+        ".github/workflows/ponto-emergency-close.yml",
+        ".github/workflows/ponto-emergency-latch-reset.yml",
+        ".github/workflows/module-availability.yml",
+        ".github/workflows/ponto-staging-recovery-rollback.yml",
+        ".github/workflows/ponto-staging-rollback-drill.yml"
       ]
     }
   ],

--- a/.github/scripts/validate-cloudflare-single-writer.mjs
+++ b/.github/scripts/validate-cloudflare-single-writer.mjs
@@ -188,10 +188,6 @@ function callBlocks(source, pattern) {
   return blocks;
 }
 
-function escapeRegExp(value) {
-  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function cloudflareApiMutationEvidence(source) {
   const endpointPattern = /(?:api\.cloudflare\.com|cloudflare\.com\/client\/v4)/i;
   const methodPattern = /\bmethod\s*:\s*["']?(?:POST|PUT|PATCH|DELETE)\b/i;
@@ -203,7 +199,9 @@ function cloudflareApiMutationEvidence(source) {
     aliases.add(match[1]);
   }
   const endpointIn = (block) => endpointPattern.test(block)
-    || [...aliases].some((alias) => new RegExp(`\\b${escapeRegExp(alias)}\\b`).test(block));
+    // A literal containment check is intentionally conservative for this
+    // source scanner and avoids compiling input-derived regular expressions.
+    || [...aliases].some((alias) => block.includes(alias));
   const fetchBlocks = callBlocks(source, /\b(?:fetch|fetchImpl)\s*\(/g);
   if (fetchBlocks.some((block) => endpointIn(block) && methodPattern.test(block))) return true;
 
@@ -219,7 +217,11 @@ function cloudflareApiMutationEvidence(source) {
     }
   }
   for (const wrapper of wrapperNames) {
-    const wrapperCalls = callBlocks(source, new RegExp(`\\b${escapeRegExp(wrapper)}\\s*\\(`, "g"));
+    const wrapperCalls = callBlocks(source, /\b[A-Za-z_$][\w$]*\s*\(/g)
+      .filter((block) => {
+        const trimmed = block.trimStart();
+        return trimmed.startsWith(`${wrapper}(`) || trimmed.startsWith(`${wrapper} (`);
+      });
     if (wrapperCalls.some((block) => methodPattern.test(block))) return true;
   }
 

--- a/.github/scripts/validate-cloudflare-single-writer.mjs
+++ b/.github/scripts/validate-cloudflare-single-writer.mjs
@@ -10,7 +10,9 @@ const SOURCE_EXTENSIONS = ["", ".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx", ".y
 const REPO_ROOT_PREFIX = /^(?:\.\/)?(?:\.github|scripts|ops|platform|shared|api|booking|crm|finance|inventory|workforce|website|orb|integration|identity)\//;
 
 const MUTATION_PATTERNS = [
-  /\bwrangler(?:@[A-Za-z0-9._-]+)?\b[^\r\n]*(?:\bpages\b[^\r\n]*\bdeploy\b|\bversions\b[^\r\n]*(?:\bupload\b|\bdeploy\b)|\bdeploy\b|\bsecret\b[^\r\n]*(?:\bput\b|\bbulk\b|\bdelete\b)|\bd1\b[^\r\n]*(?:\bexecute\b|\bmigrations\b[^\r\n]*\bapply\b)|\br2\b[^\r\n]*\bobject\b[^\r\n]*(?:\bput\b|\bdelete\b))/i,
+  /\bwrangler(?:@[A-Za-z0-9._-]+)?\b[^\r\n]*(?:\bpages\b[^\r\n]*\bdeploy\b|\bversions\b[^\r\n]*(?:\bupload\b|\bdeploy\b)|\bdeploy\b|\brollback\b|\bsecret\b[^\r\n]*(?:\bput\b|\bbulk\b|\bdelete\b)|\bkv\b[^\r\n]*\bkey\b[^\r\n]*(?:\bput\b|\bdelete\b)|\bd1\b[^\r\n]*(?:\bexecute\b|\bmigrations\b[^\r\n]*\bapply\b)|\br2\b[^\r\n]*\bobject\b[^\r\n]*(?:\bput\b|\bdelete\b))/i,
+  /\b(?:terraform|tofu)\b[^\r\n]*(?:\bapply\b|\bdestroy\b|\bimport\b|\bstate\s+(?:mv|rm|push)\b)/i,
+  /\bpulumi\b[^\r\n]*(?:\bup\b|\bdestroy\b|\bimport\b|\bstate\s+(?:rename|delete|repair)\b)/i,
   /\bpages\s+deploy\b/i,
   /\b(?:POST|PUT|PATCH|DELETE)\b[^\r\n]*(?:api\.cloudflare\.com|cloudflare\.com\/client\/v4)/i,
   /(?:api\.cloudflare\.com|cloudflare\.com\/client\/v4)[^\r\n]*(?:method\s*[:=]\s*["']?(?:POST|PUT|PATCH|DELETE)\b|\bcurl\b[^\r\n]*\s-X\s*(?:POST|PUT|PATCH|DELETE)\b)/i,
@@ -126,10 +128,112 @@ function lineIsMutation(line) {
   return MUTATION_PATTERNS.some((pattern) => pattern.test(line));
 }
 
+function callBlocks(source, pattern) {
+  const blocks = [];
+  for (const match of source.matchAll(pattern)) {
+    const opening = match.index + match[0].lastIndexOf("(");
+    let depth = 0;
+    let quote = "";
+    let escaped = false;
+    let lineComment = false;
+    let blockComment = false;
+    for (let index = opening; index < source.length; index += 1) {
+      const character = source[index];
+      const next = source[index + 1];
+      if (lineComment) {
+        if (character === "\n") lineComment = false;
+        continue;
+      }
+      if (blockComment) {
+        if (character === "*" && next === "/") {
+          blockComment = false;
+          index += 1;
+        }
+        continue;
+      }
+      if (quote) {
+        if (escaped) {
+          escaped = false;
+        } else if (character === "\\") {
+          escaped = true;
+        } else if (character === quote) {
+          quote = "";
+        }
+        continue;
+      }
+      if (character === "/" && next === "/") {
+        lineComment = true;
+        index += 1;
+        continue;
+      }
+      if (character === "/" && next === "*") {
+        blockComment = true;
+        index += 1;
+        continue;
+      }
+      if (character === "'" || character === '"' || character === "`") {
+        quote = character;
+        continue;
+      }
+      if (character === "(") depth += 1;
+      if (character === ")") {
+        depth -= 1;
+        if (depth === 0) {
+          blocks.push(source.slice(match.index, index + 1));
+          break;
+        }
+      }
+    }
+  }
+  return blocks;
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function cloudflareApiMutationEvidence(source) {
+  const endpointPattern = /(?:api\.cloudflare\.com|cloudflare\.com\/client\/v4)/i;
+  const methodPattern = /\bmethod\s*:\s*["']?(?:POST|PUT|PATCH|DELETE)\b/i;
+  const aliases = new Set();
+  for (const match of source.matchAll(/\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*["'`]https:\/\/(?:api\.cloudflare\.com|cloudflare\.com\/client\/v4)/gi)) {
+    aliases.add(match[1]);
+  }
+  for (const match of source.matchAll(/\b([A-Za-z_$][\w$]*)\s*:\s*["'`]https:\/\/(?:api\.cloudflare\.com|cloudflare\.com\/client\/v4)/gi)) {
+    aliases.add(match[1]);
+  }
+  const endpointIn = (block) => endpointPattern.test(block)
+    || [...aliases].some((alias) => new RegExp(`\\b${escapeRegExp(alias)}\\b`).test(block));
+  const fetchBlocks = callBlocks(source, /\b(?:fetch|fetchImpl)\s*\(/g);
+  if (fetchBlocks.some((block) => endpointIn(block) && methodPattern.test(block))) return true;
+
+  const wrapperNames = new Set();
+  const definitionPatterns = [
+    /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>/g,
+    /\b(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*\{/g,
+  ];
+  for (const pattern of definitionPatterns) {
+    for (const match of source.matchAll(pattern)) {
+      const body = source.slice(match.index, match.index + 6000);
+      if (endpointIn(body) && /\bfetch(?:Impl)?\s*\(/.test(body) && /\.\.\.\s*init\b/.test(body)) wrapperNames.add(match[1]);
+    }
+  }
+  for (const wrapper of wrapperNames) {
+    const wrapperCalls = callBlocks(source, new RegExp(`\\b${escapeRegExp(wrapper)}\\s*\\(`, "g"));
+    if (wrapperCalls.some((block) => methodPattern.test(block))) return true;
+  }
+
+  const curlMutation = /\bcurl\b[\s\S]{0,900}(?:api\.cloudflare\.com|cloudflare\.com\/client\/v4)[\s\S]{0,900}(?:-X|--request)\s*(?:POST|PUT|PATCH|DELETE)\b|\bcurl\b[\s\S]{0,900}(?:-X|--request)\s*(?:POST|PUT|PATCH|DELETE)\b[\s\S]{0,900}(?:api\.cloudflare\.com|cloudflare\.com\/client\/v4)/i;
+  return curlMutation.test(source);
+}
+
 export function mutationEvidence(graph) {
   const evidence = [];
   for (const [file, source] of graph.texts) {
     for (const line of source.split(/\r?\n/)) if (lineIsMutation(line)) evidence.push({ file, line: line.trim().slice(0, 240) });
+    if (cloudflareApiMutationEvidence(source) && !evidence.some((item) => item.file === file && item.line.includes("Cloudflare API"))) {
+      evidence.push({ file, line: "transitive Cloudflare API mutation detected across source lines" });
+    }
   }
   return evidence;
 }
@@ -166,6 +270,29 @@ export function validatePolicy(policy = loadPolicy()) {
   }
 
   const covered = new Set();
+  const nonPublishing = new Map();
+  for (const entry of policy.nonPublishingWorkflows || []) {
+    if (!entry?.workflow || nonPublishing.has(entry.workflow)) {
+      errors.push("non-publishing workflow exceptions require unique workflow paths");
+      continue;
+    }
+    const absolute = path.join(ROOT, entry.workflow);
+    if (!fs.existsSync(absolute)) {
+      errors.push(`non-publishing exception references missing workflow ${entry.workflow}`);
+      continue;
+    }
+    if (!Array.isArray(entry.requiredMarkers) || entry.requiredMarkers.length === 0) {
+      errors.push(`non-publishing exception ${entry.workflow} requires static safety markers`);
+      continue;
+    }
+    const graph = traceMutationGraph({ sourcePath: entry.workflow });
+    const text = [...graph.texts.values()].join("\n");
+    for (const marker of entry.requiredMarkers) {
+      if (!text.includes(marker)) errors.push(`${entry.workflow} is missing non-publishing safety marker ${marker}`);
+    }
+    if (graph.missing.length) errors.push(`${entry.workflow} references missing local files: ${graph.missing.join(", ")}`);
+    nonPublishing.set(entry.workflow, entry);
+  }
   for (const surface of policy.surfaces || []) {
     if (!surface?.id || !surface.canonicalDeployWorkflow || !surface.coordinationGroup) {
       errors.push("every Cloudflare surface requires id, canonicalDeployWorkflow and coordinationGroup");
@@ -204,7 +331,7 @@ export function validatePolicy(policy = loadPolicy()) {
     const workflow = `.github/workflows/${entry}`;
     const graph = traceMutationGraph({ sourcePath: workflow });
     const evidence = mutationEvidence(graph);
-    if (evidence.length && !covered.has(workflow) && !retired.has(workflow)) {
+    if (evidence.length && !covered.has(workflow) && !retired.has(workflow) && !nonPublishing.has(workflow)) {
       errors.push(`${workflow} contains a transitive Cloudflare mutation but is not classified in the single-writer policy: ${evidence.slice(0, 2).map((item) => `${item.file}:${item.line}`).join(" | ")}`);
     }
   }

--- a/.github/scripts/validate-cloudflare-single-writer.test.mjs
+++ b/.github/scripts/validate-cloudflare-single-writer.test.mjs
@@ -37,3 +37,60 @@ test("local and dry-run operations remain non-mutating", () => {
   });
   assert.deepEqual(mutationEvidence(local), []);
 });
+
+test("single-writer graph detects indirect Cloudflare API, Terraform and Pulumi mutations", () => {
+  const mutationFiles = [
+    ".github/workflows/demo.yml",
+    ".github/actions/demo/action.yml",
+    ".github/scripts/demo-deploy.mjs",
+  ];
+  const mutationContents = {
+    ".github/workflows/demo.yml": "uses: ./.github/actions/demo",
+    ".github/actions/demo/action.yml": "run: node .github/scripts/demo-deploy.mjs",
+    ".github/scripts/demo-deploy.mjs": [
+      "await fetch('https://api.cloudflare.com/client/v4/accounts/demo/workers', {",
+      "  method: 'POST',",
+      "});",
+      "terraform -chdir=ops/cloudflare apply -auto-approve",
+      "pulumi up --yes",
+    ].join("\n"),
+  };
+  const graph = traceMutationGraph({ sourcePath: ".github/workflows/demo.yml", files: mutationFiles, readFile: (file) => mutationContents[file] });
+  const evidence = mutationEvidence(graph);
+  assert.ok(evidence.some((item) => item.line.includes("Cloudflare API")));
+  assert.ok(evidence.some((item) => item.line.includes("terraform")));
+  assert.ok(evidence.some((item) => item.line.includes("pulumi")));
+});
+
+test("Terraform plan and Pulumi preview remain read-only", () => {
+  const graph = traceMutationGraph({
+    sourcePath: ".github/scripts/demo-read.mjs",
+    files: [".github/scripts/demo-read.mjs"],
+    readFile: () => "terraform plan\npulumi preview\nfetch('https://api.cloudflare.com/client/v4/accounts/demo')",
+  });
+  assert.deepEqual(mutationEvidence(graph), []);
+});
+
+test("a Cloudflare read is not tainted by an unrelated external POST", () => {
+  const graph = traceMutationGraph({
+    sourcePath: ".github/scripts/demo-read.mjs",
+    files: [".github/scripts/demo-read.mjs"],
+    readFile: () => [
+      "await fetch('https://api.cloudflare.com/client/v4/accounts/demo', { headers: auth });",
+      "await fetch('https://synthetic.example.test/probe', { method: 'POST' });",
+    ].join("\n"),
+  });
+  assert.deepEqual(mutationEvidence(graph), []);
+});
+
+test("a local Cloudflare wrapper is classified when a caller supplies a mutating method", () => {
+  const graph = traceMutationGraph({
+    sourcePath: ".github/scripts/demo-deploy.mjs",
+    files: [".github/scripts/demo-deploy.mjs"],
+    readFile: () => [
+      "const cloudflare = async (pathname, init = {}) => fetch(`https://api.cloudflare.com/client/v4${pathname}`, { ...init });",
+      "await cloudflare('/accounts/demo/pages/projects/demo/deployments/id/rollback', { method: 'POST' });",
+    ].join("\n"),
+  });
+  assert.ok(mutationEvidence(graph).some((item) => item.line.includes("Cloudflare API")));
+});

--- a/.github/scripts/validate-dependency-closures.mjs
+++ b/.github/scripts/validate-dependency-closures.mjs
@@ -81,10 +81,29 @@ function resolveLocal(source, request, files) {
     if (candidate.includes("/node_modules/")) continue;
     if (files.has(candidate)) return candidate;
   }
+  for (const entrypoint of ["action.yml", "action.yaml"]) {
+    const candidate = normalize(path.posix.join(base, entrypoint));
+    if (candidate.includes("/node_modules/")) continue;
+    if (files.has(candidate)) return candidate;
+  }
   return base;
 }
 
-function referencesFrom(sourcePath, source, files) {
+function packageScriptRequests(source, files, readFile) {
+  const references = new Set();
+  for (const match of source.matchAll(/\bnpm(?:\s+--prefix\s+["']?([^\s"']+)["']?)?\s+run\s+([A-Za-z0-9:_-]+)/g)) {
+    const prefix = normalize(match[1] || "").replace(/\/$/, "");
+    const packagePath = prefix && prefix !== "." ? `${prefix}/package.json` : "package.json";
+    if (!files.has(packagePath)) continue;
+    let packageJson;
+    try { packageJson = JSON.parse(readFile(packagePath)); } catch { continue; }
+    const command = packageJson?.scripts?.[match[2]];
+    if (typeof command === "string") references.add(`${packagePath}\0${match[2]}\0${command}`);
+  }
+  return references;
+}
+
+function referencesFrom(sourcePath, source, files, readFile, packageScriptStack = new Set()) {
   const references = new Set();
   const add = (request) => {
     const resolved = resolveLocal(sourcePath, request, files);
@@ -97,17 +116,28 @@ function referencesFrom(sourcePath, source, files) {
   ]) {
     for (const match of source.matchAll(pattern)) add(match[1]);
   }
-  for (const match of source.matchAll(/\buses:\s*(\.[^\s@#]+)/g)) {
+  for (const match of source.matchAll(/\buses:\s*["']?(\.[^\s"'@#]+)/g)) {
     const candidate = normalize(match[1]).replace(/^\.\//, "");
     if (!candidate.includes("/node_modules/") && files.has(candidate)) references.add(candidate);
   }
-  for (const match of source.matchAll(/\b(?:node|bash|sh|python3?)\s+((?:\.github|scripts|ops|platform|shared|api|booking|crm|finance|inventory|workforce|website|orb|integration)\/[A-Za-z0-9_./-]+)/g)) {
+  for (const match of source.matchAll(/\b(?:node|bash|sh|python3?)\s+((?:\.\/)?(?:\.github|scripts|ops|platform|shared|api|booking|crm|finance|inventory|workforce|website|orb|integration)\/[A-Za-z0-9_./-]+)/g)) {
     const candidate = normalize(match[1]).replace(/^\.\//, "");
     if (!candidate.includes("/node_modules/") && files.has(candidate)) references.add(candidate);
   }
   for (const match of source.matchAll(/(?:--config|--wrangler-config|CONFIG_FILE=)\s*["']?([^\s"']+wrangler\.toml)/g)) {
     const candidate = normalize(match[1]).replace(/^\.\//, "");
     if (!candidate.includes("/node_modules/") && files.has(candidate)) references.add(candidate);
+  }
+  if (!sourcePath.endsWith("/package.json") && sourcePath !== "package.json") {
+    for (const request of packageScriptRequests(source, files, readFile)) {
+      const [packagePath, scriptName, command] = request.split("\0");
+      references.add(packagePath);
+      const key = `${packagePath}\0${scriptName}`;
+      if (packageScriptStack.has(key)) continue;
+      for (const dependency of referencesFrom(packagePath, command, files, readFile, new Set([...packageScriptStack, key]))) {
+        references.add(dependency);
+      }
+    }
   }
   return [...references].sort();
 }
@@ -166,7 +196,6 @@ export function validateDependencyClosures({
       const source = pending.pop();
       if (visited.has(source) || !fileSet.has(source)) continue;
       visited.add(source);
-      if (source === "package.json" || source.endsWith("/package.json")) continue;
       let sourceText = localSourceCache.get(source);
       try {
         if (sourceText === undefined) {
@@ -174,7 +203,8 @@ export function validateDependencyClosures({
           localSourceCache.set(source, sourceText);
         }
       } catch { errors.push(`${module}: cannot read ${source}`); continue; }
-      const references = localReferenceCache.get(source) || referencesFrom(source, sourceText, fileSet);
+      if (source === "package.json" || source.endsWith("/package.json")) continue;
+      const references = localReferenceCache.get(source) || referencesFrom(source, sourceText, fileSet, readFile);
       localReferenceCache.set(source, references);
       for (const dependency of references) {
         edges.push({ source, dependency });

--- a/.github/scripts/validate-dependency-closures.test.mjs
+++ b/.github/scripts/validate-dependency-closures.test.mjs
@@ -59,3 +59,63 @@ test("glob matching stays bounded for recursive and segment wildcards", () => {
   assert.deepEqual(result.errors, []);
   assert.equal(result.reports[0].selectedFileCount, 2);
 });
+
+test("dependency closure follows reusable local actions and shared helpers", () => {
+  const files = [
+    ".github/workflows/demo.yml",
+    ".github/actions/demo/action.yml",
+    ".github/scripts/demo.mjs",
+    "shared/common.mjs",
+    "docs/independent.md",
+  ];
+  const contents = {
+    ".github/workflows/demo.yml": 'uses: "./.github/actions/demo"',
+    ".github/actions/demo/action.yml": "run: node .github/scripts/demo.mjs",
+    ".github/scripts/demo.mjs": 'import "../../shared/common.mjs";',
+    "shared/common.mjs": "export const ok = true;",
+    "docs/independent.md": "documentation only",
+  };
+  const result = validateDependencyClosures({
+    policy: {
+      sharedInputs: [],
+      releaseClosures: { demo: { patterns: [".github/**", "shared/**"], sharedInputs: false } },
+    },
+    files,
+    readFile: (file) => contents[file],
+    modules: ["demo"],
+  });
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.reports[0].reachableFileCount, 4);
+});
+
+test("unrelated documentation stays outside the observed dependency closure", () => {
+  const base = fixture();
+  const first = validateDependencyClosures({ ...base, modules: ["demo"] });
+  const second = validateDependencyClosures({
+    ...base,
+    files: [...base.files, "docs/independent.md"],
+    readFile: (file) => file === "docs/independent.md" ? "changed docs" : base.readFile(file),
+    modules: ["demo"],
+  });
+  assert.deepEqual(second.errors, first.errors);
+  assert.equal(second.reports[0].dependencyClosureDigest, first.reports[0].dependencyClosureDigest);
+  assert.equal(second.reports[0].reachableFileCount, first.reports[0].reachableFileCount);
+});
+
+test("dependency closure resolves npm scripts to their package helpers", () => {
+  const files = [".github/workflows/demo.yml", "package.json", ".github/scripts/demo.mjs", "shared/common.mjs"];
+  const contents = {
+    ".github/workflows/demo.yml": "run: npm run demo:check",
+    "package.json": JSON.stringify({ scripts: { "demo:check": "node ./.github/scripts/demo.mjs" } }),
+    ".github/scripts/demo.mjs": 'import "../../shared/common.mjs";',
+    "shared/common.mjs": "export const ok = true;",
+  };
+  const result = validateDependencyClosures({
+    policy: { sharedInputs: [], releaseClosures: { demo: { patterns: [".github/**", "shared/**", "package.json"], sharedInputs: false } } },
+    files,
+    readFile: (file) => contents[file],
+    modules: ["demo"],
+  });
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.reports[0].reachableFileCount, 4);
+});


### PR DESCRIPTION
## Objetivo

Fazer a validação de dependency closure observar o grafo real de execução sem ampliar a autoridade de release.

## Alterações

- segue `uses: ./.github/actions/...` até `action.yml`/`action.yaml`;
- segue helpers invocados por `node`, `bash`, `python` e scripts de `npm run`/`npm --prefix ... run`;
- mantém o digest baseado apenas nos arquivos alcançáveis da closure;
- mantém exclusões explícitas para documentação independente;
- adiciona testes para import compartilhado, action/workflow local, package helper, documentação independente e aresta externa.

## Validação

- teste focal: 7/7;
- validador completo: todos os 13 módulos declarados sem erros;
- `git diff --check` limpo.