### PR TITLE
fix(governance): publish coordinator custody atomically

### DIFF
--- a/.github/workflows/deploy-global-coordinator.yml
+++ b/.github/workflows/deploy-global-coordinator.yml
@@ -194,22 +194,33 @@ jobs:
             wrangler_vars+=(--var "COORDINATION_PREVIOUS_KEY_ID:${COORDINATION_PREVIOUS_KEY_ID}")
             wrangler_vars+=(--var "COORDINATION_PREVIOUS_KEY_EXPIRES_AT:${COORDINATION_PREVIOUS_KEY_EXPIRES_AT}")
           fi
+          # Keep code, non-secret vars and secret bindings in the same Worker
+          # version. `wrangler secret put` creates and deploys a separate
+          # version, which can otherwise pair the new key with the previous
+          # version's keyId during rotation.
+          export SECRETS_FILE="$RUNNER_TEMP/skincos-global-coordinator-secrets.json"
+          trap 'rm -f -- "$SECRETS_FILE"' EXIT
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+
+          const names = [
+            'COORDINATION_SHARED_SECRET',
+            'COORDINATION_ADMIN_SECRET',
+            'COORDINATION_ACTIVE_KEY',
+            'COORDINATION_PREVIOUS_KEY',
+            'COORDINATION_RECOVERY_SECRET',
+          ];
+          const secrets = Object.fromEntries(names
+            .map((name) => [name, process.env[name]])
+            .filter(([, value]) => typeof value === 'string' && value.length > 0));
+          fs.writeFileSync(process.env.SECRETS_FILE, JSON.stringify(secrets), { mode: 0o600 });
+          NODE
           npx --yes wrangler@4.120.0 deploy \
             --config wrangler.toml \
             --env "$TARGET" \
             "${wrangler_vars[@]}" \
+            --secrets-file "$SECRETS_FILE" \
             --message "global-coordinator:${TARGET}:${GITHUB_SHA}"
-          printf '%s' "$COORDINATION_SHARED_SECRET" | npx --yes wrangler@4.120.0 secret put COORDINATION_SHARED_SECRET --config wrangler.toml --env "$TARGET" >/dev/null
-          printf '%s' "$COORDINATION_ADMIN_SECRET" | npx --yes wrangler@4.120.0 secret put COORDINATION_ADMIN_SECRET --config wrangler.toml --env "$TARGET" >/dev/null
-          if [[ -n "${COORDINATION_ACTIVE_KEY:-}" ]]; then
-            printf '%s' "$COORDINATION_ACTIVE_KEY" | npx --yes wrangler@4.120.0 secret put COORDINATION_ACTIVE_KEY --config wrangler.toml --env "$TARGET" >/dev/null
-          fi
-          if [[ -n "${COORDINATION_PREVIOUS_KEY:-}" ]]; then
-            printf '%s' "$COORDINATION_PREVIOUS_KEY" | npx --yes wrangler@4.120.0 secret put COORDINATION_PREVIOUS_KEY --config wrangler.toml --env "$TARGET" >/dev/null
-          fi
-          if [[ -n "${COORDINATION_RECOVERY_SECRET:-}" ]]; then
-            printf '%s' "$COORDINATION_RECOVERY_SECRET" | npx --yes wrangler@4.120.0 secret put COORDINATION_RECOVERY_SECRET --config wrangler.toml --env "$TARGET" >/dev/null
-          fi
 
       - name: Read back the active version and verify the signed live gate
         id: postdeploy

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -239,8 +239,12 @@ test("merge:main is a fail-closed GitHub mutation authority", () => {
   assert.match(read("ops/cloudflare/global-coordinator/index.js"), /keyCandidatesForRequest/);
   assert.match(read("ops/cloudflare/global-coordinator/key-ring.mjs"), /PREVIOUS_KEY_EXPIRES_AT/);
   assert.match(read("ops/cloudflare/global-coordinator/key-ring.mjs"), /allowUnpinnedKeyDuringGrace/);
-  assert.match(read(".github/workflows/deploy-global-coordinator.yml"), /explicit active key cannot retain the legacy key id/);
-  assert.match(read(".github/workflows/deploy-global-coordinator.yml"), /COORDINATION_ACTIVE_KEY \|\| process\.env\.COORDINATION_SHARED_SECRET/);
+  const coordinatorDeploy = read(".github/workflows/deploy-global-coordinator.yml");
+  assert.match(coordinatorDeploy, /explicit active key cannot retain the legacy key id/);
+  assert.match(coordinatorDeploy, /COORDINATION_ACTIVE_KEY \|\| process\.env\.COORDINATION_SHARED_SECRET/);
+  assert.match(coordinatorDeploy, /--secrets-file \"\$SECRETS_FILE\"/);
+  assert.match(coordinatorDeploy, /mode: 0o600/);
+  assert.doesNotMatch(coordinatorDeploy, /wrangler@4\.120\.0 secret put/);
   assert.match(read("scripts/codex-global-coordination-workflow.mjs"), /admission paths are not bound/);
   assert.match(script, /\/pulls\/\$\{pullNumber\}\/merge/);
   assert.match(workflow, /pull_request_target/);


### PR DESCRIPTION
## What changed

- publish coordinator code, non-secret vars, and all available custody secrets in one Worker version through the Wrangler secrets-file option;
- remove sequential secret put calls that created independently deployed versions;
- keep the temporary secret file outside the checkout with mode 0600 and deterministic cleanup;
- add a static governance regression test preventing the old non-atomic path.

## Why

During the first production-key rotation attempt, the canonical workflow deployed the code and then used secret put, which creates and immediately deploys a separate Worker version. The signed live gate rejected the active key and the workflow correctly rolled back. Atomic version publication preserves keyId/secret consistency and keeps rollback meaningful.

## Validation

- scripts/tests/global-concurrency-governance-static.test.mjs — 14/14;
- git diff --check.