### PR TITLE
feat(website): add Clube Botox Asaas short links

### DIFF
--- a/website/src/lib/esfaManagedRedirects.ts
+++ b/website/src/lib/esfaManagedRedirects.ts
@@ -38,6 +38,7 @@ function inferPlacement(slugPath: string, destinationHost: string | null): strin
     if (host === "www.google.com") return "maps";
     if (host === "www.facebook.com" || host === "www.instagram.com") return "social";
     if (host === "payment-link-v3.stone.com.br") return "payment";
+    if (host === "asaas.com" || host === "www.asaas.com") return "payment";
     if (host === "auto.bsbank.com.br") return "campaign";
     if (
         host === "espacofacial.com" ||

--- a/website/src/lib/esfaRedirects.ts
+++ b/website/src/lib/esfaRedirects.ts
@@ -41,6 +41,10 @@ export const ESFA_REDIRECTS: Record<string, string> = {
 
   // Campanhas
   ...ANIVERSARIO_7_ESFA_REDIRECTS,
+  // Clube Botox
+  "/clubebotox40u": "https://www.asaas.com/c/85kw6n2otrtdhjqe",
+  "/clubebotox50u": "https://www.asaas.com/c/93fcmgkhgcin2igk",
+  "/clubebotox60u": "https://www.asaas.com/c/hqown86982e9y7f4",
   "/bebadessafonte": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+HealthBodyRun+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
 
   // Interno

--- a/website/src/lib/siteCustomUrls.ts
+++ b/website/src/lib/siteCustomUrls.ts
@@ -64,6 +64,7 @@ const ALLOWED_DESTINATION_HOSTS = new Set([
     "www.instagram.com",
     "chat.whatsapp.com",
     "auto.bsbank.com.br",
+    "www.asaas.com",
 ]);
 
 function textOrNull(value: unknown, max = 160): string | null {

--- a/website/tests/esfaManagedRedirects.test.ts
+++ b/website/tests/esfaManagedRedirects.test.ts
@@ -6,7 +6,7 @@ import {
     listEsfaFallbackRedirects,
     listEsfaManagedRedirectSeeds,
 } from "../src/lib/esfaManagedRedirects";
-import { ESFA_REDIRECTS } from "../src/lib/esfaRedirects";
+import { ESFA_REDIRECTS, normalizeEsfaRedirectPath } from "../src/lib/esfaRedirects";
 import { ANIVERSARIO_7_ESFA_REDIRECTS, ANIVERSARIO_7_LEGACY_REDIRECTS } from "../src/lib/aniversario7Redirects";
 
 test("buildEsfaManagedRedirectSeed infers metadata for migrated esfa redirects", () => {
@@ -23,6 +23,23 @@ test("buildEsfaManagedRedirectSeed infers metadata for migrated esfa redirects",
     assert.equal(seed.unitSlug, "barrashoppingsul");
     assert.equal(seed.source, ESFA_MIGRATED_SOURCE);
     assert.equal(seed.createdAtMs, 123);
+});
+
+test("Clube Botox U aliases resolve to the requested Asaas payment links", () => {
+    const redirects = {
+        "/ClubeBotox40U": "https://www.asaas.com/c/85kw6n2otrtdhjqe",
+        "/ClubeBotox50U": "https://www.asaas.com/c/93fcmgkhgcin2igk",
+        "/ClubeBotox60U": "https://www.asaas.com/c/hqown86982e9y7f4",
+    };
+
+    for (const [requestedPath, destinationUrl] of Object.entries(redirects)) {
+        const slugPath = normalizeEsfaRedirectPath(requestedPath);
+        assert.equal(ESFA_REDIRECTS[slugPath], destinationUrl);
+
+        const seed = buildEsfaManagedRedirectSeed({ slugPath, destinationUrl, now: 789 });
+        assert.equal(seed.destinationHost, "www.asaas.com");
+        assert.equal(seed.placement, "payment");
+    }
 });
 
 test("listEsfaManagedRedirectSeeds covers the full static catalog", () => {

--- a/website/tests/siteCustomUrls.test.ts
+++ b/website/tests/siteCustomUrls.test.ts
@@ -55,6 +55,19 @@ test("normalizeSiteCustomUrlInput preserves unicode slugs and accepts approved e
     assert.equal(input.destinationHost, "www.google.com");
 });
 
+test("normalizeSiteCustomUrlInput accepts Asaas payment links", () => {
+    const input = normalizeSiteCustomUrlInput({
+        siteHost: "esfa.co",
+        name: "Clube Botox 40U",
+        slugPath: "/ClubeBotox40U",
+        destinationUrl: "https://www.asaas.com/c/85kw6n2otrtdhjqe",
+    });
+
+    assert.equal(input.slugPath, "/clubebotox40u");
+    assert.equal(input.destinationHost, "www.asaas.com");
+    assert.equal(input.destinationUrl, "https://www.asaas.com/c/85kw6n2otrtdhjqe");
+});
+
 test("normalizeSiteCustomUrlInput allows esfa aliases but prevents redirect loops", () => {
     const alias = normalizeSiteCustomUrlInput({
         siteHost: "esfa.co",


### PR DESCRIPTION
# Summary

Add the three requested `esfa.co` short links for Clube Botox 40U, 50U, and 60U. The aliases are normalized case-insensitively by the existing redirect Worker and point to the requested Asaas payment links. The Asaas host is added to the managed-redirect allowlist and classified as a payment destination so the official D1 sync can materialize the catalog safely.

## Type of change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (existing README already documents the deploy/sync flow; no new operational rule needed)
- [ ] Security review (CodeQL, gitleaks)
- [ ] Performance impact measured

## Links
- Issue: Not provided
- Design/ADR: Not applicable
- Migration steps: No schema migration. The official website deployment runs `npm run custom-urls:migrate:esfa -- --apply --remote` after the redirects Worker deploy, inserting/updating the three managed `site_custom_urls` rows idempotently.

## Screenshots / Evidence
- Source SHA: `fc8ea8effe9c9a9a2946ee9fbcaad738d1e4d6a1`
- Local focused validation: 11/11 tests passed for `esfaManagedRedirects.test.ts` and `siteCustomUrls.test.ts`; `git diff --check` passed.
- Pre-change public baseline: all three requested URLs returned `404 Not Found`.
- Production smoke after merge/deploy must verify each URL returns `301` to the exact Asaas destination, including the case-normalized request path and query-string preservation.
- Rollback: redeploy the previous website release SHA/Worker version; if D1 rows have already been synced, deactivate only these three managed rows by `site_host='esfa.co'` and the exact slugs `/clubebotox40u`, `/clubebotox50u`, and `/clubebotox60u` (reversible `active=0` update, no deletion).