### PR TITLE
chore: govern local storage footprint

### DIFF
--- a/docs/operations/storage-governance.md
+++ b/docs/operations/storage-governance.md
@@ -1,0 +1,98 @@
+# SKINCOS development storage governance
+
+This runbook governs local development storage on Windows. It is separate from
+production release custody and never mutates the WSL VHDX, `SKINCOS_STAGING`,
+the canonical checkout, or Codex session files directly.
+
+## Policy
+
+The versioned policy is `ops/codex/storage-retention-policy.json`. Its default
+thresholds are warning at 100 GB free, high at 50 GB, critical at 25 GB and
+emergency at 10 GB. New cleanup behavior is dry-run unless an operator invokes
+`-Apply` explicitly.
+
+The private runtime stores reports and action history at:
+
+`C:\CodexRuntime\operator\admin\skincos\storage-governance`
+
+It must not be placed in the shared checkout.
+
+## Modes
+
+```powershell
+# Quick report; no mutation
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\skincos-storage-governance.ps1 -Mode audit
+
+# Full targeted inventory, including worktrees, source archives and workerd paths
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\skincos-storage-governance.ps1 -Mode audit -Deep -IncludeWorktreeStatus
+
+# Dry-run of allowlisted temporary cleanup
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\skincos-storage-governance.ps1 -Mode cleanup
+
+# Official Codex session lifecycle; audit first
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\codex-session-retention.ps1 -Mode audit
+```
+
+`cleanup` only considers expired files in the allowlisted `%TEMP%` and npm
+`_npx` roots. `C:\Temp`, `C:\tmp`, pnpm stores, SKINCOS runtime caches and
+builds are report-only until a narrower owner-specific rule is validated.
+
+## Worktree lifecycle
+
+`new-shared-worktree.ps1` records owner, task, branch, commit, timestamps,
+status, pin and lease fields in the private lifecycle directory. CRM Local
+private source worktrees register the same metadata. The classifier also reads
+the first `session_meta` line from active Codex JSONL sessions and blocks a
+worktree whose path is an active session `cwd`. A worktree is eligible for
+regenerable cleanup only when it is clean, merged into `origin/main`, outside
+protected rollback paths, has no associated process/session and is not pinned
+or leased.
+
+Use `close-shared-worktree.ps1` for a dry-run classification. It must never be
+replaced by `git clean -fdx`, recursive directory deletion or an unreviewed
+`git worktree prune`. The governance cleanup mode removes only the outermost
+`node_modules`, `dist`, `.vite`, `.next`, `.turbo`, `coverage` and
+`playwright-report` directories from eligible worktrees. Worktree removal is a
+separate opt-in (`-AllowWorktreeRemoval`) and is disabled by default.
+
+Install the read-only monitor after validating the worktree path used by the
+task:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-skincos-storage-governance-task.ps1 `
+  -RepositoryRoot (Get-Location).Path `
+  -ScriptPath (Join-Path (Get-Location).Path 'scripts\skincos-storage-governance.ps1') `
+  -IntervalHours 6 -Apply
+```
+
+The registered task runs `-Mode audit` only. Cleanup and hardlink deduplication
+remain explicit operator actions.
+
+## Release archives
+
+`dedupe-source-tars.ps1` hashes the bounded release/checkpoint roots and only
+considers exact SHA-256 and byte-size duplicates. With explicit hardlink mode,
+it preserves every original path, quarantines the duplicate transactionally,
+creates a hardlink to the canonical artifact, verifies the hash and link list,
+and removes the temporary quarantine copy. Different ACLs, volumes, recent
+files and reparse points are blocked.
+
+This preserves rollback path names while avoiding repeated physical content.
+The operation is idempotent: a later scan reports an existing canonical
+hardlink as `already-hardlinked` and does not move it again. It does not expire
+releases or checkpoints automatically; those remain pinned until a
+release-custody manifest supplies an explicit retention decision.
+
+## Codex sessions
+
+Codex CLI 0.144.4 provides the supported `archive`, `unarchive` and `delete`
+commands. `codex-session-retention.ps1` uses those commands rather than
+editing JSONL or SQLite files. Active sessions are always protected; deletion
+requires the archived-session TTL and never runs for pinned IDs.
+
+## WSL
+
+Use `scripts/storage/audit-wsl-readonly.sh` through the typed WSL gateway with
+`WSL_BOUNDARY_EXCEPTION=storage-readonly-audit`. It is a diagnostic probe only.
+No compaction, unregister, repair or VHDX deletion is permitted until backup,
+filesystem consistency and internal consumer analysis are complete.

--- a/ops/codex/storage-retention-policy.json
+++ b/ops/codex/storage-retention-policy.json
@@ -1,0 +1,97 @@
+{
+  "schemaVersion": 1,
+  "policyId": "skincos-development-storage-2026-08",
+  "thresholdsGB": {
+    "warning": 100,
+    "high": 50,
+    "critical": 25,
+    "emergency": 10
+  },
+  "retentionDays": {
+    "temporary": 14,
+    "build": 14,
+    "endedWorktree": 14,
+    "release": 90,
+    "checkpoint": 30,
+    "codexSession": 30,
+    "codexArchivedSession": 90,
+    "governanceReport": 30
+  },
+  "paths": {
+    "projectRoot": "C:\\CodexShared\\Projetos\\skincos",
+    "worktreeRoot": "C:\\CodexShared\\Worktrees\\skincos\\admin",
+    "runtimeRoot": "C:\\CodexRuntime",
+    "codexHome": "%USERPROFILE%\\.codex",
+    "privateStateRoot": "C:\\CodexRuntime\\operator\\admin\\skincos\\storage-governance"
+  },
+  "safeCleanupRoots": [
+    "%LOCALAPPDATA%\\Temp",
+    "%LOCALAPPDATA%\\npm-cache\\_npx"
+  ],
+  "reportOnlyRoots": [
+    "C:\\Temp",
+    "C:\\tmp",
+    "%LOCALAPPDATA%\\pnpm-cache",
+    "C:\\CodexRuntime\\operator\\admin\\skincos\\cache",
+    "C:\\CodexRuntime\\operator\\admin\\skincos\\playwright-browsers"
+  ],
+  "protectedRoots": [
+    "C:\\Users\\admin\\AppData\\Local\\wsl",
+    "C:\\WSL",
+    "C:\\SKINCOS_STAGING",
+    "C:\\CodexShared\\Projetos\\skincos",
+    "%USERPROFILE%\\.codex\\sessions",
+    "%USERPROFILE%\\.codex\\archived_sessions",
+    "C:\\pagefile.sys",
+    "C:\\swapfile.sys"
+  ],
+  "regenerableDirectoryNames": [
+    "node_modules",
+    "dist",
+    ".vite",
+    ".next",
+    ".turbo",
+    "coverage",
+    "playwright-report"
+  ],
+  "protectedArtifactDirectories": [
+    "native-releases",
+    "native-promotions",
+    "releases",
+    "checkpoints",
+    "retired-worktrees",
+    "backups",
+    "recovered-worktree-artifacts"
+  ],
+  "protectedNamePatterns": [
+    "*.env",
+    "*.dev.vars",
+    "*.cloudflared",
+    "*.jsonl",
+    "*.sqlite",
+    "*.sqlite-*",
+    "*.vhdx",
+    "*.dmp",
+    "*.etl",
+    "*.tar",
+    "*.zip",
+    "*.mp4",
+    "*.mov",
+    "*.MOV",
+    "*.HEIC"
+  ],
+  "defaults": {
+    "dryRun": true,
+    "deepScan": false,
+    "worktreeRemoval": false,
+    "artifactHardlinkDeduplication": false,
+    "codexSessionRemoval": false,
+    "wslMutation": false
+  },
+  "scheduledAudit": {
+    "taskName": "SKINCOS Storage Governance Audit",
+    "intervalHours": 6,
+    "runAtLogon": true,
+    "runLevel": "limited"
+  }
+}

--- a/scripts/audit-skincos-footprint.ps1
+++ b/scripts/audit-skincos-footprint.ps1
@@ -91,8 +91,16 @@ $backupFiles = if (Test-Path -LiteralPath $backupRoot) {
 } else { @() }
 $latestBackup = if ($backupFiles.Count -gt 0) { $backupFiles[0] } else { $null }
 $orphanTask = Get-ScheduledTask -TaskName "Orb Stack WSL Supervisor" -ErrorAction SilentlyContinue
-$gitFsck = & git -C $ProjectRoot fsck --no-dangling 2>$null
-$gitFsckOk = $LASTEXITCODE -eq 0
+$gitFsckError = $null
+try {
+    $gitFsck = & git -C $ProjectRoot fsck --no-dangling 2>&1
+    $gitFsckOk = $LASTEXITCODE -eq 0
+    if (-not $gitFsckOk) { $gitFsckError = (@($gitFsck) -join "`n") }
+} catch {
+    $gitFsckOk = $false
+    $gitFsckError = $_.Exception.Message
+    $gitFsck = @()
+}
 $drive = Get-PSDrive -Name C
 
 $result = [pscustomobject]@{
@@ -102,6 +110,7 @@ $result = [pscustomobject]@{
         branch = (@(Get-GitOutput -Arguments @("branch", "--show-current")) | Select-Object -First 1)
         dirtyCount = @(Get-GitOutput -Arguments @("status", "--porcelain")).Count
         fsckOk = $gitFsckOk
+        fsckError = $gitFsckError
     }
     footprints = @(
         Get-DirectoryFootprint -Path $ProjectRoot

--- a/scripts/close-shared-worktree.ps1
+++ b/scripts/close-shared-worktree.ps1
@@ -1,0 +1,120 @@
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+param(
+    [Parameter(Mandatory = $true)][string]$WorktreePath,
+    [string]$ProjectRoot = 'C:\CodexShared\Projetos\skincos',
+    [string]$WorktreeRoot = 'C:\CodexShared\Worktrees\skincos\admin',
+    [string]$LifecycleRoot = 'C:\CodexRuntime\operator\admin\skincos\storage-governance\worktrees',
+    [string]$CodexHome = '%USERPROFILE%\.codex',
+    [switch]$RemoveRegenerable,
+    [switch]$RemoveWorktree,
+    [switch]$Apply
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$WorktreePath = (Resolve-Path -LiteralPath $WorktreePath).Path
+$ProjectRoot = (Resolve-Path -LiteralPath $ProjectRoot).Path
+$WorktreeRoot = (Resolve-Path -LiteralPath $WorktreeRoot).Path
+$CodexHome = [Environment]::ExpandEnvironmentVariables($CodexHome)
+
+function Test-Within([string]$Path, [string]$Root) {
+    $p = [IO.Path]::GetFullPath($Path).TrimEnd('\', '/')
+    $r = [IO.Path]::GetFullPath($Root).TrimEnd('\', '/')
+    return $p.StartsWith($r + [IO.Path]::DirectorySeparatorChar, [StringComparison]::OrdinalIgnoreCase)
+}
+if (-not (Test-Within $WorktreePath $WorktreeRoot)) { throw "Refusing a path outside the approved worktree root: $WorktreePath" }
+if ($WorktreePath.Equals($ProjectRoot, [StringComparison]::OrdinalIgnoreCase)) { throw 'The canonical checkout cannot be closed by this command.' }
+
+$status = @(& git -C $WorktreePath status --porcelain 2>$null)
+$branch = (& git -C $WorktreePath branch --show-current 2>$null | Select-Object -First 1)
+$commit = (& git -C $WorktreePath rev-parse --verify 'HEAD^{commit}' 2>$null | Select-Object -First 1)
+$merged = $false
+if ($branch -and $branch -ne 'main') { & git -C $ProjectRoot merge-base --is-ancestor $branch origin/main 2>$null; $merged = $LASTEXITCODE -eq 0 }
+$normalized = ($WorktreePath -replace '/', '\').ToLowerInvariant()
+$protected = $normalized -match '\\(immutable|recovery|rollback|release|checkpoint|pinned)([-_][^\\]+|\\|$)'
+$processMatch = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { [string]$_.CommandLine -and (([string]$_.CommandLine).Replace('/', '\').ToLowerInvariant().Contains($normalized)) })
+$lifecycleRecord = $null
+if (Test-Path -LiteralPath $LifecycleRoot -PathType Container) {
+    foreach ($recordFile in @(Get-ChildItem -LiteralPath $LifecycleRoot -Force -File -Filter '*.json' -ErrorAction SilentlyContinue)) {
+        try {
+            $candidateRecord = Get-Content -LiteralPath $recordFile.FullName -Raw | ConvertFrom-Json
+            if ($candidateRecord.path -and ([IO.Path]::GetFullPath([string]$candidateRecord.path)).TrimEnd('\').Equals($WorktreePath.TrimEnd('\'), [StringComparison]::OrdinalIgnoreCase)) { $lifecycleRecord = $candidateRecord; break }
+        } catch {}
+    }
+}
+$sessionMatches = @()
+$sessionRoot = Join-Path $CodexHome 'sessions'
+if (Test-Path -LiteralPath $sessionRoot -PathType Container) {
+    foreach ($sessionFile in @(Get-ChildItem -LiteralPath $sessionRoot -Recurse -Force -File -Filter '*.jsonl' -ErrorAction SilentlyContinue)) {
+        try {
+            $meta = (Get-Content -LiteralPath $sessionFile.FullName -TotalCount 1 -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop)
+            $cwd = ([string]$meta.payload.cwd).Replace('/', '\').TrimEnd('\')
+            if ($cwd -and $cwd.StartsWith($WorktreePath.TrimEnd('\'), [StringComparison]::OrdinalIgnoreCase)) { $sessionMatches += [pscustomobject]@{ session_id = [string]$meta.payload.session_id; cwd = $cwd; file = $sessionFile.FullName } }
+        } catch {}
+    }
+}
+$lifecyclePinned = $null -ne $lifecycleRecord -and $null -ne $lifecycleRecord.PSObject.Properties['pinned'] -and [bool]$lifecycleRecord.pinned
+$lifecycleActive = $null -ne $lifecycleRecord -and $null -ne $lifecycleRecord.PSObject.Properties['lifecycle_status'] -and [string]$lifecycleRecord.lifecycle_status -eq 'active'
+$lifecycleBlocked = $lifecyclePinned -or $lifecycleActive
+$eligible = $status.Count -eq 0 -and $merged -and -not $protected -and $processMatch.Count -eq 0 -and -not $lifecycleBlocked -and $sessionMatches.Count -eq 0
+$regenerableNames = @('node_modules', 'dist', '.vite', '.next', '.turbo', 'coverage', 'playwright-report')
+$regenerableDirs = @()
+foreach ($dir in @(Get-ChildItem -LiteralPath $WorktreePath -Recurse -Force -Directory -ErrorAction SilentlyContinue | Where-Object { $regenerableNames -contains $_.Name -and -not ($_.Attributes -band [IO.FileAttributes]::ReparsePoint) } | Sort-Object @{ Expression = { $_.FullName.Length } })) {
+    if (-not ($regenerableDirs | Where-Object { Test-Within $dir.FullName $_.FullName })) { $regenerableDirs += $dir }
+}
+$regenerableInventory = @($regenerableDirs | ForEach-Object {
+    $files = @(Get-ChildItem -LiteralPath $_.FullName -Recurse -Force -File -ErrorAction SilentlyContinue)
+    $bytes = 0L
+    if ($files.Count -gt 0) { $bytes = [int64](($files | Measure-Object Length -Sum).Sum) }
+    [pscustomobject]@{ path = $_.FullName; bytes = $bytes; size_gb = [math]::Round($bytes / 1GB, 3) }
+})
+$regenerableBytes = 0L
+if ($regenerableInventory.Count -gt 0) { $regenerableBytes = [int64](($regenerableInventory | Measure-Object bytes -Sum).Sum) }
+
+$record = [ordered]@{
+    schema_version = 1
+    path = $WorktreePath
+    branch = [string]$branch
+    commit = [string]$commit
+    dirty_count = $status.Count
+    merged_into_origin_main = $merged
+    protected_by_path = $protected
+    process_matches = @($processMatch | ForEach-Object { [ordered]@{ name = $_.Name; pid = $_.ProcessId } })
+    lifecycle_record = $null -ne $lifecycleRecord
+    lifecycle_blocked = $lifecycleBlocked
+    codex_session_matches = $sessionMatches
+    eligible = $eligible
+    regenerable_inventory = $regenerableInventory
+    regenerable_bytes = $regenerableBytes
+    regenerable_size_gb = [math]::Round($regenerableBytes / 1GB, 3)
+    requested_remove_regenerable = [bool]$RemoveRegenerable
+    requested_remove_worktree = [bool]$RemoveWorktree
+    applied = [bool]$Apply
+    generated_at_utc = [datetime]::UtcNow.ToString('o')
+    actions = @()
+}
+if (-not $eligible) { $record.actions += 'blocked: dirty, unmerged, protected or process-associated worktree' }
+elseif ($Apply) {
+    if ($RemoveRegenerable) {
+        foreach ($entry in $regenerableInventory) {
+            if (-not (Test-Path -LiteralPath $entry.path -PathType Container)) { continue }
+            if ($PSCmdlet.ShouldProcess($entry.path, 'Remove regenerable output from eligible closed worktree')) {
+                Remove-Item -LiteralPath $entry.path -Recurse -Force
+                $record.actions += [ordered]@{ action = 'removed'; path = $entry.path; bytes = $entry.bytes; size_gb = $entry.size_gb }
+            }
+        }
+    }
+    if ($RemoveWorktree) {
+        if ($PSCmdlet.ShouldProcess($WorktreePath, 'Remove eligible clean integrated Git worktree')) {
+            & git -C $ProjectRoot worktree remove $WorktreePath
+            if ($LASTEXITCODE -ne 0) { throw "git worktree remove failed for $WorktreePath" }
+            $record.actions += 'git-worktree-removed'
+        }
+    }
+} else { $record.actions += 'dry-run' }
+
+New-Item -ItemType Directory -Force -Path $LifecycleRoot | Out-Null
+$key = [BitConverter]::ToString(([Security.Cryptography.SHA256]::Create()).ComputeHash([Text.Encoding]::UTF8.GetBytes($WorktreePath))).Replace('-', '').ToLowerInvariant()
+$recordPath = Join-Path $LifecycleRoot "$key.json"
+$record | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $recordPath -Encoding UTF8
+$record | ConvertTo-Json -Depth 12

--- a/scripts/codex-session-retention.ps1
+++ b/scripts/codex-session-retention.ps1
@@ -1,0 +1,115 @@
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+param(
+    [ValidateSet('audit', 'cleanup')]
+    [string]$Mode = 'audit',
+    [string]$CodexHome = "$env:USERPROFILE\.codex",
+    [string]$StateRoot = 'C:\CodexRuntime\operator\admin\skincos\storage-governance\codex-sessions',
+    [int]$ArchiveAfterDays = 30,
+    [int]$DeleteAfterDays = 90,
+    [switch]$Apply
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$CodexHome = [IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($CodexHome))
+$StateRoot = [IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($StateRoot))
+$sessionsRoot = Join-Path $CodexHome 'sessions'
+$archivedRoot = Join-Path $CodexHome 'archived_sessions'
+$pinsPath = Join-Path $StateRoot 'pins.json'
+New-Item -ItemType Directory -Force -Path $StateRoot | Out-Null
+
+function Get-SessionId([string]$Name) {
+    $match = [regex]::Match($Name, '(?<id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$', [Text.RegularExpressions.RegexOptions]::IgnoreCase)
+    if ($match.Success) { return $match.Groups['id'].Value.ToLowerInvariant() }
+    return $null
+}
+
+function Read-Pins {
+    if (-not (Test-Path -LiteralPath $pinsPath -PathType Leaf)) { return @() }
+    try { return @((Get-Content -Raw -LiteralPath $pinsPath | ConvertFrom-Json).session_ids | ForEach-Object { [string]$_ }) } catch { throw "Invalid Codex session pins file: $pinsPath" }
+}
+
+function Read-SessionIndex {
+    $index = @{}
+    $path = Join-Path $CodexHome 'session_index.jsonl'
+    if (-not (Test-Path -LiteralPath $path)) { return $index }
+    foreach ($line in Get-Content -LiteralPath $path -ErrorAction SilentlyContinue) {
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        try { $row = $line | ConvertFrom-Json; if ($row.id) { $index[[string]$row.id] = $row } } catch {}
+    }
+    return $index
+}
+
+function Get-SessionRows([string]$Root, [string]$Class, [hashtable]$Index, [string[]]$Pinned) {
+    if (-not (Test-Path -LiteralPath $Root -PathType Container)) { return @() }
+    $rows = foreach ($file in Get-ChildItem -LiteralPath $Root -Recurse -Force -File -Filter '*.jsonl' -ErrorAction SilentlyContinue) {
+        $id = Get-SessionId $file.Name
+        $indexed = if ($id -and $Index.ContainsKey($id)) { $Index[$id] } else { $null }
+        $updated = $file.LastWriteTimeUtc
+        if ($indexed -and $indexed.updated_at) { try { $updated = ([datetime]$indexed.updated_at).ToUniversalTime() } catch {} }
+        [pscustomobject]@{
+            id = $id
+            path = $file.FullName
+            class = $Class
+            bytes = [int64]$file.Length
+            size_gb = [math]::Round($file.Length / 1GB, 3)
+            updated_at_utc = $updated.ToString('o')
+            thread_name = if ($indexed) { [string]$indexed.thread_name } else { $null }
+            pinned = [bool]($id -and ($Pinned -contains $id))
+            active = $Class -eq 'active'
+        }
+    }
+    return @($rows)
+}
+
+function Invoke-CodexSessionCommand([string]$Command, [string]$SessionId) {
+    $arguments = if ($Command -eq 'delete') { @($Command, $SessionId, '--force') } else { @($Command, $SessionId) }
+    $output = @(& codex @arguments 2>&1)
+    [pscustomobject]@{ command = $Command; session_id = $SessionId; exit_code = $LASTEXITCODE; output = (@($output) -join "`n") }
+}
+
+$now = [datetime]::UtcNow
+$pins = @(Read-Pins)
+$index = Read-SessionIndex
+$active = @(Get-SessionRows -Root $sessionsRoot -Class 'active' -Index $index -Pinned $pins)
+$archived = @(Get-SessionRows -Root $archivedRoot -Class 'archived' -Index $index -Pinned $pins)
+$activeIds = @($active | Where-Object id | Select-Object -ExpandProperty id)
+$archiveCutoff = $now.AddDays(-$ArchiveAfterDays)
+$deleteCutoff = $now.AddDays(-$DeleteAfterDays)
+$toArchive = @($active | Where-Object { -not $_.pinned -and $_.id -and ([datetime]$_.updated_at_utc) -lt $archiveCutoff })
+$toDelete = @($archived | Where-Object { -not $_.pinned -and $_.id -and ([datetime]$_.updated_at_utc) -lt $deleteCutoff -and $activeIds -notcontains $_.id })
+$actions = @()
+
+if ($Mode -eq 'cleanup' -and $Apply) {
+    foreach ($row in $toArchive) {
+        if ($PSCmdlet.ShouldProcess($row.id, 'Archive old Codex session using official CLI')) { $actions += Invoke-CodexSessionCommand -Command 'archive' -SessionId $row.id }
+    }
+    foreach ($row in $toDelete) {
+        if ($PSCmdlet.ShouldProcess($row.id, 'Permanently delete expired archived Codex session using official CLI')) { $actions += Invoke-CodexSessionCommand -Command 'delete' -SessionId $row.id }
+    }
+}
+
+$document = [ordered]@{
+    schema_version = 1
+    generated_at_utc = $now.ToString('o')
+    mode = $Mode
+    applied = [bool]$Apply
+    archive_after_days = $ArchiveAfterDays
+    delete_after_days = $DeleteAfterDays
+    active = $active
+    archived = $archived
+    archive_candidates = $toArchive
+    delete_candidates = $toDelete
+    actions = $actions
+    safety = @(
+        'All currently unarchived sessions are protected from deletion.',
+        'Deletion is performed only through the official codex delete --force command.',
+        'Pinned IDs are never archived or deleted.',
+        'This script never edits session JSONL files or SQLite indexes directly.'
+    )
+}
+$latest = Join-Path $StateRoot 'latest.json'
+$history = Join-Path $StateRoot 'history.jsonl'
+$document | ConvertTo-Json -Depth 30 | Set-Content -LiteralPath $latest -Encoding UTF8
+Add-Content -LiteralPath $history -Value (($document | ConvertTo-Json -Depth 30 -Compress)) -Encoding UTF8
+$document | ConvertTo-Json -Depth 30

--- a/scripts/dedupe-source-tars.ps1
+++ b/scripts/dedupe-source-tars.ps1
@@ -1,0 +1,148 @@
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+param(
+    [string]$RuntimeRoot = 'C:\CodexRuntime',
+    [string]$StateRoot = 'C:\CodexRuntime\operator\admin\skincos\storage-governance\source-tars',
+    [int]$MinimumAgeDays = 2,
+    [switch]$Apply,
+    [switch]$AllowHardlinkDeduplication,
+    [string]$OutputPath = ''
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$RuntimeRoot = [IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($RuntimeRoot))
+$StateRoot = [IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($StateRoot))
+$root = Join-Path $RuntimeRoot 'operator\admin\skincos'
+$now = [datetime]::UtcNow
+$cutoff = $now.AddDays(-$MinimumAgeDays)
+New-Item -ItemType Directory -Force -Path $StateRoot | Out-Null
+
+function Test-SameFileSecurity([string]$First, [string]$Second) {
+    try {
+        $a = Get-Acl -LiteralPath $First -ErrorAction Stop
+        $b = Get-Acl -LiteralPath $Second -ErrorAction Stop
+        return [string]$a.Sddl -eq [string]$b.Sddl
+    } catch { return $false }
+}
+
+function Get-LinkNames([string]$Path) {
+    try {
+        $driveRoot = [IO.Path]::GetPathRoot($Path)
+        return @(& fsutil hardlink list $Path 2>$null | ForEach-Object {
+            $line = ([string]$_).Trim()
+            if ([string]::IsNullOrWhiteSpace($line)) { return }
+            if ($line -match '^[A-Za-z]:\\') { return [IO.Path]::GetFullPath($line) }
+            if ($line.StartsWith('\')) { return [IO.Path]::GetFullPath($driveRoot + $line.TrimStart('\')) }
+            return $line
+        })
+    } catch { return @() }
+}
+
+$files = @(Get-ChildItem -LiteralPath $root -Force -File -ErrorAction SilentlyContinue | Where-Object {
+    $_.Name -match 'source.*\.tar$' -and $_.LastWriteTimeUtc -lt $cutoff -and -not ($_.Attributes -band [IO.FileAttributes]::ReparsePoint)
+})
+foreach ($name in @('native-releases', 'native-promotions', 'releases', 'checkpoints', 'native-source-release', 'livia-reel-frame-contract', 'livia-1dee4fc2', 'livia-c525f5e1', 'mcp-readonly-gateway')) {
+    $candidateRoot = Join-Path $root $name
+    if (Test-Path -LiteralPath $candidateRoot -PathType Container) { $files += @(Get-ChildItem -LiteralPath $candidateRoot -Depth 2 -Recurse -Force -File -ErrorAction SilentlyContinue | Where-Object {
+        $_.Name -match 'source.*\.tar$' -and $_.LastWriteTimeUtc -lt $cutoff -and -not ($_.Attributes -band [IO.FileAttributes]::ReparsePoint)
+    }) }
+}
+$rows = foreach ($file in $files) {
+    $hash = (Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256).Hash.ToUpperInvariant()
+    [pscustomobject]@{ path = $file.FullName; bytes = [int64]$file.Length; sha256 = $hash; last_write_utc = $file.LastWriteTimeUtc.ToString('o'); security_checked = $false; hardlink_names = @() }
+}
+$groups = @($rows | Group-Object sha256, bytes | Where-Object Count -gt 1)
+$operations = @()
+$quarantineRoot = Join-Path $StateRoot 'quarantine'
+
+foreach ($group in $groups) {
+    $members = @($group.Group | Sort-Object @{Expression={ if ($_.path -match '\\(native-releases|native-promotions)\\') { 0 } elseif ($_.path -match '\\releases\\') { 1 } else { 2 } }}, last_write_utc, path)
+    $canonical = $members[0]
+    foreach ($duplicate in @($members | Select-Object -Skip 1)) {
+        $row = [ordered]@{
+            sha256 = $canonical.sha256
+            bytes = $canonical.bytes
+            canonical = $canonical.path
+            duplicate = $duplicate.path
+            action = 'dry-run'
+            reason = 'exact-sha256-and-size-duplicate'
+            quarantine = $null
+            hardlink_names = @()
+        }
+        $existingLinks = @(Get-LinkNames -Path $duplicate.path)
+        if ($existingLinks -contains ([IO.Path]::GetFullPath($canonical.path))) {
+            $row.action = 'already-hardlinked'
+            $row.reason = 'exact-duplicate-already-shares-the-canonical-file'
+            $row.hardlink_names = $existingLinks
+            $operations += [pscustomobject]$row
+            continue
+        }
+        if (-not (Test-SameFileSecurity -First $canonical.path -Second $duplicate.path)) {
+            $row.action = 'blocked'
+            $row.reason = 'file-security-descriptors-differ-or-unreadable'
+            $operations += [pscustomobject]$row
+            continue
+        }
+        $duplicateRoot = [IO.Path]::GetPathRoot($duplicate.path)
+        if ($duplicateRoot -ne [IO.Path]::GetPathRoot($canonical.path)) {
+            $row.action = 'blocked'
+            $row.reason = 'different-volume'
+            $operations += [pscustomobject]$row
+            continue
+        }
+        if (-not $Apply -or -not $AllowHardlinkDeduplication) {
+            $row.reason = if (-not $AllowHardlinkDeduplication) { 'explicit-hardlink-flag-required' } else { 'dry-run' }
+            $operations += [pscustomobject]$row
+            continue
+        }
+        if ($PSCmdlet.ShouldProcess($duplicate.path, "Replace exact duplicate with hardlink to $($canonical.path)")) {
+            $quarantine = Join-Path (Join-Path $quarantineRoot $canonical.sha256) ("{0}.{1}.quarantine" -f ([IO.Path]::GetFileName($duplicate.path)), ([guid]::NewGuid().ToString('N')))
+            New-Item -ItemType Directory -Force -Path (Split-Path -Parent $quarantine) | Out-Null
+            $row.quarantine = $quarantine
+            try {
+                Move-Item -LiteralPath $duplicate.path -Destination $quarantine -ErrorAction Stop
+                & fsutil hardlink create $duplicate.path $canonical.path | Out-Null
+                if ($LASTEXITCODE -ne 0) { throw 'fsutil hardlink create failed' }
+                $afterHash = (Get-FileHash -LiteralPath $duplicate.path -Algorithm SHA256).Hash.ToUpperInvariant()
+                $links = @(Get-LinkNames -Path $duplicate.path)
+                if ($afterHash -ne $canonical.sha256 -or -not ($links -contains $canonical.path)) { throw 'hardlink verification failed' }
+                Remove-Item -LiteralPath $quarantine -Force -ErrorAction Stop
+                $row.action = 'hardlink-deduplicated'
+                $row.hardlink_names = $links
+            } catch {
+                try {
+                    if (Test-Path -LiteralPath $duplicate.path) { Remove-Item -LiteralPath $duplicate.path -Force -ErrorAction SilentlyContinue }
+                    if (Test-Path -LiteralPath $quarantine) { Move-Item -LiteralPath $quarantine -Destination $duplicate.path -ErrorAction SilentlyContinue }
+                } catch {}
+                $row.action = 'rollback-or-error'
+                $row.reason = $_.Exception.Message
+            }
+        } else { $row.action = 'what-if' }
+        $operations += [pscustomobject]$row
+    }
+}
+
+$document = [ordered]@{
+    schema_version = 1
+    generated_at_utc = $now.ToString('o')
+    runtime_root = $root
+    minimum_age_days = $MinimumAgeDays
+    applied = [bool]$Apply
+    hardlink_deduplication_allowed = [bool]$AllowHardlinkDeduplication
+    source_tar_count = $rows.Count
+    source_tar_bytes = [int64](($rows | Measure-Object bytes -Sum).Sum)
+    duplicate_groups = $groups.Count
+    operations = $operations
+    safety = @(
+        'Only exact SHA-256 and byte-size duplicates are considered.',
+        'The original path is preserved as a hardlink, so manifests and rollback references remain valid.',
+        'The original duplicate is quarantined transactionally and removed only after hardlink/hash verification.',
+        'Different ACLs, volumes, recent files and reparse points are blocked.'
+    )
+}
+$latest = Join-Path $StateRoot 'latest.json'
+$history = Join-Path $StateRoot 'history.jsonl'
+$document | ConvertTo-Json -Depth 30 | Set-Content -LiteralPath $latest -Encoding UTF8
+Add-Content -LiteralPath $history -Value (($document | ConvertTo-Json -Depth 30 -Compress)) -Encoding UTF8
+if (-not [string]::IsNullOrWhiteSpace($OutputPath)) { $document | ConvertTo-Json -Depth 30 | Set-Content -LiteralPath $OutputPath -Encoding UTF8 }
+$document | ConvertTo-Json -Depth 30

--- a/scripts/install-skincos-storage-governance-task.ps1
+++ b/scripts/install-skincos-storage-governance-task.ps1
@@ -1,0 +1,34 @@
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+param(
+    [string]$RepositoryRoot = 'C:\CodexShared\Projetos\skincos',
+    [string]$TaskName = 'SKINCOS Storage Governance Audit',
+    [string]$ScriptPath = '',
+    [int]$IntervalHours = 6,
+    [switch]$Apply
+)
+
+$ErrorActionPreference = 'Stop'
+if ([string]::IsNullOrWhiteSpace($ScriptPath)) {
+    $ScriptPath = Join-Path $RepositoryRoot 'scripts\skincos-storage-governance.ps1'
+}
+if (-not (Test-Path -LiteralPath $ScriptPath -PathType Leaf)) { throw "Governance script not found: $ScriptPath" }
+if ($IntervalHours -lt 1 -or $IntervalHours -gt 24) { throw 'IntervalHours must be between 1 and 24.' }
+
+$powershell = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe'
+$arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$ScriptPath`" -Mode audit -IncludeWorktreeStatus"
+$action = New-ScheduledTaskAction -Execute $powershell -Argument $arguments -WorkingDirectory (Split-Path -Parent $ScriptPath)
+$start = (Get-Date).AddMinutes(5)
+$trigger = New-ScheduledTaskTrigger -Once -At $start -RepetitionInterval (New-TimeSpan -Hours $IntervalHours) -RepetitionDuration (New-TimeSpan -Days 3650)
+$logonTrigger = New-ScheduledTaskTrigger -AtLogOn -User "$env:USERDOMAIN\$env:USERNAME"
+$triggers = @($trigger, $logonTrigger)
+$principal = New-ScheduledTaskPrincipal -UserId "$env:USERDOMAIN\$env:USERNAME" -LogonType Interactive -RunLevel Limited
+$settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Minutes 20) -MultipleInstances IgnoreNew -StartWhenAvailable
+
+if (-not $Apply) {
+    [pscustomobject]@{ task_name = $TaskName; script = $ScriptPath; interval_hours = $IntervalHours; run_at_logon = $true; action = 'dry-run'; user = "$env:USERDOMAIN\$env:USERNAME" } | ConvertTo-Json
+    exit 0
+}
+if ($PSCmdlet.ShouldProcess($TaskName, 'Register scheduled read-only storage audit')) {
+    Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $triggers -Principal $principal -Settings $settings -Force | Out-Null
+    [pscustomobject]@{ task_name = $TaskName; script = $ScriptPath; interval_hours = $IntervalHours; run_at_logon = $true; action = 'registered'; user = "$env:USERDOMAIN\$env:USERNAME" } | ConvertTo-Json
+}

--- a/scripts/new-shared-worktree.ps1
+++ b/scripts/new-shared-worktree.ps1
@@ -50,6 +50,43 @@ function Ensure-SafeDirectory {
     }
 }
 
+function Write-WorktreeLifecycleRecord {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepoPath,
+        [Parameter(Mandatory = $true)][string]$TaskSlug,
+        [Parameter(Mandatory = $true)][string]$Branch,
+        [Parameter(Mandatory = $true)][string]$Base
+    )
+
+    $lifecycleRoot = 'C:\CodexRuntime\operator\admin\skincos\storage-governance\worktrees'
+    New-Item -ItemType Directory -Force -Path $lifecycleRoot | Out-Null
+    $hash = [Security.Cryptography.SHA256]::Create()
+    try {
+        $digest = [BitConverter]::ToString($hash.ComputeHash([Text.Encoding]::UTF8.GetBytes($RepoPath))).Replace('-', '').ToLowerInvariant()
+    } finally { $hash.Dispose() }
+    $recordPath = Join-Path $lifecycleRoot "$digest.json"
+    $record = [ordered]@{
+        schema_version = 1
+        path = (Resolve-Path -LiteralPath $RepoPath).Path
+        owner = $Actor
+        task_slug = $TaskSlug
+        branch = $Branch
+        base_ref = $Base
+        commit = ((git -C $RepoPath rev-parse --verify 'HEAD^{commit}' 2>$null | Select-Object -First 1).Trim().ToLowerInvariant())
+        created_at_utc = (Get-Date).ToUniversalTime().ToString('o')
+        last_seen_at_utc = (Get-Date).ToUniversalTime().ToString('o')
+        lifecycle_status = 'active'
+        pinned = $false
+        lease = $null
+        dependency_state = 'unknown'
+        associated_artifacts = @()
+    }
+    $temporary = "$recordPath.$([Guid]::NewGuid().ToString('N')).tmp"
+    $record | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $temporary -Encoding UTF8
+    Move-Item -LiteralPath $temporary -Destination $recordPath -Force
+    return $recordPath
+}
+
 $normalizedActor = Normalize-Actor -Value $Actor
 $normalizedTask = Normalize-Slug -Value $TaskSlug
 
@@ -83,6 +120,7 @@ if ($branchExists) {
 
 git -C $ProjectRoot worktree add $worktreePath -b $BranchName $BaseRef
 Ensure-SafeDirectory -RepoPath $worktreePath
+$lifecycleRecord = Write-WorktreeLifecycleRecord -RepoPath $worktreePath -TaskSlug $normalizedTask -Branch $BranchName -Base $BaseRef
 
 $result = [pscustomobject]@{
     actor = $normalizedActor
@@ -92,6 +130,7 @@ $result = [pscustomobject]@{
     projectRoot = $ProjectRoot
     worktreePath = $worktreePath
     validationCommand = "powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\validate-skincos-worktree.ps1 -ProjectRoot '$worktreePath' -TaskSlug '$normalizedTask' -Mode edit"
+    lifecycleRecord = $lifecycleRecord
 }
 
 $result | ConvertTo-Json -Depth 4

--- a/scripts/run-shared-codex-shortcut.ps1
+++ b/scripts/run-shared-codex-shortcut.ps1
@@ -200,6 +200,56 @@ function Ensure-LocalState {
     }
 }
 
+function Register-PrivateWorktreeLifecycle {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorktreePath,
+        [Parameter(Mandatory = $true)][string]$Purpose,
+        [Parameter(Mandatory = $true)][string]$TargetCommit,
+        [bool]$Pinned = $false
+    )
+    $lifecycleRoot = Join-Path $operatorRuntimeRoot 'storage-governance\worktrees'
+    New-Item -ItemType Directory -Force -Path $lifecycleRoot | Out-Null
+    $hash = [Security.Cryptography.SHA256]::Create()
+    try { $key = [BitConverter]::ToString($hash.ComputeHash([Text.Encoding]::UTF8.GetBytes($WorktreePath))).Replace('-', '').ToLowerInvariant() } finally { $hash.Dispose() }
+    $recordPath = Join-Path $lifecycleRoot "$key.json"
+    $now = (Get-Date).ToUniversalTime().ToString('o')
+    $record = [ordered]@{
+        schema_version = 1
+        path = (Resolve-Path -LiteralPath $WorktreePath).Path
+        owner = [string]$env:USERNAME
+        task_slug = $Purpose
+        branch = $null
+        base_ref = $TargetCommit
+        commit = $TargetCommit
+        created_at_utc = $now
+        last_seen_at_utc = $now
+        lifecycle_status = 'active'
+        pinned = $Pinned
+        lease = $null
+        dependency_state = 'unknown'
+        associated_artifacts = @()
+    }
+    $temporary = "$recordPath.$([Guid]::NewGuid().ToString('N')).tmp"
+    $record | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $temporary -Encoding UTF8
+    Move-Item -LiteralPath $temporary -Destination $recordPath -Force
+    return $recordPath
+}
+
+function Assert-WorktreePathAvailable {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepoPath,
+        [Parameter(Mandatory = $true)][string]$WorktreePath
+    )
+    $target = [IO.Path]::GetFullPath($WorktreePath).TrimEnd('\', '/')
+    $lines = @(& git -C $RepoPath worktree list --porcelain 2>$null)
+    foreach ($line in $lines | Where-Object { $_ -like 'worktree *' }) {
+        $registered = [IO.Path]::GetFullPath($line.Substring(9)).TrimEnd('\', '/')
+        if ($registered.Equals($target, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "O caminho do worktree '$WorktreePath' ainda está registrado pelo Git. A criação foi bloqueada; use close-shared-worktree.ps1 para resolver o registro de forma explícita."
+        }
+    }
+}
+
 function Convert-WindowsPathToWsl {
     param([string]$Path)
 
@@ -686,6 +736,7 @@ function Sync-CrmLocalSourceRoot {
             }
             & git -C $ProjectRoot worktree add --detach $snapshotRoot $TargetCommit | Out-Host
             if ($LASTEXITCODE -ne 0) { throw "Não foi possível criar o worktree isolado do snapshot do CRM Local em '$snapshotRoot'." }
+            Register-PrivateWorktreeLifecycle -WorktreePath $snapshotRoot -Purpose "crm-local-snapshot-$($TargetCommit.Substring(0,12))" -TargetCommit $TargetCommit | Out-Null
             try {
                 Apply-CrmLocalSourceSnapshot -Snapshot $Snapshot -DestinationRoot $snapshotRoot
             } catch {
@@ -712,11 +763,12 @@ function Sync-CrmLocalSourceRoot {
         }
 
         if (-not (Test-Path -LiteralPath $sourceRoot)) {
-            & git -C $ProjectRoot worktree prune | Out-Null
+            Assert-WorktreePathAvailable -RepoPath $ProjectRoot -WorktreePath $sourceRoot
             & git -C $ProjectRoot worktree add --detach $sourceRoot $TargetCommit | Out-Host
             if ($LASTEXITCODE -ne 0) {
                 throw "Não foi possível criar o worktree limpo do CRM Local em '$sourceRoot'."
             }
+            Register-PrivateWorktreeLifecycle -WorktreePath $sourceRoot -Purpose "crm-local-$($Persona.ToLowerInvariant())" -TargetCommit $TargetCommit | Out-Null
             return $sourceRoot
         }
 
@@ -781,7 +833,7 @@ function Sync-CrmLocalImmutableSourceRoot {
                 New-Item -ItemType Directory -Path $quarantineRoot -Force | Out-Null
                 $quarantinePath = Join-Path $quarantineRoot ("{0}-{1}" -f $sourceKey, (Get-Date -Format 'yyyyMMddHHmmssfff'))
                 Move-Item -LiteralPath $sourceRoot -Destination $quarantinePath
-                & git -C $snapshotSourceRoot worktree prune | Out-Null
+                Assert-WorktreePathAvailable -RepoPath $ProjectRoot -WorktreePath $sourceRoot
                 Write-Host "[crm-local] Fonte incompleta preservada em quarentena: '$quarantinePath'."
             } else {
                 $metadata = Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json
@@ -793,11 +845,12 @@ function Sync-CrmLocalImmutableSourceRoot {
             }
         }
 
-        & git -C $snapshotSourceRoot worktree prune | Out-Null
-        & git -C $snapshotSourceRoot worktree add --detach $sourceRoot $TargetCommit | Out-Host
+        Assert-WorktreePathAvailable -RepoPath $ProjectRoot -WorktreePath $sourceRoot
+        & git -C $ProjectRoot worktree add --detach $sourceRoot $TargetCommit | Out-Host
         if ($LASTEXITCODE -ne 0) {
             throw "Não foi possível criar a fonte imutável do CRM Local em '$sourceRoot'."
         }
+        Register-PrivateWorktreeLifecycle -WorktreePath $sourceRoot -Purpose "crm-local-immutable-$sourceKey" -TargetCommit $TargetCommit -Pinned $true | Out-Null
         try {
             Apply-CrmLocalSourceSnapshot -Snapshot $Snapshot -DestinationRoot $sourceRoot
             $metadata = [ordered]@{

--- a/scripts/skincos-storage-governance.ps1
+++ b/scripts/skincos-storage-governance.ps1
@@ -1,0 +1,428 @@
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+param(
+    [ValidateSet('audit', 'cleanup', 'emergency', 'classify-worktrees')]
+    [string]$Mode = 'audit',
+    [string]$PolicyPath = '',
+    [string]$OutputPath = '',
+    [switch]$Deep,
+    [switch]$Apply,
+    [switch]$AllowWorktreeCleanup,
+    [switch]$AllowWorktreeRemoval,
+    [switch]$AllowArtifactHardlinkDeduplication,
+    [switch]$IncludeWorktreeStatus,
+    [int]$MaxWorktrees = 700
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$script:ScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$script:RepositoryRoot = Split-Path -Parent $script:ScriptRoot
+if ([string]::IsNullOrWhiteSpace($PolicyPath)) {
+    $PolicyPath = Join-Path $script:RepositoryRoot 'ops\codex\storage-retention-policy.json'
+}
+
+function Expand-StoragePath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    $expanded = [Environment]::ExpandEnvironmentVariables($Path)
+    if ($expanded.StartsWith('~')) {
+        $expanded = Join-Path $HOME $expanded.Substring(1).TrimStart('\', '/')
+    }
+    return [IO.Path]::GetFullPath($expanded)
+}
+
+function Read-Policy {
+    if (-not (Test-Path -LiteralPath $PolicyPath -PathType Leaf)) {
+        throw "Storage policy was not found: $PolicyPath"
+    }
+    $policy = Get-Content -Raw -LiteralPath $PolicyPath | ConvertFrom-Json
+    if ([int]$policy.schemaVersion -ne 1) { throw 'Unsupported storage policy schema.' }
+    return $policy
+}
+
+function Write-AtomicJson {
+    param([Parameter(Mandatory = $true)][string]$Path, [Parameter(Mandatory = $true)]$Value)
+    $parent = Split-Path -Parent $Path
+    New-Item -ItemType Directory -Force -Path $parent | Out-Null
+    $temporary = "$Path.$([guid]::NewGuid().ToString('N')).tmp"
+    $json = $Value | ConvertTo-Json -Depth 30
+    [IO.File]::WriteAllText($temporary, $json, (New-Object Text.UTF8Encoding($false)))
+    Move-Item -LiteralPath $temporary -Destination $Path -Force
+}
+
+function Append-JsonLine {
+    param([Parameter(Mandatory = $true)][string]$Path, [Parameter(Mandatory = $true)]$Value)
+    $parent = Split-Path -Parent $Path
+    New-Item -ItemType Directory -Force -Path $parent | Out-Null
+    [IO.File]::AppendAllText($Path, (($Value | ConvertTo-Json -Depth 30 -Compress) + "`n"), (New-Object Text.UTF8Encoding($false)))
+}
+
+function Get-BytesGB {
+    param([long]$Bytes)
+    return [math]::Round($Bytes / 1GB, 3)
+}
+
+function Get-DriveSnapshot {
+    $drive = Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='C:'"
+    [pscustomobject]@{
+        device = 'C:'
+        size_bytes = [int64]$drive.Size
+        free_bytes = [int64]$drive.FreeSpace
+        size_gb = Get-BytesGB $drive.Size
+        free_gb = Get-BytesGB $drive.FreeSpace
+        free_percent = [math]::Round(100 * $drive.FreeSpace / $drive.Size, 3)
+    }
+}
+
+function Get-ThresholdState {
+    param([double]$FreeGB, [object]$Thresholds)
+    if ($FreeGB -lt [double]$Thresholds.emergency) { return 'emergency' }
+    if ($FreeGB -lt [double]$Thresholds.critical) { return 'critical' }
+    if ($FreeGB -lt [double]$Thresholds.high) { return 'high' }
+    if ($FreeGB -lt [double]$Thresholds.warning) { return 'warning' }
+    return 'healthy'
+}
+
+function Test-PathWithin {
+    param([Parameter(Mandatory = $true)][string]$Path, [Parameter(Mandatory = $true)][string]$Root)
+    $candidate = [IO.Path]::GetFullPath($Path).TrimEnd('\', '/')
+    $boundary = [IO.Path]::GetFullPath($Root).TrimEnd('\', '/')
+    return $candidate.Equals($boundary, [StringComparison]::OrdinalIgnoreCase) -or
+        $candidate.StartsWith($boundary + [IO.Path]::DirectorySeparatorChar, [StringComparison]::OrdinalIgnoreCase)
+}
+
+function Get-ProcessSnapshot {
+    $interesting = @('node', 'git', 'wsl', 'wslhost', 'vmmemWSL', 'workerd', 'npm', 'pnpm', 'wrangler')
+    $rows = @()
+    foreach ($process in @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $interesting -contains $_.Name.Replace('.exe', '') })) {
+        $rows += [pscustomobject]@{
+            name = [string]$process.Name
+            pid = [int]$process.ProcessId
+            parent_pid = [int]$process.ParentProcessId
+            started = $null
+            commandline_path_match = $false
+        }
+    }
+    return $rows
+}
+
+function Get-FileLengthSafe {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    try { return [int64](Get-Item -LiteralPath $Path -Force -ErrorAction Stop).Length } catch { return 0L }
+}
+
+function Get-DirectDirectorySnapshot {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        return [pscustomobject]@{ path = $Path; exists = $false; files = 0; directories = 0; bytes = 0L; size_gb = 0; errors = 0 }
+    }
+    $files = 0L; $bytes = 0L; $directories = 0L; $errors = 0L
+    try {
+        foreach ($entry in @(Get-ChildItem -LiteralPath $Path -Force -ErrorAction Stop)) {
+            if ($entry.PSIsContainer) { $directories++ } else { $files++; $bytes += [int64]$entry.Length }
+        }
+    } catch { $errors++ }
+    [pscustomobject]@{ path = $Path; exists = $true; files = $files; directories = $directories; bytes = $bytes; size_gb = Get-BytesGB $bytes; errors = $errors }
+}
+
+function Get-DeepDirectorySnapshot {
+    param([Parameter(Mandatory = $true)][string]$Path, [int]$TopFiles = 20)
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        return [pscustomobject]@{ path = $Path; exists = $false; files = 0; directories = 0; bytes = 0L; size_gb = 0; errors = 0; top_files = @(); extensions = @{} }
+    }
+    $files = 0L; $directories = 0L; $bytes = 0L; $errors = 0L; $largest = @(); $extensions = @{}
+    try {
+        foreach ($entry in Get-ChildItem -LiteralPath $Path -Recurse -Force -File -ErrorAction SilentlyContinue) {
+            if ($entry.Attributes -band [IO.FileAttributes]::ReparsePoint) { continue }
+            $files++; $bytes += [int64]$entry.Length
+            $extension = if ([string]::IsNullOrWhiteSpace($entry.Extension)) { '[none]' } else { $entry.Extension.ToLowerInvariant() }
+            if (-not $extensions.ContainsKey($extension)) { $extensions[$extension] = 0L }
+            $extensions[$extension] += [int64]$entry.Length
+            if ($largest.Count -lt $TopFiles) { $largest += [pscustomobject]@{ path = $entry.FullName; bytes = [int64]$entry.Length } }
+            else {
+                $smallest = $largest | Sort-Object bytes | Select-Object -First 1
+                if ([int64]$entry.Length -gt [int64]$smallest.bytes) {
+                    $largest = @($largest | Where-Object { $_.path -ne $smallest.path }) + [pscustomobject]@{ path = $entry.FullName; bytes = [int64]$entry.Length }
+                }
+            }
+        }
+        Get-ChildItem -LiteralPath $Path -Recurse -Force -Directory -ErrorAction SilentlyContinue | ForEach-Object { $directories++ }
+    } catch { $errors++ }
+    [pscustomobject]@{
+        path = $Path; exists = $true; files = $files; directories = $directories; bytes = $bytes; size_gb = Get-BytesGB $bytes; errors = $errors
+        top_files = @($largest | Sort-Object bytes -Descending)
+        extensions = [ordered]@{}
+    } | ForEach-Object {
+        foreach ($key in ($extensions.Keys | Sort-Object)) { $_.extensions[$key] = $extensions[$key] }
+        $_
+    }
+}
+
+function Get-FileSnapshot {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return $null }
+    $item = Get-Item -LiteralPath $Path -Force
+    [pscustomobject]@{ path = $Path; exists = $true; bytes = [int64]$item.Length; size_gb = Get-BytesGB $item.Length; last_write_utc = $item.LastWriteTimeUtc.ToString('o') }
+}
+
+function Get-CodexSessionCwds {
+    param([Parameter(Mandatory = $true)][string]$CodexHome)
+    $sessionRoot = Join-Path $CodexHome 'sessions'
+    if (-not (Test-Path -LiteralPath $sessionRoot -PathType Container)) { return @() }
+    $rows = @()
+    foreach ($file in @(Get-ChildItem -LiteralPath $sessionRoot -Recurse -Force -File -Filter '*.jsonl' -ErrorAction SilentlyContinue)) {
+        try {
+            $firstLine = Get-Content -LiteralPath $file.FullName -TotalCount 1 -ErrorAction Stop
+            $meta = $firstLine | ConvertFrom-Json -ErrorAction Stop
+            if ($meta.payload.cwd) {
+                $rows += [pscustomobject]@{
+                    session_id = [string]$meta.payload.session_id
+                    cwd = [string]$meta.payload.cwd
+                    file = $file.FullName
+                }
+            }
+        } catch {}
+    }
+    return $rows
+}
+
+function Get-WorktreeRecords {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectRoot,
+        [Parameter(Mandatory = $true)][string]$WorktreeRoot,
+        [string]$LifecycleRoot = '',
+        [object[]]$ProcessDetails = @(),
+        [object[]]$SessionDetails = @(),
+        [switch]$IncludeStatus
+    )
+    $lines = @(& git -C $ProjectRoot worktree list --porcelain 2>$null)
+    $lifecycle = @{}
+    if (-not [string]::IsNullOrWhiteSpace($LifecycleRoot) -and (Test-Path -LiteralPath $LifecycleRoot -PathType Container)) {
+        foreach ($recordFile in Get-ChildItem -LiteralPath $LifecycleRoot -Force -File -Filter '*.json' -ErrorAction SilentlyContinue) {
+            try {
+                $record = Get-Content -Raw -LiteralPath $recordFile.FullName | ConvertFrom-Json
+                if ($record.path) { $lifecycle[(($record.path -replace '/', '\').TrimEnd('\')).ToLowerInvariant()] = $record }
+            } catch {}
+        }
+    }
+    $records = @(); $current = $null
+    foreach ($line in $lines + '') {
+        if ($line -like 'worktree *') { $current = [ordered]@{ path = $line.Substring(9); branch = $null; commit = $null; detached = $false }; continue }
+        if ($line -like 'HEAD *' -and $current) { $current.commit = $line.Substring(5); continue }
+        if ($line -like 'branch refs/heads/*' -and $current) { $current.branch = $line.Substring(18); continue }
+        if ($line -eq 'detached' -and $current) { $current.detached = $true; continue }
+        if ([string]::IsNullOrWhiteSpace($line) -and $current) {
+            $path = [string]$current.path
+            $exists = Test-Path -LiteralPath $path -PathType Container
+            $dirty = $null; $merged = $false; $lastWrite = $null
+            if ($exists -and $IncludeStatus) {
+                $dirty = @(& git -C $path status --porcelain 2>$null).Count
+                if ($current.branch -and $current.branch -ne 'main') { & git -C $ProjectRoot merge-base --is-ancestor $current.branch origin/main 2>$null; $merged = $LASTEXITCODE -eq 0 }
+                try { $lastWrite = (Get-ChildItem -LiteralPath $path -Force -ErrorAction SilentlyContinue | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1).LastWriteTimeUtc.ToString('o') } catch {}
+            }
+            $normalized = ($path -replace '/', '\').TrimEnd('\', '/').ToLowerInvariant()
+            $rootNorm = ($WorktreeRoot -replace '/', '\').TrimEnd('\', '/').ToLowerInvariant()
+            $protected = $normalized -match '\\(immutable|recovery|rollback|release|checkpoint|pinned)([-_][^\\]+|\\|$)'
+            $life = if ($lifecycle.ContainsKey($normalized)) { $lifecycle[$normalized] } else { $null }
+            $processMatches = @($ProcessDetails | Where-Object { [string]$_.CommandLine -and ([string]$_.CommandLine).Replace('/', '\').ToLowerInvariant().Contains($normalized) })
+            $processAssociated = $processMatches.Count -gt 0
+            $sessionMatches = @($SessionDetails | Where-Object { [string]$_.cwd -and ([string]$_.cwd).Replace('/', '\').TrimEnd('\').ToLowerInvariant().StartsWith($normalized) })
+            $sessionAssociated = $sessionMatches.Count -gt 0
+            $lifecyclePinned = $null -ne $life -and $null -ne $life.PSObject.Properties['pinned'] -and [bool]$life.pinned
+            $lifecycleActive = $null -ne $life -and $null -ne $life.PSObject.Properties['lifecycle_status'] -and [string]$life.lifecycle_status -eq 'active'
+            $classification = if (-not $exists) { 'orphan' } elseif ($protected -or $lifecyclePinned) { 'rollback-required' } elseif ($processAssociated -or $sessionAssociated) { 'active' } elseif ($null -eq $dirty) { 'uncertain' } elseif ($dirty -gt 0 -or $lifecycleActive) { 'potential-active' } elseif ($merged) { 'integrated-clean' } else { 'uncertain' }
+            $classCode = switch ($classification) { 'active' { 'A' } 'potential-active' { 'B' } 'integrated-clean' { 'C' } 'orphan' { 'D' } 'rollback-required' { 'E' } default { 'F' } }
+            $records += [pscustomobject]@{ path = $path; under_worktree_root = $normalized.StartsWith($rootNorm + '\'); branch = $current.branch; commit = $current.commit; detached = [bool]$current.detached; exists = $exists; dirty_count = $dirty; merged_into_origin_main = $merged; last_write_utc = $lastWrite; protected_by_path = $protected; lifecycle_record = $null -ne $life; lifecycle_pinned = $lifecyclePinned; process_associated = $processAssociated; process_count = $processMatches.Count; codex_session_cwd_associated = $sessionAssociated; codex_session_count = $sessionMatches.Count; classification_code = $classCode; classification = $classification; eligible_for_cleanup = ($classification -eq 'integrated-clean' -and $normalized.StartsWith($rootNorm + '\') -and -not $processAssociated -and -not $sessionAssociated -and -not $lifecyclePinned) }
+            $current = $null
+        }
+    }
+    return $records
+}
+
+function Get-SourceTarRecords {
+    param([Parameter(Mandatory = $true)][string]$RuntimeRoot)
+    $root = Join-Path $RuntimeRoot 'operator\admin\skincos'
+    if (-not (Test-Path -LiteralPath $root -PathType Container)) { return @() }
+    $files = @(Get-ChildItem -LiteralPath $root -Recurse -Force -File -ErrorAction SilentlyContinue | Where-Object { $_.Name -match 'source.*\.tar$' })
+    $rows = foreach ($file in $files) {
+        $hash = $null
+        try { $hash = (Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256 -ErrorAction Stop).Hash.ToUpperInvariant() } catch {}
+        [pscustomobject]@{ path = $file.FullName; bytes = [int64]$file.Length; size_gb = Get-BytesGB $file.Length; sha256 = $hash; last_write_utc = $file.LastWriteTimeUtc.ToString('o') }
+    }
+    return $rows
+}
+
+function Get-WorkerdRecords {
+    param([Parameter(Mandatory = $true)][string[]]$Roots)
+    $rows = @()
+    foreach ($root in $Roots) {
+        if (-not (Test-Path -LiteralPath $root -PathType Container)) { continue }
+        foreach ($file in @(Get-ChildItem -LiteralPath $root -Recurse -Force -File -ErrorAction SilentlyContinue | Where-Object { $_.Name -like 'workerd*' })) {
+            $rows += [pscustomobject]@{ path = $file.FullName; bytes = [int64]$file.Length; size_mb = [math]::Round($file.Length / 1MB, 3); sha256 = $null; link_type = [string]$file.LinkType }
+        }
+    }
+    return $rows
+}
+
+function Get-CleanupCandidates {
+    param([Parameter(Mandatory = $true)]$Policy, [Parameter(Mandatory = $true)]$Now)
+    $rows = @()
+    $cutoff = $Now.AddDays(-[double]$Policy.retentionDays.temporary)
+    foreach ($rootValue in @($Policy.safeCleanupRoots)) {
+        $root = Expand-StoragePath ([string]$rootValue)
+        if (-not (Test-Path -LiteralPath $root -PathType Container)) { continue }
+        foreach ($file in @(Get-ChildItem -LiteralPath $root -Recurse -Force -File -ErrorAction SilentlyContinue)) {
+            if ($file.LastWriteTimeUtc -gt $cutoff -or ($file.Attributes -band [IO.FileAttributes]::ReparsePoint)) { continue }
+            if ([string]$file.Name -match '\.(env|dev\.vars|cloudflared|jsonl|sqlite|vhdx|dmp|etl|tar|zip|mp4|mov|MOV|HEIC)$') { continue }
+            $rows += [pscustomobject]@{ path = $file.FullName; safe_root = $root; category = 'regenerable-temporary'; bytes = [int64]$file.Length; size_gb = Get-BytesGB $file.Length; reason = "older-than-$([int]$Policy.retentionDays.temporary)-days"; eligible = $true }
+        }
+    }
+    return $rows | Sort-Object bytes -Descending
+}
+
+function Remove-SafeFile {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    param([Parameter(Mandatory = $true)]$Candidate, [switch]$Execute)
+    if (-not (Test-PathWithin -Path $Candidate.path -Root $Candidate.safe_root)) { return [pscustomobject]@{ path = $Candidate.path; action = 'blocked'; bytes = $Candidate.bytes; reason = 'outside-safe-root' } }
+    if (-not $Execute) { return [pscustomobject]@{ path = $Candidate.path; action = 'dry-run'; bytes = $Candidate.bytes; reason = $Candidate.reason } }
+    if ($PSCmdlet.ShouldProcess($Candidate.path, 'Remove regenerable expired temporary')) {
+        try { Remove-Item -LiteralPath $Candidate.path -Force -ErrorAction Stop; return [pscustomobject]@{ path = $Candidate.path; action = 'removed'; bytes = $Candidate.bytes; reason = $Candidate.reason } }
+        catch { return [pscustomobject]@{ path = $Candidate.path; action = 'error'; bytes = $Candidate.bytes; reason = $_.Exception.Message } }
+    }
+    return [pscustomobject]@{ path = $Candidate.path; action = 'what-if'; bytes = $Candidate.bytes; reason = $Candidate.reason }
+}
+
+function Get-RegenerableInventory {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string[]]$Names
+    )
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) { return [pscustomobject]@{ entries = @(); bytes = 0L } }
+    $topDirs = @()
+    foreach ($dir in @(Get-ChildItem -LiteralPath $Path -Recurse -Force -Directory -ErrorAction SilentlyContinue | Where-Object { $Names -contains $_.Name -and -not ($_.Attributes -band [IO.FileAttributes]::ReparsePoint) } | Sort-Object @{ Expression = { $_.FullName.Length } })) {
+        if (-not ($topDirs | Where-Object { Test-PathWithin -Path $dir.FullName -Root $_.FullName })) { $topDirs += $dir }
+    }
+    $entries = @()
+    foreach ($dir in $topDirs) {
+        $bytes = 0L
+        $files = @(Get-ChildItem -LiteralPath $dir.FullName -Recurse -Force -File -ErrorAction SilentlyContinue)
+        if ($files.Count -gt 0) { $bytes = [int64](($files | Measure-Object Length -Sum).Sum) }
+        $entries += [pscustomobject]@{ path = $dir.FullName; bytes = $bytes; size_gb = [math]::Round($bytes / 1GB, 3) }
+    }
+    $total = 0L
+    if ($entries.Count -gt 0) { $total = [int64](($entries | Measure-Object bytes -Sum).Sum) }
+    [pscustomobject]@{ entries = $entries; bytes = $total }
+}
+
+function Get-WorktreeCleanupCandidates {
+    param([object[]]$Worktrees, [Parameter(Mandatory = $true)]$Policy, [Parameter(Mandatory = $true)]$Now)
+    $cutoff = $Now.AddDays(-[double]$Policy.retentionDays.endedWorktree)
+    foreach ($worktree in @($Worktrees | Where-Object { $_.eligible_for_cleanup -and $_.last_write_utc })) {
+        $lastWrite = $null
+        try { $lastWrite = [datetime]$worktree.last_write_utc } catch {}
+        if ($null -eq $lastWrite -or $lastWrite.ToUniversalTime() -gt $cutoff) { continue }
+        $inventory = Get-RegenerableInventory -Path $worktree.path -Names @($Policy.regenerableDirectoryNames)
+        [pscustomobject]@{
+            path = $worktree.path
+            category = 'integrated-clean-worktree'
+            classification = $worktree.classification
+            classification_code = $worktree.classification_code
+            branch = $worktree.branch
+            commit = $worktree.commit
+            last_write_utc = $worktree.last_write_utc
+            bytes = $inventory.bytes
+            size_gb = [math]::Round($inventory.bytes / 1GB, 3)
+            regenerable_inventory = $inventory.entries
+            reason = "clean-merged-and-older-than-$([int]$Policy.retentionDays.endedWorktree)-days"
+            eligible = $true
+        }
+    }
+}
+
+$Policy = Read-Policy
+$now = [DateTime]::UtcNow
+$stateRoot = Expand-StoragePath ([string]$Policy.paths.privateStateRoot)
+New-Item -ItemType Directory -Force -Path $stateRoot | Out-Null
+$drive = Get-DriveSnapshot
+$thresholdState = Get-ThresholdState -FreeGB $drive.free_gb -Thresholds $Policy.thresholdsGB
+$paths = [ordered]@{}
+foreach ($property in $Policy.paths.PSObject.Properties) { $paths[$property.Name] = Expand-StoragePath ([string]$property.Value) }
+$quickRoots = @($paths.projectRoot, $paths.worktreeRoot, $paths.runtimeRoot, $paths.codexHome)
+$directorySnapshots = @()
+foreach ($root in $quickRoots) { $directorySnapshots += Get-DirectDirectorySnapshot -Path $root }
+if ($Deep -or [bool]$Policy.defaults.deepScan) {
+    $directorySnapshots = @()
+    foreach ($root in $quickRoots) { $directorySnapshots += Get-DeepDirectorySnapshot -Path $root }
+}
+$fileSnapshots = @()
+foreach ($filePath in @('C:\pagefile.sys', 'C:\swapfile.sys', 'C:\Users\admin\AppData\Local\wsl\{aa973afc-c57c-49d3-810d-ff364865ce84}\ext4.vhdx', 'C:\WSL\Ubuntu-24.04\ext4.vhdx')) {
+    $snapshot = Get-FileSnapshot -Path $filePath
+    if ($null -ne $snapshot) { $fileSnapshots += $snapshot }
+}
+$processes = @(Get-ProcessSnapshot)
+$worktrees = @()
+$codexSessionCwds = @()
+if ($IncludeWorktreeStatus -or $Mode -in @('cleanup', 'emergency', 'classify-worktrees')) {
+    $processDetails = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine })
+    $codexSessionCwds = @(Get-CodexSessionCwds -CodexHome $paths.codexHome)
+    $worktrees = @(Get-WorktreeRecords -ProjectRoot $paths.projectRoot -WorktreeRoot $paths.worktreeRoot -LifecycleRoot (Join-Path $stateRoot 'worktrees') -ProcessDetails $processDetails -SessionDetails $codexSessionCwds -IncludeStatus)
+    if ($worktrees.Count -gt $MaxWorktrees) { throw "Refusing to classify $($worktrees.Count) worktrees; MaxWorktrees=$MaxWorktrees." }
+}
+$sourceTars = @()
+$workerd = @()
+if ($Deep) {
+    $sourceTars = @(Get-SourceTarRecords -RuntimeRoot $paths.runtimeRoot)
+    $workerd = @(Get-WorkerdRecords -Roots @($paths.projectRoot, $paths.worktreeRoot, (Join-Path $paths.runtimeRoot 'operator\admin\skincos\source')))
+}
+$candidates = @()
+$worktreeCandidates = @()
+$actions = @()
+if ($Mode -in @('cleanup', 'emergency', 'classify-worktrees')) {
+    $candidates = @(Get-CleanupCandidates -Policy $Policy -Now $now)
+    $worktreeCandidates = @(Get-WorktreeCleanupCandidates -Worktrees $worktrees -Policy $Policy -Now $now)
+    foreach ($candidate in $candidates) { $actions += Remove-SafeFile -Candidate $candidate -Execute:$Apply }
+    if ($AllowWorktreeCleanup) {
+        foreach ($candidate in $worktreeCandidates) {
+            if (-not $Apply) { $actions += [pscustomobject]@{ path = $candidate.path; action = 'dry-run'; bytes = 0L; reason = $candidate.reason } ; continue }
+            if ($PSCmdlet.ShouldProcess($candidate.path, 'Close eligible integrated clean worktree and remove regenerable contents')) {
+                $closeScript = Join-Path $script:ScriptRoot 'close-shared-worktree.ps1'
+                $closeParams = [ordered]@{ WorktreePath = $candidate.path; ProjectRoot = $paths.projectRoot; WorktreeRoot = $paths.worktreeRoot; RemoveRegenerable = $true; Apply = $true }
+                if ($AllowWorktreeRemoval) { $closeParams.RemoveWorktree = $true }
+                $closeOutput = @(& $closeScript @closeParams -Confirm:$false 2>&1)
+                $actions += [pscustomobject]@{ path = $candidate.path; action = if ($LASTEXITCODE -eq 0) { if ($AllowWorktreeRemoval) { 'worktree-closed' } else { 'worktree-regenerable-cleaned' } } else { 'worktree-close-error' }; bytes = [int64]$candidate.bytes; reason = (@($closeOutput) -join "`n") }
+            }
+        }
+    }
+}
+$document = [ordered]@{
+    schema_version = 1
+    generated_at_utc = $now.ToString('o')
+    mode = $Mode
+    applied = [bool]$Apply
+    deep_scan = [bool]$Deep
+    threshold_state = $thresholdState
+    drive = $drive
+    paths = $paths
+    directories = $directorySnapshots
+    files = $fileSnapshots
+    processes = $processes
+    codex_session_cwds = $codexSessionCwds
+    worktrees = $worktrees
+    worktree_cleanup_candidates = $worktreeCandidates
+    source_tars = $sourceTars
+    workerd = $workerd
+    cleanup_candidates = $candidates
+    actions = $actions
+    limitations = @(
+        'Directory sizes are logical file-length sums; hardlinks can overcount physical allocation.',
+        'Reparse points are skipped by deep scans.',
+        'WSL VHDX mutation is never performed by this script.',
+        'Codex sessions and protected release/checkpoint directories are report-only unless a separate explicit policy is added.'
+    )
+}
+$latestPath = Join-Path $stateRoot 'latest.json'
+$historyPath = Join-Path $stateRoot 'history.jsonl'
+Write-AtomicJson -Path $latestPath -Value $document
+Append-JsonLine -Path $historyPath -Value $document
+if (-not [string]::IsNullOrWhiteSpace($OutputPath)) { Write-AtomicJson -Path (Expand-StoragePath $OutputPath) -Value $document }
+$document | ConvertTo-Json -Depth 30

--- a/scripts/storage/audit-wsl-readonly.sh
+++ b/scripts/storage/audit-wsl-readonly.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${WSL_BOUNDARY_EXCEPTION:?WSL_BOUNDARY_EXCEPTION is required for this read-only infrastructure probe}"
+
+printf 'wsl_boundary_exception=%s\n' "$WSL_BOUNDARY_EXCEPTION"
+printf 'generated_at_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf '%s\n' '--- df ---'
+df -P -h / 2>&1 || true
+
+printf '%s\n' '--- top-level entries ---'
+find / -mindepth 1 -maxdepth 1 -xdev -printf '%y %s %p\n' 2>&1 || true
+
+printf '%s\n' '--- selected directory entries ---'
+for root in /home /var /opt /tmp /root /usr/local /mnt; do
+  if [[ -d "$root" ]]; then
+    printf 'root=%s\n' "$root"
+    find "$root" -mindepth 1 -maxdepth 1 -xdev -printf '%y %s %p\n' 2>&1 || true
+  fi
+done
+
+printf '%s\n' '--- du probe ---'
+if command -v du >/dev/null 2>&1; then
+  du -x -h -d 1 / 2>&1 || true
+else
+  printf '%s\n' 'du=missing'
+fi
+
+printf '%s\n' '--- health ---'
+if [[ -r /proc/mounts ]]; then grep -E ' / |/mnt/c ' /proc/mounts || true; fi
+if [[ -r /proc/sys/fs/file-nr ]]; then cat /proc/sys/fs/file-nr || true; fi

--- a/scripts/tests/test-skincos-storage-governance.ps1
+++ b/scripts/tests/test-skincos-storage-governance.ps1
@@ -1,0 +1,14 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$script = Join-Path (Split-Path -Parent $PSScriptRoot) 'skincos-storage-governance.ps1'
+$policy = Join-Path (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) 'ops\codex\storage-retention-policy.json'
+if (-not (Test-Path -LiteralPath $script)) { throw 'governance script missing' }
+if (-not (Test-Path -LiteralPath $policy)) { throw 'governance policy missing' }
+
+$result = & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $script -Mode audit -PolicyPath $policy
+$document = ($result -join "`n") | ConvertFrom-Json
+if ($document.schema_version -ne 1) { throw 'unexpected schema version' }
+if ($document.drive.device -ne 'C:') { throw 'drive snapshot missing' }
+if ($document.threshold_state -notin @('healthy','warning','high','critical','emergency')) { throw 'invalid threshold state' }
+if ($document.limitations.Count -lt 3) { throw 'safety limitations missing' }
+Write-Output 'PASS: storage governance audit emits a versioned, fail-closed report.'


### PR DESCRIPTION
# Summary

Adds fail-closed storage governance for the SKINCOS/Codex development footprint after the Windows disk audit found repeated worktrees, regenerable dependencies/builds, release/checkpoint archives, and duplicated source.tar artifacts.

## What changed

- Versioned retention policy with protected roots and dry-run defaults.
- Read-only audit/classification for disk usage, worktrees, Codex sessions, and WSL.
- Explicit cleanup paths for regenerable worktree contents and exact source.tar hardlink deduplication.
- Lifecycle records for shared worktrees and safer path checks in the launchers.
- Official Codex session archive/delete commands only; no direct session-state mutation.
- Scheduled six-hour audit task installer.

## Validation

- Focused storage governance test: PASS.
- Git diff check: PASS.
- Changed PowerShell files parse cleanly.
- Existing unrelated legacy parser error remains outside this diff.
- WSL probe is read-only and records existing ext4 I/O errors/emergency read-only state; no shutdown, repair, unregister, deletion, or VHDX compaction is included.

## Operational impact

Defaults are audit/dry-run and fail closed. The implementation does not automatically delete protected artifacts, Codex sessions, worktrees, WSL data, or release/checkpoint evidence. Rollback is reverting this commit and unregistering the scheduled task; existing audit reports remain private runtime evidence.