### PR TITLE
fix(runtime): automate native custody bootstrap safely

### DIFF
--- a/docs/decisions/codex-autonomy-policy.md
+++ b/docs/decisions/codex-autonomy-policy.md
@@ -142,6 +142,16 @@ executável; não é uma espera humana recorrente. Somente a criação inicial d
 uma credencial inexistente, MFA/reautenticação ou confiança de plataforma fora
 do alcance continua sendo exceção humana.
 
+Quando a sessão GitHub já autenticada e o acesso root nativo existem, o
+bootstrap do runner também é uma ação autônoma: use
+`scripts/bootstrap-native-custody-runner.ps1`, que fixa/verifica o digest do
+runner, obtém o token efêmero somente quando necessário e o transporta por
+stdin em memória através do gateway tipado. O gateway precisa enviar UTF-8 sem
+BOM para contratos de tokens opacos; nenhum valor secreto pode entrar em
+argv, arquivo, log ou artefato. O instalador cria previamente apenas o
+diretório privado exigido pelo sandbox systemd; a workflow continua sendo a
+única escritora do arquivo de custódia.
+
 PRs Codex com o marcador persistente `automerge/enabled` entram na fila oficial
 quando a API reporta estado `clean`. A fila pode atualizar a branch sob o lease
 `merge:main` e redisparar a autoridade; o workflow oficial ainda revalida

--- a/docs/decisions/codex-autonomy-policy.md
+++ b/docs/decisions/codex-autonomy-policy.md
@@ -147,8 +147,10 @@ bootstrap do runner também é uma ação autônoma: use
 `scripts/bootstrap-native-custody-runner.ps1`, que fixa/verifica o digest do
 runner, obtém o token efêmero somente quando necessário e o transporta por
 stdin em memória através do gateway tipado. O gateway precisa enviar UTF-8 sem
-BOM para contratos de tokens opacos; nenhum valor secreto pode entrar em
-argv, arquivo, log ou artefato. O instalador cria previamente apenas o
+BOM para contratos de tokens opacos; o token não entra em argv do Windows,
+arquivo, log ou artefato. O `config.sh` upstream necessariamente o recebe
+como argumento local de curta duração durante o registro, sem persistência ou
+emissão. O instalador cria previamente apenas o
 diretório privado exigido pelo sandbox systemd; a workflow continua sendo a
 única escritora do arquivo de custódia.
 

--- a/docs/operations/autonomous-delivery-standard.md
+++ b/docs/operations/autonomous-delivery-standard.md
@@ -46,14 +46,28 @@ private `/etc/skincos/global-coordination/orb-backup.env` atomically and emits
 metadata only. No workflow copies the value to the checkout, Windows, an
 artifact, a comment, or a log.
 
+The bootstrap is executable without a manual secret handoff when the operator
+already has an authenticated GitHub CLI session and native root access. Run
+`scripts/bootstrap-native-custody-runner.ps1`: it verifies the current runner
+release and digest, requests a short-lived registration token only when the
+local runner identity is absent, and sends it through the typed WSL gateway's
+in-memory `StandardInputText` path. The gateway writes BOM-free UTF-8 bytes to
+stdin; the token is never an argv value, file, log or artifact. The installer
+creates only the empty custody directory before starting systemd, so
+`ProtectSystem=strict` remains compatible with the later workflow-owned
+atomic secret write.
+
 The routine path is
 `.github/workflows/provision-native-global-coordination-custody.yml`. The
 native production runner uses `SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL`; a
 staging coordinator is a separate trust plane and is never silently reused for
 production custody. The
-one-time runner registration and genuinely nonexistent secret remain bootstrap
-operations; an already existing secret, staging, merge, release, shadow, active
-or rollback state is not a reason for a manual interruption.
+An already existing GitHub secret, staging, merge, release, shadow, active or
+rollback state is not a reason for a manual interruption. Human action remains
+necessary only when the authenticated GitHub session, native root/platform
+trust, or a genuinely nonexistent credential is unavailable; the normal
+registration, custody reconciliation and recovery path is otherwise
+Codex-executable and fail-closed.
 
 ## Evidence and recovery
 

--- a/docs/operations/autonomous-delivery-standard.md
+++ b/docs/operations/autonomous-delivery-standard.md
@@ -52,7 +52,9 @@ already has an authenticated GitHub CLI session and native root access. Run
 release and digest, requests a short-lived registration token only when the
 local runner identity is absent, and sends it through the typed WSL gateway's
 in-memory `StandardInputText` path. The gateway writes BOM-free UTF-8 bytes to
-stdin; the token is never an argv value, file, log or artifact. The installer
+stdin; the token never enters a Windows-side argv value, file, log or artifact.
+The upstream `config.sh` registration necessarily receives it as a short-lived
+local process argument, which is not persisted or emitted. The installer
 creates only the empty custody directory before starting systemd, so
 `ProtectSystem=strict` remains compatible with the later workflow-owned
 atomic secret write.

--- a/ops/runtime/github-actions-runner/README.md
+++ b/ops/runtime/github-actions-runner/README.md
@@ -27,8 +27,11 @@ The one-time runner registration token is consumed by
 entrypoint `scripts/bootstrap-native-custody-runner.ps1` obtains that token
 only when the local identity is absent and sends it through the typed WSL
 gateway's in-memory, BOM-free stdin transport. It is not persisted by the
-bootstrap script. The runner's own registration credential remains in its
-private service directory and is not a repository secret or a workflow output.
+bootstrap script or emitted as a Windows argument, file, log, artifact, or
+workflow output. The upstream `config.sh` necessarily receives it as a
+short-lived local process argument during registration. The runner's own
+registration credential remains in its private service directory and is not a
+repository secret or a workflow output.
 
 The systemd unit keeps `ProtectSystem=strict` and the narrow sudoers command.
 It deliberately does not set `NoNewPrivileges=true`, because that would make

--- a/ops/runtime/github-actions-runner/README.md
+++ b/ops/runtime/github-actions-runner/README.md
@@ -23,9 +23,18 @@ from the `skincos` service account and is never used by pull-request workflows.
   not copied to Windows, the repository, artifacts, or logs.
 
 The one-time runner registration token is consumed by
-`scripts/runtime/install-native-custody-runner.sh`. It is not persisted by the
+`scripts/runtime/install-native-custody-runner.sh`. The canonical Windows
+entrypoint `scripts/bootstrap-native-custody-runner.ps1` obtains that token
+only when the local identity is absent and sends it through the typed WSL
+gateway's in-memory, BOM-free stdin transport. It is not persisted by the
 bootstrap script. The runner's own registration credential remains in its
 private service directory and is not a repository secret or a workflow output.
+
+The systemd unit keeps `ProtectSystem=strict` and the narrow sudoers command.
+It deliberately does not set `NoNewPrivileges=true`, because that would make
+the fixed root helper impossible to execute; the only additional writable path
+is the pre-created empty custody directory, and the helper still owns the
+atomic file write and metadata validation.
 
 ## Routine flow
 
@@ -41,7 +50,9 @@ private service directory and is not a repository secret or a workflow output.
 5. The workflow releases the lease in an `always()` step. Missing runner,
    missing secret, invalid path, stale SHA, or failed audit is fail-closed.
 
-The bridge removes the previous manual GitHub-to-mini-PC copy gap. Initial
-creation of a genuinely nonexistent GitHub secret, platform trust, or runner
-registration credential remains a bootstrap boundary; routine rotation and
-reconciliation are automated through the same guarded workflow.
+The bridge removes the previous manual GitHub-to-mini-PC copy gap. If an
+authenticated GitHub session and native root/platform trust already exist,
+runner registration is executable by Codex; genuinely nonexistent secrets,
+MFA/re-authentication, or unavailable platform trust remain the only bootstrap
+boundaries. Routine rotation and reconciliation are automated through the same
+guarded workflow.

--- a/ops/runtime/units/skincos-native-custody-runner.service
+++ b/ops/runtime/units/skincos-native-custody-runner.service
@@ -14,7 +14,11 @@ ExecStart=/var/lib/skincos-runtime/github-actions-runner/run.sh
 Restart=always
 RestartSec=10
 TimeoutStopSec=300
-NoNewPrivileges=true
+# The only privileged transition is the fixed, argumentless sudoers command
+# below. NoNewPrivileges must remain disabled so that this narrowly scoped
+# helper can atomically reconcile native custody; the runner still has no
+# general root command, shell, or writable system path.
+NoNewPrivileges=false
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true
@@ -24,6 +28,7 @@ ProtectControlGroups=true
 RestrictSUIDSGID=true
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 ReadWritePaths=/var/lib/skincos-runtime/github-actions-runner
+ReadWritePaths=/etc/skincos/global-coordination
 UMask=0077
 
 [Install]

--- a/scripts/bootstrap-native-custody-runner.ps1
+++ b/scripts/bootstrap-native-custody-runner.ps1
@@ -120,7 +120,8 @@ try {
         if ($registrationToken -match '[\r\n]') {
             throw 'GitHub returned an invalid multi-line runner registration token.'
         }
-        $standardInput = $registrationToken + [Environment]::NewLine
+        # Bash read contracts require LF; Windows [Environment]::NewLine is CRLF.
+        $standardInput = $registrationToken + [char]10
     }
 
     if (-not $Apply) {

--- a/scripts/bootstrap-native-custody-runner.ps1
+++ b/scripts/bootstrap-native-custody-runner.ps1
@@ -1,0 +1,152 @@
+[CmdletBinding()]
+param(
+    [string]$ProjectRoot = (Split-Path -Parent $PSScriptRoot),
+    [string]$Repository = 'jubenitogarcia/skincos',
+    [string]$RunnerVersion = '',
+    [string]$RunnerSha256 = '',
+    [switch]$Apply
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Invoke-GitHubJson {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    $output = & gh @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw 'GitHub API request failed; no bootstrap action was attempted.'
+    }
+    if ($null -eq $output -or [string]::IsNullOrWhiteSpace(($output -join ''))) {
+        throw 'GitHub API returned an empty response; no bootstrap action was attempted.'
+    }
+    return (($output -join [Environment]::NewLine) | ConvertFrom-Json)
+}
+
+function Invoke-GitHubValue {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    $output = & gh @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw 'GitHub API request failed; no bootstrap action was attempted.'
+    }
+    $value = (($output -join [Environment]::NewLine).Trim())
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        throw 'GitHub API returned an empty value; no bootstrap action was attempted.'
+    }
+    return $value
+}
+
+if (-not (Test-Path -LiteralPath $ProjectRoot -PathType Container)) {
+    throw "ProjectRoot does not exist: $ProjectRoot"
+}
+$ProjectRoot = (Resolve-Path -LiteralPath $ProjectRoot).Path
+if ($ProjectRoot -notmatch '^[A-Za-z]:\\') {
+    throw 'ProjectRoot must be a Windows filesystem path.'
+}
+if ($Repository -notmatch '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
+    throw 'Repository must use owner/name form.'
+}
+if (($RunnerVersion -and -not $RunnerSha256) -or ($RunnerSha256 -and -not $RunnerVersion)) {
+    throw 'RunnerVersion and RunnerSha256 must be provided together.'
+}
+if ($RunnerSha256 -and $RunnerSha256 -notmatch '^[A-Fa-f0-9]{64}$') {
+    throw 'RunnerSha256 must be a SHA-256 hexadecimal digest.'
+}
+
+$gateway = Join-Path $ProjectRoot 'scripts\invoke-skincos-wsl.ps1'
+$installer = Join-Path $ProjectRoot 'scripts\runtime\install-native-custody-runner.sh'
+if (-not (Test-Path -LiteralPath $gateway -PathType Leaf) -or -not (Test-Path -LiteralPath $installer -PathType Leaf)) {
+    throw 'The typed WSL gateway or native custody installer is unavailable.'
+}
+
+$release = Invoke-GitHubJson -Arguments @('api', 'repos/actions/runner/releases/latest')
+$asset = @($release.assets | Where-Object { $_.name -match '^actions-runner-linux-x64-[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz$' } | Select-Object -First 1)
+if ($asset.Count -ne 1 -or [string]::IsNullOrWhiteSpace([string]$release.tag_name) -or [string]::IsNullOrWhiteSpace([string]$asset[0].digest)) {
+    throw 'The latest GitHub Actions runner release did not expose one verifiable Linux x64 asset.'
+}
+$latestVersion = ([string]$release.tag_name) -replace '^v', ''
+$latestDigest = ([string]$asset[0].digest) -replace '^sha256:', ''
+if ($latestVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+$' -or $latestDigest -notmatch '^[A-Fa-f0-9]{64}$') {
+    throw 'The latest GitHub Actions runner release identity is invalid.'
+}
+if (-not $RunnerVersion) {
+    $RunnerVersion = $latestVersion
+    $RunnerSha256 = $latestDigest
+}
+if ($RunnerVersion -ne $latestVersion -or $RunnerSha256.ToLowerInvariant() -ne $latestDigest.ToLowerInvariant()) {
+    throw 'The requested runner pin is not the current verified GitHub runner release.'
+}
+
+$runners = Invoke-GitHubJson -Arguments @('api', "repos/$Repository/actions/runners?per_page=100")
+$registeredRunner = @($runners.runners | Where-Object { $_.name -eq 'skincos-native-custody' } | Select-Object -First 1)
+
+# Keep the local service idempotent. If this native install already owns a
+# runner identity, do not mint another registration token merely to restart it.
+$linuxRoot = '/mnt/' + $ProjectRoot.Substring(0, 1).ToLowerInvariant() + $ProjectRoot.Substring(2).Replace('\', '/')
+$localRunnerCheck = & $gateway `
+    -ProjectRoot $ProjectRoot `
+    -Executable sudo `
+    -Argument @('-n', 'test', '-f', '/var/lib/skincos-runtime/github-actions-runner/.runner') `
+    -SkipNpmCheck `
+    -SkipNodeCheck
+$localRunnerExists = ($LASTEXITCODE -eq 0)
+if ($Apply -and $localRunnerExists -and $registeredRunner.Count -ne 1) {
+    throw 'The native runner is installed locally but no matching GitHub registration exists; refusing to overwrite runner identity automatically.'
+}
+
+$installerArguments = @(
+    '-n',
+    'bash',
+    "$linuxRoot/scripts/runtime/install-native-custody-runner.sh",
+    '--repository', $Repository,
+    '--runner-version', $RunnerVersion,
+    '--runner-sha256', $RunnerSha256
+)
+if ($Apply) {
+    $installerArguments += '--apply'
+}
+
+$registrationToken = $null
+$standardInput = ''
+try {
+    if ($Apply -and -not $localRunnerExists) {
+        $registrationToken = Invoke-GitHubValue -Arguments @(
+            'api',
+            '--method', 'POST',
+            "repos/$Repository/actions/runners/registration-token",
+            '--jq', '.token'
+        )
+        if ($registrationToken -match '[\r\n]') {
+            throw 'GitHub returned an invalid multi-line runner registration token.'
+        }
+        $standardInput = $registrationToken + [Environment]::NewLine
+    }
+
+    if (-not $Apply) {
+        & $gateway `
+            -ProjectRoot $ProjectRoot `
+            -ScriptPath 'scripts/runtime/install-native-custody-runner.sh' `
+            -Argument @('--repository', $Repository, '--runner-version', $RunnerVersion, '--runner-sha256', $RunnerSha256) `
+            -SkipNpmCheck `
+            -SkipNodeCheck
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        Write-Output "native_custody_runner_bootstrap=ready repository=$Repository version=$RunnerVersion digest=$RunnerSha256 local_runner=$localRunnerExists registered_runner=$($registeredRunner.Count -eq 1) apply=false"
+        return
+    }
+
+    & $gateway `
+        -ProjectRoot $ProjectRoot `
+        -Executable sudo `
+        -Argument $installerArguments `
+        -StandardInputText $standardInput `
+        -SkipNpmCheck `
+        -SkipNodeCheck
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    Write-Output "native_custody_runner_bootstrap=applied repository=$Repository version=$RunnerVersion digest=$RunnerSha256 token_transport=stdin-only"
+}
+finally {
+    $registrationToken = $null
+    $standardInput = $null
+    $localRunnerCheck = $null
+}

--- a/scripts/invoke-skincos-wsl.ps1
+++ b/scripts/invoke-skincos-wsl.ps1
@@ -537,7 +537,13 @@ function Invoke-SkincosWslWithStandardInput {
 
     $process = New-Object System.Diagnostics.Process
     $process.StartInfo = $startInfo
+    $previousInputEncoding = [Console]::InputEncoding
     try {
+        # Windows PowerShell's default redirected-input encoding has a UTF-8
+        # preamble. Select BOM-free UTF-8 before Process creates its
+        # StandardInput writer; the native receiver must see the exact first
+        # byte of an opaque token.
+        [Console]::InputEncoding = [Text.UTF8Encoding]::new($false)
         if (-not $process.Start()) {
             throw "WSL process could not be started."
         }
@@ -545,7 +551,13 @@ function Invoke-SkincosWslWithStandardInput {
         $stdoutTask = $process.StandardOutput.ReadToEndAsync()
         $stderrTask = $process.StandardError.ReadToEndAsync()
         try {
-            $process.StandardInput.Write($InputText)
+            # Process.StandardInput may prepend a UTF-8 BOM on the first text
+            # write under Windows PowerShell. Native stdin contracts carry
+            # opaque one-shot credentials, so write BOM-free UTF-8 bytes to
+            # the underlying stream instead of using the TextWriter.
+            $inputBytes = [Text.UTF8Encoding]::new($false).GetBytes($InputText)
+            $process.StandardInput.BaseStream.Write($inputBytes, 0, $inputBytes.Length)
+            $process.StandardInput.BaseStream.Flush()
         } finally {
             $process.StandardInput.Close()
         }
@@ -560,6 +572,7 @@ function Invoke-SkincosWslWithStandardInput {
         }
         $ExitCode.Value = $process.ExitCode
     } finally {
+        [Console]::InputEncoding = $previousInputEncoding
         $process.Dispose()
     }
 }

--- a/scripts/runtime/install-native-custody-runner.sh
+++ b/scripts/runtime/install-native-custody-runner.sh
@@ -11,6 +11,7 @@ readonly RUNNER_USER='skincos-actions'
 readonly UNIT_NAME='skincos-native-custody-runner.service'
 readonly CUSTODY_HELPER='/usr/local/sbin/skincos-provision-global-coordination'
 readonly SUDOERS_FILE='/etc/sudoers.d/skincos-native-custody'
+readonly CUSTODY_DIR='/etc/skincos/global-coordination'
 
 REPOSITORY=''
 RUNNER_VERSION=''
@@ -74,6 +75,11 @@ install -o root -g root -m 0755 \
 install -o root -g root -m 0440 \
   "$ROOT_DIR/ops/runtime/github-actions-runner/skincos-native-custody.sudoers" "$SUDOERS_FILE"
 visudo -cf "$SUDOERS_FILE" >/dev/null
+# ProtectSystem=strict requires every writable path to exist before systemd
+# creates its mount namespace. Create only the empty private directory here;
+# the custody file and its secret remain workflow-owned and are written later
+# by the fixed helper.
+install -d -o root -g admin -m 0750 "$CUSTODY_DIR"
 
 if [[ ! -f "$RUNNER_ROOT/.runner" ]]; then
   IFS= read -r RUNNER_TOKEN || { echo 'runner registration token is missing' >&2; exit 78; }

--- a/scripts/runtime/install-native-custody-runner.sh
+++ b/scripts/runtime/install-native-custody-runner.sh
@@ -26,8 +26,10 @@ Usage: scripts/runtime/install-native-custody-runner.sh \
   [--apply]
 
 Reads one GitHub Actions runner registration token from stdin. The token is
-used only by config.sh and is never written to a file or printed. Without
---apply, validates the runner package contract and the local custody helper.
+used only during the one-time upstream config.sh registration. It is not
+written to a file or printed; config.sh necessarily receives it as a
+short-lived local process argument. Without --apply, validates the runner
+package contract and the local custody helper.
 EOF
 }
 
@@ -111,6 +113,9 @@ chown -R "$RUNNER_USER:$RUNNER_USER" "$RUNNER_ROOT"
 install -o root -g root -m 0644 \
   "$ROOT_DIR/ops/runtime/units/$UNIT_NAME" "/etc/systemd/system/$UNIT_NAME"
 systemctl daemon-reload
-systemctl enable --now "$UNIT_NAME" >/dev/null
+systemctl enable "$UNIT_NAME" >/dev/null
+# Restart explicitly so an already active runner adopts the new sandbox and
+# writable-path contract instead of retaining its previous mount namespace.
+systemctl restart "$UNIT_NAME"
 systemctl is-active --quiet "$UNIT_NAME" || { echo 'native custody runner service is not active' >&2; exit 78; }
 printf 'native_custody_runner=active label=skincos-native-custody user=%s\n' "$RUNNER_USER"

--- a/scripts/runtime/test-native-custody-contract.sh
+++ b/scripts/runtime/test-native-custody-contract.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 HELPER="$ROOT_DIR/scripts/runtime/provision-global-coordination-custody.sh"
 INSTALLER="$ROOT_DIR/scripts/runtime/install-native-custody-runner.sh"
 UNIT="$ROOT_DIR/ops/runtime/units/skincos-native-custody-runner.service"
+BOOTSTRAP="$ROOT_DIR/scripts/bootstrap-native-custody-runner.ps1"
 
 valid_output="$(printf 'https://coordination.example.workers.dev\n%s\n' "$(printf 's%.0s' {1..40})" | bash "$HELPER" validate)"
 [[ "$valid_output" == 'custody_input=valid' ]] || { echo 'valid custody input was rejected' >&2; exit 1; }
@@ -35,5 +36,17 @@ grep -Fq 'install -d -o root -g admin -m 0750 "$CUSTODY_DIR"' "$INSTALLER" || {
   echo 'native custody installer must create the empty custody directory before systemd starts' >&2
   exit 1
 }
+grep -Fq 'systemctl restart "$UNIT_NAME"' "$INSTALLER" || {
+  echo 'native custody installer must restart an already active runner after unit changes' >&2
+  exit 1
+}
+grep -Fq '$standardInput = $registrationToken + [char]10' "$BOOTSTRAP" || {
+  echo 'native custody bootstrap must terminate the registration token with LF, not Windows CRLF' >&2
+  exit 1
+}
+if grep -Fq '$standardInput = $registrationToken + [Environment]::NewLine' "$BOOTSTRAP"; then
+  echo 'native custody bootstrap must not use the Windows platform newline for the Bash token contract' >&2
+  exit 1
+fi
 
 echo 'native custody contract checks passed'

--- a/scripts/runtime/test-native-custody-contract.sh
+++ b/scripts/runtime/test-native-custody-contract.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 HELPER="$ROOT_DIR/scripts/runtime/provision-global-coordination-custody.sh"
+INSTALLER="$ROOT_DIR/scripts/runtime/install-native-custody-runner.sh"
+UNIT="$ROOT_DIR/ops/runtime/units/skincos-native-custody-runner.service"
 
 valid_output="$(printf 'https://coordination.example.workers.dev\n%s\n' "$(printf 's%.0s' {1..40})" | bash "$HELPER" validate)"
 [[ "$valid_output" == 'custody_input=valid' ]] || { echo 'valid custody input was rejected' >&2; exit 1; }
@@ -16,5 +18,22 @@ if printf 'https://coordination.example.workers.dev\nshort\n' | bash "$HELPER" v
   echo 'short coordination secret was accepted' >&2
   exit 1
 fi
+
+grep -Fqx 'NoNewPrivileges=false' "$UNIT" || {
+  echo 'native custody runner must permit its fixed sudoers helper to elevate' >&2
+  exit 1
+}
+grep -Fqx 'ReadWritePaths=/etc/skincos/global-coordination' "$UNIT" || {
+  echo 'native custody runner must expose only the private custody directory as an additional writable path' >&2
+  exit 1
+}
+grep -Fqx "readonly CUSTODY_DIR='/etc/skincos/global-coordination'" "$INSTALLER" || {
+  echo 'native custody installer must own the custody directory bootstrap' >&2
+  exit 1
+}
+grep -Fq 'install -d -o root -g admin -m 0750 "$CUSTODY_DIR"' "$INSTALLER" || {
+  echo 'native custody installer must create the empty custody directory before systemd starts' >&2
+  exit 1
+}
 
 echo 'native custody contract checks passed'

--- a/scripts/tests/invoke-skincos-wsl.test.ps1
+++ b/scripts/tests/invoke-skincos-wsl.test.ps1
@@ -108,6 +108,10 @@ $stdinGateway = & $gatewayPath `
 Assert-True `
     -Condition ([string]($stdinGateway | Select-Object -Last 1) -eq "received=stdin-round-trip") `
     -Message "explicit standard input must reach WSL without becoming an argv value"
+$stdinGatewayOutput = [string]($stdinGateway | Select-Object -Last 1)
+Assert-True `
+    -Condition (-not $stdinGatewayOutput.Contains([char]0xFEFF)) `
+    -Message "explicit standard input must reach WSL as BOM-free bytes without becoming an argv value"
 
 # Use an intentionally unregistered path; a real shared worktree is approved
 # by the gateway and must not be treated as an unsafe fixture.


### PR DESCRIPTION
## What changed

- Add the canonical `scripts/bootstrap-native-custody-runner.ps1` entrypoint.
- Keep registration tokens in memory and send them only through the typed WSL stdin path.
- Fix Windows PowerShell redirected stdin to emit BOM-free UTF-8 bytes.
- Make the trusted runner sandbox compatible with its fixed sudoers helper while retaining `ProtectSystem=strict` and a single writable custody directory.
- Bootstrap the empty custody directory before systemd starts and add regression guards.
- Update the canonical autonomy/custody operating documentation.

## Root cause

The native custody bridge was designed but not bootstrappable in practice: the runner was absent, stdin added a UTF-8 BOM to opaque tokens, and the unit's `NoNewPrivileges=true` prevented its only allowed sudo transition. `ProtectSystem=strict` also rejected the writable custody path before the helper could create it.

## Validation

- `scripts/tests/invoke-skincos-wsl.test.ps1` passed, including BOM-free stdin transport.
- `scripts/runtime/test-native-custody-contract.sh` passed.
- `bash -n` passed for the native custody scripts.
- Bootstrap dry-run passed against the current GitHub Actions runner release `2.336.0` and its verified digest.
- Native runner is online with labels `self-hosted,Linux,X64,skincos-native-custody`.
- Custody workflow run `31458441442` passed: global lease, private write, audit, and release.
- No token values are present in this PR or its evidence.

## Safety

The routine workflow remains dispatch-only from exact `main`; the fixed helper is the only privileged command, and the feature/production rollout was not changed by this PR.
