### PR TITLE
fix(governance): normalize coordination custody signatures

### DIFF
--- a/scripts/codex-global-coordination-client.mjs
+++ b/scripts/codex-global-coordination-client.mjs
@@ -30,8 +30,12 @@ export function sha256(value) {
 }
 
 export function hmac(secret, value) {
-  if (!String(secret || "").trim()) throw new Error("global coordination custody is unavailable");
-  return crypto.createHmac("sha256", String(secret)).update(value).digest("base64url");
+  // GitHub secret transport may preserve a terminal newline. The Worker key
+  // ring trims custody before verification, so clients must canonicalize the
+  // same way before signing or verifying responses.
+  const normalizedSecret = String(secret || "").trim();
+  if (!normalizedSecret) throw new Error("global coordination custody is unavailable");
+  return crypto.createHmac("sha256", normalizedSecret).update(value).digest("base64url");
 }
 
 export function newRequestNonce() {

--- a/scripts/tests/codex-global-coordination-client.test.mjs
+++ b/scripts/tests/codex-global-coordination-client.test.mjs
@@ -142,6 +142,27 @@ test("GitHub and mini-PC clients produce the same signed envelope contract", () 
   }).headers.authorization, "Bearer admin-secret");
 });
 
+test("secret transport whitespace does not change the signed envelope", () => {
+  const args = {
+    url: "https://coordination.example.test",
+    action: "check",
+    secret,
+    keyId: "active-v2",
+    proof: {
+      resource: "deploy:website:staging",
+      leaseId: "lease-0000000000000001",
+      fencingToken: 4,
+      intentDigest: "a".repeat(64),
+      owner: { provider: "github", missionId: "mission-1", threadId: "thread-1", actor: "actions" },
+    },
+    nonce: "w".repeat(32),
+    requestedAt: "2026-08-09T18:00:00.000Z",
+  };
+  const clean = buildAuthenticatedRequest(args);
+  const transported = buildAuthenticatedRequest({ ...args, secret: `\n ${secret} \r\n` });
+  assert.equal(transported.headers["x-skincos-coordination-request-signature"], clean.headers["x-skincos-coordination-request-signature"]);
+});
+
 test("response signatures cover the authority envelope and tampering fails closed", () => {
   const unsigned = { schemaVersion: 1, contractId: CONTRACT_ID, passed: true, accepted: true, reason: "lease-acquired" };
   const responseDigest = crypto.createHash("sha256").update(canonicalJson(unsigned)).digest("hex");


### PR DESCRIPTION
## Summary\n\n- normalize coordination HMAC custody before signing and response verification\n- keep client behavior aligned with the Worker key ring, which trims deployed custody\n- add a regression test for transport-added whitespace/newlines\n\n## Validation\n\n- 
ode --test scripts/tests/codex-global-coordination-client.test.mjs\n- 
ode --test ops/cloudflare/global-coordinator/index.test.mjs\n- 
ode --test scripts/tests/global-concurrency-governance-static.test.mjs\n\nThis closes the observed staging rotation failure where the atomic Worker version had all bindings but the signed gate returned 401.