### PR TITLE
feat(influencer-intelligence): add deterministic analytics

### DIFF
--- a/.github/workflows/architecture-governance.yml
+++ b/.github/workflows/architecture-governance.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Validate domain import boundaries
         run: node .github/scripts/validate-domain-boundaries.mjs
       - name: Test Influencer Intelligence contracts, providers and snapshots
-        run: node --test social/influencer-intelligence/tests/contracts.test.mjs social/influencer-intelligence/tests/registry.test.mjs social/influencer-intelligence/tests/providers.test.mjs social/influencer-intelligence/tests/provider-router-contract.test.mjs social/influencer-intelligence/tests/architecture.test.mjs social/influencer-intelligence/tests/data-model.test.mjs social/influencer-intelligence/tests/snapshots.test.mjs
+        run: node --test social/influencer-intelligence/tests/contracts.test.mjs social/influencer-intelligence/tests/registry.test.mjs social/influencer-intelligence/tests/providers.test.mjs social/influencer-intelligence/tests/provider-router-contract.test.mjs social/influencer-intelligence/tests/architecture.test.mjs social/influencer-intelligence/tests/data-model.test.mjs social/influencer-intelligence/tests/snapshots.test.mjs social/influencer-intelligence/tests/analytics.test.mjs
       - name: Validate reproducible staging manifest
         run: node .github/scripts/validate-staging-manifest.mjs
       - name: Validate staging bootstrap safety guards

--- a/social/influencer-intelligence/ANALYTICS.md
+++ b/social/influencer-intelligence/ANALYTICS.md
@@ -1,0 +1,161 @@
+# Deterministic analytics v1
+
+The analytics boundary is `analytics.mjs` and exports
+`computeInfluencerAnalytics(input)`. It is a pure ESM module: it receives
+normalized profile/media snapshots and a canonical `computedAt` timestamp, and
+returns a frozen derived artifact. It does not call a provider, read a secret,
+open a database connection, schedule work, or expose an HTTP route.
+
+The architecture defines this domain as runtime-free ESM and the existing
+provider, contract, repository, and test boundaries are Node ESM. Python would
+introduce a second runtime boundary without a current SKINCOS dependency, so
+this milestone deliberately stays in the existing Node boundary.
+
+## Input and evidence rules
+
+Each profile snapshot has an opaque `snapshotKey`, `provider`, `observedAt`, and
+the normalized count fields `followersCount`, `followingCount`, and
+`mediaCount`. Each media snapshot has an opaque `snapshotKey`, `mediaKey`,
+`provider`, `observedAt`, optional `publishedAt`, `mediaKind`, and the count
+fields `likesCount`, `commentsCount`, `viewsCount`, `reachCount`, and an
+optional per-media `followersCount`.
+
+Missing fields and explicit `null` are unavailable. A numeric zero is observed
+and remains a usable value. The engine rejects a value paired with
+`evidenceState: unavailable`; it never converts a missing value into zero.
+Analytics output uses `evidenceState: derived` only for calculations with at
+least one usable input. A missing denominator produces `value: null` and an
+explicit reason such as `zero_or_missing_initial_followers`,
+`zero_denominator`, or `no_media_with_complete_engagement_denominator`.
+
+The engine uses an as-of join for engagement denominators: if a media snapshot
+does not carry `followersCount`, it uses the latest observed profile follower
+snapshot at or before that media snapshot's `observedAt`. It never uses a
+future profile observation and never creates a pre-first-snapshot value.
+
+When `windowStart` and/or `windowEnd` is supplied, only snapshots whose
+`observedAt` falls inside the inclusive interval are used. The window is an
+as-of observation window; it does not fabricate a publication or profile value
+at either boundary. Without an explicit window, the result derives its bounds
+from the retained snapshot timestamps.
+
+## Statistics
+
+For a finite series `x` of `n` available observations:
+
+- `mean = sum(x) / n`.
+- `median` is the 50th percentile.
+- Percentiles `p10`, `p25`, `p50`, `p75`, and `p90` use sorted values with
+  linear interpolation at position `(n - 1) * p`.
+- `standardDeviation` is population standard deviation,
+  `sqrt(sum((x - mean)^2) / n)`, and is reported only when `n >= 2`.
+- `IQR = p75 - p25`.
+- `MAD = median(abs(x - median))`.
+- `trimmedMean` removes 10% from each tail when at least five observations
+  permit removing a complete value from both tails.
+- `winsorizedMean` replaces the lowest/highest 10% with the nearest retained
+  boundary. When fewer than 10% can be removed, it equals the ordinary mean
+  for a series with at least two observations.
+
+The engine reports the available count, expected count, ratio, confidence, and
+limitations alongside these values. Expected counts are never zero in the
+output coverage envelope; an empty input uses a one-unit unavailable envelope
+with an explicit reason, so no division by zero is hidden.
+
+## Profile growth
+
+Profile snapshots are ordered by `observedAt` and then `snapshotKey`.
+
+- `absoluteDelta = lastFollowers - firstFollowers` requires two distinct
+  timestamped follower observations and may legitimately be zero.
+- `relativeGrowthRate = absoluteDelta / firstFollowers` is unavailable when
+  the initial follower count is missing or zero.
+- For adjacent usable observations,
+  `growthVelocity = deltaFollowers / elapsedDays`.
+- For adjacent velocity intervals,
+  `growthAcceleration = (velocity2 - velocity1) / averageIntervalDays`.
+
+Following and media count receive the same descriptive statistics but are not
+treated as quality scores. Growth anomalies compare at least three valid
+velocity intervals against a robust baseline: median ± 3 MAD when MAD is
+positive, Tukey 1.5 IQR fences otherwise, and a distinct-from-constant rule
+when both scales are zero. An anomaly is labeled only as a bounded
+`growth_pattern_anomaly`; it is not a fake-follower determination.
+
+## Posting cadence
+
+Cadence uses one publication per distinct `mediaKey`, ordered by `publishedAt`.
+Repeated metric snapshots for the same media do not create extra posts.
+
+- `postingInterval` is the distribution of positive differences between
+  adjacent publication timestamps, in days.
+- `postsPerDay = distinctPublications / (lastPublishedAt - firstPublishedAt)`
+  is unavailable for fewer than two distinct publications or a zero-length
+  publication window.
+
+## Engagement and media performance
+
+- `engagementRate = (likes + comments) / followersAtObservation`.
+- `commentLikeRatio = comments / likes`; it is unavailable when likes are
+  missing or zero.
+- `viewsFollowerRatio = views / followersAtObservation`.
+- `medianViews` is the median of available views; missing views are not zero.
+
+Follower, likes, comments, views, reach, and the ratio series all retain the
+same robust summary shape. Reel/video performance is calculated only from
+`reel`, `video`, `short`, and `live` media kinds. A provider that does not
+return views or reach leaves the corresponding metric unavailable.
+
+## Volatility, trend, and outliers
+
+- `coefficientOfVariation = standardDeviation / mean` is reported only for a
+  positive mean.
+- `robustMadRatio = MAD / median` is reported only for a positive median.
+- Trend is an ordinary least-squares slope per day over timestamped values.
+  Direction is `up`, `down`, or `flat` from the slope sign. `rSquared` is
+  unavailable for a constant series rather than being forced to zero.
+- The ordinary outlier ratio uses Tukey fences
+  `[p25 - 1.5*IQR, p75 + 1.5*IQR]`.
+- The viral outlier ratio uses an upper robust fence
+  `max(p75 + 3*IQR, median + 3*MAD)`. When both robust scales are zero, a
+  value must be strictly above the median to be viral. Both ratios require at
+  least three observations.
+
+These rules are scale-normalized and do not classify a creator from an
+absolute follower threshold or let one viral post replace the rest of the
+series. A viral post remains observed evidence and is available for separate
+inspection; robust summaries reduce its leverage.
+
+## Follower-tier benchmark structure
+
+The result always contains `followerTierBenchmark` with `source:
+skincos_internal`, `status`, `tierKey`, `sampleSize`, and `metrics`. With no
+governed internal benchmark dataset it is:
+
+```json
+{
+  "evidenceState": "unavailable",
+  "status": "unavailable",
+  "source": "skincos_internal",
+  "tierKey": null,
+  "sampleSize": 0,
+  "metrics": {},
+  "unavailableReason": "no_internal_benchmark_dataset"
+}
+```
+
+The engine does not define external tier cutoffs, import industry norms, or
+claim that a sample is a benchmark. A later calibration milestone may supply a
+governed internal benchmark artifact with its own provenance and version.
+
+## Determinism and persistence handoff
+
+The result carries `algorithmVersion`, `computedAt`, `window`,
+`inputSnapshotKeys`, `providers`, and structured provenance. The caller may
+persist it through the existing append-only analysis repository as a new
+versioned artifact. Recomputing with the same input and `computedAt` produces
+the same metrics; changing snapshots or the algorithm version produces a new
+derived artifact rather than mutating history.
+
+
+

--- a/social/influencer-intelligence/README.md
+++ b/social/influencer-intelligence/README.md
@@ -1,7 +1,8 @@
 # Influencer Intelligence
 
-Status: architecture v1 defined; M2 provider boundary merged, and data model
-v1 is an additive, unapplied artifact in this milestone. The domain remains
+Status: architecture v1 defined; M2 provider boundary and M4 deterministic
+analytics are implemented in source control, and data model v1 is an additive,
+unapplied artifact in this milestone. The domain remains
 experimental, not exposed, and off by default.
 
 This domain provides read-only intelligence about Instagram creators for
@@ -120,6 +121,22 @@ These migrations are not applied to local, staging, or production through an
 operational runner; they are validated as source-controlled artifacts and
 through synthetic repository tests. No UI, feature wiring,
 runtime, CRM, MCP, Orb, systemd, or external provider call is included.
+
+## M4 decision: deterministic analytics
+
+[`analytics.mjs`](./analytics.mjs) is a pure ESM engine over normalized profile
+and media snapshots. It emits versioned, coverage-aware metrics for profile
+growth, cadence, likes, comments, engagement, views/reach, video performance,
+volatility, trends, robust outliers, and bounded growth anomalies. The formulas
+and limitations are documented in [`ANALYTICS.md`](./ANALYTICS.md).
+
+Missing values stay unavailable and zero denominators never produce a numeric
+result. A viral post is retained as observed evidence but cannot replace the
+robust series summary. Follower-tier benchmark output is an explicit
+`skincos_internal` structure and remains unavailable until a governed internal
+calibration dataset exists. The engine does not infer follower quality or fake
+followers and does not connect providers, PostgreSQL, Orb, CRM, or runtime
+routes.
 
 ## M3 snapshot operations
 
@@ -267,7 +284,7 @@ production configuration.
 | Architecture | Canonical architecture v1 | Defined in the ADR and runtime-free manifest |
 | M2 | Official-first router and controlled collectors | Merged in #1305; injected synthetic transports only |
 | M3 | Append-only snapshots, retention, and Orb scheduling | Snapshot operations implemented; Orb scheduling pending |
-| M4 | Robust analytics and outlier-resistant metrics | Pending |
+| M4 | Robust analytics and outlier-resistant metrics | Implemented in this PR; pure deterministic engine, golden fixtures, and formula documentation |
 | M5 | Deterministic score, confidence, coverage, and provenance | Pending |
 | M6 | Authenticated, sanitized, rate-limited read-only MCP | Pending |
 | M7 | `skincos-influencer-intelligence` Codex skill | Pending |

--- a/social/influencer-intelligence/analytics.mjs
+++ b/social/influencer-intelligence/analytics.mjs
@@ -1,0 +1,931 @@
+/**
+ * Pure, deterministic analytics over normalized Influencer Intelligence
+ * snapshots.
+ *
+ * This module deliberately owns no provider, persistence, scheduling, network,
+ * credential, or runtime boundary. Callers provide immutable-shaped snapshot
+ * projections and a canonical computation timestamp. Missing source values are
+ * represented as unavailable; observed zeroes remain valid values.
+ */
+
+export const ANALYTICS_CONTRACT_VERSION = 'influencer-intelligence/analytics/v1';
+export const ANALYTICS_ALGORITHM_VERSION = 'influencer-intelligence-analytics/v1';
+
+const SOURCE_EVIDENCE_STATES = new Set(['observed', 'unavailable']);
+const MEDIA_KINDS = new Set(['post', 'reel', 'video', 'short', 'live', 'unknown']);
+const VIDEO_KINDS = new Set(['reel', 'video', 'short', 'live']);
+const COUNT_FIELDS = Object.freeze([
+  'followersCount',
+  'followingCount',
+  'mediaCount',
+  'likesCount',
+  'commentsCount',
+  'viewsCount',
+  'reachCount',
+]);
+const PERCENTILES = Object.freeze({ p10: 0.1, p25: 0.25, p50: 0.5, p75: 0.75, p90: 0.9 });
+const DAY_MS = 24 * 60 * 60 * 1000;
+const TRIM_FRACTION = 0.1;
+
+function fail(code, message) {
+  const error = new TypeError(`${code}: ${message}`);
+  error.code = code;
+  throw error;
+}
+
+function assertRecord(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    fail('INVALID_RECORD', `${label} must be an object`);
+  }
+}
+
+function requiredString(value, label, pattern = /^[^\s]{1,160}$/) {
+  if (typeof value !== 'string' || !value || !pattern.test(value)) {
+    fail('INVALID_STRING', `${label} must be a bounded string`);
+  }
+  return value;
+}
+
+function optionalString(value, label, pattern = /^[^\s]{1,160}$/) {
+  if (value === undefined || value === null) return null;
+  return requiredString(value, label, pattern);
+}
+
+function timestamp(value, label, { required = true } = {}) {
+  if (value === undefined || value === null) {
+    if (!required) return null;
+    fail('INVALID_TIMESTAMP', `${label} is required`);
+  }
+  if (typeof value !== 'string') fail('INVALID_TIMESTAMP', `${label} must be an ISO string`);
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) fail('INVALID_TIMESTAMP', `${label} must be parseable`);
+  return new Date(parsed).toISOString();
+}
+
+function finiteNumber(value, label, { integer = false } = {}) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    fail('INVALID_NUMBER', `${label} must be a finite non-negative number`);
+  }
+  if (integer && !Number.isInteger(value)) fail('INVALID_NUMBER', `${label} must be an integer`);
+  return value;
+}
+
+function normalizeEvidenceState(value, label) {
+  if (!SOURCE_EVIDENCE_STATES.has(value)) {
+    fail('INVALID_EVIDENCE_STATE', `${label} must be observed or unavailable`);
+  }
+  return value;
+}
+
+function normalizeCount(record, field, label) {
+  const recordState = record.evidenceState || 'observed';
+  normalizeEvidenceState(recordState, `${label}.evidenceState`);
+
+  let value = record[field];
+  let fieldState = recordState;
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    if (!Object.prototype.hasOwnProperty.call(value, 'value')) {
+      fail('INVALID_METRIC', `${label}.${field} object must expose value`);
+    }
+    fieldState = value.evidenceState || fieldState;
+    value = value.value;
+  }
+  normalizeEvidenceState(fieldState, `${label}.${field}.evidenceState`);
+  if ((recordState === 'unavailable' || fieldState === 'unavailable') && value !== undefined && value !== null) {
+    fail('UNAVAILABLE_HAS_VALUE', `${label}.${field} cannot have a value`);
+  }
+  if (value === undefined || value === null || fieldState === 'unavailable') {
+    return Object.freeze({ value: null, evidenceState: 'unavailable' });
+  }
+  return Object.freeze({
+
+    value: finiteNumber(value, `${label}.${field}`, { integer: true }),
+    evidenceState: 'observed',
+  });
+}
+
+function normalizeProvider(value, label) {
+  return requiredString(value, label, /^[a-z0-9][a-z0-9-]{0,79}$/);
+}
+
+function normalizeSnapshotKey(value, label) {
+  return requiredString(value, label, /^[a-zA-Z0-9][a-zA-Z0-9._/-]{0,159}$/);
+}
+
+function normalizeProfileSnapshots(value) {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) fail('INVALID_SNAPSHOTS', 'profileSnapshots must be an array');
+  const keys = new Set();
+  return value.map((item, index) => {
+    const label = `profileSnapshots[${index}]`;
+    assertRecord(item, label);
+    const snapshotKey = normalizeSnapshotKey(item.snapshotKey, `${label}.snapshotKey`);
+    if (keys.has(snapshotKey)) fail('DUPLICATE_SNAPSHOT_KEY', `${label}.snapshotKey is duplicated`);
+    keys.add(snapshotKey);
+    const observedAt = timestamp(item.observedAt, `${label}.observedAt`);
+    const retrievedAt = timestamp(item.retrievedAt, `${label}.retrievedAt`, { required: false });
+    if (retrievedAt && Date.parse(retrievedAt) < Date.parse(observedAt)) {
+      fail('INVALID_TIMESTAMP_ORDER', `${label}.retrievedAt must not precede observedAt`);
+    }
+    const provider = normalizeProvider(item.provider, `${label}.provider`);
+    return Object.freeze({
+      snapshotKey,
+      provider,
+      observedAt,
+      retrievedAt,
+      evidenceState: normalizeEvidenceState(item.evidenceState || 'observed', `${label}.evidenceState`),
+      followersCount: normalizeCount(item, 'followersCount', label),
+      followingCount: normalizeCount(item, 'followingCount', label),
+      mediaCount: normalizeCount(item, 'mediaCount', label),
+    });
+  });
+}
+
+function normalizeMediaSnapshots(value) {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) fail('INVALID_SNAPSHOTS', 'mediaSnapshots must be an array');
+  const keys = new Set();
+  return value.map((item, index) => {
+    const label = `mediaSnapshots[${index}]`;
+    assertRecord(item, label);
+    const snapshotKey = normalizeSnapshotKey(item.snapshotKey, `${label}.snapshotKey`);
+    if (keys.has(snapshotKey)) fail('DUPLICATE_SNAPSHOT_KEY', `${label}.snapshotKey is duplicated`);
+    keys.add(snapshotKey);
+    const mediaKey = normalizeSnapshotKey(item.mediaKey, `${label}.mediaKey`);
+    const observedAt = timestamp(item.observedAt, `${label}.observedAt`);
+    const publishedAt = timestamp(item.publishedAt, `${label}.publishedAt`, { required: false });
+    const retrievedAt = timestamp(item.retrievedAt, `${label}.retrievedAt`, { required: false });
+    if (retrievedAt && Date.parse(retrievedAt) < Date.parse(observedAt)) {
+      fail('INVALID_TIMESTAMP_ORDER', `${label}.retrievedAt must not precede observedAt`);
+    }
+    const provider = normalizeProvider(item.provider, `${label}.provider`);
+    const mediaKind = item.mediaKind || 'unknown';
+    if (!MEDIA_KINDS.has(mediaKind)) fail('INVALID_MEDIA_KIND', `${label}.mediaKind is unsupported`);
+    return Object.freeze({
+      snapshotKey,
+      mediaKey,
+      provider,
+      observedAt,
+      publishedAt,
+      retrievedAt,
+      mediaKind,
+      evidenceState: normalizeEvidenceState(item.evidenceState || 'observed', `${label}.evidenceState`),
+      likesCount: normalizeCount(item, 'likesCount', label),
+      commentsCount: normalizeCount(item, 'commentsCount', label),
+      viewsCount: normalizeCount(item, 'viewsCount', label),
+      reachCount: normalizeCount(item, 'reachCount', label),
+      followersCount: normalizeCount(item, 'followersCount', label),
+    });
+  });
+}
+
+function normalizeInput(input) {
+  assertRecord(input, 'input');
+  const creatorKey = requiredString(input.creatorKey, 'creatorKey', /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,159}$/);
+  const computedAt = timestamp(input.computedAt, 'computedAt');
+  const profileSnapshots = normalizeProfileSnapshots(input.profileSnapshots);
+  const mediaSnapshots = normalizeMediaSnapshots(input.mediaSnapshots);
+  const windowStart = timestamp(input.windowStart, 'windowStart', { required: false });
+  const windowEnd = timestamp(input.windowEnd, 'windowEnd', { required: false });
+  if (windowStart && windowEnd && Date.parse(windowEnd) <= Date.parse(windowStart)) {
+    fail('INVALID_WINDOW', 'windowEnd must follow windowStart');
+  }
+  const startMs = windowStart ? Date.parse(windowStart) : null;
+  const endMs = windowEnd ? Date.parse(windowEnd) : null;
+  const inWindow = (item) => {
+    const observedMs = Date.parse(item.observedAt);
+    return (startMs === null || observedMs >= startMs) && (endMs === null || observedMs <= endMs);
+  };
+  return Object.freeze({
+    creatorKey,
+    computedAt,
+    windowStart,
+    windowEnd,
+    profileSnapshots: profileSnapshots.filter(inWindow),
+    mediaSnapshots: mediaSnapshots.filter(inWindow),
+    followerTierBenchmark: input.followerTierBenchmark || null,
+  });
+
+}
+
+function round(value, digits = 12) {
+  if (value === null || value === undefined) return null;
+  if (!Number.isFinite(value)) return null;
+  const factor = 10 ** digits;
+  return Math.round((value + Number.EPSILON) * factor) / factor;
+}
+
+function numericValues(values) {
+  return values.filter((value) => typeof value === 'number' && Number.isFinite(value));
+}
+
+function sortedNumbers(values) {
+  return [...values].sort((left, right) => left - right);
+}
+
+function percentile(values, probability) {
+  const sorted = sortedNumbers(values);
+  if (sorted.length === 0) return null;
+  if (sorted.length === 1) return sorted[0];
+  const position = (sorted.length - 1) * probability;
+  const lower = Math.floor(position);
+  const upper = Math.ceil(position);
+  if (lower === upper) return sorted[lower];
+  return sorted[lower] + (sorted[upper] - sorted[lower]) * (position - lower);
+}
+
+function mean(values) {
+  const clean = numericValues(values);
+  if (clean.length === 0) return null;
+  return clean.reduce((total, value) => total + value, 0) / clean.length;
+}
+
+function median(values) {
+  return percentile(values, 0.5);
+}
+
+function standardDeviation(values) {
+  const clean = numericValues(values);
+  if (clean.length < 2) return null;
+  const average = mean(clean);
+  return Math.sqrt(clean.reduce((total, value) => total + ((value - average) ** 2), 0) / clean.length);
+}
+
+function medianAbsoluteDeviation(values) {
+  const clean = numericValues(values);
+  if (clean.length === 0) return null;
+  const center = median(clean);
+  return median(clean.map((value) => Math.abs(value - center)));
+}
+
+function trimmedMean(values) {
+  const sorted = sortedNumbers(numericValues(values));
+  const trimCount = Math.floor(sorted.length * TRIM_FRACTION);
+  if (sorted.length < 5 || trimCount < 1 || (trimCount * 2) >= sorted.length) return null;
+  const retained = sorted.slice(trimCount, sorted.length - trimCount);
+  return mean(retained);
+}
+
+function winsorizedMean(values) {
+  const sorted = sortedNumbers(numericValues(values));
+  if (sorted.length < 2) return null;
+  const trimCount = Math.floor(sorted.length * TRIM_FRACTION);
+  if (trimCount < 1) return mean(sorted);
+  const winsorized = [...sorted];
+  const lower = sorted[trimCount];
+  const upper = sorted[sorted.length - trimCount - 1];
+  for (let index = 0; index < trimCount; index += 1) winsorized[index] = lower;
+  for (let index = sorted.length - trimCount; index < sorted.length; index += 1) winsorized[index] = upper;
+  return mean(winsorized);
+}
+
+function coverage(available, expected) {
+  const safeAvailable = Math.max(0, Math.trunc(available));
+  const safeExpected = Math.max(1, Math.trunc(expected));
+  return Object.freeze({
+    availableMetrics: Math.min(safeAvailable, safeExpected),
+    expectedMetrics: safeExpected,
+    ratio: round(Math.min(safeAvailable, safeExpected) / safeExpected, 12),
+  });
+}
+
+function unavailableReasonForEmpty(expected) {
+  return expected > 0 ? 'no_observed_values' : 'no_input_rows';
+}
+
+function summary(values, expected, unit) {
+  const clean = numericValues(values);
+  const result = {
+    evidenceState: clean.length > 0 ? 'derived' : 'unavailable',
+    confidence: clean.length > 0 ? coverage(clean.length, expected).ratio : 0,
+    coverage: coverage(clean.length, expected),
+    unit,
+    count: clean.length,
+    mean: mean(clean),
+    median: median(clean),
+    standardDeviation: standardDeviation(clean),
+    percentiles: {
+      p10: percentile(clean, PERCENTILES.p10),
+
+      p25: percentile(clean, PERCENTILES.p25),
+      p50: percentile(clean, PERCENTILES.p50),
+      p75: percentile(clean, PERCENTILES.p75),
+      p90: percentile(clean, PERCENTILES.p90),
+    },
+    trimmedMean: trimmedMean(clean),
+    winsorizedMean: winsorizedMean(clean),
+    iqr: clean.length > 0 ? percentile(clean, 0.75) - percentile(clean, 0.25) : null,
+    mad: medianAbsoluteDeviation(clean),
+    outlierRatio: null,
+    viralOutlierRatio: null,
+    unavailableReason: clean.length > 0 ? null : unavailableReasonForEmpty(expected),
+    limitations: [],
+  };
+
+  if (clean.length < 2) result.limitations.push('standard_deviation_requires_two_values');
+  if (clean.length < 5) result.limitations.push('trimmed_mean_requires_at_least_five_values');
+  if (clean.length < 3) {
+    result.limitations.push('outlier_ratios_require_at_least_three_values');
+  } else {
+    const q1 = result.percentiles.p25;
+    const q3 = result.percentiles.p75;
+    const center = result.median;
+    const spread = result.iqr;
+    const flags = clean.map((value) => (
+      spread === 0
+        ? value !== center
+        : value < (q1 - (1.5 * spread)) || value > (q3 + (1.5 * spread))
+    ));
+    const viralSpread = Math.max(spread, (result.mad || 0));
+    const viralUpper = viralSpread === 0
+      ? center
+      : Math.max(q3 + (3 * spread), center + (3 * (result.mad || 0)));
+    const viralFlags = clean.map((value) => value > viralUpper);
+    result.outlierRatio = round(flags.filter(Boolean).length / clean.length, 12);
+    result.viralOutlierRatio = round(viralFlags.filter(Boolean).length / clean.length, 12);
+  }
+  if (clean.length > 0 && result.mean === 0) result.limitations.push('relative_volatility_requires_nonzero_mean');
+  if (clean.length > 0 && result.median === 0) result.limitations.push('relative_mad_requires_nonzero_median');
+  return result;
+}
+
+function scalar(value, expected = 1, available = value === null ? 0 : 1, unavailableReason = null, unit = null) {
+  const isAvailable = value !== null && value !== undefined && Number.isFinite(value);
+  const result = {
+    value: isAvailable ? round(value) : null,
+    evidenceState: isAvailable ? 'derived' : 'unavailable',
+    confidence: isAvailable ? coverage(available, expected).ratio : 0,
+    coverage: coverage(available, expected),
+    ...(unit ? { unit } : {}),
+    unavailableReason: isAvailable ? null : (unavailableReason || unavailableReasonForEmpty(expected)),
+  };
+  return result;
+}
+
+function uniqueProviders(profiles, media) {
+  return [...new Set([...profiles, ...media].map((item) => item.provider))].sort();
+}
+
+function sourceProvenance(profiles, media) {
+  return [...profiles.map((item) => ({
+    provider: item.provider,
+    sourceType: 'profile',
+    evidenceState: item.evidenceState,
+    observedAt: item.observedAt,
+    ...(item.retrievedAt ? { retrievedAt: item.retrievedAt } : {}),
+    sourceRef: item.snapshotKey,
+  })), ...media.map((item) => ({
+    provider: item.provider,
+    sourceType: 'media',
+    evidenceState: item.evidenceState,
+    observedAt: item.observedAt,
+    ...(item.retrievedAt ? { retrievedAt: item.retrievedAt } : {}),
+    sourceRef: item.snapshotKey,
+  }))].sort((left, right) => (
+    `${left.provider}:${left.sourceType}:${left.observedAt}:${left.sourceRef}`
+      .localeCompare(`${right.provider}:${right.sourceType}:${right.observedAt}:${right.sourceRef}`)
+  ));
+}
+
+function observationForMetric(snapshot, field) {
+  const item = snapshot[field];
+  return item.value === null ? null : { value: item.value, observedAt: snapshot.observedAt, snapshotKey: snapshot.snapshotKey };
+}
+
+function sortedProfileSnapshots(profiles) {
+  return [...profiles].sort((left, right) => (
+    Date.parse(left.observedAt) - Date.parse(right.observedAt) || left.snapshotKey.localeCompare(right.snapshotKey)
+  ));
+}
+
+function sortedMediaSnapshots(media) {
+  return [...media].sort((left, right) => (
+    Date.parse(left.observedAt) - Date.parse(right.observedAt) || left.snapshotKey.localeCompare(right.snapshotKey)
+  ));
+}
+
+function followerForMedia(media, profiles) {
+  if (media.followersCount.value !== null) {
+    return { ...observationForMetric(media, 'followersCount'), source: 'media_snapshot' };
+
+  }
+  const target = Date.parse(media.observedAt);
+  const candidates = sortedProfileSnapshots(profiles)
+    .filter((profile) => Date.parse(profile.observedAt) <= target)
+    .map((profile) => observationForMetric(profile, 'followersCount'))
+    .filter(Boolean);
+  if (candidates.length === 0) return null;
+  return { ...candidates[candidates.length - 1], source: 'profile_snapshot' };
+}
+
+function mediaRows(media, profiles) {
+  return media.map((item) => ({
+    item,
+    followers: followerForMedia(item, profiles),
+    engagementRate: null,
+    commentLikeRatio: null,
+    viewsFollowerRatio: null,
+  })).map((row) => {
+    const likes = row.item.likesCount.value;
+    const comments = row.item.commentsCount.value;
+    const views = row.item.viewsCount.value;
+    const followers = row.followers?.value ?? null;
+    if (likes !== null && comments !== null && followers !== null && followers > 0) {
+      row.engagementRate = (likes + comments) / followers;
+    }
+    if (likes !== null && comments !== null && likes > 0) {
+      row.commentLikeRatio = comments / likes;
+    }
+    if (views !== null && followers !== null && followers > 0) {
+      row.viewsFollowerRatio = views / followers;
+    }
+    return row;
+  });
+}
+
+function linearTrend(points, expected, unit) {
+  const usable = points
+    .filter((point) => point && Number.isFinite(point.value) && point.at)
+    .map((point) => ({ ...point, time: Date.parse(point.at) / DAY_MS }));
+  const result = {
+    evidenceState: 'unavailable',
+    confidence: 0,
+    coverage: coverage(usable.length, expected),
+    unit,
+    pointCount: usable.length,
+    slopePerDay: null,
+    intercept: null,
+    rSquared: null,
+    direction: null,
+    unavailableReason: unavailableReasonForEmpty(expected),
+    limitations: [],
+  };
+  if (usable.length < 2) {
+    result.limitations.push('trend_requires_two_timestamped_values');
+    return result;
+  }
+  const origin = Math.min(...usable.map((point) => point.time));
+  const x = usable.map((point) => point.time - origin);
+  const y = usable.map((point) => point.value);
+  const xMean = mean(x);
+  const yMean = mean(y);
+  const denominator = x.reduce((total, value) => total + ((value - xMean) ** 2), 0);
+  if (denominator === 0) {
+    result.limitations.push('trend_requires_nonzero_time_span');
+    result.unavailableReason = 'zero_time_span';
+    return result;
+  }
+  const slope = x.reduce((total, value, index) => total + ((value - xMean) * (y[index] - yMean)), 0) / denominator;
+  const intercept = yMean - (slope * xMean);
+  const predicted = x.map((value) => intercept + (slope * value));
+  const totalSumSquares = y.reduce((total, value) => total + ((value - yMean) ** 2), 0);
+  const residualSumSquares = y.reduce((total, value, index) => total + ((value - predicted[index]) ** 2), 0);
+  result.evidenceState = 'derived';
+  result.confidence = result.coverage.ratio;
+  result.slopePerDay = round(slope);
+  result.intercept = round(intercept);
+  result.rSquared = totalSumSquares === 0 ? null : round(1 - (residualSumSquares / totalSumSquares));
+  result.direction = slope > 0 ? 'up' : (slope < 0 ? 'down' : 'flat');
+  result.unavailableReason = null;
+  if (totalSumSquares === 0) result.limitations.push('r_squared_unavailable_for_constant_series');
+  return result;
+}
+
+function volatility(values, expected, unit) {
+  const statistics = summary(values, expected, unit);
+  const result = {
+    evidenceState: statistics.evidenceState,
+    confidence: statistics.confidence,
+    coverage: statistics.coverage,
+    unit,
+    coefficientOfVariation: null,
+    robustMadRatio: null,
+    unavailableReason: statistics.unavailableReason,
+    limitations: [...statistics.limitations],
+  };
+  if (statistics.mean !== null && statistics.mean > 0 && statistics.standardDeviation !== null) {
+    result.coefficientOfVariation = round(statistics.standardDeviation / statistics.mean);
+  }
+  if (statistics.median !== null && statistics.median > 0 && statistics.mad !== null) {
+    result.robustMadRatio = round(statistics.mad / statistics.median);
+
+  }
+  if (statistics.evidenceState === 'derived' && result.coefficientOfVariation === null) {
+    result.limitations.push('coefficient_of_variation_unavailable_for_zero_mean_or_short_series');
+  }
+  if (statistics.evidenceState === 'derived' && result.robustMadRatio === null) {
+    result.limitations.push('robust_mad_ratio_unavailable_for_zero_median');
+  }
+  return result;
+}
+
+function latestUniquePublishedMedia(media) {
+  const selected = new Map();
+  for (const item of [...media].sort((left, right) => (
+    Date.parse(left.publishedAt || left.observedAt) - Date.parse(right.publishedAt || right.observedAt)
+      || left.snapshotKey.localeCompare(right.snapshotKey)
+  ))) {
+    if (!item.publishedAt) continue;
+    selected.set(item.mediaKey, item);
+  }
+  return [...selected.values()].sort((left, right) => (
+    Date.parse(left.publishedAt) - Date.parse(right.publishedAt) || left.mediaKey.localeCompare(right.mediaKey)
+  ));
+}
+
+function postingCadence(media) {
+  const published = latestUniquePublishedMedia(media);
+  const intervals = [];
+  for (let index = 1; index < published.length; index += 1) {
+    const days = (Date.parse(published[index].publishedAt) - Date.parse(published[index - 1].publishedAt)) / DAY_MS;
+    if (days > 0) intervals.push(days);
+  }
+  const intervalSummary = summary(intervals, Math.max(1, published.length - 1), 'days');
+  const result = {
+    evidenceState: published.length > 0 ? 'derived' : 'unavailable',
+    confidence: coverage(published.length, Math.max(1, media.length)).ratio,
+    coverage: coverage(published.length, Math.max(1, media.length)),
+    publicationCount: published.length,
+    postingInterval: intervalSummary,
+    postsPerDay: scalar(null, 1, 0, 'insufficient_publication_span', 'posts_per_day'),
+    unavailableReason: published.length > 0 ? null : unavailableReasonForEmpty(media.length),
+    limitations: [],
+  };
+  if (published.length < 2) result.limitations.push('posting_interval_requires_two_distinct_publications');
+  if (intervals.length < published.length - 1) result.limitations.push('duplicate_or_zero_length_publication_intervals_excluded');
+  if (published.length >= 2) {
+    const first = Date.parse(published[0].publishedAt);
+    const last = Date.parse(published[published.length - 1].publishedAt);
+    const spanDays = (last - first) / DAY_MS;
+    if (spanDays > 0) {
+      result.postsPerDay = scalar(published.length / spanDays, 1, 1, null, 'posts_per_day');
+    } else {
+      result.limitations.push('posting_frequency_requires_nonzero_publication_span');
+    }
+  }
+  return result;
+}
+
+function profileGrowth(profiles) {
+  const ordered = sortedProfileSnapshots(profiles);
+  const followerValues = ordered.map((item) => item.followersCount.value).filter((value) => value !== null);
+  const followingValues = ordered.map((item) => item.followingCount.value).filter((value) => value !== null);
+  const mediaValues = ordered.map((item) => item.mediaCount.value).filter((value) => value !== null);
+  const followerSummary = summary(followerValues, Math.max(1, ordered.length), 'followers');
+  const followingSummary = summary(followingValues, Math.max(1, ordered.length), 'following');
+  const mediaSummary = summary(mediaValues, Math.max(1, ordered.length), 'media_count');
+  const followerPoints = ordered.map((item) => observationForMetric(item, 'followersCount')).filter(Boolean);
+  const intervals = [];
+  for (let index = 1; index < followerPoints.length; index += 1) {
+    const previous = followerPoints[index - 1];
+    const current = followerPoints[index];
+    const days = (Date.parse(current.observedAt) - Date.parse(previous.observedAt)) / DAY_MS;
+    if (days > 0) {
+      intervals.push({
+        from: previous,
+        to: current,
+        days,
+        delta: current.value - previous.value,
+        velocityPerDay: (current.value - previous.value) / days,
+      });
+    }
+  }
+  const first = followerPoints[0] || null;
+  const last = followerPoints[followerPoints.length - 1] || null;
+  const comparisonAvailable = Boolean(first && last && first.snapshotKey !== last.snapshotKey
+    && Date.parse(last.observedAt) > Date.parse(first.observedAt));
+  const absoluteDelta = comparisonAvailable
+    ? scalar(last.value - first.value, 1, 1, null, 'followers')
+    : scalar(null, 1, 0, 'insufficient_distinct_profile_snapshots', 'followers');
+  const relativeGrowthRate = comparisonAvailable && first.value > 0
+    ? scalar((last.value - first.value) / first.value, 1, 1, null, 'ratio')
+    : scalar(null, 1, 0, first ? 'zero_or_missing_initial_followers' : 'insufficient_distinct_profile_snapshots', 'ratio');
+  const velocitySummary = summary(intervals.map((item) => item.velocityPerDay), Math.max(1, ordered.length - 1), 'followers_per_day');
+  const accelerations = [];
+  for (let index = 1; index < intervals.length; index += 1) {
+    const previous = intervals[index - 1];
+    const current = intervals[index];
+    const averageDays = (previous.days + current.days) / 2;
+    if (averageDays > 0) {
+      accelerations.push((current.velocityPerDay - previous.velocityPerDay) / averageDays);
+    }
+
+  }
+  const accelerationSummary = summary(accelerations, Math.max(1, intervals.length - 1), 'followers_per_day_squared');
+  const result = {
+    evidenceState: followerValues.length > 0 ? 'derived' : 'unavailable',
+    confidence: followerSummary.confidence,
+    coverage: followerSummary.coverage,
+    followers: {
+      summary: followerSummary,
+      first: first ? { value: first.value, observedAt: first.observedAt, snapshotKey: first.snapshotKey } : null,
+      last: last ? { value: last.value, observedAt: last.observedAt, snapshotKey: last.snapshotKey } : null,
+      absoluteDelta,
+      relativeGrowthRate,
+      growthVelocity: velocitySummary,
+      growthAcceleration: accelerationSummary,
+    },
+    following: followingSummary,
+    mediaCount: mediaSummary,
+    unavailableReason: followerValues.length > 0 ? null : unavailableReasonForEmpty(ordered.length),
+    limitations: [],
+  };
+  if (followerPoints.length < ordered.length) result.limitations.push('profile_growth_uses_available_follower_snapshots_only');
+  if (intervals.length < Math.max(0, followerPoints.length - 1)) result.limitations.push('non_positive_time_intervals_excluded');
+  return result;
+}
+
+function categoryPerformance(media, profiles) {
+  const rows = mediaRows(media, profiles);
+  const likes = summary(media.map((item) => item.likesCount.value).filter((value) => value !== null), Math.max(1, media.length), 'likes');
+  const comments = summary(media.map((item) => item.commentsCount.value).filter((value) => value !== null), Math.max(1, media.length), 'comments');
+  const views = summary(media.map((item) => item.viewsCount.value).filter((value) => value !== null), Math.max(1, media.length), 'views');
+  const reach = summary(media.map((item) => item.reachCount.value).filter((value) => value !== null), Math.max(1, media.length), 'reach');
+  const engagementRates = rows.map((row) => row.engagementRate).filter((value) => value !== null);
+  const commentLikeRatios = rows.map((row) => row.commentLikeRatio).filter((value) => value !== null);
+  const viewsFollowerRatios = rows.map((row) => row.viewsFollowerRatio).filter((value) => value !== null);
+  const engagementRate = summary(engagementRates, Math.max(1, media.length), 'ratio');
+  const commentLikeRatio = summary(commentLikeRatios, Math.max(1, media.length), 'ratio');
+  const viewsFollowerRatio = summary(viewsFollowerRatios, Math.max(1, media.length), 'ratio');
+  return {
+    evidenceState: media.length > 0 && (likes.count > 0 || comments.count > 0 || views.count > 0 || reach.count > 0) ? 'derived' : 'unavailable',
+    confidence: coverage(media.length > 0 ? Math.max(likes.count, comments.count, views.count, reach.count) : 0, Math.max(1, media.length)).ratio,
+    coverage: coverage(media.length > 0 ? Math.max(likes.count, comments.count, views.count, reach.count) : 0, Math.max(1, media.length)),
+    mediaCount: media.length,
+    likes,
+    comments,
+    views,
+    reach,
+    engagementRate,
+    commentLikeRatio,
+    viewsFollowerRatio,
+    medianViews: scalar(views.median, views.coverage.expectedMetrics, views.count, views.unavailableReason, 'views'),
+    unavailableReason: media.length === 0
+      ? 'no_matching_media'
+      : (likes.count > 0 || comments.count > 0 || views.count > 0 || reach.count > 0
+        ? null
+        : 'no_available_media_metrics'),
+    limitations: [],
+  };
+}
+
+function outlierView(statistics) {
+  const available = statistics.outlierRatio !== null && statistics.viralOutlierRatio !== null;
+  return {
+    evidenceState: available ? 'derived' : 'unavailable',
+    confidence: available ? statistics.confidence : 0,
+    coverage: statistics.coverage,
+    count: statistics.count,
+    outlierRatio: statistics.outlierRatio,
+    viralOutlierRatio: statistics.viralOutlierRatio,
+    method: 'tukey_1_5_iqr_and_upper_3_robust_scale',
+    unavailableReason: available ? null : 'insufficient_values_for_robust_outlier_detection',
+  };
+}
+
+function growthAnomalies(profiles) {
+  const ordered = sortedProfileSnapshots(profiles);
+  const points = ordered.map((item) => observationForMetric(item, 'followersCount')).filter(Boolean);
+  const intervals = [];
+  for (let index = 1; index < points.length; index += 1) {
+    const previous = points[index - 1];
+    const current = points[index];
+    const days = (Date.parse(current.observedAt) - Date.parse(previous.observedAt)) / DAY_MS;
+    if (days > 0) intervals.push({
+      from: previous,
+      to: current,
+      days,
+      delta: current.value - previous.value,
+      velocityPerDay: (current.value - previous.value) / days,
+    });
+  }
+  const velocities = intervals.map((interval) => interval.velocityPerDay);
+  const result = {
+    evidenceState: 'unavailable',
+    confidence: 0,
+    coverage: coverage(velocities.length, Math.max(1, ordered.length - 1)),
+    intervalCount: intervals.length,
+    anomalyRatio: null,
+    thresholdMethod: null,
+    baselineMedian: null,
+    mad: null,
+    iqr: null,
+    anomalies: [],
+    unavailableReason: velocities.length < 3 ? 'growth_anomaly_detection_requires_three_intervals' : null,
+    limitations: [],
+  };
+
+  if (velocities.length < 3) {
+    result.limitations.push('growth_anomaly_detection_requires_three_valid_growth_intervals');
+    return result;
+  }
+  const center = median(velocities);
+  const mad = medianAbsoluteDeviation(velocities);
+  const q1 = percentile(velocities, 0.25);
+  const q3 = percentile(velocities, 0.75);
+  const iqr = q3 - q1;
+  let lower;
+  let upper;
+  if (mad > 0) {
+    lower = center - (3 * mad);
+    upper = center + (3 * mad);
+    result.thresholdMethod = 'median_plus_or_minus_3_mad';
+  } else if (iqr > 0) {
+    lower = q1 - (1.5 * iqr);
+    upper = q3 + (1.5 * iqr);
+    result.thresholdMethod = 'tukey_1_5_iqr';
+  } else {
+    lower = center;
+    upper = center;
+    result.thresholdMethod = 'distinct_from_constant_baseline';
+  }
+  result.evidenceState = 'derived';
+  result.confidence = result.coverage.ratio;
+  result.baselineMedian = round(center);
+  result.mad = round(mad);
+  result.iqr = round(iqr);
+  result.anomalies = intervals.filter((interval) => interval.velocityPerDay < lower || interval.velocityPerDay > upper).map((interval) => ({
+    fromSnapshotKey: interval.from.snapshotKey,
+    toSnapshotKey: interval.to.snapshotKey,
+    fromObservedAt: interval.from.observedAt,
+    toObservedAt: interval.to.observedAt,
+    delta: round(interval.delta),
+    velocityPerDay: round(interval.velocityPerDay),
+    direction: interval.velocityPerDay > upper ? 'spike' : 'drop',
+    interpretation: 'growth_pattern_anomaly',
+  }));
+  result.anomalyRatio = round(result.anomalies.length / intervals.length, 12);
+  return result;
+}
+
+function normalizeBenchmark(value) {
+  if (value === null || value === undefined) {
+    return {
+      evidenceState: 'unavailable',
+      status: 'unavailable',
+      source: 'skincos_internal',
+      tierKey: null,
+      sampleSize: 0,
+      metrics: {},
+      unavailableReason: 'no_internal_benchmark_dataset',
+    };
+  }
+  assertRecord(value, 'followerTierBenchmark');
+  if (value.source !== 'skincos_internal') {
+    fail('UNTRUSTED_BENCHMARK_SOURCE', 'followerTierBenchmark must use skincos_internal');
+  }
+  const status = value.status || 'unavailable';
+  if (!['available', 'unavailable'].includes(status)) fail('INVALID_BENCHMARK_STATUS', 'benchmark status is invalid');
+  const sampleSize = value.sampleSize === undefined ? 0 : finiteNumber(value.sampleSize, 'followerTierBenchmark.sampleSize', { integer: true });
+  const tierKey = optionalString(value.tierKey, 'followerTierBenchmark.tierKey', /^[a-z0-9][a-z0-9._-]{0,79}$/);
+  if (status !== 'available' || sampleSize < 1 || !tierKey) {
+    return {
+      evidenceState: 'unavailable',
+      status: 'unavailable',
+      source: 'skincos_internal',
+      tierKey,
+      sampleSize,
+      metrics: {},
+      unavailableReason: 'insufficient_internal_benchmark_data',
+    };
+  }
+  assertRecord(value.metrics, 'followerTierBenchmark.metrics');
+  const metrics = {};
+  for (const [key, metric] of Object.entries(value.metrics)) {
+    if (!/^[a-z0-9][a-z0-9._-]{0,79}$/.test(key)) fail('INVALID_BENCHMARK_METRIC', `invalid benchmark metric ${key}`);
+    metrics[key] = finiteNumber(metric, `followerTierBenchmark.metrics.${key}`);
+  }
+  return {
+    evidenceState: 'observed',
+    status: 'available',
+    source: 'skincos_internal',
+    tierKey,
+    sampleSize,
+    metrics,
+    unavailableReason: null,
+  };
+}
+
+function derivedWindow(input) {
+  const sourceTimes = [
+    ...input.profileSnapshots.map((item) => item.observedAt),
+    ...input.mediaSnapshots.map((item) => item.observedAt),
+  ].map(Date.parse);
+  const start = input.windowStart || (sourceTimes.length > 0 ? new Date(Math.min(...sourceTimes)).toISOString() : null);
+  const end = input.windowEnd || (sourceTimes.length > 0 ? new Date(Math.max(...sourceTimes)).toISOString() : null);
+  if (!start || !end) {
+    return { evidenceState: 'unavailable', start: null, end: null, unavailableReason: 'no_snapshot_timestamps' };
+
+  }
+  return { evidenceState: 'derived', start, end, unavailableReason: null };
+}
+
+function deepFreeze(value, seen = new Set()) {
+  if (!value || typeof value !== 'object' || seen.has(value)) return value;
+  seen.add(value);
+  for (const child of Object.values(value)) deepFreeze(child, seen);
+  return Object.freeze(value);
+}
+
+export function computeInfluencerAnalytics(input) {
+  const normalized = normalizeInput(input);
+  const profiles = normalized.profileSnapshots;
+  const media = normalized.mediaSnapshots;
+  const rows = mediaRows(media, profiles);
+  const profile = profileGrowth(profiles);
+  const cadence = postingCadence(media);
+  const likes = summary(media.map((item) => item.likesCount.value).filter((value) => value !== null), Math.max(1, media.length), 'likes');
+  const comments = summary(media.map((item) => item.commentsCount.value).filter((value) => value !== null), Math.max(1, media.length), 'comments');
+  const engagementRates = rows.map((row) => row.engagementRate).filter((value) => value !== null);
+  const commentLikeRatios = rows.map((row) => row.commentLikeRatio).filter((value) => value !== null);
+  const viewsFollowerRatios = rows.map((row) => row.viewsFollowerRatio).filter((value) => value !== null);
+  const views = summary(media.map((item) => item.viewsCount.value).filter((value) => value !== null), Math.max(1, media.length), 'views');
+  const reach = summary(media.map((item) => item.reachCount.value).filter((value) => value !== null), Math.max(1, media.length), 'reach');
+  const engagement = {
+    evidenceState: engagementRates.length > 0 ? 'derived' : 'unavailable',
+    confidence: coverage(engagementRates.length, Math.max(1, media.length)).ratio,
+    coverage: coverage(engagementRates.length, Math.max(1, media.length)),
+    engagementRate: summary(engagementRates, Math.max(1, media.length), 'ratio'),
+    commentLikeRatio: summary(commentLikeRatios, Math.max(1, media.length), 'ratio'),
+    viewsFollowerRatio: summary(viewsFollowerRatios, Math.max(1, media.length), 'ratio'),
+    medianViews: scalar(views.median, views.coverage.expectedMetrics, views.count, views.unavailableReason, 'views'),
+    unavailableReason: engagementRates.length > 0 ? null : 'no_media_with_complete_engagement_denominator',
+    limitations: [],
+  };
+  if (engagementRates.length < media.length) engagement.limitations.push('engagement_rate_requires_likes_comments_and_positive_followers');
+  if (commentLikeRatios.length < media.length) engagement.limitations.push('comment_like_ratio_requires_positive_likes');
+  if (viewsFollowerRatios.length < media.length) engagement.limitations.push('views_follower_ratio_requires_views_and_positive_followers');
+
+  const videoMedia = media.filter((item) => VIDEO_KINDS.has(item.mediaKind));
+  const videoPerformance = categoryPerformance(videoMedia, profiles);
+  const trend = {
+    followers: linearTrend(sortedProfileSnapshots(profiles).map((item) => {
+      const observation = observationForMetric(item, 'followersCount');
+      return observation ? { value: observation.value, at: observation.observedAt } : null;
+    }), Math.max(1, profiles.length), 'followers_per_day'),
+    likes: linearTrend(media.map((item) => item.likesCount.value === null ? null : { value: item.likesCount.value, at: item.observedAt }), Math.max(1, media.length), 'likes_per_day'),
+    comments: linearTrend(media.map((item) => item.commentsCount.value === null ? null : { value: item.commentsCount.value, at: item.observedAt }), Math.max(1, media.length), 'comments_per_day'),
+    views: linearTrend(media.map((item) => item.viewsCount.value === null ? null : { value: item.viewsCount.value, at: item.observedAt }), Math.max(1, media.length), 'views_per_day'),
+    engagementRate: linearTrend(rows.map((row) => row.engagementRate === null ? null : { value: row.engagementRate, at: row.item.observedAt }), Math.max(1, media.length), 'ratio_per_day'),
+  };
+  const volatilityResult = {
+    followers: volatility(profiles.map((item) => item.followersCount.value).filter((value) => value !== null), Math.max(1, profiles.length), 'followers'),
+    likes: volatility(media.map((item) => item.likesCount.value).filter((value) => value !== null), Math.max(1, media.length), 'likes'),
+    comments: volatility(media.map((item) => item.commentsCount.value).filter((value) => value !== null), Math.max(1, media.length), 'comments'),
+    views: volatility(media.map((item) => item.viewsCount.value).filter((value) => value !== null), Math.max(1, media.length), 'views'),
+    engagementRate: volatility(engagementRates, Math.max(1, media.length), 'ratio'),
+  };
+  const outliers = {
+    likes: outlierView(likes),
+    comments: outlierView(comments),
+    views: outlierView(views),
+  };
+  const growthAnomalyResult = growthAnomalies(profiles);
+  const coreAvailable = [
+    ...profiles.flatMap((item) => [item.followersCount, item.followingCount, item.mediaCount]),
+    ...media.flatMap((item) => [item.likesCount, item.commentsCount]),
+  ].filter((item) => item.value !== null).length;
+  const coreExpected = Math.max(1, (profiles.length * 3) + (media.length * 2));
+  const overallCoverage = coverage(coreAvailable, coreExpected);
+  const anyDerived = [profile, cadence, engagement, videoPerformance, growthAnomalyResult]
+    .some((item) => item.evidenceState === 'derived');
+  const limitations = [];
+  if (profiles.length === 0 && media.length === 0) limitations.push('no_snapshot_input');
+  if (views.evidenceState === 'unavailable') limitations.push('views_unavailable');
+  if (reach.evidenceState === 'unavailable') limitations.push('reach_unavailable');
+  if (growthAnomalyResult.evidenceState === 'unavailable') limitations.push('growth_anomaly_coverage_limited');
+  return deepFreeze({
+    contractVersion: ANALYTICS_CONTRACT_VERSION,
+    algorithmVersion: ANALYTICS_ALGORITHM_VERSION,
+    creatorKey: normalized.creatorKey,
+    computedAt: normalized.computedAt,
+    window: derivedWindow(normalized),
+    evidenceState: anyDerived ? 'derived' : 'unavailable',
+    confidence: anyDerived ? overallCoverage.ratio : 0,
+    coverage: overallCoverage,
+    providers: uniqueProviders(profiles, media),
+    provenance: sourceProvenance(profiles, media),
+    inputSnapshotKeys: [...profiles, ...media].map((item) => item.snapshotKey).sort(),
+    profileGrowth: profile,
+    postingCadence: cadence,
+    likes,
+    comments,
+    engagement,
+    videoPerformance,
+    volatility: volatilityResult,
+    trend,
+    outliers,
+
+    growthAnomalies: growthAnomalyResult,
+    followerTierBenchmark: normalizeBenchmark(normalized.followerTierBenchmark),
+    limitations,
+  });
+}
+
+export const __testing = Object.freeze({
+  percentile,
+  standardDeviation,
+  medianAbsoluteDeviation,
+  trimmedMean,
+  winsorizedMean,
+});

--- a/social/influencer-intelligence/architecture.mjs
+++ b/social/influencer-intelligence/architecture.mjs
@@ -334,7 +334,7 @@ export const IMPLEMENTATION_PLAN = deepFreeze([
   { id: 'M1', title: 'Creator registry and additive PostgreSQL artifact', status: 'merged #1304; unapplied artifact', acceptance: ['minimal pseudonymous registry', 'additive/idempotent SQL', 'destination and grant gates before apply'] },
   { id: 'M2', title: 'Official-first provider router and bounded collectors', status: 'merged #1305; synthetic transport only', acceptance: ['Meta first', 'controlled instagrapi fallback', 'fail-closed classification', 'no duplicate scraper'] },
   { id: 'M3', title: 'Append-only snapshots, retention, and Orb job contract', status: 'snapshot operations implemented; Orb scheduling pending', acceptance: ['new additive tables', 'immutable evidence lifecycle', 'bounded snapshot_creator and snapshot_creator_media operations', 'dry-run/shadow scheduling', 'resume/recovery without live workflow import'] },
-  { id: 'M4', title: 'Robust analytics', status: 'pending', acceptance: ['time windows', 'viral-outlier resistance', 'explicit unavailable coverage'] },
+  { id: 'M4', title: 'Robust analytics', status: 'implemented in this PR; pure deterministic ESM boundary', acceptance: ['time windows', 'viral-outlier resistance', 'explicit unavailable coverage'] },
   { id: 'M5', title: 'Deterministic scores and confidence', status: 'pending', acceptance: ['versioned algorithms', 'score/confidence/coverage/provenance completeness', 'calibration fixtures'] },
   { id: 'M6', title: 'Hardened read-only MCP', status: 'pending', acceptance: ['auth', 'sanitization', 'rate limit', 'timeout', 'audit', 'bounded tools', 'read-only role'] },
   { id: 'M7', title: 'Codex skill', status: 'pending', acceptance: ['read-only tool use', 'safe question routing', 'no provider or shell bypass'] },

--- a/social/influencer-intelligence/tests/analytics.test.mjs
+++ b/social/influencer-intelligence/tests/analytics.test.mjs
@@ -1,0 +1,237 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  ANALYTICS_ALGORITHM_VERSION,
+  computeInfluencerAnalytics,
+} from '../analytics.mjs';
+import { GOLDEN_FIXTURES } from './fixtures/analytics-golden-fixtures.mjs';
+
+function analyze(fixture) {
+  return computeInfluencerAnalytics(structuredClone(fixture));
+}
+
+function assertNoNonFinite(value, path = 'result') {
+  if (typeof value === 'number') {
+    assert.equal(Number.isFinite(value), true, `${path} must be finite`);
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoNonFinite(item, `${path}[${index}]`));
+    return;
+  }
+  if (value && typeof value === 'object') {
+    for (const [key, child] of Object.entries(value)) assertNoNonFinite(child, `${path}.${key}`);
+  }
+}
+
+test('small stable creator produces complete normalized profile and cadence metrics', () => {
+  const result = analyze(GOLDEN_FIXTURES.smallStable);
+
+  assert.equal(result.evidenceState, 'derived');
+  assert.equal(result.algorithmVersion, ANALYTICS_ALGORITHM_VERSION);
+  assert.equal(result.profileGrowth.followers.absoluteDelta.value, 20);
+  assert.equal(result.profileGrowth.followers.relativeGrowthRate.value, 0.02);
+  assert.equal(result.postingCadence.publicationCount, 5);
+  assert.equal(result.postingCadence.postingInterval.median, 3);
+  assert.equal(result.engagement.engagementRate.evidenceState, 'derived');
+  assert.equal(result.engagement.engagementRate.count, 5);
+  assert.equal(result.engagement.commentLikeRatio.median, 2 / 20);
+  assert.equal(result.engagement.medianViews.value, null);
+  assert.equal(result.followerTierBenchmark.status, 'unavailable');
+  assert.equal(result.window.start, '2026-01-01T00:00:00.000Z');
+  assert.equal(result.window.end, '2026-01-15T00:00:00.000Z');
+  assertNoNonFinite(result);
+});
+
+test('large creator keeps quality ratios normalized instead of treating follower scale as quality', () => {
+  const result = analyze(GOLDEN_FIXTURES.largeCreator);
+
+  assert.equal(result.profileGrowth.followers.first.value, 1000000);
+  assert.equal(result.profileGrowth.followers.absoluteDelta.value, 10000);
+  assert.ok(result.likes.mean > analyze(GOLDEN_FIXTURES.smallStable).likes.mean);
+  assert.ok(Math.abs(result.engagement.engagementRate.median - 0.0208) < 0.002);
+  assert.equal(result.profileGrowth.followers.relativeGrowthRate.value, 0.01);
+  assertNoNonFinite(result);
+});
+
+test('viral post is visible as an outlier while robust summaries retain the regular series', () => {
+  const result = analyze(GOLDEN_FIXTURES.viralPost);
+
+  assert.equal(result.likes.median, 15);
+  assert.ok(result.likes.mean > result.likes.trimmedMean);
+  assert.ok(result.likes.outlierRatio > 0);
+  assert.ok(result.likes.viralOutlierRatio > 0);
+  assert.ok(result.outliers.likes.viralOutlierRatio > 0);
+  assert.ok(result.videoPerformance.views.median > 0);
+  assertNoNonFinite(result);
+});
+
+test('follower spike is reported as a growth-pattern anomaly, never as a fake-follower fact', () => {
+  const result = analyze(GOLDEN_FIXTURES.followerSpike);
+
+  assert.equal(result.growthAnomalies.evidenceState, 'derived');
+  assert.ok(result.growthAnomalies.anomalyRatio > 0);
+  assert.ok(result.growthAnomalies.anomalies.some((item) => item.direction === 'spike'));
+  assert.ok(result.growthAnomalies.anomalies.every((item) => item.interpretation === 'growth_pattern_anomaly'));
+  assert.equal(JSON.stringify(result).includes('fake'), false);
+  assertNoNonFinite(result);
+});
+
+test('incomplete series carries partial coverage and does not impute missing counts', () => {
+  const result = analyze(GOLDEN_FIXTURES.incompleteSeries);
+
+  assert.equal(result.profileGrowth.followers.summary.count, 2);
+  assert.equal(result.profileGrowth.followers.summary.coverage.availableMetrics, 2);
+  assert.equal(result.profileGrowth.followers.summary.coverage.expectedMetrics, 3);
+  assert.equal(result.comments.count, 1);
+  assert.equal(result.engagement.evidenceState, 'unavailable');
+  assert.equal(result.engagement.engagementRate.mean, null);
+  assert.equal(result.window.start, '2026-01-01T00:00:00.000Z');
+  assertNoNonFinite(result);
+});
+
+test('irregular engagement exposes normalized volatility and robust outliers', () => {
+  const result = analyze(GOLDEN_FIXTURES.irregularEngagement);
+
+  assert.equal(result.engagement.engagementRate.count, 8);
+  assert.ok(result.volatility.engagementRate.coefficientOfVariation > 0.8);
+  assert.ok(result.outliers.likes.outlierRatio > 0);
+  assertNoNonFinite(result);
+});
+
+test('missing views remain unavailable for video performance', () => {
+  const result = analyze(GOLDEN_FIXTURES.noViews);
+
+  assert.equal(result.likes.evidenceState, 'derived');
+  assert.equal(result.videoPerformance.views.evidenceState, 'unavailable');
+  assert.equal(result.videoPerformance.views.median, null);
+  assert.equal(result.engagement.medianViews.value, null);
+  assert.equal(result.engagement.viewsFollowerRatio.evidenceState, 'unavailable');
+  assert.equal(result.limitations.includes('views_unavailable'), true);
+  assertNoNonFinite(result);
+});
+
+test('few posts do not manufacture a posting interval or an outlier ratio', () => {
+  const result = analyze(GOLDEN_FIXTURES.fewPosts);
+
+  assert.equal(result.likes.mean, 5);
+  assert.equal(result.postingCadence.postingInterval.evidenceState, 'unavailable');
+  assert.equal(result.postingCadence.postingInterval.median, null);
+  assert.equal(result.likes.outlierRatio, null);
+  assert.equal(result.outliers.likes.evidenceState, 'unavailable');
+  assertNoNonFinite(result);
+});
+
+test('zero denominators are explicit and observed zero metrics remain zero', () => {
+  const result = computeInfluencerAnalytics({
+    creatorKey: 'creator-zero-denominator',
+    computedAt: '2026-02-01T00:00:00.000Z',
+    profileSnapshots: [
+      {
+        snapshotKey: 'profile-snapshot-zero-001',
+        provider: 'meta-graph',
+        observedAt: '2026-01-01T00:00:00.000Z',
+        followersCount: 0,
+        followingCount: 0,
+        mediaCount: 0,
+      },
+      {
+        snapshotKey: 'profile-snapshot-zero-002',
+        provider: 'meta-graph',
+        observedAt: '2026-01-02T00:00:00.000Z',
+        followersCount: 0,
+        followingCount: 0,
+        mediaCount: 0,
+      },
+    ],
+    mediaSnapshots: [{
+      snapshotKey: 'media-snapshot-zero-001',
+      mediaKey: 'media-zero-001',
+      provider: 'meta-graph',
+      observedAt: '2026-01-02T00:00:00.000Z',
+      publishedAt: '2026-01-02T00:00:00.000Z',
+      mediaKind: 'post',
+      likesCount: 0,
+      commentsCount: 0,
+      viewsCount: 0,
+    }],
+  });
+
+  assert.equal(result.likes.mean, 0);
+  assert.equal(result.comments.mean, 0);
+  assert.equal(result.engagement.engagementRate.evidenceState, 'unavailable');
+  assert.equal(result.engagement.commentLikeRatio.evidenceState, 'unavailable');
+  assert.equal(result.engagement.viewsFollowerRatio.evidenceState, 'unavailable');
+  assert.equal(result.profileGrowth.followers.relativeGrowthRate.value, null);
+  assert.equal(result.profileGrowth.followers.relativeGrowthRate.unavailableReason, 'zero_or_missing_initial_followers');
+  assertNoNonFinite(result);
+});
+
+test('same snapshots and computation timestamp are bit-for-bit deterministic', () => {
+  const first = analyze(GOLDEN_FIXTURES.viralPost);
+  const second = analyze(GOLDEN_FIXTURES.viralPost);
+  assert.deepEqual(first, second);
+});
+
+test('invalid unavailable values are rejected instead of silently coerced', () => {
+  assert.throws(() => computeInfluencerAnalytics({
+    creatorKey: 'creator-invalid-unavailable',
+    computedAt: '2026-02-01T00:00:00.000Z',
+    profileSnapshots: [{
+      snapshotKey: 'profile-invalid-001',
+      provider: 'meta-graph',
+      observedAt: '2026-01-01T00:00:00.000Z',
+      evidenceState: 'unavailable',
+      followersCount: 10,
+    }],
+  }), (error) => error.code === 'UNAVAILABLE_HAS_VALUE');
+});
+
+test('explicit windows exclude observations outside the requested as-of interval', () => {
+  const result = computeInfluencerAnalytics({
+    ...structuredClone(GOLDEN_FIXTURES.smallStable),
+    windowStart: '2026-01-04T00:00:00.000Z',
+    windowEnd: '2026-01-10T00:00:00.000Z',
+  });
+
+  assert.deepEqual(result.inputSnapshotKeys, [
+    'media-snapshot-small-002',
+    'media-snapshot-small-003',
+    'media-snapshot-small-004',
+    'profile-snapshot-small-002',
+  ]);
+  assert.equal(result.postingCadence.publicationCount, 3);
+  assert.equal(result.profileGrowth.followers.first.value, 1010);
+  assert.equal(result.profileGrowth.followers.last.value, 1010);
+  assert.equal(result.window.start, '2026-01-04T00:00:00.000Z');
+  assert.equal(result.window.end, '2026-01-10T00:00:00.000Z');
+  assertNoNonFinite(result);
+});
+
+test('media with no available metrics remains unavailable with an explicit reason', () => {
+  const result = computeInfluencerAnalytics({
+    creatorKey: 'creator-no-media-metrics',
+    computedAt: '2026-02-01T00:00:00.000Z',
+    mediaSnapshots: [{
+      snapshotKey: 'media-snapshot-no-metrics-001',
+      mediaKey: 'media-no-metrics-001',
+      provider: 'meta-graph',
+      observedAt: '2026-01-01T00:00:00.000Z',
+      publishedAt: '2026-01-01T00:00:00.000Z',
+      mediaKind: 'post',
+      likesCount: null,
+      commentsCount: null,
+      viewsCount: null,
+      reachCount: null,
+    }],
+  });
+
+  assert.equal(result.likes.evidenceState, 'unavailable');
+  assert.equal(result.videoPerformance.evidenceState, 'unavailable');
+  assert.equal(result.videoPerformance.unavailableReason, 'no_matching_media');
+  assertNoNonFinite(result);
+});
+
+
+

--- a/social/influencer-intelligence/tests/fixtures/analytics-golden-fixtures.mjs
+++ b/social/influencer-intelligence/tests/fixtures/analytics-golden-fixtures.mjs
@@ -1,0 +1,167 @@
+const computedAt = '2026-02-01T00:00:00.000Z';
+
+function profile(snapshotKey, observedAt, followersCount, overrides = {}) {
+  return {
+    snapshotKey,
+    provider: 'meta-graph',
+    observedAt,
+    followersCount,
+    followingCount: overrides.followingCount ?? 100,
+    mediaCount: overrides.mediaCount ?? 20,
+    ...overrides,
+  };
+}
+
+function media(snapshotKey, publishedAt, {
+  mediaKey = snapshotKey.replace('media-snapshot-', 'media-'),
+  mediaKind = 'post',
+  likesCount,
+  commentsCount,
+  viewsCount,
+  reachCount,
+  followersCount,
+} = {}) {
+  return {
+    snapshotKey,
+    mediaKey,
+    provider: 'meta-graph',
+    observedAt: publishedAt,
+    publishedAt,
+    mediaKind,
+    likesCount,
+    commentsCount,
+    ...(viewsCount === undefined ? {} : { viewsCount }),
+    ...(reachCount === undefined ? {} : { reachCount }),
+    ...(followersCount === undefined ? {} : { followersCount }),
+  };
+}
+
+const smallStable = {
+  creatorKey: 'creator-small-stable',
+  computedAt,
+  profileSnapshots: [
+    profile('profile-snapshot-small-001', '2026-01-01T00:00:00.000Z', 1000),
+    profile('profile-snapshot-small-002', '2026-01-08T00:00:00.000Z', 1010, { followingCount: 101, mediaCount: 22 }),
+    profile('profile-snapshot-small-003', '2026-01-15T00:00:00.000Z', 1020, { followingCount: 102, mediaCount: 24 }),
+  ],
+  mediaSnapshots: [
+    media('media-snapshot-small-001', '2026-01-02T00:00:00.000Z', { likesCount: 20, commentsCount: 2 }),
+    media('media-snapshot-small-002', '2026-01-04T00:00:00.000Z', { likesCount: 21, commentsCount: 2 }),
+    media('media-snapshot-small-003', '2026-01-07T00:00:00.000Z', { likesCount: 19, commentsCount: 2 }),
+    media('media-snapshot-small-004', '2026-01-10T00:00:00.000Z', { likesCount: 20, commentsCount: 2 }),
+    media('media-snapshot-small-005', '2026-01-13T00:00:00.000Z', { likesCount: 20, commentsCount: 2 }),
+  ],
+};
+
+const largeCreator = {
+  creatorKey: 'creator-large',
+  computedAt,
+  profileSnapshots: [
+    profile('profile-snapshot-large-001', '2026-01-01T00:00:00.000Z', 1000000, { followingCount: 500, mediaCount: 500 }),
+    profile('profile-snapshot-large-002', '2026-01-11T00:00:00.000Z', 1010000, { followingCount: 501, mediaCount: 504 }),
+  ],
+  mediaSnapshots: [
+    media('media-snapshot-large-001', '2026-01-02T00:00:00.000Z', { likesCount: 20000, commentsCount: 200 }),
+    media('media-snapshot-large-002', '2026-01-04T00:00:00.000Z', { likesCount: 21000, commentsCount: 210 }),
+    media('media-snapshot-large-003', '2026-01-07T00:00:00.000Z', { likesCount: 19000, commentsCount: 190 }),
+    media('media-snapshot-large-004', '2026-01-10T00:00:00.000Z', { likesCount: 20500, commentsCount: 205 }),
+  ],
+};
+
+const postValues = [10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 1000];
+const viralPost = {
+  creatorKey: 'creator-viral-post',
+  computedAt,
+  profileSnapshots: [
+    profile('profile-snapshot-viral-001', '2026-01-01T00:00:00.000Z', 2000),
+    profile('profile-snapshot-viral-002', '2026-01-12T00:00:00.000Z', 2100),
+  ],
+  mediaSnapshots: postValues.map((likesCount, index) => media(
+    `media-snapshot-viral-${String(index + 1).padStart(3, '0')}`,
+    `2026-01-${String(index + 1).padStart(2, '0')}T00:00:00.000Z`,
+    {
+      likesCount,
+      commentsCount: likesCount === 1000 ? 50 : 1,
+      viewsCount: likesCount === 1000 ? 10000 : 100 + likesCount,
+      mediaKind: likesCount === 1000 ? 'reel' : 'post',
+    },
+  )),
+};
+
+const followerSpike = {
+  creatorKey: 'creator-follower-spike',
+  computedAt,
+  profileSnapshots: [
+    profile('profile-snapshot-spike-001', '2026-01-01T00:00:00.000Z', 1000),
+    profile('profile-snapshot-spike-002', '2026-01-02T00:00:00.000Z', 1010),
+    profile('profile-snapshot-spike-003', '2026-01-03T00:00:00.000Z', 1020),
+    profile('profile-snapshot-spike-004', '2026-01-04T00:00:00.000Z', 6000),
+    profile('profile-snapshot-spike-005', '2026-01-05T00:00:00.000Z', 6030),
+  ],
+  mediaSnapshots: [],
+};
+
+const incompleteSeries = {
+  creatorKey: 'creator-incomplete-series',
+  computedAt,
+  profileSnapshots: [
+    profile('profile-snapshot-incomplete-001', '2026-01-01T00:00:00.000Z', 1000),
+    profile('profile-snapshot-incomplete-002', '2026-01-08T00:00:00.000Z', null, { followingCount: null }),
+    profile('profile-snapshot-incomplete-003', '2026-01-15T00:00:00.000Z', 1100),
+  ],
+  mediaSnapshots: [
+    media('media-snapshot-incomplete-001', '2026-01-02T00:00:00.000Z', { likesCount: 10, commentsCount: null }),
+    media('media-snapshot-incomplete-002', '2026-01-09T00:00:00.000Z', { likesCount: null, commentsCount: 2 }),
+  ],
+};
+
+const irregularEngagement = {
+  creatorKey: 'creator-irregular-engagement',
+  computedAt,
+  profileSnapshots: [
+    profile('profile-snapshot-irregular-001', '2026-01-01T00:00:00.000Z', 10000),
+  ],
+  mediaSnapshots: [0.01, 0.02, 0.03, 0.02, 0.05, 0.04, 0.08, 0.5].map((rate, index) => media(
+    `media-snapshot-irregular-${String(index + 1).padStart(3, '0')}`,
+    `2026-01-${String(index + 2).padStart(2, '0')}T00:00:00.000Z`,
+    { likesCount: Math.round(rate * 10000), commentsCount: Math.round(rate * 1000) },
+  )),
+};
+
+const noViews = {
+  creatorKey: 'creator-no-views',
+  computedAt,
+  profileSnapshots: [
+    profile('profile-snapshot-no-views-001', '2026-01-01T00:00:00.000Z', 3000),
+  ],
+  mediaSnapshots: [
+    media('media-snapshot-no-views-001', '2026-01-02T00:00:00.000Z', { mediaKind: 'reel', likesCount: 30, commentsCount: 3, viewsCount: null, reachCount: null }),
+    media('media-snapshot-no-views-002', '2026-01-04T00:00:00.000Z', { mediaKind: 'reel', likesCount: 32, commentsCount: 4, viewsCount: null, reachCount: null }),
+  ],
+};
+
+const fewPosts = {
+  creatorKey: 'creator-few-posts',
+  computedAt,
+  profileSnapshots: [
+    profile('profile-snapshot-few-001', '2026-01-01T00:00:00.000Z', 500),
+  ],
+  mediaSnapshots: [
+    media('media-snapshot-few-001', '2026-01-02T00:00:00.000Z', { likesCount: 5, commentsCount: 1 }),
+  ],
+};
+
+export const GOLDEN_FIXTURES = Object.freeze({
+  smallStable,
+  largeCreator,
+  viralPost,
+  followerSpike,
+  incompleteSeries,
+  irregularEngagement,
+  noViews,
+  fewPosts,
+});
+
+
+
+


### PR DESCRIPTION
## Scope

Add the pure deterministic Influencer Intelligence analytics boundary (M4).

## Included

- profile growth, cadence, likes/comments/engagement and video/reach metrics;
- robust summaries, percentiles, trimmed/winsorized means, IQR/MAD, outlier and viral-outlier ratios;
- trend, volatility, growth velocity/acceleration and bounded growth anomaly signals;
- explicit unavailable/null handling, zero-denominator guards, inclusive observation windows and provenance/version output;
- synthetic golden fixtures and focused regression tests;
- architecture-governance coverage.

## Safety and operations

- No provider transport, scraping, credentials, database connection, scheduler, CRM, MCP or runtime route.
- No migration, flag, grant, Token Vault, workflow import, external call or real creator data.
- Feature remains off by default and the artifact is runtime-free.
- Rollback: revert this single commit before merge, or revert the merged commit if required.

## Validation

- 74 focused Influencer Intelligence tests passed through the canonical WSL wrapper.
- architecture, module-catalog and domain-boundary validators passed.