### PR TITLE
fix(ponto): checkout before module coordination action

### DIFF
--- a/.github/scripts/ponto-module-availability-workflow.test.mjs
+++ b/.github/scripts/ponto-module-availability-workflow.test.mjs
@@ -16,6 +16,16 @@ const setState = workflow.slice(setStateStart, emergencyStart);
 
 test("Ponto control-plane mutation remains protected and GitHub-hosted without changing Finance", () => {
   assert.ok(setStateStart >= 0 && setStateStart < emergencyStart);
+  assert.match(
+    setState,
+    /- name: Checkout trusted Ponto custody guard\n\s+uses: actions\/checkout@[0-9a-f]+/,
+  );
+  const checkoutStep = setState.indexOf("      - name: Checkout trusted Ponto custody guard");
+  const coordinationAction = setState.indexOf(
+    "        uses: ./.github/actions/global-coordination-check",
+    checkoutStep,
+  );
+  assert.ok(checkoutStep >= 0 && coordinationAction > checkoutStep);
   assert.match(setState, /runs-on: ubuntu-latest/);
   assert.match(setState, /environment: \$\{\{ inputs\.target \}\}/);
   assert.match(setState, /CLOUDFLARE_API_TOKEN: \$\{\{ secrets\.CLOUDFLARE_API_TOKEN \}\}/);

--- a/.github/workflows/module-availability.yml
+++ b/.github/workflows/module-availability.yml
@@ -163,7 +163,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout trusted Ponto custody guard
-        if: ${{ inputs.orchestrator_run_id != '' && contains(fromJSON('["canary","active"]'), inputs.state) }}
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
         with:
           ref: ${{ github.sha }}
@@ -223,7 +222,6 @@ jobs:
             echo "NAMESPACE_ID=$NAMESPACE_ID"
             echo "OPPOSITE_NAMESPACE_ID=$OPPOSITE_NAMESPACE_ID"
           } >> "$GITHUB_ENV"
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
       - name: Attest exact Ponto module-control identity before any state mutation
         if: ${{ inputs.module == 'timekeeping' }}
         env:


### PR DESCRIPTION
## Summary
- checkout the trusted workflow revision before invoking the local global-coordination-check action in module-availability
- remove the redundant later checkout
- add a structural regression assertion for the ordering

## Validation
- node --test .github/scripts/ponto-module-availability-workflow.test.mjs
- npm run codex:deploy-topology:test
- git diff --check

This unblocks the governed Ponto release path observed in failed run 31489608456, where set-state could not find .github/actions/global-coordination-check.