### PR TITLE
fix(ponto): pass coordinator proof to timekeeping release

### DIFF
--- a/.github/scripts/ponto-live-deployment-precondition.test.mjs
+++ b/.github/scripts/ponto-live-deployment-precondition.test.mjs
@@ -199,3 +199,14 @@ test("Timekeeping candidate upload requires both root secrets in the selected en
   assert.match(block, /\["PONTO_PROFILE_DATA_KEY", "PONTO_IDEMPOTENCY_KEY"\]/);
   assert.match(block, /repository fallback is refused/);
 });
+
+test("Timekeeping release receives the coordinator proof before global mutation", () => {
+  const workflow = fs.readFileSync(new URL("../workflows/deploy-timekeeping.yml", import.meta.url), "utf8");
+  const releaseStart = workflow.indexOf("\n  release:");
+  const coordinationReleaseStart = workflow.indexOf("\n  global-coordination-release:", releaseStart);
+  assert.ok(releaseStart >= 0 && coordinationReleaseStart > releaseStart);
+  const release = workflow.slice(releaseStart, coordinationReleaseStart);
+  assert.match(release, /needs: \[coordination, promotion, progressive\]/);
+  assert.match(release, /needs\.coordination\.outputs\.global_coordinator_url/);
+  assert.match(release, /needs\.coordination\.outputs\.global_proof_b64/);
+});

--- a/.github/workflows/deploy-timekeeping.yml
+++ b/.github/workflows/deploy-timekeeping.yml
@@ -182,7 +182,7 @@ jobs:
           if-no-files-found: error
 
   release:
-    needs: [promotion, progressive]
+    needs: [coordination, promotion, progressive]
     if: >-
       ${{
         always() &&


### PR DESCRIPTION
## Summary
- include the reusable coordination job in the Timekeeping release job needs graph
- ensure the global coordinator URL and proof outputs are available before mutation
- add a structural regression test

## Validation
- node --test .github/scripts/ponto-live-deployment-precondition.test.mjs
- node --test .github/scripts/ponto-module-availability-workflow.test.mjs
- npm run codex:deploy-topology:test
- git diff --check

Root cause: staging run 31492787416 dispatched deploy-timekeeping run 31494436554, whose release job referenced needs.coordination outputs without declaring coordination as a dependency, producing empty custody values and failing closed.