### PR TITLE
feat(social): implement Influencer Intelligence provider router

### DIFF
--- a/.github/workflows/architecture-governance.yml
+++ b/.github/workflows/architecture-governance.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Validate domain import boundaries
         run: node .github/scripts/validate-domain-boundaries.mjs
       - name: Test Influencer Intelligence contract boundary
-        run: node --test social/influencer-intelligence/tests/contracts.test.mjs social/influencer-intelligence/tests/registry.test.mjs social/influencer-intelligence/tests/providers.test.mjs social/influencer-intelligence/tests/architecture.test.mjs social/influencer-intelligence/tests/data-model.test.mjs
+        run: node --test social/influencer-intelligence/tests/contracts.test.mjs social/influencer-intelligence/tests/registry.test.mjs social/influencer-intelligence/tests/providers.test.mjs social/influencer-intelligence/tests/provider-router-contract.test.mjs social/influencer-intelligence/tests/architecture.test.mjs social/influencer-intelligence/tests/data-model.test.mjs
       - name: Validate reproducible staging manifest
         run: node .github/scripts/validate-staging-manifest.mjs
       - name: Validate staging bootstrap safety guards

--- a/docs/decisions/adr-influencer-intelligence-architecture.md
+++ b/docs/decisions/adr-influencer-intelligence-architecture.md
@@ -85,27 +85,35 @@ actual deployable surface to govern.
 
 ## 4. Provider interface
 
-The interface is a logical contract, not a new provider implementation:
+The interface is a logical contract implemented by the bounded
+`provider-contracts.mjs`/`.d.ts` boundary and the injected adapters:
 
 ```text
 ProviderAdapter {
   id: ProviderId
   officialFirst: boolean
   capabilities: ReadOnlyCapability[]
-  collect(request: ProviderRequest): Promise<ProviderResult>
+  resolve_creator(request, context): Promise<ProviderResult>
+  get_profile(request, context): Promise<ProviderResult>
+  get_recent_media(request, context): Promise<ProviderResult>
+  get_media_metrics(request, context): Promise<ProviderResult>
+  get_comments_sample(request, context): Promise<ProviderResult>
+  get_profile_metrics(request, context): Promise<ProviderResult>
 }
 ```
 
-`ProviderRequest` contains only an opaque `creatorKey`, optional approved
-canonical handle, requested normalized fields, observation/retrieval
-timestamps, time window, and correlation id. It does not contain a raw
-provider account reference, credential material, session material, arbitrary
-query, engagement instruction, or publication instruction.
+`ProviderRequest` contains an operation, an opaque `creatorKey` or approved
+canonical handle according to that operation, bounded normalized fields,
+observation/retrieval timestamps, an optional time window, and a correlation
+id. It does not contain a raw provider account reference, credential material,
+session material, arbitrary query, engagement instruction, or publication
+instruction.
 
-`ProviderResult` is either `collected` or `unavailable` and contains the
-provider id, provider adapter version, bounded scalar observations, and
-provenance. It never contains a raw provider object, direct contact field,
-raw comment text, media binary, credential, or session.
+`ProviderResult` is either `ok` or `unavailable` and contains the provider id,
+retrieval timestamp, `observed`/`derived`/`inferred` classification, freshness,
+limitations, bounded provider-specific evidence, and operation-specific data.
+Unavailable data is `null`; the result never contains a raw provider object,
+direct contact field, raw comment text, media binary, credential, or session.
 
 The v1 provider allowlist and order are closed:
 
@@ -117,12 +125,13 @@ The v1 provider allowlist and order are closed:
    measured coverage/permission gap, privacy review, cost/risk review, and a
    separate contract/PR.
 
-The only fallback reason codes in v1 are
-`provider_unavailable`, `permission_gap`, `coverage_gap`, and `timeout`.
-`policy_block`, `invalid_response`, and unclassified transport failures fail
-closed and do not trigger a fallback. A provider response with a missing or
-invalid metric is an explicit unavailable observation, never a fabricated
-zero.
+The fallback reason codes are `provider_unavailable`, `permission_gap`,
+`coverage_gap`, `timeout`, `circuit_open`, and `retry_exhausted`.
+Retries are bounded and limited to safe transient transport/timeout classes;
+failure state is isolated by provider and operation. `policy_block`,
+`invalid_response`, and unclassified transport failures fail closed and do not
+trigger a fallback. A provider response with a missing or invalid metric is an
+explicit unavailable observation, never a fabricated zero.
 
 The M2 provider boundary already implements this injected-transport shape for
 synthetic tests. The architecture PR adds no real transport, HTTP client,

--- a/social/influencer-intelligence/README.md
+++ b/social/influencer-intelligence/README.md
@@ -64,29 +64,36 @@ the artifact is the source-controlled schema proposal only.
 
 ## M2 decision: official-first provider router
 
-M2 adds [`provider-router.mjs`](./provider-router.mjs) and the two explicit
-adapters under [`providers/`](./providers/). The router has a closed provider
-allowlist and requires `meta-graph` to be the first configured provider. It
-falls back to `instagrapi` only for explicit gap codes
-(`provider_unavailable`, `permission_gap`, `coverage_gap`, or `timeout`).
-Invalid responses, policy blocks, and unclassified transport errors fail
-closed and do not trigger fallback.
+The M2 baseline adds [`provider-router.mjs`](./provider-router.mjs) and the two
+explicit adapters under [`providers/`](./providers/). The router requires
+`meta-graph` to be first and falls back to `instagrapi` only for explicit gap
+codes (`provider_unavailable`, `permission_gap`, `coverage_gap`, `timeout`,
+`circuit_open`, or `retry_exhausted`). Invalid responses, policy blocks, and
+unclassified transport errors fail closed and do not trigger fallback.
 
-Both adapters accept an injected `readProfile` function. The function receives
-an immutable read-only request and must return only the bounded projection
-`handle`, `followersCount`, and `mediaCount`; raw Graph/instagrapi payloads,
-credentials, sessions, comments, media, and contact fields never enter the
-normalized provider contract. Every returned metric is `observed` or explicit
-`unavailable`, then passes through the versioned M0 snapshot contract.
+The provider-router extension defines the typed operations
+`resolve_creator`, `get_profile`, `get_recent_media`, `get_media_metrics`,
+`get_comments_sample`, and `get_profile_metrics`. Every result is a bounded
+envelope carrying `provider`, `retrieved_at`, `data_classification`,
+`freshness`, `limitations`, and provider-specific evidence. Missing coverage is
+returned as `unavailable` with `data: null`; the router never substitutes or
+invents metrics. Adapters receive injected read-only transports and expose no
+follow, like, DM, post, session, credential, or raw-payload surface.
 
-M2 is merged as PR #1305. The Meta adapter is a boundary around the existing
-official CRM integration, not a second HTTP client. The instagrapi adapter is a
-narrow boundary around
-the existing `social/instagram` read path, not a new scraper or session
-implementation. M2 uses synthetic transports only: it does not call Graph,
-instagrapi, Token Vault, PostgreSQL, Orb, or any runtime endpoint. A future
-transport must establish a separate read-only analytics allowlist and Token
-Vault custody before it can be connected.
+Retries are bounded to safe transient transport/timeout classes, and circuit
+state is isolated by provider and operation. Future external providers are
+interfaces only until they are explicitly enabled and allowlisted after a
+measured gap review. No new scraper, Instaloader path, or duplicate instagrapi
+implementation is introduced.
+
+The original M2 boundary is merged as PR #1305. The Meta adapter remains a
+boundary around the existing official CRM integration, not a second HTTP
+client; the instagrapi adapter remains a narrow boundary around the existing
+`social/instagram` read path. This milestone continues to use synthetic,
+injected transports only: it does not call Graph, instagrapi, Token Vault,
+PostgreSQL, Orb, or any runtime endpoint. A future transport must establish a
+separate read-only analytics allowlist and Token Vault custody before it can be
+connected.
 
 ## Data model v1 decision
 

--- a/social/influencer-intelligence/architecture.mjs
+++ b/social/influencer-intelligence/architecture.mjs
@@ -44,10 +44,13 @@ export const BOUNDARIES = deepFreeze([
   {
     id: 'provider-router',
     owner: DOMAIN_ROOT,
-    owns: ['provider ordering', 'explicit gap classification', 'bounded adapter projection'],
+    owns: ['provider ordering', 'explicit gap classification', 'bounded adapter projection', 'timeout and safe retry', 'per-provider operation circuit state'],
     order: ['meta-graph', 'instagrapi'],
-    fallbackOnlyFor: ['provider_unavailable', 'permission_gap', 'coverage_gap', 'timeout'],
+    fallbackOnlyFor: ['provider_unavailable', 'permission_gap', 'coverage_gap', 'timeout', 'circuit_open', 'retry_exhausted'],
     failClosedFor: ['policy_block', 'invalid_response', 'unclassified_transport'],
+    retryPolicy: 'Only bounded provider_unavailable, transport_error, rate_limited, and timeout failures may retry; policy and invalid responses never retry.',
+    circuitPolicy: 'Failures are isolated by provider and operation; an open circuit is a fallback gap and never produces data.',
+    externalPolicy: 'Future external providers require explicit configuration and allowlisting after a measured gap review.',
   },
   {
     id: 'token-vault',
@@ -87,25 +90,28 @@ export const BOUNDARIES = deepFreeze([
 export const PROVIDER_INTERFACE = deepFreeze({
   contractVersion: 'influencer-intelligence/provider-interface/v1',
   request: {
-    required: ['creatorKey', 'observedAt', 'retrievedAt', 'requestedFields', 'correlationId'],
-    optional: ['canonicalHandle', 'window'],
+    required: ['operation', 'observedAt', 'retrievedAt', 'correlationId'],
+    identityRules: ['resolve_creator requires canonicalHandle', 'all other operations require creatorKey', 'get_media_metrics requires bounded mediaKeys'],
+    optional: ['creatorKey', 'canonicalHandle', 'window', 'limit', 'mediaKeys', 'metricSet', 'requestedFields'],
     forbidden: ['rawProviderAccountReference', 'credentialMaterial', 'sessionMaterial', 'rawQuery', 'engagementAction'],
   },
   result: {
-    statuses: ['collected', 'unavailable'],
-    fields: ['provider', 'providerAdapterVersion', 'observedAt', 'retrievedAt', 'observations', 'provenance'],
+    statuses: ['ok', 'unavailable'],
+    fields: ['provider', 'retrievedAt', 'dataClassification', 'freshness', 'limitations', 'providerSpecificEvidence', 'data'],
     forbidden: ['rawProviderPayload', 'directContactFields', 'rawCommentText', 'mediaBinary', 'credentialMaterial'],
   },
   operations: [
-    { name: 'collectProfile', readOnly: true, lifecycle: 'M2 boundary; synthetic transport only until a later gate' },
-    { name: 'collectMediaSummary', readOnly: true, lifecycle: 'M3/M4 design; no implementation in architecture PR' },
-    { name: 'collectCommentsAggregate', readOnly: true, lifecycle: 'M9 design; aggregate-only output' },
-    { name: 'collectInsights', readOnly: true, lifecycle: 'M4 design; explicit unavailable state when permission is missing' },
+    { name: 'resolve_creator', readOnly: true, lifecycle: 'provider identity resolution; bounded public handle projection' },
+    { name: 'get_profile', readOnly: true, lifecycle: 'bounded profile projection; synthetic transport only until a later gate' },
+    { name: 'get_recent_media', readOnly: true, lifecycle: 'bounded media identity projection; no binary archive' },
+    { name: 'get_media_metrics', readOnly: true, lifecycle: 'bounded media metrics projection; unavailable when coverage is missing' },
+    { name: 'get_comments_sample', readOnly: true, lifecycle: 'aggregate/sample intelligence only; no raw comment text' },
+    { name: 'get_profile_metrics', readOnly: true, lifecycle: 'bounded profile aggregate metrics; unavailable when not supplied' },
   ],
   providerIdentity: {
     allowed: ['meta-graph', 'instagrapi'],
     officialFirst: 'meta-graph',
-    futureProviders: 'M13 may add a provider only after a measured, documented gap and a separate review.',
+    futureProviders: 'Only explicitly configured and allowlisted after a measured, documented gap and a separate review.',
   },
 });
 

--- a/social/influencer-intelligence/provider-router.mjs
+++ b/social/influencer-intelligence/provider-router.mjs
@@ -1,27 +1,56 @@
 import {
-  assertNoSensitiveFields,
-  normalizeCanonicalHandle,
-  normalizeCreatorKey,
-  normalizeProviderId,
   normalizeProviderSnapshot,
+  normalizeProviderId,
 } from './contracts.mjs';
 import {
-  PROVIDER_COLLECTION_CODES,
+  isFallbackCode,
+  normalizeProviderCandidate,
+  normalizeProviderOperation,
+  normalizeProviderRequest,
+  normalizeProviderSlug,
+  PROVIDER_FALLBACK_CODES,
+  PROVIDER_OPERATIONS,
+  PROVIDER_RETRYABLE_CODES,
+  unavailableProviderResult,
+} from './providers/provider-contracts.mjs';
+import {
   ProviderCollectionError,
   ProviderGapError,
 } from './providers/profile-provider.mjs';
 
-export const PROVIDER_ROUTER_CONTRACT_VERSION = 'influencer-intelligence-provider-router/v1';
+export const PROVIDER_ROUTER_CONTRACT_VERSION = 'influencer-intelligence-provider-router/v2';
 export const DEFAULT_PROVIDER_ORDER = Object.freeze(['meta-graph', 'instagrapi']);
+export const DEFAULT_PROVIDER_TIMEOUT_MS = 12000;
+export const DEFAULT_PROVIDER_MAX_ATTEMPTS = 2;
+export const DEFAULT_CIRCUIT_FAILURE_THRESHOLD = 3;
+export const DEFAULT_CIRCUIT_RESET_MS = 30000;
 
-const providerCollectionCodeSet = new Set(PROVIDER_COLLECTION_CODES);
+const CORE_PROVIDER_IDS = new Set(DEFAULT_PROVIDER_ORDER);
+const retryableCodeSet = new Set(PROVIDER_RETRYABLE_CODES);
+const fallbackCodeSet = new Set(PROVIDER_FALLBACK_CODES);
+const terminalProviderCodes = new Set(['policy_block', 'invalid_response', 'unclassified_transport']);
 
 export class ProviderRouterError extends Error {
-  constructor(reasonCode, provider = undefined) {
+  constructor(reasonCode, provider = undefined, operation = undefined, details = {}) {
     super(`Influencer Intelligence provider router rejected the request: ${reasonCode}`);
     this.name = 'ProviderRouterError';
+    this.code = reasonCode;
     this.reasonCode = reasonCode;
-    if (provider) this.provider = provider;
+    if (provider !== undefined) this.provider = provider;
+    if (operation !== undefined) this.operation = operation;
+    this.retryable = details.retryable === true;
+    this.fallbackAllowed = details.fallbackAllowed === true;
+  }
+
+  toJSON() {
+    return {
+      code: this.code,
+      reason_code: this.reasonCode,
+      ...(this.provider !== undefined ? { provider: this.provider } : {}),
+      ...(this.operation !== undefined ? { operation: this.operation } : {}),
+      retryable: this.retryable,
+      fallback_allowed: this.fallbackAllowed,
+    };
   }
 }
 
@@ -36,72 +65,54 @@ function deepFreeze(value, seen = new Set()) {
   return Object.freeze(value);
 }
 
-function canonicalTimestamp(value, label) {
-  if (typeof value !== 'string' || !value.trim()) {
-    throw new ProviderRouterError('invalid_request');
-  }
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) {
-    throw new ProviderRouterError('invalid_request');
-  }
-  return parsed.toISOString();
-}
-
-function normalizeCollectionRequest(input) {
-  if (!isRecord(input)) throw new ProviderRouterError('invalid_request');
-  try {
-    assertNoSensitiveFields(input, 'providerRouter.request');
-  } catch {
-    throw new ProviderRouterError('policy_block');
-  }
-  const allowedKeys = new Set(['creatorKey', 'handle', 'observedAt', 'retrievedAt']);
-  if (Object.keys(input).some((key) => !allowedKeys.has(key))) {
-    throw new ProviderRouterError('invalid_request');
-  }
-  let creatorKey;
-  let handle;
-  try {
-    creatorKey = normalizeCreatorKey(input.creatorKey);
-    handle = normalizeCanonicalHandle(input.handle);
-  } catch {
-    throw new ProviderRouterError('invalid_request');
-  }
-  if (!handle) throw new ProviderRouterError('invalid_request');
-  const observedAt = canonicalTimestamp(input.observedAt, 'observedAt');
-  const retrievedAt = input.retrievedAt === undefined
-    ? undefined
-    : canonicalTimestamp(input.retrievedAt, 'retrievedAt');
-  if (retrievedAt && new Date(retrievedAt).getTime() < new Date(observedAt).getTime()) {
-    throw new ProviderRouterError('invalid_request');
-  }
-  return Object.freeze({
-    creatorKey,
-    handle,
-    observedAt,
-    ...(retrievedAt ? { retrievedAt } : {}),
-  });
-}
-
 function providerEntries(value) {
   if (value instanceof Map) return [...value.entries()];
   if (isRecord(value)) return Object.entries(value);
   throw new ProviderRouterError('invalid_request');
 }
 
-function normalizeConfiguredProviders(value) {
+function externalConfig(value) {
+  if (value === undefined) return { enabled: false, allowlist: new Set() };
+  if (!isRecord(value)) throw new ProviderRouterError('invalid_request');
+  const allowlist = value.allowlist || value.providers || [];
+  if (!Array.isArray(allowlist)) throw new ProviderRouterError('invalid_request');
+  const normalized = new Set();
+  for (const item of allowlist) {
+    try {
+      normalized.add(normalizeProviderSlug(item, 'externalProvider.allowlist'));
+    } catch {
+      throw new ProviderRouterError('invalid_request');
+    }
+  }
+  return { enabled: value.enabled === true, allowlist: normalized };
+}
+
+function normalizeConfiguredProviders(value, configuredExternal) {
   const normalized = new Map();
   for (const [rawId, provider] of providerEntries(value)) {
     let id;
     try {
-      id = normalizeProviderId(rawId, 'providerRouter.provider');
+      id = normalizeProviderSlug(rawId, 'providerRouter.provider');
     } catch {
       throw new ProviderRouterError('unknown_provider');
     }
-    if (normalized.has(id) || !isRecord(provider) || typeof provider.collect !== 'function') {
+    if (normalized.has(id) || !isRecord(provider)) {
       throw new ProviderRouterError('invalid_request', id);
     }
+    if (!CORE_PROVIDER_IDS.has(id)) {
+      if (!configuredExternal.enabled || !configuredExternal.allowlist.has(id) || provider.external !== true) {
+        throw new ProviderRouterError('unknown_provider', id);
+      }
+    }
     if (provider.id !== id) throw new ProviderRouterError('invalid_request', id);
+    if (typeof provider.collect !== 'function'
+      && !PROVIDER_OPERATIONS.some((operation) => typeof provider[operation] === 'function')) {
+      throw new ProviderRouterError('invalid_request', id);
+    }
     if (id === 'meta-graph' && provider.officialFirst !== true) {
+      throw new ProviderRouterError('official_first_required', id);
+    }
+    if (id !== 'meta-graph' && provider.officialFirst === true) {
       throw new ProviderRouterError('official_first_required', id);
     }
     normalized.set(id, provider);
@@ -109,73 +120,403 @@ function normalizeConfiguredProviders(value) {
   return normalized;
 }
 
-function normalizeOrder(value) {
+function normalizeOrder(value, configuredExternal) {
   if (!Array.isArray(value) || value.length === 0) throw new ProviderRouterError('invalid_request');
-  const order = value.map((item, index) => {
+  const order = value.map((item) => {
+    let id;
     try {
-      return normalizeProviderId(item, `providerRouter.providerOrder[${index}]`);
+      id = normalizeProviderSlug(item, 'providerRouter.providerOrder');
     } catch {
       throw new ProviderRouterError('unknown_provider');
     }
+    if (!CORE_PROVIDER_IDS.has(id)
+      && (!configuredExternal.enabled || !configuredExternal.allowlist.has(id))) {
+      throw new ProviderRouterError('unknown_provider', id);
+    }
+    return id;
   });
   if (new Set(order).size !== order.length) throw new ProviderRouterError('invalid_request');
   if (order[0] !== 'meta-graph') throw new ProviderRouterError('official_first_required');
   return order;
 }
 
-function terminalReason(error) {
-  if (error instanceof ProviderCollectionError && providerCollectionCodeSet.has(error.reasonCode)) {
-    return error.reasonCode;
-  }
-  return 'provider_failed';
+function clockMs(clock) {
+  const value = typeof clock === 'function' ? clock() : clock;
+  const result = value instanceof Date ? value.getTime() : Number(value);
+  if (!Number.isFinite(result)) throw new ProviderRouterError('invalid_request');
+  return result;
 }
 
-export function createProviderRouter({ providers, providerOrder = DEFAULT_PROVIDER_ORDER } = {}) {
-  const configuredProviders = normalizeConfiguredProviders(providers);
-  const requestedOrder = normalizeOrder(providerOrder);
+function classifyError(error) {
+  const rawCode = error?.reasonCode || error?.code;
+  if (error instanceof ProviderGapError) {
+    return {
+      code: rawCode,
+      retryable: false,
+      fallback: fallbackCodeSet.has(rawCode),
+    };
+  }
+  if (rawCode === 'timeout' || error?.name === 'AbortError') {
+    return { code: 'timeout', retryable: true, fallback: true };
+  }
+  if (rawCode === 'transport_error') {
+    return { code: 'provider_unavailable', retryable: true, fallback: true };
+  }
+  if (typeof rawCode === 'string' && fallbackCodeSet.has(rawCode)) {
+    return { code: rawCode, retryable: retryableCodeSet.has(rawCode), fallback: true };
+  }
+  if (typeof rawCode === 'string' && terminalProviderCodes.has(rawCode)) {
+    return { code: rawCode, retryable: false, fallback: false };
+  }
+  return { code: 'unclassified_transport', retryable: false, fallback: false };
+}
+
+function defaultSleep(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, Math.max(0, Math.min(delayMs, 1000))));
+}
+
+function retryDelay(attempt, baseDelayMs) {
+  return Math.min(1000, Math.max(0, baseDelayMs) * (2 ** Math.max(0, attempt - 1)));
+}
+
+function boundedInteger(value, fallback, minimum, maximum) {
+  const candidate = value === undefined ? fallback : Number(value);
+  if (!Number.isInteger(candidate) || candidate < minimum || candidate > maximum) {
+    throw new ProviderRouterError('invalid_request');
+  }
+  return candidate;
+}
+
+function createCircuitState() {
+  return { failures: 0, openedAt: null, halfOpen: false };
+}
+
+function legacyAttempts(attempts) {
+  return attempts.map((attempt) => ({
+    provider: attempt.provider,
+    status: attempt.status === 'ok' ? 'collected' : attempt.status,
+    ...(attempt.classification ? { reasonCode: attempt.classification } : {}),
+    ...(attempt.retry_count ? { retryCount: attempt.retry_count } : {}),
+  }));
+}
+
+function legacyObservation(snapshot, key) {
+  const observation = Array.isArray(snapshot?.observations)
+    ? snapshot.observations.find((item) => item?.key === key)
+    : undefined;
+  return observation?.value === undefined ? null : observation.value;
+}
+
+function legacyCollectionCandidate(providerId, result, request) {
+  if (!isRecord(result)) throw new ProviderCollectionError('invalid_response');
+  if (result.status === 'unavailable' || result.snapshot === null) {
+    return {
+      status: 'unavailable',
+      limitations: ['coverage_gap'],
+    };
+  }
+  const snapshot = isRecord(result.snapshot) ? result.snapshot : result;
+  const sourceRef = snapshot.provenance?.sourceRef || `${providerId}:legacy:${request.creator_key}`;
+  return {
+    observed_at: snapshot.observedAt || request.observed_at,
+    retrieved_at: snapshot.retrievedAt || request.retrieved_at,
+    data: {
+      canonical_handle: snapshot.handle || request.canonical_handle || null,
+      followers_count: legacyObservation(snapshot, 'followers_count'),
+      media_count: legacyObservation(snapshot, 'media_count'),
+    },
+    data_classification: 'observed',
+    provider_specific_evidence: {
+      adapter_version: `${providerId}-legacy-adapter-v1`,
+      source_ref: sourceRef,
+      fields: ['followers_count', 'media_count'],
+      endpoint_family: 'legacy-read-only-profile',
+    },
+  };
+}
+
+function legacySnapshot(result, request) {
+  if (result.status === 'unavailable') return null;
+  const provider = result.provider;
+  let supportedProvider;
+  try {
+    supportedProvider = normalizeProviderId(provider);
+  } catch {
+    throw new ProviderRouterError('invalid_response', provider, 'get_profile');
+  }
+  const data = result.data || {};
+  const observedAt = result.freshness.observed_at || request.observed_at;
+  const values = [
+    ['followers_count', data.followers_count],
+    ['media_count', data.media_count],
+  ];
+  const observations = values.map(([key, value]) => {
+    const available = value !== undefined && value !== null;
+    const state = available ? 'observed' : 'unavailable';
+    return {
+      key,
+      unit: 'count',
+      value: available ? value : null,
+      evidenceState: state,
+      confidence: available ? 1 : 0,
+      provenance: {
+        provider: supportedProvider,
+        sourceType: 'profile',
+        evidenceState: state,
+        observedAt,
+        retrievedAt: result.retrieved_at,
+        sourceRef: result.provider_specific_evidence.source_ref,
+      },
+    };
+  });
+  const evidenceState = observations.some(({ evidenceState: state }) => state === 'observed')
+    ? 'observed'
+    : 'unavailable';
+  try {
+    return normalizeProviderSnapshot({
+      creatorKey: request.creator_key,
+      handle: data.canonical_handle || request.canonical_handle,
+      provider: supportedProvider,
+      observedAt,
+      evidenceState,
+      provenance: {
+        provider: supportedProvider,
+        sourceType: 'profile',
+        evidenceState,
+        observedAt,
+        retrievedAt: result.retrieved_at,
+        sourceRef: result.provider_specific_evidence.source_ref,
+      },
+      observations,
+    });
+  } catch {
+    throw new ProviderRouterError('invalid_response', provider, 'get_profile');
+  }
+}
+
+export function createProviderRouter({
+  providers,
+  providerOrder = DEFAULT_PROVIDER_ORDER,
+  externalProviderConfig,
+  timeoutMs = DEFAULT_PROVIDER_TIMEOUT_MS,
+  retryPolicy = {},
+  circuitBreaker = {},
+  clock = () => Date.now(),
+  sleep = defaultSleep,
+} = {}) {
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > DEFAULT_PROVIDER_TIMEOUT_MS) {
+    throw new ProviderRouterError('invalid_request');
+  }
+  if (typeof sleep !== 'function') throw new ProviderRouterError('invalid_request');
+  if (!isRecord(retryPolicy) || !isRecord(circuitBreaker)) {
+    throw new ProviderRouterError('invalid_request');
+  }
+  const configuredExternal = externalConfig(externalProviderConfig);
+  const configuredProviders = normalizeConfiguredProviders(providers, configuredExternal);
+  const requestedOrder = normalizeOrder(providerOrder, configuredExternal);
   const activeOrder = requestedOrder.filter((providerId) => configuredProviders.has(providerId));
   if (!activeOrder.includes('meta-graph') || activeOrder[0] !== 'meta-graph') {
     throw new ProviderRouterError('official_first_required');
   }
 
-  return Object.freeze({
-    contractVersion: PROVIDER_ROUTER_CONTRACT_VERSION,
-    providerOrder: Object.freeze(activeOrder),
-    capabilities: Object.freeze(['read-profile']),
-    async collect(input) {
-      const request = normalizeCollectionRequest(input);
-      const attempts = [];
-      for (const providerId of activeOrder) {
-        const provider = configuredProviders.get(providerId);
-        try {
-          const candidate = await provider.collect(request);
-          let snapshot;
-          try {
-            snapshot = normalizeProviderSnapshot(candidate);
-          } catch {
-            throw new ProviderCollectionError('invalid_response');
-          }
-          if (snapshot.provider !== providerId || snapshot.creatorKey !== request.creatorKey) {
-            throw new ProviderCollectionError('invalid_response');
-          }
-          attempts.push({ provider: providerId, status: 'collected' });
-          return deepFreeze({
-            contractVersion: PROVIDER_ROUTER_CONTRACT_VERSION,
-            status: 'collected',
-            provider: providerId,
-            snapshot,
-            attempts,
-          });
-        } catch (error) {
-          if (error instanceof ProviderGapError) {
-            attempts.push({ provider: providerId, status: 'gap', reasonCode: error.reasonCode });
-            continue;
-          }
-          const reasonCode = terminalReason(error);
-          attempts.push({ provider: providerId, status: 'blocked', reasonCode });
-          throw new ProviderRouterError(reasonCode, providerId);
+  const maxAttempts = boundedInteger(retryPolicy.maxAttempts, DEFAULT_PROVIDER_MAX_ATTEMPTS, 1, 3);
+  const retryBaseDelayMs = boundedInteger(retryPolicy.baseDelayMs, 25, 0, 1000);
+  const failureThreshold = boundedInteger(
+    circuitBreaker.failureThreshold,
+    DEFAULT_CIRCUIT_FAILURE_THRESHOLD,
+    1,
+    10,
+  );
+  const resetAfterMs = boundedInteger(circuitBreaker.resetAfterMs, DEFAULT_CIRCUIT_RESET_MS, 1, 300000);
+  const circuitStates = new Map();
+
+  function stateKey(provider, operation) {
+    return `${provider}:${operation}`;
+  }
+
+  function getState(provider, operation) {
+    const key = stateKey(provider, operation);
+    if (!circuitStates.has(key)) circuitStates.set(key, createCircuitState());
+    return circuitStates.get(key);
+  }
+
+  function circuitStatus(provider, operation) {
+    const state = getState(provider, operation);
+    if (state.openedAt === null) return 'closed';
+    const elapsed = clockMs(clock) - state.openedAt;
+    if (elapsed >= resetAfterMs) {
+      state.halfOpen = true;
+      return 'half-open';
+    }
+    return 'open';
+  }
+
+  function recordSuccess(provider, operation) {
+    const state = getState(provider, operation);
+    state.failures = 0;
+    state.openedAt = null;
+    state.halfOpen = false;
+  }
+
+  function recordFailure(provider, operation, classification) {
+    if (!['provider_unavailable', 'timeout', 'retry_exhausted'].includes(classification)) return;
+    const state = getState(provider, operation);
+    state.failures += 1;
+    if (state.failures >= failureThreshold) {
+      state.openedAt = clockMs(clock);
+      state.halfOpen = false;
+    }
+  }
+
+  async function callWithTimeout(provider, operation, request, attempt) {
+    const handler = provider[operation];
+    const legacyCollect = typeof handler !== 'function'
+      && operation === 'get_profile'
+      && typeof provider.collect === 'function';
+    if (typeof handler !== 'function' && !legacyCollect) throw new ProviderGapError('coverage_gap');
+    if (legacyCollect && !request.canonical_handle) throw new ProviderGapError('coverage_gap');
+    const controller = new AbortController();
+    let timer;
+    const timeout = new Promise((_, reject) => {
+      timer = setTimeout(() => {
+        controller.abort();
+        const error = new Error('timeout');
+        error.code = 'timeout';
+        reject(error);
+      }, timeoutMs);
+    });
+    try {
+      return await Promise.race([
+        Promise.resolve().then(() => legacyCollect
+          ? provider.collect({
+            creatorKey: request.creator_key,
+            handle: request.canonical_handle,
+            observedAt: request.observed_at,
+            retrievedAt: request.retrieved_at,
+          })
+          : handler(request, { signal: controller.signal, attempt })),
+        timeout,
+      ]);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async function callProvider(providerId, operation, request, attempts) {
+    const provider = configuredProviders.get(providerId);
+    const status = circuitStatus(providerId, operation);
+    if (status === 'open') {
+      attempts.push({ provider: providerId, operation, status: 'skipped', classification: 'circuit_open', retry_count: 0 });
+      return { kind: 'gap', code: 'circuit_open', retryCount: 0 };
+    }
+    let retryCount = 0;
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        const response = await callWithTimeout(provider, operation, request, attempt);
+        const raw = typeof provider[operation] === 'function'
+          ? response
+          : legacyCollectionCandidate(providerId, response, request);
+        const candidate = normalizeProviderCandidate({
+          operation,
+          provider: providerId,
+          request,
+          candidate: raw,
+          adapterVersion: provider.adapterVersion || `${providerId}-adapter-v1`,
+          sourceRef: `${providerId}:${operation}:${request.creator_key || 'unresolved'}`,
+        });
+        if (candidate.provider !== providerId || candidate.operation !== operation) {
+          throw new ProviderCollectionError('invalid_response');
         }
+        if (candidate.status === 'unavailable') {
+          const limitation = candidate.limitations.find((item) => isFallbackCode(item)) || 'coverage_gap';
+          recordFailure(providerId, operation, limitation);
+          attempts.push({ provider: providerId, operation, status: 'gap', classification: limitation, retry_count: retryCount });
+          return { kind: 'gap', code: limitation, retryCount };
+        }
+        recordSuccess(providerId, operation);
+        attempts.push({ provider: providerId, operation, status: 'ok', retry_count: retryCount });
+        return { kind: 'ok', candidate, retryCount };
+      } catch (error) {
+        const classification = classifyError(error);
+        if (classification.retryable && attempt < maxAttempts) {
+          retryCount += 1;
+          await sleep(retryDelay(attempt, retryBaseDelayMs));
+          continue;
+        }
+        const finalClassification = classification.retryable && retryCount > 0
+          ? 'retry_exhausted'
+          : classification.code;
+        if (classification.fallback) recordFailure(providerId, operation, finalClassification);
+        const statusValue = classification.fallback ? 'gap' : 'blocked';
+        attempts.push({
+          provider: providerId,
+          operation,
+          status: statusValue,
+          classification: finalClassification,
+          retry_count: retryCount,
+        });
+        return { kind: classification.fallback ? 'gap' : 'blocked', code: finalClassification, retryCount };
       }
+    }
+    throw new ProviderRouterError('unclassified_transport', providerId, operation);
+  }
+
+  async function execute(operation, input = {}) {
+    let normalizedOperation;
+    try {
+      normalizedOperation = normalizeProviderOperation(operation);
+    } catch {
+      throw new ProviderRouterError('invalid_request', undefined, operation);
+    }
+    let request;
+    try {
+      request = normalizeProviderRequest(input, normalizedOperation, {
+        now: () => new Date(clockMs(clock)).toISOString(),
+      });
+    } catch (error) {
+      throw new ProviderRouterError(error?.reasonCode || 'invalid_request', undefined, normalizedOperation);
+    }
+    const attempts = [];
+    for (const providerId of activeOrder) {
+      const outcome = await callProvider(providerId, normalizedOperation, request, attempts);
+      if (outcome.kind === 'ok') {
+        return deepFreeze({
+          contract_version: PROVIDER_ROUTER_CONTRACT_VERSION,
+          ...outcome.candidate,
+          attempts: Object.freeze(attempts.map((attempt) => ({ ...attempt }))),
+        });
+      }
+      if (outcome.kind === 'blocked') {
+        throw new ProviderRouterError(outcome.code, providerId, normalizedOperation, {
+          retryable: false,
+          fallbackAllowed: false,
+        });
+      }
+    }
+    const result = unavailableProviderResult({
+      operation: normalizedOperation,
+      retrievedAt: request.retrieved_at,
+      limitations: attempts.map(({ classification }) => classification).filter(Boolean),
+      provider: null,
+    });
+    return deepFreeze({
+      ...result,
+      attempts: Object.freeze(attempts.map((attempt) => ({ ...attempt }))),
+    });
+  }
+
+  async function collect(input = {}) {
+    let request;
+    try {
+      request = normalizeProviderRequest(input, 'get_profile', {
+        now: () => new Date(clockMs(clock)).toISOString(),
+      });
+    } catch (error) {
+      throw new ProviderRouterError(error?.reasonCode || 'invalid_request', undefined, 'get_profile');
+    }
+    const result = await execute('get_profile', request);
+    const attempts = legacyAttempts(result.attempts || []);
+    if (result.status === 'unavailable') {
       return deepFreeze({
         contractVersion: PROVIDER_ROUTER_CONTRACT_VERSION,
         status: 'unavailable',
@@ -183,6 +524,33 @@ export function createProviderRouter({ providers, providerOrder = DEFAULT_PROVID
         snapshot: null,
         attempts,
       });
-    },
-  });
+    }
+    return deepFreeze({
+      contractVersion: PROVIDER_ROUTER_CONTRACT_VERSION,
+      status: 'collected',
+      provider: result.provider,
+      snapshot: legacySnapshot(result, request),
+      attempts,
+    });
+  }
+
+  const router = {
+    contractVersion: PROVIDER_ROUTER_CONTRACT_VERSION,
+    providerOrder: Object.freeze(activeOrder),
+    capabilities: Object.freeze(PROVIDER_OPERATIONS.map((operation) => `read-${operation}`)),
+    execute,
+    collect,
+    getCircuitState: () => deepFreeze(Object.fromEntries(
+      [...circuitStates.entries()].map(([key, value]) => [key, { ...value }]),
+    )),
+  };
+  for (const operation of PROVIDER_OPERATIONS) {
+    Object.defineProperty(router, operation, {
+      configurable: false,
+      enumerable: true,
+      writable: false,
+      value: (input = {}) => execute(operation, input),
+    });
+  }
+  return Object.freeze(router);
 }

--- a/social/influencer-intelligence/providers/instagrapi-adapter.mjs
+++ b/social/influencer-intelligence/providers/instagrapi-adapter.mjs
@@ -1,4 +1,4 @@
-import { createProfileProvider } from './profile-provider.mjs';
+import { createOperationProvider } from './operation-provider.mjs';
 
 // This is a narrow wrapper around the existing social/instagram read path. It
 // does not own sessions, credentials, scraping, downloads, or engagement APIs.
@@ -8,12 +8,25 @@ export const INSTAGRAPI_PROFILE_FIELDS = Object.freeze([
   'media_count',
 ]);
 
+export const INSTAGRAPI_OPERATION_FIELDS = Object.freeze({
+  resolve_creator: Object.freeze(['username']),
+  get_profile: INSTAGRAPI_PROFILE_FIELDS,
+  get_recent_media: Object.freeze(['pk', 'media_type', 'taken_at']),
+  get_media_metrics: Object.freeze(['pk', 'like_count', 'comment_count', 'view_count']),
+  get_comments_sample: Object.freeze(['comments']),
+  get_profile_metrics: Object.freeze(['follower_count', 'media_count', 'insights']),
+});
+
 export function createInstagrapiProvider(options = {}) {
-  return createProfileProvider({
+  return createOperationProvider({
     provider: 'instagrapi',
     officialFirst: false,
     sourceRefPrefix: 'instagrapi',
-    requestFields: INSTAGRAPI_PROFILE_FIELDS,
+    fieldsByOperation: options.fieldsByOperation || INSTAGRAPI_OPERATION_FIELDS,
+    operations: options.operations,
     readProfile: options.readProfile,
+    readProfileMetrics: options.readProfileMetrics,
+    resolveCreator: options.resolveCreator,
+    adapterVersion: options.adapterVersion || 'instagrapi-adapter-v1',
   });
 }

--- a/social/influencer-intelligence/providers/meta-graph-adapter.mjs
+++ b/social/influencer-intelligence/providers/meta-graph-adapter.mjs
@@ -1,4 +1,4 @@
-import { createProfileProvider } from './profile-provider.mjs';
+import { createOperationProvider } from './operation-provider.mjs';
 
 // The injected transport must already map the official Graph response into the
 // small projection accepted by the provider boundary. This keeps credentials,
@@ -9,12 +9,25 @@ export const META_GRAPH_PROFILE_FIELDS = Object.freeze([
   'media_count',
 ]);
 
+export const META_GRAPH_OPERATION_FIELDS = Object.freeze({
+  resolve_creator: Object.freeze(['username']),
+  get_profile: META_GRAPH_PROFILE_FIELDS,
+  get_recent_media: Object.freeze(['id', 'media_type', 'timestamp']),
+  get_media_metrics: Object.freeze(['id', 'like_count', 'comments_count', 'views']),
+  get_comments_sample: Object.freeze(['comments']),
+  get_profile_metrics: Object.freeze(['followers_count', 'media_count', 'insights']),
+});
+
 export function createMetaGraphProvider(options = {}) {
-  return createProfileProvider({
+  return createOperationProvider({
     provider: 'meta-graph',
     officialFirst: true,
     sourceRefPrefix: 'meta-graph',
-    requestFields: META_GRAPH_PROFILE_FIELDS,
+    fieldsByOperation: options.fieldsByOperation || META_GRAPH_OPERATION_FIELDS,
+    operations: options.operations,
     readProfile: options.readProfile,
+    readProfileMetrics: options.readProfileMetrics,
+    resolveCreator: options.resolveCreator,
+    adapterVersion: options.adapterVersion || 'meta-graph-adapter-v1',
   });
 }

--- a/social/influencer-intelligence/providers/operation-provider.mjs
+++ b/social/influencer-intelligence/providers/operation-provider.mjs
@@ -1,0 +1,240 @@
+import {
+  assertNoSensitiveFields,
+  normalizeProviderId,
+  normalizeProviderSnapshot,
+} from '../contracts.mjs';
+import {
+  normalizeProviderCandidate,
+  normalizeProviderOperation,
+  normalizeProviderRequest,
+  normalizeProviderSlug,
+  PROVIDER_OPERATIONS,
+} from './provider-contracts.mjs';
+import {
+  ProviderAdapterError,
+  ProviderCollectionError,
+  ProviderGapError,
+} from './profile-provider.mjs';
+
+const operationSet = new Set(PROVIDER_OPERATIONS);
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function camelOperation(operation) {
+  return operation.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
+}
+
+function fieldList(value, label) {
+  if (!Array.isArray(value) || value.length === 0 || value.length > 64) {
+    throw new ProviderAdapterError(`${label} must be a bounded field list`);
+  }
+  if (value.some((item) => typeof item !== 'string' || !/^[a-z][a-z0-9_]*$/.test(item))) {
+    throw new ProviderAdapterError(`${label} contains an invalid field`);
+  }
+  return Object.freeze([...new Set(value)]);
+}
+
+function mapLegacyProfile(value) {
+  if (!isRecord(value)) return value;
+  return {
+    ...(value.handle !== undefined ? { canonical_handle: value.handle } : {}),
+    ...(value.canonicalHandle !== undefined ? { canonical_handle: value.canonicalHandle } : {}),
+    ...(value.followersCount !== undefined ? { followers_count: value.followersCount } : {}),
+    ...(value.followingCount !== undefined ? { following_count: value.followingCount } : {}),
+    ...(value.mediaCount !== undefined ? { media_count: value.mediaCount } : {}),
+    ...(value.isPrivate !== undefined ? { is_private: value.isPrivate } : {}),
+    ...(value.isVerified !== undefined ? { is_verified: value.isVerified } : {}),
+  };
+}
+
+function legacyDataForOperation(operation, value, request) {
+  const profile = mapLegacyProfile(value);
+  if (operation === 'resolve_creator') {
+    return {
+      resolved: Boolean(profile && (profile.canonical_handle || profile.followers_count !== undefined || profile.media_count !== undefined)),
+      canonical_handle: profile?.canonical_handle || request.canonical_handle || null,
+      match_type: 'canonical_handle',
+    };
+  }
+  return profile;
+}
+
+function transportResult(operation, raw, request, legacy) {
+  try {
+    assertNoSensitiveFields(raw, 'providerResult');
+  } catch {
+    throw new ProviderCollectionError('policy_block');
+  }
+  if (!legacy) return raw;
+  if (raw && typeof raw === 'object' && Object.prototype.hasOwnProperty.call(raw, 'data')) {
+    return { ...raw, data: legacyDataForOperation(operation, raw.data, request) };
+  }
+  return legacyDataForOperation(operation, raw, request);
+}
+
+function legacySnapshotFromResult(result, request) {
+  if (result.status === 'unavailable') {
+    throw new ProviderGapError(result.limitations[0] || 'coverage_gap');
+  }
+  const data = result.data || {};
+  let provider;
+  try {
+    provider = normalizeProviderId(result.provider);
+  } catch {
+    throw new ProviderCollectionError('invalid_response');
+  }
+  const observedAt = result.freshness.observed_at || request.observed_at;
+  const observations = [
+    ['followers_count', data.followers_count],
+    ['media_count', data.media_count],
+  ].map(([key, value]) => ({
+    key,
+    unit: 'count',
+    value: value === undefined ? null : value,
+    evidenceState: value === undefined || value === null ? 'unavailable' : 'observed',
+    confidence: value === undefined || value === null ? 0 : 1,
+    provenance: {
+      provider,
+      sourceType: 'profile',
+      evidenceState: value === undefined || value === null ? 'unavailable' : 'observed',
+      observedAt,
+      retrievedAt: result.retrieved_at,
+      sourceRef: result.provider_specific_evidence.source_ref,
+    },
+  }));
+  const evidenceState = observations.some(({ evidenceState: state }) => state === 'observed')
+    ? 'observed'
+    : 'unavailable';
+  try {
+    return normalizeProviderSnapshot({
+      creatorKey: request.creator_key,
+      handle: data.canonical_handle || request.canonical_handle,
+      provider,
+      observedAt,
+      evidenceState,
+      provenance: {
+        provider,
+        sourceType: 'profile',
+        evidenceState,
+        observedAt,
+        retrievedAt: result.retrieved_at,
+        sourceRef: result.provider_specific_evidence.source_ref,
+      },
+      observations,
+    });
+  } catch {
+    throw new ProviderCollectionError('invalid_response');
+  }
+}
+
+/**
+ * Builds a provider adapter around injected, already-authorized read
+ * transports. This module owns normalization and operation shape only; it
+ * never owns credentials, sessions, HTTP clients, scrapers, or write methods.
+ */
+export function createOperationProvider({
+  provider,
+  officialFirst,
+  sourceRefPrefix,
+  adapterVersion,
+  fieldsByOperation = {},
+  operations = {},
+  readProfile,
+  readProfileMetrics,
+  resolveCreator,
+} = {}) {
+  let providerId;
+  try {
+    providerId = normalizeProviderSlug(provider);
+  } catch {
+    throw new ProviderAdapterError('provider is not supported');
+  }
+  if (typeof officialFirst !== 'boolean') throw new ProviderAdapterError('officialFirst is required');
+  if (typeof sourceRefPrefix !== 'string' || !/^[a-z][a-z0-9-]*$/.test(sourceRefPrefix)) {
+    throw new ProviderAdapterError('sourceRefPrefix must be a lowercase slug');
+  }
+  const normalizedAdapterVersion = adapterVersion || `${providerId}-adapter-v1`;
+  if (!/^[a-z][a-z0-9._/-]{0,79}$/.test(normalizedAdapterVersion)) {
+    throw new ProviderAdapterError('adapterVersion must be a bounded version');
+  }
+
+  const fields = new Map();
+  for (const operation of PROVIDER_OPERATIONS) {
+    const configured = fieldsByOperation[operation] || fieldsByOperation[camelOperation(operation)] || ['normalized'];
+    fields.set(operation, fieldList(configured, `${providerId}.${operation}`));
+  }
+
+  const configuredOperations = new Map();
+  for (const operation of PROVIDER_OPERATIONS) {
+    const named = operations[operation] || operations[camelOperation(operation)];
+    const legacy = operation === 'get_profile'
+      ? readProfile
+      : operation === 'get_profile_metrics'
+        ? readProfileMetrics
+        : operation === 'resolve_creator'
+          ? (resolveCreator || readProfile)
+          : undefined;
+    if (typeof named === 'function') configuredOperations.set(operation, { fn: named, legacy: false });
+    else if (typeof legacy === 'function') configuredOperations.set(operation, { fn: legacy, legacy: true });
+  }
+
+  const methods = new Map();
+  for (const operation of PROVIDER_OPERATIONS) {
+    const configured = configuredOperations.get(operation);
+    const method = async (input = {}, context = {}) => {
+      const request = isRecord(input) && input.operation === operation
+        ? input
+        : normalizeProviderRequest(input, operation);
+      if (!configured) throw new ProviderGapError('coverage_gap');
+      const transportRequest = configured.legacy
+        ? Object.freeze({
+          handle: request.canonical_handle,
+          fields: fields.get(operation),
+          mode: 'read-only',
+        })
+        : Object.freeze({
+          ...request,
+          requested_fields: request.requested_fields || fields.get(operation) || [],
+        });
+      let raw;
+      try {
+        raw = await configured.fn(transportRequest, context);
+      } catch (error) {
+        if (error instanceof ProviderGapError || error instanceof ProviderCollectionError) throw error;
+        throw new ProviderCollectionError('transport_error');
+      }
+      return normalizeProviderCandidate({
+        operation,
+        provider: providerId,
+        request,
+        candidate: transportResult(operation, raw, request, configured.legacy),
+        adapterVersion: normalizedAdapterVersion,
+        sourceRef: `${sourceRefPrefix}:${operation}:${request.creator_key || 'unresolved'}`,
+      });
+    };
+    methods.set(operation, method);
+  }
+
+  const capabilities = Object.freeze([...configuredOperations.keys()]);
+  const adapter = {
+    id: providerId,
+    officialFirst,
+    capabilities,
+    collect: async (input = {}, context = {}) => {
+      const request = normalizeProviderRequest(input, 'get_profile');
+      const result = await methods.get('get_profile')(request, context);
+      return legacySnapshotFromResult(result, request);
+    },
+  };
+  for (const operation of PROVIDER_OPERATIONS) {
+    Object.defineProperty(adapter, operation, {
+      configurable: false,
+      enumerable: false,
+      writable: false,
+      value: methods.get(operation),
+    });
+  }
+  return Object.freeze(adapter);
+}

--- a/social/influencer-intelligence/providers/provider-contracts.d.ts
+++ b/social/influencer-intelligence/providers/provider-contracts.d.ts
@@ -1,0 +1,88 @@
+export type ProviderOperation =
+  | 'resolve_creator'
+  | 'get_profile'
+  | 'get_recent_media'
+  | 'get_media_metrics'
+  | 'get_comments_sample'
+  | 'get_profile_metrics';
+
+export type DataClassification = 'observed' | 'derived' | 'inferred';
+export type FreshnessStatus = 'fresh' | 'stale' | 'unknown';
+export type ProviderResultStatus = 'ok' | 'unavailable';
+
+export interface ProviderWindow {
+  start: string;
+  end: string;
+}
+
+export interface ProviderRequest {
+  operation: ProviderOperation;
+  creator_key?: string;
+  canonical_handle?: string;
+  observed_at: string;
+  retrieved_at: string;
+  correlation_id: string;
+  window?: ProviderWindow;
+  limit: number;
+  media_keys?: readonly string[];
+  metric_set?: readonly string[];
+  requested_fields?: readonly string[];
+}
+
+export interface ProviderFreshness {
+  status: FreshnessStatus;
+  observed_at: string | null;
+  retrieved_at: string;
+  age_seconds: number | null;
+  max_age_seconds: number;
+}
+
+export interface ProviderSpecificEvidence {
+  provider: string;
+  operation: ProviderOperation;
+  adapter_version: string;
+  source_ref: string;
+  correlation_id: string;
+  fields?: readonly string[];
+  endpoint_family?: string;
+  coverage_code?: string;
+}
+
+export interface ProviderAttempt {
+  provider: string;
+  operation: ProviderOperation;
+  status: 'ok' | 'gap' | 'blocked' | 'skipped';
+  classification?: string;
+  retry_count: number;
+}
+
+export interface ProviderResult<TData = unknown> {
+  contract_version: string;
+  operation: ProviderOperation;
+  status: ProviderResultStatus;
+  provider: string | null;
+  retrieved_at: string;
+  data_classification: DataClassification;
+  freshness: ProviderFreshness;
+  limitations: readonly string[];
+  provider_specific_evidence: ProviderSpecificEvidence;
+  data: TData | null;
+  attempts?: readonly ProviderAttempt[];
+}
+
+export interface ProviderCallContext {
+  signal: AbortSignal;
+  attempt: number;
+}
+
+export interface ProviderAdapter {
+  readonly id: string;
+  readonly officialFirst: boolean;
+  readonly capabilities: readonly ProviderOperation[];
+  resolve_creator(request: ProviderRequest, context: ProviderCallContext): Promise<ProviderResult>;
+  get_profile(request: ProviderRequest, context: ProviderCallContext): Promise<ProviderResult>;
+  get_recent_media(request: ProviderRequest, context: ProviderCallContext): Promise<ProviderResult>;
+  get_media_metrics(request: ProviderRequest, context: ProviderCallContext): Promise<ProviderResult>;
+  get_comments_sample(request: ProviderRequest, context: ProviderCallContext): Promise<ProviderResult>;
+  get_profile_metrics(request: ProviderRequest, context: ProviderCallContext): Promise<ProviderResult>;
+}

--- a/social/influencer-intelligence/providers/provider-contracts.mjs
+++ b/social/influencer-intelligence/providers/provider-contracts.mjs
@@ -1,0 +1,596 @@
+import {
+  assertNoSensitiveFields,
+  normalizeCanonicalHandle,
+  normalizeCreatorKey,
+} from '../contracts.mjs';
+
+/**
+ * Provider operations are deliberately transport-neutral. An adapter may use
+ * Meta Graph, the existing social/instagram read path, or a future approved
+ * provider, but the router only sees these normalized operation names.
+ */
+export const PROVIDER_OPERATIONS = Object.freeze([
+  'resolve_creator',
+  'get_profile',
+  'get_recent_media',
+  'get_media_metrics',
+  'get_comments_sample',
+  'get_profile_metrics',
+]);
+
+export const DATA_CLASSIFICATIONS = Object.freeze(['observed', 'derived', 'inferred']);
+
+export const FRESHNESS_STATUSES = Object.freeze(['fresh', 'stale', 'unknown']);
+
+export const PROVIDER_FALLBACK_CODES = Object.freeze([
+  'provider_unavailable',
+  'permission_gap',
+  'coverage_gap',
+  'timeout',
+  'circuit_open',
+  'retry_exhausted',
+]);
+
+export const PROVIDER_RETRYABLE_CODES = Object.freeze([
+  'provider_unavailable',
+  'transport_error',
+  'timeout',
+  'rate_limited',
+]);
+
+export const PROVIDER_TERMINAL_CODES = Object.freeze([
+  'policy_block',
+  'invalid_response',
+  'unclassified_transport',
+]);
+
+export const PROVIDER_OPERATION_CONTRACT_VERSION =
+  'influencer-intelligence/provider-operation/v1';
+
+const operationSet = new Set(PROVIDER_OPERATIONS);
+const classificationSet = new Set(DATA_CLASSIFICATIONS);
+const freshnessSet = new Set(FRESHNESS_STATUSES);
+const fallbackCodeSet = new Set(PROVIDER_FALLBACK_CODES);
+const slugPattern = /^[a-z][a-z0-9._-]{0,79}$/;
+const opaquePattern = /^[A-Za-z0-9._:-]{1,160}$/;
+const sourceRefPattern = /^[A-Za-z0-9._:/-]{1,240}$/;
+const COUNT_KEYS = new Set([
+  'followers_count',
+  'following_count',
+  'media_count',
+  'likes_count',
+  'comments_count',
+  'shares_count',
+  'saves_count',
+  'views_count',
+  'reach_count',
+  'impressions_count',
+  'comment_count',
+  'sample_size',
+]);
+
+const OPERATION_LIMITS = Object.freeze({
+  resolve_creator: 1,
+  get_profile: 1,
+  get_recent_media: 50,
+  get_media_metrics: 50,
+  get_comments_sample: 100,
+  get_profile_metrics: 1,
+});
+
+const OPERATION_DATA_KEYS = Object.freeze({
+  resolve_creator: new Set(['resolved', 'canonical_handle', 'match_type', 'confidence']),
+  get_profile: new Set([
+    'canonical_handle',
+    'followers_count',
+    'following_count',
+    'media_count',
+    'is_private',
+    'is_verified',
+  ]),
+  get_recent_media: new Set(['media_key', 'media_kind', 'published_at', 'permalink_ref']),
+  get_media_metrics: new Set([
+    'media_key',
+    'likes_count',
+    'comments_count',
+    'shares_count',
+    'saves_count',
+    'views_count',
+    'reach_count',
+    'impressions_count',
+    'engagement_rate',
+  ]),
+  get_comments_sample: new Set([
+    'topic_key',
+    'language_code',
+    'sentiment_label',
+    'safety_label',
+    'comment_count',
+    'sample_size',
+    'spam_ratio',
+    'sentiment_score',
+    'model_version',
+  ]),
+  get_profile_metrics: new Set([
+    'followers_count',
+    'following_count',
+    'media_count',
+    'engagement_rate',
+    'average_likes',
+    'average_comments',
+    'posting_frequency',
+  ]),
+});
+
+export class ProviderContractError extends Error {
+  constructor(code, message = code) {
+    super(message);
+    this.name = 'ProviderContractError';
+    this.code = code;
+    this.reasonCode = code;
+  }
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function deepFreeze(value, seen = new Set()) {
+  if (!value || typeof value !== 'object' || seen.has(value)) return value;
+  seen.add(value);
+  for (const child of Object.values(value)) deepFreeze(child, seen);
+  return Object.freeze(value);
+}
+
+function fail(code, message = code) {
+  throw new ProviderContractError(code, message);
+}
+
+function protect(value, label) {
+  try {
+    assertNoSensitiveFields(value, label);
+  } catch {
+    fail('policy_block');
+  }
+}
+
+function normalizedString(value, label, { maxLength = 160, required = true } = {}) {
+  if (value === undefined || value === null || value === '') {
+    if (required) fail('invalid_request', `${label} is required`);
+    return undefined;
+  }
+  if (typeof value !== 'string') fail('invalid_request', `${label} must be a string`);
+  const result = value.trim();
+  if (!result && required) fail('invalid_request', `${label} must not be empty`);
+  if (result.length > maxLength || /[\u0000-\u001f\u007f]/.test(result)) {
+    fail('invalid_request', `${label} is not bounded`);
+  }
+  return result || undefined;
+}
+
+function slug(value, label, { maxLength = 80 } = {}) {
+  const result = normalizedString(value, label, { maxLength });
+  if (!slugPattern.test(result)) fail('invalid_request', `${label} must be a lowercase slug`);
+  return result;
+}
+
+function opaque(value, label) {
+  const result = normalizedString(value, label, { maxLength: 160 });
+  if (!opaquePattern.test(result)) fail('invalid_request', `${label} must be opaque`);
+  return result;
+}
+
+function timestamp(value, label, fallback) {
+  const source = value === undefined ? fallback : value;
+  const result = normalizedString(source, label, { maxLength: 40 });
+  const parsed = new Date(result);
+  if (Number.isNaN(parsed.getTime())) fail('invalid_request', `${label} must be an ISO timestamp`);
+  return parsed.toISOString();
+}
+
+function alias(input, snake, camel) {
+  if (input[snake] !== undefined && input[camel] !== undefined && input[snake] !== input[camel]) {
+    fail('invalid_request', `${snake} and ${camel} disagree`);
+  }
+  return input[snake] !== undefined ? input[snake] : input[camel];
+}
+
+function normalizeWindow(value) {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) fail('invalid_request', 'window must be an object');
+  protect(value, 'providerRequest.window');
+  const start = alias(value, 'start', 'windowStart');
+  const end = alias(value, 'end', 'windowEnd');
+  if (start === undefined && end === undefined) fail('invalid_request', 'window is empty');
+  const normalizedStart = timestamp(start, 'window.start', end || new Date().toISOString());
+  const normalizedEnd = timestamp(end, 'window.end', normalizedStart);
+  const startMs = Date.parse(normalizedStart);
+  const endMs = Date.parse(normalizedEnd);
+  if (endMs < startMs || endMs - startMs > 365 * 24 * 60 * 60 * 1000) {
+    fail('invalid_request', 'window must be ordered and at most 365 days');
+  }
+  return Object.freeze({ start: normalizedStart, end: normalizedEnd });
+}
+
+function normalizeList(value, label, { maxItems, itemNormalizer }) {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.length > maxItems) fail('invalid_request', `${label} is not bounded`);
+  const items = value.map((item, index) => itemNormalizer(item, `${label}[${index}]`));
+  if (new Set(items).size !== items.length) fail('invalid_request', `${label} must be unique`);
+  return Object.freeze(items);
+}
+
+function nowIso(now) {
+  const value = typeof now === 'function' ? now() : now;
+  const date = value instanceof Date ? value : new Date(value === undefined ? Date.now() : value);
+  if (Number.isNaN(date.getTime())) fail('invalid_request', 'clock returned an invalid timestamp');
+  return date.toISOString();
+}
+
+export function normalizeProviderOperation(value) {
+  if (typeof value !== 'string' || !operationSet.has(value)) {
+    fail('invalid_request', 'unsupported provider operation');
+  }
+  return value;
+}
+
+export function normalizeProviderSlug(value, label = 'provider') {
+  return slug(value, label);
+}
+
+export function normalizeProviderRequest(input, operation, { now = Date.now } = {}) {
+  if (!isRecord(input)) fail('invalid_request', 'provider request must be an object');
+  protect(input, 'providerRequest');
+  const normalizedOperation = normalizeProviderOperation(operation);
+  if (input.operation !== undefined && normalizeProviderOperation(input.operation) !== normalizedOperation) {
+    fail('operation_mismatch', 'request operation does not match the invoked operation');
+  }
+  const allowed = new Set([
+    'operation',
+    'creatorKey',
+    'creator_key',
+    'handle',
+    'canonicalHandle',
+    'canonical_handle',
+    'observedAt',
+    'observed_at',
+    'retrievedAt',
+    'retrieved_at',
+    'correlationId',
+    'correlation_id',
+    'window',
+    'limit',
+    'mediaKeys',
+    'media_keys',
+    'metricSet',
+    'metric_set',
+    'requestedFields',
+    'requested_fields',
+  ]);
+  if (Object.keys(input).some((key) => !allowed.has(key))) {
+    fail('invalid_request', 'provider request contains an unsupported field');
+  }
+
+  const creatorKeyValue = alias(input, 'creator_key', 'creatorKey');
+  const handleValue = input.canonical_handle ?? input.canonicalHandle ?? input.handle;
+  let creatorKey;
+  let handle;
+  try {
+    creatorKey = creatorKeyValue === undefined ? undefined : normalizeCreatorKey(creatorKeyValue);
+    handle = handleValue === undefined ? undefined : normalizeCanonicalHandle(handleValue);
+  } catch {
+    fail('invalid_request', 'creator identity is invalid');
+  }
+  if (normalizedOperation === 'resolve_creator' && !handle) {
+    fail('invalid_request', 'resolve_creator requires a canonical handle');
+  }
+  if (normalizedOperation !== 'resolve_creator' && !creatorKey) {
+    fail('invalid_request', `${normalizedOperation} requires creator_key`);
+  }
+
+  const observedAt = timestamp(alias(input, 'observed_at', 'observedAt'), 'observed_at', nowIso(now));
+  const retrievedAt = timestamp(alias(input, 'retrieved_at', 'retrievedAt'), 'retrieved_at', nowIso(now));
+  if (Date.parse(retrievedAt) < Date.parse(observedAt)) {
+    fail('invalid_request', 'retrieved_at must not precede observed_at');
+  }
+
+  const rawLimit = input.limit === undefined ? Math.min(20, OPERATION_LIMITS[normalizedOperation]) : input.limit;
+  if (!Number.isInteger(rawLimit) || rawLimit < 1 || rawLimit > OPERATION_LIMITS[normalizedOperation]) {
+    fail('invalid_request', 'limit is outside the operation bound');
+  }
+  const correlationId = normalizedString(
+    alias(input, 'correlation_id', 'correlationId'),
+    'correlation_id',
+    { maxLength: 160, required: false },
+  ) || `ii:${normalizedOperation}:${creatorKey || handle}`;
+  const mediaKeys = normalizeList(
+    alias(input, 'media_keys', 'mediaKeys'),
+    'media_keys',
+    { maxItems: OPERATION_LIMITS.get_media_metrics, itemNormalizer: opaque },
+  );
+  const metricSet = normalizeList(
+    alias(input, 'metric_set', 'metricSet'),
+    'metric_set',
+    { maxItems: 32, itemNormalizer: slug },
+  );
+  const requestedFields = normalizeList(
+    alias(input, 'requested_fields', 'requestedFields'),
+    'requested_fields',
+    { maxItems: 64, itemNormalizer: slug },
+  );
+  if (normalizedOperation === 'get_media_metrics' && (!mediaKeys || mediaKeys.length === 0)) {
+    fail('invalid_request', 'get_media_metrics requires media_keys');
+  }
+
+  const window = normalizeWindow(input.window);
+
+  return deepFreeze({
+    operation: normalizedOperation,
+    ...(creatorKey ? { creator_key: creatorKey } : {}),
+    ...(handle ? { canonical_handle: handle } : {}),
+    observed_at: observedAt,
+    retrieved_at: retrievedAt,
+    correlation_id: correlationId,
+    ...(window ? { window } : {}),
+    limit: rawLimit,
+    ...(mediaKeys ? { media_keys: mediaKeys } : {}),
+    ...(metricSet ? { metric_set: metricSet } : {}),
+    ...(requestedFields ? { requested_fields: requestedFields } : {}),
+  });
+}
+
+function camelToSnake(value) {
+  return value.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+}
+
+function unwrapData(operation, value) {
+  if (!isRecord(value)) return value;
+  const wrapper = {
+    resolve_creator: 'creator',
+    get_profile: 'profile',
+    get_recent_media: 'media',
+    get_media_metrics: 'metrics',
+    get_comments_sample: 'samples',
+    get_profile_metrics: 'metrics',
+  }[operation];
+  if (wrapper && value[wrapper] !== undefined) return value[wrapper];
+  return value;
+}
+
+function scalar(value, key) {
+  if (value === null) return null;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) fail('invalid_response', `${key} must be finite`);
+    if (COUNT_KEYS.has(key) && (!Number.isInteger(value) || value < 0)) {
+      fail('invalid_response', `${key} must be a non-negative integer`);
+    }
+    if (key === 'confidence' && (value < 0 || value > 1)) fail('invalid_response', `${key} is outside a safe range`);
+    if (key.endsWith('_ratio') && (value < 0 || value > 1)) fail('invalid_response', `${key} is outside a safe range`);
+    if (key === 'sentiment_score' && (value < -1 || value > 1)) fail('invalid_response', `${key} is outside a safe range`);
+    if (key.endsWith('_rate') && (value < 0 || value > 100)) fail('invalid_response', `${key} is outside a safe range`);
+    return Number(value.toFixed(6));
+  }
+  if (typeof value === 'string') {
+    if (value.length > 240 || /[\u0000-\u001f\u007f]/.test(value)) fail('invalid_response');
+    return value.trim();
+  }
+  fail('invalid_response', `${key} must be scalar`);
+}
+
+function normalizeDataObject(operation, value) {
+  const raw = unwrapData(operation, value);
+  const allowed = OPERATION_DATA_KEYS[operation];
+  if (!isRecord(raw)) fail('invalid_response', `${operation} data must be an object`);
+  const result = {};
+  for (const [rawKey, rawValue] of Object.entries(raw)) {
+    const key = camelToSnake(rawKey);
+    if (!allowed.has(key)) fail('invalid_response', `${operation} returned an unsupported field`);
+    if (result[key] !== undefined) fail('invalid_response', `${operation} returned duplicate fields`);
+    if (key === 'canonical_handle') {
+      try {
+        result[key] = rawValue === null ? null : normalizeCanonicalHandle(rawValue);
+      } catch {
+        fail('invalid_response', 'canonical_handle is invalid');
+      }
+    } else if (key === 'media_key') {
+      result[key] = rawValue === null ? null : opaque(rawValue, 'media_key');
+    } else if (key === 'permalink_ref') {
+      const ref = normalizedString(rawValue, 'permalink_ref', { maxLength: 240 });
+      if (!sourceRefPattern.test(ref)) fail('policy_block', 'permalink_ref must be opaque');
+      result[key] = ref;
+    } else if (key === 'published_at') {
+      result[key] = rawValue === null ? null : timestamp(rawValue, 'published_at');
+    } else if (key === 'topic_key' || key === 'match_type' || key === 'language_code' || key === 'sentiment_label' || key === 'safety_label' || key === 'model_version' || key === 'media_kind') {
+      result[key] = rawValue === null ? null : slug(rawValue, key);
+    } else if (key === 'resolved' || key === 'is_private' || key === 'is_verified') {
+      if (rawValue !== null && typeof rawValue !== 'boolean') fail('invalid_response', `${key} must be boolean`);
+      result[key] = rawValue;
+    } else {
+      result[key] = scalar(rawValue, key);
+    }
+  }
+  return deepFreeze(result);
+}
+
+function normalizeData(operation, value) {
+  const raw = unwrapData(operation, value);
+  const collectionOperations = new Set(['get_recent_media', 'get_media_metrics', 'get_comments_sample']);
+  if (!collectionOperations.has(operation)) return normalizeDataObject(operation, raw);
+  const items = Array.isArray(raw)
+    ? raw
+    : isRecord(raw) && Array.isArray(raw.items)
+      ? raw.items
+      : isRecord(raw) && Array.isArray(raw.media)
+        ? raw.media
+        : isRecord(raw) && Array.isArray(raw.metrics)
+          ? raw.metrics
+          : isRecord(raw) && Array.isArray(raw.samples)
+            ? raw.samples
+            : null;
+  if (!items || items.length > OPERATION_LIMITS[operation]) fail('invalid_response', `${operation} data must be a bounded array`);
+  return deepFreeze(items.map((item) => normalizeDataObject(operation, item)));
+}
+
+function normalizeLimitations(value, status) {
+  if (value === undefined) return status === 'unavailable' ? Object.freeze(['coverage_gap']) : Object.freeze([]);
+  if (!Array.isArray(value) || value.length > 16) fail('invalid_response', 'limitations must be bounded');
+  const values = value.map((item) => slug(item, 'limitation', { maxLength: 80 }));
+  if (status === 'unavailable' && values.length === 0) values.push('coverage_gap');
+  return Object.freeze([...new Set(values)]);
+}
+
+function normalizeEvidence(value, { provider, operation, request, adapterVersion, sourceRef }) {
+  const input = value === undefined ? {} : value;
+  if (!isRecord(input)) fail('invalid_response', 'provider_specific_evidence must be an object');
+  protect(input, 'providerSpecificEvidence');
+  const allowed = new Set([
+    'adapter_version',
+    'adapterVersion',
+    'source_ref',
+    'sourceRef',
+    'fields',
+    'observed_fields',
+    'endpoint_family',
+    'coverage_code',
+    'provider',
+    'operation',
+    'correlation_id',
+  ]);
+  if (Object.keys(input).some((key) => !allowed.has(key))) fail('policy_block', 'provider-specific evidence is not bounded');
+  if (input.provider !== undefined && input.provider !== provider) {
+    fail('invalid_response', 'provider-specific evidence provider mismatch');
+  }
+  if (input.operation !== undefined && input.operation !== operation) {
+    fail('invalid_response', 'provider-specific evidence operation mismatch');
+  }
+  if (input.correlation_id !== undefined && input.correlation_id !== request.correlation_id) {
+    fail('invalid_response', 'provider-specific evidence correlation mismatch');
+  }
+  const evidence = {
+    adapter_version: slug(input.adapter_version ?? input.adapterVersion ?? adapterVersion, 'adapter_version'),
+    source_ref: input.source_ref ?? input.sourceRef ?? sourceRef,
+  };
+  if (!sourceRefPattern.test(evidence.source_ref)) fail('policy_block', 'source_ref is not opaque');
+  const fields = input.fields || input.observed_fields;
+  if (fields !== undefined) {
+    evidence.fields = normalizeList(fields, 'provider_specific_evidence.fields', { maxItems: 64, itemNormalizer: slug });
+  }
+  if (input.endpoint_family !== undefined) evidence.endpoint_family = slug(input.endpoint_family, 'endpoint_family');
+  if (input.coverage_code !== undefined) evidence.coverage_code = slug(input.coverage_code, 'coverage_code');
+  evidence.provider = provider;
+  evidence.operation = operation;
+  evidence.correlation_id = request.correlation_id;
+  return deepFreeze(evidence);
+}
+
+function normalizeFreshness(value, observedAt, retrievedAt) {
+  const raw = value === undefined ? {} : value;
+  if (!isRecord(raw)) fail('invalid_response', 'freshness must be an object');
+  protect(raw, 'freshness');
+  const maxAge = raw.max_age_seconds ?? raw.maxAgeSeconds ?? 86400;
+  if (!Number.isInteger(maxAge) || maxAge < 0 || maxAge > 315360000) fail('invalid_response', 'freshness max age is invalid');
+  const age = observedAt ? Math.max(0, Math.floor((Date.parse(retrievedAt) - Date.parse(observedAt)) / 1000)) : null;
+  const status = age === null ? 'unknown' : age <= maxAge ? 'fresh' : 'stale';
+  if (!freshnessSet.has(status)) fail('invalid_response');
+  return deepFreeze({
+    status,
+    observed_at: observedAt || null,
+    retrieved_at: retrievedAt,
+    age_seconds: age,
+    max_age_seconds: maxAge,
+  });
+}
+
+export function normalizeProviderCandidate({
+  operation,
+  provider,
+  request,
+  candidate,
+  adapterVersion = 'provider-adapter/v1',
+  sourceRef,
+} = {}) {
+  const normalizedOperation = normalizeProviderOperation(operation);
+  const normalizedProvider = normalizeProviderSlug(provider);
+  if (!isRecord(candidate)) fail('invalid_response', 'provider candidate must be an object');
+  protect(candidate, 'providerCandidate');
+  if (candidate.contract_version !== undefined && candidate.contract_version !== PROVIDER_OPERATION_CONTRACT_VERSION) {
+    fail('invalid_response', 'provider contract version is unsupported');
+  }
+  if (candidate.operation !== undefined && candidate.operation !== normalizedOperation) {
+    fail('invalid_response', 'provider candidate operation mismatch');
+  }
+  if (candidate.provider !== undefined && candidate.provider !== normalizedProvider) {
+    fail('invalid_response', 'provider candidate provider mismatch');
+  }
+  const dataEnvelope = Object.prototype.hasOwnProperty.call(candidate, 'data');
+  const rawData = dataEnvelope ? candidate.data : candidate;
+  const requestedStatus = candidate.status;
+  if (requestedStatus !== undefined && requestedStatus !== 'ok' && requestedStatus !== 'unavailable') {
+    fail('invalid_response', 'provider status is invalid');
+  }
+  const status = requestedStatus || (rawData === null ? 'unavailable' : 'ok');
+  const observedAt = timestamp(
+    candidate.observed_at ?? candidate.observedAt ?? candidate.freshness?.observed_at,
+    'observed_at',
+    request.observed_at,
+  );
+  const retrievedAt = timestamp(
+    candidate.retrieved_at ?? candidate.retrievedAt ?? candidate.freshness?.retrieved_at,
+    'retrieved_at',
+    request.retrieved_at,
+  );
+  if (Date.parse(retrievedAt) < Date.parse(observedAt)) fail('invalid_response', 'provider timestamps are reversed');
+  const dataClassification = candidate.data_classification ?? candidate.dataClassification ?? 'observed';
+  if (!classificationSet.has(dataClassification)) fail('invalid_response', 'data_classification is invalid');
+  const data = status === 'unavailable' ? null : normalizeData(normalizedOperation, rawData);
+  const limitations = normalizeLimitations(candidate.limitations, status);
+  const evidence = normalizeEvidence(
+    candidate.provider_specific_evidence ?? candidate.providerSpecificEvidence,
+    {
+      provider: normalizedProvider,
+      operation: normalizedOperation,
+      request,
+      adapterVersion,
+      sourceRef: sourceRef || `${normalizedProvider}:${normalizedOperation}:${request.creator_key || 'unresolved'}`,
+    },
+  );
+  return deepFreeze({
+    contract_version: PROVIDER_OPERATION_CONTRACT_VERSION,
+    operation: normalizedOperation,
+    status,
+    provider: normalizedProvider,
+    retrieved_at: retrievedAt,
+    data_classification: dataClassification,
+    freshness: normalizeFreshness(candidate.freshness, observedAt, retrievedAt),
+    limitations,
+    provider_specific_evidence: evidence,
+    data,
+  });
+}
+
+export function unavailableProviderResult({ operation, retrievedAt, limitations = [], provider = null } = {}) {
+  const normalizedOperation = normalizeProviderOperation(operation);
+  const normalizedRetrievedAt = timestamp(retrievedAt, 'retrieved_at', new Date().toISOString());
+  const safeLimitations = normalizeLimitations(limitations, 'unavailable');
+  return deepFreeze({
+    contract_version: PROVIDER_OPERATION_CONTRACT_VERSION,
+    operation: normalizedOperation,
+    status: 'unavailable',
+    provider: provider === null ? null : normalizeProviderSlug(provider),
+    retrieved_at: normalizedRetrievedAt,
+    data_classification: 'observed',
+    freshness: normalizeFreshness(undefined, undefined, normalizedRetrievedAt),
+    limitations: safeLimitations,
+    provider_specific_evidence: deepFreeze({
+      adapter_version: 'provider-router/v1',
+      source_ref: `router:${normalizedOperation}:unavailable`,
+      operation: normalizedOperation,
+    }),
+    data: null,
+  });
+}
+
+export function isFallbackCode(value) {
+  return fallbackCodeSet.has(value);
+}

--- a/social/influencer-intelligence/tests/architecture.test.mjs
+++ b/social/influencer-intelligence/tests/architecture.test.mjs
@@ -40,13 +40,32 @@ test('keeps the provider boundary official-first and fail-closed', () => {
     'permission_gap',
     'coverage_gap',
     'timeout',
+    'circuit_open',
+    'retry_exhausted',
   ]);
   assert.deepEqual(BOUNDARIES.find(({ id }) => id === 'provider-router').failClosedFor, [
     'policy_block',
     'invalid_response',
     'unclassified_transport',
   ]);
+  assert.deepEqual(PROVIDER_INTERFACE.operations.map(({ name }) => name), [
+    'resolve_creator',
+    'get_profile',
+    'get_recent_media',
+    'get_media_metrics',
+    'get_comments_sample',
+    'get_profile_metrics',
+  ]);
   assert.ok(PROVIDER_INTERFACE.operations.every(({ readOnly }) => readOnly === true));
+  assert.deepEqual(PROVIDER_INTERFACE.result.fields, [
+    'provider',
+    'retrievedAt',
+    'dataClassification',
+    'freshness',
+    'limitations',
+    'providerSpecificEvidence',
+    'data',
+  ]);
 });
 
 test('models evidence as append-only and provenance-complete', () => {

--- a/social/influencer-intelligence/tests/provider-router-contract.test.mjs
+++ b/social/influencer-intelligence/tests/provider-router-contract.test.mjs
@@ -1,0 +1,389 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  createInstagrapiProvider,
+} from '../providers/instagrapi-adapter.mjs';
+import {
+  createMetaGraphProvider,
+} from '../providers/meta-graph-adapter.mjs';
+import {
+  PROVIDER_OPERATIONS,
+} from '../providers/provider-contracts.mjs';
+import {
+  ProviderCollectionError,
+  ProviderGapError,
+} from '../providers/profile-provider.mjs';
+import {
+  createProviderRouter,
+  ProviderRouterError,
+} from '../provider-router.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const observedAt = '2026-08-10T14:00:00.000Z';
+const retrievedAt = '2026-08-10T14:00:02.000Z';
+const baseRequest = {
+  creatorKey: 'creator:synthetic-001',
+  handle: '@Synthetic.Creator',
+  observedAt,
+  retrievedAt,
+};
+
+function requestFor(operation) {
+  if (operation === 'resolve_creator') {
+    return { handle: baseRequest.handle, observedAt, retrievedAt };
+  }
+  if (operation === 'get_media_metrics') {
+    return { ...baseRequest, mediaKeys: ['media:synthetic-001'] };
+  }
+  return { ...baseRequest };
+}
+
+function candidateFor(operation) {
+  const data = {
+    resolve_creator: {
+      resolved: true,
+      canonical_handle: 'synthetic.creator',
+      match_type: 'canonical_handle',
+      confidence: 0.99,
+    },
+    get_profile: {
+      canonical_handle: 'synthetic.creator',
+      followers_count: 12000,
+      media_count: 42,
+      is_private: false,
+      is_verified: false,
+    },
+    get_recent_media: [{
+      media_key: 'media:synthetic-001',
+      media_kind: 'image',
+      published_at: retrievedAt,
+      permalink_ref: 'meta-graph:media:synthetic-001',
+    }],
+    get_media_metrics: [{
+      media_key: 'media:synthetic-001',
+      likes_count: 10,
+      comments_count: 2,
+      views_count: 120,
+      engagement_rate: 0.1,
+    }],
+    get_comments_sample: [{
+      topic_key: 'product',
+      language_code: 'pt',
+      sentiment_label: 'positive',
+      safety_label: 'safe',
+      comment_count: 4,
+      sample_size: 4,
+      spam_ratio: 0,
+      sentiment_score: 0.8,
+      model_version: 'comments-v1',
+    }],
+    get_profile_metrics: {
+      followers_count: 12000,
+      media_count: 42,
+      average_likes: 10,
+      average_comments: 2,
+      engagement_rate: 0.1,
+      posting_frequency: 0.5,
+    },
+  }[operation];
+  return {
+    data,
+    data_classification: operation === 'get_comments_sample' ? 'derived' : 'observed',
+    freshness: { max_age_seconds: 3600 },
+    limitations: [],
+    provider_specific_evidence: {
+      adapter_version: 'fixture-adapter-v1',
+      source_ref: `fixture:${operation}:synthetic-001`,
+      fields: ['synthetic_projection'],
+      endpoint_family: 'read-only-analytics',
+    },
+  };
+}
+
+test('router executes all six typed operations with bounded evidence envelopes', async () => {
+  const calls = [];
+  const meta = createMetaGraphProvider({
+    operations: Object.fromEntries(PROVIDER_OPERATIONS.map((operation) => [
+      operation,
+      async (request, context) => {
+        calls.push({ operation, request, context });
+        return candidateFor(operation);
+      },
+    ])),
+  });
+  const router = createProviderRouter({ providers: { 'meta-graph': meta } });
+
+  for (const operation of PROVIDER_OPERATIONS) {
+    const result = await router[operation](requestFor(operation));
+    assert.equal(result.status, 'ok');
+    assert.equal(result.provider, 'meta-graph');
+    assert.equal(result.operation, operation);
+    assert.equal(result.retrieved_at, retrievedAt);
+    assert.ok(['observed', 'derived', 'inferred'].includes(result.data_classification));
+    assert.ok(['fresh', 'stale', 'unknown'].includes(result.freshness.status));
+    assert.ok(Array.isArray(result.limitations));
+    assert.equal(result.provider_specific_evidence.provider, 'meta-graph');
+    assert.equal(result.provider_specific_evidence.operation, operation);
+    assert.equal(result.provider_specific_evidence.adapter_version, 'fixture-adapter-v1');
+    assert.equal(result.attempts.length, 1);
+    assert.equal(result.attempts[0].status, 'ok');
+  }
+
+  assert.equal(calls.length, PROVIDER_OPERATIONS.length);
+  assert.equal(calls[0].context.signal instanceof AbortSignal, true);
+  assert.deepEqual(calls[0].request.requested_fields, ['username']);
+  assert.equal('access_token' in calls[0].request, false);
+});
+
+test('Meta is attempted before the existing private provider and only explicit gaps fall back', async () => {
+  const calls = [];
+  const meta = createMetaGraphProvider({
+    operations: {
+      get_recent_media: async () => {
+        calls.push('meta-graph');
+        throw new ProviderGapError('coverage_gap');
+      },
+    },
+  });
+  const instagrapi = createInstagrapiProvider({
+    operations: {
+      get_recent_media: async () => {
+        calls.push('instagrapi');
+        return candidateFor('get_recent_media');
+      },
+    },
+  });
+  const router = createProviderRouter({ providers: { 'meta-graph': meta, instagrapi } });
+
+  const result = await router.get_recent_media(requestFor('get_recent_media'));
+  assert.equal(result.provider, 'instagrapi');
+  assert.deepEqual(calls, ['meta-graph', 'instagrapi']);
+  assert.deepEqual(result.attempts.map(({ provider, status, classification }) => ({
+    provider,
+    status,
+    classification,
+  })), [
+    { provider: 'meta-graph', status: 'gap', classification: 'coverage_gap' },
+    { provider: 'instagrapi', status: 'ok', classification: undefined },
+  ]);
+});
+
+test('timeout is safely retried once and returns the provider result without inventing data', async () => {
+  let calls = 0;
+  const sleeps = [];
+  const meta = createMetaGraphProvider({
+    operations: {
+      get_profile: async (_request, context) => {
+        calls += 1;
+        assert.equal(context.signal.aborted, false);
+        if (calls === 1) {
+          const error = new Error('synthetic timeout');
+          error.code = 'timeout';
+          throw error;
+        }
+        return candidateFor('get_profile');
+      },
+    },
+  });
+  const router = createProviderRouter({
+    providers: { 'meta-graph': meta },
+    timeoutMs: 50,
+    retryPolicy: { maxAttempts: 2, baseDelayMs: 0 },
+    sleep: async (delay) => sleeps.push(delay),
+  });
+
+  const result = await router.get_profile(baseRequest);
+  assert.equal(calls, 2);
+  assert.deepEqual(sleeps, [0]);
+  assert.equal(result.data.followers_count, 12000);
+  assert.equal(result.attempts[0].retry_count, 1);
+});
+
+test('exhausted transient retries become an explicit gap classification', async () => {
+  const meta = createMetaGraphProvider({
+    operations: {
+      get_profile: async () => {
+        const error = new Error('synthetic timeout');
+        error.code = 'timeout';
+        throw error;
+      },
+    },
+  });
+  const router = createProviderRouter({
+    providers: { 'meta-graph': meta },
+    timeoutMs: 50,
+    retryPolicy: { maxAttempts: 2, baseDelayMs: 0 },
+    sleep: async () => {},
+  });
+
+  const result = await router.get_profile(baseRequest);
+  assert.equal(result.status, 'unavailable');
+  assert.equal(result.data, null);
+  assert.equal(result.attempts[0].classification, 'retry_exhausted');
+  assert.equal(result.attempts[0].retry_count, 1);
+});
+
+test('the router aborts a hung provider call at the configured timeout', async () => {
+  let aborted = false;
+  const meta = createMetaGraphProvider({
+    operations: {
+      get_profile: async (_request, { signal }) => new Promise((resolve, reject) => {
+        signal.addEventListener('abort', () => {
+          aborted = true;
+          const error = new Error('aborted by router');
+          error.code = 'timeout';
+          reject(error);
+        }, { once: true });
+      }),
+    },
+  });
+  const router = createProviderRouter({
+    providers: { 'meta-graph': meta },
+    timeoutMs: 5,
+    retryPolicy: { maxAttempts: 1 },
+  });
+
+  const result = await router.get_profile(baseRequest);
+  assert.equal(aborted, true);
+  assert.equal(result.status, 'unavailable');
+  assert.equal(result.data, null);
+  assert.equal(result.attempts[0].classification, 'timeout');
+});
+
+test('transient failures open a per-provider/per-operation circuit and skip the open provider', async () => {
+  let metaCalls = 0;
+  const meta = createMetaGraphProvider({
+    operations: {
+      get_comments_sample: async () => {
+        metaCalls += 1;
+        throw new ProviderCollectionError('transport_error');
+      },
+    },
+  });
+  const instagrapi = createInstagrapiProvider({
+    operations: {
+      get_comments_sample: async () => candidateFor('get_comments_sample'),
+    },
+  });
+  const router = createProviderRouter({
+    providers: { 'meta-graph': meta, instagrapi },
+    circuitBreaker: { failureThreshold: 1, resetAfterMs: 30000 },
+    retryPolicy: { maxAttempts: 1 },
+  });
+
+  const first = await router.get_comments_sample(baseRequest);
+  const second = await router.get_comments_sample(baseRequest);
+  assert.equal(first.provider, 'instagrapi');
+  assert.equal(second.provider, 'instagrapi');
+  assert.equal(metaCalls, 1);
+  assert.equal(second.attempts[0].classification, 'circuit_open');
+  assert.equal(router.getCircuitState()['meta-graph:get_comments_sample'].failures, 1);
+});
+
+test('unsupported operation coverage remains unavailable and never fabricates metric values', async () => {
+  const meta = createMetaGraphProvider({ readProfile: async () => ({
+    handle: 'synthetic.creator',
+    followersCount: 12000,
+    mediaCount: 42,
+  }) });
+  const instagrapi = createInstagrapiProvider({ readProfile: async () => ({}) });
+  const router = createProviderRouter({ providers: { 'meta-graph': meta, instagrapi } });
+
+  const result = await router.get_profile_metrics(baseRequest);
+  assert.equal(result.status, 'unavailable');
+  assert.equal(result.provider, null);
+  assert.equal(result.data, null);
+  assert.ok(result.limitations.includes('coverage_gap'));
+  assert.equal(result.attempts.every(({ status }) => status === 'gap'), true);
+});
+
+test('the router keeps the pre-existing collect-only adapter boundary compatible', async () => {
+  const legacyMeta = {
+    id: 'meta-graph',
+    officialFirst: true,
+    capabilities: ['profile'],
+    collect: async () => ({
+      creatorKey: 'creator:synthetic-001',
+      handle: 'synthetic.creator',
+      provider: 'meta-graph',
+      observedAt,
+      evidenceState: 'observed',
+      provenance: {
+        provider: 'meta-graph',
+        sourceRef: 'meta-graph:legacy:creator:synthetic-001',
+      },
+      observations: [
+        { key: 'followers_count', value: 12000 },
+        { key: 'media_count', value: 42 },
+      ],
+    }),
+  };
+  const router = createProviderRouter({ providers: { 'meta-graph': legacyMeta } });
+
+  const result = await router.get_profile(baseRequest);
+  assert.equal(result.status, 'ok');
+  assert.equal(result.provider, 'meta-graph');
+  assert.equal(result.data.followers_count, 12000);
+  assert.equal(result.data.media_count, 42);
+});
+
+test('future external providers require explicit opt-in and still use the same contract', async () => {
+  const meta = createMetaGraphProvider({
+    operations: {
+      get_profile: async () => {
+        throw new ProviderGapError('coverage_gap');
+      },
+    },
+  });
+  const future = {
+    id: 'future-provider',
+    officialFirst: false,
+    external: true,
+    capabilities: ['get_profile'],
+    get_profile: async () => candidateFor('get_profile'),
+  };
+
+  assert.throws(() => createProviderRouter({
+    providers: { 'meta-graph': meta, 'future-provider': future },
+    providerOrder: ['meta-graph', 'future-provider'],
+  }), (error) => error instanceof ProviderRouterError && error.reasonCode === 'unknown_provider');
+
+  const router = createProviderRouter({
+    providers: { 'meta-graph': meta, 'future-provider': future },
+    providerOrder: ['meta-graph', 'future-provider'],
+    externalProviderConfig: { enabled: true, allowlist: ['future-provider'] },
+  });
+  const result = await router.get_profile(baseRequest);
+  assert.equal(result.provider, 'future-provider');
+  assert.equal(result.data.followers_count, 12000);
+});
+
+test('credential-like request fields and provider writes are rejected at the boundary', async () => {
+  const meta = createMetaGraphProvider({ readProfile: async () => ({}) });
+  const router = createProviderRouter({ providers: { 'meta-graph': meta } });
+  await assert.rejects(
+    router.get_profile({ ...baseRequest, access_token: 'synthetic-secret' }),
+    (error) => error instanceof ProviderRouterError && error.reasonCode === 'policy_block',
+  );
+  for (const operation of ['follow', 'like', 'send_dm', 'post']) {
+    assert.equal(typeof router[operation], 'undefined');
+  }
+});
+
+test('provider implementation remains transport-injected and contains no network or scraper dependency', () => {
+  const providerFiles = [
+    '../provider-router.mjs',
+    '../providers/provider-contracts.mjs',
+    '../providers/operation-provider.mjs',
+    '../providers/profile-provider.mjs',
+    '../providers/meta-graph-adapter.mjs',
+    '../providers/instagrapi-adapter.mjs',
+  ].map((relativePath) => fs.readFileSync(path.join(here, relativePath), 'utf8')).join('\n');
+  assert.doesNotMatch(providerFiles, /\bfetch\s*\(/i);
+  assert.doesNotMatch(providerFiles, /from\s+['"]node:(?:http|https|net|tls)['"]/i);
+  assert.doesNotMatch(providerFiles, /InstagramModuleSimulator|instaloader/i);
+});


### PR DESCRIPTION
## Summary

- Implement the Influencer Intelligence provider-operation contracts and router for `resolve_creator`, `get_profile`, `get_recent_media`, `get_media_metrics`, `get_comments_sample`, and `get_profile_metrics`.
- Keep Meta Graph official-first and route the existing `social/instagram`/instagrapi boundary only as a controlled fallback.
- Add bounded timeout, safe retry, per-provider/per-operation circuit state, structured failure classification, external-provider opt-in, and typed contract declarations.
- Add synthetic contract tests and synchronize the architecture/ADR and governance workflow.

## Guardrails and scope

- All provider transports remain injected; this PR does not make network calls, read Token Vault credentials, open sessions, add a scraper, or duplicate instagrapi/Instaloader.
- Results carry provider, retrieval time, classification, freshness, limitations, bounded provider-specific evidence, and `data: null` when coverage is unavailable.
- No follow, like, DM, post, publication, engagement, CRM registration, MCP registration, Orb workflow, systemd/runtime, feature activation, or migration application is included.
- External providers are rejected unless explicitly enabled, allowlisted, and marked external; the default runtime remains Meta then instagrapi.

## Validation

- `node --test social/influencer-intelligence/tests/architecture.test.mjs social/influencer-intelligence/tests/contracts.test.mjs social/influencer-intelligence/tests/data-model.test.mjs social/influencer-intelligence/tests/provider-router-contract.test.mjs social/influencer-intelligence/tests/providers.test.mjs social/influencer-intelligence/tests/registry.test.mjs` — 45 passing.
- `npm run architecture:validate` — passed; existing unrelated legacy-import warnings remain reported by the repository validator.
- `npm run quality:security` — passed (`js-security-exceptions`, `no-demo-guard`).
- `git diff --check` — passed.

## Risk and rollback

- Risk: medium at the contract boundary; the feature remains off and no live provider transport is connected.
- Migration: none applied.
- Flag/grant: unchanged and off by default.
- Rollback: revert this PR or restore `origin/main` base `8477d02486950d9848609e09100b4b0cc7099a7b`.
