### PR TITLE
fix(crm): upload production smoke evidence

### DIFF
--- a/.github/workflows/insumos-production-users-smoke.yml
+++ b/.github/workflows/insumos-production-users-smoke.yml
@@ -81,6 +81,6 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: insumos-production-users-smoke-${{ github.run_id }}
-          path: output/playwright/insumos-users-production-*.json
+          path: crm/output/playwright/insumos-users-production-*.json
           if-no-files-found: ignore
           retention-days: 7


### PR DESCRIPTION
## Summary
- point the authenticated production smoke upload at the directory where the harness writes its sanitized JSON
- preserve the read-only smoke behavior and seven-day retention

## Validation
- git diff --check
- node .github/scripts/validate-github-governance.mjs
- node .github/scripts/validate-cloudflare-single-writer.mjs