### PR TITLE
feat(site): add Clube do Botox payment aliases

### DIFF
--- a/website/src/lib/esfaRedirects.ts
+++ b/website/src/lib/esfaRedirects.ts
@@ -3,9 +3,25 @@ import { ANIVERSARIO_7_ESFA_REDIRECTS } from "@/lib/aniversario7Redirects";
 export const ESFA_PRESERVE_QUERYSTRING = true;
 
 export const CLUBE_BOTOX_ASAAS_REDIRECTS: Record<string, string> = {
+  // Novo Hamburgo — Clube do Botox
   "/nh/clubebotox40u": "https://www.asaas.com/c/85kw6n2otrtdhjqe",
   "/nh/clubebotox50u": "https://www.asaas.com/c/93fcmgkhgcin2igk",
   "/nh/clubebotox60u": "https://www.asaas.com/c/hqown86982e9y7f4",
+  "/nh/clubebotox90u": "https://www.asaas.com/c/y27jhi7xoq0nhiwi",
+  "/nh/clubebotox40urec": "https://www.asaas.com/c/d6wi6vey83vare5o",
+  "/nh/clubebotox50urec": "https://www.asaas.com/c/qfh7xmfkx75thufp",
+  "/nh/clubebotox60urec": "https://www.asaas.com/c/s6pzbxxek5zupn20",
+  "/nh/clubebotox90urec": "https://www.asaas.com/c/nhimvltr035trkro",
+
+  // BarraShoppingSul — Clube do Botox
+  "/bss/clubebotox40u": "https://www.asaas.com/c/bv1wikkg0l1h53wc",
+  "/bss/clubebotox50u": "https://www.asaas.com/c/tfy2w7livbb3pby9",
+  "/bss/clubebotox60u": "https://www.asaas.com/c/0tt8mgwk40cs58gk",
+  "/bss/clubebotox90u": "https://www.asaas.com/c/kjt19ogowi7an6gu",
+  "/bss/clubebotox40urec": "https://www.asaas.com/c/pf2r6q16tiyrp9bc",
+  "/bss/clubebotox50urec": "https://www.asaas.com/c/prjvdv7v95x50y32",
+  "/bss/clubebotox60urec": "https://www.asaas.com/c/lr38ej38lji2kyuz",
+  "/bss/clubebotox90urec": "https://www.asaas.com/c/zmfwvjotop3vpmjz",
 };
 
 export const ESFA_RETIRED_REDIRECTS: Record<string, string> = {

--- a/website/tests/esfaManagedRedirects.test.ts
+++ b/website/tests/esfaManagedRedirects.test.ts
@@ -29,11 +29,24 @@ test("buildEsfaManagedRedirectSeed infers metadata for migrated esfa redirects",
     assert.equal(seed.createdAtMs, 123);
 });
 
-test("Clube Botox U aliases resolve to the requested Asaas payment links", () => {
+test("Clube Botox aliases resolve to the requested Asaas payment links", () => {
     const redirects = {
         "/nh/ClubeBotox40U": "https://www.asaas.com/c/85kw6n2otrtdhjqe",
         "/nh/ClubeBotox50U": "https://www.asaas.com/c/93fcmgkhgcin2igk",
         "/nh/ClubeBotox60U": "https://www.asaas.com/c/hqown86982e9y7f4",
+        "/nh/ClubeBotox90U": "https://www.asaas.com/c/y27jhi7xoq0nhiwi",
+        "/nh/ClubeBotox40URec": "https://www.asaas.com/c/d6wi6vey83vare5o",
+        "/nh/ClubeBotox50URec": "https://www.asaas.com/c/qfh7xmfkx75thufp",
+        "/nh/ClubeBotox60URec": "https://www.asaas.com/c/s6pzbxxek5zupn20",
+        "/nh/ClubeBotox90URec": "https://www.asaas.com/c/nhimvltr035trkro",
+        "/bss/ClubeBotox40U": "https://www.asaas.com/c/bv1wikkg0l1h53wc",
+        "/bss/ClubeBotox50U": "https://www.asaas.com/c/tfy2w7livbb3pby9",
+        "/bss/ClubeBotox60U": "https://www.asaas.com/c/0tt8mgwk40cs58gk",
+        "/bss/ClubeBotox90U": "https://www.asaas.com/c/kjt19ogowi7an6gu",
+        "/bss/ClubeBotox40URec": "https://www.asaas.com/c/pf2r6q16tiyrp9bc",
+        "/bss/ClubeBotox50URec": "https://www.asaas.com/c/prjvdv7v95x50y32",
+        "/bss/ClubeBotox60URec": "https://www.asaas.com/c/lr38ej38lji2kyuz",
+        "/bss/ClubeBotox90URec": "https://www.asaas.com/c/zmfwvjotop3vpmjz",
     };
 
     for (const [requestedPath, destinationUrl] of Object.entries(redirects)) {
@@ -43,7 +56,7 @@ test("Clube Botox U aliases resolve to the requested Asaas payment links", () =>
         const seed = buildEsfaManagedRedirectSeed({ slugPath, destinationUrl, now: 789 });
         assert.equal(seed.destinationHost, "www.asaas.com");
         assert.equal(seed.placement, "payment");
-        assert.equal(seed.unitSlug, "novo-hamburgo");
+        assert.equal(seed.unitSlug, slugPath.startsWith("/nh/") ? "novo-hamburgo" : "barrashoppingsul");
     }
 });
 


### PR DESCRIPTION
# Summary

Adds the 13 requested custom payment aliases for Clube do Botox, scoped to Novo Hamburgo (/nh) and BarraShoppingSul (/bss). Each alias resolves to its corresponding Asaas checkout URL through the existing esfa.co managed-redirect catalog.

## Type of change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (not applicable: catalog-only change)
- [ ] Security review (covered by existing HTTPS destination allowlist and CI)
- [ ] Performance impact measured (not applicable: constant catalog lookup)

## Links
- Issue: User-requested payment aliases
- Design/ADR: Existing esfa.co managed redirect/D1 catalog
- Migration steps: The official website deploy workflow runs npm run custom-urls:migrate:esfa -- --apply --remote after deploying the redirects Worker.

## Validation
- Focused redirect tests: 9 passing, including all requested aliases, unit metadata, Asaas host, payment placement, and attribution-preserving Worker behavior.
- git diff --check: passing.
- Pre-production: GitHub CI and the official preview/staging promotion gates.
- Production smoke: verify every requested https://esfa.co/... alias returns 301 to the exact Asaas URL.

## Rollback
- Revert commit c78625fc and redeploy the prior website release.
- No data deletion or reinterpretation is required; the D1 sync is additive and idempotent for these slugs.
- Trigger the standard website deployment workflow and re-run the 13-alias smoke after rollback.