### PR TITLE
fix(storage): keep scheduled audit bounded

### DIFF
--- a/docs/operations/storage-governance.md
+++ b/docs/operations/storage-governance.md
@@ -23,6 +23,12 @@ It must not be placed in the shared checkout.
 # Quick report; no mutation
 powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\skincos-storage-governance.ps1 -Mode audit
 
+# Focal inventory for the active project and release roots, without Git status
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\skincos-storage-governance.ps1 -Mode audit -IncludeFocalArtifacts
+
+# Focal inventory including worktrees, source archives and workerd paths
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\skincos-storage-governance.ps1 -Mode audit -IncludeFocalArtifacts -IncludeWorktreeFocalArtifacts
+
 # Full targeted inventory, including worktrees, source archives and workerd paths
 powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\skincos-storage-governance.ps1 -Mode audit -Deep -IncludeWorktreeStatus
 
@@ -65,11 +71,13 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-skincos-st
   -IntervalHours 6 -Apply
 ```
 
-The registered task runs `-Mode audit` only. Cleanup and hardlink deduplication
-remain explicit operator actions. The default scheduled audit intentionally
-omits `-IncludeWorktreeStatus`: detailed classification invokes Git status and
-merge-base checks for every registered worktree and should be run explicitly
-when needed:
+The registered task runs `-Mode audit -IncludeFocalArtifacts` by default. This
+keeps `source.tar` and active-project `workerd*` visible without invoking Git
+status and merge-base checks for every registered worktree. Cleanup and hardlink
+deduplication remain explicit operator actions. Worktree artifact scanning and
+detailed worktree classification should be run explicitly when needed. The
+scheduled focal scan records archive metadata without rehashing all archive
+bytes; use `-Deep` when SHA-256 recomputation is required:
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-skincos-storage-governance-task.ps1 `

--- a/docs/operations/storage-governance.md
+++ b/docs/operations/storage-governance.md
@@ -66,7 +66,17 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-skincos-st
 ```
 
 The registered task runs `-Mode audit` only. Cleanup and hardlink deduplication
-remain explicit operator actions.
+remain explicit operator actions. The default scheduled audit intentionally
+omits `-IncludeWorktreeStatus`: detailed classification invokes Git status and
+merge-base checks for every registered worktree and should be run explicitly
+when needed:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-skincos-storage-governance-task.ps1 `
+  -RepositoryRoot (Get-Location).Path `
+  -ScriptPath (Join-Path (Get-Location).Path 'scripts\skincos-storage-governance.ps1') `
+  -IncludeWorktreeStatus -Apply
+```
 
 ## Release archives
 

--- a/scripts/install-skincos-storage-governance-task.ps1
+++ b/scripts/install-skincos-storage-governance-task.ps1
@@ -4,6 +4,7 @@ param(
     [string]$TaskName = 'SKINCOS Storage Governance Audit',
     [string]$ScriptPath = '',
     [int]$IntervalHours = 6,
+    [switch]$IncludeWorktreeStatus,
     [switch]$Apply
 )
 
@@ -15,7 +16,8 @@ if (-not (Test-Path -LiteralPath $ScriptPath -PathType Leaf)) { throw "Governanc
 if ($IntervalHours -lt 1 -or $IntervalHours -gt 24) { throw 'IntervalHours must be between 1 and 24.' }
 
 $powershell = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe'
-$arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$ScriptPath`" -Mode audit -IncludeWorktreeStatus"
+$statusArgument = if ($IncludeWorktreeStatus) { ' -IncludeWorktreeStatus' } else { '' }
+$arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$ScriptPath`" -Mode audit$statusArgument"
 $action = New-ScheduledTaskAction -Execute $powershell -Argument $arguments -WorkingDirectory (Split-Path -Parent $ScriptPath)
 $start = (Get-Date).AddMinutes(5)
 $trigger = New-ScheduledTaskTrigger -Once -At $start -RepetitionInterval (New-TimeSpan -Hours $IntervalHours) -RepetitionDuration (New-TimeSpan -Days 3650)
@@ -25,10 +27,10 @@ $principal = New-ScheduledTaskPrincipal -UserId "$env:USERDOMAIN\$env:USERNAME" 
 $settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Minutes 20) -MultipleInstances IgnoreNew -StartWhenAvailable
 
 if (-not $Apply) {
-    [pscustomobject]@{ task_name = $TaskName; script = $ScriptPath; interval_hours = $IntervalHours; run_at_logon = $true; action = 'dry-run'; user = "$env:USERDOMAIN\$env:USERNAME" } | ConvertTo-Json
+    [pscustomobject]@{ task_name = $TaskName; script = $ScriptPath; interval_hours = $IntervalHours; include_worktree_status = [bool]$IncludeWorktreeStatus; run_at_logon = $true; action = 'dry-run'; user = "$env:USERDOMAIN\$env:USERNAME" } | ConvertTo-Json
     exit 0
 }
 if ($PSCmdlet.ShouldProcess($TaskName, 'Register scheduled read-only storage audit')) {
     Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $triggers -Principal $principal -Settings $settings -Force | Out-Null
-    [pscustomobject]@{ task_name = $TaskName; script = $ScriptPath; interval_hours = $IntervalHours; run_at_logon = $true; action = 'registered'; user = "$env:USERDOMAIN\$env:USERNAME" } | ConvertTo-Json
+    [pscustomobject]@{ task_name = $TaskName; script = $ScriptPath; interval_hours = $IntervalHours; include_worktree_status = [bool]$IncludeWorktreeStatus; run_at_logon = $true; action = 'registered'; user = "$env:USERDOMAIN\$env:USERNAME" } | ConvertTo-Json
 }

--- a/scripts/install-skincos-storage-governance-task.ps1
+++ b/scripts/install-skincos-storage-governance-task.ps1
@@ -5,6 +5,7 @@ param(
     [string]$ScriptPath = '',
     [int]$IntervalHours = 6,
     [switch]$IncludeWorktreeStatus,
+    [switch]$SkipFocalArtifacts,
     [switch]$Apply
 )
 
@@ -17,7 +18,9 @@ if ($IntervalHours -lt 1 -or $IntervalHours -gt 24) { throw 'IntervalHours must 
 
 $powershell = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe'
 $statusArgument = if ($IncludeWorktreeStatus) { ' -IncludeWorktreeStatus' } else { '' }
-$arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$ScriptPath`" -Mode audit$statusArgument"
+$includeFocalArtifacts = -not $SkipFocalArtifacts
+$focalArgument = if ($includeFocalArtifacts) { ' -IncludeFocalArtifacts' } else { '' }
+$arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$ScriptPath`" -Mode audit$statusArgument$focalArgument"
 $action = New-ScheduledTaskAction -Execute $powershell -Argument $arguments -WorkingDirectory (Split-Path -Parent $ScriptPath)
 $start = (Get-Date).AddMinutes(5)
 $trigger = New-ScheduledTaskTrigger -Once -At $start -RepetitionInterval (New-TimeSpan -Hours $IntervalHours) -RepetitionDuration (New-TimeSpan -Days 3650)
@@ -27,10 +30,10 @@ $principal = New-ScheduledTaskPrincipal -UserId "$env:USERDOMAIN\$env:USERNAME" 
 $settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Minutes 20) -MultipleInstances IgnoreNew -StartWhenAvailable
 
 if (-not $Apply) {
-    [pscustomobject]@{ task_name = $TaskName; script = $ScriptPath; interval_hours = $IntervalHours; include_worktree_status = [bool]$IncludeWorktreeStatus; run_at_logon = $true; action = 'dry-run'; user = "$env:USERDOMAIN\$env:USERNAME" } | ConvertTo-Json
+    [pscustomobject]@{ task_name = $TaskName; script = $ScriptPath; arguments = $arguments; interval_hours = $IntervalHours; include_worktree_status = [bool]$IncludeWorktreeStatus; include_focal_artifacts = $includeFocalArtifacts; run_at_logon = $true; action = 'dry-run'; user = "$env:USERDOMAIN\$env:USERNAME" } | ConvertTo-Json
     exit 0
 }
 if ($PSCmdlet.ShouldProcess($TaskName, 'Register scheduled read-only storage audit')) {
     Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $triggers -Principal $principal -Settings $settings -Force | Out-Null
-    [pscustomobject]@{ task_name = $TaskName; script = $ScriptPath; interval_hours = $IntervalHours; include_worktree_status = [bool]$IncludeWorktreeStatus; run_at_logon = $true; action = 'registered'; user = "$env:USERDOMAIN\$env:USERNAME" } | ConvertTo-Json
+    [pscustomobject]@{ task_name = $TaskName; script = $ScriptPath; arguments = $arguments; interval_hours = $IntervalHours; include_worktree_status = [bool]$IncludeWorktreeStatus; include_focal_artifacts = $includeFocalArtifacts; run_at_logon = $true; action = 'registered'; user = "$env:USERDOMAIN\$env:USERNAME" } | ConvertTo-Json
 }

--- a/scripts/skincos-storage-governance.ps1
+++ b/scripts/skincos-storage-governance.ps1
@@ -10,6 +10,8 @@ param(
     [switch]$AllowWorktreeRemoval,
     [switch]$AllowArtifactHardlinkDeduplication,
     [switch]$IncludeWorktreeStatus,
+    [switch]$IncludeFocalArtifacts,
+    [switch]$IncludeWorktreeFocalArtifacts,
     [int]$MaxWorktrees = 700
 )
 
@@ -240,13 +242,19 @@ function Get-WorktreeRecords {
 }
 
 function Get-SourceTarRecords {
-    param([Parameter(Mandatory = $true)][string]$RuntimeRoot)
+    param([Parameter(Mandatory = $true)][string]$RuntimeRoot, [string[]]$RelativeRoots = @(), [switch]$ComputeHash)
     $root = Join-Path $RuntimeRoot 'operator\admin\skincos'
     if (-not (Test-Path -LiteralPath $root -PathType Container)) { return @() }
-    $files = @(Get-ChildItem -LiteralPath $root -Recurse -Force -File -ErrorAction SilentlyContinue | Where-Object { $_.Name -match 'source.*\.tar$' })
+    $scanRoots = @($root)
+    if (@($RelativeRoots).Count -gt 0) { $scanRoots = @($RelativeRoots | ForEach-Object { Join-Path $root $_ }) }
+    $files = @()
+    foreach ($scanRoot in $scanRoots) {
+        if (-not (Test-Path -LiteralPath $scanRoot -PathType Container)) { continue }
+        $files += @(Get-ChildItem -LiteralPath $scanRoot -Recurse -Force -File -Filter '*source*.tar' -ErrorAction SilentlyContinue | Where-Object { $_.Name -match 'source.*\.tar$' })
+    }
     $rows = foreach ($file in $files) {
         $hash = $null
-        try { $hash = (Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256 -ErrorAction Stop).Hash.ToUpperInvariant() } catch {}
+        if ($ComputeHash) { try { $hash = (Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256 -ErrorAction Stop).Hash.ToUpperInvariant() } catch {} }
         [pscustomobject]@{ path = $file.FullName; bytes = [int64]$file.Length; size_gb = Get-BytesGB $file.Length; sha256 = $hash; last_write_utc = $file.LastWriteTimeUtc.ToString('o') }
     }
     return $rows
@@ -254,14 +262,30 @@ function Get-SourceTarRecords {
 
 function Get-WorkerdRecords {
     param([Parameter(Mandatory = $true)][string[]]$Roots)
-    $rows = @()
+    $rows = [System.Collections.Generic.List[object]]::new()
     foreach ($root in $Roots) {
         if (-not (Test-Path -LiteralPath $root -PathType Container)) { continue }
-        foreach ($file in @(Get-ChildItem -LiteralPath $root -Recurse -Force -File -ErrorAction SilentlyContinue | Where-Object { $_.Name -like 'workerd*' })) {
-            $rows += [pscustomobject]@{ path = $file.FullName; bytes = [int64]$file.Length; size_mb = [math]::Round($file.Length / 1MB, 3); sha256 = $null; link_type = [string]$file.LinkType }
+        $pending = [System.Collections.Generic.Stack[string]]::new()
+        $pending.Push([IO.Path]::GetFullPath($root))
+        while ($pending.Count -gt 0) {
+            $current = $pending.Pop()
+            try {
+                foreach ($filePath in [IO.Directory]::EnumerateFiles($current, 'workerd*', [IO.SearchOption]::TopDirectoryOnly)) {
+                    try {
+                        $file = Get-Item -LiteralPath $filePath -Force -ErrorAction Stop
+                        $rows.Add([pscustomobject]@{ path = $file.FullName; bytes = [int64]$file.Length; size_mb = [math]::Round($file.Length / 1MB, 3); sha256 = $null; link_type = [string]$file.LinkType })
+                    } catch {}
+                }
+                foreach ($directoryPath in [IO.Directory]::EnumerateDirectories($current)) {
+                    try {
+                        $attributes = [IO.File]::GetAttributes($directoryPath)
+                        if (($attributes -band [IO.FileAttributes]::ReparsePoint) -eq 0) { $pending.Push($directoryPath) }
+                    } catch {}
+                }
+            } catch {}
         }
     }
-    return $rows
+    return @($rows)
 }
 
 function Get-CleanupCandidates {
@@ -370,9 +394,13 @@ if ($IncludeWorktreeStatus -or $Mode -in @('cleanup', 'emergency', 'classify-wor
 }
 $sourceTars = @()
 $workerd = @()
-if ($Deep) {
-    $sourceTars = @(Get-SourceTarRecords -RuntimeRoot $paths.runtimeRoot)
-    $workerd = @(Get-WorkerdRecords -Roots @($paths.projectRoot, $paths.worktreeRoot, (Join-Path $paths.runtimeRoot 'operator\admin\skincos\source')))
+if ($Deep -or $IncludeFocalArtifacts) {
+    $sourceTarRoots = @()
+    if (-not $Deep) { $sourceTarRoots = @($Policy.protectedArtifactDirectories) }
+    $sourceTars = @(Get-SourceTarRecords -RuntimeRoot $paths.runtimeRoot -RelativeRoots $sourceTarRoots -ComputeHash:$Deep)
+    $focalRoots = @($paths.projectRoot)
+    if ($Deep -or $IncludeWorktreeFocalArtifacts) { $focalRoots = @($paths.projectRoot, $paths.worktreeRoot, (Join-Path $paths.runtimeRoot 'operator\admin\skincos\source')) }
+    $workerd = @(Get-WorkerdRecords -Roots $focalRoots)
 }
 $candidates = @()
 $worktreeCandidates = @()
@@ -400,6 +428,9 @@ $document = [ordered]@{
     mode = $Mode
     applied = [bool]$Apply
     deep_scan = [bool]$Deep
+    focal_artifact_scan = [bool]($Deep -or $IncludeFocalArtifacts)
+    focal_worktree_scan = [bool]($Deep -or $IncludeWorktreeFocalArtifacts)
+    source_tar_hashes_computed = [bool]$Deep
     threshold_state = $thresholdState
     drive = $drive
     paths = $paths

--- a/scripts/tests/test-skincos-storage-governance.ps1
+++ b/scripts/tests/test-skincos-storage-governance.ps1
@@ -15,4 +15,5 @@ if ($document.threshold_state -notin @('healthy','warning','high','critical','em
 if ($document.limitations.Count -lt 3) { throw 'safety limitations missing' }
 $taskPreview = (& powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer -RepositoryRoot (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) -ScriptPath $script | Out-String) | ConvertFrom-Json
 if ($taskPreview.action -ne 'dry-run' -or $taskPreview.include_worktree_status) { throw 'scheduled audit must default to quick mode' }
+if (-not $taskPreview.include_focal_artifacts -or $taskPreview.arguments -notmatch '-IncludeFocalArtifacts') { throw 'scheduled audit must include focal artifact scan' }
 Write-Output 'PASS: storage governance audit emits a versioned, fail-closed report.'

--- a/scripts/tests/test-skincos-storage-governance.ps1
+++ b/scripts/tests/test-skincos-storage-governance.ps1
@@ -2,8 +2,10 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 $script = Join-Path (Split-Path -Parent $PSScriptRoot) 'skincos-storage-governance.ps1'
 $policy = Join-Path (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) 'ops\codex\storage-retention-policy.json'
+$installer = Join-Path (Split-Path -Parent $PSScriptRoot) 'install-skincos-storage-governance-task.ps1'
 if (-not (Test-Path -LiteralPath $script)) { throw 'governance script missing' }
 if (-not (Test-Path -LiteralPath $policy)) { throw 'governance policy missing' }
+if (-not (Test-Path -LiteralPath $installer)) { throw 'governance task installer missing' }
 
 $result = & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $script -Mode audit -PolicyPath $policy
 $document = ($result -join "`n") | ConvertFrom-Json
@@ -11,4 +13,6 @@ if ($document.schema_version -ne 1) { throw 'unexpected schema version' }
 if ($document.drive.device -ne 'C:') { throw 'drive snapshot missing' }
 if ($document.threshold_state -notin @('healthy','warning','high','critical','emergency')) { throw 'invalid threshold state' }
 if ($document.limitations.Count -lt 3) { throw 'safety limitations missing' }
+$taskPreview = (& powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer -RepositoryRoot (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) -ScriptPath $script | Out-String) | ConvertFrom-Json
+if ($taskPreview.action -ne 'dry-run' -or $taskPreview.include_worktree_status) { throw 'scheduled audit must default to quick mode' }
 Write-Output 'PASS: storage governance audit emits a versioned, fail-closed report.'


### PR DESCRIPTION
# Summary

Bounds the recurring storage governance task so it remains a reliable monitor on machines with hundreds of Git worktrees.

## Change

- Scheduled installation defaults to -Mode audit without per-worktree Git status/merge-base checks.
- Detailed worktree classification remains available explicitly with -IncludeWorktreeStatus.
- Adds a regression assertion to the focused storage governance test.
- Documents the distinction between quick recurring audit and detailed classification.

## Validation

- Focused storage governance test: PASS.
- Changed PowerShell files parse cleanly.
- Git diff check: PASS.

## Operational impact

This keeps recurring free-space/process/root monitoring bounded and fail-closed. It does not delete files or alter WSL; cleanup, deduplication, and detailed worktree classification remain explicit operator actions.