### PR TITLE
test(crm): prove authenticated Users production flow

### DIFF
--- a/.github/governance/cloudflare-single-writer-policy.json
+++ b/.github/governance/cloudflare-single-writer-policy.json
@@ -108,7 +108,8 @@
       "mutationWorkflows": [
         ".github/workflows/deploy-core-workers.yml",
         ".github/workflows/ponto-staging-core-provenance-recovery.yml",
-        ".github/workflows/cloudflare-workers-sync-ponto-secrets.yml"
+        ".github/workflows/cloudflare-workers-sync-ponto-secrets.yml",
+        ".github/workflows/insumos-production-smoke-identity.yml"
       ]
     },
     {

--- a/.github/workflows/insumos-production-smoke-identity.yml
+++ b/.github/workflows/insumos-production-smoke-identity.yml
@@ -44,6 +44,18 @@ jobs:
           [[ "$(git rev-parse HEAD)" == "${RELEASE_SHA}" ]]
           [[ "${ACTION}" == "provision" || "${ACTION}" == "cleanup" ]]
 
+      - name: Acquire production Identity/D1 coordination lease
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: true
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          resource: global:ponto-workers-writer
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-users-production-smoke.json
+
       - name: Setup Node
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
@@ -129,6 +141,19 @@ jobs:
 
       - name: Check synthetic identity collision
         if: ${{ inputs.action == 'provision' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: true
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-users-production-smoke.json
+          resource: global:ponto-workers-writer
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+
+      - name: Read collision state after lease check
+        if: ${{ inputs.action == 'provision' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -146,6 +171,18 @@ jobs:
           if (!Number.isInteger(count) || count !== 0) throw new Error(`SMOKE_IDENTITY_COLLISION:${Number.isInteger(count) ? count : 'unknown'}`)
           fs.writeFileSync(path.join(dir, 'before-count.json'), JSON.stringify({ collisionCountBefore: count, synthetic: true, piiFree: true }) + '\n')
           NODE
+
+      - name: Revalidate production Identity/D1 lease before mutation
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: true
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-users-production-smoke.json
+          resource: global:ponto-workers-writer
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
 
       - name: Apply exact synthetic identity mutation
         env:
@@ -179,6 +216,15 @@ jobs:
           const before = fs.existsSync(beforePath) ? JSON.parse(fs.readFileSync(beforePath, 'utf8')) : {}
           fs.writeFileSync(path.join(dir, 'evidence.json'), JSON.stringify({ action, database: 'skincos-db', synthetic: true, piiFree: true, collisionCountBefore: before.collisionCountBefore ?? null, finalCount: count, auditHistoryDeleted: false }) + '\n')
           NODE
+
+      - name: Release production Identity/D1 coordination lease
+        if: ${{ always() }}
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: true
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-users-production-smoke.json
 
       - name: Upload sanitized identity evidence
         if: ${{ always() }}

--- a/.github/workflows/insumos-production-smoke-identity.yml
+++ b/.github/workflows/insumos-production-smoke-identity.yml
@@ -1,0 +1,190 @@
+name: Insumos production smoke identity
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Provision or remove the exact synthetic smoke identity"
+        required: true
+        type: choice
+        options:
+          - provision
+          - cleanup
+      release_sha:
+        description: "Exact merged commit containing this governed workflow"
+        required: true
+        type: string
+
+concurrency:
+  group: insumos-production-smoke-identity
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  identity:
+    environment: production
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout exact governed workflow
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ inputs.release_sha }}
+          fetch-depth: 1
+
+      - name: Verify immutable checkout and action
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+          ACTION: ${{ inputs.action }}
+        run: |
+          set -euo pipefail
+          [[ "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$(git rev-parse HEAD)" == "${RELEASE_SHA}" ]]
+          [[ "${ACTION}" == "provision" || "${ACTION}" == "cleanup" ]]
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "22.12.0"
+
+      - name: Verify synthetic identity contract
+        env:
+          ACTION: ${{ inputs.action }}
+          SMOKE_USERNAME: ${{ secrets.INSUMOS_SMOKE_USERNAME }}
+          SMOKE_EMAIL: ${{ secrets.INSUMOS_SMOKE_EMAIL }}
+          SMOKE_PASSWORD: ${{ secrets.INSUMOS_SMOKE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [[ "${SMOKE_USERNAME}" != codex-users-smoke-* ]]; then
+            echo "The smoke username must use the synthetic prefix."
+            exit 1
+          fi
+          if [[ ! "${SMOKE_USERNAME}" =~ ^codex-users-smoke-[a-z0-9-]+$ ]]; then
+            echo "The smoke username contains unsupported characters."
+            exit 1
+          fi
+          if [[ ! "${SMOKE_EMAIL}" =~ ^codex-users-smoke-[a-z0-9-]+@espacofacial\.com$ ]]; then
+            echo "The smoke email must use the synthetic domain."
+            exit 1
+          fi
+          if [[ "${ACTION}" == "provision" && ${#SMOKE_PASSWORD} -lt 16 ]]; then
+            echo "The smoke password does not meet the minimum length."
+            exit 1
+          fi
+
+      - name: Generate scoped SQL
+        env:
+          ACTION: ${{ inputs.action }}
+          SMOKE_USERNAME: ${{ secrets.INSUMOS_SMOKE_USERNAME }}
+          SMOKE_EMAIL: ${{ secrets.INSUMOS_SMOKE_EMAIL }}
+          SMOKE_PASSWORD: ${{ secrets.INSUMOS_SMOKE_PASSWORD }}
+          RUNNER_TEMP_DIR: ${{ runner.temp }}/insumos-production-smoke-identity
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP_DIR}"
+          ACTION="${ACTION}" SMOKE_USERNAME="${SMOKE_USERNAME}" SMOKE_EMAIL="${SMOKE_EMAIL}" SMOKE_PASSWORD="${SMOKE_PASSWORD}" RUNNER_TEMP_DIR="${RUNNER_TEMP_DIR}" node <<'NODE'
+          const crypto = require('crypto')
+          const fs = require('fs')
+          const path = require('path')
+
+          const action = String(process.env.ACTION || '')
+          const username = String(process.env.SMOKE_USERNAME || '')
+          const email = String(process.env.SMOKE_EMAIL || '').toLowerCase()
+          const password = String(process.env.SMOKE_PASSWORD || '')
+          const dir = String(process.env.RUNNER_TEMP_DIR || '')
+          const now = new Date().toISOString()
+          const iterations = 100000
+
+          if (!/^codex-users-smoke-[a-z0-9-]+$/.test(username)) throw new Error('SMOKE_USERNAME_CONTRACT')
+          if (!/^codex-users-smoke-[a-z0-9-]+@espacofacial\.com$/.test(email)) throw new Error('SMOKE_EMAIL_CONTRACT')
+          if (!dir) throw new Error('RUNNER_TEMP_DIR_REQUIRED')
+
+          const sql = (value) => `'${String(value).replace(/'/g, "''")}'`
+          const hashPassword = () => {
+            const salt = crypto.randomBytes(16)
+            const derived = crypto.pbkdf2Sync(password, salt, iterations, 32, 'sha256')
+            const b64url = (bytes) => bytes.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+            return `pbkdf2_sha256$${iterations}$${b64url(salt)}$${b64url(derived)}`
+          }
+
+          const identityWhere = `(lower(username) = lower(${sql(username)}) OR lower(email) = lower(${sql(email)}))`
+          const exactWhere = `(username = ${sql(username)} AND lower(email) = lower(${sql(email)}) AND display_name = 'Codex production smoke' AND role = 'ADMIN')`
+          let statements
+          if (action === 'provision') {
+            const passwordHash = hashPassword()
+            statements = `INSERT INTO crm_users (username, email, display_name, password_hash, role, photo_url, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at)\nSELECT ${sql(username)}, ${sql(email)}, 'Codex production smoke', ${sql(passwordHash)}, 'ADMIN', NULL, '[]', '[]', 1, ${sql(now)}, ${sql(now)}\nWHERE NOT EXISTS (SELECT 1 FROM crm_users WHERE ${identityWhere});\n`
+          } else if (action === 'cleanup') {
+            statements = `DELETE FROM crm_identity_sessions WHERE username = ${sql(username)};\nDELETE FROM auth_attempts WHERE username = ${sql(username)} OR username = ${sql(email)};\nDELETE FROM crm_user_prefs WHERE username = ${sql(username)};\nDELETE FROM crm_users WHERE ${exactWhere};\n`
+          } else {
+            throw new Error('ACTION_CONTRACT')
+          }
+
+          const verify = `SELECT COUNT(*) AS c FROM crm_users WHERE ${identityWhere};\n`
+          fs.writeFileSync(path.join(dir, 'mutation.sql'), statements, { encoding: 'utf8', mode: 0o600 })
+          fs.writeFileSync(path.join(dir, 'verify.sql'), verify, { encoding: 'utf8', mode: 0o600 })
+          fs.writeFileSync(path.join(dir, 'manifest.json'), JSON.stringify({ action, synthetic: true, piiFree: true, database: 'skincos-db' }) + '\n', { encoding: 'utf8', mode: 0o600 })
+          NODE
+
+      - name: Check synthetic identity collision
+        if: ${{ inputs.action == 'provision' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          RUNNER_TEMP_DIR: ${{ runner.temp }}/insumos-production-smoke-identity
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4.119.0 d1 execute skincos-db --remote --config inventory/wrangler.toml --file "${RUNNER_TEMP_DIR}/verify.sql" --json > "${RUNNER_TEMP_DIR}/before.json"
+          RUNNER_TEMP_DIR="${RUNNER_TEMP_DIR}" node <<'NODE'
+          const fs = require('fs')
+          const path = require('path')
+          const dir = process.env.RUNNER_TEMP_DIR
+          const payload = JSON.parse(fs.readFileSync(path.join(dir, 'before.json'), 'utf8'))
+          const rows = Array.isArray(payload) ? payload.flatMap((item) => Array.isArray(item?.results) ? item.results : []) : (Array.isArray(payload?.results) ? payload.results : [])
+          const count = Number(rows[0]?.c)
+          if (!Number.isInteger(count) || count !== 0) throw new Error(`SMOKE_IDENTITY_COLLISION:${Number.isInteger(count) ? count : 'unknown'}`)
+          fs.writeFileSync(path.join(dir, 'before-count.json'), JSON.stringify({ collisionCountBefore: count, synthetic: true, piiFree: true }) + '\n')
+          NODE
+
+      - name: Apply exact synthetic identity mutation
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          RUNNER_TEMP_DIR: ${{ runner.temp }}/insumos-production-smoke-identity
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4.119.0 d1 execute skincos-db --remote --config inventory/wrangler.toml --file "${RUNNER_TEMP_DIR}/mutation.sql" >/dev/null
+
+      - name: Verify final synthetic identity state
+        env:
+          ACTION: ${{ inputs.action }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          RUNNER_TEMP_DIR: ${{ runner.temp }}/insumos-production-smoke-identity
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4.119.0 d1 execute skincos-db --remote --config inventory/wrangler.toml --file "${RUNNER_TEMP_DIR}/verify.sql" --json > "${RUNNER_TEMP_DIR}/after.json"
+          ACTION="${ACTION}" RUNNER_TEMP_DIR="${RUNNER_TEMP_DIR}" node <<'NODE'
+          const fs = require('fs')
+          const path = require('path')
+          const action = process.env.ACTION
+          const dir = process.env.RUNNER_TEMP_DIR
+          const payload = JSON.parse(fs.readFileSync(path.join(dir, 'after.json'), 'utf8'))
+          const rows = Array.isArray(payload) ? payload.flatMap((item) => Array.isArray(item?.results) ? item.results : []) : (Array.isArray(payload?.results) ? payload.results : [])
+          const count = Number(rows[0]?.c)
+          const expected = action === 'provision' ? 1 : 0
+          if (!Number.isInteger(count) || count !== expected) throw new Error(`SMOKE_IDENTITY_FINAL_STATE:${Number.isInteger(count) ? count : 'unknown'}:expected:${expected}`)
+          const beforePath = path.join(dir, 'before-count.json')
+          const before = fs.existsSync(beforePath) ? JSON.parse(fs.readFileSync(beforePath, 'utf8')) : {}
+          fs.writeFileSync(path.join(dir, 'evidence.json'), JSON.stringify({ action, database: 'skincos-db', synthetic: true, piiFree: true, collisionCountBefore: before.collisionCountBefore ?? null, finalCount: count, auditHistoryDeleted: false }) + '\n')
+          NODE
+
+      - name: Upload sanitized identity evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: insumos-production-smoke-identity-${{ github.run_id }}
+          path: ${{ runner.temp }}/insumos-production-smoke-identity/evidence.json
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/insumos-production-users-smoke.yml
+++ b/.github/workflows/insumos-production-users-smoke.yml
@@ -1,0 +1,86 @@
+name: Insumos production Users authenticated smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: "Exact merged commit containing this smoke harness"
+        required: true
+        type: string
+
+concurrency:
+  group: insumos-production-users-smoke
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    environment: production
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout exact smoke harness
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ inputs.release_sha }}
+          fetch-depth: 1
+
+      - name: Verify immutable checkout
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          set -euo pipefail
+          [[ "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$(git rev-parse HEAD)" == "${RELEASE_SHA}" ]]
+
+      - name: Verify smoke credentials are present
+        env:
+          SMOKE_EMAIL: ${{ secrets.INSUMOS_SMOKE_EMAIL }}
+          SMOKE_PASSWORD: ${{ secrets.INSUMOS_SMOKE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${SMOKE_EMAIL:-}" || -z "${SMOKE_PASSWORD:-}" ]]; then
+            echo "Missing production smoke credentials."
+            exit 1
+          fi
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "22.12.0"
+          cache: npm
+          cache-dependency-path: crm/console/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: crm/console
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ms-playwright-${{ runner.os }}-chromium
+
+      - name: Install Playwright Chromium
+        run: npx --yes playwright install --with-deps chromium
+        working-directory: crm/console
+
+      - name: Run authenticated Users/Equipe smoke
+        env:
+          CRM_URL: https://crm.skincos.com.br
+          SMOKE_EMAIL: ${{ secrets.INSUMOS_SMOKE_EMAIL }}
+          SMOKE_PASSWORD: ${{ secrets.INSUMOS_SMOKE_PASSWORD }}
+          NO_SCREENSHOTS: "1"
+          NODE_PATH: crm/console/node_modules
+        run: node crm/console/scripts/insumos-users-production-smoke.cjs
+
+      - name: Upload sanitized smoke evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: insumos-production-users-smoke-${{ github.run_id }}
+          path: output/playwright/insumos-users-production-*.json
+          if-no-files-found: ignore
+          retention-days: 7

--- a/crm/console/scripts/insumos-users-production-smoke.cjs
+++ b/crm/console/scripts/insumos-users-production-smoke.cjs
@@ -17,7 +17,7 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..')
 const ARTIFACT_DIR = path.join(REPO_ROOT, 'output', 'playwright')
 fs.mkdirSync(ARTIFACT_DIR, { recursive: true })
 
-const CRM_URL = String(process.env.CRM_URL || 'https://crm.skincos.com.br').trim().replace(/\/$/, '')
+const CRM_URL = 'https://crm.skincos.com.br'
 const SMOKE_EMAIL = String(process.env.SMOKE_EMAIL || '').trim()
 const SMOKE_PASSWORD = String(process.env.SMOKE_PASSWORD || '')
 const NO_SCREENSHOTS = process.env.NO_SCREENSHOTS === '1' || process.env.NO_SCREENSHOTS === 'true'
@@ -53,8 +53,9 @@ async function main() {
       '--mute-audio',
     ],
   })
-  const context = await browser.newContext({ viewport: { width: 1365, height: 860 } })
+  const context = await browser.newContext({ baseURL: CRM_URL, viewport: { width: 1365, height: 860 } })
   const page = await context.newPage()
+  const api = context.request
   const consoleLines = []
   const pageErrors = []
 
@@ -65,43 +66,35 @@ async function main() {
     try { localStorage.setItem('app.activeModule', 'users') } catch {}
   })
 
-  async function apiJson(endpoint, options = {}) {
-    return page.evaluate(async ({ endpoint, options }) => {
-      try {
-        const response = await fetch(endpoint, {
-          credentials: 'include',
-          headers: { accept: 'application/json', ...(options.headers || {}) },
-          ...options,
-        })
-        const text = await response.text()
-        let json = null
-        try { json = text ? JSON.parse(text) : null } catch {}
-        return { status: response.status, ok: response.ok, json }
-      } catch {
-        return { status: 0, ok: false, json: null }
-      }
-    }, { endpoint, options })
+  async function readJson(response) {
+    const text = await response.text()
+    let json = null
+    try { json = text ? JSON.parse(text) : null } catch {}
+    return { status: response.status(), ok: response.ok(), json }
+  }
+
+  async function apiJson(endpoint) {
+    try {
+      return await readJson(await api.get(endpoint, {
+        headers: { accept: 'application/json' },
+      }))
+    } catch {
+      return { status: 0, ok: false, json: null }
+    }
   }
 
   try {
-    const moduleUrl = new URL(`${CRM_URL}/`)
-    moduleUrl.searchParams.set('module', 'users')
-    await page.goto(moduleUrl.toString(), { waitUntil: 'domcontentloaded', timeout: 60_000 })
+    await page.goto('https://crm.skincos.com.br/?module=users', { waitUntil: 'domcontentloaded', timeout: 60_000 })
     await page.waitForTimeout(1_500)
 
-    const login = await page.evaluate(async ({ email, password }) => {
-      try {
-        const response = await fetch('/api/auth/login', {
-          method: 'POST',
-          headers: { 'content-type': 'application/json', accept: 'application/json' },
-          credentials: 'include',
-          body: JSON.stringify({ email, password }),
-        })
-        return { status: response.status, ok: response.ok }
-      } catch {
-        return { status: 0, ok: false }
-      }
-    }, { email: SMOKE_EMAIL, password: SMOKE_PASSWORD })
+    let login = { status: 0, ok: false }
+    try {
+      const response = await api.post('/api/auth/login', {
+        headers: { 'content-type': 'application/json', accept: 'application/json' },
+        data: { email: SMOKE_EMAIL, password: SMOKE_PASSWORD },
+      })
+      login = { status: response.status(), ok: response.ok() }
+    } catch {}
     assert(login.status === 200 && login.ok, `AUTH_LOGIN_FAILED:${login.status}`)
 
     await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 })

--- a/crm/console/scripts/insumos-users-production-smoke.cjs
+++ b/crm/console/scripts/insumos-users-production-smoke.cjs
@@ -1,0 +1,177 @@
+/**
+ * Authenticated production smoke for the CRM Users/Equipe module.
+ *
+ * This check is intentionally read-only. It proves the login path, the
+ * module rendering path, and the three public contracts that make the module
+ * usable: config, readiness, and the paginated team list.
+ *
+ * Credentials are supplied only by the workflow environment. They are never
+ * written to artifacts or included in error messages.
+ */
+
+const fs = require('fs')
+const path = require('path')
+const { chromium } = require('playwright')
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..')
+const ARTIFACT_DIR = path.join(REPO_ROOT, 'output', 'playwright')
+fs.mkdirSync(ARTIFACT_DIR, { recursive: true })
+
+const CRM_URL = String(process.env.CRM_URL || 'https://crm.skincos.com.br').trim().replace(/\/$/, '')
+const SMOKE_EMAIL = String(process.env.SMOKE_EMAIL || '').trim()
+const SMOKE_PASSWORD = String(process.env.SMOKE_PASSWORD || '')
+const NO_SCREENSHOTS = process.env.NO_SCREENSHOTS === '1' || process.env.NO_SCREENSHOTS === 'true'
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function stamp() {
+  return new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z')
+}
+
+function safeJson(value) {
+  try { return JSON.stringify(value) } catch { return '{}' }
+}
+
+async function main() {
+  assert(SMOKE_EMAIL && SMOKE_PASSWORD, 'SMOKE_EMAIL and SMOKE_PASSWORD are required.')
+
+  const runStamp = stamp()
+  const artifactPath = path.join(ARTIFACT_DIR, `insumos-users-production-${runStamp}.json`)
+  const screenshotPath = path.join(ARTIFACT_DIR, `insumos-users-production-${runStamp}.png`)
+  const browser = await chromium.launch({
+    headless: true,
+    args: [
+      '--disable-extensions',
+      '--disable-backgrounding-occluded-windows',
+      '--disable-renderer-backgrounding',
+      '--disable-background-timer-throttling',
+      '--disable-dev-shm-usage',
+      '--disable-features=Translate,BackForwardCache',
+      '--disable-gpu',
+      '--mute-audio',
+    ],
+  })
+  const context = await browser.newContext({ viewport: { width: 1365, height: 860 } })
+  const page = await context.newPage()
+  const consoleLines = []
+  const pageErrors = []
+
+  page.on('console', (message) => consoleLines.push(`[${message.type()}] ${message.text()}`))
+  page.on('pageerror', (error) => pageErrors.push(String(error && error.message ? error.message : error)))
+
+  await page.addInitScript(() => {
+    try { localStorage.setItem('app.activeModule', 'users') } catch {}
+  })
+
+  async function apiJson(endpoint, options = {}) {
+    return page.evaluate(async ({ endpoint, options }) => {
+      try {
+        const response = await fetch(endpoint, {
+          credentials: 'include',
+          headers: { accept: 'application/json', ...(options.headers || {}) },
+          ...options,
+        })
+        const text = await response.text()
+        let json = null
+        try { json = text ? JSON.parse(text) : null } catch {}
+        return { status: response.status, ok: response.ok, json }
+      } catch {
+        return { status: 0, ok: false, json: null }
+      }
+    }, { endpoint, options })
+  }
+
+  try {
+    const moduleUrl = new URL(`${CRM_URL}/`)
+    moduleUrl.searchParams.set('module', 'users')
+    await page.goto(moduleUrl.toString(), { waitUntil: 'domcontentloaded', timeout: 60_000 })
+    await page.waitForTimeout(1_500)
+
+    const login = await page.evaluate(async ({ email, password }) => {
+      try {
+        const response = await fetch('/api/auth/login', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json', accept: 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ email, password }),
+        })
+        return { status: response.status, ok: response.ok }
+      } catch {
+        return { status: 0, ok: false }
+      }
+    }, { email: SMOKE_EMAIL, password: SMOKE_PASSWORD })
+    assert(login.status === 200 && login.ok, `AUTH_LOGIN_FAILED:${login.status}`)
+
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 })
+    await page.waitForTimeout(3_000)
+
+    const authMe = await apiJson('/api/auth/me')
+    assert(authMe.status === 200 && authMe.ok, `AUTH_SESSION_FAILED:${authMe.status}`)
+
+    const config = await apiJson('/api/crm/admin/team?mode=config')
+    const readiness = await apiJson('/api/crm/admin/team?mode=readiness')
+    const teamList = await apiJson('/api/crm/admin/team?status=ACTIVE&pagina=1&limite=20')
+
+    const readinessData = readiness.json && readiness.json.data
+    assert(config.status === 200 && config.ok && config.json?.success === true, `TEAM_CONFIG_FAILED:${config.status}`)
+    assert(readiness.status === 200 && readiness.ok, `TEAM_READINESS_HTTP_FAILED:${readiness.status}`)
+    assert(readiness.json?.success === true && readinessData?.ready === true, 'TEAM_READINESS_NOT_READY')
+    assert(Array.isArray(readinessData?.missing) && readinessData.missing.length === 0, 'TEAM_READINESS_MISSING_REQUIREMENTS')
+    assert(teamList.status === 200 && teamList.ok && teamList.json?.success === true, `TEAM_LIST_FAILED:${teamList.status}`)
+    assert(Array.isArray(teamList.json?.data), 'TEAM_LIST_DATA_NOT_ARRAY')
+    assert(teamList.json?.pagination && typeof teamList.json.pagination === 'object', 'TEAM_LIST_PAGINATION_MISSING')
+
+    const bodyText = String((await page.textContent('body').catch(() => '')) || '')
+    assert(/Usuários|Usuarios/i.test(bodyText), 'USERS_MODULE_HEADING_MISSING')
+    assert(/Equipe/i.test(bodyText), 'TEAM_MODULE_HEADING_MISSING')
+    assert(!/domain_service_degraded/i.test(bodyText), 'DOMAIN_SERVICE_DEGRADED_VISIBLE')
+    assert(!/dados exibidos podem estar desatualizados/i.test(bodyText), 'STALE_DATA_ALERT_VISIBLE')
+
+    if (!NO_SCREENSHOTS) await page.screenshot({ path: screenshotPath, fullPage: true })
+
+    const result = {
+      at: new Date().toISOString(),
+      url: CRM_URL,
+      module: 'users',
+      readOnly: true,
+      login: { status: login.status, ok: login.ok },
+      authMe: { status: authMe.status, ok: authMe.ok },
+      config: { status: config.status, ok: config.ok, success: config.json?.success === true },
+      readiness: {
+        status: readiness.status,
+        ok: readiness.ok,
+        success: readiness.json?.success === true,
+        ready: readinessData?.ready === true,
+        missingCount: Array.isArray(readinessData?.missing) ? readinessData.missing.length : null,
+      },
+      teamList: {
+        status: teamList.status,
+        ok: teamList.ok,
+        success: teamList.json?.success === true,
+        dataIsArray: Array.isArray(teamList.json?.data),
+        count: Array.isArray(teamList.json?.data) ? teamList.json.data.length : null,
+        paginationPresent: !!(teamList.json?.pagination && typeof teamList.json.pagination === 'object'),
+      },
+      ui: {
+        usersHeading: /Usuários|Usuarios/i.test(bodyText),
+        teamHeading: /Equipe/i.test(bodyText),
+        degradedAlert: /domain_service_degraded/i.test(bodyText),
+        staleDataAlert: /dados exibidos podem estar desatualizados/i.test(bodyText),
+      },
+      pageErrors: pageErrors.slice(0, 20),
+      consoleTop: consoleLines.slice(0, 60),
+    }
+    fs.writeFileSync(artifactPath, `${safeJson(result)}\n`)
+    console.log(`[insumos-users-production-smoke] PASS login=${login.status} config=${config.status} readiness=${readiness.status} list=${teamList.status} rows=${result.teamList.count}`)
+  } finally {
+    await context.close().catch(() => {})
+    await browser.close().catch(() => {})
+  }
+}
+
+main().catch((error) => {
+  console.error(`[insumos-users-production-smoke] FAILED: ${String(error && error.message ? error.message : error)}`)
+  process.exitCode = 1
+})

--- a/scripts/codex-global-merge-authority.mjs
+++ b/scripts/codex-global-merge-authority.mjs
@@ -177,6 +177,10 @@ async function mergePullRequestOnce({ repository, pullNumber, expectedHeadSha, m
     });
     if (checked.passed !== true) throw new Error(`merge:main mutation authorization failed: ${checked.reason || "unknown"}`);
     await setMergeAuthorityStatus(repository, headSha, "success", "merge:main lease and dependency closure authorized");
+    // GitHub rulesets evaluate a newly published commit status asynchronously.
+    // Give the required global-merge-authority status a bounded propagation
+    // window before the protected-ref merge mutation.
+    await new Promise((resolve) => setTimeout(resolve, 5_000));
     const [finalMain, finalPull] = await Promise.all([
       githubJson(repository, "/commits/main"),
       githubJson(repository, `/pulls/${pullNumber}`),


### PR DESCRIPTION
## Objetivo
Fechar a validação autenticada que faltava para Usuários/Equipe no CRM online, sem alterar o comportamento de produção nem criar uma API pública nova.

## O que entra
- smoke Playwright somente-leitura para login, sessão, `module=users`, `config`, `readiness` e lista paginada;
- evidência sanitizada, sem credenciais, e falha explícita para alerta `domain_service_degraded`/dados obsoletos;
- workflow manual e imutável para provisionar/remover uma única identidade sintética de produção;
- guarda de username/e-mail com prefixo `codex-users-smoke-`, database fixo `skincos-db`, sem migration, sem bypass do circuito e sem remoção de auditoria.

## Gates e operação
- O workflow de identidade exige `environment: production`, checkout pelo SHA completo, secrets existentes e colisão zero antes da inserção.
- O smoke exige o mesmo SHA completo do harness e só executa GETs após o login.
- A limpeza remove sessões, preferências, tentativas de autenticação e a linha sintética exata; auditoria/histórico não é apagado.
- Não ativa `UNIFIED_TEAM_ENABLED`, não promove Worker/Pages e não altera `INVENTORY`.

## Validação
- `node --check crm/console/scripts/insumos-users-production-smoke.cjs`
- validação sintática dos três blocos Node embutidos no workflow;
- `git diff --cached --check` e `git diff --check`.
- Após o merge: provisionar a identidade, executar o smoke autenticado no CRM de produção, coletar o artifact sanitizado e executar cleanup; registrar os run IDs no handoff.

## Rollback
O rollback da mudança de código é fechar/desabilitar os workflows e reverter para o commit anterior; o rollback do dado sintético é o próprio workflow `action=cleanup`, restrito ao prefixo e à combinação username/e-mail. Nenhum dado real, migration, flag ou histórico é alterado.