### PR TITLE
fix(website): scope Clube Botox links to Novo Hamburgo

### DIFF
--- a/website/scripts/migrate-esfa-redirects.ts
+++ b/website/scripts/migrate-esfa-redirects.ts
@@ -154,6 +154,10 @@ function buildPlan(existingRows: ExistingRedirectRow[], seeds: EsfaManagedUrlSee
             plan.conflicts.push({ existing, seed });
             continue;
         }
+        if (!seed.active && existing.source !== ESFA_MIGRATED_SOURCE) {
+            plan.conflicts.push({ existing, seed });
+            continue;
+        }
         if (seedMatchesExisting(existing, seed)) {
             plan.skips.push({ existing, seed });
             continue;

--- a/website/src/lib/esfaManagedRedirects.ts
+++ b/website/src/lib/esfaManagedRedirects.ts
@@ -1,5 +1,6 @@
 import {
     buildEsfaRedirectLabel,
+    ESFA_RETIRED_REDIRECTS,
     listEsfaRedirects,
     normalizeEsfaRedirectPath,
 } from "@/lib/esfaRedirects";
@@ -63,6 +64,7 @@ export function buildEsfaManagedRedirectSeed(params: {
     slugPath: string;
     destinationUrl: string;
     now?: number;
+    active?: boolean;
 }): EsfaManagedUrlSeed {
     const normalizedSlugPath = normalizeEsfaRedirectPath(params.slugPath);
     const now = params.now ?? Date.now();
@@ -75,7 +77,7 @@ export function buildEsfaManagedRedirectSeed(params: {
         source: ESFA_MIGRATED_SOURCE,
         placement: inferPlacement(normalizedSlugPath, null),
         unitSlug: inferUnitSlug(normalizedSlugPath),
-        active: true,
+        active: params.active ?? true,
     });
     return {
         ...normalized,
@@ -88,13 +90,22 @@ export function buildEsfaManagedRedirectSeed(params: {
 }
 
 export function listEsfaManagedRedirectSeeds(now = Date.now()): EsfaManagedUrlSeed[] {
-    return listEsfaRedirects().map((entry) =>
+    const activeSeeds = listEsfaRedirects().map((entry) =>
         buildEsfaManagedRedirectSeed({
             slugPath: entry.slugPath,
             destinationUrl: entry.destinationUrl,
             now,
         }),
     );
+    const retiredSeeds = Object.entries(ESFA_RETIRED_REDIRECTS).map(([slugPath, destinationUrl]) =>
+        buildEsfaManagedRedirectSeed({
+            slugPath,
+            destinationUrl,
+            now,
+            active: false,
+        }),
+    );
+    return [...activeSeeds, ...retiredSeeds];
 }
 
 export function listEsfaFallbackRedirects(identities: ManagedUrlIdentity[]) {

--- a/website/src/lib/esfaRedirects.ts
+++ b/website/src/lib/esfaRedirects.ts
@@ -2,6 +2,18 @@ import { ANIVERSARIO_7_ESFA_REDIRECTS } from "@/lib/aniversario7Redirects";
 
 export const ESFA_PRESERVE_QUERYSTRING = true;
 
+export const CLUBE_BOTOX_ASAAS_REDIRECTS: Record<string, string> = {
+  "/nh/clubebotox40u": "https://www.asaas.com/c/85kw6n2otrtdhjqe",
+  "/nh/clubebotox50u": "https://www.asaas.com/c/93fcmgkhgcin2igk",
+  "/nh/clubebotox60u": "https://www.asaas.com/c/hqown86982e9y7f4",
+};
+
+export const ESFA_RETIRED_REDIRECTS: Record<string, string> = {
+  "/clubebotox40u": "https://www.asaas.com/c/85kw6n2otrtdhjqe",
+  "/clubebotox50u": "https://www.asaas.com/c/93fcmgkhgcin2igk",
+  "/clubebotox60u": "https://www.asaas.com/c/hqown86982e9y7f4",
+};
+
 export const ESFA_REDIRECTS: Record<string, string> = {
   // BarraShoppingSul
   "/bss/comochegar": "https://www.google.com/maps/place/Espaço+Facial/@-30.0846697,-51.2458384,17z/data=!3m1!4b1!4m6!3m5!1s0x9519795c306ed865:0xb5f05aac9b865daa!8m2!3d-30.0846697!4d-51.2458384!16s%2Fg%2F11vywknzbf?entry=ttu&g_ep=EgoyMDI1MDMxMS4wIKXMDSoASAFQAw%3D%3D",
@@ -41,10 +53,8 @@ export const ESFA_REDIRECTS: Record<string, string> = {
 
   // Campanhas
   ...ANIVERSARIO_7_ESFA_REDIRECTS,
-  // Clube Botox
-  "/clubebotox40u": "https://www.asaas.com/c/85kw6n2otrtdhjqe",
-  "/clubebotox50u": "https://www.asaas.com/c/93fcmgkhgcin2igk",
-  "/clubebotox60u": "https://www.asaas.com/c/hqown86982e9y7f4",
+  // Clube Botox — Novo Hamburgo
+  ...CLUBE_BOTOX_ASAAS_REDIRECTS,
   "/bebadessafonte": "https://api.whatsapp.com/send?phone=5551995811008&text=Ganhei+um+%2Adesconto+exclusivo%2A+da+HealthBodyRun+para+o+meu+momento+de+%2Aauto-cuidado+e+bem-estar%2A+na+Espa%C3%A7o+Facial.+Quero+saber+mais%21+%F0%9F%92%A5",
 
   // Interno

--- a/website/tests/esfaManagedRedirects.test.ts
+++ b/website/tests/esfaManagedRedirects.test.ts
@@ -6,7 +6,11 @@ import {
     listEsfaFallbackRedirects,
     listEsfaManagedRedirectSeeds,
 } from "../src/lib/esfaManagedRedirects";
-import { ESFA_REDIRECTS, normalizeEsfaRedirectPath } from "../src/lib/esfaRedirects";
+import {
+    ESFA_REDIRECTS,
+    ESFA_RETIRED_REDIRECTS,
+    normalizeEsfaRedirectPath,
+} from "../src/lib/esfaRedirects";
 import { ANIVERSARIO_7_ESFA_REDIRECTS, ANIVERSARIO_7_LEGACY_REDIRECTS } from "../src/lib/aniversario7Redirects";
 
 test("buildEsfaManagedRedirectSeed infers metadata for migrated esfa redirects", () => {
@@ -27,9 +31,9 @@ test("buildEsfaManagedRedirectSeed infers metadata for migrated esfa redirects",
 
 test("Clube Botox U aliases resolve to the requested Asaas payment links", () => {
     const redirects = {
-        "/ClubeBotox40U": "https://www.asaas.com/c/85kw6n2otrtdhjqe",
-        "/ClubeBotox50U": "https://www.asaas.com/c/93fcmgkhgcin2igk",
-        "/ClubeBotox60U": "https://www.asaas.com/c/hqown86982e9y7f4",
+        "/nh/ClubeBotox40U": "https://www.asaas.com/c/85kw6n2otrtdhjqe",
+        "/nh/ClubeBotox50U": "https://www.asaas.com/c/93fcmgkhgcin2igk",
+        "/nh/ClubeBotox60U": "https://www.asaas.com/c/hqown86982e9y7f4",
     };
 
     for (const [requestedPath, destinationUrl] of Object.entries(redirects)) {
@@ -39,15 +43,30 @@ test("Clube Botox U aliases resolve to the requested Asaas payment links", () =>
         const seed = buildEsfaManagedRedirectSeed({ slugPath, destinationUrl, now: 789 });
         assert.equal(seed.destinationHost, "www.asaas.com");
         assert.equal(seed.placement, "payment");
+        assert.equal(seed.unitSlug, "novo-hamburgo");
     }
 });
 
-test("listEsfaManagedRedirectSeeds covers the full static catalog", () => {
+test("listEsfaManagedRedirectSeeds covers the active and retired catalog", () => {
     const seeds = listEsfaManagedRedirectSeeds(456);
 
-    assert.equal(seeds.length, Object.keys(ESFA_REDIRECTS).length);
+    assert.equal(seeds.length, Object.keys(ESFA_REDIRECTS).length + Object.keys(ESFA_RETIRED_REDIRECTS).length);
     assert.equal(new Set(seeds.map((seed) => seed.slugPath)).size, seeds.length);
     assert.equal(seeds.every((seed) => seed.siteHost === "esfa.co"), true);
+});
+
+test("generic Clube Botox aliases are retired when the NH catalog is promoted", () => {
+    const seeds = listEsfaManagedRedirectSeeds(789);
+    const retired = seeds.filter((seed) => Object.hasOwn(ESFA_RETIRED_REDIRECTS, seed.slugPath));
+
+    assert.equal(retired.length, 3);
+    assert.equal(retired.every((seed) => seed.active === false), true);
+    assert.deepEqual(
+        retired.map((seed) => seed.slugPath).sort(),
+        Object.keys(ESFA_RETIRED_REDIRECTS).sort(),
+    );
+    assert.equal(ESFA_REDIRECTS["/clubebotox40u"], undefined);
+    assert.equal(ESFA_REDIRECTS["/nh/clubebotox40u"], "https://www.asaas.com/c/85kw6n2otrtdhjqe");
 });
 
 test("aniversario 7 campaign aliases converge to the canonical short links", () => {

--- a/website/tests/siteCustomUrls.test.ts
+++ b/website/tests/siteCustomUrls.test.ts
@@ -59,11 +59,11 @@ test("normalizeSiteCustomUrlInput accepts Asaas payment links", () => {
     const input = normalizeSiteCustomUrlInput({
         siteHost: "esfa.co",
         name: "Clube Botox 40U",
-        slugPath: "/ClubeBotox40U",
+        slugPath: "/nh/ClubeBotox40U",
         destinationUrl: "https://www.asaas.com/c/85kw6n2otrtdhjqe",
     });
 
-    assert.equal(input.slugPath, "/clubebotox40u");
+    assert.equal(input.slugPath, "/nh/clubebotox40u");
     assert.equal(input.destinationHost, "www.asaas.com");
     assert.equal(input.destinationUrl, "https://www.asaas.com/c/85kw6n2otrtdhjqe");
 });


### PR DESCRIPTION
# Summary

Scope the three Clube Botox Asaas links to the Novo Hamburgo unit by adding the `/nh/` prefix. The previous generic paths are retained in the managed catalog as inactive retired records so the official D1 sync removes them from active resolution without losing rollback/audit state.

## Type of change
- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated
- [ ] Docs updated (README, API refs, diagrams)
- [ ] Security review (CodeQL, gitleaks)
- [ ] Performance impact measured

## Links
- Issue: None
- Design/ADR: None
- Migration steps: The governed website deployment runs the existing remote D1 synchronization. It promotes the three `/nh/` rows and deactivates the three old generic rows; no schema change is required.

## Screenshots / Evidence
New active links:
- `https://esfa.co/nh/ClubeBotox40U` -> `https://www.asaas.com/c/85kw6n2otrtdhjqe`
- `https://esfa.co/nh/ClubeBotox50U` -> `https://www.asaas.com/c/93fcmgkhgcin2igk`
- `https://esfa.co/nh/ClubeBotox60U` -> `https://www.asaas.com/c/hqown86982e9y7f4`

Rollback: redeploy the prior release or restore the retired rows to active through the same governed migration path, then rerun the redirect smoke checks.