### PR TITLE
feat(influencer-intelligence): add deterministic scoring v0

### DIFF
--- a/.github/workflows/architecture-governance.yml
+++ b/.github/workflows/architecture-governance.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Validate domain import boundaries
         run: node .github/scripts/validate-domain-boundaries.mjs
       - name: Test Influencer Intelligence contracts, providers and snapshots
-        run: node --test social/influencer-intelligence/tests/contracts.test.mjs social/influencer-intelligence/tests/registry.test.mjs social/influencer-intelligence/tests/providers.test.mjs social/influencer-intelligence/tests/provider-router-contract.test.mjs social/influencer-intelligence/tests/architecture.test.mjs social/influencer-intelligence/tests/data-model.test.mjs social/influencer-intelligence/tests/snapshots.test.mjs social/influencer-intelligence/tests/analytics.test.mjs
+        run: node --test social/influencer-intelligence/tests/contracts.test.mjs social/influencer-intelligence/tests/registry.test.mjs social/influencer-intelligence/tests/providers.test.mjs social/influencer-intelligence/tests/provider-router-contract.test.mjs social/influencer-intelligence/tests/architecture.test.mjs social/influencer-intelligence/tests/data-model.test.mjs social/influencer-intelligence/tests/snapshots.test.mjs social/influencer-intelligence/tests/analytics.test.mjs social/influencer-intelligence/tests/scoring.test.mjs
       - name: Validate reproducible staging manifest
         run: node .github/scripts/validate-staging-manifest.mjs
       - name: Validate staging bootstrap safety guards

--- a/social/influencer-intelligence/README.md
+++ b/social/influencer-intelligence/README.md
@@ -1,8 +1,9 @@
 # Influencer Intelligence
 
-Status: architecture v1 defined; M2 provider boundary and M4 deterministic
-analytics are implemented in source control, and data model v1 is an additive,
-unapplied artifact in this milestone. The domain remains
+Status: architecture v1 defined; M2 provider boundary, M4 deterministic
+analytics, and M5 deterministic scoring are implemented in source control, and
+data model v1 plus scoring metadata remain additive, unapplied artifacts in
+this milestone. The domain remains
 experimental, not exposed, and off by default.
 
 This domain provides read-only intelligence about Instagram creators for
@@ -220,8 +221,8 @@ deployment hardening.
   contact fields are not values in this contract.
 - `ScoreEnvelope`: a score from 0 to 100 or an explicit `null` when
   unavailable, confidence from 0 to 1, derived data coverage, provider list,
-  provenance, timestamp, deterministic `algorithmVersion`, and structured
-  signals.
+  provenance, timestamp, deterministic `algorithmVersion`, `weightsVersion`,
+  and structured signals.
 - `StructuredSignal`: a bounded scalar, explicit evidence state, confidence,
   evidence references, and an optional model version. Free-form LLM rationale
   or prompt/completion text is not persisted here.
@@ -285,7 +286,7 @@ production configuration.
 | M2 | Official-first router and controlled collectors | Merged in #1305; injected synthetic transports only |
 | M3 | Append-only snapshots, retention, and Orb scheduling | Snapshot operations implemented; Orb scheduling pending |
 | M4 | Robust analytics and outlier-resistant metrics | Implemented in this PR; pure deterministic engine, golden fixtures, and formula documentation |
-| M5 | Deterministic score, confidence, coverage, and provenance | Pending |
+| M5 | Deterministic score, confidence, coverage, and provenance | Implemented in this PR; versioned weights, confidence factors, explanations, additive persistence metadata, and golden tests |
 | M6 | Authenticated, sanitized, rate-limited read-only MCP | Pending |
 | M7 | `skincos-influencer-intelligence` Codex skill | Pending |
 | M8 | Read-only CRM contracts and dashboard | Pending |

--- a/social/influencer-intelligence/SCORING.md
+++ b/social/influencer-intelligence/SCORING.md
@@ -1,0 +1,57 @@
+# Influencer Score v0
+
+`scoring.mjs` is a pure deterministic boundary over the versioned analytics
+artifact. It does not call providers, an LLM, PostgreSQL, Orb, CRM, MCP, or a
+network. A caller supplies optional comments, commercial-saturation, and
+brand-fit values only as bounded structured signals with evidence references.
+
+The output always includes `overall_score`, `confidence_score`,
+`data_coverage`, `algorithm_version`, `weights_version`, `calculated_at`,
+`input_snapshot_keys`, `input_evidence_refs`, `input_fingerprint`, component
+scores, and deterministic explanation codes. The result is frozen and can be
+persisted as a new append-only score artifact.
+
+## Components and weights
+
+| Component | Weight | Source rule |
+| --- | ---: | --- |
+| `engagement_quality` | 0.20 | Median engagement rate, with comment/like ratio when available |
+| `growth_integrity` | 0.14 | Profile growth history and bounded growth-pattern anomalies |
+| `content_performance` | 0.16 | Engagement rate and views/follower ratio when available |
+| `consistency` | 0.12 | Posting-interval dispersion and engagement volatility |
+| `comment_quality` | 0.08 | Structured aggregate comment signal; unavailable by default |
+| `commercial_saturation` | 0.08 | Structured saturation signal; unavailable by default |
+| `brand_fit` | 0.08 | Structured campaign/brand signal; unavailable without a brief |
+| `risk` | 0.08 | Bounded pattern/outlier indicators; never a fake-follower fact |
+| `profile_integrity` | 0.06 | Profile metric coverage and history length |
+
+Weights are configuration, not prompt instructions. When a component is
+unavailable, its configured weight is excluded from the weighted mean and the
+remaining weights are normalized. This avoids treating missing data as a zero
+score; `data_coverage` and `confidence_score` expose the missing component and
+limit decision confidence.
+
+The score uses normalized rates and robust analytics, never absolute follower
+count as a quality input. Ratio thresholds are versioned internal v0 scoring
+configuration, not external benchmarks. Follower-tier benchmarks remain
+unavailable until a governed SKINCOS calibration dataset exists.
+
+## Confidence and coverage
+
+`confidence_score` is an objective 0..100 envelope over history length, media
+history, comment sample size, freshness, provider reliability, official-provider
+availability, and analytics metric coverage. A one-snapshot or stale fallback
+result therefore cannot receive high confidence even if a component can be
+computed.
+
+`data_coverage` combines analytics metric coverage (65%) with the configured
+weight of components that have usable evidence (35%). `null` and
+`unavailable` remain distinct from observed numeric zero.
+
+## Safety and explanations
+
+Every component carries an evidence state, confidence, bounded references, and
+a deterministic explanation `{ code, inputs, limitations }`. Growth and
+outlier signals are pattern indicators only; the engine never labels a creator
+or follower as fake from indirect evidence. LLM text or free-form rationale is
+not accepted by this boundary.

--- a/social/influencer-intelligence/architecture.mjs
+++ b/social/influencer-intelligence/architecture.mjs
@@ -151,7 +151,7 @@ export const DATA_MODEL = deepFreeze({
     {
       name: 'score_snapshots',
       lifecycle: 'append-only derived artifact',
-      fields: ['scoreKey', 'creatorKey', 'scoreKind', 'score', 'confidence', 'coverage', 'evidenceState', 'providers', 'provenance', 'timestamp', 'algorithmVersion', 'signals'],
+      fields: ['scoreKey', 'creatorKey', 'scoreKind', 'score', 'confidence', 'coverage', 'evidenceState', 'providers', 'provenance', 'timestamp', 'algorithmVersion', 'weightsVersion', 'signals'],
     },
     {
       name: 'structured_signals',
@@ -220,7 +220,7 @@ export const PROVENANCE_CONTRACT = deepFreeze({
 
 export const SCORE_CONTRACT = deepFreeze({
   contractVersion: 'influencer-intelligence/score/v1',
-  requiredFields: ['scoreKind', 'score', 'confidence', 'coverage', 'evidenceState', 'providers', 'provenance', 'timestamp', 'algorithmVersion', 'signals'],
+  requiredFields: ['scoreKind', 'score', 'confidence', 'coverage', 'evidenceState', 'providers', 'provenance', 'timestamp', 'algorithmVersion', 'weightsVersion', 'signals'],
   ranges: { score: '0..100 or null', confidence: '0..1', coverageRatio: '0..1' },
   scoreKinds: ['influencer', 'campaign-fit', 'brand-fit', 'risk'],
   deterministicFirst: true,
@@ -335,7 +335,7 @@ export const IMPLEMENTATION_PLAN = deepFreeze([
   { id: 'M2', title: 'Official-first provider router and bounded collectors', status: 'merged #1305; synthetic transport only', acceptance: ['Meta first', 'controlled instagrapi fallback', 'fail-closed classification', 'no duplicate scraper'] },
   { id: 'M3', title: 'Append-only snapshots, retention, and Orb job contract', status: 'snapshot operations implemented; Orb scheduling pending', acceptance: ['new additive tables', 'immutable evidence lifecycle', 'bounded snapshot_creator and snapshot_creator_media operations', 'dry-run/shadow scheduling', 'resume/recovery without live workflow import'] },
   { id: 'M4', title: 'Robust analytics', status: 'implemented in this PR; pure deterministic ESM boundary', acceptance: ['time windows', 'viral-outlier resistance', 'explicit unavailable coverage'] },
-  { id: 'M5', title: 'Deterministic scores and confidence', status: 'pending', acceptance: ['versioned algorithms', 'score/confidence/coverage/provenance completeness', 'calibration fixtures'] },
+  { id: 'M5', title: 'Deterministic scores and confidence', status: 'implemented in this PR; weights and algorithm versioned', acceptance: ['versioned algorithms', 'score/confidence/coverage/provenance completeness', 'calibration fixtures'] },
   { id: 'M6', title: 'Hardened read-only MCP', status: 'pending', acceptance: ['auth', 'sanitization', 'rate limit', 'timeout', 'audit', 'bounded tools', 'read-only role'] },
   { id: 'M7', title: 'Codex skill', status: 'pending', acceptance: ['read-only tool use', 'safe question routing', 'no provider or shell bypass'] },
   { id: 'M8', title: 'CRM read-only surface', status: 'pending', acceptance: ['internal API only', 'server grant and flag', 'shadow UI', 'no direct provider access'] },

--- a/social/influencer-intelligence/contracts.mjs
+++ b/social/influencer-intelligence/contracts.mjs
@@ -389,6 +389,12 @@ export function normalizeScoreEnvelope(input) {
   const scoreKind = enumValue(input.scoreKind, 'scoreKind', SCORE_KINDS, scoreKindSet);
   const evidenceState = normalizeEvidenceState(input.evidenceState, 'score.evidenceState');
   const algorithmVersion = versionValue(input.algorithmVersion, 'algorithmVersion');
+  const weightsVersion = input.weightsVersion === undefined || input.weightsVersion === null
+    ? null
+    : versionValue(input.weightsVersion, 'weightsVersion');
+  if (algorithmVersion.startsWith('influencer-intelligence-scoring/') && !weightsVersion) {
+    fail('score.weightsVersion is required for Influencer Score v0');
+  }
   const timestamp = timestampValue(input.timestamp, 'score.timestamp');
   const coverage = normalizeCoverage(input.coverage);
   const providers = normalizeProviders(input.providers, evidenceState);
@@ -415,6 +421,7 @@ export function normalizeScoreEnvelope(input) {
     providers,
     provenance,
     algorithmVersion,
+    weightsVersion,
     timestamp,
     signals,
   });

--- a/social/influencer-intelligence/migrations/20260811_influencer_intelligence_scoring_v0.up.sql
+++ b/social/influencer-intelligence/migrations/20260811_influencer_intelligence_scoring_v0.up.sql
@@ -1,0 +1,24 @@
+-- Influencer Intelligence scoring v0 is an additive, unapplied artifact.
+-- It records the exact weights configuration used for each score snapshot.
+BEGIN;
+SET LOCAL TIME ZONE 'UTC';
+
+DO $$
+begin
+  if to_regclass('influencer_intelligence.creator_score') is null then
+    raise exception 'influencer_intelligence.creator_score must exist before scoring v0';
+  end if;
+END
+$$;
+
+ALTER TABLE influencer_intelligence.creator_score
+  ADD COLUMN IF NOT EXISTS weights_version text;
+
+COMMENT ON COLUMN influencer_intelligence.creator_score.weights_version IS
+  'Immutable identifier for the versioned deterministic scoring weights/configuration.';
+
+INSERT INTO public.schema_migrations (version, applied_at)
+VALUES ('20260811_influencer_intelligence_scoring_v0', now())
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/social/influencer-intelligence/repository.mjs
+++ b/social/influencer-intelligence/repository.mjs
@@ -310,8 +310,8 @@ export const SQL = Object.freeze({
     returning analysis_key, ingest_key, creator_key, evidence_state, computed_at`,
   recordScore: `
     insert into influencer_intelligence.creator_score
-      (score_key, ingest_key, creator_key, score_kind, score, confidence, coverage_available, coverage_expected, evidence_state, algorithm_version, model_version, providers, input_fingerprint, provenance, computed_at, retention_policy_version)
-    values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::text[], $13, $14::jsonb, $15::timestamptz, $16)
+      (score_key, ingest_key, creator_key, score_kind, score, confidence, coverage_available, coverage_expected, evidence_state, algorithm_version, model_version, providers, input_fingerprint, provenance, computed_at, retention_policy_version, weights_version)
+    values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::text[], $13, $14::jsonb, $15::timestamptz, $16, $17)
     on conflict (ingest_key) do nothing
     returning score_key, ingest_key, creator_key, score_kind, score, evidence_state, computed_at`,
   recordScoreComponent: `
@@ -343,7 +343,7 @@ export const SQL = Object.freeze({
     order by observed_at desc, retrieved_at desc, snapshot_key desc
     limit $2`,
   latestScores: `
-    select score_key, ingest_key, creator_key, score_kind, score, confidence, coverage_available, coverage_expected, evidence_state, algorithm_version, model_version, providers, provenance, computed_at
+    select score_key, ingest_key, creator_key, score_kind, score, confidence, coverage_available, coverage_expected, evidence_state, algorithm_version, model_version, providers, provenance, computed_at, weights_version
     from influencer_intelligence.creator_score
     where creator_key = $1
     order by computed_at desc, score_key desc
@@ -561,6 +561,11 @@ export function createInfluencerIntelligenceRepository({ queryable }) {
       safeInput(input, 'creatorScore');
       const scoreKind = requiredString(input.scoreKind, 'scoreKind', /^(influencer|campaign-fit|brand-fit|risk)$/);
       const evidenceState = requiredString(input.evidenceState, 'evidenceState', /^(derived|inferred|unavailable)$/);
+      const algorithmVersion = version(input.algorithmVersion, 'algorithmVersion');
+      const weightsVersion = optionalString(input.weightsVersion ?? input.weights_version, 'weightsVersion', VERSION_PATTERN);
+      if (algorithmVersion.startsWith('influencer-intelligence-scoring/') && !weightsVersion) {
+        fail('WEIGHTS_VERSION_REQUIRED');
+      }
       const score = decimal(input.score, 'score', { minimum: 0, maximum: 100 });
       if (evidenceState === 'unavailable' && score !== null) fail('UNAVAILABLE_SCORE_MUST_BE_NULL');
       if (evidenceState !== 'unavailable' && score === null) fail('AVAILABLE_SCORE_REQUIRED');
@@ -576,9 +581,9 @@ export function createInfluencerIntelligenceRepository({ queryable }) {
          requiredString(input.scoreKey, 'scoreKey'), requiredString(input.ingestKey, 'ingestKey'), requiredString(input.creatorKey, 'creatorKey'),
          scoreKind, score, confidence,
          coverageAvailable, coverageExpected,
-         evidenceState, version(input.algorithmVersion, 'algorithmVersion'), optionalString(input.modelVersion, 'modelVersion', VERSION_PATTERN),
+         evidenceState, algorithmVersion, optionalString(input.modelVersion, 'modelVersion', VERSION_PATTERN),
          providers, digest(input.inputFingerprint, 'inputFingerprint'), { entries: provenanceEntries },
-         timestamp(input.computedAt, 'computedAt'), version(input.retentionPolicyVersion, 'retentionPolicyVersion'),
+         timestamp(input.computedAt, 'computedAt'), version(input.retentionPolicyVersion, 'retentionPolicyVersion'), weightsVersion,
       ].map((value) => (value && typeof value === 'object' && !Array.isArray(value) ? JSON.stringify(value) : value)));
       return { inserted: Boolean(row), row };
     },

--- a/social/influencer-intelligence/scoring.mjs
+++ b/social/influencer-intelligence/scoring.mjs
@@ -1,0 +1,515 @@
+/**
+ * Deterministic Influencer Score v0 over the normalized analytics artifact.
+ *
+ * This boundary intentionally owns no provider, persistence, scheduling,
+ * prompt, or network behavior. Optional comment, commercial, and brand-fit
+ * inputs must arrive as bounded structured signals with evidence references.
+ * Missing signals remain unavailable; they are never coerced to zero.
+ */
+
+import { createHash } from 'node:crypto';
+
+export const SCORING_CONTRACT_VERSION = 'influencer-intelligence/scoring/v0';
+export const SCORING_ALGORITHM_VERSION = 'influencer-intelligence-scoring/v0';
+export const SCORING_WEIGHTS_VERSION = 'influencer-intelligence-scoring-weights/v0';
+
+export const SCORE_COMPONENTS = Object.freeze([
+  'engagement_quality',
+  'growth_integrity',
+  'content_performance',
+  'consistency',
+  'comment_quality',
+  'commercial_saturation',
+  'brand_fit',
+  'risk',
+  'profile_integrity',
+]);
+
+export const SCORE_WEIGHTS = Object.freeze({
+  engagement_quality: 0.20,
+  growth_integrity: 0.14,
+  content_performance: 0.16,
+  consistency: 0.12,
+  comment_quality: 0.08,
+  commercial_saturation: 0.08,
+  brand_fit: 0.08,
+  risk: 0.08,
+  profile_integrity: 0.06,
+});
+
+export const SCORE_THRESHOLDS = Object.freeze({
+  engagementRate: Object.freeze({ low: 0, high: 0.08 }),
+  commentLikeRatio: Object.freeze({ low: 0, high: 0.25 }),
+  viewsFollowerRatio: Object.freeze({ low: 0, high: 2 }),
+  freshnessDays: Object.freeze({ fresh: 2, recent: 7, aging: 30, stale: 90 }),
+  minimumProfileHistory: 6,
+  minimumMediaHistory: 12,
+  commentSampleConfidenceSize: 100,
+});
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const PROVIDER_RELIABILITY = Object.freeze({
+  'meta-graph': 1,
+  instagrapi: 0.68,
+});
+
+function fail(code, message) {
+  const error = new TypeError(`${code}: ${message}`);
+  error.code = code;
+  throw error;
+}
+
+function assertRecord(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    fail('INVALID_RECORD', `${label} must be an object`);
+  }
+}
+
+function finite(value, label, { minimum = -Infinity, maximum = Infinity } = {}) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < minimum || value > maximum) {
+    fail('INVALID_NUMBER', `${label} must be finite and within its allowed range`);
+  }
+  return value;
+}
+
+function optionalFinite(value, label, options) {
+  if (value === undefined || value === null) return null;
+  return finite(value, label, options);
+}
+
+function boundedInteger(value, label, { minimum = 0, maximum = 10000 } = {}) {
+  if (!Number.isInteger(value) || value < minimum || value > maximum) {
+    fail('INVALID_INTEGER', `${label} must be a bounded integer`);
+  }
+  return value;
+}
+
+function boundedString(value, label, pattern = /^[a-zA-Z0-9][a-zA-Z0-9._:/-]{0,159}$/) {
+  if (typeof value !== 'string' || !pattern.test(value)) fail('INVALID_STRING', `${label} is invalid`);
+  return value;
+}
+
+function isoTimestamp(value, label) {
+  if (typeof value !== 'string' || !Number.isFinite(Date.parse(value))) {
+    fail('INVALID_TIMESTAMP', `${label} must be a parseable ISO timestamp`);
+  }
+  return new Date(Date.parse(value)).toISOString();
+}
+
+function clamp(value, minimum = 0, maximum = 100) {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function round(value, digits = 6) {
+  if (value === null || value === undefined || !Number.isFinite(value)) return null;
+  const factor = 10 ** digits;
+  return Math.round((value + Number.EPSILON) * factor) / factor;
+}
+
+function deepFreeze(value, seen = new Set()) {
+  if (!value || typeof value !== 'object' || seen.has(value)) return value;
+  seen.add(value);
+  for (const child of Object.values(value)) deepFreeze(child, seen);
+  return Object.freeze(value);
+}
+
+function get(record, path) {
+  return path.split('.').reduce((current, key) => current?.[key], record);
+}
+
+function availableMetric(record, path) {
+  const value = get(record, path);
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'object' && value !== null && 'value' in value) {
+    if (value.value === null || value.evidenceState === 'unavailable') return null;
+    return Number.isFinite(value.value) ? value.value : null;
+  }
+  return Number.isFinite(value) ? value : null;
+}
+
+function metricEvidence(record, path) {
+  const value = get(record, path);
+  if (value && typeof value === 'object' && 'evidenceState' in value) return value.evidenceState;
+  return availableMetric(record, path) === null ? 'unavailable' : 'derived';
+}
+
+function ratioScore(value, { low, high }) {
+  if (value === null) return null;
+  if (high <= low) fail('INVALID_THRESHOLD', 'ratio threshold must have positive span');
+  return clamp(((value - low) / (high - low)) * 100);
+}
+
+function unique(values) {
+  return [...new Set(values.filter((value) => typeof value === 'string' && value))].sort();
+}
+
+function sourceRefs(analytics, extra = []) {
+  const refs = [
+    ...(Array.isArray(analytics.inputSnapshotKeys) ? analytics.inputSnapshotKeys : []),
+    ...(Array.isArray(analytics.provenance) ? analytics.provenance.map((item) => item.sourceRef) : []),
+    ...extra,
+  ];
+  return unique(refs).slice(0, 32);
+}
+
+function providersFor(analytics, signals) {
+  return unique([
+    ...(Array.isArray(analytics.providers) ? analytics.providers : []),
+    ...Object.values(signals || {}).flatMap((signal) => Array.isArray(signal?.providers) ? signal.providers : []),
+  ]);
+}
+
+function unavailableComponent(name, weight, reasonCode, inputs = {}) {
+  return {
+    component_name: name,
+    score: null,
+    weight,
+    effective_weight: 0,
+    contribution: null,
+    evidence_state: 'unavailable',
+    confidence: 0,
+    evidence_refs: [],
+    explanation: {
+      code: reasonCode,
+      inputs,
+      limitations: ['insufficient_observed_or_derived_inputs'],
+    },
+  };
+}
+
+function derivedComponent(name, weight, score, confidence, refs, code, inputs, limitations = []) {
+  return {
+    component_name: name,
+    score: round(clamp(score)),
+    weight,
+    effective_weight: weight,
+    contribution: null,
+    evidence_state: 'derived',
+    confidence: round(clamp(confidence, 0, 1), 6),
+    evidence_refs: unique(refs).slice(0, 32),
+    explanation: {
+      code,
+      inputs,
+      limitations,
+    },
+  };
+}
+
+function normalizeStructuredSignal(name, signal, weight) {
+  if (signal === undefined || signal === null) return unavailableComponent(name, weight, 'structured_signal_unavailable');
+  assertRecord(signal, `${name} signal`);
+  const evidenceState = signal.evidence_state || signal.evidenceState;
+  if (!['observed', 'derived', 'inferred', 'unavailable'].includes(evidenceState)) {
+    fail('INVALID_SIGNAL_STATE', `${name} signal evidence state is invalid`);
+  }
+  const score = optionalFinite(signal.score ?? signal.value, `${name}.score`, { minimum: 0, maximum: 100 });
+  const confidence = finite(signal.confidence ?? 0, `${name}.confidence`, { minimum: 0, maximum: 1 });
+  const refs = signal.evidence_refs || signal.evidenceRefs || [];
+  if (!Array.isArray(refs) || refs.length > 32 || refs.some((ref) => typeof ref !== 'string' || !ref)) {
+    fail('INVALID_SIGNAL_REFS', `${name} signal evidence references are invalid`);
+  }
+  if (evidenceState === 'unavailable') {
+    if (score !== null || confidence !== 0) fail('UNAVAILABLE_SIGNAL_HAS_VALUE', `${name} unavailable signal must be value-free`);
+    return unavailableComponent(name, weight, 'structured_signal_unavailable', { sample_size: signal.sample_size ?? null });
+  }
+  if (score === null || refs.length === 0) fail('AVAILABLE_SIGNAL_EVIDENCE_REQUIRED', `${name} signal requires score and evidence refs`);
+  const modelVersion = signal.model_version || signal.modelVersion || null;
+  if (evidenceState === 'inferred' && !modelVersion) fail('INFERRED_SIGNAL_MODEL_REQUIRED', `${name} inferred signal requires model version`);
+  return {
+    component_name: name,
+    score: round(score),
+    weight,
+    effective_weight: weight,
+    contribution: null,
+    evidence_state: evidenceState,
+    confidence: round(confidence, 6),
+    evidence_refs: unique(refs).slice(0, 32),
+    ...(modelVersion ? { model_version: boundedString(modelVersion, `${name}.model_version`) } : {}),
+    explanation: {
+      code: 'structured_signal_used_without_recalculation',
+      inputs: {
+        sample_size: signal.sample_size ?? signal.sampleSize ?? null,
+        signal_state: evidenceState,
+      },
+      limitations: [],
+    },
+  };
+}
+
+function profileHistoryLength(analytics) {
+  return Array.isArray(analytics.provenance)
+    ? new Set(analytics.provenance.filter((item) => item.sourceType === 'profile').map((item) => item.sourceRef)).size
+    : 0;
+}
+
+function mediaHistoryLength(analytics) {
+  const publicationCount = get(analytics, 'postingCadence.publicationCount');
+  if (Number.isInteger(publicationCount)) return publicationCount;
+  return Array.isArray(analytics.provenance)
+    ? new Set(analytics.provenance.filter((item) => item.sourceType === 'media').map((item) => item.sourceRef)).size
+    : 0;
+}
+
+function engagementQuality(analytics, weight) {
+  const engagementRate = availableMetric(analytics, 'engagement.engagementRate.median');
+  if (engagementRate === null) return unavailableComponent('engagement_quality', weight, 'engagement_rate_unavailable');
+  const commentLike = availableMetric(analytics, 'engagement.commentLikeRatio.median');
+  const rateScore = ratioScore(engagementRate, SCORE_THRESHOLDS.engagementRate);
+  const commentScore = ratioScore(commentLike, SCORE_THRESHOLDS.commentLikeRatio);
+  const score = commentScore === null ? rateScore : ((rateScore * 0.8) + (commentScore * 0.2));
+  const confidence = clamp((get(analytics, 'engagement.confidence') ?? 0) * (commentScore === null ? 0.75 : 1), 0, 1);
+  return derivedComponent(
+    'engagement_quality', weight, score, confidence, sourceRefs(analytics),
+    commentScore === null ? 'median_engagement_rate_normalized' : 'engagement_and_comment_like_ratio_normalized',
+    { median_engagement_rate: engagementRate, median_comment_like_ratio: commentLike, rate_score: round(rateScore), comment_score: round(commentScore) },
+    commentScore === null ? ['comment_like_ratio_unavailable'] : [],
+  );
+}
+
+function growthIntegrity(analytics, weight) {
+  const absoluteDelta = availableMetric(analytics, 'profileGrowth.followers.absoluteDelta');
+  if (absoluteDelta === null) return unavailableComponent('growth_integrity', weight, 'growth_history_unavailable');
+  const anomalyRatio = availableMetric(analytics, 'growthAnomalies.anomalyRatio');
+  const anomalyAvailable = metricEvidence(analytics, 'growthAnomalies.anomalyRatio') !== 'unavailable';
+  const score = anomalyAvailable ? 75 - (clamp(anomalyRatio, 0, 1) * 75) : 60;
+  const history = profileHistoryLength(analytics);
+  const confidence = clamp(Math.min(1, history / SCORE_THRESHOLDS.minimumProfileHistory) * (anomalyAvailable ? 1 : 0.55));
+  return derivedComponent(
+    'growth_integrity', weight, score, confidence, sourceRefs(analytics),
+    anomalyAvailable ? 'growth_anomaly_ratio_penalty' : 'growth_history_without_anomaly_coverage',
+    { absolute_delta: absoluteDelta, anomaly_ratio: anomalyRatio, history_length: history },
+    anomalyAvailable ? [] : ['growth_anomaly_coverage_limited'],
+  );
+}
+
+function contentPerformance(analytics, weight) {
+  const engagementRate = availableMetric(analytics, 'engagement.engagementRate.median');
+  const viewsFollowerRatio = availableMetric(analytics, 'engagement.viewsFollowerRatio.median');
+  if (engagementRate === null && viewsFollowerRatio === null) return unavailableComponent('content_performance', weight, 'normalized_content_metrics_unavailable');
+  const engagementScore = ratioScore(engagementRate, SCORE_THRESHOLDS.engagementRate);
+  const viewsScore = ratioScore(viewsFollowerRatio, SCORE_THRESHOLDS.viewsFollowerRatio);
+  const score = engagementScore === null ? viewsScore : (viewsScore === null ? engagementScore : ((engagementScore * 0.6) + (viewsScore * 0.4)));
+  const availableSignals = [engagementScore, viewsScore].filter((value) => value !== null).length;
+  const confidence = clamp((availableSignals / 2) * (get(analytics, 'engagement.confidence') ?? 0));
+  return derivedComponent(
+    'content_performance', weight, score, confidence, sourceRefs(analytics),
+    availableSignals === 2 ? 'engagement_and_views_per_follower_normalized' : 'single_normalized_content_metric',
+    { median_engagement_rate: engagementRate, median_views_follower_ratio: viewsFollowerRatio, available_signals: availableSignals },
+    availableSignals === 1 ? ['one_normalized_content_metric_unavailable'] : [],
+  );
+}
+
+function consistency(analytics, weight) {
+  const intervalMean = availableMetric(analytics, 'postingCadence.postingInterval.mean');
+  const intervalStd = availableMetric(analytics, 'postingCadence.postingInterval.standardDeviation');
+  const engagementCv = availableMetric(analytics, 'volatility.engagementRate.coefficientOfVariation');
+  if (intervalMean === null && engagementCv === null) return unavailableComponent('consistency', weight, 'cadence_and_volatility_unavailable');
+  const cadenceScore = intervalMean !== null && intervalStd !== null && intervalMean > 0
+    ? clamp(100 - ((intervalStd / intervalMean) * 100))
+    : null;
+  const engagementScore = engagementCv !== null ? clamp(100 - (engagementCv * 50)) : null;
+  const values = [cadenceScore, engagementScore].filter((value) => value !== null);
+  const score = values.reduce((sum, value) => sum + value, 0) / values.length;
+  const postCount = mediaHistoryLength(analytics);
+  const confidence = clamp((values.length / 2) * Math.min(1, postCount / SCORE_THRESHOLDS.minimumMediaHistory));
+  return derivedComponent(
+    'consistency', weight, score, confidence, sourceRefs(analytics),
+    values.length === 2 ? 'cadence_and_engagement_volatility' : 'single_consistency_signal',
+    { posting_interval_mean: intervalMean, posting_interval_standard_deviation: intervalStd, engagement_cv: engagementCv, media_history_length: postCount },
+    values.length === 1 ? ['one_consistency_signal_unavailable'] : [],
+  );
+}
+
+function risk(analytics, weight) {
+  const anomalyRatio = availableMetric(analytics, 'growthAnomalies.anomalyRatio');
+  const likesOutlierRatio = availableMetric(analytics, 'outliers.likes.viralOutlierRatio');
+  const viewsOutlierRatio = availableMetric(analytics, 'outliers.views.viralOutlierRatio');
+  if (anomalyRatio === null && likesOutlierRatio === null && viewsOutlierRatio === null) {
+    return unavailableComponent('risk', weight, 'risk_signals_unavailable');
+  }
+  const growthPenalty = anomalyRatio === null ? 0 : clamp(anomalyRatio, 0, 1) * 70;
+  const outlierPenalty = Math.max(likesOutlierRatio ?? 0, viewsOutlierRatio ?? 0) * 20;
+  const score = clamp(100 - growthPenalty - outlierPenalty);
+  const availableSignals = [anomalyRatio, likesOutlierRatio, viewsOutlierRatio].filter((value) => value !== null).length;
+  const confidence = clamp(availableSignals / 3);
+  return derivedComponent(
+    'risk', weight, score, confidence, sourceRefs(analytics),
+    'bounded_pattern_risk_not_fake_followers_claim',
+    { growth_anomaly_ratio: anomalyRatio, likes_viral_outlier_ratio: likesOutlierRatio, views_viral_outlier_ratio: viewsOutlierRatio },
+    ['pattern_signals_are_not_a_fake_followers_determination'],
+  );
+}
+
+function profileIntegrity(analytics, weight) {
+  const history = profileHistoryLength(analytics);
+  const profileCoverage = optionalFinite(get(analytics, 'profileGrowth.coverage.ratio'), 'profileGrowth.coverage.ratio', { minimum: 0, maximum: 1 });
+  if (history === 0 || profileCoverage === null) return unavailableComponent('profile_integrity', weight, 'profile_observations_unavailable');
+  const score = clamp(profileCoverage * 100);
+  const confidence = clamp(Math.min(1, history / SCORE_THRESHOLDS.minimumProfileHistory) * profileCoverage);
+  return derivedComponent(
+    'profile_integrity', weight, score, confidence, sourceRefs(analytics),
+    'profile_metric_coverage_and_history_length',
+    { profile_history_length: history, profile_metric_coverage: profileCoverage },
+    history < SCORE_THRESHOLDS.minimumProfileHistory ? ['short_profile_history'] : [],
+  );
+}
+
+function normalizeAnalytics(analytics) {
+  assertRecord(analytics, 'analytics');
+  const creatorKey = boundedString(analytics.creatorKey, 'analytics.creatorKey', /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,159}$/);
+  const calculatedAt = isoTimestamp(analytics.computedAt, 'analytics.computedAt');
+  const evidenceState = analytics.evidenceState;
+  if (!['derived', 'unavailable'].includes(evidenceState)) fail('INVALID_ANALYTICS_STATE', 'analytics must be derived or unavailable');
+  assertRecord(analytics.coverage, 'analytics.coverage');
+  const coverageRatio = finite(analytics.coverage.ratio, 'analytics.coverage.ratio', { minimum: 0, maximum: 1 });
+  const providers = unique(Array.isArray(analytics.providers) ? analytics.providers : []);
+  const provenance = Array.isArray(analytics.provenance) ? analytics.provenance : [];
+  return { ...analytics, creatorKey, calculatedAt, evidenceState, coverageRatio, providers, provenance };
+}
+
+function freshnessFactor(analytics, calculatedAt) {
+  const observedTimes = analytics.provenance.map((item) => Date.parse(item.observedAt)).filter(Number.isFinite);
+  if (observedTimes.length === 0) return 0;
+  const ageDays = Math.max(0, (Date.parse(calculatedAt) - Math.max(...observedTimes)) / DAY_MS);
+  const { fresh, recent, aging, stale } = SCORE_THRESHOLDS.freshnessDays;
+  if (ageDays <= fresh) return 1;
+  if (ageDays <= recent) return 0.8;
+  if (ageDays <= aging) return 0.5;
+  if (ageDays <= stale) return 0.2;
+  return 0.05;
+}
+
+function providerFactor(providers) {
+  if (providers.length === 0) return 0;
+  return Math.min(...providers.map((provider) => PROVIDER_RELIABILITY[provider] ?? 0.4));
+}
+
+function optionalSignalFactor(signal) {
+  if (!signal || signal.evidence_state === 'unavailable' || signal.evidenceState === 'unavailable') return 0.2;
+  const sampleSize = signal.sample_size ?? signal.sampleSize;
+  if (Number.isFinite(sampleSize)) return Math.min(1, Math.max(0, sampleSize) / SCORE_THRESHOLDS.commentSampleConfidenceSize);
+  return finite(signal.confidence ?? 0, 'structured signal confidence', { minimum: 0, maximum: 1 });
+}
+
+function confidenceScore(analytics, components, signals) {
+  const historyFactor = Math.min(1, profileHistoryLength(analytics) / SCORE_THRESHOLDS.minimumProfileHistory);
+  const mediaFactor = Math.min(1, mediaHistoryLength(analytics) / SCORE_THRESHOLDS.minimumMediaHistory);
+  const freshness = freshnessFactor(analytics, analytics.calculatedAt);
+  const providers = providersFor(analytics, signals);
+  const official = providers.includes('meta-graph') ? 1 : (providers.includes('instagrapi') ? 0.55 : 0);
+  const comments = optionalSignalFactor(signals.comment_quality);
+  const metricCoverage = analytics.coverageRatio;
+  const reliability = providerFactor(providers);
+  const factors = {
+    history_length: historyFactor,
+    media_history_length: mediaFactor,
+    comment_sample_size: comments,
+    freshness,
+    provider_reliability: reliability,
+    official_availability: official,
+    metric_coverage: metricCoverage,
+  };
+  const weighted = (
+    (historyFactor * 0.18)
+    + (mediaFactor * 0.18)
+    + (comments * 0.10)
+    + (freshness * 0.14)
+    + (reliability * 0.14)
+    + (official * 0.10)
+    + (metricCoverage * 0.16)
+  );
+  const available = Object.values(components).filter((component) => component.score !== null).length;
+  return { score: round(clamp(weighted * 100)), factors, available_components: available };
+}
+
+function dataCoverage(analytics, components) {
+  const availableWeight = Object.values(components).reduce((sum, component) => sum + (component.score === null ? 0 : component.weight), 0);
+  const ratio = (analytics.coverageRatio * 0.65) + (availableWeight * 0.35);
+  return { score: round(clamp(ratio * 100)), analytics_ratio: analytics.coverageRatio, component_weight_ratio: round(availableWeight) };
+}
+
+function inputFingerprint(analytics, components) {
+  const canonical = JSON.stringify({
+    creatorKey: analytics.creatorKey,
+    algorithmVersion: analytics.algorithmVersion || null,
+    computedAt: analytics.calculatedAt,
+    snapshots: [...(analytics.inputSnapshotKeys || [])].sort(),
+    components: Object.values(components).map((component) => ({
+      component_name: component.component_name,
+      score: component.score,
+      evidence_state: component.evidence_state,
+      evidence_refs: component.evidence_refs,
+    })),
+  });
+  return createHash('sha256').update(canonical).digest('hex');
+}
+
+export function computeInfluencerScore(input) {
+  assertRecord(input, 'input');
+  const analytics = normalizeAnalytics(input.analytics);
+  const structuredSignals = input.structured_signals || input.structuredSignals || {};
+  assertRecord(structuredSignals, 'structuredSignals');
+  const weights = { ...SCORE_WEIGHTS };
+  const components = {
+    engagement_quality: engagementQuality(analytics, weights.engagement_quality),
+    growth_integrity: growthIntegrity(analytics, weights.growth_integrity),
+    content_performance: contentPerformance(analytics, weights.content_performance),
+    consistency: consistency(analytics, weights.consistency),
+    comment_quality: normalizeStructuredSignal('comment_quality', structuredSignals.comment_quality, weights.comment_quality),
+    commercial_saturation: normalizeStructuredSignal('commercial_saturation', structuredSignals.commercial_saturation, weights.commercial_saturation),
+    brand_fit: normalizeStructuredSignal('brand_fit', structuredSignals.brand_fit, weights.brand_fit),
+    risk: risk(analytics, weights.risk),
+    profile_integrity: profileIntegrity(analytics, weights.profile_integrity),
+  };
+  const available = Object.values(components).filter((component) => component.score !== null);
+  const weightTotal = available.reduce((sum, component) => sum + component.weight, 0);
+  if (weightTotal > 0) {
+    for (const component of available) {
+      component.effective_weight = component.weight / weightTotal;
+      component.contribution = round(component.score * component.effective_weight);
+    }
+  }
+  const overall = weightTotal > 0
+    ? available.reduce((sum, component) => sum + component.contribution, 0)
+    : null;
+  const providers = providersFor(analytics, structuredSignals);
+  const provenance = analytics.provenance.slice(0, 32);
+  const coverage = dataCoverage(analytics, components);
+  const confidence = confidenceScore(analytics, components, structuredSignals);
+  const calculatedAt = isoTimestamp(input.calculated_at || input.calculatedAt || analytics.calculatedAt, 'calculatedAt');
+  const result = {
+    contract_version: SCORING_CONTRACT_VERSION,
+    score_kind: 'influencer',
+    creator_key: analytics.creatorKey,
+    overall_score: overall === null ? null : round(clamp(overall)),
+    confidence_score: analytics.evidenceState === 'unavailable' ? 0 : confidence.score,
+    data_coverage: coverage.score,
+    evidence_state: overall === null ? 'unavailable' : 'derived',
+    algorithm_version: SCORING_ALGORITHM_VERSION,
+    weights_version: SCORING_WEIGHTS_VERSION,
+    calculated_at: calculatedAt,
+    component_scores: components,
+    weights,
+    confidence_factors: confidence.factors,
+    coverage,
+    providers,
+    provenance,
+    input_snapshot_keys: [...(analytics.inputSnapshotKeys || [])].sort(),
+    input_evidence_refs: sourceRefs(analytics, Object.values(structuredSignals).flatMap((signal) => signal?.evidence_refs || signal?.evidenceRefs || [])),
+    input_fingerprint: inputFingerprint(analytics, components),
+    explanations: Object.values(components).map((component) => ({
+      component_name: component.component_name,
+      code: component.explanation.code,
+      inputs: component.explanation.inputs,
+      limitations: component.explanation.limitations,
+    })),
+    limitations: [
+      ...(weightTotal < 1 ? ['one_or_more_component_inputs_unavailable'] : []),
+      ...(confidence.score < 60 ? ['confidence_limited_by_history_freshness_provider_or_metric_coverage'] : []),
+      ...(analytics.evidenceState === 'unavailable' ? ['analytics_unavailable'] : []),
+    ],
+  };
+  return deepFreeze(result);
+}
+
+export const __testing = Object.freeze({ ratioScore, freshnessFactor, providerFactor, inputFingerprint });

--- a/social/influencer-intelligence/tests/data-model.test.mjs
+++ b/social/influencer-intelligence/tests/data-model.test.mjs
@@ -14,8 +14,10 @@ import {
 const here = path.dirname(fileURLToPath(import.meta.url));
 const migrationPath = path.join(here, '..', 'migrations', '20260811_influencer_intelligence_data_model_v1.up.sql');
 const snapshotMetadataMigrationPath = path.join(here, '..', 'migrations', '20260811_influencer_intelligence_snapshots_v1.up.sql');
+const scoringMigrationPath = path.join(here, '..', 'migrations', '20260811_influencer_intelligence_scoring_v0.up.sql');
 const migration = fs.readFileSync(migrationPath, 'utf8');
 const snapshotMetadataMigration = fs.readFileSync(snapshotMetadataMigrationPath, 'utf8');
+const scoringMigration = fs.readFileSync(scoringMigrationPath, 'utf8');
 const digestA = 'a'.repeat(64);
 const digestB = 'b'.repeat(64);
 const observedAt = '2026-08-11T12:00:00.000Z';
@@ -109,6 +111,15 @@ test('defines additive durable coverage and freshness metadata for snapshot coll
   assert.doesNotMatch(snapshotMetadataMigration, /DROP\s+(?:TABLE|SCHEMA|COLUMN)/i);
   assert.doesNotMatch(snapshotMetadataMigration, /TRUNCATE\s+/i);
   assert.match(snapshotMetadataMigration, /COMMIT;\s*$/);
+});
+
+test('defines additive score weights version metadata without destructive DDL', () => {
+  assert.match(scoringMigration, /BEGIN;[\s\S]*SET LOCAL TIME ZONE 'UTC'/);
+  assert.match(scoringMigration, /ADD COLUMN IF NOT EXISTS weights_version/);
+  assert.match(scoringMigration, /creator_score/);
+  assert.doesNotMatch(scoringMigration, /DROP\s+(?:TABLE|SCHEMA|COLUMN)/i);
+  assert.doesNotMatch(scoringMigration, /TRUNCATE\s+/i);
+  assert.match(scoringMigration, /COMMIT;\s*$/);
 });
 
 test('repository exposes a parameterized, injected PostgreSQL boundary', async () => {
@@ -226,6 +237,26 @@ test('scores accept future provider slugs but require auditable provenance and v
   await assert.rejects(
     repository.recordScore(baseScore({ scoreKey: 'score-3', ingestKey: 'score-ingest-3', evidenceState: 'unavailable', score: 1, providers: [], provenance: [] })),
     (error) => error.code === 'UNAVAILABLE_SCORE_MUST_BE_NULL',
+  );
+});
+
+test('scoring v0 persistence requires and binds the exact weights version', async () => {
+  const queryable = fakeQueryable([{ rows: [{ score_key: 'score-v0' }] }]);
+  const repository = createInfluencerIntelligenceRepository({ queryable });
+  await repository.recordScore(baseScore({
+    scoreKey: 'score-v0',
+    ingestKey: 'score-ingest-v0',
+    algorithmVersion: 'influencer-intelligence-scoring/v0',
+    weightsVersion: 'influencer-intelligence-scoring-weights/v0',
+  }));
+  assert.equal(queryable.calls[0].values[16], 'influencer-intelligence-scoring-weights/v0');
+  await assert.rejects(
+    repository.recordScore(baseScore({
+      scoreKey: 'score-v0-missing-weights',
+      ingestKey: 'score-ingest-v0-missing-weights',
+      algorithmVersion: 'influencer-intelligence-scoring/v0',
+    })),
+    (error) => error.code === 'WEIGHTS_VERSION_REQUIRED',
   );
 });
 

--- a/social/influencer-intelligence/tests/scoring.test.mjs
+++ b/social/influencer-intelligence/tests/scoring.test.mjs
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { computeInfluencerAnalytics } from '../analytics.mjs';
+import {
+  SCORING_ALGORITHM_VERSION,
+  SCORING_WEIGHTS_VERSION,
+  computeInfluencerScore,
+} from '../scoring.mjs';
+import { GOLDEN_FIXTURES } from './fixtures/analytics-golden-fixtures.mjs';
+
+function analyticsFor(fixture) {
+  return computeInfluencerAnalytics(structuredClone(fixture));
+}
+
+function scoreFor(fixture, extra = {}) {
+  return computeInfluencerScore({ analytics: analyticsFor(fixture), ...extra });
+}
+
+function assertFiniteNumbers(value, path = 'result') {
+  if (typeof value === 'number') {
+    assert.equal(Number.isFinite(value), true, `${path} must be finite`);
+  } else if (Array.isArray(value)) {
+    value.forEach((child, index) => assertFiniteNumbers(child, `${path}[${index}]`));
+  } else if (value && typeof value === 'object') {
+    Object.entries(value).forEach(([key, child]) => assertFiniteNumbers(child, `${path}.${key}`));
+  }
+}
+
+test('stable creator receives a versioned deterministic score with separate confidence and coverage', () => {
+  const result = scoreFor(GOLDEN_FIXTURES.smallStable);
+
+  assert.equal(result.algorithm_version, SCORING_ALGORITHM_VERSION);
+  assert.equal(result.weights_version, SCORING_WEIGHTS_VERSION);
+  assert.equal(result.evidence_state, 'derived');
+  assert.equal(typeof result.overall_score, 'number');
+  assert.equal(typeof result.confidence_score, 'number');
+  assert.equal(typeof result.data_coverage, 'number');
+  assert.equal(result.component_scores.engagement_quality.evidence_state, 'derived');
+  assert.equal(result.component_scores.comment_quality.evidence_state, 'unavailable');
+  assert.ok(result.confidence_score < 80, 'sparse and stale synthetic history must not look highly confident');
+  assert.equal(result.explanations.length, 9);
+  assertFiniteNumbers(result);
+});
+
+test('large follower count does not dominate normalized quality components', () => {
+  const small = scoreFor(GOLDEN_FIXTURES.smallStable);
+  const large = scoreFor(GOLDEN_FIXTURES.largeCreator);
+
+  assert.ok(Math.abs(small.component_scores.engagement_quality.score - large.component_scores.engagement_quality.score) < 35);
+  assert.equal(large.component_scores.engagement_quality.explanation.inputs.median_engagement_rate !== null, true);
+  assert.equal(Object.prototype.hasOwnProperty.call(large, 'followers'), false);
+  assertFiniteNumbers(large);
+});
+
+test('viral media remains a bounded pattern signal and does not become the whole score', () => {
+  const result = scoreFor(GOLDEN_FIXTURES.viralPost);
+
+  assert.ok(result.component_scores.risk.score < 100);
+  assert.equal(result.component_scores.risk.explanation.code, 'bounded_pattern_risk_not_fake_followers_claim');
+  assert.equal(result.component_scores.risk.explanation.limitations.includes('pattern_signals_are_not_a_fake_followers_determination'), true);
+  assert.ok(result.overall_score < 100);
+  assertFiniteNumbers(result);
+});
+
+test('growth spike is penalized as a bounded anomaly without a fake-follower conclusion', () => {
+  const result = scoreFor(GOLDEN_FIXTURES.followerSpike);
+
+  assert.equal(result.component_scores.growth_integrity.evidence_state, 'derived');
+  assert.equal(result.component_scores.growth_integrity.explanation.code, 'growth_anomaly_ratio_penalty');
+  assert.equal(JSON.stringify(result).includes('fake follower'), false);
+  assert.equal(JSON.stringify(result).includes('fake_followers'), true);
+  assertFiniteNumbers(result);
+});
+
+test('missing views, comments, and short history reduce coverage/confidence without zero filling', () => {
+  const result = scoreFor(GOLDEN_FIXTURES.noViews);
+
+  assert.equal(result.component_scores.comment_quality.score, null);
+  assert.equal(result.component_scores.commercial_saturation.score, null);
+  assert.equal(result.component_scores.brand_fit.score, null);
+  assert.ok(result.data_coverage < 100);
+  assert.ok(result.confidence_score < 70);
+  assert.equal(result.component_scores.content_performance.explanation.inputs.median_views_follower_ratio, null);
+  assertFiniteNumbers(result);
+});
+
+test('structured optional signals retain evidence state, model version, and bounded references', () => {
+  const result = scoreFor(GOLDEN_FIXTURES.smallStable, {
+    structured_signals: {
+      comment_quality: {
+        score: 74,
+        evidence_state: 'inferred',
+        confidence: 0.62,
+        evidence_refs: ['comment-sample-001'],
+        model_version: 'comments-model/v1',
+        sample_size: 50,
+      },
+      commercial_saturation: {
+        score: 38,
+        evidence_state: 'derived',
+        confidence: 0.8,
+        evidence_refs: ['content-analysis-001'],
+      },
+      brand_fit: {
+        score: 82,
+        evidence_state: 'derived',
+        confidence: 0.9,
+        evidence_refs: ['campaign-brief-001'],
+      },
+    },
+  });
+
+  assert.equal(result.component_scores.comment_quality.evidence_state, 'inferred');
+  assert.equal(result.component_scores.comment_quality.model_version, 'comments-model/v1');
+  assert.equal(result.component_scores.comment_quality.score, 74);
+  assert.equal(result.component_scores.brand_fit.score, 82);
+  assert.ok(result.data_coverage > scoreFor(GOLDEN_FIXTURES.smallStable).data_coverage);
+  assertFiniteNumbers(result);
+});
+
+test('same inputs and calculated timestamp are bit-for-bit deterministic', () => {
+  const input = { analytics: analyticsFor(GOLDEN_FIXTURES.viralPost) };
+  assert.deepEqual(computeInfluencerScore(input), computeInfluencerScore(structuredClone(input)));
+});
+
+test('unavailable analytics cannot produce an overall score or confidence', () => {
+  const analytics = analyticsFor({
+    creatorKey: 'creator-unavailable',
+    computedAt: '2026-02-01T00:00:00.000Z',
+    profileSnapshots: [],
+    mediaSnapshots: [],
+  });
+  const result = computeInfluencerScore({ analytics });
+
+  assert.equal(result.overall_score, null);
+  assert.equal(result.confidence_score, 0);
+  assert.equal(result.evidence_state, 'unavailable');
+  assertFiniteNumbers(result);
+});
+
+test('inferred optional signals require closed evidence and model metadata', () => {
+  assert.throws(() => scoreFor(GOLDEN_FIXTURES.smallStable, {
+    structured_signals: {
+      comment_quality: {
+        score: 70,
+        evidence_state: 'inferred',
+        confidence: 0.5,
+        evidence_refs: ['comment-sample-001'],
+      },
+    },
+  }), (error) => error.code === 'INFERRED_SIGNAL_MODEL_REQUIRED');
+});


### PR DESCRIPTION
## Scope

Add the deterministic Influencer Score v0 boundary (M5) over the merged analytics artifact.

## Included

- versioned algorithm and weights configuration;
- engagement quality, growth integrity, content performance, consistency, comment quality, commercial saturation, brand fit, risk and profile integrity components;
- separate overall score, confidence score and data coverage;
- objective confidence factors for history, media, comment sample, freshness, provider reliability, official availability and metric coverage;
- bounded deterministic component explanations, provenance and input fingerprint;
- structured optional signals with evidence/model-version requirements;
- additive PostgreSQL metadata artifact for `weights_version` and repository binding;
- synthetic golden tests and governance coverage.

## Safety and operations

- Missing values remain unavailable and never become zero.
- Follower count is not a quality input; viral/spike behavior is bounded pattern evidence and never a fake-followers fact.
- No LLM scoring, provider transport, scraping, credentials, scheduler, CRM, MCP, runtime route or engagement action.
- The scoring migration is source-controlled and intentionally unapplied; feature flag/grant remain off.
- Rollback: revert this single commit before merge, or revert the merged commit and leave the additive migration unapplied.

## Validation

- 85 focused Influencer Intelligence tests passed through the canonical WSL wrapper.
- architecture, module-catalog and domain-boundary validators passed.