### PR TITLE
fix(ponto): bind core production authorization input

### DIFF
--- a/.github/scripts/ponto-orchestrator-lease.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.mjs
@@ -56,6 +56,7 @@ const GOVERNED_INTENT_SCHEMAS = {
     unit: stringField("all"),
     bootstrap_finance_context: booleanField(false),
     unified_team_enabled: booleanField(false),
+    production_unified_team_authorized: booleanField(false),
     release_sha: stringField(),
     preview_run_id: stringField(),
     staging_run_id: stringField(),

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -490,12 +490,13 @@ test("typed intent binds every dispatch input and derives the exact nonce run na
   ), /unknown inputs/);
 });
 
-test("core intent binds unified-team rollout and derives the exact team-aware run name", () => {
+test("core intent binds unified-team rollout and production authorization", () => {
   const input = {
     target: "staging",
     unit: "inventory",
     bootstrap_finance_context: false,
     unified_team_enabled: true,
+    production_unified_team_authorized: false,
     release_sha: releaseSha,
     release_scope: "ponto",
     orchestrator_run_id: orchestratorRunId,
@@ -511,8 +512,15 @@ test("core intent binds unified-team rollout and derives the exact team-aware ru
     ".github/workflows/deploy-core-workers.yml",
     { ...input, unified_team_enabled: false },
   );
+  const authorized = canonicalizeGovernedIntent(
+    ".github/workflows/deploy-core-workers.yml",
+    { ...input, production_unified_team_authorized: true },
+  );
   assert.equal(enabled.normalizedInputs.unified_team_enabled, true);
+  assert.equal(enabled.normalizedInputs.production_unified_team_authorized, false);
+  assert.equal(authorized.normalizedInputs.production_unified_team_authorized, true);
   assert.notEqual(enabled.digest, disabled.digest);
+  assert.notEqual(enabled.digest, authorized.digest);
   assert.equal(
     expectedGovernedRunName(".github/workflows/deploy-core-workers.yml", enabled.normalizedInputs),
     `Core inventory staging team=true ${releaseSha} orchestrator=${orchestratorRunId} nonce=${dispatchNonce}`,


### PR DESCRIPTION
## Objective
Align the governed Core Worker intent schema with the existing production_unified_team_authorized workflow input so staging and production child capability consumption can proceed fail-closed.

## Scope
- Add the boolean input to the canonical signed intent schema with a false default.
- Extend the focal lease contract test to prove false/true are bound into the digest.

## Validation
- node --test .github/scripts/ponto-orchestrator-lease.test.mjs (33/33)
- npm run codex:deploy-topology:test

## Rollback
Revert commit e77da06e; no runtime data or migrations are changed.