### PR TITLE
fix(ponto): carry release identity through module transitions

### DIFF
--- a/.github/scripts/ponto-environment-protection-workflow.test.mjs
+++ b/.github/scripts/ponto-environment-protection-workflow.test.mjs
@@ -148,6 +148,22 @@ test("staging cleanup does not dispatch a transition before release identity exi
   );
 });
 
+test("every coordinator module transition carries the immutable release SHA", () => {
+  const source = workflow("ponto-progressive-release.yml");
+  for (const marker of [
+    "Put Ponto in maintenance before staging or live mutation",
+    "Activate exact staging release for the synthetic journey",
+    "Restore staging Ponto to maintenance after the journey",
+    "Open the approved live cohort or activate production",
+  ]) {
+    const start = source.indexOf(`- name: ${marker}`);
+    assert.ok(start >= 0, marker);
+    const end = source.indexOf("\n      - name:", start + 1);
+    const block = source.slice(start, end === -1 ? source.length : end);
+    assert.match(block, /release_sha: process\.env\.RELEASE_SHA/, marker);
+  }
+});
+
 test("emergency broker environments allow only the implicit protected-branch rule", () => {
   const source = workflow("ponto-progressive-release.yml");
   const start = source.indexOf(

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -943,6 +943,7 @@ jobs:
             module: "timekeeping",
             target: process.env.STAGE === "staging" ? "staging" : "production",
             state: "maintenance",
+            release_sha: process.env.RELEASE_SHA,
             message: "Ponto release in progress.",
             orchestrator_run_id: process.env.GITHUB_RUN_ID,
           }));
@@ -1287,7 +1288,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           node - "$RUNNER_TEMP/module-staging-restore.json" <<'NODE'
-          const fs = require("fs"); fs.writeFileSync(process.argv[2], JSON.stringify({ module: "timekeeping", target: "staging", state: "maintenance", message: "Staging Ponto journey complete; awaiting the next governed release.", orchestrator_run_id: process.env.GITHUB_RUN_ID }));
+          const fs = require("fs"); fs.writeFileSync(process.argv[2], JSON.stringify({ module: "timekeeping", target: "staging", state: "maintenance", release_sha: process.env.RELEASE_SHA, message: "Staging Ponto journey complete; awaiting the next governed release.", orchestrator_run_id: process.env.GITHUB_RUN_ID }));
           NODE
           node .github/scripts/ponto-dispatch-workflow.mjs module-availability.yml "$GITHUB_RUN_ID" "$RUNNER_TEMP/module-staging-restore.json" "$PONTO_ARTIFACT_DIR/runs/module-staging-restore.json"
           run_id="$(node -e "process.stdout.write(require(process.argv[1]).runId)" "$PONTO_ARTIFACT_DIR/runs/module-staging-restore.json")"


### PR DESCRIPTION
## Summary
- include the immutable release_sha in coordinator maintenance and staging-restore payloads
- assert that all coordinator module transitions carry the release identity

## Root cause
The staging coordinator reached the pre-mutation maintenance step, but module-availability rejected its child because the generated payload omitted release_sha. No candidate or availability mutation was performed; the existing recovery path kept staging fail-closed.

## Validation
- node --test .github/scripts/ponto-environment-protection-workflow.test.mjs
- npm run codex:deploy-topology:test
- git diff --check
