### PR TITLE
fix(storage): cover all focal archive roots

### DIFF
--- a/docs/operations/storage-governance.md
+++ b/docs/operations/storage-governance.md
@@ -88,7 +88,8 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-skincos-st
 
 ## Release archives
 
-`dedupe-source-tars.ps1` hashes the bounded release/checkpoint roots and only
+`dedupe-source-tars.ps1` hashes the bounded release, checkpoint and snapshot
+roots and only
 considers exact SHA-256 and byte-size duplicates. With explicit hardlink mode,
 it preserves every original path, quarantines the duplicate transactionally,
 creates a hardlink to the canonical artifact, verifies the hash and link list,

--- a/ops/codex/storage-retention-policy.json
+++ b/ops/codex/storage-retention-policy.json
@@ -59,6 +59,9 @@
     "native-promotions",
     "releases",
     "checkpoints",
+    "native-source-release",
+    "livia-reel-frame-contract",
+    "mcp-readonly-gateway",
     "retired-worktrees",
     "backups",
     "recovered-worktree-artifacts"

--- a/scripts/tests/test-skincos-storage-governance.ps1
+++ b/scripts/tests/test-skincos-storage-governance.ps1
@@ -13,6 +13,11 @@ if ($document.schema_version -ne 1) { throw 'unexpected schema version' }
 if ($document.drive.device -ne 'C:') { throw 'drive snapshot missing' }
 if ($document.threshold_state -notin @('healthy','warning','high','critical','emergency')) { throw 'invalid threshold state' }
 if ($document.limitations.Count -lt 3) { throw 'safety limitations missing' }
+$policyDocument = Get-Content -LiteralPath $policy -Raw | ConvertFrom-Json
+$requiredFocalRoots = @('native-source-release', 'livia-reel-frame-contract', 'mcp-readonly-gateway')
+foreach ($root in $requiredFocalRoots) {
+    if ($policyDocument.protectedArtifactDirectories -notcontains $root) { throw "focal artifact root missing from policy: $root" }
+}
 $taskPreview = (& powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer -RepositoryRoot (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) -ScriptPath $script | Out-String) | ConvertFrom-Json
 if ($taskPreview.action -ne 'dry-run' -or $taskPreview.include_worktree_status) { throw 'scheduled audit must default to quick mode' }
 if (-not $taskPreview.include_focal_artifacts -or $taskPreview.arguments -notmatch '-IncludeFocalArtifacts') { throw 'scheduled audit must include focal artifact scan' }


### PR DESCRIPTION
# Summary

Extend the storage governance focal scan policy to cover the remaining known source archive roots: `native-source-release`, `livia-reel-frame-contract`, and `mcp-readonly-gateway`. This keeps the scheduled metadata scan aligned with all currently present `source.tar` producers without enabling deep hashing or worktree classification.

## Type of change
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [x] Docs updated (README, API refs, diagrams)
- [ ] Security review (CodeQL, gitleaks)
- [x] Performance impact measured

## Links
- Issue: storage governance continuation
- Design/ADR: `docs/operations/storage-governance.md`
- Migration steps: rematerialize the durable runtime after merge and rerun the scheduled audit

## Screenshots / Evidence
- Focused governance test: PASS
- Focal audit: 89 source archives, 20 workerd records, 8.1 seconds, zero actions