### PR TITLE
feat(social): add Influencer Intelligence registry schema

### DIFF
--- a/.github/workflows/architecture-governance.yml
+++ b/.github/workflows/architecture-governance.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Validate domain import boundaries
         run: node .github/scripts/validate-domain-boundaries.mjs
       - name: Test Influencer Intelligence contract boundary
-        run: node --test social/influencer-intelligence/tests/contracts.test.mjs
+        run: node --test social/influencer-intelligence/tests/contracts.test.mjs social/influencer-intelligence/tests/registry.test.mjs
       - name: Validate reproducible staging manifest
         run: node .github/scripts/validate-staging-manifest.mjs
       - name: Validate staging bootstrap safety guards

--- a/social/influencer-intelligence/README.md
+++ b/social/influencer-intelligence/README.md
@@ -1,6 +1,6 @@
 # Influencer Intelligence
 
-Status: M0 contract-only, experimental, not exposed, and off by default.
+Status: M1 registry artifact, experimental, not exposed, and off by default.
 
 This domain provides read-only intelligence about Instagram creators for
 analysis, comparison, and campaign fit. It is not an engagement automation
@@ -18,6 +18,32 @@ The focused tests use only synthetic creator identifiers and provider-shaped
 observations. They prove the contract rejects credentials, direct contact
 identifiers, raw provider objects, query-string provenance, and unauditable
 inferred signals.
+
+M0 is merged as PR #1303 at merge SHA
+`26b17ef3f64482ac1d3aa0182af597262bb633d1`. Its CI gate remains the owner of
+the contract test and no runtime was enabled.
+
+## M1 decision: registry and PostgreSQL artifact
+
+M1 adds [`registry.mjs`](./registry.mjs) and the reviewed additive migration
+[`20260810_influencer_intelligence_registry_v1.up.sql`](./migrations/20260810_influencer_intelligence_registry_v1.up.sql).
+The registry stores only:
+
+- an opaque internal `creator_key` and optional public canonical handle;
+- a closed registry state (`candidate`, `paused`, `unavailable`);
+- the approved provider identifier and a SHA-256 digest of the provider account
+  reference, never the raw provider account id;
+- explicit provider/evidence state, bounded timestamps, and an opaque source
+  reference without query strings or fragments.
+
+The migration is idempotent and additive. It creates the domain schema, a
+schema-migration ledger, creator registry, provider registry, and narrow
+indexes. It has no seed rows, no clear credentials, no direct contact fields,
+no public grants, and no destructive rollback SQL. M1 does not apply the
+migration to local, staging, or production PostgreSQL: the future runner must
+first prove destination identity, role custody, checkpoint, lock/statement
+timeouts, scoped grants, and post-apply verification. Until that runner exists,
+the artifact is the source-controlled schema proposal only.
 
 ## Concrete target architecture
 
@@ -82,6 +108,9 @@ deployment hardening.
 - `StructuredSignal`: a bounded scalar, explicit evidence state, confidence,
   evidence references, and an optional model version. Free-form LLM rationale
   or prompt/completion text is not persisted here.
+- `CreatorRegistryEntry`: a minimal registry projection that accepts only
+  pseudonymous provider digests and the state needed to decide whether a
+  future collector may observe the creator.
 
 Every evidence-bearing shape uses exactly one of:
 
@@ -114,8 +143,8 @@ ratio.
 
 ## Rollout and access
 
-The planned module flag is `INFLUENCER_INTELLIGENCE_ENABLED=false`. M0 does
-not wire it. When the CRM surface is introduced, access must be independently
+The planned module flag is `INFLUENCER_INTELLIGENCE_ENABLED=false`. M0 and M1
+do not wire it. When the CRM surface is introduced, access must be independently
 enforced by the server-side grant `module.influencer-intelligence.access` and
 the module catalog; navigation visibility is not authorization.
 
@@ -125,17 +154,17 @@ The only permitted progression is:
 off -> shadow (synthetic or approved staging evidence) -> active (explicit gate)
 ```
 
-No M0 artifact enables a real user, calls an external provider with business
+No M0/M1 artifact enables a real user, calls an external provider with business
 effects, publishes content, sends engagement actions, or changes production
 configuration.
 
 ## Milestone map
 
-| Milestone | Deliverable | M0 status |
+| Milestone | Deliverable | Status |
 | --- | --- | --- |
-| M0 | Architecture and normalized contracts | In progress |
-| M1 | Creator registry and additive PostgreSQL schema | Pending; no migration in M0 |
-| M2 | Official-first router and controlled collectors | Pending; no provider code in M0 |
+| M0 | Architecture and normalized contracts | Merged in #1303 |
+| M1 | Creator registry and additive PostgreSQL schema | In progress; artifact only, not applied |
+| M2 | Official-first router and controlled collectors | Pending; no provider code in M1 |
 | M3 | Append-only snapshots, retention, and Orb scheduling | Pending |
 | M4 | Robust analytics and outlier-resistant metrics | Pending |
 | M5 | Deterministic score, confidence, coverage, and provenance | Pending |
@@ -148,16 +177,17 @@ configuration.
 | M12 | Synthetic validation and calibration | Pending |
 | M13 | Optional provider gap analysis | Pending; only if a measured gap remains |
 
-## M0 risk, validation, and rollback
+## M0/M1 risk, validation, and rollback
 
-- Risk: medium, limited to a new social-domain contract and synthetic tests.
-- Surfaces: `social/influencer-intelligence/**` plus one read-only test step in
-  `.github/workflows/architecture-governance.yml`; no runtime, database, CRM,
-  MCP, Orb, systemd, Cloudflare, or user-facing surface.
-- Migration: none.
+- Risk: high because a PostgreSQL artifact is being reviewed, but no database
+  connection or mutation occurs in this milestone.
+- Surfaces: `social/influencer-intelligence/**`; no runtime, CRM, MCP, Orb,
+  systemd, Cloudflare, or user-facing surface.
+- Migration: additive SQL artifact only; remote apply is prohibited in M1.
 - Flag: declared for the future, not wired; default remains `false`.
-- Validation: focused Node contract tests, architecture/domain-boundary
-  checks, forbidden-surface/secret scan, and terminal hosted checks on the
-  exact pull-request SHA.
-- Rollback: close or revert the single-purpose change to the M0 base SHA. No
-  user data or remote state is created by this milestone.
+- Validation: focused M0/M1 Node tests, SQL shape and privilege checks,
+  architecture/domain-boundary checks, forbidden-surface/secret scan, and
+  terminal hosted checks on the exact pull-request SHA.
+- Rollback: close or revert the single-purpose change to merge SHA
+  `26b17ef3f64482ac1d3aa0182af597262bb633d1`. No user data or remote database
+  state is created by this milestone.

--- a/social/influencer-intelligence/contracts.mjs
+++ b/social/influencer-intelligence/contracts.mjs
@@ -58,6 +58,7 @@ const forbiddenKeySet = new Set([
   'telephone',
   'username',
 ]);
+const forbiddenKeyPattern = /(?:token|secret|password|cookie|session|authorization|email|phone|username)/i;
 const sensitiveStringPattern = /(?:^|[?&\s])(?:access[_-]?token|refresh[_-]?token|authorization|cookie|password|secret|api[_-]?key)\s*[:=]/i;
 const controlCharacterPattern = /[\u0000-\u001f\u007f]/;
 
@@ -106,7 +107,10 @@ export function assertNoSensitiveFields(value, path = 'input', seen = new Set())
     return;
   }
   for (const [key, child] of Object.entries(value)) {
-    if (forbiddenKeySet.has(normalizedKey(key))) fail(`${path}.${key} is not permitted in a domain contract`);
+    const keyName = normalizedKey(key);
+    if (forbiddenKeySet.has(keyName) || forbiddenKeyPattern.test(keyName)) {
+      fail(`${path}.${key} is not permitted in a domain contract`);
+    }
     assertNoSensitiveFields(child, `${path}.${key}`, seen);
   }
   seen.delete(value);
@@ -214,6 +218,26 @@ function normalizeProvider(value, label = 'provider') {
 
 function normalizeEvidenceState(value, label = 'evidenceState') {
   return enumValue(value, label, EVIDENCE_STATES, evidenceStateSet);
+}
+
+export function normalizeCreatorKey(value) {
+  return opaqueId(value, 'creatorKey');
+}
+
+export function normalizeCanonicalHandle(value) {
+  return normalizeHandle(value);
+}
+
+export function normalizeProviderId(value, label = 'provider') {
+  return normalizeProvider(value, label);
+}
+
+export function normalizeEvidenceStateValue(value, label = 'evidenceState') {
+  return normalizeEvidenceState(value, label);
+}
+
+export function normalizeProvenanceSourceRef(value, label = 'sourceRef') {
+  return safeSourceRef(value, label);
 }
 
 export function normalizeProvenance(input) {

--- a/social/influencer-intelligence/migrations/20260810_influencer_intelligence_registry_v1.up.sql
+++ b/social/influencer-intelligence/migrations/20260810_influencer_intelligence_registry_v1.up.sql
@@ -1,0 +1,56 @@
+-- Reviewed additive artifact for the Influencer Intelligence registry.
+-- Apply only through a future controlled PostgreSQL runner after the staging
+-- role, destination identity, checkpoint, and verification gates exist.
+-- The runner records this id in schema_migrations after the transaction:
+-- 20260810_influencer_intelligence_registry_v1.
+
+CREATE SCHEMA IF NOT EXISTS influencer_intelligence;
+
+CREATE TABLE IF NOT EXISTS influencer_intelligence.schema_migrations (
+  id text PRIMARY KEY,
+  applied_at timestamptz NOT NULL DEFAULT now(),
+  rolled_back_at timestamptz,
+  details jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE IF NOT EXISTS influencer_intelligence.creator_registry (
+  creator_key text PRIMARY KEY
+    CHECK (creator_key ~ '^[A-Za-z0-9._:-]{1,128}$'),
+  canonical_handle text
+    CHECK (canonical_handle IS NULL OR canonical_handle ~ '^[a-z0-9._]{1,30}$'),
+  registry_state text NOT NULL DEFAULT 'candidate'
+    CHECK (registry_state IN ('candidate', 'paused', 'unavailable')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS influencer_intelligence.creator_provider_registry (
+  creator_key text NOT NULL
+    REFERENCES influencer_intelligence.creator_registry(creator_key)
+    ON DELETE RESTRICT,
+  provider text NOT NULL
+    CHECK (provider IN ('meta-graph', 'instagrapi')),
+  provider_account_digest text
+    CHECK (provider_account_digest IS NULL OR provider_account_digest ~ '^[0-9a-f]{64}$'),
+  provider_state text NOT NULL DEFAULT 'unavailable'
+    CHECK (provider_state IN ('configured', 'revoked', 'unavailable')),
+  evidence_state text NOT NULL DEFAULT 'unavailable'
+    CHECK (evidence_state IN ('observed', 'unavailable')),
+  last_observed_at timestamptz,
+  last_retrieved_at timestamptz,
+  source_ref text
+    CHECK (source_ref IS NULL OR (char_length(btrim(source_ref)) BETWEEN 1 AND 240 AND source_ref !~ '[?#]')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (creator_key, provider),
+  CHECK ((provider_state = 'unavailable') = (provider_account_digest IS NULL)),
+  CHECK ((provider_state = 'unavailable') = (evidence_state = 'unavailable')),
+  CHECK (provider_state = 'unavailable' OR last_observed_at IS NOT NULL),
+  CHECK (last_retrieved_at IS NULL OR (last_observed_at IS NOT NULL AND last_retrieved_at >= last_observed_at))
+);
+
+CREATE INDEX IF NOT EXISTS creator_registry_state_idx
+  ON influencer_intelligence.creator_registry(registry_state, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS creator_provider_registry_state_idx
+  ON influencer_intelligence.creator_provider_registry(provider, provider_state, updated_at DESC);

--- a/social/influencer-intelligence/registry.mjs
+++ b/social/influencer-intelligence/registry.mjs
@@ -1,0 +1,137 @@
+import {
+  assertNoSensitiveFields,
+  normalizeCanonicalHandle,
+  normalizeCreatorKey,
+  normalizeEvidenceStateValue,
+  normalizeProviderId,
+  normalizeProvenanceSourceRef,
+} from './contracts.mjs';
+
+export const REGISTRY_CONTRACT_VERSION = 'influencer-intelligence-registry/v1';
+
+export const CREATOR_REGISTRY_STATES = Object.freeze([
+  'candidate',
+  'paused',
+  'unavailable',
+]);
+
+export const PROVIDER_REGISTRY_STATES = Object.freeze([
+  'configured',
+  'revoked',
+  'unavailable',
+]);
+
+const creatorRegistryStateSet = new Set(CREATOR_REGISTRY_STATES);
+const providerRegistryStateSet = new Set(PROVIDER_REGISTRY_STATES);
+
+function fail(message) {
+  throw new Error(`InfluencerIntelligenceRegistryError: ${message}`);
+}
+
+function deepFreeze(value, seen = new Set()) {
+  if (!value || typeof value !== 'object' || seen.has(value)) return value;
+  seen.add(value);
+  for (const child of Object.values(value)) deepFreeze(child, seen);
+  return Object.freeze(value);
+}
+
+function normalizedString(value, label, { maxLength = 40, required = false } = {}) {
+  if (value === undefined || value === null || value === '') {
+    if (required) fail(`${label} is required`);
+    return null;
+  }
+  if (typeof value !== 'string') fail(`${label} must be a string`);
+  const normalized = value.trim();
+  if (!normalized && required) fail(`${label} must not be empty`);
+  if (normalized.length > maxLength) fail(`${label} exceeds ${maxLength} characters`);
+  return normalized || null;
+}
+
+function timestamp(value, label, { required = false } = {}) {
+  const normalized = normalizedString(value, label, { maxLength: 40, required });
+  if (normalized === null) return null;
+  const parsed = new Date(normalized);
+  if (Number.isNaN(parsed.getTime())) fail(`${label} must be an ISO timestamp`);
+  return parsed.toISOString();
+}
+
+function digest(value) {
+  const normalized = normalizedString(value, 'providerAccountDigest', { maxLength: 64 });
+  if (normalized === null) return null;
+  if (!/^[0-9a-f]{64}$/i.test(normalized)) fail('providerAccountDigest must be a SHA-256 hex digest');
+  return normalized.toLowerCase();
+}
+
+function registryState(value) {
+  const normalized = normalizedString(value, 'registryState', { maxLength: 20, required: true }).toLowerCase();
+  if (!creatorRegistryStateSet.has(normalized)) fail(`registryState must be one of ${CREATOR_REGISTRY_STATES.join(', ')}`);
+  return normalized;
+}
+
+function providerState(value) {
+  const normalized = normalizedString(value, 'providerState', { maxLength: 20, required: true }).toLowerCase();
+  if (!providerRegistryStateSet.has(normalized)) fail(`providerState must be one of ${PROVIDER_REGISTRY_STATES.join(', ')}`);
+  return normalized;
+}
+
+function normalizeProviderBinding(input) {
+  assertNoSensitiveFields(input, 'providerBinding');
+  if (!input || typeof input !== 'object' || Array.isArray(input)) fail('providerBinding must be an object');
+  if (Object.prototype.hasOwnProperty.call(input, 'providerAccountId')) {
+    fail('providerAccountId is not permitted; use providerAccountDigest');
+  }
+  const provider = normalizeProviderId(input.provider, 'providerBinding.provider');
+  const state = providerState(input.providerState || (input.providerAccountDigest ? 'configured' : 'unavailable'));
+  const providerAccountDigest = digest(input.providerAccountDigest);
+  if (state === 'unavailable' && providerAccountDigest !== null) {
+    fail('unavailable provider bindings must not contain a provider account digest');
+  }
+  if (state !== 'unavailable' && providerAccountDigest === null) {
+    fail('configured or revoked provider bindings require a provider account digest');
+  }
+  const evidenceState = normalizeEvidenceStateValue(
+    input.evidenceState || (state === 'unavailable' ? 'unavailable' : 'observed'),
+    'providerBinding.evidenceState',
+  );
+  if (!['observed', 'unavailable'].includes(evidenceState)) {
+    fail('provider registry evidenceState must be observed or unavailable');
+  }
+  if ((state === 'unavailable') !== (evidenceState === 'unavailable')) {
+    fail('providerState and evidenceState must agree on availability');
+  }
+  const lastObservedAt = timestamp(input.lastObservedAt, 'lastObservedAt', { required: evidenceState === 'observed' });
+  const lastRetrievedAt = timestamp(input.lastRetrievedAt, 'lastRetrievedAt');
+  if (lastRetrievedAt && !lastObservedAt) fail('lastRetrievedAt requires lastObservedAt');
+  if (lastRetrievedAt && new Date(lastRetrievedAt).getTime() < new Date(lastObservedAt).getTime()) {
+    fail('lastRetrievedAt must not precede lastObservedAt');
+  }
+  const sourceRef = normalizeProvenanceSourceRef(input.sourceRef, 'providerBinding.sourceRef');
+  return {
+    provider,
+    providerAccountDigest,
+    providerState: state,
+    evidenceState,
+    lastObservedAt,
+    lastRetrievedAt,
+    sourceRef: sourceRef || null,
+  };
+}
+
+export function normalizeCreatorRegistryEntry(input) {
+  assertNoSensitiveFields(input, 'creatorRegistryEntry');
+  if (!input || typeof input !== 'object' || Array.isArray(input)) fail('creatorRegistryEntry must be an object');
+  const creatorKey = normalizeCreatorKey(input.creatorKey);
+  const canonicalHandle = normalizeCanonicalHandle(input.canonicalHandle);
+  const state = registryState(input.registryState || 'candidate');
+  if (!Array.isArray(input.providers)) fail('creatorRegistryEntry.providers must be an array');
+  const providers = input.providers.map(normalizeProviderBinding).sort((left, right) => left.provider.localeCompare(right.provider));
+  const providerIds = providers.map((item) => item.provider);
+  if (new Set(providerIds).size !== providerIds.length) fail('creatorRegistryEntry.providers must be unique by provider');
+  return deepFreeze({
+    contractVersion: REGISTRY_CONTRACT_VERSION,
+    creatorKey,
+    canonicalHandle: canonicalHandle || null,
+    registryState: state,
+    providers,
+  });
+}

--- a/social/influencer-intelligence/tests/registry.test.mjs
+++ b/social/influencer-intelligence/tests/registry.test.mjs
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  CREATOR_REGISTRY_STATES,
+  PROVIDER_REGISTRY_STATES,
+  REGISTRY_CONTRACT_VERSION,
+  normalizeCreatorRegistryEntry,
+} from '../registry.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const migrationPath = path.join(here, '..', 'migrations', '20260810_influencer_intelligence_registry_v1.up.sql');
+const observedAt = '2026-08-10T13:00:00.000Z';
+const retrievedAt = '2026-08-10T13:00:02.000Z';
+const digest = 'a'.repeat(64);
+
+function assertRegistryError(callback, pattern) {
+  assert.throws(callback, (error) => {
+    assert.match(error.message, /InfluencerIntelligenceRegistryError|not permitted in a domain contract/i);
+    if (pattern) assert.match(error.message, pattern);
+    return true;
+  });
+}
+
+test('keeps registry states closed and versioned', () => {
+  assert.deepEqual(CREATOR_REGISTRY_STATES, ['candidate', 'paused', 'unavailable']);
+  assert.deepEqual(PROVIDER_REGISTRY_STATES, ['configured', 'revoked', 'unavailable']);
+  assert.equal(REGISTRY_CONTRACT_VERSION, 'influencer-intelligence-registry/v1');
+});
+
+test('normalizes a minimal candidate without provider identity material', () => {
+  const entry = normalizeCreatorRegistryEntry({
+    creatorKey: 'creator:synthetic-001',
+    canonicalHandle: '@Synthetic.Creator',
+    providers: [],
+  });
+  assert.deepEqual(entry, {
+    contractVersion: REGISTRY_CONTRACT_VERSION,
+    creatorKey: 'creator:synthetic-001',
+    canonicalHandle: 'synthetic.creator',
+    registryState: 'candidate',
+    providers: [],
+  });
+  assert.equal(Object.isFrozen(entry), true);
+});
+
+test('normalizes pseudonymous provider digests and retains provenance timestamps only', () => {
+  const entry = normalizeCreatorRegistryEntry({
+    creatorKey: 'creator:synthetic-001',
+    registryState: 'candidate',
+    providers: [
+      {
+        provider: 'instagrapi',
+        providerState: 'unavailable',
+        evidenceState: 'unavailable',
+      },
+      {
+        provider: 'META-GRAPH',
+        providerAccountDigest: digest.toUpperCase(),
+        providerState: 'configured',
+        evidenceState: 'observed',
+        lastObservedAt: observedAt,
+        lastRetrievedAt: retrievedAt,
+        sourceRef: 'meta-graph:ig-user:synthetic-001',
+      },
+    ],
+  });
+  assert.deepEqual(entry.providers.map(({ provider }) => provider), ['instagrapi', 'meta-graph']);
+  assert.equal(entry.providers[1].providerAccountDigest, digest);
+  assert.equal('providerAccountId' in entry.providers[1], false);
+  assert.equal('token' in entry.providers[1], false);
+});
+
+test('rejects raw account identifiers, direct contact fields, and invalid binding states', () => {
+  assertRegistryError(() => normalizeCreatorRegistryEntry({
+    creatorKey: 'creator:synthetic-001',
+    email: 'not-retained@example.invalid',
+    providers: [],
+  }), /email/);
+
+  assertRegistryError(() => normalizeCreatorRegistryEntry({
+    creatorKey: 'creator:synthetic-001',
+    providers: [{ provider: 'meta-graph', providerAccountId: 'raw-id' }],
+  }), /providerAccountId/);
+
+  assertRegistryError(() => normalizeCreatorRegistryEntry({
+    creatorKey: 'creator:synthetic-001',
+    providers: [{
+      provider: 'meta-graph',
+      providerState: 'unavailable',
+      evidenceState: 'unavailable',
+      providerAccountDigest: digest,
+    }],
+  }), /unavailable/);
+
+  assertRegistryError(() => normalizeCreatorRegistryEntry({
+    creatorKey: 'creator:synthetic-001',
+    providers: [{
+      provider: 'meta-graph',
+      providerState: 'configured',
+      evidenceState: 'observed',
+      providerAccountDigest: 'not-a-sha256',
+      lastObservedAt: observedAt,
+    }],
+  }), /SHA-256/);
+
+  assertRegistryError(() => normalizeCreatorRegistryEntry({
+    creatorKey: 'creator:synthetic-001',
+    providers: [{
+      provider: 'meta-graph',
+      providerState: 'unavailable',
+      evidenceState: 'observed',
+      lastObservedAt: observedAt,
+    }],
+  }), /agree on availability/);
+});
+
+test('migration is additive, scoped, idempotent, and does not grant public access', () => {
+  const sql = fs.readFileSync(migrationPath, 'utf8');
+  assert.match(sql, /CREATE SCHEMA IF NOT EXISTS influencer_intelligence/i);
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS influencer_intelligence\.schema_migrations/i);
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS influencer_intelligence\.creator_registry/i);
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS influencer_intelligence\.creator_provider_registry/i);
+  assert.match(sql, /provider_account_digest/i);
+  assert.match(sql, /provider IN \('meta-graph', 'instagrapi'\)/i);
+  assert.match(sql, /source_ref !~ '\[\?\#\]'/i);
+  assert.match(sql, /CREATE INDEX IF NOT EXISTS/i);
+  assert.match(sql, /provider_state = 'unavailable'\)\s*=\s*\(evidence_state = 'unavailable'\)/i);
+  assert.doesNotMatch(sql, /\bdrop\s+(?:table|schema)\b|\btruncate\b|\bdelete\s+from\b/i);
+  assert.doesNotMatch(sql, /\bgrant\b[\s\S]*\bpublic\b/i);
+  assert.doesNotMatch(sql, /access[_-]?token|refresh[_-]?token|\bemail\b|\bphone\b/i);
+});


### PR DESCRIPTION
## What changed

Continues the merged Influencer Intelligence M0 with the M1 registry boundary:

- adds a pure `registry.mjs` projection for creator registry entries and provider bindings;
- stores only an opaque internal creator key, optional public handle, closed registry/provider states, and a SHA-256 digest of an external provider reference;
- adds the reviewed additive PostgreSQL artifact `20260810_influencer_intelligence_registry_v1.up.sql` with schema ledger, creator registry, provider registry, constraints, and narrow indexes;
- extends the architecture-governance test step with the M1 registry and SQL-shape tests;
- documents the migration custody and non-application boundary.

## Safety and scope

- Module remains experimental and off by default.
- `INFLUENCER_INTELLIGENCE_ENABLED=false` remains unwired.
- No provider call, scraper, API, MCP, CRM surface, Orb job, systemd unit, Cloudflare resource, Token Vault operation, or production configuration is added.
- No migration is applied to local, staging, or production PostgreSQL.
- No raw provider account id, token, cookie, email, phone, caption, comment archive, or seed row is included.
- The future runner must prove destination identity, role custody, checkpoint, lock/statement timeouts, scoped grants, and post-apply verification before any database mutation.

## Risk and rollback

- Risk: high because a database artifact is reviewed, with zero database connections or writes in this PR.
- Migration: additive artifact only; no down migration or destructive DDL.
- Rollback: close or revert to M0 merge SHA `26b17ef3f64482ac1d3aa0182af597262bb633d1`; no remote data is created.
- Exact candidate commit: `20f889761c3762e02323ff4bcf69c5153ea2360e`.

## Validation

- `node --test social/influencer-intelligence/tests/contracts.test.mjs social/influencer-intelligence/tests/registry.test.mjs` — 12/12 passed through the typed WSL gateway.
- `npm run architecture:test` — passed; existing tracked legacy-import warnings remain unchanged.
- `node .github/scripts/validate-github-governance.mjs` — passed.
- `node scripts/check-js-security-exceptions.mjs` — passed.
- static migration scan — no destructive DDL, public grants, token fields, email, or phone matches.
- `psql 16.14` is installed, but no local PostgreSQL server is listening on `127.0.0.1:5432`; SQL execution was not claimed and no remote target was queried or mutated.

No production, staging, PostgreSQL, CRM, MCP, Orb, Token Vault, or external provider state was changed.