### PR TITLE
fix(ponto): unblock governed release gates

### DIFF
--- a/.github/scripts/ponto-environment-protection-workflow.test.mjs
+++ b/.github/scripts/ponto-environment-protection-workflow.test.mjs
@@ -135,6 +135,19 @@ test("ordinary and watchdog rollback revalidate governance and use dedicated int
   }
 });
 
+test("staging cleanup does not dispatch a transition before release identity exists", () => {
+  const source = workflow("ponto-progressive-release.yml");
+  const cleanup = source.indexOf(
+    "- name: Restore staging Ponto to maintenance after the journey",
+  );
+  assert.ok(cleanup >= 0);
+  const cleanupBlock = source.slice(cleanup, source.indexOf("\n      - name:", cleanup + 1));
+  assert.match(
+    cleanupBlock,
+    /if: \$\{\{ always\(\) && inputs\.stage == 'staging' && steps\.release_identity\.outcome == 'success' \}\}/,
+  );
+});
+
 test("emergency broker environments allow only the implicit protected-branch rule", () => {
   const source = workflow("ponto-progressive-release.yml");
   const start = source.indexOf(

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -1282,7 +1282,7 @@ jobs:
           run_id="$(node -e "process.stdout.write(require(process.argv[1]).runId)" "$PONTO_ARTIFACT_DIR/runs/staging-journey.json")"
           gh run download "$run_id" --repo "$GITHUB_REPOSITORY" --name "timekeeping-staging-journey-${RELEASE_SHA}" --dir "$PONTO_ARTIFACT_DIR/staging-slo"
       - name: Restore staging Ponto to maintenance after the journey
-        if: ${{ always() && inputs.stage == 'staging' }}
+        if: ${{ always() && inputs.stage == 'staging' && steps.release_identity.outcome == 'success' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/orb/engine/.env.example
+++ b/orb/engine/.env.example
@@ -50,7 +50,7 @@ META_ADS_REPORT_COMPAT_EXPORT_TARGET=google_sheets_optional
 
 # Campaign Creative Creator executor (keep LIVE disabled unless explicitly governed)
 CCG_EXECUTOR_BASE_URL=http://127.0.0.1:8790
-CCG_EXECUTOR_AUTH_TOKEN=
+CCG_EXECUTOR_AUTH_TOKEN= # gitleaks:allow - intentionally empty example value; use a private overlay for governed runs
 CCG_EXECUTOR_LIVE_ENABLED=0
 CCG_EXECUTOR_LISTEN_ADDRESS=127.0.0.1
 CCG_EXECUTOR_PORT=8790

--- a/orb/engine/tests/campaign-creative-creator-continuous.test.js
+++ b/orb/engine/tests/campaign-creative-creator-continuous.test.js
@@ -515,7 +515,7 @@ test('CCG-99 classifies executor 429 and resumes from its checkpoint idempotentl
     content_id: 'content-ccg99-executor',
     campaign_id: 'campaign-ccg99-executor',
     request_hash: 'request-ccg99-executor',
-    idempotency_key: 'idempotency-ccg99-executor',
+    idempotency_key: 'idempotency-ccg99-executor', // gitleaks:allow - deterministic non-secret test fixture
   };
   const raw = {
     ...ids,


### PR DESCRIPTION
## Summary
- allow only the two intentional non-secret CCG examples that Gitleaks flagged
- skip staging cleanup dispatch when release identity was never established
- add a focused workflow regression assertion

## Root cause
The canonical staging run on the current main SHA was blocked by Gitleaks false positives in an empty .env.example setting and a deterministic test fixture. Its failure path also attempted a module transition without a release identity, producing a secondary cleanup error.

## Validation
- node --test .github/scripts/ponto-environment-protection-workflow.test.mjs
- node orb/engine/tests/campaign-creative-creator-continuous.test.js
- npm run codex:deploy-topology:test
- git diff --check
