### PR TITLE
feat(social): establish Influencer Intelligence M0 contracts

### DIFF
--- a/.github/workflows/architecture-governance.yml
+++ b/.github/workflows/architecture-governance.yml
@@ -58,6 +58,8 @@ jobs:
         run: node .github/scripts/validate-module-catalog.mjs && node .github/scripts/validate-module-maturity.mjs
       - name: Validate domain import boundaries
         run: node .github/scripts/validate-domain-boundaries.mjs
+      - name: Test Influencer Intelligence contract boundary
+        run: node --test social/influencer-intelligence/tests/contracts.test.mjs
       - name: Validate reproducible staging manifest
         run: node .github/scripts/validate-staging-manifest.mjs
       - name: Validate staging bootstrap safety guards

--- a/social/influencer-intelligence/README.md
+++ b/social/influencer-intelligence/README.md
@@ -1,0 +1,163 @@
+# Influencer Intelligence
+
+Status: M0 contract-only, experimental, not exposed, and off by default.
+
+This domain provides read-only intelligence about Instagram creators for
+analysis, comparison, and campaign fit. It is not an engagement automation
+surface, a publication surface, or a new scraping project.
+
+## M0 decision
+
+M0 establishes the boundary in
+[`contracts.mjs`](./contracts.mjs). The contract is pure and versioned, and it
+accepts only normalized evidence, structured signals, and score envelopes. It
+does not make network calls, read secrets, persist data, schedule jobs, expose
+HTTP, register a CRM module, or activate a feature flag.
+
+The focused tests use only synthetic creator identifiers and provider-shaped
+observations. They prove the contract rejects credentials, direct contact
+identifiers, raw provider objects, query-string provenance, and unauditable
+inferred signals.
+
+## Concrete target architecture
+
+```text
+Codex
+  -> skincos-influencer-intelligence skill (M7)
+  -> read-only Influencer Intelligence MCP (M6)
+  -> internal service/API (M2-M5)
+  -> provider router
+       -> Meta Graph official adapter (first preference)
+       -> existing social/instagram instagrapi adapter (controlled fallback)
+       -> optional future provider only after a documented gap (M13)
+  -> PostgreSQL append-only snapshots (M1/M3)
+  -> deterministic analytics and scoring (M4/M5)
+  -> read-only CRM contract and dashboard (M8+)
+  -> Orb scheduling/orchestration only (M3)
+```
+
+The provider boundary is intentionally closed in M0 to the two already
+identified sources: `meta-graph` and `instagrapi`. No Apify, Modash,
+Instaloader, or new scraper is introduced. The existing
+`InstagramModuleSimulator` is not a source, and the temporary FastAPI surface
+under `social/instagram/module/api/` must not be exposed as the domain API
+without independent authentication, input, timeout, rate-limit, audit, and
+deployment hardening.
+
+### Incumbent integrations to reuse
+
+- Official-first collection will wrap the existing CRM Graph adapter in
+  `crm/console/functions/_lib/instagramGraph.ts` and its authenticated
+  connection boundary in `instagramStore.ts`; the CRM UI must not call Graph
+  or instagrapi directly.
+- The controlled fallback will reuse the existing
+  `social/instagram/module/instagram_site_sync.py` and its vendored instagrapi
+  session path. It will not duplicate that implementation.
+- Credentials belong in `platform/security/token-vault`. Clear tokens,
+  cookies, authorization headers, and connection payloads never cross this
+  contract. The existing Token Vault publish gateway is not silently treated
+  as an analytics gateway; M2 must establish a separate read-only analytics
+  allowlist/adapter before collection is implemented.
+- Orb/n8n will schedule and resume jobs after the service contract exists. It
+  will not become a provider, scoring engine, shell bridge, or arbitrary SQL
+  executor.
+- `website` Instagram cache data is not a historical intelligence source.
+  Historical snapshots begin only when the additive PostgreSQL migration and
+  retention policy are reviewed in M1/M3.
+
+## Contract rules
+
+`contracts.mjs` exposes these versioned shapes:
+
+- `ProviderSnapshot`: an opaque internal creator key, optional canonical
+  handle, one approved provider, one observation timestamp, metric
+  observations, and provenance.
+- `MetricObservation`: a scalar value, unit, explicit evidence state, bounded
+  confidence, and provenance. Raw profiles, captions, comments, tokens, and
+  contact fields are not values in this contract.
+- `ScoreEnvelope`: a score from 0 to 100 or an explicit `null` when
+  unavailable, confidence from 0 to 1, derived data coverage, provider list,
+  provenance, timestamp, deterministic `algorithmVersion`, and structured
+  signals.
+- `StructuredSignal`: a bounded scalar, explicit evidence state, confidence,
+  evidence references, and an optional model version. Free-form LLM rationale
+  or prompt/completion text is not persisted here.
+
+Every evidence-bearing shape uses exactly one of:
+
+| State | Meaning | Allowed interpretation |
+| --- | --- | --- |
+| `observed` | Returned or directly measured by an approved provider | Evidence, not quality judgment |
+| `derived` | Deterministically calculated from observed data | Reproducible with the algorithm version |
+| `inferred` | A bounded interpretation or model signal | Must carry confidence, evidence references, and model version when model-derived |
+| `unavailable` | The provider or permission did not supply the signal | Value is `null`; consumers must not impute it as zero |
+
+Provenance references are opaque, bounded paths without query strings or
+fragments. Timestamps are canonical ISO values. Coverage is calculated from
+`availableMetrics / expectedMetrics`; callers cannot assert a more favorable
+ratio.
+
+## Analytics guardrails
+
+- Absolute follower count is an observed scale signal, never a quality score.
+- M4 must use time-bounded, post-level robust statistics and explicitly handle
+  viral outliers; a single post must not dominate a creator comparison.
+- The system must not state that an account has fake followers from indirect
+  evidence. It may report a bounded, clearly labeled inferred signal such as
+  `suspicious_growth_pattern` with confidence, coverage, provenance, and the
+  algorithm/model version.
+- Comments intelligence stores aggregate, minimized signals (for example
+  topic, sentiment, safety, and spam proportions) rather than an unbounded
+  comment archive. Raw text retention requires a separate privacy decision.
+- A score is not complete without score, confidence, coverage, provenance,
+  timestamp, provider identifiers, evidence state, and algorithm version.
+
+## Rollout and access
+
+The planned module flag is `INFLUENCER_INTELLIGENCE_ENABLED=false`. M0 does
+not wire it. When the CRM surface is introduced, access must be independently
+enforced by the server-side grant `module.influencer-intelligence.access` and
+the module catalog; navigation visibility is not authorization.
+
+The only permitted progression is:
+
+```text
+off -> shadow (synthetic or approved staging evidence) -> active (explicit gate)
+```
+
+No M0 artifact enables a real user, calls an external provider with business
+effects, publishes content, sends engagement actions, or changes production
+configuration.
+
+## Milestone map
+
+| Milestone | Deliverable | M0 status |
+| --- | --- | --- |
+| M0 | Architecture and normalized contracts | In progress |
+| M1 | Creator registry and additive PostgreSQL schema | Pending; no migration in M0 |
+| M2 | Official-first router and controlled collectors | Pending; no provider code in M0 |
+| M3 | Append-only snapshots, retention, and Orb scheduling | Pending |
+| M4 | Robust analytics and outlier-resistant metrics | Pending |
+| M5 | Deterministic score, confidence, coverage, and provenance | Pending |
+| M6 | Authenticated, sanitized, rate-limited read-only MCP | Pending |
+| M7 | `skincos-influencer-intelligence` Codex skill | Pending |
+| M8 | Read-only CRM contracts and dashboard | Pending |
+| M9 | Minimized comments intelligence | Pending |
+| M10 | Semantic content and Reels signals | Pending |
+| M11 | Campaign and brand fit | Pending |
+| M12 | Synthetic validation and calibration | Pending |
+| M13 | Optional provider gap analysis | Pending; only if a measured gap remains |
+
+## M0 risk, validation, and rollback
+
+- Risk: medium, limited to a new social-domain contract and synthetic tests.
+- Surfaces: `social/influencer-intelligence/**` plus one read-only test step in
+  `.github/workflows/architecture-governance.yml`; no runtime, database, CRM,
+  MCP, Orb, systemd, Cloudflare, or user-facing surface.
+- Migration: none.
+- Flag: declared for the future, not wired; default remains `false`.
+- Validation: focused Node contract tests, architecture/domain-boundary
+  checks, forbidden-surface/secret scan, and terminal hosted checks on the
+  exact pull-request SHA.
+- Rollback: close or revert the single-purpose change to the M0 base SHA. No
+  user data or remote state is created by this milestone.

--- a/social/influencer-intelligence/contracts.mjs
+++ b/social/influencer-intelligence/contracts.mjs
@@ -1,0 +1,397 @@
+/**
+ * Stable boundary for Influencer Intelligence evidence and score payloads.
+ *
+ * This module is deliberately pure: it performs no network, filesystem,
+ * database, provider, or scheduling work. Provider adapters and consumers must
+ * normalize through this boundary before a payload can be persisted or scored.
+ */
+
+export const INFLUENCER_INTELLIGENCE_CONTRACT_VERSION = 'influencer-intelligence/v1';
+
+export const EVIDENCE_STATES = Object.freeze([
+  'observed',
+  'derived',
+  'inferred',
+  'unavailable',
+]);
+
+export const SUPPORTED_PROVIDER_IDS = Object.freeze([
+  'meta-graph',
+  'instagrapi',
+]);
+
+export const SOURCE_TYPES = Object.freeze([
+  'profile',
+  'media',
+  'comments-aggregate',
+  'insights',
+  'synthetic',
+]);
+
+export const SCORE_KINDS = Object.freeze([
+  'influencer',
+  'campaign-fit',
+  'brand-fit',
+  'risk',
+]);
+
+const evidenceStateSet = new Set(EVIDENCE_STATES);
+const providerSet = new Set(SUPPORTED_PROVIDER_IDS);
+const sourceTypeSet = new Set(SOURCE_TYPES);
+const scoreKindSet = new Set(SCORE_KINDS);
+const forbiddenKeySet = new Set([
+  'accesstoken',
+  'refreshtoken',
+  'idtoken',
+  'token',
+  'authorization',
+  'cookie',
+  'cookies',
+  'session',
+  'sessionid',
+  'password',
+  'secret',
+  'apikey',
+  'clientsecret',
+  'email',
+  'phone',
+  'telephone',
+  'username',
+]);
+const sensitiveStringPattern = /(?:^|[?&\s])(?:access[_-]?token|refresh[_-]?token|authorization|cookie|password|secret|api[_-]?key)\s*[:=]/i;
+const controlCharacterPattern = /[\u0000-\u001f\u007f]/;
+
+export class InfluencerIntelligenceContractError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'InfluencerIntelligenceContractError';
+  }
+}
+
+function fail(message) {
+  throw new InfluencerIntelligenceContractError(message);
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function deepFreeze(value, seen = new Set()) {
+  if (!value || typeof value !== 'object' || seen.has(value)) return value;
+  seen.add(value);
+  for (const child of Object.values(value)) deepFreeze(child, seen);
+  return Object.freeze(value);
+}
+
+function normalizedKey(value) {
+  return String(value).replace(/[^a-z0-9]/gi, '').toLowerCase();
+}
+
+/**
+ * Rejects secrets and direct contact identifiers before normalization. This is
+ * intentionally stricter than the current incumbent integrations: the new
+ * contract is not allowed to become a transport for credentials or raw PII.
+ */
+export function assertNoSensitiveFields(value, path = 'input', seen = new Set()) {
+  if (typeof value === 'string') {
+    if (sensitiveStringPattern.test(value)) fail(`${path} contains a credential-like assignment`);
+    return;
+  }
+  if (!value || typeof value !== 'object') return;
+  if (seen.has(value)) fail(`${path} contains a circular value`);
+  seen.add(value);
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoSensitiveFields(item, `${path}[${index}]`, seen));
+    seen.delete(value);
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (forbiddenKeySet.has(normalizedKey(key))) fail(`${path}.${key} is not permitted in a domain contract`);
+    assertNoSensitiveFields(child, `${path}.${key}`, seen);
+  }
+  seen.delete(value);
+}
+
+function assertRecord(value, label) {
+  if (!isRecord(value)) fail(`${label} must be an object`);
+}
+
+function stringValue(value, label, { maxLength = 160, required = true } = {}) {
+  if (value === undefined || value === null || value === '') {
+    if (required) fail(`${label} is required`);
+    return undefined;
+  }
+  if (typeof value !== 'string') fail(`${label} must be a string`);
+  const normalized = value.trim();
+  if (!normalized && required) fail(`${label} must not be empty`);
+  if (normalized.length > maxLength) fail(`${label} exceeds ${maxLength} characters`);
+  if (controlCharacterPattern.test(normalized)) fail(`${label} contains a control character`);
+  if (sensitiveStringPattern.test(normalized)) fail(`${label} contains a credential-like assignment`);
+  return normalized;
+}
+
+function slugValue(value, label, { maxLength = 64 } = {}) {
+  const normalized = stringValue(value, label, { maxLength });
+  if (!/^[a-z][a-z0-9._-]*$/.test(normalized)) fail(`${label} must be a lowercase slug`);
+  return normalized;
+}
+
+function versionValue(value, label) {
+  const normalized = stringValue(value, label, { maxLength: 80 });
+  if (!/^[a-z][a-z0-9._/-]*$/.test(normalized)) fail(`${label} must be a lowercase version identifier`);
+  return normalized;
+}
+
+function opaqueId(value, label, { maxLength = 128 } = {}) {
+  const normalized = stringValue(value, label, { maxLength });
+  if (!/^[A-Za-z0-9._:-]+$/.test(normalized)) fail(`${label} must be an opaque identifier`);
+  return normalized;
+}
+
+function enumValue(value, label, values, allowed) {
+  const normalized = stringValue(value, label, { maxLength: 64 }).toLowerCase();
+  if (!allowed.has(normalized)) fail(`${label} must be one of ${values.join(', ')}`);
+  return normalized;
+}
+
+function unitInterval(value, label) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 1) {
+    fail(`${label} must be a finite number between 0 and 1`);
+  }
+  return Number(value.toFixed(6));
+}
+
+function scoreValue(value, label) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 100) {
+    fail(`${label} must be a finite number between 0 and 100`);
+  }
+  return Number(value.toFixed(4));
+}
+
+function integerValue(value, label, { minimum = 0 } = {}) {
+  if (!Number.isInteger(value) || value < minimum) fail(`${label} must be an integer >= ${minimum}`);
+  return value;
+}
+
+function timestampValue(value, label) {
+  const normalized = stringValue(value, label, { maxLength: 40 });
+  const parsed = new Date(normalized);
+  if (Number.isNaN(parsed.getTime())) fail(`${label} must be an ISO timestamp`);
+  return parsed.toISOString();
+}
+
+function safeSourceRef(value, label = 'sourceRef') {
+  const normalized = stringValue(value, label, { maxLength: 240, required: false });
+  if (normalized === undefined) return undefined;
+  if (!/^[A-Za-z0-9._:/-]+$/.test(normalized)) {
+    fail(`${label} must be an opaque path without query strings or fragments`);
+  }
+  return normalized;
+}
+
+function safeScalar(value, label) {
+  if (value === undefined) return undefined;
+  if (value === null || typeof value === 'boolean') return value;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) fail(`${label} must be finite`);
+    return Number(value.toFixed(6));
+  }
+  if (typeof value === 'string') return stringValue(value, label, { maxLength: 160 });
+  fail(`${label} must be a scalar; raw provider objects and text payloads are not allowed`);
+}
+
+function normalizeHandle(value) {
+  const normalized = stringValue(value, 'handle', { maxLength: 30, required: false });
+  if (normalized === undefined) return undefined;
+  const handle = normalized.replace(/^@/, '').toLowerCase();
+  if (!/^[a-z0-9._]{1,30}$/.test(handle)) fail('handle must be a valid Instagram handle');
+  return handle;
+}
+
+function normalizeProvider(value, label = 'provider') {
+  return enumValue(value, label, SUPPORTED_PROVIDER_IDS, providerSet);
+}
+
+function normalizeEvidenceState(value, label = 'evidenceState') {
+  return enumValue(value, label, EVIDENCE_STATES, evidenceStateSet);
+}
+
+export function normalizeProvenance(input) {
+  assertNoSensitiveFields(input, 'provenance');
+  assertRecord(input, 'provenance');
+  const provider = normalizeProvider(input.provider);
+  const sourceType = enumValue(input.sourceType, 'sourceType', SOURCE_TYPES, sourceTypeSet);
+  const evidenceState = normalizeEvidenceState(input.evidenceState);
+  const observedAt = timestampValue(input.observedAt, 'observedAt');
+  const retrievedAt = input.retrievedAt === undefined
+    ? undefined
+    : timestampValue(input.retrievedAt, 'retrievedAt');
+  if (retrievedAt && new Date(retrievedAt).getTime() < new Date(observedAt).getTime()) {
+    fail('retrievedAt must not precede observedAt');
+  }
+  const sourceRef = safeSourceRef(input.sourceRef);
+  return deepFreeze({
+    contractVersion: INFLUENCER_INTELLIGENCE_CONTRACT_VERSION,
+    provider,
+    sourceType,
+    evidenceState,
+    observedAt,
+    ...(retrievedAt ? { retrievedAt } : {}),
+    ...(sourceRef ? { sourceRef } : {}),
+  });
+}
+
+export function normalizeCoverage(input) {
+  assertNoSensitiveFields(input, 'coverage');
+  assertRecord(input, 'coverage');
+  const availableMetrics = integerValue(input.availableMetrics, 'coverage.availableMetrics');
+  const expectedMetrics = integerValue(input.expectedMetrics, 'coverage.expectedMetrics', { minimum: 1 });
+  if (availableMetrics > expectedMetrics) fail('coverage.availableMetrics cannot exceed expectedMetrics');
+  return deepFreeze({
+    availableMetrics,
+    expectedMetrics,
+    ratio: Number((availableMetrics / expectedMetrics).toFixed(6)),
+  });
+}
+
+export function normalizeMetricObservation(input) {
+  assertNoSensitiveFields(input, 'observation');
+  assertRecord(input, 'observation');
+  const key = slugValue(input.key, 'observation.key', { maxLength: 80 });
+  const unit = slugValue(input.unit, 'observation.unit', { maxLength: 32 });
+  const evidenceState = normalizeEvidenceState(input.evidenceState);
+  const provenance = normalizeProvenance(input.provenance);
+  const hasValue = input.value !== undefined && input.value !== null;
+  if (evidenceState === 'unavailable' && hasValue) {
+    fail('unavailable observations must not contain a value');
+  }
+  if (evidenceState !== 'unavailable' && !hasValue) {
+    fail(`${key} must contain a value unless it is unavailable`);
+  }
+  if (provenance.evidenceState !== evidenceState) {
+    fail(`${key} evidenceState must match provenance.evidenceState`);
+  }
+  if (provenance.provider !== normalizeProvider(input.provenance.provider, `${key}.provenance.provider`)) {
+    fail(`${key} provider must match provenance.provider`);
+  }
+  const confidence = evidenceState === 'unavailable'
+    ? 0
+    : unitInterval(input.confidence === undefined ? (evidenceState === 'observed' ? 1 : 0) : input.confidence, 'observation.confidence');
+  return deepFreeze({
+    contractVersion: INFLUENCER_INTELLIGENCE_CONTRACT_VERSION,
+    key,
+    unit,
+    value: evidenceState === 'unavailable' ? null : safeScalar(input.value, `observation.${key}.value`),
+    evidenceState,
+    confidence,
+    provenance,
+  });
+}
+
+export function normalizeProviderSnapshot(input) {
+  assertNoSensitiveFields(input, 'providerSnapshot');
+  assertRecord(input, 'providerSnapshot');
+  const provider = normalizeProvider(input.provider, 'providerSnapshot.provider');
+  const creatorKey = opaqueId(input.creatorKey, 'providerSnapshot.creatorKey');
+  const handle = normalizeHandle(input.handle);
+  const observedAt = timestampValue(input.observedAt, 'providerSnapshot.observedAt');
+  const evidenceState = normalizeEvidenceState(input.evidenceState, 'providerSnapshot.evidenceState');
+  if (!Array.isArray(input.observations)) fail('providerSnapshot.observations must be an array');
+  const observations = input.observations.map(normalizeMetricObservation);
+  for (const observation of observations) {
+    if (observation.provenance.provider !== provider) fail('all snapshot observations must use the snapshot provider');
+    if (observation.provenance.observedAt !== observedAt) fail('all snapshot observations must use the snapshot observedAt');
+  }
+  const provenance = normalizeProvenance({
+    ...input.provenance,
+    provider,
+    sourceType: input.provenance?.sourceType || 'profile',
+    evidenceState,
+    observedAt,
+  });
+  return deepFreeze({
+    contractVersion: INFLUENCER_INTELLIGENCE_CONTRACT_VERSION,
+    creatorKey,
+    ...(handle ? { handle } : {}),
+    provider,
+    observedAt,
+    evidenceState,
+    observations,
+    provenance,
+  });
+}
+
+function normalizeEvidenceRefs(value) {
+  if (!Array.isArray(value)) fail('signal.evidenceRefs must be an array');
+  if (value.length > 8) fail('signal.evidenceRefs may contain at most 8 references');
+  const refs = value.map((item, index) => safeSourceRef(item, `signal.evidenceRefs[${index}]`));
+  if (new Set(refs).size !== refs.length) fail('signal.evidenceRefs must be unique');
+  return refs;
+}
+
+export function normalizeStructuredSignal(input) {
+  assertNoSensitiveFields(input, 'signal');
+  assertRecord(input, 'signal');
+  const key = slugValue(input.key, 'signal.key', { maxLength: 80 });
+  const evidenceState = normalizeEvidenceState(input.evidenceState, 'signal.evidenceState');
+  const evidenceRefs = normalizeEvidenceRefs(input.evidenceRefs || []);
+  if (evidenceState !== 'unavailable' && evidenceRefs.length === 0) {
+    fail(`${key} must cite at least one evidence reference`);
+  }
+  const modelVersion = stringValue(input.modelVersion, 'signal.modelVersion', { maxLength: 80, required: false });
+  if (evidenceState === 'inferred' && !modelVersion) fail(`${key} inferred signals require modelVersion`);
+  const value = evidenceState === 'unavailable' ? null : safeScalar(input.value, `signal.${key}.value`);
+  if (evidenceState !== 'unavailable' && value === undefined) fail(`${key} must contain a value unless it is unavailable`);
+  return deepFreeze({
+    key,
+    value,
+    evidenceState,
+    confidence: evidenceState === 'unavailable' ? 0 : unitInterval(input.confidence, `signal.${key}.confidence`),
+    evidenceRefs,
+    ...(modelVersion ? { modelVersion } : {}),
+  });
+}
+
+function normalizeProviders(value, evidenceState) {
+  if (!Array.isArray(value)) fail('providers must be an array');
+  const providers = [...new Set(value.map((item, index) => normalizeProvider(item, `providers[${index}]`)))].sort();
+  if (evidenceState !== 'unavailable' && providers.length === 0) fail('available scores require at least one provider');
+  return providers;
+}
+
+export function normalizeScoreEnvelope(input) {
+  assertNoSensitiveFields(input, 'score');
+  assertRecord(input, 'score');
+  const scoreKind = enumValue(input.scoreKind, 'scoreKind', SCORE_KINDS, scoreKindSet);
+  const evidenceState = normalizeEvidenceState(input.evidenceState, 'score.evidenceState');
+  const algorithmVersion = versionValue(input.algorithmVersion, 'algorithmVersion');
+  const timestamp = timestampValue(input.timestamp, 'score.timestamp');
+  const coverage = normalizeCoverage(input.coverage);
+  const providers = normalizeProviders(input.providers, evidenceState);
+  if (!Array.isArray(input.provenance)) fail('score.provenance must be an array');
+  const provenance = input.provenance.map(normalizeProvenance).sort((left, right) => (
+    `${left.provider}:${left.sourceType}:${left.observedAt}:${left.sourceRef || ''}`
+      .localeCompare(`${right.provider}:${right.sourceType}:${right.observedAt}:${right.sourceRef || ''}`)
+  ));
+  if (evidenceState !== 'unavailable' && provenance.length === 0) fail('available scores require provenance');
+  for (const item of provenance) {
+    if (!providers.includes(item.provider)) fail('score provenance provider must be listed in providers');
+  }
+  const signals = (input.signals || []).map(normalizeStructuredSignal).sort((left, right) => left.key.localeCompare(right.key));
+  if (signals.length > 32) fail('score.signals may contain at most 32 signals');
+  const score = evidenceState === 'unavailable' ? null : scoreValue(input.score, 'score.score');
+  const confidence = evidenceState === 'unavailable' ? 0 : unitInterval(input.confidence, 'score.confidence');
+  return deepFreeze({
+    contractVersion: INFLUENCER_INTELLIGENCE_CONTRACT_VERSION,
+    scoreKind,
+    score,
+    confidence,
+    coverage,
+    evidenceState,
+    providers,
+    provenance,
+    algorithmVersion,
+    timestamp,
+    signals,
+  });
+}

--- a/social/influencer-intelligence/tests/contracts.test.mjs
+++ b/social/influencer-intelligence/tests/contracts.test.mjs
@@ -1,0 +1,233 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  EVIDENCE_STATES,
+  INFLUENCER_INTELLIGENCE_CONTRACT_VERSION,
+  InfluencerIntelligenceContractError,
+  normalizeCoverage,
+  normalizeMetricObservation,
+  normalizeProviderSnapshot,
+  normalizeScoreEnvelope,
+  normalizeStructuredSignal,
+} from '../contracts.mjs';
+
+const observedAt = '2026-08-10T12:00:00.000Z';
+const retrievedAt = '2026-08-10T12:00:03.000Z';
+
+function provenance(overrides = {}) {
+  return {
+    provider: 'meta-graph',
+    sourceType: 'profile',
+    evidenceState: 'observed',
+    observedAt,
+    retrievedAt,
+    sourceRef: 'meta-graph:ig-user:synthetic-001',
+    ...overrides,
+  };
+}
+
+function assertContractError(callback, message) {
+  assert.throws(callback, (error) => {
+    assert.equal(error instanceof InfluencerIntelligenceContractError, true);
+    if (message) assert.match(error.message, message);
+    return true;
+  });
+}
+
+test('exposes a closed, versioned evidence vocabulary', () => {
+  assert.equal(INFLUENCER_INTELLIGENCE_CONTRACT_VERSION, 'influencer-intelligence/v1');
+  assert.deepEqual(EVIDENCE_STATES, ['observed', 'derived', 'inferred', 'unavailable']);
+});
+
+test('normalizes a provider snapshot without carrying raw profile payloads', () => {
+  const snapshot = normalizeProviderSnapshot({
+    creatorKey: 'creator:synthetic-001',
+    handle: '@Synthetic.Creator',
+    provider: 'META-GRAPH',
+    observedAt,
+    evidenceState: 'observed',
+    provenance: provenance(),
+    profile: {
+      biography: 'This field is deliberately ignored by the boundary.',
+      profilePictureUrl: 'https://example.invalid/not-persisted',
+    },
+    observations: [
+      {
+        key: 'followers_count',
+        unit: 'count',
+        value: 12000,
+        evidenceState: 'observed',
+        provenance: provenance(),
+      },
+      {
+        key: 'media_count',
+        unit: 'count',
+        value: 42,
+        evidenceState: 'observed',
+        provenance: provenance(),
+      },
+    ],
+  });
+
+  assert.equal(snapshot.contractVersion, INFLUENCER_INTELLIGENCE_CONTRACT_VERSION);
+  assert.equal(snapshot.handle, 'synthetic.creator');
+  assert.equal(snapshot.provider, 'meta-graph');
+  assert.deepEqual(snapshot.observations.map(({ key, value }) => ({ key, value })), [
+    { key: 'followers_count', value: 12000 },
+    { key: 'media_count', value: 42 },
+  ]);
+  assert.equal('profile' in snapshot, false);
+  assert.equal(Object.isFrozen(snapshot), true);
+  assert.equal(Object.isFrozen(snapshot.observations[0]), true);
+});
+
+test('rejects credentials and direct contact identifiers at the contract boundary', () => {
+  assertContractError(() => normalizeProviderSnapshot({
+    creatorKey: 'creator:synthetic-001',
+    provider: 'meta-graph',
+    observedAt,
+    evidenceState: 'observed',
+    provenance: provenance(),
+    profile: { email: 'not-for-analytics@example.invalid' },
+    observations: [],
+  }), /email/);
+
+  assertContractError(() => normalizeProviderSnapshot({
+    creatorKey: 'creator:synthetic-001',
+    provider: 'meta-graph',
+    observedAt,
+    evidenceState: 'observed',
+    provenance: provenance(),
+    access_token: 'never-accepted',
+    observations: [],
+  }), /access_token/);
+
+  assertContractError(() => normalizeMetricObservation({
+    key: 'followers_count',
+    unit: 'count',
+    value: 12,
+    evidenceState: 'observed',
+    provenance: provenance({ sourceRef: 'meta-graph:ig-user:synthetic-001?access_token=leak' }),
+  }), /credential-like|sourceRef/);
+});
+
+test('keeps unavailable observations explicit and value-free', () => {
+  const unavailable = normalizeMetricObservation({
+    key: 'audience_age_distribution',
+    unit: 'ratio',
+    value: null,
+    evidenceState: 'unavailable',
+    confidence: 1,
+    provenance: provenance({
+      sourceType: 'insights',
+      evidenceState: 'unavailable',
+    }),
+  });
+  assert.deepEqual(unavailable, {
+    contractVersion: INFLUENCER_INTELLIGENCE_CONTRACT_VERSION,
+    key: 'audience_age_distribution',
+    unit: 'ratio',
+    value: null,
+    evidenceState: 'unavailable',
+    confidence: 0,
+    provenance: {
+      contractVersion: INFLUENCER_INTELLIGENCE_CONTRACT_VERSION,
+      provider: 'meta-graph',
+      sourceType: 'insights',
+      evidenceState: 'unavailable',
+      observedAt,
+      retrievedAt,
+      sourceRef: 'meta-graph:ig-user:synthetic-001',
+    },
+  });
+
+  assertContractError(() => normalizeMetricObservation({
+    key: 'audience_age_distribution',
+    unit: 'ratio',
+    value: 0.4,
+    evidenceState: 'unavailable',
+    provenance: provenance({ sourceType: 'insights', evidenceState: 'unavailable' }),
+  }), /unavailable/);
+});
+
+test('calculates coverage rather than accepting a caller-provided ratio', () => {
+  assert.deepEqual(normalizeCoverage({ availableMetrics: 3, expectedMetrics: 5 }), {
+    availableMetrics: 3,
+    expectedMetrics: 5,
+    ratio: 0.6,
+  });
+  assertContractError(() => normalizeCoverage({ availableMetrics: 6, expectedMetrics: 5 }), /cannot exceed/);
+});
+
+test('normalizes score envelopes deterministically with provenance and structured signals', () => {
+  const envelope = normalizeScoreEnvelope({
+    scoreKind: 'influencer',
+    score: 78.45678,
+    confidence: 0.81,
+    coverage: { availableMetrics: 4, expectedMetrics: 5 },
+    evidenceState: 'derived',
+    providers: ['instagrapi', 'meta-graph', 'meta-graph'],
+    provenance: [
+      provenance({ provider: 'instagrapi', sourceType: 'media', sourceRef: 'instagrapi:media:synthetic-001' }),
+      provenance(),
+    ],
+    algorithmVersion: 'influencer-score/v1',
+    timestamp: retrievedAt,
+    signals: [
+      {
+        key: 'engagement_stability',
+        value: 0.73,
+        evidenceState: 'derived',
+        confidence: 0.9,
+        evidenceRefs: ['meta-graph:ig-user:synthetic-001'],
+      },
+      {
+        key: 'suspicious_growth_pattern',
+        value: true,
+        evidenceState: 'inferred',
+        confidence: 0.42,
+        modelVersion: 'risk-signals/v1',
+        evidenceRefs: ['instagrapi:media:synthetic-001'],
+      },
+    ],
+  });
+
+  assert.equal(envelope.score, 78.4568);
+  assert.equal(envelope.coverage.ratio, 0.8);
+  assert.deepEqual(envelope.providers, ['instagrapi', 'meta-graph']);
+  assert.deepEqual(envelope.signals.map(({ key }) => key), ['engagement_stability', 'suspicious_growth_pattern']);
+  assert.equal(envelope.signals[1].modelVersion, 'risk-signals/v1');
+  assert.equal(envelope.provenance[0].provider, 'instagrapi');
+  assert.equal('rationale' in envelope.signals[0], false);
+});
+
+test('requires auditability for inferred signals and scores', () => {
+  assertContractError(() => normalizeStructuredSignal({
+    key: 'brand_safety',
+    value: 'unknown',
+    evidenceState: 'inferred',
+    confidence: 0.4,
+    evidenceRefs: [],
+  }), /evidence reference/);
+
+  assertContractError(() => normalizeStructuredSignal({
+    key: 'brand_safety',
+    value: 'unknown',
+    evidenceState: 'inferred',
+    confidence: 0.4,
+    evidenceRefs: ['meta-graph:ig-user:synthetic-001'],
+  }), /modelVersion/);
+
+  assertContractError(() => normalizeScoreEnvelope({
+    scoreKind: 'campaign-fit',
+    score: 54,
+    confidence: 0.5,
+    coverage: { availableMetrics: 1, expectedMetrics: 2 },
+    evidenceState: 'derived',
+    providers: [],
+    provenance: [],
+    algorithmVersion: 'campaign-fit/v1',
+    timestamp: retrievedAt,
+  }), /at least one provider/);
+});


### PR DESCRIPTION
## What changed

Establishes the M0 contract-only boundary for the new `social/influencer-intelligence` domain:

- adds a pure, versioned runtime contract for provider snapshots, metric observations, structured signals, coverage, provenance, and score envelopes;
- enforces explicit `observed`, `derived`, `inferred`, and `unavailable` states;
- rejects credentials, direct contact identifiers, raw provider objects, query-string provenance, and unauditable inferred signals;
- adds synthetic Node tests and wires them into the existing architecture-governance workflow;
- documents the official-first provider plan and the controlled reuse boundaries for the existing Meta Graph and instagrapi integrations.

## Scope and safety

- Module remains experimental and off by default.
- `INFLUENCER_INTELLIGENCE_ENABLED=false` is documented but not wired in M0.
- No CRM route/module, API, MCP server, Orb job, systemd unit, Cloudflare resource, provider call, scraper, migration, or production configuration is added.
- No real-user activation or external business-effect call is performed.
- The existing `InstagramModuleSimulator` and temporary FastAPI surface are explicitly excluded as sources.

## Risk and rollback

- Risk: medium; new contract/tests/docs plus one read-only CI test step.
- Migration: none.
- Future access grant: `module.influencer-intelligence.access`, to be enforced server-side in a later CRM milestone.
- Rollback: close or revert this PR to base `a86125ee4da775fc18ac284984f2adce1a0bfed9`; no user or remote data is created by M0.
- Exact candidate commit: `07dc0b73a3b1428b8e1e383602b6cac8229ed8df`.

## Validation

- `node --test social/influencer-intelligence/tests/contracts.test.mjs` — 7/7 passed through the typed WSL gateway.
- `npm run architecture:test` — architecture, module catalog, domain boundaries, and dependency closures passed; existing tracked legacy-import warnings remain unchanged.
- `node .github/scripts/validate-github-governance.mjs` — passed.
- `node scripts/check-js-security-exceptions.mjs` — passed.
- `git diff --cached --check` — passed.

No production, staging, Token Vault, PostgreSQL, CRM, MCP, Orb, or external provider state was changed.