### PR TITLE
fix(crm): prevent users table checkbox overflow

### DIFF
--- a/crm/console/UsersModule.tsx
+++ b/crm/console/UsersModule.tsx
@@ -855,8 +855,8 @@ export function UsersModule() {
             <div className="hidden overflow-auto rounded-xl border border-white/10 md:block">
                 <table className="w-full table-fixed text-sm">
                   <colgroup>
-                  <col className="w-[4%]" />
-                  <col className="w-[19%]" />
+                  <col className="w-[6%]" />
+                  <col className="w-[17%]" />
                   <col className="w-[12%]" />
                   <col className="w-[10%]" />
                   <col className="w-[11%]" />


### PR DESCRIPTION
## Objetivo\nCorrigir o overflow material observado pelo Central E2E Smoke em 768px na tabela desktop de Usuários.\n\n## Mudança\nA coluna de seleção passa de 4% para 6% e a coluna Nome de 19% para 17%, mantendo o total em 100% e acomodando o checkbox com o padding existente. Nenhum teste ou regra de negócio foi alterado.\n\n## Validação\n- git diff --check\n- CI do PR: teste focal Usuários e Equipe › does not overflow at 390, 768 or 1280 pixels\n- O E2E local não pôde iniciar porque o Ubuntu-24.04 estava impedido por ERROR_SHARING_VIOLATION no ext4.vhdx; não foi alterado nem reiniciado dado do projeto.\n\n## Risco e rollback\nMudança somente de distribuição de largura da tabela; rollback revertendo este commit.