### PR TITLE
feat(site): refine Beauty Movement card dealing

### DIFF
--- a/scripts/run-local-website.sh
+++ b/scripts/run-local-website.sh
@@ -302,6 +302,7 @@ start_detached_supervisor() {
     OPEN_BROWSER=0 \
     WEBSITE_SUPERVISOR_MODE=1 \
     WEBSITE_DETACH=0 \
+    WEBSITE_SOURCE_ROOT="$WEBSITE_SOURCE_ROOT" \
     WEBSITE_HOST="$WEBSITE_HOST" \
     WEBSITE_PORT="$WEBSITE_PORT" \
     WEBSITE_STATE_DIR="$WEBSITE_STATE_DIR" \
@@ -309,6 +310,10 @@ start_detached_supervisor() {
     WEBSITE_LOG_FILE="$LOG_FILE" \
     WEBSITE_PORT_FILE="$PORT_FILE" \
     WEBSITE_ROUTE="$WEBSITE_ROUTE" \
+    TMPDIR="${TMPDIR:-}" \
+    TMP="${TMP:-}" \
+    TEMP="${TEMP:-}" \
+    XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-}" \
     bash "$SCRIPT_PATH" >>"$LOG_FILE" 2>&1 < /dev/null &
   DETACHED_SUPERVISOR_PID=$!
 }

--- a/website/src/app/beleza-em-movimento/local-preview/page.tsx
+++ b/website/src/app/beleza-em-movimento/local-preview/page.tsx
@@ -18,7 +18,7 @@ export default function BeautyMovementLocalPreviewPage() {
 
     return (
         <>
-            <Header preferredUnitSlug="novo-hamburgo" fixedUnitSlug="novo-hamburgo" />
+            <Header preferredUnitSlug="novo-hamburgo" fixedUnitSlug="novo-hamburgo" scrollAware />
             <BeautyMovementLocalPreview />
             <Footer />
         </>

--- a/website/src/app/beleza-em-movimento/page.tsx
+++ b/website/src/app/beleza-em-movimento/page.tsx
@@ -7,7 +7,7 @@ const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://espacofacial.com")
 
 export const metadata: Metadata = {
   title: "Cartas da Beleza em Movimento | Espaço Facial",
-  description: "Uma experiência editorial exclusiva da Espaço Facial Novo Hamburgo em parceria com a Velocity.",
+  description: "Uma experiência editorial exclusiva da Espaço Facial Novo Hamburgo para celebrar 3 anos de beleza em movimento.",
   alternates: {
     canonical: `${siteUrl}/beleza-em-movimento`,
   },
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
 export default function BeautyMovementPage() {
   return (
     <>
-      <Header preferredUnitSlug="novo-hamburgo" fixedUnitSlug="novo-hamburgo" />
+      <Header preferredUnitSlug="novo-hamburgo" fixedUnitSlug="novo-hamburgo" scrollAware />
       <BeautyMovementCampaign />
       <Footer />
     </>

--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -13,7 +13,7 @@
   position: relative;
   overflow-x: hidden;
   min-height: 0;
-  padding: clamp(48px, 7vw, 88px) 0 clamp(32px, 4vw, 56px);
+  padding: clamp(24px, 3.5vw, 46px) 0 clamp(32px, 4vw, 56px);
   background: var(--bm-bg);
   color: var(--bm-ink);
 }
@@ -41,33 +41,66 @@
   text-align: center;
 }
 
-.brandLine {
+.heroDeckPrompt {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 12px;
+  gap: 10px;
+  width: min(100%, 220px);
+  max-width: 100%;
+  min-height: 40px;
+  margin: 0 0 clamp(14px, 2.4vw, 22px);
+  padding: 9px 18px;
+  border: 1px solid var(--bm-yellow-ink);
+  border-radius: 999px;
+  background: var(--bm-yellow-soft);
   color: var(--bm-ink);
+  cursor: pointer;
   font-family: var(--font-brand-ui);
-  font-size: 0.76rem;
+  font-size: clamp(0.76rem, 1vw, 0.86rem);
   font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  line-height: 1.25;
+  text-align: center;
+  white-space: nowrap;
+  box-shadow: 0 8px 18px rgba(48, 48, 48, 0.1);
+  transition: background 180ms ease, box-shadow 180ms ease, transform 180ms ease;
 }
 
-.brandDivider {
-  color: var(--bm-muted);
-  font-size: 1.25rem;
-  font-weight: 400;
-  line-height: 1;
+.heroDeckPrompt::before {
+  flex: 0 0 auto;
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--bm-yellow);
+  content: "";
 }
 
-.partnerName {
+.heroDeckPrompt:hover {
+  background: #ffe9a0;
+  box-shadow: 0 12px 24px rgba(48, 48, 48, 0.14);
+  transform: translateY(-2px);
+}
+
+.heroDeckPrompt:focus-visible {
+  outline: 3px solid var(--bm-yellow);
+  outline-offset: 4px;
+}
+
+.heroDeckPromptArrow {
   color: var(--bm-yellow-ink);
+  font-size: 1.15rem;
+  line-height: 1;
+  transition: transform 180ms ease;
+}
+
+.heroDeckPrompt:hover .heroDeckPromptArrow {
+  transform: translateY(3px);
 }
 
 .hero h1 {
   max-width: 760px;
-  margin: 18px 0 0;
+  margin: 0;
   color: var(--bm-ink);
   font-family: var(--font-brand-ui);
   font-size: clamp(2.7rem, 7vw, 5.7rem);
@@ -77,37 +110,152 @@
   text-wrap: balance;
 }
 
-.heroCopy {
-  max-width: 610px;
-  margin: 24px 0 0;
+.progressRow {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: clamp(16px, 3vw, 42px);
+  width: min(100%, 930px);
+  margin: -4px auto 0;
+}
+
+.progressGroup {
+  display: grid;
+  justify-items: stretch;
+  gap: 3px;
+  width: max-content;
+  max-width: 100%;
+}
+
+.tablePrompt {
+  max-width: 560px;
+  margin: 0;
   color: var(--bm-muted);
   font-family: var(--font-brand-text);
-  font-size: clamp(1.03rem, 1.8vw, 1.22rem);
-  line-height: 1.62;
+  font-size: clamp(0.9rem, 1.25vw, 1.02rem);
+  line-height: 1.45;
   text-wrap: pretty;
+  overflow: visible;
+}
+
+.promptTitle,
+.promptSubtitle {
+  display: block;
+}
+
+.promptTitle {
+  color: var(--bm-ink);
+  font-family: var(--font-brand-ui);
+  font-size: clamp(0.92rem, 1.25vw, 1.06rem);
+  font-weight: 600;
+  letter-spacing: -0.012em;
+  line-height: 1.28;
+}
+
+.promptTitle .promptWord {
+  font-weight: 600;
+}
+
+.promptSubtitle {
+  margin-top: 0.22rem;
+  color: var(--bm-muted);
+  font-size: 0.96em;
+  line-height: 1.4;
+}
+
+.tablePromptIntro .promptTitle,
+.tablePromptIntroHolding .promptTitle,
+.tablePromptIntroExit .promptTitle {
+  color: inherit;
+  font-family: var(--font-brand-text);
+  font-size: inherit;
+  font-weight: 400;
+  letter-spacing: normal;
+  line-height: inherit;
+}
+
+.tablePromptIntro {
+  animation: none;
+}
+
+.tablePromptIntroHolding {
+  opacity: 1;
+  transform: translateX(0);
+  animation: none;
+}
+
+.tablePromptIntroExit,
+.tablePromptExit {
+  animation: none;
+}
+
+.promptWord {
+  display: inline-block;
+  margin-inline-end: 0.28em;
+  opacity: 0;
+  filter: blur(6px);
+  transform: translate3d(0, 9px, 0) scale(0.985);
+  animation: promptWordMaterialize var(--bm-prompt-word-animation-ms) cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: calc(var(--prompt-word-index) * var(--bm-prompt-word-delay-ms));
+  will-change: opacity, filter, transform;
+}
+
+.promptWord:last-child {
+  margin-inline-end: 0;
+}
+
+.tablePromptIntroHolding .promptWord {
+  opacity: 1;
+  filter: blur(0);
+  transform: translate3d(0, 0, 0) scale(1);
+  animation: none;
+}
+
+.tablePromptIntroExit .promptWord,
+.tablePromptExit .promptWord {
+  animation: promptWordDissolve var(--bm-prompt-exit-ms) cubic-bezier(0.4, 0, 1, 1) both;
+  animation-delay: calc(var(--prompt-word-index) * var(--bm-prompt-exit-delay-ms));
 }
 
 .progress {
+  --bm-progress-active-label-size: clamp(1rem, 1.5vw, 1.18rem);
+  position: relative;
+  isolation: isolate;
   display: flex;
   align-items: stretch;
-  justify-content: center;
-  gap: clamp(22px, 4vw, 56px);
-  max-width: 930px;
-  margin: clamp(28px, 4vw, 48px) auto 0;
-  padding: 0 8px;
+  justify-content: flex-end;
+  gap: clamp(10px, 1.8vw, 24px);
+  width: 100%;
+  max-width: 100%;
+  margin: 0;
+  padding: 0;
   list-style: none;
 }
 
-.tableStage > .progress {
-  position: relative;
-  z-index: 2;
-  width: min(100%, 930px);
-  margin: -10px auto 0;
-  padding-bottom: 2px;
+.progressTransfer {
+  position: absolute;
+  z-index: 0;
+  top: var(--progress-from-top);
+  left: var(--progress-from-left);
+  width: var(--progress-from-width);
+  height: var(--progress-from-height);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border-radius: 8px;
+  background: var(--bm-yellow);
+  box-shadow: 0 8px 18px rgba(245, 179, 1, 0.18);
+  pointer-events: none;
+  animation: progressHighlightTransfer var(--bm-progress-total-ms) cubic-bezier(0.22, 1, 0.36, 1) both;
+  will-change: left, top, width, height;
 }
 
 .progressItem {
+  display: grid;
+  justify-items: stretch;
   min-height: 0;
+  position: relative;
+  z-index: 1;
   background: transparent;
   color: var(--bm-muted);
   transition: color 180ms ease;
@@ -116,8 +264,8 @@
 .progressButton {
   display: grid;
   justify-items: center;
-  gap: 4px;
-  width: auto;
+  gap: 0;
+  width: 100%;
   min-height: 44px;
   padding: 8px 2px 10px;
   border: 0;
@@ -159,15 +307,9 @@
 .progressItem strong {
   color: currentColor;
   font-family: var(--font-brand-ui);
-  font-size: 0.88rem;
+  font-size: 0.78rem;
   font-weight: 700;
   letter-spacing: 0.02em;
-}
-
-.progressItem small {
-  color: inherit;
-  font-size: 0.73rem;
-  line-height: 1.25;
 }
 
 .progressItemCurrent {
@@ -179,7 +321,13 @@
   border-radius: 8px;
   background: var(--bm-yellow);
   color: var(--bm-ink);
-  padding-inline: 14px;
+  min-height: 50px;
+  padding: 10px 18px;
+}
+
+.progressItemCurrent .progressButton strong {
+  font-size: clamp(1rem, 1.5vw, 1.18rem);
+  font-size: var(--bm-progress-active-label-size);
 }
 
 .progressItemCurrent .progressButton:hover {
@@ -195,19 +343,65 @@
   opacity: 0.68;
 }
 
+.progressMotionActive .progressButton {
+  background: transparent !important;
+  border-bottom-color: transparent !important;
+}
+
+.progressMotionActive .progressItemTransferFrom .progressButton,
+.progressMotionActive .progressItemTransferTo .progressButton {
+  opacity: 1;
+}
+
+.progressItemTransferFrom .progressButton {
+  color: var(--bm-ink);
+  min-height: 50px;
+  padding: 10px 18px;
+  border-radius: 8px;
+  animation: progressButtonCollapse var(--bm-progress-collapse-ms) cubic-bezier(0.4, 0, 0.2, 1) both;
+  will-change: min-height, padding, transform;
+}
+
+.progressItemTransferFrom strong {
+  font-size: var(--bm-progress-active-label-size);
+  animation: progressLabelCollapse var(--bm-progress-collapse-ms) cubic-bezier(0.4, 0, 0.2, 1) both;
+  will-change: font-size;
+}
+
+.progressItemTransferTo {
+  color: var(--bm-muted);
+}
+
+.progressItemTransferTo .progressButton {
+  color: var(--bm-muted);
+  opacity: 1;
+  min-height: 44px;
+  padding: 8px 2px 10px;
+  animation: progressButtonExpand var(--bm-progress-expand-ms) cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: calc(var(--bm-progress-collapse-ms) + var(--bm-progress-transfer-ms));
+  will-change: min-height, padding, transform;
+}
+
+.progressItemTransferTo strong {
+  font-size: 0.78rem;
+  animation: progressLabelExpand var(--bm-progress-expand-ms) cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: calc(var(--bm-progress-collapse-ms) + var(--bm-progress-transfer-ms));
+  will-change: font-size;
+}
+
 .tableStage,
 .resultStage {
   width: min(100%, 1040px);
-  margin: clamp(24px, 3.5vw, 40px) auto 0;
+  margin: clamp(16px, 2.4vw, 26px) auto 0;
   scroll-margin-top: 32px;
 }
 
 .tableStage {
   position: relative;
   display: grid;
-  gap: 18px;
-  padding: clamp(18px, 2.5vw, 28px) 0 clamp(16px, 2vw, 24px);
-  border-top: 1px solid var(--bm-line);
+  gap: 8px;
+  padding: clamp(4px, 0.8vw, 8px) 0 clamp(8px, 1vw, 12px);
+  overflow-anchor: none;
   isolation: isolate;
 }
 
@@ -239,8 +433,8 @@
 .tableSurface {
   position: relative;
   width: min(100%, 920px);
-  margin: 2px auto 0;
-  padding: clamp(18px, 2.5vw, 28px) clamp(14px, 2vw, 22px) clamp(132px, 12vw, 150px);
+  margin: 0 auto;
+  padding: clamp(10px, 1.5vw, 16px) clamp(10px, 1.4vw, 16px) clamp(126px, 10vw, 136px);
   border: 1px solid var(--bm-line);
   border-radius: 14px;
   background: rgba(255, 255, 255, 0.48);
@@ -248,14 +442,14 @@
 }
 
 .tableSurface[data-deck-state="waiting"] {
-  min-height: 252px;
+  min-height: 220px;
 }
 
 .deckStage {
   appearance: none;
   position: absolute;
   z-index: 2;
-  bottom: 18px;
+  bottom: 14px;
   left: 50%;
   width: 82px;
   height: 106px;
@@ -265,6 +459,7 @@
   color: inherit;
   cursor: pointer;
   transform: translateX(-50%);
+  will-change: auto;
 }
 
 .deckStage .deckCard,
@@ -282,51 +477,6 @@
   outline: 3px solid var(--bm-yellow);
   outline-offset: 7px;
   border-radius: 12px;
-}
-
-.deckPrompt {
-  position: absolute;
-  z-index: 3;
-  bottom: 148px;
-  left: 50%;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  min-height: 42px;
-  padding: 0 14px;
-  border: 1px solid var(--bm-yellow-ink);
-  border-radius: 999px;
-  background: var(--bm-yellow-soft);
-  color: var(--bm-ink);
-  cursor: default;
-  font-family: var(--font-brand-ui);
-  font-size: 0.73rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  white-space: nowrap;
-  box-shadow: 0 8px 18px rgba(48, 48, 48, 0.1);
-  pointer-events: none;
-  transform: translateX(-50%);
-}
-
-.deckPrompt::before {
-  width: 7px;
-  height: 7px;
-  border-radius: 999px;
-  background: var(--bm-yellow);
-  content: "";
-}
-
-.deckPromptArrow {
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 50%;
-  color: var(--bm-yellow-ink);
-  font-family: var(--font-brand-ui);
-  font-size: 1rem;
-  font-weight: 700;
-  line-height: 1;
-  transform: translateX(-50%);
 }
 
 .deckCard {
@@ -374,14 +524,35 @@
   animation: deckDealPulse 780ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
 }
 
+.tableStage[data-hand-stage="expand"] .tableSurface {
+  height: var(--bm-table-expand-height, 220px);
+  overflow: hidden;
+  transition: height var(--bm-hand-expand-ms) cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: height;
+}
+
+.tableStage[data-hand-stage="expand"] .deckStage {
+  animation: deckStageExpand var(--bm-hand-expand-ms) cubic-bezier(0.22, 1, 0.36, 1) both;
+  will-change: transform;
+}
+
+.tableStage[data-hand-stage="expand"] .cardGrid {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.tableStage[data-hand-stage="deal"] .deckStage {
+  animation: deckStageDeal var(--bm-hand-deal-ms) cubic-bezier(0.22, 1, 0.36, 1) both;
+  will-change: transform;
+}
+
 .tableStage[data-hand-stage="reveal"] .deckCardTop {
   animation: deckReceivePulse 680ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
 }
 
-.actHeading {
-  max-width: 610px;
-  margin: 0 auto;
-  text-align: center;
+.tableStage[data-hand-stage="collect"] .deckStage {
+  animation: deckStageCollect var(--bm-hand-collect-ms) cubic-bezier(0.22, 1, 0.36, 1) both;
+  will-change: transform;
 }
 
 .sectionLabel {
@@ -392,10 +563,6 @@
   font-weight: 700;
   letter-spacing: 0.15em;
   text-transform: uppercase;
-}
-
-.actHeading h2 {
-  margin-top: 0;
 }
 
 .resultLead h2 {
@@ -409,20 +576,8 @@
   text-wrap: balance;
 }
 
-.actHeading h2 {
-  margin: 0;
-  color: var(--bm-ink);
-  font-family: var(--font-brand-ui);
-  font-size: clamp(2.25rem, 5vw, 4rem);
-  font-weight: 700;
-  letter-spacing: -0.065em;
-  line-height: 0.95;
-  text-wrap: balance;
-}
-
-.actHeading p:last-child,
 .resultLead > p:last-child {
-  margin: 14px 0 0;
+  margin: 10px 0 0;
   color: var(--bm-muted);
   font-family: var(--font-brand-text);
   font-size: 1.02rem;
@@ -432,7 +587,7 @@
 .cardGrid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: clamp(14px, 2.8vw, 30px);
+  gap: clamp(10px, 1.8vw, 20px);
   width: min(100%, 920px);
   margin: 2px auto 0;
 }
@@ -466,23 +621,30 @@
 }
 
 .tableStage[data-hand-stage="finale"][data-finale-stage="merging"] .deckCardTop {
-  animation: deckReceivePulse 1120ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
+  animation: deckReceivePulse var(--bm-finale-merge-ms) cubic-bezier(0.18, 0.86, 0.24, 1) both;
 }
 
-.tableStage[data-hand-stage="finale"][data-finale-stage="collecting"] .finaleCardGridHolding .finaleCard {
-  animation: finaleCardsHold 880ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
+.tableStage[data-hand-stage="finale"][data-finale-stage="merging"] .deckStage {
+  animation: deckStageReceive var(--bm-finale-merge-ms) cubic-bezier(0.22, 1, 0.36, 1) both;
+  will-change: transform;
+}
+
+.tableStage[data-hand-stage="finale"][data-finale-stage="assembling"] .finaleCardGridHolding .finaleCard {
+  animation: finaleCardsHold var(--bm-finale-enter-ms) cubic-bezier(0.18, 0.86, 0.24, 1) both;
+  will-change: transform, opacity;
 }
 
 .tableStage[data-hand-stage="finale"] .finaleCardGridMerging .finaleCard {
-  animation: finaleCardsMerge 1120ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
+  animation: finaleCardsMerge var(--bm-finale-card-merge-ms) cubic-bezier(0.18, 0.86, 0.24, 1) both;
+  will-change: transform, opacity;
 }
 
 .tableStage[data-hand-stage="finale"] .finaleCardGridMerging .finaleCard:nth-child(2) {
-  animation-delay: 40ms;
+  animation-delay: var(--bm-finale-merge-stagger-ms);
 }
 
 .tableStage[data-hand-stage="finale"] .finaleCardGridMerging .finaleCard:nth-child(3) {
-  animation-delay: 80ms;
+  animation-delay: calc(var(--bm-finale-merge-stagger-ms) * 2);
 }
 
 .finaleCardFace {
@@ -762,7 +924,7 @@
 .cardButton {
   position: relative;
   display: block;
-  min-height: 360px;
+  min-height: clamp(280px, 25vw, 304px);
   padding: 0;
   overflow: hidden;
   border: 0;
@@ -773,27 +935,27 @@
   perspective: 1200px;
   text-align: left;
   transition: transform 320ms cubic-bezier(0.22, 1, 0.36, 1), filter 320ms ease;
-  will-change: transform;
+  will-change: auto;
   --deal-x: 0px;
-  --deal-y: 122px;
+  --deal-y: 106px;
   --deal-rotate: 0deg;
 }
 
 .cardButton:nth-child(1) {
   --deal-x: clamp(170px, 23vw, 320px);
-  --deal-y: 122px;
+  --deal-y: 106px;
   --deal-rotate: -8deg;
 }
 
 .cardButton:nth-child(2) {
   --deal-x: 0px;
-  --deal-y: 122px;
+  --deal-y: 106px;
   --deal-rotate: 0deg;
 }
 
 .cardButton:nth-child(3) {
   --deal-x: clamp(-320px, -23vw, -170px);
-  --deal-y: 122px;
+  --deal-y: 106px;
   --deal-rotate: 8deg;
 }
 
@@ -829,24 +991,18 @@
 }
 
 .cardButtonSelected .cardInner {
-  animation: cardFlipAndSettle 1.35s cubic-bezier(0.18, 0.86, 0.24, 1) both;
+  animation: cardFlipAndSettle var(--bm-hand-reveal-ms) cubic-bezier(0.18, 0.86, 0.24, 1) both;
+  will-change: transform;
 }
 
 .cardButtonSelected {
   z-index: 3;
-  animation: cardLiftAndSettle 1.5s cubic-bezier(0.18, 0.86, 0.24, 1) both;
+  animation: cardLiftAndSettle var(--bm-hand-reveal-ms) cubic-bezier(0.18, 0.86, 0.24, 1) both;
+  will-change: transform;
 }
 
 .tableStage[data-hand-stage="reveal"] .cardButton:not(.cardButtonSelected) {
   pointer-events: none;
-}
-
-.tableStage[data-hand-stage="reveal"] .cardButton:nth-child(2) {
-  animation-delay: 90ms;
-}
-
-.tableStage[data-hand-stage="reveal"] .cardButton:nth-child(3) {
-  animation-delay: 150ms;
 }
 
 .tableStage[data-hand-stage="held"] .cardButton:not(.cardButtonSelected) {
@@ -858,15 +1014,18 @@
 }
 
 .tableStage[data-hand-stage="collect"] .cardButtonSelected {
-  animation: cardSelectedReturnToDeck 720ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
+  animation: cardSelectedReturnToDeck var(--bm-hand-collect-ms) cubic-bezier(0.18, 0.86, 0.24, 1) both;
+  will-change: transform, opacity;
 }
 
 .tableStage[data-hand-stage="collect"] .cardButtonSelected .cardInner {
-  animation: cardFlipToDeck 720ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
+  animation: cardFlipToDeck var(--bm-hand-collect-ms) cubic-bezier(0.18, 0.86, 0.24, 1) both;
+  will-change: transform;
 }
 
 .tableStage[data-hand-stage="deal"] .cardButton {
-  animation: cardDealFromDeck 780ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
+  animation: cardDealFromDeck var(--bm-hand-deal-ms) cubic-bezier(0.18, 0.86, 0.24, 1) both;
+  will-change: transform, opacity;
 }
 
 .cardSparkles {
@@ -1119,19 +1278,20 @@
 
 @keyframes finaleCardsMerge {
   0% {
-    opacity: 0;
-    transform: translate3d(var(--finale-x), var(--finale-y), 0) rotate(var(--finale-rotate)) scale(0.58);
+    opacity: 1;
+    transform: translate3d(0, 0, 0) rotate(0deg) scale(1);
   }
 
   42% {
     opacity: 1;
-    transform: translate3d(calc(var(--finale-x) * 0.08), calc(var(--finale-y) * 0.08), 0)
-      rotate(calc(var(--finale-rotate) * 0.12)) scale(1.04);
+    transform: translate3d(calc(var(--finale-x) * 0.36), calc(var(--finale-merge-y, 0px) * 0.36), 0)
+      rotate(calc(var(--finale-rotate) * 0.34)) scale(0.94);
   }
 
   64% {
     opacity: 1;
-    transform: translate3d(0, 0, 0) rotate(0deg) scale(1);
+    transform: translate3d(calc(var(--finale-x) * 0.76), calc(var(--finale-merge-y, 0px) * 0.76), 0)
+      rotate(calc(var(--finale-rotate) * 0.16)) scale(0.62);
   }
 
   100% {
@@ -1223,7 +1383,7 @@
   align-items: flex-start;
   justify-content: space-between;
   flex-direction: column;
-  padding: 24px;
+  padding: 20px;
   border: 1px solid var(--bm-ink);
   background: var(--bm-ink);
   box-shadow: var(--bm-shadow);
@@ -1283,8 +1443,8 @@
 .cardBrandMark {
   position: relative;
   display: grid;
-  width: 164px;
-  height: 164px;
+  width: 140px;
+  height: 140px;
   place-items: center;
   align-self: center;
   margin: auto;
@@ -1319,7 +1479,7 @@
   position: relative;
   z-index: 1;
   display: block;
-  width: 82px;
+  width: 70px;
   height: auto;
   object-fit: contain;
 }
@@ -1329,8 +1489,8 @@
   z-index: 1;
   display: grid;
   place-items: center;
-  width: 148px;
-  height: 148px;
+  width: 128px;
+  height: 128px;
   align-self: center;
   flex: 0 0 auto;
 }
@@ -1348,8 +1508,8 @@
 }
 
 .cardBack .cardIllustration {
-  width: 126px;
-  height: 126px;
+  width: 110px;
+  height: 110px;
   margin: 0 auto 2px;
   color: var(--bm-ink);
   opacity: 0;
@@ -1364,7 +1524,7 @@
 }
 
 .cardButtonSelected .cardBack .cardIllustration svg {
-  animation: cardIllustrationFloat 5.8s ease-in-out 1.35s infinite alternate;
+  animation: cardIllustrationFloat 5.8s ease-in-out var(--bm-hand-reveal-ms) infinite alternate;
   transform-origin: center;
 }
 
@@ -1419,8 +1579,8 @@
 .cardBack {
   flex-direction: column;
   justify-content: flex-start;
-  gap: 14px;
-  padding: 28px;
+  gap: 10px;
+  padding: 22px;
   border: 1px solid var(--bm-line-strong);
   border-top: 3px solid var(--bm-yellow);
   background: var(--bm-surface);
@@ -1431,7 +1591,7 @@
 
 .cardBack strong {
   font-family: var(--font-brand-ui);
-  font-size: clamp(1.85rem, 3.5vw, 2.8rem);
+  font-size: clamp(1.55rem, 3vw, 2.35rem);
   font-weight: 700;
   letter-spacing: -0.06em;
   line-height: 0.95;
@@ -1451,38 +1611,52 @@
 }
 
 .autoAdvance {
-  display: grid;
-  justify-items: center;
-  gap: 8px;
-  width: min(100%, 280px);
-  color: var(--bm-muted);
-  font-family: var(--font-brand-ui);
-  text-align: center;
+  display: block;
+  width: 100%;
+  height: 4px;
+  margin-top: 8px;
+  border-radius: 999px;
+  background: rgba(48, 48, 48, 0.16);
+  overflow: hidden;
 }
 
 .autoAdvance::after {
+  display: block;
   width: 100%;
-  height: 3px;
-  border-radius: 999px;
-  background: var(--bm-yellow);
+  height: 100%;
+  border-radius: inherit;
+  background: var(--bm-ink);
   content: "";
   transform-origin: left center;
-  animation: autoAdvanceProgress 5s linear both;
+  animation: autoAdvanceProgress var(--bm-auto-advance-ms) linear both;
 }
 
-.autoAdvanceLabel {
-  color: var(--bm-muted);
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.13em;
-  text-transform: uppercase;
+@keyframes promptWordMaterialize {
+  from {
+    opacity: 0;
+    filter: blur(6px);
+    transform: translate3d(0, 9px, 0) scale(0.985);
+  }
+
+  to {
+    opacity: 1;
+    filter: blur(0);
+    transform: translate3d(0, 0, 0) scale(1);
+  }
 }
 
-.autoAdvanceHint {
-  color: var(--bm-muted);
-  font-family: var(--font-brand-text);
-  font-size: 0.78rem;
-  line-height: 1.4;
+@keyframes promptWordDissolve {
+  from {
+    opacity: 1;
+    filter: blur(0);
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+
+  to {
+    opacity: 0;
+    filter: blur(5px);
+    transform: translate3d(0, -7px, 0) scale(0.985);
+  }
 }
 
 @keyframes autoAdvanceProgress {
@@ -1492,6 +1666,148 @@
 
   to {
     transform: scaleX(1);
+  }
+}
+
+@keyframes progressHighlightTransfer {
+  0%,
+  23% {
+    top: var(--progress-from-top);
+    left: var(--progress-from-left);
+    width: var(--progress-from-width);
+    height: var(--progress-from-height);
+  }
+
+  73% {
+    top: var(--progress-to-top);
+    left: var(--progress-from-left);
+    width: calc(var(--progress-to-left) + var(--progress-to-width) - var(--progress-from-left));
+    height: var(--progress-to-height);
+  }
+
+  100% {
+    top: var(--progress-to-top);
+    left: var(--progress-to-left);
+    width: var(--progress-to-width);
+    height: var(--progress-to-height);
+  }
+}
+
+@keyframes progressButtonCollapse {
+  from {
+    min-height: 50px;
+    padding: 10px 18px;
+  }
+
+  to {
+    min-height: 44px;
+    padding: 8px 2px 10px;
+  }
+}
+
+@keyframes progressButtonExpand {
+  from {
+    min-height: 44px;
+    padding: 8px 2px 10px;
+    color: var(--bm-muted);
+  }
+
+  to {
+    min-height: 50px;
+    padding: 10px 18px;
+    color: var(--bm-ink);
+  }
+}
+
+@keyframes progressLabelCollapse {
+  from {
+    font-size: var(--bm-progress-active-label-size);
+  }
+
+  to {
+    font-size: 0.78rem;
+  }
+}
+
+@keyframes progressLabelExpand {
+  from {
+    font-size: 0.78rem;
+  }
+
+  to {
+    font-size: var(--bm-progress-active-label-size);
+  }
+}
+
+@keyframes deckStageDeal {
+  0% {
+    transform: translateX(-50%) translateY(0) scale(1) rotate(0deg);
+  }
+
+  34% {
+    transform: translateX(-50%) translateY(8px) scale(0.97) rotate(-1deg);
+  }
+
+  68% {
+    transform: translateX(-50%) translateY(4px) scale(0.99) rotate(0.5deg);
+  }
+
+  100% {
+    transform: translateX(-50%) translateY(0) scale(1) rotate(0deg);
+  }
+}
+
+@keyframes deckStageExpand {
+  0% {
+    transform: translateX(-50%) translateY(-24px) scale(0.96) rotate(-1deg);
+  }
+
+  42% {
+    transform: translateX(-50%) translateY(-10px) scale(1.015) rotate(0.6deg);
+  }
+
+  76% {
+    transform: translateX(-50%) translateY(3px) scale(0.99) rotate(-0.25deg);
+  }
+
+  100% {
+    transform: translateX(-50%) translateY(0) scale(1) rotate(0deg);
+  }
+}
+
+@keyframes deckStageCollect {
+  0% {
+    transform: translateX(-50%) translateY(0) scale(1) rotate(0deg);
+  }
+
+  30% {
+    transform: translateX(-50%) translateY(-8px) scale(1.04) rotate(-1deg);
+  }
+
+  62% {
+    transform: translateX(-50%) translateY(-4px) scale(1.015) rotate(0.5deg);
+  }
+
+  100% {
+    transform: translateX(-50%) translateY(0) scale(1) rotate(0deg);
+  }
+}
+
+@keyframes deckStageReceive {
+  0% {
+    transform: translateX(-50%) translateY(0) scale(1) rotate(0deg);
+  }
+
+  32% {
+    transform: translateX(-50%) translateY(-6px) scale(1.035) rotate(-0.8deg);
+  }
+
+  68% {
+    transform: translateX(-50%) translateY(2px) scale(0.99) rotate(0.35deg);
+  }
+
+  100% {
+    transform: translateX(-50%) translateY(0) scale(1) rotate(0deg);
   }
 }
 
@@ -1813,7 +2129,7 @@
 
 @media (max-width: 720px) {
   .page {
-    padding-top: 42px;
+    padding-top: 24px;
   }
 
   .shell {
@@ -1824,8 +2140,26 @@
     font-size: clamp(2.75rem, 14vw, 4.6rem);
   }
 
+  .progressRow {
+    grid-template-columns: 1fr;
+    gap: 2px;
+    margin-top: 0;
+  }
+
+  .progressGroup {
+    width: 100%;
+  }
+
+  .tablePrompt {
+    max-width: 620px;
+    margin-inline: auto;
+    text-align: center;
+  }
+
   .progress {
-    gap: clamp(18px, 5vw, 32px);
+    --bm-progress-active-label-size: 0.96rem;
+    justify-content: center;
+    gap: clamp(12px, 4vw, 24px);
     padding: 0 4px;
   }
 
@@ -1838,18 +2172,12 @@
     padding: 7px 10px 9px;
   }
 
-  .deckPrompt {
-    bottom: 136px;
-    left: 50%;
-    transform: translateX(-50%);
-  }
-
   .progressItem strong {
     font-size: 0.72rem;
   }
 
-  .progressItem small {
-    display: none;
+  .progressItemCurrent .progressButton strong {
+    font-size: 0.96rem;
   }
 
   .cardGrid {
@@ -1902,19 +2230,19 @@
   }
 
   .cardButton:nth-child(1) {
-    --deal-y: 122px;
+    --deal-y: 96px;
   }
 
   .cardButton:nth-child(2) {
-    --deal-y: 470px;
+    --deal-y: 372px;
   }
 
   .cardButton:nth-child(3) {
-    --deal-y: 818px;
+    --deal-y: 648px;
   }
 
   .cardButton {
-    min-height: 334px;
+    min-height: 280px;
   }
 
   .cardIllustration {
@@ -1923,17 +2251,17 @@
   }
 
   .cardBrandMark {
-    width: 144px;
-    height: 144px;
+    width: 132px;
+    height: 132px;
   }
 
   .cardBrandLogo {
-    width: 72px;
+    width: 66px;
   }
 
   .cardBack .cardIllustration {
-    width: 112px;
-    height: 112px;
+    width: 104px;
+    height: 104px;
   }
 
   .resultStage {
@@ -1956,12 +2284,6 @@
 }
 
 @media (max-width: 440px) {
-  .brandLine {
-    gap: 8px;
-    font-size: 0.66rem;
-    letter-spacing: 0.08em;
-  }
-
   .progressItem {
     min-height: 0;
   }
@@ -1971,8 +2293,12 @@
     padding: 6px 7px 8px;
   }
 
-  .progressCopy > small {
-    display: none;
+  .tableSurface {
+    padding-bottom: 130px;
+  }
+
+  .cardButton {
+    min-height: 280px;
   }
 
   .cardFront,
@@ -2011,6 +2337,11 @@
   }
 
   .autoAdvance::after,
+  .progressTransfer,
+  .progressItemTransferFrom .progressButton,
+  .progressItemTransferFrom strong,
+  .progressItemTransferTo .progressButton,
+  .progressItemTransferTo strong,
   .cardBack .cardIllustration,
   .cardBack .cardIllustration svg,
   .cardBack .cardIllustration svg > * {

--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -159,8 +159,12 @@ const INITIAL_TABLE_HEIGHT = 220;
 const AUTO_ADVANCE_SECONDS = BEAUTY_MOVEMENT_MOTION.autoAdvanceMs / 1_000;
 const FINALE_HOLD_SECONDS = BEAUTY_MOVEMENT_MOTION.finaleHoldMs / 1_000;
 
-function motionDuration(durationMs: number, reducedMotion: boolean): number {
-    return reducedMotion ? 0 : durationMs;
+function motionDuration(durationMs: number, reducedMotion: boolean, preserveTiming = false): number {
+    return reducedMotion && !preserveTiming ? 0 : durationMs;
+}
+
+function promptReadingDelay(text: string, reducedMotion: boolean): number {
+    return reducedMotion ? BEAUTY_MOVEMENT_MOTION.promptReadingHoldMs : promptReadingDuration(text);
 }
 
 function useReducedMotionPreference(): boolean {
@@ -507,6 +511,7 @@ function drawStoryCardIllustration(context: CanvasRenderingContext2D, cardId: st
 
 function createStoryBlob(
     reading: ReturnType<typeof getBeautyMovementReading>,
+    partnerName?: string | null,
 ): Promise<Blob | null> {
     return new Promise((resolve) => {
         const canvas = document.createElement("canvas");
@@ -578,7 +583,7 @@ function createStoryBlob(
         context.fillText("Beleza que se move com você.", 104, 1644);
         context.font = `400 26px ${textFont}`;
         context.fillStyle = "#505050";
-        context.fillText("Espaço Facial · 3 anos em movimento", 104, 1700);
+        context.fillText(partnerName?.trim() || "Espaço Facial · 3 anos em movimento", 104, 1700);
 
         canvas.toBlob((blob) => resolve(blob), "image/png", 0.96);
     });
@@ -995,13 +1000,18 @@ export default function BeautyMovementExperience({
         return handTransitionGateRef.current.start();
     }
 
-    function scheduleHandTransition(token: number, delayMs: number, callback: () => void) {
+    function scheduleHandTransition(
+        token: number,
+        delayMs: number,
+        callback: () => void,
+        preserveTiming = false,
+    ) {
         clearHandTransitionTimer();
         handTransitionTimerRef.current = window.setTimeout(() => {
             handTransitionTimerRef.current = null;
             if (!mountedRef.current || !handTransitionGateRef.current.isCurrent(token)) return;
             callback();
-        }, motionDuration(delayMs, reducedMotionRef.current));
+        }, motionDuration(delayMs, reducedMotionRef.current, preserveTiming));
     }
 
     function scheduleDealSequence(token: number, onReady: () => void) {
@@ -1072,13 +1082,18 @@ export default function BeautyMovementExperience({
         return introTransitionGateRef.current.start();
     }
 
-    function scheduleIntroTransition(token: number, delayMs: number, callback: () => void) {
+    function scheduleIntroTransition(
+        token: number,
+        delayMs: number,
+        callback: () => void,
+        preserveTiming = false,
+    ) {
         clearIntroTransitionTimer();
         introTimerRef.current = window.setTimeout(() => {
             introTimerRef.current = null;
             if (!mountedRef.current || !introTransitionGateRef.current.isCurrent(token)) return;
             callback();
-        }, motionDuration(delayMs, reducedMotionRef.current));
+        }, motionDuration(delayMs, reducedMotionRef.current, preserveTiming));
     }
 
     function startInitialDeal() {
@@ -1100,7 +1115,7 @@ export default function BeautyMovementExperience({
                 scheduleIntroTransition(introToken, promptExitTransitionDuration(initialExperienceCopy), () => {
                     setCurrentIntroStage("hidden");
                     setCurrentHandStage("prompt");
-                    scheduleHandTransition(handToken, promptReadingDuration(tableDefinition.prompt), () => {
+                    scheduleHandTransition(handToken, promptReadingDelay(tableDefinition.prompt, reducedMotionRef.current), () => {
                         setCurrentHandStage("prompt-out");
                         scheduleHandTransition(handToken, promptExitTransitionDuration(tableDefinition.prompt), () => {
                             scheduleDealSequence(handToken, () => {
@@ -1109,9 +1124,9 @@ export default function BeautyMovementExperience({
                                 window.requestAnimationFrame(scrollToTable);
                             });
                         });
-                    });
+                    }, true);
                 });
-            });
+            }, true);
         });
     }
 
@@ -1157,7 +1172,7 @@ export default function BeautyMovementExperience({
                             }
                         },
                     );
-                });
+                }, true);
             });
         });
     }
@@ -1177,20 +1192,25 @@ export default function BeautyMovementExperience({
         scheduleHandTransition(handToken, BEAUTY_MOVEMENT_MOTION.handCollectMs, () => {
             setCurrentActIndex(nextIndex);
             setCurrentHandStage("prompt");
-            scheduleHandTransition(handToken, promptReadingDuration(BEAUTY_MOVEMENT_ACT_DEFINITIONS[nextIndex]?.prompt || ""), () => {
-                setCurrentHandStage("prompt-out");
-                scheduleHandTransition(
-                    handToken,
-                    promptExitTransitionDuration(BEAUTY_MOVEMENT_ACT_DEFINITIONS[nextIndex]?.prompt || ""),
-                    () => {
-                        scheduleDealSequence(handToken, () => {
-                            transitionInFlightRef.current = false;
-                            setCurrentHandStage("ready");
-                            window.requestAnimationFrame(scrollToTable);
-                        });
-                    },
-                );
-            });
+            scheduleHandTransition(
+                handToken,
+                promptReadingDelay(BEAUTY_MOVEMENT_ACT_DEFINITIONS[nextIndex]?.prompt || "", reducedMotionRef.current),
+                () => {
+                    setCurrentHandStage("prompt-out");
+                    scheduleHandTransition(
+                        handToken,
+                        promptExitTransitionDuration(BEAUTY_MOVEMENT_ACT_DEFINITIONS[nextIndex]?.prompt || ""),
+                        () => {
+                            scheduleDealSequence(handToken, () => {
+                                transitionInFlightRef.current = false;
+                                setCurrentHandStage("ready");
+                                window.requestAnimationFrame(scrollToTable);
+                            });
+                        },
+                    );
+                },
+                true,
+            );
         });
     }
 
@@ -1412,7 +1432,7 @@ export default function BeautyMovementExperience({
         if (reading.length !== BEAUTY_MOVEMENT_ACTS.length) return;
 
         setShareStatus(null);
-        const blob = await createStoryBlob(reading);
+        const blob = await createStoryBlob(reading, initialState.campaign.partnerName);
         if (!blob) {
             setShareStatus("Não foi possível preparar o Story neste navegador.");
             return;

--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { type KeyboardEvent as ReactKeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
+import {
+    type AnimationEvent as ReactAnimationEvent,
+    type CSSProperties,
+    type KeyboardEvent as ReactKeyboardEvent,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
 import {
     BEAUTY_MOVEMENT_ACTS,
     BEAUTY_MOVEMENT_ACT_DEFINITIONS,
@@ -21,6 +30,7 @@ import type {
     BeautyMovementDiscountKind,
     BeautyMovementRewardType,
 } from "@/lib/beautyMovementRewards";
+import { BEAUTY_MOVEMENT_MOTION, createBeautyMovementMotionGate } from "@/lib/beautyMovementMotion";
 import styles from "./BeautyMovementExperience.module.css";
 
 export type BeautyMovementBenefit = {
@@ -110,9 +120,33 @@ export type BeautyMovementExperienceProps = {
     isLocalPreview?: boolean;
 };
 
-type HandStage = "waiting" | "ready" | "reveal" | "held" | "collect" | "deal" | "finale";
-type FinaleStage = "hidden" | "collecting" | "merging" | "confirmation" | "result";
+type HandStage =
+    | "waiting"
+    | "prompt"
+    | "prompt-out"
+    | "ready"
+    | "reveal"
+    | "held"
+    | "collect"
+    | "expand"
+    | "deal"
+    | "finale";
+type IntroStage = "hidden" | "entering" | "holding" | "exiting";
+type FinaleStage = "hidden" | "assembling" | "collecting" | "merging" | "confirmation" | "result";
 type SpecialCardKind = "velocity" | "discount" | "free_procedure" | "reserved";
+type ProgressRect = {
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+};
+type ProgressMotion = {
+    fromIndex: number;
+    toIndex: number;
+    from: ProgressRect;
+    to: ProgressRect;
+    key: number;
+};
 
 type ShareNavigator = Navigator & {
     canShare?: (data?: ShareData) => boolean;
@@ -121,19 +155,62 @@ type ShareNavigator = Navigator & {
 
 const STORY_WIDTH = 1080;
 const STORY_HEIGHT = 1920;
-const AUTO_ADVANCE_SECONDS = 5;
-const FINALE_HOLD_SECONDS = 5;
-const HAND_REVEAL_MS = 1350;
-const HAND_COLLECT_MS = 720;
-const HAND_DEAL_MS = 880;
-const HAND_FINALE_MS = 1120;
+const INITIAL_TABLE_HEIGHT = 220;
+const AUTO_ADVANCE_SECONDS = BEAUTY_MOVEMENT_MOTION.autoAdvanceMs / 1_000;
+const FINALE_HOLD_SECONDS = BEAUTY_MOVEMENT_MOTION.finaleHoldMs / 1_000;
 
-function prefersReducedMotion(): boolean {
-    return typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+function motionDuration(durationMs: number, reducedMotion: boolean): number {
+    return reducedMotion ? 0 : durationMs;
 }
 
-function motionDuration(durationMs: number): number {
-    return prefersReducedMotion() ? 0 : durationMs;
+function useReducedMotionPreference(): boolean {
+    const [reducedMotion, setReducedMotion] = useState(false);
+
+    useEffect(() => {
+        const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+        const syncPreference = () => setReducedMotion(media.matches);
+
+        syncPreference();
+        media.addEventListener("change", syncPreference);
+        return () => media.removeEventListener("change", syncPreference);
+    }, []);
+
+    return reducedMotion;
+}
+
+function promptWordCount(text: string): number {
+    return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+function promptEntryDuration(text: string): number {
+    return BEAUTY_MOVEMENT_MOTION.promptWordAnimationMs + Math.max(0, promptWordCount(text) - 1) * BEAUTY_MOVEMENT_MOTION.promptWordDelayMs;
+}
+
+function promptReadingDuration(text: string): number {
+    return promptEntryDuration(text) + BEAUTY_MOVEMENT_MOTION.promptReadingHoldMs;
+}
+
+function promptExitDuration(text: string): number {
+    return BEAUTY_MOVEMENT_MOTION.promptExitBaseMs + Math.max(0, promptWordCount(text) - 1) * BEAUTY_MOVEMENT_MOTION.promptExitWordDelayMs;
+}
+
+function promptExitTransitionDuration(text: string): number {
+    return promptExitDuration(text) + BEAUTY_MOVEMENT_MOTION.promptExitBreathMs;
+}
+
+function renderPromptWords(text: string, wordOffset = 0) {
+    const words = text.trim().split(/\s+/).filter(Boolean);
+
+    return words.map((word, index) => (
+        <span
+            className={styles.promptWord}
+            key={`${word}-${index}`}
+            style={{ "--prompt-word-index": wordOffset + index } as CSSProperties}
+        >
+            {word}
+            {index < words.length - 1 ? " " : null}
+        </span>
+    ));
 }
 
 function getSelectionsFromReveals(
@@ -430,7 +507,6 @@ function drawStoryCardIllustration(context: CanvasRenderingContext2D, cardId: st
 
 function createStoryBlob(
     reading: ReturnType<typeof getBeautyMovementReading>,
-    partnerName: string,
 ): Promise<Blob | null> {
     return new Promise((resolve) => {
         const canvas = document.createElement("canvas");
@@ -502,7 +578,7 @@ function createStoryBlob(
         context.fillText("Beleza que se move com você.", 104, 1644);
         context.font = `400 26px ${textFont}`;
         context.fillStyle = "#505050";
-        context.fillText(`Espaço Facial · com ${partnerName}`, 104, 1700);
+        context.fillText("Espaço Facial · 3 anos em movimento", 104, 1700);
 
         canvas.toBlob((blob) => resolve(blob), "image/png", 0.96);
     });
@@ -527,6 +603,7 @@ export default function BeautyMovementExperience({
     onTrack,
     isLocalPreview = false,
 }: BeautyMovementExperienceProps) {
+    const reducedMotion = useReducedMotionPreference();
     const incomingSelections = useMemo(
         () => getSelectionsFromReveals(initialState.palette, initialState.reveals),
         [initialState.palette, initialState.reveals],
@@ -536,6 +613,7 @@ export default function BeautyMovementExperience({
     const [displayedActIndex, setDisplayedActIndex] = useState(() =>
         Math.min(getCurrentActIndex(incomingSelections), BEAUTY_MOVEMENT_ACTS.length - 1),
     );
+    const [introStage, setIntroStage] = useState<IntroStage>("hidden");
     const [handStage, setHandStage] = useState<HandStage>(() =>
         initialState.confirmed || initialReadingComplete ? "ready" : "waiting",
     );
@@ -550,25 +628,67 @@ export default function BeautyMovementExperience({
         initialState.confirmed ? "result" : initialReadingComplete ? "confirmation" : "hidden",
     );
     const [finaleHoldRemaining, setFinaleHoldRemaining] = useState(0);
+    const [tableExpansionHeight, setTableExpansionHeight] = useState<number | null>(null);
     const [autoAdvanceActive, setAutoAdvanceActive] = useState(false);
+    const [progressMotion, setProgressMotion] = useState<ProgressMotion | null>(null);
     const openedRef = useRef(false);
     const viewedActsRef = useRef(new Set<number>());
     const viewedResultRef = useRef(false);
     const conditionsOpenedRef = useRef(false);
     const autoAdvanceTimerRef = useRef<number | null>(null);
+    const autoAdvanceFrameRef = useRef<number | null>(null);
     const handTransitionTimerRef = useRef<number | null>(null);
+    const introTimerRef = useRef<number | null>(null);
+    const handExpansionFrameRef = useRef<number | null>(null);
+    const progressMotionTimerRef = useRef<number | null>(null);
     const scrollAnimationFrameRef = useRef<number | null>(null);
+    const scrollInterruptCleanupRef = useRef<(() => void) | null>(null);
     const tableRef = useRef<HTMLElement | null>(null);
+    const tableSurfaceRef = useRef<HTMLDivElement | null>(null);
+    const progressListRef = useRef<HTMLOListElement | null>(null);
+    const progressButtonRefs = useRef<Array<HTMLButtonElement | null>>([]);
     const finaleRef = useRef<HTMLElement | null>(null);
     const confirmationActionRef = useRef<HTMLElement | null>(null);
     const selectionsRef = useRef(selections);
     const displayedActIndexRef = useRef(displayedActIndex);
+    const introStageRef = useRef(introStage);
     const handStageRef = useRef(handStage);
     const finaleStageRef = useRef(finaleStage);
+    const reducedMotionRef = useRef(reducedMotion);
     const revealInFlightRef = useRef(false);
     const transitionInFlightRef = useRef(false);
     const confirmInFlightRef = useRef(false);
     const mountedRef = useRef(true);
+    const revealTransitionTokenRef = useRef<number | null>(null);
+    const autoAdvanceGateRef = useRef(createBeautyMovementMotionGate());
+    const handTransitionGateRef = useRef(createBeautyMovementMotionGate());
+    const introTransitionGateRef = useRef(createBeautyMovementMotionGate());
+    const progressMotionKeyRef = useRef(0);
+
+    const motionCssVariables = useMemo(
+        () =>
+            ({
+                "--bm-auto-advance-ms": `${BEAUTY_MOVEMENT_MOTION.autoAdvanceMs}ms`,
+                "--bm-hand-reveal-ms": `${BEAUTY_MOVEMENT_MOTION.handRevealMs}ms`,
+                "--bm-hand-collect-ms": `${BEAUTY_MOVEMENT_MOTION.handCollectMs}ms`,
+                "--bm-hand-expand-ms": `${BEAUTY_MOVEMENT_MOTION.handExpandMs}ms`,
+                "--bm-hand-deal-ms": `${BEAUTY_MOVEMENT_MOTION.handDealMs}ms`,
+                "--bm-table-expand-height": `${tableExpansionHeight ?? INITIAL_TABLE_HEIGHT}px`,
+                "--bm-progress-collapse-ms": `${BEAUTY_MOVEMENT_MOTION.progressCollapseMs}ms`,
+                "--bm-progress-transfer-ms": `${BEAUTY_MOVEMENT_MOTION.progressTransferMs}ms`,
+                "--bm-progress-expand-ms": `${BEAUTY_MOVEMENT_MOTION.progressExpandMs}ms`,
+                "--bm-progress-total-ms": `${BEAUTY_MOVEMENT_MOTION.progressTransitionMs}ms`,
+                "--bm-finale-enter-ms": `${BEAUTY_MOVEMENT_MOTION.finaleCardsEnterMs}ms`,
+                "--bm-finale-merge-ms": `${BEAUTY_MOVEMENT_MOTION.finaleMergeMs}ms`,
+                "--bm-finale-card-merge-ms": `${BEAUTY_MOVEMENT_MOTION.finaleCardMergeMs}ms`,
+                "--bm-finale-merge-stagger-ms": `${BEAUTY_MOVEMENT_MOTION.finaleMergeStaggerMs}ms`,
+                "--bm-prompt-word-delay-ms": `${BEAUTY_MOVEMENT_MOTION.promptWordDelayMs}ms`,
+                "--bm-prompt-word-animation-ms": `${BEAUTY_MOVEMENT_MOTION.promptWordAnimationMs}ms`,
+                "--bm-prompt-exit-ms": `${BEAUTY_MOVEMENT_MOTION.promptExitBaseMs}ms`,
+                "--bm-prompt-exit-delay-ms": `${BEAUTY_MOVEMENT_MOTION.promptExitWordDelayMs}ms`,
+            }) as CSSProperties,
+        [tableExpansionHeight],
+    );
 
     useEffect(() => {
         selectionsRef.current = incomingSelections;
@@ -584,12 +704,20 @@ export default function BeautyMovementExperience({
     }, [displayedActIndex]);
 
     useEffect(() => {
+        introStageRef.current = introStage;
+    }, [introStage]);
+
+    useEffect(() => {
         handStageRef.current = handStage;
     }, [handStage]);
 
     useEffect(() => {
         finaleStageRef.current = finaleStage;
     }, [finaleStage]);
+
+    useEffect(() => {
+        reducedMotionRef.current = reducedMotion;
+    }, [reducedMotion]);
 
     useEffect(() => {
         if (initialState.confirmed) {
@@ -641,17 +769,37 @@ export default function BeautyMovementExperience({
     }, [finaleStage]);
 
     useEffect(() => {
+        mountedRef.current = true;
+        const autoAdvanceGate = autoAdvanceGateRef.current;
+        const handTransitionGate = handTransitionGateRef.current;
+        const introTransitionGate = introTransitionGateRef.current;
         return () => {
             mountedRef.current = false;
+            autoAdvanceGate.invalidate();
+            handTransitionGate.invalidate();
+            introTransitionGate.invalidate();
             if (autoAdvanceTimerRef.current !== null) {
                 window.clearTimeout(autoAdvanceTimerRef.current);
+            }
+            if (autoAdvanceFrameRef.current !== null) {
+                window.cancelAnimationFrame(autoAdvanceFrameRef.current);
             }
             if (handTransitionTimerRef.current !== null) {
                 window.clearTimeout(handTransitionTimerRef.current);
             }
+            if (introTimerRef.current !== null) {
+                window.clearTimeout(introTimerRef.current);
+            }
+            if (handExpansionFrameRef.current !== null) {
+                window.cancelAnimationFrame(handExpansionFrameRef.current);
+            }
+            if (progressMotionTimerRef.current !== null) {
+                window.clearTimeout(progressMotionTimerRef.current);
+            }
             if (scrollAnimationFrameRef.current !== null) {
                 window.cancelAnimationFrame(scrollAnimationFrameRef.current);
             }
+            scrollInterruptCleanupRef.current?.();
         };
     }, []);
 
@@ -660,7 +808,6 @@ export default function BeautyMovementExperience({
         [initialState.palette, selections],
     );
     const consentInvalid = confirmationAttempted && !operationalConsent;
-    const partnerName = initialState.campaign.partnerName?.trim() || "Velocity";
     const primaryWhatsappLabel = initialState.campaign.whatsappLabel?.trim() || "Falar com a equipe";
     const invitationTitle = initialState.campaign.invitationTitle?.trim() || "Seu convite para celebrar";
     const invitationText =
@@ -676,7 +823,53 @@ export default function BeautyMovementExperience({
         });
     }
 
+    function measureProgressButton(index: number): ProgressRect | null {
+        const list = progressListRef.current;
+        const button = progressButtonRefs.current[index];
+        if (!list || !button) return null;
+
+        const listRect = list.getBoundingClientRect();
+        const buttonRect = button.getBoundingClientRect();
+        return {
+            left: buttonRect.left - listRect.left,
+            top: buttonRect.top - listRect.top,
+            width: buttonRect.width,
+            height: buttonRect.height,
+        };
+    }
+
+    function startProgressMotion(fromIndex: number, toIndex: number) {
+        if (fromIndex === toIndex || reducedMotionRef.current) {
+            if (progressMotionTimerRef.current !== null) {
+                window.clearTimeout(progressMotionTimerRef.current);
+                progressMotionTimerRef.current = null;
+            }
+            setProgressMotion(null);
+            return;
+        }
+
+        const from = measureProgressButton(fromIndex);
+        const to = measureProgressButton(toIndex);
+        if (!from || !to) return;
+
+        if (progressMotionTimerRef.current !== null) {
+            window.clearTimeout(progressMotionTimerRef.current);
+        }
+
+        const key = progressMotionKeyRef.current + 1;
+        progressMotionKeyRef.current = key;
+        setProgressMotion({ fromIndex, toIndex, from, to, key });
+        progressMotionTimerRef.current = window.setTimeout(() => {
+            progressMotionTimerRef.current = null;
+            if (mountedRef.current && progressMotionKeyRef.current === key) {
+                setProgressMotion(null);
+            }
+        }, BEAUTY_MOVEMENT_MOTION.progressTransitionMs);
+    }
+
     function setCurrentActIndex(next: number) {
+        const previous = displayedActIndexRef.current;
+        startProgressMotion(previous, next);
         displayedActIndexRef.current = next;
         setDisplayedActIndex(next);
     }
@@ -684,6 +877,11 @@ export default function BeautyMovementExperience({
     function setCurrentHandStage(next: HandStage) {
         handStageRef.current = next;
         setHandStage(next);
+    }
+
+    function setCurrentIntroStage(next: IntroStage) {
+        introStageRef.current = next;
+        setIntroStage(next);
     }
 
     function setCurrentFinaleStage(next: FinaleStage) {
@@ -695,32 +893,41 @@ export default function BeautyMovementExperience({
         return index === 0 || Boolean(selectionsRef.current[BEAUTY_MOVEMENT_ACTS[index - 1]]);
     }
 
-    function cancelAutoAdvance() {
+    const cancelAutoAdvance = useCallback(() => {
+        autoAdvanceGateRef.current.invalidate();
         if (autoAdvanceTimerRef.current !== null) {
             window.clearTimeout(autoAdvanceTimerRef.current);
             autoAdvanceTimerRef.current = null;
         }
+        if (autoAdvanceFrameRef.current !== null) {
+            window.cancelAnimationFrame(autoAdvanceFrameRef.current);
+            autoAdvanceFrameRef.current = null;
+        }
         setAutoAdvanceActive(false);
-    }
+    }, []);
 
-    function cancelScrollAnimation() {
+    const cancelScrollAnimation = useCallback(() => {
         if (scrollAnimationFrameRef.current !== null) {
             window.cancelAnimationFrame(scrollAnimationFrameRef.current);
             scrollAnimationFrameRef.current = null;
         }
-    }
+        scrollInterruptCleanupRef.current?.();
+        scrollInterruptCleanupRef.current = null;
+    }, []);
 
     function scrollToElement(target: HTMLElement | null) {
         cancelScrollAnimation();
         if (!target) return;
 
-        if (prefersReducedMotion()) {
+        if (reducedMotion) {
             target.scrollIntoView({ behavior: "auto", block: "start" });
             return;
         }
 
         const startTop = window.scrollY;
-        const targetTop = Math.max(0, startTop + target.getBoundingClientRect().top - 32);
+        const stickyHeader = document.querySelector("header");
+        const scrollOffset = stickyHeader instanceof HTMLElement ? stickyHeader.getBoundingClientRect().height + 4 : 32;
+        const targetTop = Math.max(0, startTop + target.getBoundingClientRect().top - scrollOffset);
         const distance = targetTop - startTop;
         const duration = Math.min(1040, Math.max(680, Math.abs(distance) * 0.55));
         const startedAt = performance.now();
@@ -729,6 +936,19 @@ export default function BeautyMovementExperience({
                 ? 4 * progress * progress * progress
                 : 1 - Math.pow(-2 * progress + 2, 3) / 2;
 
+        const interruptOnUserIntent = () => cancelScrollAnimation();
+        const removeScrollInterrupts = () => {
+            window.removeEventListener("wheel", interruptOnUserIntent);
+            window.removeEventListener("touchstart", interruptOnUserIntent);
+            window.removeEventListener("pointerdown", interruptOnUserIntent);
+            window.removeEventListener("keydown", interruptOnUserIntent);
+        };
+        window.addEventListener("wheel", interruptOnUserIntent, { passive: true, once: true });
+        window.addEventListener("touchstart", interruptOnUserIntent, { passive: true, once: true });
+        window.addEventListener("pointerdown", interruptOnUserIntent, { passive: true, once: true });
+        window.addEventListener("keydown", interruptOnUserIntent, { once: true });
+        scrollInterruptCleanupRef.current = removeScrollInterrupts;
+
         const animate = (now: number) => {
             const progress = Math.min(1, (now - startedAt) / duration);
             window.scrollTo(0, startTop + distance * easeInOut(progress));
@@ -736,6 +956,8 @@ export default function BeautyMovementExperience({
                 scrollAnimationFrameRef.current = window.requestAnimationFrame(animate);
             } else {
                 scrollAnimationFrameRef.current = null;
+                removeScrollInterrupts();
+                scrollInterruptCleanupRef.current = null;
             }
         };
 
@@ -751,25 +973,146 @@ export default function BeautyMovementExperience({
         scrollToElement(finaleRef.current);
     }
 
-    function clearHandTransition() {
+    function clearHandTransitionTimer() {
         if (handTransitionTimerRef.current !== null) {
             window.clearTimeout(handTransitionTimerRef.current);
             handTransitionTimerRef.current = null;
         }
     }
 
-    function startInitialDeal() {
-        if (handStageRef.current !== "waiting" || finaleStageRef.current !== "hidden" || transitionInFlightRef.current) return;
+    function cancelHandTransition() {
+        handTransitionGateRef.current.invalidate();
+        revealTransitionTokenRef.current = null;
+        clearHandTransitionTimer();
+        if (handExpansionFrameRef.current !== null) {
+            window.cancelAnimationFrame(handExpansionFrameRef.current);
+            handExpansionFrameRef.current = null;
+        }
+    }
 
-        transitionInFlightRef.current = true;
-        clearHandTransition();
-        setCurrentHandStage("deal");
+    function beginHandTransition() {
+        cancelHandTransition();
+        return handTransitionGateRef.current.start();
+    }
+
+    function scheduleHandTransition(token: number, delayMs: number, callback: () => void) {
+        clearHandTransitionTimer();
         handTransitionTimerRef.current = window.setTimeout(() => {
             handTransitionTimerRef.current = null;
-            if (!mountedRef.current) return;
-            transitionInFlightRef.current = false;
-            setCurrentHandStage("ready");
-        }, motionDuration(HAND_DEAL_MS));
+            if (!mountedRef.current || !handTransitionGateRef.current.isCurrent(token)) return;
+            callback();
+        }, motionDuration(delayMs, reducedMotionRef.current));
+    }
+
+    function scheduleDealSequence(token: number, onReady: () => void) {
+        if (reducedMotionRef.current) {
+            setCurrentHandStage("deal");
+            scheduleHandTransition(
+                token,
+                BEAUTY_MOVEMENT_MOTION.handDealMs + BEAUTY_MOVEMENT_MOTION.handDealSettleMs,
+                onReady,
+            );
+            return;
+        }
+
+        // Freeze the compact surface height before revealing the next hand.
+        // The expand class then transitions from this measured height to the
+        // full card-grid height, instead of asking CSS to animate from `auto`.
+        // This keeps the deck visibly anchored to the lower edge while the
+        // white table grows around it.
+        const surfaceBeforeExpand = tableSurfaceRef.current;
+        const startHeight = Math.max(
+            INITIAL_TABLE_HEIGHT,
+            Math.ceil(surfaceBeforeExpand?.getBoundingClientRect().height ?? INITIAL_TABLE_HEIGHT),
+        );
+        setTableExpansionHeight(startHeight);
+        setCurrentHandStage("expand");
+        // Wait for the expansion state to render the next hand before measuring it.
+        // A second frame avoids measuring the previous hand's layout during a fast
+        // state transition, especially on mobile and after a smooth scroll.
+        handExpansionFrameRef.current = window.requestAnimationFrame(() => {
+            if (!mountedRef.current || !handTransitionGateRef.current.isCurrent(token)) return;
+
+            handExpansionFrameRef.current = window.requestAnimationFrame(() => {
+                handExpansionFrameRef.current = null;
+                if (!mountedRef.current || !handTransitionGateRef.current.isCurrent(token)) return;
+
+                const surface = tableSurfaceRef.current;
+                const targetHeight = Math.max(
+                    startHeight,
+                    Math.ceil(surface?.scrollHeight ?? startHeight),
+                );
+                setTableExpansionHeight(targetHeight);
+                scheduleHandTransition(token, BEAUTY_MOVEMENT_MOTION.handExpandMs, () => {
+                    setCurrentHandStage("deal");
+                    scheduleHandTransition(
+                        token,
+                        BEAUTY_MOVEMENT_MOTION.handDealMs + BEAUTY_MOVEMENT_MOTION.handDealSettleMs,
+                        onReady,
+                    );
+                });
+            });
+        });
+    }
+
+    function clearIntroTransitionTimer() {
+        if (introTimerRef.current !== null) {
+            window.clearTimeout(introTimerRef.current);
+            introTimerRef.current = null;
+        }
+    }
+
+    function cancelIntroTransition() {
+        introTransitionGateRef.current.invalidate();
+        clearIntroTransitionTimer();
+    }
+
+    function beginIntroTransition() {
+        cancelIntroTransition();
+        return introTransitionGateRef.current.start();
+    }
+
+    function scheduleIntroTransition(token: number, delayMs: number, callback: () => void) {
+        clearIntroTransitionTimer();
+        introTimerRef.current = window.setTimeout(() => {
+            introTimerRef.current = null;
+            if (!mountedRef.current || !introTransitionGateRef.current.isCurrent(token)) return;
+            callback();
+        }, motionDuration(delayMs, reducedMotionRef.current));
+    }
+
+    function startInitialDeal() {
+        if (
+            handStageRef.current !== "waiting" ||
+            introStageRef.current !== "hidden" ||
+            finaleStageRef.current !== "hidden" ||
+            transitionInFlightRef.current
+        ) return;
+
+        transitionInFlightRef.current = true;
+        const handToken = beginHandTransition();
+        const introToken = beginIntroTransition();
+        setCurrentIntroStage("entering");
+        scheduleIntroTransition(introToken, promptEntryDuration(initialExperienceCopy), () => {
+            setCurrentIntroStage("holding");
+            scheduleIntroTransition(introToken, BEAUTY_MOVEMENT_MOTION.initialIntroHoldMs, () => {
+                setCurrentIntroStage("exiting");
+                scheduleIntroTransition(introToken, promptExitTransitionDuration(initialExperienceCopy), () => {
+                    setCurrentIntroStage("hidden");
+                    setCurrentHandStage("prompt");
+                    scheduleHandTransition(handToken, promptReadingDuration(tableDefinition.prompt), () => {
+                        setCurrentHandStage("prompt-out");
+                        scheduleHandTransition(handToken, promptExitTransitionDuration(tableDefinition.prompt), () => {
+                            scheduleDealSequence(handToken, () => {
+                                transitionInFlightRef.current = false;
+                                setCurrentHandStage("ready");
+                                window.requestAnimationFrame(scrollToTable);
+                            });
+                        });
+                    });
+                });
+            });
+        });
     }
 
     function handleDeckKeyDown(event: ReactKeyboardEvent<HTMLButtonElement>) {
@@ -786,34 +1129,37 @@ export default function BeautyMovementExperience({
 
         transitionInFlightRef.current = true;
         cancelAutoAdvance();
-        clearHandTransition();
+        const handToken = beginHandTransition();
         setCurrentHandStage("collect");
-        handTransitionTimerRef.current = window.setTimeout(() => {
-            if (!mountedRef.current) return;
+        scheduleHandTransition(handToken, BEAUTY_MOVEMENT_MOTION.handCollectMs, () => {
             setCurrentHandStage("finale");
-            setCurrentFinaleStage("collecting");
-            handTransitionTimerRef.current = window.setTimeout(() => {
-                if (!mountedRef.current) return;
-                setFinaleHoldRemaining(0);
-                setCurrentFinaleStage("merging");
-                handTransitionTimerRef.current = window.setTimeout(() => {
-                    handTransitionTimerRef.current = null;
-                    if (!mountedRef.current) return;
-                    transitionInFlightRef.current = false;
-                    setCurrentHandStage("ready");
-                    setCurrentFinaleStage(confirmed ? "result" : "confirmation");
-                    if (confirmed) {
-                        window.requestAnimationFrame(() => {
-                            window.requestAnimationFrame(scrollToFinale);
-                        });
-                    } else {
-                        window.requestAnimationFrame(() => {
-                            confirmationActionRef.current?.focus({ preventScroll: true });
-                        });
-                    }
-                }, motionDuration(HAND_FINALE_MS));
-            }, FINALE_HOLD_SECONDS * 1000);
-        }, motionDuration(HAND_COLLECT_MS));
+            setCurrentFinaleStage("assembling");
+            scheduleHandTransition(handToken, BEAUTY_MOVEMENT_MOTION.finaleCardsEnterMs, () => {
+                setCurrentFinaleStage("collecting");
+                scheduleHandTransition(handToken, BEAUTY_MOVEMENT_MOTION.finaleHoldMs, () => {
+                    setFinaleHoldRemaining(0);
+                    setCurrentFinaleStage("merging");
+                    scheduleHandTransition(
+                        handToken,
+                        BEAUTY_MOVEMENT_MOTION.finaleMergeMs + BEAUTY_MOVEMENT_MOTION.finaleMergeSettleMs,
+                        () => {
+                            transitionInFlightRef.current = false;
+                            setCurrentHandStage("ready");
+                            setCurrentFinaleStage(confirmed ? "result" : "confirmation");
+                            if (confirmed) {
+                                window.requestAnimationFrame(() => {
+                                    window.requestAnimationFrame(scrollToFinale);
+                                });
+                            } else {
+                                window.requestAnimationFrame(() => {
+                                    confirmationActionRef.current?.focus({ preventScroll: true });
+                                });
+                            }
+                        },
+                    );
+                });
+            });
+        });
     }
 
     function moveToNextHand(index: number) {
@@ -826,30 +1172,153 @@ export default function BeautyMovementExperience({
         }
 
         transitionInFlightRef.current = true;
-        clearHandTransition();
+        const handToken = beginHandTransition();
         setCurrentHandStage("collect");
-        handTransitionTimerRef.current = window.setTimeout(() => {
-            if (!mountedRef.current) return;
+        scheduleHandTransition(handToken, BEAUTY_MOVEMENT_MOTION.handCollectMs, () => {
             setCurrentActIndex(nextIndex);
-            setCurrentHandStage("deal");
-            handTransitionTimerRef.current = window.setTimeout(() => {
-                handTransitionTimerRef.current = null;
-                if (!mountedRef.current) return;
-                transitionInFlightRef.current = false;
-                setCurrentHandStage("ready");
-            }, motionDuration(HAND_DEAL_MS));
-        }, motionDuration(HAND_COLLECT_MS));
+            setCurrentHandStage("prompt");
+            scheduleHandTransition(handToken, promptReadingDuration(BEAUTY_MOVEMENT_ACT_DEFINITIONS[nextIndex]?.prompt || ""), () => {
+                setCurrentHandStage("prompt-out");
+                scheduleHandTransition(
+                    handToken,
+                    promptExitTransitionDuration(BEAUTY_MOVEMENT_ACT_DEFINITIONS[nextIndex]?.prompt || ""),
+                    () => {
+                        scheduleDealSequence(handToken, () => {
+                            transitionInFlightRef.current = false;
+                            setCurrentHandStage("ready");
+                            window.requestAnimationFrame(scrollToTable);
+                        });
+                    },
+                );
+            });
+        });
+    }
+
+    function startAutoAdvance(index: number, delayMs = BEAUTY_MOVEMENT_MOTION.autoAdvanceMs) {
+        const token = autoAdvanceGateRef.current.start();
+        autoAdvanceFrameRef.current = window.requestAnimationFrame(() => {
+            autoAdvanceFrameRef.current = null;
+            if (
+                !mountedRef.current ||
+                reducedMotionRef.current ||
+                !autoAdvanceGateRef.current.isCurrent(token) ||
+                handStageRef.current !== "held" ||
+                displayedActIndexRef.current !== index ||
+                finaleStageRef.current !== "hidden"
+            ) return;
+
+            setAutoAdvanceActive(true);
+            autoAdvanceTimerRef.current = window.setTimeout(() => {
+                autoAdvanceTimerRef.current = null;
+                if (
+                    !mountedRef.current ||
+                    !autoAdvanceGateRef.current.isCurrent(token) ||
+                    handStageRef.current !== "held" ||
+                    displayedActIndexRef.current !== index ||
+                    finaleStageRef.current !== "hidden"
+                ) return;
+
+                setAutoAdvanceActive(false);
+                moveToNextHand(index);
+            }, delayMs);
+        });
     }
 
     function scheduleNextHand(index: number) {
-        if (prefersReducedMotion()) return;
+        if (reducedMotion) return;
         cancelAutoAdvance();
-        setAutoAdvanceActive(true);
-        autoAdvanceTimerRef.current = window.setTimeout(() => {
-            autoAdvanceTimerRef.current = null;
-            setAutoAdvanceActive(false);
-            moveToNextHand(index);
-        }, AUTO_ADVANCE_SECONDS * 1000);
+        startAutoAdvance(index);
+    }
+
+    useEffect(() => {
+        if (!autoAdvanceActive) return;
+
+        const cancelOnReadingIntent = () => cancelAutoAdvance();
+        window.addEventListener("wheel", cancelOnReadingIntent, { passive: true });
+        window.addEventListener("touchmove", cancelOnReadingIntent, { passive: true });
+        window.addEventListener("keydown", cancelOnReadingIntent);
+
+        return () => {
+            window.removeEventListener("wheel", cancelOnReadingIntent);
+            window.removeEventListener("touchmove", cancelOnReadingIntent);
+            window.removeEventListener("keydown", cancelOnReadingIntent);
+        };
+    }, [autoAdvanceActive, cancelAutoAdvance]);
+
+    useEffect(() => {
+        if (!reducedMotion) return;
+        cancelAutoAdvance();
+        cancelScrollAnimation();
+    }, [reducedMotion, cancelAutoAdvance, cancelScrollAnimation]);
+
+    useEffect(() => {
+        if (handStage !== "expand") return;
+
+        let resizeFrame: number | null = null;
+        const syncExpansionHeight = () => {
+            if (resizeFrame !== null) window.cancelAnimationFrame(resizeFrame);
+            resizeFrame = window.requestAnimationFrame(() => {
+                resizeFrame = null;
+                const surface = tableSurfaceRef.current;
+                if (!surface || handStageRef.current !== "expand") return;
+                setTableExpansionHeight(Math.max(220, surface.scrollHeight));
+            });
+        };
+
+        window.addEventListener("resize", syncExpansionHeight);
+        const surfaceObserver = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(syncExpansionHeight);
+        if (surfaceObserver && tableSurfaceRef.current) surfaceObserver.observe(tableSurfaceRef.current);
+        return () => {
+            window.removeEventListener("resize", syncExpansionHeight);
+            surfaceObserver?.disconnect();
+            if (resizeFrame !== null) window.cancelAnimationFrame(resizeFrame);
+        };
+    }, [handStage]);
+
+    useEffect(() => {
+        const cancelWhenBackgrounded = () => {
+            if (document.visibilityState === "hidden") cancelAutoAdvance();
+        };
+
+        document.addEventListener("visibilitychange", cancelWhenBackgrounded);
+        return () => document.removeEventListener("visibilitychange", cancelWhenBackgrounded);
+    }, [cancelAutoAdvance]);
+
+    function handleProgressClick(index: number) {
+        if (index !== displayedActIndexRef.current || !isActUnlocked(index)) return;
+
+        const act = BEAUTY_MOVEMENT_ACTS[index];
+        const hasSelection = Boolean(act && selectionsRef.current[act]);
+        if (hasSelection && handStageRef.current === "held") {
+            if (index === BEAUTY_MOVEMENT_ACTS.length - 1) {
+                beginFinale();
+            } else {
+                moveToNextHand(index);
+            }
+            return;
+        }
+
+        scrollToTable();
+    }
+
+    function settleReveal(actIndex: number, token: number) {
+        if (
+            !handTransitionGateRef.current.isCurrent(token) ||
+            handStageRef.current !== "reveal" ||
+            displayedActIndexRef.current !== actIndex
+        ) return;
+
+        clearHandTransitionTimer();
+        revealTransitionTokenRef.current = null;
+        setCurrentHandStage("held");
+        scheduleNextHand(actIndex);
+    }
+
+    function handleSelectedCardAnimationEnd(event: ReactAnimationEvent<HTMLButtonElement>, actIndex: number) {
+        if (event.currentTarget !== event.target || event.animationName !== "cardLiftAndSettle") return;
+        const token = revealTransitionTokenRef.current;
+        if (token === null) return;
+        settleReveal(actIndex, token);
     }
 
     async function handleReveal(actIndex: number, card: BeautyMovementCard) {
@@ -881,14 +1350,12 @@ export default function BeautyMovementExperience({
                 ...(committedSelections ?? {}),
                 [act]: committedSelections?.[act] ?? card.id,
             }));
-            clearHandTransition();
+            const handToken = beginHandTransition();
+            revealTransitionTokenRef.current = handToken;
             setCurrentHandStage("reveal");
-            handTransitionTimerRef.current = window.setTimeout(() => {
-                handTransitionTimerRef.current = null;
-                if (!mountedRef.current) return;
-                setCurrentHandStage("held");
-                scheduleNextHand(actIndex);
-            }, motionDuration(HAND_REVEAL_MS));
+            scheduleHandTransition(handToken, BEAUTY_MOVEMENT_MOTION.handRevealFallbackMs, () => {
+                settleReveal(actIndex, handToken);
+            });
             onTrack?.("beauty_movement_card_revealed", { actIndex: actIndex + 1 });
         } catch {
             if (mountedRef.current) {
@@ -945,7 +1412,7 @@ export default function BeautyMovementExperience({
         if (reading.length !== BEAUTY_MOVEMENT_ACTS.length) return;
 
         setShareStatus(null);
-        const blob = await createStoryBlob(reading, partnerName);
+        const blob = await createStoryBlob(reading);
         if (!blob) {
             setShareStatus("Não foi possível preparar o Story neste navegador.");
             return;
@@ -984,12 +1451,33 @@ export default function BeautyMovementExperience({
 
     const tableAct = BEAUTY_MOVEMENT_ACTS[displayedActIndex] ?? BEAUTY_MOVEMENT_ACTS[0];
     const tableDefinition = BEAUTY_MOVEMENT_ACT_DEFINITIONS[displayedActIndex] ?? BEAUTY_MOVEMENT_ACT_DEFINITIONS[0];
+    const initialExperienceCopy =
+        initialState.campaign.description?.trim() ||
+        "3 anos. 3 cartas. Um novo movimento para celebrar tudo o que ainda vem pela frente.";
     const tableCards = getBeautyMovementCardsForAct(initialState.palette, tableAct);
     const tableSelectedCardId = selections[tableAct];
     const tableSelected = Boolean(tableSelectedCardId);
     const nextDefinition = BEAUTY_MOVEMENT_ACT_DEFINITIONS[displayedActIndex + 1];
     const tableIsUnlocked = isActUnlocked(displayedActIndex);
-    const waitingForInitialDeal = handStage === "waiting" && finaleStage === "hidden";
+    const waitingForInitialDeal = handStage === "waiting" && introStage === "hidden" && finaleStage === "hidden";
+    const tablePromptCopy =
+        introStage !== "hidden"
+            ? { title: initialExperienceCopy, subtitle: "" }
+            : handStage === "prompt" || handStage === "prompt-out"
+              ? { title: tableDefinition.promptTitle, subtitle: tableDefinition.promptSubtitle }
+              : null;
+    const tablePromptText = tablePromptCopy ? [tablePromptCopy.title, tablePromptCopy.subtitle].filter(Boolean).join(" ") : null;
+    const promptTitleWordCount = tablePromptCopy ? promptWordCount(tablePromptCopy.title) : 0;
+    const tablePromptClassName =
+        introStage === "entering"
+            ? styles.tablePromptIntro
+            : introStage === "holding"
+              ? styles.tablePromptIntroHolding
+              : introStage === "exiting"
+                ? styles.tablePromptIntroExit
+                : handStage === "prompt-out"
+                  ? styles.tablePromptExit
+                  : "";
 
     function renderCard(card: BeautyMovementCard, cardIndex: number) {
         const pendingKey = `${displayedActIndex}:${card.id}`;
@@ -1002,6 +1490,13 @@ export default function BeautyMovementExperience({
                 className={`${styles.cardButton} ${isPending ? styles.cardButtonPending : ""} ${isSelected ? styles.cardButtonSelected : ""}`.trim()}
                 key={card.id}
                 onClick={() => void handleReveal(displayedActIndex, card)}
+                onKeyDown={(event) => {
+                    if ((event.key === "Enter" || event.key === " ") && !event.repeat) {
+                        event.preventDefault();
+                        void handleReveal(displayedActIndex, card);
+                    }
+                }}
+                onAnimationEnd={isSelected ? (event) => handleSelectedCardAnimationEnd(event, displayedActIndex) : undefined}
                 disabled={!tableIsUnlocked || handStage !== "ready" || Boolean(revealPendingCardId) || tableSelected}
                 aria-busy={isPending || undefined}
                 aria-pressed={isSelected}
@@ -1266,67 +1761,135 @@ export default function BeautyMovementExperience({
 
             <section className={styles.shell} aria-labelledby="beauty-movement-title">
                 <header className={styles.hero}>
-                    <div className={styles.brandLine} aria-label={`Espaço Facial em parceria com ${partnerName}`}>
-                        <span>Espaço Facial</span>
-                        <span className={styles.brandDivider} aria-hidden="true">
-                            ×
-                        </span>
-                        <span className={styles.partnerName}>{partnerName}</span>
-                    </div>
+                    {waitingForInitialDeal ? (
+                        <button
+                            className={styles.heroDeckPrompt}
+                            id="beauty-movement-deck-prompt"
+                            type="button"
+                            onClick={scrollToTable}
+                            aria-label="Ir ao baralho e começar sua leitura"
+                        >
+                            <span>Começar a leitura</span>
+                            <span className={styles.heroDeckPromptArrow} aria-hidden="true">
+                                ↓
+                            </span>
+                        </button>
+                    ) : null}
                     <h1 id="beauty-movement-title">{initialState.campaign.title?.trim() || "Beleza que se move com você."}</h1>
-                    <p className={styles.heroCopy}>
-                        {initialState.campaign.description?.trim() ||
-                            "Cartas da Beleza em Movimento celebra os 3 anos da Espaço Facial Novo Hamburgo."}
-                    </p>
                 </header>
 
                 <section
                     ref={tableRef}
                     className={styles.tableStage}
                     id="mesa-de-cartas"
-                    aria-labelledby="table-stage-title"
+                    aria-label={tableDefinition.label}
+                    aria-describedby={tablePromptText ? "table-stage-prompt" : undefined}
                     data-hand-stage={handStage}
                     data-act-index={displayedActIndex}
                     data-finale-stage={finaleStage}
+                    style={motionCssVariables}
                 >
-                    <ol className={styles.progress} aria-label="Progresso da experiência">
-                        {BEAUTY_MOVEMENT_ACT_DEFINITIONS.map((act, index) => {
-                            const isDone = Boolean(selections[act.id]);
-                            const isCurrent = index === displayedActIndex;
-                            const isLocked = !isActUnlocked(index);
-                            return (
-                                <li
-                                    className={`${styles.progressItem} ${isDone ? styles.progressItemDone : ""} ${isCurrent ? styles.progressItemCurrent : ""}`.trim()}
-                                    key={act.id}
-                                >
-                                    <button
-                                        className={styles.progressButton}
-                                        type="button"
-                                        onClick={scrollToTable}
-                                        disabled={!isCurrent}
-                                        aria-current={isCurrent ? "step" : undefined}
-                                        aria-label={`Acompanhar a mesa de cartas em ${act.label}${isLocked ? ", ainda bloqueada" : ""}`}
-                                    >
-                                        <span className={styles.progressCopy}>
-                                            <strong>{act.label}</strong>
-                                            <small>{isDone ? "Escolha guardada" : act.progressLabel}</small>
-                                        </span>
-                                    </button>
-                                </li>
-                            );
-                        })}
-                    </ol>
+                    <div className={styles.progressRow}>
+                        <div className={styles.progressGroup}>
+                            <ol
+                                ref={progressListRef}
+                                className={`${styles.progress} ${progressMotion ? styles.progressMotionActive : ""}`.trim()}
+                                aria-label="Progresso da experiência"
+                            >
+                                {progressMotion ? (
+                                    <li
+                                        className={styles.progressTransfer}
+                                        aria-hidden="true"
+                                        style={
+                                            {
+                                                "--progress-from-left": `${progressMotion.from.left}px`,
+                                                "--progress-from-top": `${progressMotion.from.top}px`,
+                                                "--progress-from-width": `${progressMotion.from.width}px`,
+                                                "--progress-from-height": `${progressMotion.from.height}px`,
+                                                "--progress-to-left": `${progressMotion.to.left}px`,
+                                                "--progress-to-top": `${progressMotion.to.top}px`,
+                                                "--progress-to-width": `${progressMotion.to.width}px`,
+                                                "--progress-to-height": `${progressMotion.to.height}px`,
+                                            } as CSSProperties
+                                        }
+                                    />
+                                ) : null}
+                                {BEAUTY_MOVEMENT_ACT_DEFINITIONS.map((act, index) => {
+                                    const isDone = Boolean(selections[act.id]);
+                                    const isCurrent = introStage === "hidden" && !waitingForInitialDeal && index === displayedActIndex;
+                                    const isLocked = !isActUnlocked(index);
+                                    const isProgressSource = progressMotion?.fromIndex === index;
+                                    const isProgressTarget = progressMotion?.toIndex === index;
+                                    const isAdvanceReady = isCurrent && isDone && handStage === "held";
+                                    const nextAct = BEAUTY_MOVEMENT_ACT_DEFINITIONS[index + 1];
+                                    const progressActionLabel = isAdvanceReady
+                                        ? index === BEAUTY_MOVEMENT_ACTS.length - 1
+                                            ? "Continuar para confirmação"
+                                            : `Continuar para ${nextAct?.label || "a próxima etapa"}`
+                                        : `Acompanhar a mesa de cartas em ${act.label}${isLocked ? ", ainda bloqueada" : ""}`;
+                                    return (
+                                        <li
+                                            className={[
+                                                styles.progressItem,
+                                                isDone ? styles.progressItemDone : "",
+                                                isCurrent && !progressMotion ? styles.progressItemCurrent : "",
+                                                isProgressSource ? styles.progressItemTransferFrom : "",
+                                                isProgressTarget ? styles.progressItemTransferTo : "",
+                                            ].filter(Boolean).join(" ")}
+                                            key={act.id}
+                                        >
+                                            <button
+                                                className={styles.progressButton}
+                                                type="button"
+                                                onClick={() => handleProgressClick(index)}
+                                                ref={(element) => {
+                                                    progressButtonRefs.current[index] = element;
+                                                }}
+                                                disabled={!isCurrent || Boolean(progressMotion)}
+                                                aria-current={isCurrent ? "step" : undefined}
+                                                aria-label={progressActionLabel}
+                                            >
+                                                <span className={styles.progressCopy}>
+                                                    <strong>{act.label}</strong>
+                                                </span>
+                                                {isCurrent && !progressMotion && autoAdvanceActive ? (
+                                                    <span className={styles.autoAdvance} role="status" aria-live="polite">
+                                                        <span className={styles.srOnly}>
+                                                            {nextDefinition ? "Próxima mão" : "Confirmação"} automática em {AUTO_ADVANCE_SECONDS} segundos.
+                                                        </span>
+                                                    </span>
+                                                ) : null}
+                                            </button>
+                                        </li>
+                                    );
+                                })}
+                            </ol>
+                        </div>
 
-                    <div className={styles.actHeading}>
-                        <h2 id="table-stage-title">{tableDefinition.label}</h2>
-                        <p>{tableDefinition.prompt}</p>
+                        {tablePromptCopy ? (
+                            <p
+                                className={`${styles.tablePrompt} ${tablePromptClassName}`.trim()}
+                                id="table-stage-prompt"
+                                key={introStage !== "hidden" ? "experience-intro" : tableDefinition.id}
+                            >
+                                <span className={styles.promptTitle}>{renderPromptWords(tablePromptCopy.title)}</span>
+                                {tablePromptCopy.subtitle ? (
+                                    <span className={styles.promptSubtitle}>
+                                        {renderPromptWords(tablePromptCopy.subtitle, promptTitleWordCount)}
+                                    </span>
+                                ) : null}
+                            </p>
+                        ) : null}
                     </div>
 
                     <div
+                        ref={tableSurfaceRef}
                         className={styles.tableSurface}
                         data-deck-state={
-                            waitingForInitialDeal
+                            waitingForInitialDeal || introStage !== "hidden" || handStage === "prompt" || handStage === "prompt-out"
                                 ? "waiting"
+                                : handStage === "expand"
+                                  ? "expanding"
                                 : finaleStage === "confirmation" || finaleStage === "result"
                                   ? "final"
                                   : "ready"
@@ -1347,19 +1910,7 @@ export default function BeautyMovementExperience({
                                 <BrandMark className={styles.deckBrandLogo} tone="light" title="" />
                             </span>
                         </button>
-                        {waitingForInitialDeal ? (
-                            <span
-                                className={styles.deckPrompt}
-                                id="beauty-movement-deck-prompt"
-                                role="note"
-                            >
-                                Clique no baralho
-                                <span className={styles.deckPromptArrow} aria-hidden="true">
-                                    ↓
-                                </span>
-                            </span>
-                        ) : null}
-                        {finaleStage === "collecting" || finaleStage === "merging" ? (
+                        {finaleStage === "assembling" || finaleStage === "collecting" || finaleStage === "merging" ? (
                             <div
                                 className={`${styles.finaleCardGrid} ${finaleStage === "merging" ? styles.finaleCardGridMerging : styles.finaleCardGridHolding}`}
                                 aria-hidden="true"
@@ -1375,7 +1926,7 @@ export default function BeautyMovementExperience({
                                 {finaleStage === "confirmation" ? renderConfirmationAction() : null}
                                 {renderSpecialCard(finaleStage === "result")}
                             </div>
-                        ) : finaleStage === "hidden" && !waitingForInitialDeal ? (
+                        ) : finaleStage === "hidden" && introStage === "hidden" && handStage !== "waiting" && handStage !== "prompt" && handStage !== "prompt-out" ? (
                             <div className={styles.cardGrid} role="group" aria-label={`Cartas da etapa ${tableDefinition.label}`}>
                                 {tableCards.map(renderCard)}
                             </div>
@@ -1389,53 +1940,6 @@ export default function BeautyMovementExperience({
                         ) : null}
                     </div>
 
-                    {finaleStage === "hidden" ? (
-                        <div className={styles.actAdvance}>
-                            <p className={styles.advanceNote} role="status">
-                                {waitingForInitialDeal
-                                    ? "Clique no baralho para distribuir esta mão."
-                                    : tableSelected
-                                      ? "Carta revelada. As outras cartas serão recolhidas antes da próxima mão."
-                                      : handStage === "ready"
-                                        ? "Escolha uma carta para liberar o avanço."
-                                      : handStage === "held"
-                                        ? "Escolha uma carta para liberar o avanço."
-                                        : "A próxima mão está sendo preparada."}
-                            </p>
-                            {autoAdvanceActive ? (
-                                <div className={styles.autoAdvance} role="status" aria-live="polite">
-                                    <span className={styles.autoAdvanceLabel}>
-                                        {nextDefinition ? "Próxima mão" : "Confirmação"}
-                                    </span>
-                                    <span className={styles.autoAdvanceHint}>
-                                        Você pode continuar antes pelo botão.
-                                    </span>
-                                    <span className={styles.srOnly}>
-                                        {nextDefinition ? "Próxima mão" : "Confirmação"} automática em {AUTO_ADVANCE_SECONDS} segundos.
-                                    </span>
-                                </div>
-                            ) : null}
-                            {nextDefinition ? (
-                                <button
-                                    className={styles.continueButton}
-                                    type="button"
-                                    onClick={() => moveToNextHand(displayedActIndex)}
-                                    disabled={!tableSelected || handStage !== "held"}
-                                >
-                                    Continuar para {nextDefinition.label}
-                                </button>
-                            ) : (
-                                <button
-                                    className={styles.continueButton}
-                                    type="button"
-                                    onClick={beginFinale}
-                                    disabled={!tableSelected || handStage !== "held"}
-                                >
-                                    Continuar para confirmar
-                                </button>
-                            )}
-                        </div>
-                    ) : null}
                 </section>
 
                 {actionError && finaleStage === "hidden" ? (

--- a/website/src/components/BeautyMovementLocalPreview.tsx
+++ b/website/src/components/BeautyMovementLocalPreview.tsx
@@ -31,7 +31,7 @@ const INITIAL_PREVIEW_STATE: BeautyMovementExperienceInitialState = {
     confirmed: false,
     campaign: {
         title: "Beleza que se move com você.",
-        description: "Cartas da Beleza em Movimento celebra os 3 anos da Espaço Facial Novo Hamburgo.",
+        description: "3 anos. 3 cartas. Um novo movimento para celebrar tudo o que ainda vem pela frente.",
         invitationTitle: "Seu convite para celebrar",
         invitationText: "A equipe vai confirmar os próximos detalhes com você.",
         partnerName: "Velocity",

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -2,35 +2,40 @@ import AgendeCta from "@/components/AgendeCta";
 import UnitChooser from "@/components/UnitChooser";
 import Brand from "@/components/Brand";
 import HeaderMobileMenu from "@/components/HeaderMobileMenu";
+import HeaderScrollBehavior from "@/components/HeaderScrollBehavior";
 import SmoothAnchorLink from "@/components/SmoothAnchorLink";
 
 type HeaderProps = {
   preferredUnitSlug?: string | null;
   fixedUnitSlug?: string | null;
+  scrollAware?: boolean;
 };
 
-export default function Header({ preferredUnitSlug = null, fixedUnitSlug = null }: HeaderProps) {
+export default function Header({ preferredUnitSlug = null, fixedUnitSlug = null, scrollAware = false }: HeaderProps) {
   return (
-    <header className="header">
-      <div className="container">
-        <div className="nav">
-          <div className="navLeft">
-            <HeaderMobileMenu />
-            <Brand className="brand--header" />
-          </div>
+    <>
+      <header className="header" data-scroll-aware-header={scrollAware ? "true" : undefined}>
+        <div className="container">
+          <div className="nav">
+            <div className="navLeft">
+              <HeaderMobileMenu />
+              <Brand className="brand--header" />
+            </div>
 
-          <nav className="menu menu--center" aria-label="Menu principal">
-            <SmoothAnchorLink href="/#sobre-nos">Sobre Nós</SmoothAnchorLink>
-            <SmoothAnchorLink href="/#doutores">Equipe</SmoothAnchorLink>
-            <SmoothAnchorLink href="/#unidades">Unidades</SmoothAnchorLink>
-          </nav>
+            <nav className="menu menu--center" aria-label="Menu principal">
+              <SmoothAnchorLink href="/#sobre-nos">Sobre Nós</SmoothAnchorLink>
+              <SmoothAnchorLink href="/#doutores">Equipe</SmoothAnchorLink>
+              <SmoothAnchorLink href="/#unidades">Unidades</SmoothAnchorLink>
+            </nav>
 
-          <div className="headerActions">
-            <UnitChooser preferredUnitSlug={preferredUnitSlug} fixedUnitSlug={fixedUnitSlug} />
-            <AgendeCta preferredUnitSlug={preferredUnitSlug} fixedUnitSlug={fixedUnitSlug} />
+            <div className="headerActions">
+              <UnitChooser preferredUnitSlug={preferredUnitSlug} fixedUnitSlug={fixedUnitSlug} />
+              <AgendeCta preferredUnitSlug={preferredUnitSlug} fixedUnitSlug={fixedUnitSlug} />
+            </div>
           </div>
         </div>
-      </div>
-    </header>
+      </header>
+      {scrollAware ? <HeaderScrollBehavior /> : null}
+    </>
   );
 }

--- a/website/src/components/HeaderScrollBehavior.tsx
+++ b/website/src/components/HeaderScrollBehavior.tsx
@@ -11,12 +11,16 @@ export default function HeaderScrollBehavior() {
         let lastScrollY = Math.max(window.scrollY, 0);
         let frame: number | null = null;
 
+        const revealHeader = () => {
+            header.classList.remove("header--hidden");
+        };
+
         const update = () => {
             const currentScrollY = Math.max(window.scrollY, 0);
             const delta = currentScrollY - lastScrollY;
 
             if (currentScrollY <= 12 || delta < -4) {
-                header.classList.remove("header--hidden");
+                revealHeader();
             } else if (delta > 4) {
                 header.classList.add("header--hidden");
             }
@@ -30,11 +34,20 @@ export default function HeaderScrollBehavior() {
             frame = window.requestAnimationFrame(update);
         };
 
+        const handleFocusIn = () => revealHeader();
+        const handleKeyboardIntent = (event: KeyboardEvent) => {
+            if (event.key === "Tab" || event.key === "Home" || event.key === "End") revealHeader();
+        };
+
         window.addEventListener("scroll", handleScroll, { passive: true });
+        header.addEventListener("focusin", handleFocusIn);
+        window.addEventListener("keydown", handleKeyboardIntent, true);
         return () => {
             window.removeEventListener("scroll", handleScroll);
+            header.removeEventListener("focusin", handleFocusIn);
+            window.removeEventListener("keydown", handleKeyboardIntent, true);
             if (frame !== null) window.cancelAnimationFrame(frame);
-            header.classList.remove("header--hidden");
+            revealHeader();
         };
     }, []);
 

--- a/website/src/components/HeaderScrollBehavior.tsx
+++ b/website/src/components/HeaderScrollBehavior.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+
+/** Keeps the campaign header available while reclaiming vertical space during downward scroll. */
+export default function HeaderScrollBehavior() {
+    useEffect(() => {
+        const header = document.querySelector<HTMLElement>('[data-scroll-aware-header="true"]');
+        if (!header) return;
+
+        let lastScrollY = Math.max(window.scrollY, 0);
+        let frame: number | null = null;
+
+        const update = () => {
+            const currentScrollY = Math.max(window.scrollY, 0);
+            const delta = currentScrollY - lastScrollY;
+
+            if (currentScrollY <= 12 || delta < -4) {
+                header.classList.remove("header--hidden");
+            } else if (delta > 4) {
+                header.classList.add("header--hidden");
+            }
+
+            if (Math.abs(delta) > 4) lastScrollY = currentScrollY;
+            frame = null;
+        };
+
+        const handleScroll = () => {
+            if (frame !== null) return;
+            frame = window.requestAnimationFrame(update);
+        };
+
+        window.addEventListener("scroll", handleScroll, { passive: true });
+        return () => {
+            window.removeEventListener("scroll", handleScroll);
+            if (frame !== null) window.cancelAnimationFrame(frame);
+            header.classList.remove("header--hidden");
+        };
+    }, []);
+
+    return null;
+}

--- a/website/src/lib/beautyMovementCards.ts
+++ b/website/src/lib/beautyMovementCards.ts
@@ -10,6 +10,8 @@ export type BeautyMovementActDefinition = {
     id: BeautyMovementAct;
     label: string;
     prompt: string;
+    promptTitle: string;
+    promptSubtitle: string;
     progressLabel: string;
 };
 
@@ -35,19 +37,25 @@ export const BEAUTY_MOVEMENT_ACT_DEFINITIONS: readonly BeautyMovementActDefiniti
     {
         id: "beleza",
         label: "Beleza",
-        prompt: "O que merece mais presença no seu ritual — o gesto que faz você se reconhecer no agora?",
+        prompt: "O que merece mais presença no seu ritual? O gesto que faz você se reconhecer no agora.",
+        promptTitle: "O que merece mais presença no seu ritual?",
+        promptSubtitle: "O gesto que faz você se reconhecer no agora.",
         progressLabel: "Primeira escolha",
     },
     {
         id: "movimento",
         label: "Movimento",
-        prompt: "O que sustenta o seu ritmo — a energia que transforma pequenos gestos em movimento?",
+        prompt: "O que sustenta o seu ritmo? A energia que transforma pequenos gestos em movimento.",
+        promptTitle: "O que sustenta o seu ritmo?",
+        promptSubtitle: "A energia que transforma pequenos gestos em movimento.",
         progressLabel: "Segunda escolha",
     },
     {
         id: "celebracao",
         label: "Celebração",
-        prompt: "O que você quer celebrar neste encontro — a presença, a conexão e o próximo ciclo?",
+        prompt: "O que você quer celebrar neste encontro? A presença, a conexão e o próximo ciclo.",
+        promptTitle: "O que você quer celebrar neste encontro?",
+        promptSubtitle: "A presença, a conexão e o próximo ciclo.",
         progressLabel: "Terceira escolha",
     },
 ] as const;

--- a/website/src/lib/beautyMovementMotion.ts
+++ b/website/src/lib/beautyMovementMotion.ts
@@ -1,0 +1,55 @@
+/**
+ * One source of truth for the invitation's visual choreography.
+ *
+ * The component also passes the durations to CSS custom properties, so a
+ * logical phase cannot become interactive before its matching animation ends.
+ */
+export const BEAUTY_MOVEMENT_MOTION = {
+    autoAdvanceMs: 5_000,
+    finaleHoldMs: 5_000,
+    handRevealMs: 1_500,
+    handRevealFallbackMs: 1_700,
+    handCollectMs: 860,
+    handExpandMs: 760,
+    handDealMs: 960,
+    /** A short settle window keeps the freshly dealt cards fully at rest before clicks are enabled. */
+    handDealSettleMs: 120,
+    progressCollapseMs: 220,
+    progressTransferMs: 480,
+    progressExpandMs: 260,
+    progressTransitionMs: 960,
+    finaleCardsEnterMs: 880,
+    finaleMergeMs: 1_200,
+    finaleCardMergeMs: 1_120,
+    finaleMergeStaggerMs: 40,
+    /** The third finale card has a stagger; let its last frame land before swapping the DOM. */
+    finaleMergeSettleMs: 120,
+    initialIntroHoldMs: 2_600,
+    promptWordDelayMs: 48,
+    promptWordAnimationMs: 840,
+    promptReadingHoldMs: 2_600,
+    promptExitBaseMs: 560,
+    promptExitWordDelayMs: 16,
+    promptExitBreathMs: 320,
+} as const;
+
+/**
+ * Invalidates nested timer callbacks whenever the participant takes a newer
+ * action. It is deliberately tiny so it can be tested without a DOM clock.
+ */
+export function createBeautyMovementMotionGate() {
+    let generation = 0;
+
+    return {
+        start() {
+            generation += 1;
+            return generation;
+        },
+        invalidate() {
+            generation += 1;
+        },
+        isCurrent(token: number) {
+            return token === generation;
+        },
+    };
+}

--- a/website/src/styles/globals.css
+++ b/website/src/styles/globals.css
@@ -338,6 +338,21 @@ button:focus-visible {
   border-bottom: 1px solid var(--border)
 }
 
+.header[data-scroll-aware-header="true"] {
+  transition: transform 220ms cubic-bezier(.22, 1, .36, 1);
+  will-change: transform;
+}
+
+.header[data-scroll-aware-header="true"].header--hidden {
+  transform: translateY(-100%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .header[data-scroll-aware-header="true"] {
+    transition-duration: 0.01ms;
+  }
+}
+
 .nav {
   display: flex;
   align-items: center;

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -50,7 +50,9 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(experience, /onKeyDown=\{\(event\) => \{/);
     assert.match(experience, /event\.key === "Enter" \|\| event\.key === " "/);
     assert.match(experience, /event\.preventDefault\(\);\s*void handleReveal\(displayedActIndex, card\)/);
-    assert.match(experience, /function motionDuration\(durationMs: number, reducedMotion: boolean\)/);
+    assert.match(experience, /function motionDuration\(durationMs: number, reducedMotion: boolean, preserveTiming = false\)/);
+    assert.match(experience, /function promptReadingDelay\(text: string, reducedMotion: boolean\)/);
+    assert.match(experience, /motionDuration\(delayMs, reducedMotionRef\.current, preserveTiming\)/);
     assert.match(experience, /if \(reducedMotion\) return;/);
     assert.match(experience, /handleSelectedCardAnimationEnd/);
     assert.match(experience, /handRevealFallbackMs/);
@@ -258,6 +260,7 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(styles, /\.tableStage\[data-hand-stage="expand"\] \.tableSurface[\s\S]*height: var\(--bm-table-expand-height, 220px\)/);
     assert.match(styles, /\.tableStage\[data-hand-stage="expand"\] \.cardGrid[\s\S]*visibility: hidden/);
     assert.match(styles, /transition: height var\(--bm-hand-expand-ms\)/);
+    assert.match(styles, /@keyframes deckStageExpand[\s\S]*0%\s*\{[\s\S]*translateX\(-50%\) translateY\(-24px\)[\s\S]*100%\s*\{[\s\S]*translateX\(-50%\) translateY\(0\)/);
     assert.match(styles, /animation: deckStageCollect var\(--bm-hand-collect-ms\)/);
     assert.match(styles, /@keyframes finaleCardsMerge[\s\S]*0% \{[\s\S]*opacity: 1[\s\S]*translate3d\(0, 0, 0\)/);
     assert.doesNotMatch(styles, /\.brandLine|\.brandDivider|\.partnerName/);
@@ -276,6 +279,7 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.doesNotMatch(experience, /aria-label="Cartas finais"/);
     assert.match(experience, /function drawStoryCardIllustration/);
     assert.match(experience, /drawStoryCardIllustration\(context, line\.cardId/);
+    assert.match(experience, /createStoryBlob\(reading, initialState\.campaign\.partnerName\)/);
     assert.match(experience, /getStoryCanvasFont\("--font-brand-ui"/);
     assert.match(illustrations, /case "reward-reserved"/);
     assert.match(illustrations, /case "reward-procedure"/);
@@ -293,6 +297,9 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(header, /data-scroll-aware-header/);
     assert.match(header, /HeaderScrollBehavior/);
     assert.match(headerScrollBehavior, /addEventListener\("scroll"/);
+    assert.match(headerScrollBehavior, /addEventListener\("focusin"/);
+    assert.match(headerScrollBehavior, /addEventListener\("keydown"/);
+    assert.match(headerScrollBehavior, /revealHeader/);
     assert.match(headerScrollBehavior, /header--hidden/);
     assert.match(headerScrollBehavior, /requestAnimationFrame/);
     assert.match(globalStyles, /\.header\[data-scroll-aware-header="true"\]\.header--hidden/);

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -5,13 +5,17 @@ import test from "node:test";
 const sourceUrl = (relativePath: string) => new URL(`../${relativePath}`, import.meta.url);
 
 test("continuous experience reuses the real shell and keeps the inline finale flow", async () => {
-    const [page, localPage, experience, styles, campaignStyles, illustrations] = await Promise.all([
+    const [page, localPage, experience, styles, campaignStyles, illustrations, header, headerScrollBehavior, globalStyles, cards] = await Promise.all([
         readFile(sourceUrl("src/app/beleza-em-movimento/page.tsx"), "utf8"),
         readFile(sourceUrl("src/app/beleza-em-movimento/local-preview/page.tsx"), "utf8"),
         readFile(sourceUrl("src/components/BeautyMovementExperience.tsx"), "utf8"),
         readFile(sourceUrl("src/components/BeautyMovementExperience.module.css"), "utf8"),
         readFile(sourceUrl("src/components/BeautyMovementCampaign.module.css"), "utf8"),
         readFile(sourceUrl("src/components/BeautyMovementCardIllustration.tsx"), "utf8"),
+        readFile(sourceUrl("src/components/Header.tsx"), "utf8"),
+        readFile(sourceUrl("src/components/HeaderScrollBehavior.tsx"), "utf8"),
+        readFile(sourceUrl("src/styles/globals.css"), "utf8"),
+        readFile(sourceUrl("src/lib/beautyMovementCards.ts"), "utf8"),
     ]);
 
     for (const route of [page, localPage]) {
@@ -19,6 +23,7 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
         assert.match(route, /<Header(?:\s+[^>]*)? \/>/);
         assert.match(route, /preferredUnitSlug="novo-hamburgo"/);
         assert.match(route, /fixedUnitSlug="novo-hamburgo"/);
+        assert.match(route, /scrollAware/);
         assert.match(route, /<Footer \/>/);
     }
 
@@ -29,28 +34,66 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(experience, /requestAnimationFrame\(animate\)/);
     assert.match(experience, /scrollIntoView\(\{ behavior: "auto"/);
     assert.match(experience, /prefers-reduced-motion/);
-    assert.match(experience, /AUTO_ADVANCE_SECONDS = 5/);
-    assert.match(experience, /function motionDuration\(durationMs: number\)/);
-    assert.match(experience, /if \(prefersReducedMotion\(\)\) return;/);
-    assert.match(experience, /HAND_REVEAL_MS = 1350/);
+    assert.match(experience, /import \{ BEAUTY_MOVEMENT_MOTION, createBeautyMovementMotionGate \}/);
+    assert.match(experience, /AUTO_ADVANCE_SECONDS = BEAUTY_MOVEMENT_MOTION\.autoAdvanceMs \/ 1_000/);
+    assert.match(experience, /type IntroStage = "hidden" \| "entering" \| "holding" \| "exiting"/);
+    assert.match(experience, /BEAUTY_MOVEMENT_MOTION\.initialIntroHoldMs/);
+    assert.match(experience, /BEAUTY_MOVEMENT_MOTION\.promptWordDelayMs/);
+    assert.match(experience, /BEAUTY_MOVEMENT_MOTION\.promptWordAnimationMs/);
+    assert.match(experience, /BEAUTY_MOVEMENT_MOTION\.promptReadingHoldMs/);
+    assert.match(experience, /BEAUTY_MOVEMENT_MOTION\.promptExitBaseMs/);
+    assert.match(experience, /BEAUTY_MOVEMENT_MOTION\.promptExitBreathMs/);
+    assert.match(experience, /function promptEntryDuration\(text: string\)/);
+    assert.match(experience, /function promptReadingDuration\(text: string\)/);
+    assert.match(experience, /function promptExitTransitionDuration\(text: string\)/);
+    assert.match(experience, /function renderPromptWords\(text: string, wordOffset = 0\)/);
+    assert.match(experience, /onKeyDown=\{\(event\) => \{/);
+    assert.match(experience, /event\.key === "Enter" \|\| event\.key === " "/);
+    assert.match(experience, /event\.preventDefault\(\);\s*void handleReveal\(displayedActIndex, card\)/);
+    assert.match(experience, /function motionDuration\(durationMs: number, reducedMotion: boolean\)/);
+    assert.match(experience, /if \(reducedMotion\) return;/);
+    assert.match(experience, /handleSelectedCardAnimationEnd/);
+    assert.match(experience, /handRevealFallbackMs/);
     assert.match(experience, /autoAdvanceActive/);
     assert.match(experience, /function beginFinale\(\)/);
+    assert.match(experience, /function handleProgressClick\(index: number\)/);
     assert.match(experience, /revealInFlightRef/);
     assert.match(experience, /transitionInFlightRef/);
     assert.match(experience, /confirmInFlightRef/);
     assert.match(experience, /setCurrentFinaleStage\("collecting"\)/);
     assert.match(experience, /setCurrentFinaleStage\("merging"\)/);
-    assert.match(experience, /FINALE_HOLD_SECONDS = 5/);
+    assert.match(experience, /FINALE_HOLD_SECONDS = BEAUTY_MOVEMENT_MOTION\.finaleHoldMs \/ 1_000/);
     assert.match(experience, /finaleHoldRemaining/);
-    assert.match(experience, /HAND_FINALE_MS = 1120/);
+    assert.match(experience, /setCurrentFinaleStage\("assembling"\)/);
+    assert.match(experience, /BEAUTY_MOVEMENT_MOTION\.finaleCardsEnterMs/);
+    assert.match(experience, /BEAUTY_MOVEMENT_MOTION\.finaleMergeMs/);
     assert.match(experience, /className=\{styles\.inlineFinale\}/);
     assert.match(experience, /renderConfirmationAction/);
     assert.match(experience, /renderResultStage/);
     assert.match(experience, /automática em \{AUTO_ADVANCE_SECONDS\} segundos/);
     assert.doesNotMatch(experience, /confirmationTriggerRef/);
     assert.match(experience, /className=\{styles\.progressButton\}/);
-    assert.match(experience, /disabled=\{!isCurrent\}/);
+    assert.match(experience, /disabled=\{!isCurrent \|\| Boolean\(progressMotion\)\}/);
+    assert.match(experience, /onClick=\{\(\) => handleProgressClick\(index\)\}/);
     assert.match(experience, /className=\{styles\.progressCopy\}/);
+    assert.match(
+        experience,
+        /<\/span>\s*\{isCurrent && !progressMotion && autoAdvanceActive \? \(\s*<span className=\{styles\.autoAdvance\}/,
+    );
+    assert.doesNotMatch(experience, /<\/button>\s*\{isCurrent && autoAdvanceActive/);
+    assert.doesNotMatch(experience, /<\/ol>\s*\{autoAdvanceActive \? \(/);
+    assert.doesNotMatch(experience, /className=\{styles\.progressCopy\}>\s*<small>/);
+    assert.match(experience, /className=\{styles\.progressRow\}/);
+    assert.match(experience, /className=\{styles\.progressGroup\}/);
+    assert.match(experience, /\$\{styles\.tablePrompt\}/);
+    assert.match(experience, /key=\{introStage !== "hidden" \? "experience-intro" : tableDefinition\.id\}/);
+    assert.match(experience, /waitingForInitialDeal \? \(/);
+    assert.doesNotMatch(experience, /className=\{styles\.autoAdvanceLabel\}/);
+    assert.doesNotMatch(experience, /className=\{styles\.autoAdvanceHint\}/);
+    assert.doesNotMatch(experience, /className=\{styles\.brandLine\}/);
+    assert.doesNotMatch(experience, /id="table-stage-title"/);
+    assert.match(experience, /aria-label=\{tableDefinition\.label\}/);
+    assert.match(experience, /3 anos\. 3 cartas\. Um novo movimento/);
     assert.match(experience, /className=\{styles\.specialCardStage\}/);
     assert.match(experience, /role="group" aria-label=\{`Cartas da etapa \$\{tableDefinition\.label\}`\}/);
     assert.doesNotMatch(experience, /role="list" aria-label="Cartas finais"/);
@@ -58,10 +101,10 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(experience, /scrollToTable/);
     assert.doesNotMatch(experience, /preparedNote/);
     assert.doesNotMatch(experience, /choiceInstruction/);
-    assert.match(experience, /Continuar para confirmar/);
+    assert.match(experience, /Continuar para confirmação/);
     assert.match(experience, /finaleStage === "hidden" \? \(/);
-    assert.match(experience, /disabled=\{!tableSelected \|\| handStage !== "held"\}/);
-    assert.match(experience, /Escolha uma carta para liberar o avanço/);
+    assert.doesNotMatch(experience, /className=\{styles\.actAdvance\}/);
+    assert.doesNotMatch(experience, /className=\{styles\.continueButton\}/);
     assert.match(experience, /Garanta seu presente e confirme presença/);
     assert.doesNotMatch(experience, /Seu presente será revelado após a confirmação/);
     assert.match(experience, /email: null/);
@@ -75,20 +118,47 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(experience, /aria-label=\{finaleStage === "result" \? "Carta especial do benefício"/);
     assert.match(experience, /className=\{styles\.cardSparkles\}/);
     assert.match(experience, /className=\{styles\.deckStage\}/);
-    assert.match(experience, /type HandStage = "waiting"/);
+    assert.match(experience, /type HandStage =\s*\|\s*"waiting"/);
+    assert.match(experience, /"expand"\s*\|\s*"deal"/);
+    assert.match(experience, /function scheduleDealSequence\(token: number, onReady: \(\) => void\)/);
+    assert.match(experience, /tableSurfaceRef/);
+    assert.match(experience, /setCurrentHandStage\("expand"\)/);
+    assert.match(experience, /BEAUTY_MOVEMENT_MOTION\.handExpandMs/);
+    assert.match(experience, /BEAUTY_MOVEMENT_MOTION\.handDealSettleMs/);
+    assert.match(experience, /BEAUTY_MOVEMENT_MOTION\.finaleMergeSettleMs/);
+    assert.match(experience, /if \(handStage !== "expand"\) return;/);
+    assert.match(experience, /window\.addEventListener\("resize", syncExpansionHeight\)/);
+    assert.match(experience, /new ResizeObserver\(syncExpansionHeight\)/);
+    assert.match(experience, /setTableExpansionHeight\(Math\.max\(220, surface\.scrollHeight\)\)/);
+    assert.match(experience, /getBoundingClientRect\(\)\.height/);
+    assert.match(experience, /setTableExpansionHeight\(startHeight\)/);
+    assert.match(experience, /const targetHeight = Math\.max\(\s*startHeight,/);
     assert.match(experience, /"held"/);
     assert.match(experience, /function startInitialDeal\(\)/);
     assert.match(experience, /function handleDeckKeyDown\(event: ReactKeyboardEvent<HTMLButtonElement>\)/);
     assert.match(experience, /event\.key !== "Enter" && event\.key !== " " && event\.key !== "Spacebar"/);
     assert.match(experience, /onKeyDown=\{handleDeckKeyDown\}/);
-    assert.match(experience, /className=\{styles\.deckPrompt\}/);
-    assert.match(experience, /className=\{styles\.deckPromptArrow\}/);
+    assert.match(experience, /className=\{styles\.heroDeckPrompt\}/);
+    assert.match(experience, /id="beauty-movement-deck-prompt"/);
+    assert.match(experience, /onClick=\{scrollToTable\}/);
+    assert.match(experience, /Ir ao baralho e começar sua leitura/);
+    assert.match(experience, /Começar a leitura/);
+    assert.match(experience, /className=\{styles\.heroDeckPromptArrow\}/);
     assert.doesNotMatch(experience, /Clique no baralho <span aria-hidden="true">↗<\/span>/);
-    assert.match(experience, /role="note"/);
-    assert.doesNotMatch(experience, /<button\s+className=\{styles\.deckPrompt\}/);
+    assert.doesNotMatch(experience, /className=\{styles\.deckPrompt\}/);
+    assert.ok(experience.indexOf("className={styles.heroDeckPrompt}") < experience.indexOf('<h1 id="beauty-movement-title">'));
     assert.match(experience, /data-deck-state=\{/);
     assert.match(experience, /finaleStage === "confirmation" \|\| finaleStage === "result"/);
-    assert.match(experience, /const isCurrent = index === displayedActIndex/);
+    assert.match(experience, /const isCurrent = introStage === "hidden" && !waitingForInitialDeal && index === displayedActIndex/);
+    assert.match(experience, /key=\{introStage !== "hidden" \? "experience-intro" : tableDefinition\.id\}/);
+    assert.match(experience, /styles\.tablePromptIntro/);
+    assert.match(experience, /styles\.tablePromptIntroHolding/);
+    assert.match(experience, /styles\.tablePromptIntroExit/);
+    assert.match(experience, /styles\.tablePromptExit/);
+    assert.match(experience, /styles\.promptTitle/);
+    assert.match(experience, /styles\.promptSubtitle/);
+    assert.match(experience, /handStage === "prompt" \|\| handStage === "prompt-out"/);
+    assert.match(experience, /setCurrentHandStage\("prompt"\)/);
     assert.doesNotMatch(experience, /className=\{styles\.actCount\}/);
     assert.match(experience, /styles\.deckCardTop/);
     assert.doesNotMatch(experience, /role="dialog"/);
@@ -109,6 +179,10 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(styles, /@keyframes cardSparkle/);
     assert.match(styles, /@keyframes deckDealPulse/);
     assert.match(styles, /@keyframes deckReceivePulse/);
+    assert.match(styles, /@keyframes deckStageDeal/);
+    assert.match(styles, /@keyframes deckStageExpand/);
+    assert.match(styles, /@keyframes deckStageCollect/);
+    assert.match(styles, /@keyframes deckStageReceive/);
     assert.match(styles, /@keyframes cardReturnToDeck/);
     assert.match(styles, /@keyframes cardSelectedReturnToDeck/);
     assert.match(styles, /@keyframes cardFlipToDeck/);
@@ -135,6 +209,9 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(styles, /@keyframes finaleCardsMerge/);
     assert.match(styles, /@keyframes finaleCardsHold/);
     assert.match(styles, /finaleCardGridHolding/);
+    assert.match(styles, /data-finale-stage="assembling"/);
+    assert.match(styles, /animation: finaleCardsHold var\(--bm-finale-enter-ms\)/);
+    assert.match(styles, /animation: finaleCardsMerge var\(--bm-finale-card-merge-ms\)/);
     assert.match(
         styles,
         /\.tableStage\[data-hand-stage="finale"\] \.finaleCardGridMerging \.finaleCard\s*\{\s*animation: finaleCardsMerge/,
@@ -150,23 +227,45 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(styles, /@keyframes specialCardFlip/);
     assert.match(styles, /@keyframes specialCardIconFloat/);
     assert.match(styles, /\.inlineFinale/);
-    assert.match(styles, /\.deckPrompt/);
-    assert.match(styles, /\.deckPrompt[\s\S]*bottom: 148px/);
-    assert.match(styles, /\.deckPrompt[\s\S]*left: 50%/);
-    assert.match(styles, /\.deckPromptArrow[\s\S]*top: calc\(100% \+ 4px\)/);
-    assert.match(styles, /\.deckPromptArrow[\s\S]*transform: translateX\(-50%\)/);
-    assert.match(styles, /\.deckStage[\s\S]*bottom: 18px/);
+    assert.match(styles, /\.heroDeckPrompt \{[\s\S]*cursor: pointer/);
+    assert.match(styles, /\.heroDeckPromptArrow[\s\S]*font-size: 1\.15rem/);
+    assert.doesNotMatch(styles, /\.deckPrompt|\.deckPromptArrow/);
+    assert.match(styles, /\.deckStage[\s\S]*bottom: 14px/);
     assert.match(styles, /\.deckStage \.(?:deckCard|deckBrandLogo)[\s\S]*cursor: pointer/);
     assert.match(styles, /\.deckStage:disabled,[\s\S]*\.deckStage:disabled \.deckBrandLogo[\s\S]*cursor: default/);
-    assert.match(styles, /--deal-y: 122px/);
+    assert.match(styles, /--deal-y: 106px/);
     assert.match(styles, /\.progressItemCurrent \.progressButton[\s\S]*background: var\(--bm-yellow\)/);
-    assert.match(styles, /\.tableStage > \.progress[\s\S]*margin: -10px auto 0/);
+    assert.match(styles, /\.progressRow \{[\s\S]*grid-template-columns: auto minmax\(0, 1fr\)/);
+    assert.match(styles, /\.progressGroup \{[\s\S]*width: max-content/);
+    assert.match(styles, /\.tablePrompt \{[\s\S]*font-size: clamp\(0\.9rem/);
+    assert.match(styles, /\.promptWord \{[\s\S]*animation: promptWordMaterialize/);
+    assert.match(styles, /\.promptTitle,[\s\S]*\.promptSubtitle \{[\s\S]*display: block/);
+    assert.match(styles, /@keyframes promptWordMaterialize/);
+    assert.match(styles, /@keyframes promptWordDissolve/);
+    assert.match(styles, /\.tablePromptIntroHolding \{[\s\S]*animation: none/);
+    assert.match(styles, /\.tablePromptIntroExit,[\s\S]*\.tablePromptExit/);
+    assert.match(styles, /\.tablePromptIntro \.promptTitle,[\s\S]*\.tablePromptIntroHolding \.promptTitle,[\s\S]*\.tablePromptIntroExit \.promptTitle[\s\S]*font-weight: 400/);
+    assert.match(styles, /\.progressItemCurrent \.progressButton strong \{[\s\S]*font-size: clamp\(1rem/);
+    assert.doesNotMatch(styles, /\.tableStage\s*\{[^}]*border-top/);
     assert.match(styles, /\.progressButton \{[\s\S]*min-height: 44px/);
+    assert.match(styles, /\.progressItem \{[\s\S]*display: grid[\s\S]*justify-items: stretch/);
+    assert.match(styles, /\.progressButton \{[\s\S]*width: 100%/);
+    assert.match(styles, /\.autoAdvance \{[\s\S]*width: 100%[\s\S]*height: 4px[\s\S]*margin-top: 8px/);
+    assert.match(styles, /\.autoAdvance::after \{[\s\S]*background: var\(--bm-ink\)/);
+    assert.match(styles, /animation: autoAdvanceProgress var\(--bm-auto-advance-ms\)/);
+    assert.match(styles, /animation: cardLiftAndSettle var\(--bm-hand-reveal-ms\)/);
+    assert.match(styles, /animation: deckStageDeal var\(--bm-hand-deal-ms\)/);
+    assert.match(styles, /\.tableStage\[data-hand-stage="expand"\] \.tableSurface[\s\S]*height: var\(--bm-table-expand-height, 220px\)/);
+    assert.match(styles, /\.tableStage\[data-hand-stage="expand"\] \.cardGrid[\s\S]*visibility: hidden/);
+    assert.match(styles, /transition: height var\(--bm-hand-expand-ms\)/);
+    assert.match(styles, /animation: deckStageCollect var\(--bm-hand-collect-ms\)/);
+    assert.match(styles, /@keyframes finaleCardsMerge[\s\S]*0% \{[\s\S]*opacity: 1[\s\S]*translate3d\(0, 0, 0\)/);
+    assert.doesNotMatch(styles, /\.brandLine|\.brandDivider|\.partnerName/);
     assert.match(styles, /cardIllustration svg > \*/);
     assert.match(styles, /\.cardBrandMark/);
     assert.doesNotMatch(styles, /\.actsStack|\.revealedStrip|\.reopenReading/);
     assert.match(experience, /<BrandMark/);
-    assert.ok(experience.indexOf("className={styles.tableStage}") < experience.indexOf("className={styles.progress}"));
+    assert.ok(experience.indexOf("className={styles.tableStage}") < experience.indexOf("${styles.progress}"));
     assert.match(experience, /aria-hidden=\{!isSelected\}/);
     assert.match(experience, /BeautyMovementCardIllustration/);
     assert.match(experience, /function renderSpecialCard/);
@@ -189,4 +288,19 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.doesNotMatch(campaignStyles, /Georgia|coral|plum|linear-gradient|#fffaf2/i);
     assert.doesNotMatch(experience, /confirmationStage|confirmationIntro|contactSummary|confirmationForm/);
     assert.doesNotMatch(styles, /confirmationStage|confirmationIntro|contactSummary|confirmationForm/);
+
+    assert.match(header, /scrollAware\?: boolean/);
+    assert.match(header, /data-scroll-aware-header/);
+    assert.match(header, /HeaderScrollBehavior/);
+    assert.match(headerScrollBehavior, /addEventListener\("scroll"/);
+    assert.match(headerScrollBehavior, /header--hidden/);
+    assert.match(headerScrollBehavior, /requestAnimationFrame/);
+    assert.match(globalStyles, /\.header\[data-scroll-aware-header="true"\]\.header--hidden/);
+    assert.match(cards, /promptTitle: "O que merece mais presença no seu ritual\?"/);
+    assert.match(cards, /promptSubtitle: "O gesto que faz você se reconhecer no agora\."/);
+    assert.match(cards, /promptTitle: "O que sustenta o seu ritmo\?"/);
+    assert.match(cards, /promptSubtitle: "A energia que transforma pequenos gestos em movimento\."/);
+    assert.match(cards, /promptTitle: "O que você quer celebrar neste encontro\?"/);
+    assert.match(cards, /promptSubtitle: "A presença, a conexão e o próximo ciclo\."/);
+    assert.doesNotMatch(cards, /prompt: "[^"]*—/);
 });

--- a/website/tests/beautyMovementMotion.test.ts
+++ b/website/tests/beautyMovementMotion.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { BEAUTY_MOVEMENT_MOTION, createBeautyMovementMotionGate } from "../src/lib/beautyMovementMotion";
+
+test("beauty movement motion keeps its visible stages and reading windows aligned", () => {
+    assert.equal(BEAUTY_MOVEMENT_MOTION.autoAdvanceMs, 5_000);
+    assert.equal(BEAUTY_MOVEMENT_MOTION.finaleHoldMs, 5_000);
+    assert.equal(BEAUTY_MOVEMENT_MOTION.handRevealMs, 1_500);
+    assert.equal(BEAUTY_MOVEMENT_MOTION.handDealMs, 960);
+    assert.ok(BEAUTY_MOVEMENT_MOTION.handDealSettleMs > 0);
+    assert.equal(BEAUTY_MOVEMENT_MOTION.handCollectMs, 860);
+    assert.equal(BEAUTY_MOVEMENT_MOTION.handExpandMs, 760);
+    assert.equal(
+        BEAUTY_MOVEMENT_MOTION.progressCollapseMs +
+            BEAUTY_MOVEMENT_MOTION.progressTransferMs +
+            BEAUTY_MOVEMENT_MOTION.progressExpandMs,
+        BEAUTY_MOVEMENT_MOTION.progressTransitionMs,
+    );
+    assert.equal(BEAUTY_MOVEMENT_MOTION.finaleCardsEnterMs, 880);
+    assert.equal(
+        BEAUTY_MOVEMENT_MOTION.finaleCardMergeMs + BEAUTY_MOVEMENT_MOTION.finaleMergeStaggerMs * 2,
+        BEAUTY_MOVEMENT_MOTION.finaleMergeMs,
+    );
+    assert.ok(BEAUTY_MOVEMENT_MOTION.finaleMergeSettleMs > 0);
+    assert.ok(BEAUTY_MOVEMENT_MOTION.handRevealFallbackMs > BEAUTY_MOVEMENT_MOTION.handRevealMs);
+});
+
+test("beauty movement motion gates discard stale timer callbacks after a newer action", () => {
+    const gate = createBeautyMovementMotionGate();
+    const revealToken = gate.start();
+
+    assert.equal(gate.isCurrent(revealToken), true);
+
+    gate.invalidate();
+    assert.equal(gate.isCurrent(revealToken), false);
+
+    const manualAdvanceToken = gate.start();
+    assert.equal(gate.isCurrent(manualAdvanceToken), true);
+    assert.equal(gate.isCurrent(revealToken), false);
+});
+
+test("the initial hand expands the table before dealing cards", async () => {
+    const experience = await readFile(
+        new URL("../src/components/BeautyMovementExperience.tsx", import.meta.url),
+        "utf8",
+    );
+    const normalDeal = experience.slice(experience.indexOf("const startHeight ="));
+    const freezeIndex = normalDeal.indexOf("setTableExpansionHeight(startHeight)");
+    const expandIndex = normalDeal.indexOf('setCurrentHandStage("expand")');
+    const measureIndex = normalDeal.indexOf("const targetHeight =");
+    const dealIndex = normalDeal.indexOf('setCurrentHandStage("deal")');
+    const dealSettleIndex = normalDeal.indexOf(
+        "BEAUTY_MOVEMENT_MOTION.handDealMs + BEAUTY_MOVEMENT_MOTION.handDealSettleMs",
+    );
+
+    assert.ok(freezeIndex >= 0);
+    assert.ok(freezeIndex < expandIndex);
+    assert.ok(expandIndex >= 0);
+    assert.ok(measureIndex > expandIndex);
+    assert.ok(dealIndex > measureIndex);
+    assert.ok(dealSettleIndex > dealIndex);
+});


### PR DESCRIPTION
## O que mudou\n\n- reconcilia a experiência Cartas da Beleza em Movimento com o main atual;\n- mantém a mesa em altura compacta, mede a mão e expande o box branco antes da distribuição;\n- anima o baralho descendo durante a expansão e distribui as cartas somente após a fase expand;\n- preserva as melhorias de fluxo, cabeçalho, progresso, confirmação e acessibilidade da thread.\n\n## Causa e correção\n\nA mesa dependia de uma transição de altura implícita (uto), o que podia causar salto visual. A altura inicial agora é congelada com getBoundingClientRect() antes de entrar em expand; a altura alvo é aplicada após a nova mão renderizar.\n\n## Validação\n\n- testes focados eautyMovementMotion + eautyMovementContinuous: 4/4;\n- TypeScript 	sc --noEmit: passou;\n- ESLint dos arquivos TS/TSX: passou (CSS apenas ignorado pela configuração);\n- prévia local canônica em http://127.0.0.1:3418/beleza-em-movimento/local-preview: HTTP 200, título correto, sequência observada expand -> eady, mesa em 450px e console sem erros/avisos.\n\nO flag da campanha permanece fail-closed enquanto os insumos oficiais de produção não estiverem aprovados.