### PR TITLE
feat(social): add Influencer Intelligence provider router

### DIFF
--- a/.github/workflows/architecture-governance.yml
+++ b/.github/workflows/architecture-governance.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Validate domain import boundaries
         run: node .github/scripts/validate-domain-boundaries.mjs
       - name: Test Influencer Intelligence contract boundary
-        run: node --test social/influencer-intelligence/tests/contracts.test.mjs social/influencer-intelligence/tests/registry.test.mjs
+        run: node --test social/influencer-intelligence/tests/contracts.test.mjs social/influencer-intelligence/tests/registry.test.mjs social/influencer-intelligence/tests/providers.test.mjs
       - name: Validate reproducible staging manifest
         run: node .github/scripts/validate-staging-manifest.mjs
       - name: Validate staging bootstrap safety guards

--- a/social/influencer-intelligence/README.md
+++ b/social/influencer-intelligence/README.md
@@ -1,6 +1,6 @@
 # Influencer Intelligence
 
-Status: M1 registry artifact, experimental, not exposed, and off by default.
+Status: M2 provider boundary, experimental, not exposed, and off by default.
 
 This domain provides read-only intelligence about Instagram creators for
 analysis, comparison, and campaign fit. It is not an engagement automation
@@ -45,6 +45,31 @@ first prove destination identity, role custody, checkpoint, lock/statement
 timeouts, scoped grants, and post-apply verification. Until that runner exists,
 the artifact is the source-controlled schema proposal only.
 
+## M2 decision: official-first provider router
+
+M2 adds [`provider-router.mjs`](./provider-router.mjs) and the two explicit
+adapters under [`providers/`](./providers/). The router has a closed provider
+allowlist and requires `meta-graph` to be the first configured provider. It
+falls back to `instagrapi` only for explicit gap codes
+(`provider_unavailable`, `permission_gap`, `coverage_gap`, or `timeout`).
+Invalid responses, policy blocks, and unclassified transport errors fail
+closed and do not trigger fallback.
+
+Both adapters accept an injected `readProfile` function. The function receives
+an immutable read-only request and must return only the bounded projection
+`handle`, `followersCount`, and `mediaCount`; raw Graph/instagrapi payloads,
+credentials, sessions, comments, media, and contact fields never enter the
+normalized provider contract. Every returned metric is `observed` or explicit
+`unavailable`, then passes through the versioned M0 snapshot contract.
+
+The Meta adapter is a boundary around the existing official CRM integration,
+not a second HTTP client. The instagrapi adapter is a narrow boundary around
+the existing `social/instagram` read path, not a new scraper or session
+implementation. M2 uses synthetic transports only: it does not call Graph,
+instagrapi, Token Vault, PostgreSQL, Orb, or any runtime endpoint. A future
+transport must establish a separate read-only analytics allowlist and Token
+Vault custody before it can be connected.
+
 ## Concrete target architecture
 
 ```text
@@ -53,8 +78,8 @@ Codex
   -> read-only Influencer Intelligence MCP (M6)
   -> internal service/API (M2-M5)
   -> provider router
-       -> Meta Graph official adapter (first preference)
-       -> existing social/instagram instagrapi adapter (controlled fallback)
+       -> Meta Graph official adapter (first preference; M2 boundary)
+       -> existing social/instagram instagrapi adapter (controlled fallback; M2 boundary)
        -> optional future provider only after a documented gap (M13)
   -> PostgreSQL append-only snapshots (M1/M3)
   -> deterministic analytics and scoring (M4/M5)
@@ -74,8 +99,9 @@ deployment hardening.
 
 - Official-first collection will wrap the existing CRM Graph adapter in
   `crm/console/functions/_lib/instagramGraph.ts` and its authenticated
-  connection boundary in `instagramStore.ts`; the CRM UI must not call Graph
-  or instagrapi directly.
+  connection boundary in `instagramStore.ts`; M2 only defines the injected
+  projection boundary, and the CRM UI must not call Graph or instagrapi
+  directly.
 - The controlled fallback will reuse the existing
   `social/instagram/module/instagram_site_sync.py` and its vendored instagrapi
   session path. It will not duplicate that implementation.
@@ -143,8 +169,8 @@ ratio.
 
 ## Rollout and access
 
-The planned module flag is `INFLUENCER_INTELLIGENCE_ENABLED=false`. M0 and M1
-do not wire it. When the CRM surface is introduced, access must be independently
+The planned module flag is `INFLUENCER_INTELLIGENCE_ENABLED=false`. M0 through
+M2 do not wire it. When the CRM surface is introduced, access must be independently
 enforced by the server-side grant `module.influencer-intelligence.access` and
 the module catalog; navigation visibility is not authorization.
 
@@ -154,17 +180,17 @@ The only permitted progression is:
 off -> shadow (synthetic or approved staging evidence) -> active (explicit gate)
 ```
 
-No M0/M1 artifact enables a real user, calls an external provider with business
-effects, publishes content, sends engagement actions, or changes production
-configuration.
+No M0/M1/M2 artifact enables a real user, calls an external provider with
+business effects, publishes content, sends engagement actions, or changes
+production configuration.
 
 ## Milestone map
 
 | Milestone | Deliverable | Status |
 | --- | --- | --- |
 | M0 | Architecture and normalized contracts | Merged in #1303 |
-| M1 | Creator registry and additive PostgreSQL schema | In progress; artifact only, not applied |
-| M2 | Official-first router and controlled collectors | Pending; no provider code in M1 |
+| M1 | Creator registry and additive PostgreSQL schema | Merged in #1304; artifact only, not applied |
+| M2 | Official-first router and controlled collectors | In progress; injected synthetic transports only |
 | M3 | Append-only snapshots, retention, and Orb scheduling | Pending |
 | M4 | Robust analytics and outlier-resistant metrics | Pending |
 | M5 | Deterministic score, confidence, coverage, and provenance | Pending |
@@ -177,17 +203,17 @@ configuration.
 | M12 | Synthetic validation and calibration | Pending |
 | M13 | Optional provider gap analysis | Pending; only if a measured gap remains |
 
-## M0/M1 risk, validation, and rollback
+## M2 risk, validation, and rollback
 
-- Risk: high because a PostgreSQL artifact is being reviewed, but no database
-  connection or mutation occurs in this milestone.
-- Surfaces: `social/influencer-intelligence/**`; no runtime, CRM, MCP, Orb,
-  systemd, Cloudflare, or user-facing surface.
-- Migration: additive SQL artifact only; remote apply is prohibited in M1.
+- Risk: high because this milestone defines the provider boundary, but no
+  network, database, runtime, or session operation occurs.
+- Surfaces: `social/influencer-intelligence/**` and the focused architecture
+  workflow test; no CRM, MCP, Orb, systemd, Cloudflare, or user-facing surface.
+- Migration: none in M2; the additive M1 SQL artifact remains unapplied.
 - Flag: declared for the future, not wired; default remains `false`.
-- Validation: focused M0/M1 Node tests, SQL shape and privilege checks,
-  architecture/domain-boundary checks, forbidden-surface/secret scan, and
-  terminal hosted checks on the exact pull-request SHA.
+- Validation: focused M0/M1/M2 Node tests, provider static surface scan,
+  architecture/domain-boundary checks, secret scan, and terminal hosted checks
+  on the exact pull-request SHA.
 - Rollback: close or revert the single-purpose change to merge SHA
-  `26b17ef3f64482ac1d3aa0182af597262bb633d1`. No user data or remote database
-  state is created by this milestone.
+  `f0dcab87d5348941d5c28e690c8a689a3bad8a3d`. No user data, provider session,
+  network state, or remote database state is created by this milestone.

--- a/social/influencer-intelligence/provider-router.mjs
+++ b/social/influencer-intelligence/provider-router.mjs
@@ -1,0 +1,188 @@
+import {
+  assertNoSensitiveFields,
+  normalizeCanonicalHandle,
+  normalizeCreatorKey,
+  normalizeProviderId,
+  normalizeProviderSnapshot,
+} from './contracts.mjs';
+import {
+  PROVIDER_COLLECTION_CODES,
+  ProviderCollectionError,
+  ProviderGapError,
+} from './providers/profile-provider.mjs';
+
+export const PROVIDER_ROUTER_CONTRACT_VERSION = 'influencer-intelligence-provider-router/v1';
+export const DEFAULT_PROVIDER_ORDER = Object.freeze(['meta-graph', 'instagrapi']);
+
+const providerCollectionCodeSet = new Set(PROVIDER_COLLECTION_CODES);
+
+export class ProviderRouterError extends Error {
+  constructor(reasonCode, provider = undefined) {
+    super(`Influencer Intelligence provider router rejected the request: ${reasonCode}`);
+    this.name = 'ProviderRouterError';
+    this.reasonCode = reasonCode;
+    if (provider) this.provider = provider;
+  }
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function deepFreeze(value, seen = new Set()) {
+  if (!value || typeof value !== 'object' || seen.has(value)) return value;
+  seen.add(value);
+  for (const child of Object.values(value)) deepFreeze(child, seen);
+  return Object.freeze(value);
+}
+
+function canonicalTimestamp(value, label) {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new ProviderRouterError('invalid_request');
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new ProviderRouterError('invalid_request');
+  }
+  return parsed.toISOString();
+}
+
+function normalizeCollectionRequest(input) {
+  if (!isRecord(input)) throw new ProviderRouterError('invalid_request');
+  try {
+    assertNoSensitiveFields(input, 'providerRouter.request');
+  } catch {
+    throw new ProviderRouterError('policy_block');
+  }
+  const allowedKeys = new Set(['creatorKey', 'handle', 'observedAt', 'retrievedAt']);
+  if (Object.keys(input).some((key) => !allowedKeys.has(key))) {
+    throw new ProviderRouterError('invalid_request');
+  }
+  let creatorKey;
+  let handle;
+  try {
+    creatorKey = normalizeCreatorKey(input.creatorKey);
+    handle = normalizeCanonicalHandle(input.handle);
+  } catch {
+    throw new ProviderRouterError('invalid_request');
+  }
+  if (!handle) throw new ProviderRouterError('invalid_request');
+  const observedAt = canonicalTimestamp(input.observedAt, 'observedAt');
+  const retrievedAt = input.retrievedAt === undefined
+    ? undefined
+    : canonicalTimestamp(input.retrievedAt, 'retrievedAt');
+  if (retrievedAt && new Date(retrievedAt).getTime() < new Date(observedAt).getTime()) {
+    throw new ProviderRouterError('invalid_request');
+  }
+  return Object.freeze({
+    creatorKey,
+    handle,
+    observedAt,
+    ...(retrievedAt ? { retrievedAt } : {}),
+  });
+}
+
+function providerEntries(value) {
+  if (value instanceof Map) return [...value.entries()];
+  if (isRecord(value)) return Object.entries(value);
+  throw new ProviderRouterError('invalid_request');
+}
+
+function normalizeConfiguredProviders(value) {
+  const normalized = new Map();
+  for (const [rawId, provider] of providerEntries(value)) {
+    let id;
+    try {
+      id = normalizeProviderId(rawId, 'providerRouter.provider');
+    } catch {
+      throw new ProviderRouterError('unknown_provider');
+    }
+    if (normalized.has(id) || !isRecord(provider) || typeof provider.collect !== 'function') {
+      throw new ProviderRouterError('invalid_request', id);
+    }
+    if (provider.id !== id) throw new ProviderRouterError('invalid_request', id);
+    if (id === 'meta-graph' && provider.officialFirst !== true) {
+      throw new ProviderRouterError('official_first_required', id);
+    }
+    normalized.set(id, provider);
+  }
+  return normalized;
+}
+
+function normalizeOrder(value) {
+  if (!Array.isArray(value) || value.length === 0) throw new ProviderRouterError('invalid_request');
+  const order = value.map((item, index) => {
+    try {
+      return normalizeProviderId(item, `providerRouter.providerOrder[${index}]`);
+    } catch {
+      throw new ProviderRouterError('unknown_provider');
+    }
+  });
+  if (new Set(order).size !== order.length) throw new ProviderRouterError('invalid_request');
+  if (order[0] !== 'meta-graph') throw new ProviderRouterError('official_first_required');
+  return order;
+}
+
+function terminalReason(error) {
+  if (error instanceof ProviderCollectionError && providerCollectionCodeSet.has(error.reasonCode)) {
+    return error.reasonCode;
+  }
+  return 'provider_failed';
+}
+
+export function createProviderRouter({ providers, providerOrder = DEFAULT_PROVIDER_ORDER } = {}) {
+  const configuredProviders = normalizeConfiguredProviders(providers);
+  const requestedOrder = normalizeOrder(providerOrder);
+  const activeOrder = requestedOrder.filter((providerId) => configuredProviders.has(providerId));
+  if (!activeOrder.includes('meta-graph') || activeOrder[0] !== 'meta-graph') {
+    throw new ProviderRouterError('official_first_required');
+  }
+
+  return Object.freeze({
+    contractVersion: PROVIDER_ROUTER_CONTRACT_VERSION,
+    providerOrder: Object.freeze(activeOrder),
+    capabilities: Object.freeze(['read-profile']),
+    async collect(input) {
+      const request = normalizeCollectionRequest(input);
+      const attempts = [];
+      for (const providerId of activeOrder) {
+        const provider = configuredProviders.get(providerId);
+        try {
+          const candidate = await provider.collect(request);
+          let snapshot;
+          try {
+            snapshot = normalizeProviderSnapshot(candidate);
+          } catch {
+            throw new ProviderCollectionError('invalid_response');
+          }
+          if (snapshot.provider !== providerId || snapshot.creatorKey !== request.creatorKey) {
+            throw new ProviderCollectionError('invalid_response');
+          }
+          attempts.push({ provider: providerId, status: 'collected' });
+          return deepFreeze({
+            contractVersion: PROVIDER_ROUTER_CONTRACT_VERSION,
+            status: 'collected',
+            provider: providerId,
+            snapshot,
+            attempts,
+          });
+        } catch (error) {
+          if (error instanceof ProviderGapError) {
+            attempts.push({ provider: providerId, status: 'gap', reasonCode: error.reasonCode });
+            continue;
+          }
+          const reasonCode = terminalReason(error);
+          attempts.push({ provider: providerId, status: 'blocked', reasonCode });
+          throw new ProviderRouterError(reasonCode, providerId);
+        }
+      }
+      return deepFreeze({
+        contractVersion: PROVIDER_ROUTER_CONTRACT_VERSION,
+        status: 'unavailable',
+        provider: null,
+        snapshot: null,
+        attempts,
+      });
+    },
+  });
+}

--- a/social/influencer-intelligence/providers/instagrapi-adapter.mjs
+++ b/social/influencer-intelligence/providers/instagrapi-adapter.mjs
@@ -1,0 +1,19 @@
+import { createProfileProvider } from './profile-provider.mjs';
+
+// This is a narrow wrapper around the existing social/instagram read path. It
+// does not own sessions, credentials, scraping, downloads, or engagement APIs.
+export const INSTAGRAPI_PROFILE_FIELDS = Object.freeze([
+  'username',
+  'follower_count',
+  'media_count',
+]);
+
+export function createInstagrapiProvider(options = {}) {
+  return createProfileProvider({
+    provider: 'instagrapi',
+    officialFirst: false,
+    sourceRefPrefix: 'instagrapi',
+    requestFields: INSTAGRAPI_PROFILE_FIELDS,
+    readProfile: options.readProfile,
+  });
+}

--- a/social/influencer-intelligence/providers/meta-graph-adapter.mjs
+++ b/social/influencer-intelligence/providers/meta-graph-adapter.mjs
@@ -1,0 +1,20 @@
+import { createProfileProvider } from './profile-provider.mjs';
+
+// The injected transport must already map the official Graph response into the
+// small projection accepted by the provider boundary. This keeps credentials,
+// raw profile payloads, and HTTP concerns outside Influencer Intelligence.
+export const META_GRAPH_PROFILE_FIELDS = Object.freeze([
+  'username',
+  'followers_count',
+  'media_count',
+]);
+
+export function createMetaGraphProvider(options = {}) {
+  return createProfileProvider({
+    provider: 'meta-graph',
+    officialFirst: true,
+    sourceRefPrefix: 'meta-graph',
+    requestFields: META_GRAPH_PROFILE_FIELDS,
+    readProfile: options.readProfile,
+  });
+}

--- a/social/influencer-intelligence/providers/profile-provider.mjs
+++ b/social/influencer-intelligence/providers/profile-provider.mjs
@@ -1,0 +1,225 @@
+import {
+  assertNoSensitiveFields,
+  normalizeCanonicalHandle,
+  normalizeCreatorKey,
+  normalizeProviderId,
+  normalizeProviderSnapshot,
+} from '../contracts.mjs';
+
+export const PROVIDER_GAP_CODES = Object.freeze([
+  'provider_unavailable',
+  'permission_gap',
+  'coverage_gap',
+  'timeout',
+]);
+
+export const PROVIDER_COLLECTION_CODES = Object.freeze([
+  'transport_error',
+  'invalid_response',
+  'policy_block',
+]);
+
+const providerGapSet = new Set(PROVIDER_GAP_CODES);
+const providerCollectionSet = new Set(PROVIDER_COLLECTION_CODES);
+const profileProjectionKeys = new Set(['handle', 'followersCount', 'mediaCount']);
+const profileMetricDefinitions = Object.freeze([
+  { key: 'followers_count', field: 'followersCount' },
+  { key: 'media_count', field: 'mediaCount' },
+]);
+
+export class ProviderAdapterError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'ProviderAdapterError';
+  }
+}
+
+export class ProviderGapError extends Error {
+  constructor(reasonCode) {
+    if (!providerGapSet.has(reasonCode)) {
+      throw new ProviderAdapterError(`unsupported provider gap code: ${reasonCode}`);
+    }
+    super(`provider gap: ${reasonCode}`);
+    this.name = 'ProviderGapError';
+    this.reasonCode = reasonCode;
+  }
+}
+
+export class ProviderCollectionError extends Error {
+  constructor(reasonCode) {
+    if (!providerCollectionSet.has(reasonCode)) {
+      throw new ProviderAdapterError(`unsupported provider collection code: ${reasonCode}`);
+    }
+    super(`provider collection failed: ${reasonCode}`);
+    this.name = 'ProviderCollectionError';
+    this.reasonCode = reasonCode;
+  }
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function canonicalTimestamp(value, label) {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new ProviderAdapterError(`${label} is required`);
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new ProviderAdapterError(`${label} must be an ISO timestamp`);
+  }
+  return parsed.toISOString();
+}
+
+function normalizeCount(value) {
+  if (value === undefined || value === null) return null;
+  if (!Number.isInteger(value) || value < 0) {
+    throw new ProviderCollectionError('invalid_response');
+  }
+  return value;
+}
+
+function normalizeProfileProjection(value) {
+  if (!isRecord(value)) throw new ProviderCollectionError('invalid_response');
+
+  try {
+    assertNoSensitiveFields(value, 'profileProjection');
+  } catch {
+    throw new ProviderCollectionError('policy_block');
+  }
+
+  if (Object.keys(value).some((key) => !profileProjectionKeys.has(key))) {
+    throw new ProviderCollectionError('invalid_response');
+  }
+
+  let handle;
+  try {
+    handle = value.handle === undefined || value.handle === null
+      ? undefined
+      : normalizeCanonicalHandle(value.handle);
+  } catch {
+    throw new ProviderCollectionError('invalid_response');
+  }
+
+  return {
+    handle,
+    followersCount: normalizeCount(value.followersCount),
+    mediaCount: normalizeCount(value.mediaCount),
+  };
+}
+
+function makeObservation({ provider, creatorKey, observedAt, retrievedAt, key, value }) {
+  const evidenceState = value === null ? 'unavailable' : 'observed';
+  const provenance = {
+    provider,
+    sourceType: 'profile',
+    evidenceState,
+    observedAt,
+    ...(retrievedAt ? { retrievedAt } : {}),
+    sourceRef: `${provider}:profile:${creatorKey}`,
+  };
+  return {
+    key,
+    unit: 'count',
+    value,
+    evidenceState,
+    confidence: value === null ? 0 : 1,
+    provenance,
+  };
+}
+
+export function createProfileProvider({
+  provider,
+  officialFirst,
+  sourceRefPrefix = provider,
+  requestFields,
+  readProfile,
+} = {}) {
+  let providerId;
+  try {
+    providerId = normalizeProviderId(provider, 'provider');
+  } catch {
+    throw new ProviderAdapterError('provider is not supported');
+  }
+  if (typeof readProfile !== 'function') {
+    throw new ProviderAdapterError(`${providerId} requires an injected read-only profile transport`);
+  }
+  if (typeof officialFirst !== 'boolean') {
+    throw new ProviderAdapterError(`${providerId} must declare officialFirst`);
+  }
+  if (typeof sourceRefPrefix !== 'string' || !/^[a-z][a-z0-9-]*$/.test(sourceRefPrefix)) {
+    throw new ProviderAdapterError('sourceRefPrefix must be a lowercase slug');
+  }
+  if (!Array.isArray(requestFields) || requestFields.length === 0
+    || requestFields.some((field) => typeof field !== 'string' || !/^[a-z][a-z0-9_]*$/.test(field))) {
+    throw new ProviderAdapterError(`${providerId} requestFields must be a non-empty field allowlist`);
+  }
+
+  const fields = Object.freeze([...new Set(requestFields)]);
+
+  return Object.freeze({
+    id: providerId,
+    officialFirst,
+    capabilities: Object.freeze(['profile']),
+    async collect(input = {}) {
+      if (!isRecord(input)) throw new ProviderAdapterError('provider collection input must be an object');
+      const creatorKey = normalizeCreatorKey(input.creatorKey);
+      const requestedHandle = normalizeCanonicalHandle(input.handle);
+      if (!requestedHandle) throw new ProviderAdapterError('provider collection handle is required');
+      const observedAt = canonicalTimestamp(input.observedAt, 'observedAt');
+      const retrievedAt = input.retrievedAt === undefined
+        ? undefined
+        : canonicalTimestamp(input.retrievedAt, 'retrievedAt');
+      if (retrievedAt && new Date(retrievedAt).getTime() < new Date(observedAt).getTime()) {
+        throw new ProviderAdapterError('retrievedAt must not precede observedAt');
+      }
+
+      const request = Object.freeze({
+        handle: requestedHandle,
+        fields,
+        mode: 'read-only',
+      });
+      let projection;
+      try {
+        projection = await readProfile(request);
+      } catch (error) {
+        if (error instanceof ProviderGapError || error instanceof ProviderCollectionError) throw error;
+        throw new ProviderCollectionError('transport_error');
+      }
+
+      const normalizedProjection = normalizeProfileProjection(projection);
+      const observations = profileMetricDefinitions.map(({ key, field }) => makeObservation({
+        provider: providerId,
+        creatorKey,
+        observedAt,
+        retrievedAt,
+        key,
+        value: normalizedProjection[field],
+      }));
+      const evidenceState = observations.some((item) => item.evidenceState === 'observed')
+        ? 'observed'
+        : 'unavailable';
+
+      try {
+        return normalizeProviderSnapshot({
+          creatorKey,
+          handle: normalizedProjection.handle || requestedHandle,
+          provider: providerId,
+          observedAt,
+          evidenceState,
+          provenance: {
+            provider: providerId,
+            sourceType: 'profile',
+            evidenceState,
+            observedAt,
+            ...(retrievedAt ? { retrievedAt } : {}),
+            sourceRef: `${sourceRefPrefix}:profile:${creatorKey}`,
+          },
+          observations,
+        });
+      } catch {
+        throw new ProviderCollectionError('invalid_response');
+      }
+    },
+  });
+}

--- a/social/influencer-intelligence/tests/providers.test.mjs
+++ b/social/influencer-intelligence/tests/providers.test.mjs
@@ -1,0 +1,214 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  createInstagrapiProvider,
+  INSTAGRAPI_PROFILE_FIELDS,
+} from '../providers/instagrapi-adapter.mjs';
+import {
+  createMetaGraphProvider,
+  META_GRAPH_PROFILE_FIELDS,
+} from '../providers/meta-graph-adapter.mjs';
+import {
+  ProviderCollectionError,
+  ProviderGapError,
+} from '../providers/profile-provider.mjs';
+import {
+  createProviderRouter,
+  ProviderRouterError,
+} from '../provider-router.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const observedAt = '2026-08-10T14:00:00.000Z';
+const retrievedAt = '2026-08-10T14:00:02.000Z';
+const collectionInput = {
+  creatorKey: 'creator:synthetic-001',
+  handle: '@Synthetic.Creator',
+  observedAt,
+  retrievedAt,
+};
+
+test('official Meta adapter uses a read-only injected transport and normalized projection', async () => {
+  const calls = [];
+  const provider = createMetaGraphProvider({
+    readProfile: async (request) => {
+      calls.push(request);
+      return {
+        handle: 'Synthetic.Creator',
+        followersCount: 12000,
+        mediaCount: 42,
+      };
+    },
+  });
+
+  const snapshot = await provider.collect(collectionInput);
+  assert.equal(provider.id, 'meta-graph');
+  assert.equal(provider.officialFirst, true);
+  assert.deepEqual(calls, [{
+    handle: 'synthetic.creator',
+    fields: META_GRAPH_PROFILE_FIELDS,
+    mode: 'read-only',
+  }]);
+  assert.equal(snapshot.provider, 'meta-graph');
+  assert.deepEqual(snapshot.observations.map(({ key, value, evidenceState }) => ({
+    key,
+    value,
+    evidenceState,
+  })), [
+    { key: 'followers_count', value: 12000, evidenceState: 'observed' },
+    { key: 'media_count', value: 42, evidenceState: 'observed' },
+  ]);
+  assert.equal('profile' in snapshot, false);
+  assert.equal(Object.isFrozen(snapshot), true);
+});
+
+test('instagrapi adapter is a controlled fallback and keeps unavailable metrics explicit', async () => {
+  const calls = [];
+  const provider = createInstagrapiProvider({
+    readProfile: async (request) => {
+      calls.push(request);
+      return {
+        handle: 'Synthetic.Creator',
+        followersCount: null,
+        mediaCount: 7,
+      };
+    },
+  });
+
+  const snapshot = await provider.collect(collectionInput);
+  assert.equal(provider.id, 'instagrapi');
+  assert.equal(provider.officialFirst, false);
+  assert.deepEqual(calls[0].fields, INSTAGRAPI_PROFILE_FIELDS);
+  assert.deepEqual(snapshot.observations.map(({ key, value, evidenceState }) => ({
+    key,
+    value,
+    evidenceState,
+  })), [
+    { key: 'followers_count', value: null, evidenceState: 'unavailable' },
+    { key: 'media_count', value: 7, evidenceState: 'observed' },
+  ]);
+});
+
+test('adapter rejects sensitive or raw provider fields before the contract boundary', async () => {
+  const provider = createMetaGraphProvider({
+    readProfile: async () => ({
+      handle: 'synthetic.creator',
+      followersCount: 10,
+      access_token: 'never-retained',
+    }),
+  });
+
+  await assert.rejects(
+    provider.collect(collectionInput),
+    (error) => error instanceof ProviderCollectionError && error.reasonCode === 'policy_block',
+  );
+});
+
+test('router tries Meta first and falls back only for an explicit coverage gap', async () => {
+  const calls = [];
+  const meta = createMetaGraphProvider({
+    readProfile: async () => {
+      calls.push('meta-graph');
+      throw new ProviderGapError('coverage_gap');
+    },
+  });
+  const instagrapi = createInstagrapiProvider({
+    readProfile: async () => {
+      calls.push('instagrapi');
+      return { handle: 'synthetic.creator', followersCount: 90, mediaCount: 4 };
+    },
+  });
+  const router = createProviderRouter({
+    providers: { 'meta-graph': meta, instagrapi },
+  });
+
+  const result = await router.collect(collectionInput);
+  assert.deepEqual(calls, ['meta-graph', 'instagrapi']);
+  assert.equal(result.status, 'collected');
+  assert.equal(result.provider, 'instagrapi');
+  assert.deepEqual(result.attempts, [
+    { provider: 'meta-graph', status: 'gap', reasonCode: 'coverage_gap' },
+    { provider: 'instagrapi', status: 'collected' },
+  ]);
+  assert.equal('message' in result.attempts[0], false);
+});
+
+test('router fails closed and does not fall back on policy or invalid-response failures', async () => {
+  let fallbackCalls = 0;
+  const meta = createMetaGraphProvider({
+    readProfile: async () => {
+      throw new ProviderCollectionError('policy_block');
+    },
+  });
+  const instagrapi = createInstagrapiProvider({
+    readProfile: async () => {
+      fallbackCalls += 1;
+      return { handle: 'synthetic.creator', followersCount: 1, mediaCount: 1 };
+    },
+  });
+  const router = createProviderRouter({
+    providers: { 'meta-graph': meta, instagrapi },
+  });
+
+  await assert.rejects(
+    router.collect(collectionInput),
+    (error) => error instanceof ProviderRouterError
+      && error.reasonCode === 'policy_block'
+      && error.provider === 'meta-graph',
+  );
+  assert.equal(fallbackCalls, 0);
+});
+
+test('router reports unavailable only after every configured provider returns an allowed gap', async () => {
+  const meta = createMetaGraphProvider({
+    readProfile: async () => {
+      throw new ProviderGapError('provider_unavailable');
+    },
+  });
+  const instagrapi = createInstagrapiProvider({
+    readProfile: async () => {
+      throw new ProviderGapError('permission_gap');
+    },
+  });
+  const router = createProviderRouter({
+    providers: { 'meta-graph': meta, instagrapi },
+  });
+
+  const result = await router.collect(collectionInput);
+  assert.equal(result.status, 'unavailable');
+  assert.equal(result.snapshot, null);
+  assert.deepEqual(result.attempts, [
+    { provider: 'meta-graph', status: 'gap', reasonCode: 'provider_unavailable' },
+    { provider: 'instagrapi', status: 'gap', reasonCode: 'permission_gap' },
+  ]);
+});
+
+test('router enforces an official-first allowlist and providers expose no write surface', () => {
+  const meta = createMetaGraphProvider({ readProfile: async () => ({}) });
+  const instagrapi = createInstagrapiProvider({ readProfile: async () => ({}) });
+  assert.throws(() => createProviderRouter({
+    providers: { 'meta-graph': meta, instagrapi },
+    providerOrder: ['instagrapi', 'meta-graph'],
+  }), (error) => error instanceof ProviderRouterError && error.reasonCode === 'official_first_required');
+  assert.throws(() => createProviderRouter({
+    providers: { 'meta-graph': meta },
+    providerOrder: ['future-provider'],
+  }), (error) => error instanceof ProviderRouterError && error.reasonCode === 'unknown_provider');
+  assert.deepEqual(Object.keys(meta).sort(), ['capabilities', 'collect', 'id', 'officialFirst']);
+  assert.deepEqual(Object.keys(instagrapi).sort(), ['capabilities', 'collect', 'id', 'officialFirst']);
+});
+
+test('provider implementation has no network, session, scraper, or simulator dependency', () => {
+  const providerFiles = [
+    '../provider-router.mjs',
+    '../providers/profile-provider.mjs',
+    '../providers/meta-graph-adapter.mjs',
+    '../providers/instagrapi-adapter.mjs',
+  ].map((relativePath) => fs.readFileSync(path.join(here, relativePath), 'utf8')).join('\n');
+  assert.doesNotMatch(providerFiles, /\bfetch\s*\(/i);
+  assert.doesNotMatch(providerFiles, /from\s+['"]node:(?:http|https|net|tls)['"]/i);
+  assert.doesNotMatch(providerFiles, /InstagramModuleSimulator|instaloader/i);
+});


### PR DESCRIPTION
# Summary

Adds the M2 official-first provider router and controlled Meta Graph/instagrapi adapter boundaries for Influencer Intelligence. Adapters use injected read-only transports and synthetic fixtures only; no external provider, session, database, CRM, MCP, Orb, or runtime call is connected.

## Type of change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [x] Docs updated (README, API refs, diagrams)
- [x] Security review (CodeQL, gitleaks)
- [ ] Performance impact measured — no runtime path exists in M2

## Links
- Issue: Mission milestone M2, Influencer Intelligence
- Design/ADR: `social/influencer-intelligence/README.md`
- Migration steps: None; M1 additive SQL remains unapplied

## Safety and rollout
- Risk: High boundary risk, contained to `social/influencer-intelligence/**` plus its architecture test.
- Flag: `INFLUENCER_INTELLIGENCE_ENABLED=false`; not wired; future grant remains `module.influencer-intelligence.access`.
- Provider order: `meta-graph` first; `instagrapi` fallback only for explicit gap codes.
- Fallback is disabled for policy blocks, invalid responses, and unclassified transport errors.
- No new scraper/provider, simulator, FastAPI exposure, engagement, publish, or raw payload path.
- Rollback: close/revert this PR to base `f0dcab87d5348941d5c28e690c8a689a3bad8a3d`; no remote data or runtime state is created.

## Validation / Evidence
- Exact candidate SHA: `e63fb85b6c6820a09de3c873d8bd040b49d3d453`
- Focused M0/M1/M2 Node tests: 20/20 passed
- Architecture, module catalog, domain boundaries, dependency closures: passed; three pre-existing legacy-import warnings unchanged
- GitHub governance validation: passed
- JavaScript security exceptions: passed
- Provider static scan, syntax, and whitespace checks: passed
- Hosted CI must be evaluated on the exact candidate SHA before readiness/merge.

## Screenshots / Evidence
See the focused test and CI logs attached to this PR.