### PR TITLE
feat(influencer-intelligence): add inactive snapshot scheduler contract

### DIFF
--- a/.github/workflows/architecture-governance.yml
+++ b/.github/workflows/architecture-governance.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Validate domain import boundaries
         run: node .github/scripts/validate-domain-boundaries.mjs
       - name: Test Influencer Intelligence contracts, providers and snapshots
-        run: node --test social/influencer-intelligence/tests/contracts.test.mjs social/influencer-intelligence/tests/registry.test.mjs social/influencer-intelligence/tests/providers.test.mjs social/influencer-intelligence/tests/provider-router-contract.test.mjs social/influencer-intelligence/tests/architecture.test.mjs social/influencer-intelligence/tests/data-model.test.mjs social/influencer-intelligence/tests/snapshots.test.mjs social/influencer-intelligence/tests/analytics.test.mjs social/influencer-intelligence/tests/scoring.test.mjs
+        run: node --test social/influencer-intelligence/tests/contracts.test.mjs social/influencer-intelligence/tests/registry.test.mjs social/influencer-intelligence/tests/providers.test.mjs social/influencer-intelligence/tests/provider-router-contract.test.mjs social/influencer-intelligence/tests/architecture.test.mjs social/influencer-intelligence/tests/data-model.test.mjs social/influencer-intelligence/tests/snapshots.test.mjs social/influencer-intelligence/tests/analytics.test.mjs social/influencer-intelligence/tests/scoring.test.mjs social/influencer-intelligence/tests/scheduler.test.mjs
       - name: Validate reproducible staging manifest
         run: node .github/scripts/validate-staging-manifest.mjs
       - name: Validate staging bootstrap safety guards

--- a/orb/engine/workflows/influencer-intelligence-snapshot.json
+++ b/orb/engine/workflows/influencer-intelligence-snapshot.json
@@ -1,0 +1,271 @@
+{
+  "name": "SKINCOS | Influencer Intelligence Snapshot (OFF)",
+  "active": false,
+  "nodes": [
+    {
+      "id": "ii-1",
+      "name": "01_Cron_6h",
+      "type": "n8n-nodes-base.cron",
+      "typeVersion": 1,
+      "position": [
+        0,
+        0
+      ],
+      "parameters": {
+        "triggerTimes": {
+          "item": [
+            {
+              "mode": "everyX",
+              "value": 6,
+              "unit": "hours"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "ii-2",
+      "name": "02_Feature_Gate",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 1,
+      "position": [
+        220,
+        0
+      ],
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const enabled = String($env.INFLUENCER_INTELLIGENCE_ENABLED || 'false').trim().toLowerCase() === 'true';\nconst serviceUrl = String($env.INFLUENCER_INTELLIGENCE_SERVICE_URL || '').trim();\nif (enabled && !/^https?:\\/\\/(127\\.0\\.0\\.1|localhost|[a-z0-9.-]+\\.internal)(?::\\d+)?(?:\\/|$)/i.test(serviceUrl)) {\n  throw new Error('INFLUENCER_INTELLIGENCE_SERVICE_URL must resolve to an internal service');\n}\nreturn [{ json: {\n  enabled,\n  status: enabled ? 'enabled' : 'disabled',\n  reason: enabled ? null : 'feature_flag_off',\n  workflow_version: 'influencer-intelligence-snapshot-workflow/v1',\n  mode: enabled ? 'shadow' : 'off',\n  requested_at: new Date().toISOString()\n} }];"
+      }
+    },
+    {
+      "id": "ii-3",
+      "name": "03_If_Enabled",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 1,
+      "position": [
+        440,
+        0
+      ],
+      "parameters": {
+        "conditions": {
+          "string": [
+            {
+              "value1": "={{String($json.enabled)}}",
+              "operation": "equal",
+              "value2": "true"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "ii-4",
+      "name": "04_Select_Active_Creators",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 1,
+      "position": [
+        680,
+        -80
+      ],
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT DISTINCT ON (r.creator_key)\n  r.creator_key,\n  r.canonical_handle,\n  r.monitoring_interval_hours,\n  i.identity_key,\n  i.provider,\n  i.identity_state,\n  i.evidence_state\nFROM influencer_intelligence.creator_registry r\nJOIN influencer_intelligence.creator_identity i\n  ON i.creator_key = r.creator_key\nWHERE r.monitoring_enabled = true\n  AND r.registry_state = 'candidate'\n  AND i.identity_state = 'active'\n  AND i.evidence_state = 'observed'\n  AND NOT EXISTS (\n    SELECT 1\n    FROM influencer_intelligence.creator_profile_snapshot s\n    WHERE s.creator_key = r.creator_key\n      AND s.observed_at >= now() - make_interval(hours => r.monitoring_interval_hours)\n  )\nORDER BY r.creator_key,\n  CASE i.provider WHEN 'meta-graph' THEN 0 ELSE 1 END,\n  i.observed_at DESC NULLS LAST,\n  i.retrieved_at DESC NULLS LAST\nLIMIT 25;"
+      }
+    },
+    {
+      "id": "ii-5",
+      "name": "05_Build_Bounded_Snapshot_Request",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 1,
+      "position": [
+        900,
+        -80
+      ],
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const rows = $input.all().map((item) => item.json || {}).slice(0, 25);\nconst creators = rows.map((row) => ({\n  creator_key: String(row.creator_key || '').trim(),\n  identity_key: String(row.identity_key || '').trim(),\n  canonical_handle: row.canonical_handle ? String(row.canonical_handle).trim() : null,\n  provider: String(row.provider || '').trim(),\n  operations: ['snapshot_creator', 'snapshot_creator_media'],\n  bucket_seconds: 3600,\n  media_limit: 20\n})).filter((creator) => creator.creator_key && creator.identity_key && ['meta-graph', 'instagrapi'].includes(creator.provider));\nreturn [{ json: {\n  contract_version: 'influencer-intelligence/scheduler/v1',\n  workflow_version: 'influencer-intelligence-snapshot-workflow/v1',\n  mode: 'shadow',\n  max_creators: 25,\n  max_concurrency: 1,\n  timeout_ms: 30000,\n  retry_policy: {\n    max_attempts: 2,\n    same_idempotency_key: true,\n    retryable_classes: ['timeout', 'rate_limited', 'upstream_5xx', 'network_transient']\n  },\n  service_path: '/internal/influencer-intelligence/v1/snapshots',\n  creators\n} }];"
+      }
+    },
+    {
+      "id": "ii-6",
+      "name": "06_Dispatch_And_Register_Snapshot",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [
+        1140,
+        -80
+      ],
+      "retryOnFail": false,
+      "parameters": {
+        "url": "={{$env.INFLUENCER_INTELLIGENCE_SERVICE_URL.replace(/\\/$/, '')}}/internal/influencer-intelligence/v1/snapshots",
+        "method": "POST",
+        "jsonParameters": true,
+        "options": {
+          "timeout": 30000
+        },
+        "bodyParametersJson": "={{$json}}"
+      }
+    },
+    {
+      "id": "ii-7",
+      "name": "07_Record_Bounded_Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 1,
+      "position": [
+        1380,
+        -80
+      ],
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const response = $input.first()?.json || {};\nconst coverage = response.coverage && typeof response.coverage === 'object' ? response.coverage : { state: 'unavailable', available: null, expected: null, ratio: null };\nconst failures = Array.isArray(response.failures) ? response.failures.slice(0, 50).map((failure) => ({ code: String(failure.code || 'provider_failure').slice(0, 80), classification: String(failure.classification || 'permanent').slice(0, 40), retryable: failure.retryable === true })) : [];\nreturn [{ json: {\n  event_type: 'snapshot_result_registered',\n  event_version: 'influencer-intelligence/snapshot-result/v1',\n  status: String(response.status || response.collectorRun?.status || 'failed'),\n  coverage,\n  freshness: response.freshness || { status: 'unknown', observedAt: null, retrievedAt: null, ageSeconds: null },\n  failure_count: failures.length,\n  failures,\n  deduplicated: response.deduplicated === true,\n  no_provider_payload_logged: true,\n  no_credentials_logged: true\n} }];"
+      }
+    },
+    {
+      "id": "ii-8",
+      "name": "08_Feature_Off_Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 1,
+      "position": [
+        680,
+        120
+      ],
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "return [{ json: { event_type: 'snapshot_scheduler_skipped', event_version: 'influencer-intelligence/snapshot-result/v1', status: 'skipped', reason: 'feature_flag_off', no_provider_call: true } }];"
+      }
+    },
+    {
+      "id": "ii-90",
+      "name": "90_Error_Trigger",
+      "type": "n8n-nodes-base.errorTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        320
+      ],
+      "parameters": {}
+    },
+    {
+      "id": "ii-91",
+      "name": "91_Record_Sanitized_Failure",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 1,
+      "position": [
+        240,
+        320
+      ],
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const raw = $input.first()?.json || {};\nconst error = raw.error || {};\nconst message = String(error.message || 'workflow_failure').replace(/(authorization|token|api[_-]?key|secret|cookie|password)\\s*[:=]\\s*[^\\s,\\\"'}]+/ig, '$1=[REDACTED]').slice(0, 500);\nreturn [{ json: { event_type: 'snapshot_scheduler_failure', event_version: 'influencer-intelligence/snapshot-result/v1', status: 'failed', code: String(error.code || 'workflow_failure').slice(0, 80), message, retry_policy: { bounded: true, same_idempotency_key_required: true } } }];"
+      }
+    }
+  ],
+  "connections": {
+    "01_Cron_6h": {
+      "main": [
+        [
+          {
+            "node": "02_Feature_Gate",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "02_Feature_Gate": {
+      "main": [
+        [
+          {
+            "node": "03_If_Enabled",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "03_If_Enabled": {
+      "main": [
+        [
+          {
+            "node": "04_Select_Active_Creators",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "08_Feature_Off_Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "04_Select_Active_Creators": {
+      "main": [
+        [
+          {
+            "node": "05_Build_Bounded_Snapshot_Request",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "05_Build_Bounded_Snapshot_Request": {
+      "main": [
+        [
+          {
+            "node": "06_Dispatch_And_Register_Snapshot",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "06_Dispatch_And_Register_Snapshot": {
+      "main": [
+        [
+          {
+            "node": "07_Record_Bounded_Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "90_Error_Trigger": {
+      "main": [
+        [
+          {
+            "node": "91_Record_Sanitized_Failure",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "timezone": "America/Sao_Paulo",
+    "executionTimeout": 900,
+    "saveExecutionProgress": true,
+    "availableInMCP": false
+  },
+  "meta": {
+    "module": "influencer-intelligence",
+    "contract_version": "influencer-intelligence/scheduler/v1",
+    "workflow_version": "influencer-intelligence-snapshot-workflow/v1",
+    "active_default": false,
+    "feature_flag": "INFLUENCER_INTELLIGENCE_ENABLED",
+    "default_mode": "shadow",
+    "max_concurrency": 1,
+    "max_attempts": 2,
+    "timeout_ms": 30000,
+    "provider_transport": false,
+    "instagram_write": false,
+    "publish_allowed": false,
+    "no_public_webhook": true,
+    "service_path": "/internal/influencer-intelligence/v1/snapshots"
+  }
+}

--- a/social/influencer-intelligence/README.md
+++ b/social/influencer-intelligence/README.md
@@ -139,7 +139,7 @@ calibration dataset exists. The engine does not infer follower quality or fake
 followers and does not connect providers, PostgreSQL, Orb, CRM, or runtime
 routes.
 
-## M3 snapshot operations
+## M3 snapshot operations and Orb source
 
 The bounded internal operations in [`snapshots.mjs`](./snapshots.mjs) now provide
 `snapshot_creator` and `snapshot_creator_media` over the injected provider router
@@ -147,6 +147,13 @@ and PostgreSQL repository. They create and finalize `collector_run` metadata,
 persist provider failures as explicit `collector_evidence`, retain append-only
 profile/media observations, and return freshness, coverage, limitations and
 provider evidence. They do not schedule themselves and do not open a transport.
+
+The inactive Orb export in [`orb/engine/workflows/influencer-intelligence-snapshot.json`](../../orb/engine/workflows/influencer-intelligence-snapshot.json)
+is orchestration-only. It selects explicitly opted-in identities, sends one
+bounded batch to the internal snapshot service, and emits a redacted result
+receipt. The six-hour trigger, one-at-a-time service lease, feature flag,
+two-attempt retry policy, and 30-second timeout are conservative source
+defaults; the workflow is not imported or activated by this milestone.
 
 Snapshot artifact keys are deterministic for creator/provider/media/observed-time
 bucket. A repeat in the same bucket is a no-op; a later bucket records a new
@@ -159,8 +166,9 @@ remains off.
 The operation tests use only injected fixtures and cover first collection,
 replay, metric changes, fallback/partial coverage, timeout, nonexistent and
 private profiles, unavailable media metrics, provenance classification and
-credential rejection. Orb scheduling, Token Vault transport wiring, migration
-application and real provider calls remain later operational gates.
+credential rejection. Token Vault transport wiring, migration application,
+service route mounting, live Orb import and real provider calls remain later
+operational gates.
 
 ## Concrete target architecture
 

--- a/social/influencer-intelligence/SCHEDULER.md
+++ b/social/influencer-intelligence/SCHEDULER.md
@@ -1,0 +1,49 @@
+# Influencer Intelligence snapshot scheduler
+
+The scheduler is a bounded Orb orchestration contract, not a provider or
+analytics runtime. The pure contract lives in [`scheduler.mjs`](./scheduler.mjs)
+and the inactive n8n export lives in
+[`orb/engine/workflows/influencer-intelligence-snapshot.json`](../../orb/engine/workflows/influencer-intelligence-snapshot.json).
+
+## Safety boundary
+
+- `INFLUENCER_INTELLIGENCE_ENABLED` is false by default. The checked-in
+  workflow is `active: false` and starts in `shadow` mode.
+- The SQL node selects only identities with an explicit `monitoring_enabled`
+  opt-in, `identity_state = 'active'`, and observed identity evidence. The
+  additive scheduler migration defaults the opt-in to false.
+- Orb processes one creator at a time (`splitInBatches` batch size 1). The
+  internal service owns the provider router, Token Vault access, snapshot
+  transaction, collector-run persistence, and service-side lease.
+- The workflow posts only to the internal snapshot service. It has no provider
+  URL, credential field, Instagram write operation, scraping node, score, or
+  analytics formula.
+- A transient timeout, rate limit, upstream 5xx, or transient network failure
+  may be retried at most twice with the same idempotency key. Not-found,
+  private, authorization, policy, validation, and unknown failures are not
+  retried by this contract.
+- The receipt contains status, coverage, freshness, failure count, and
+  idempotency metadata only. Missing coverage remains `null`/`unavailable`; it
+  is not changed to zero.
+
+## Configuration
+
+The versioned default is a six-hour interval, one-at-a-time processing, a
+maximum of 25 creators per run, 20 media items per creator, a 30-second service
+timeout, and two total attempts. The workflow remains inactive until the
+service route, migration, flag, grant, lease, and staging evidence are
+independently proven.
+
+The service route is an internal mutation boundary for historical collection:
+
+`POST /internal/influencer-intelligence/v1/snapshots`
+
+It accepts only the bounded snapshot operation contract and must enforce the
+server-side flag/grant, internal authentication, provider selection, timeout,
+lease, idempotency, and redacted structured audit. Orb does not receive or
+forward provider credentials.
+
+## Operational status
+
+This milestone adds source and tests only. It does not import, activate, apply
+the migration, expose the endpoint, or collect real creator data.

--- a/social/influencer-intelligence/architecture.mjs
+++ b/social/influencer-intelligence/architecture.mjs
@@ -126,7 +126,7 @@ export const DATA_MODEL = deepFreeze({
     {
       name: 'creator_registry',
       lifecycle: 'minimal operational binding; current state may transition under explicit policy',
-      fields: ['creatorKey', 'canonicalHandle', 'registryState', 'createdAt', 'updatedAt'],
+      fields: ['creatorKey', 'canonicalHandle', 'registryState', 'monitoringEnabled', 'monitoringIntervalHours', 'createdAt', 'updatedAt'],
     },
     {
       name: 'creator_provider_registry',
@@ -243,6 +243,14 @@ export const API_CONTRACT = deepFreeze({
   responseEnvelope: ['contractVersion', 'requestId', 'generatedAt', 'data', 'coverage', 'provenance', 'errors'],
   routes: [
     {
+      method: 'POST',
+      path: '/internal/influencer-intelligence/v1/snapshots',
+      readOnly: false,
+      caller: 'Orb-only controlled collection operation',
+      purpose: 'Dispatch bounded snapshot_creator and snapshot_creator_media operations through the internal service; persist collector_run and append-only evidence.',
+      controls: ['server-side flag', 'workflow grant', 'internal authentication', 'bounded operation schema', 'lease', 'idempotency', 'redacted audit'],
+    },
+    {
       method: 'GET',
       path: '/internal/influencer-intelligence/v1/creators/{creatorKey}/analysis',
       readOnly: true,
@@ -307,7 +315,7 @@ export const RELEASE_CONTRACT = deepFreeze({
     providerCalls: false,
     crmRegistered: false,
     mcpRegistered: false,
-    orbWorkflowChanged: false,
+    orbWorkflowChanged: true,
   },
 });
 
@@ -333,9 +341,9 @@ export const IMPLEMENTATION_PLAN = deepFreeze([
   { id: 'M0', title: 'Normalized contracts', status: 'merged #1303', acceptance: ['pure versioned evidence, provenance, coverage, signal, and score envelopes'] },
   { id: 'M1', title: 'Creator registry and additive PostgreSQL artifact', status: 'merged #1304; unapplied artifact', acceptance: ['minimal pseudonymous registry', 'additive/idempotent SQL', 'destination and grant gates before apply'] },
   { id: 'M2', title: 'Official-first provider router and bounded collectors', status: 'merged #1305; synthetic transport only', acceptance: ['Meta first', 'controlled instagrapi fallback', 'fail-closed classification', 'no duplicate scraper'] },
-  { id: 'M3', title: 'Append-only snapshots, retention, and Orb job contract', status: 'snapshot operations implemented; Orb scheduling pending', acceptance: ['new additive tables', 'immutable evidence lifecycle', 'bounded snapshot_creator and snapshot_creator_media operations', 'dry-run/shadow scheduling', 'resume/recovery without live workflow import'] },
-  { id: 'M4', title: 'Robust analytics', status: 'implemented in this PR; pure deterministic ESM boundary', acceptance: ['time windows', 'viral-outlier resistance', 'explicit unavailable coverage'] },
-  { id: 'M5', title: 'Deterministic scores and confidence', status: 'implemented in this PR; weights and algorithm versioned', acceptance: ['versioned algorithms', 'score/confidence/coverage/provenance completeness', 'calibration fixtures'] },
+  { id: 'M3', title: 'Append-only snapshots, retention, and Orb job contract', status: 'workflow source and contract implemented; import/runtime pending', acceptance: ['new additive tables', 'immutable evidence lifecycle', 'bounded snapshot_creator and snapshot_creator_media operations', 'inactive dry-run/shadow scheduling', 'resume/recovery with idempotent service calls', 'no live workflow import'] },
+  { id: 'M4', title: 'Robust analytics', status: 'merged #1333; synthetic source/tests only', acceptance: ['time windows', 'viral-outlier resistance', 'explicit unavailable coverage'] },
+  { id: 'M5', title: 'Deterministic scores and confidence', status: 'merged #1334; synthetic source/tests only', acceptance: ['versioned algorithms', 'score/confidence/coverage/provenance completeness', 'calibration fixtures'] },
   { id: 'M6', title: 'Hardened read-only MCP', status: 'pending', acceptance: ['auth', 'sanitization', 'rate limit', 'timeout', 'audit', 'bounded tools', 'read-only role'] },
   { id: 'M7', title: 'Codex skill', status: 'pending', acceptance: ['read-only tool use', 'safe question routing', 'no provider or shell bypass'] },
   { id: 'M8', title: 'CRM read-only surface', status: 'pending', acceptance: ['internal API only', 'server grant and flag', 'shadow UI', 'no direct provider access'] },

--- a/social/influencer-intelligence/migrations/20260811_influencer_intelligence_scheduler_v1.up.sql
+++ b/social/influencer-intelligence/migrations/20260811_influencer_intelligence_scheduler_v1.up.sql
@@ -1,0 +1,41 @@
+-- Influencer Intelligence scheduler opt-in metadata v1.
+--
+-- This is an additive, unapplied artifact. It gives the Orb selector an
+-- explicit server-side opt-in instead of treating every registry candidate as
+-- a monitored creator. The default is fail-closed (disabled).
+
+BEGIN;
+SET LOCAL TIME ZONE 'UTC';
+
+DO $$
+BEGIN
+  IF to_regclass('influencer_intelligence.creator_registry') IS NULL
+    OR to_regclass('influencer_intelligence.schema_migrations') IS NULL THEN
+    RAISE EXCEPTION 'influencer intelligence registry v1 is required before scheduler v1';
+  END IF;
+END
+$$;
+
+ALTER TABLE influencer_intelligence.creator_registry
+  ADD COLUMN IF NOT EXISTS monitoring_enabled boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS monitoring_interval_hours integer NOT NULL DEFAULT 6;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'creator_registry_monitoring_interval_check'
+      AND conrelid = 'influencer_intelligence.creator_registry'::regclass
+  ) THEN
+    ALTER TABLE influencer_intelligence.creator_registry
+      ADD CONSTRAINT creator_registry_monitoring_interval_check
+      CHECK (monitoring_interval_hours BETWEEN 6 AND 168);
+  END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS creator_registry_monitoring_queue_idx
+  ON influencer_intelligence.creator_registry (monitoring_enabled, monitoring_interval_hours, updated_at)
+  WHERE monitoring_enabled = true;
+
+COMMIT;

--- a/social/influencer-intelligence/scheduler.mjs
+++ b/social/influencer-intelligence/scheduler.mjs
@@ -1,0 +1,471 @@
+import { createHash } from 'node:crypto';
+
+import {
+  normalizeCanonicalHandle,
+  normalizeCreatorKey,
+  normalizeProviderId,
+  SUPPORTED_PROVIDER_IDS,
+} from './contracts.mjs';
+
+/**
+ * Pure contract for Orb's bounded snapshot orchestration.
+ *
+ * Orb may select, dispatch, and record a result. It must not contain provider
+ * transport, credentials, analytics, scoring, or arbitrary query logic. The
+ * internal service owns the snapshot operation and reuses the same
+ * idempotency key for safe transient retries.
+ */
+export const SCHEDULER_CONTRACT_VERSION = 'influencer-intelligence/scheduler/v1';
+export const SCHEDULER_WORKFLOW_VERSION = 'influencer-intelligence-snapshot-workflow/v1';
+export const SNAPSHOT_SERVICE_PATH = '/internal/influencer-intelligence/v1/snapshots';
+export const SNAPSHOT_OPERATIONS = Object.freeze([
+  'snapshot_creator',
+  'snapshot_creator_media',
+]);
+export const RETRYABLE_FAILURE_CLASSES = Object.freeze([
+  'timeout',
+  'rate_limited',
+  'upstream_5xx',
+  'network_transient',
+]);
+export const DEFAULT_SCHEDULER_CONFIG = Object.freeze({
+  enabled: false,
+  mode: 'shadow',
+  intervalHours: 6,
+  maxCreatorsPerRun: 25,
+  concurrency: 1,
+  maxAttempts: 2,
+  timeoutMs: 30_000,
+  mediaLimit: 20,
+  bucketSeconds: 3_600,
+});
+
+const MODES = new Set(['dry-run', 'shadow', 'active']);
+const FAILURE_CLASSES = new Set(RETRYABLE_FAILURE_CLASSES);
+const SAFE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
+
+export class SnapshotSchedulerError extends Error {
+  constructor(code, details = {}) {
+    super(`Influencer Intelligence scheduler failed: ${code}`);
+    this.name = 'SnapshotSchedulerError';
+    this.code = code;
+    this.details = details;
+  }
+
+  toJSON() {
+    return {
+      code: this.code,
+      ...(Object.keys(this.details).length > 0 ? { details: this.details } : {}),
+    };
+  }
+}
+
+function fail(code, details = {}) {
+  throw new SnapshotSchedulerError(code, details);
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function boundedInteger(value, label, { fallback, minimum, maximum }) {
+  const candidate = value === undefined ? fallback : value;
+  if (!Number.isInteger(candidate) || candidate < minimum || candidate > maximum) {
+    fail(`${label.toUpperCase()}_INVALID`, { minimum, maximum });
+  }
+  return candidate;
+}
+
+function isoTimestamp(value, label, fallback = new Date()) {
+  const source = value === undefined || value === null ? fallback : value;
+  const date = source instanceof Date ? source : new Date(source);
+  if (Number.isNaN(date.getTime())) fail(`${label.toUpperCase()}_INVALID`);
+  return date.toISOString();
+}
+
+function stableSerialize(value) {
+  if (value === null) return 'null';
+  if (value === undefined) return 'undefined';
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map(stableSerialize).join(',')}]`;
+  if (isRecord(value)) {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableSerialize(value[key])}`).join(',')}}`;
+  }
+  fail('UNSAFE_HASH_INPUT');
+}
+
+function hash(value) {
+  return createHash('sha256').update(stableSerialize(value), 'utf8').digest('hex');
+}
+
+function bucketStart(timestamp, bucketSeconds) {
+  const seconds = Math.floor(Date.parse(timestamp) / 1000);
+  return new Date(Math.floor(seconds / bucketSeconds) * bucketSeconds * 1000).toISOString();
+}
+
+function creatorKey(value) {
+  try {
+    return normalizeCreatorKey(value);
+  } catch {
+    fail('CREATOR_KEY_INVALID');
+  }
+}
+
+function identityKey(value) {
+  if (typeof value !== 'string' || !/^[A-Za-z0-9._:-]{1,160}$/.test(value.trim())) {
+    fail('IDENTITY_KEY_INVALID');
+  }
+  return value.trim();
+}
+
+function providerId(value) {
+  try {
+    const normalized = normalizeProviderId(value);
+    if (!SUPPORTED_PROVIDER_IDS.includes(normalized)) fail('PROVIDER_NOT_ALLOWED');
+    return normalized;
+  } catch (error) {
+    if (error instanceof SnapshotSchedulerError) throw error;
+    fail('PROVIDER_INVALID');
+  }
+}
+
+function normalizeMode(value) {
+  const mode = value === undefined ? DEFAULT_SCHEDULER_CONFIG.mode : value;
+  if (typeof mode !== 'string' || !MODES.has(mode)) fail('MODE_INVALID');
+  return mode;
+}
+
+export function normalizeSchedulerConfig(input = {}) {
+  if (!isRecord(input)) fail('CONFIG_INVALID');
+  const config = {
+    enabled: input.enabled === undefined ? DEFAULT_SCHEDULER_CONFIG.enabled : input.enabled,
+    mode: normalizeMode(input.mode),
+    intervalHours: boundedInteger(input.intervalHours, 'intervalHours', {
+      fallback: DEFAULT_SCHEDULER_CONFIG.intervalHours,
+      minimum: 6,
+      maximum: 168,
+    }),
+    maxCreatorsPerRun: boundedInteger(input.maxCreatorsPerRun, 'maxCreatorsPerRun', {
+      fallback: DEFAULT_SCHEDULER_CONFIG.maxCreatorsPerRun,
+      minimum: 1,
+      maximum: 100,
+    }),
+    concurrency: boundedInteger(input.concurrency, 'concurrency', {
+      fallback: DEFAULT_SCHEDULER_CONFIG.concurrency,
+      minimum: 1,
+      maximum: 4,
+    }),
+    maxAttempts: boundedInteger(input.maxAttempts, 'maxAttempts', {
+      fallback: DEFAULT_SCHEDULER_CONFIG.maxAttempts,
+      minimum: 1,
+      maximum: 3,
+    }),
+    timeoutMs: boundedInteger(input.timeoutMs, 'timeoutMs', {
+      fallback: DEFAULT_SCHEDULER_CONFIG.timeoutMs,
+      minimum: 1_000,
+      maximum: 120_000,
+    }),
+    mediaLimit: boundedInteger(input.mediaLimit, 'mediaLimit', {
+      fallback: DEFAULT_SCHEDULER_CONFIG.mediaLimit,
+      minimum: 1,
+      maximum: 50,
+    }),
+    bucketSeconds: boundedInteger(input.bucketSeconds, 'bucketSeconds', {
+      fallback: DEFAULT_SCHEDULER_CONFIG.bucketSeconds,
+      minimum: 900,
+      maximum: 86_400,
+    }),
+  };
+  if (typeof config.enabled !== 'boolean') fail('ENABLED_INVALID');
+  return Object.freeze(config);
+}
+
+function skip(reason, row = {}) {
+  return {
+    reason,
+    creatorKey: typeof row.creator_key === 'string' ? row.creator_key : null,
+  };
+}
+
+/**
+ * Selects only explicitly opted-in, observed identities. Missing or malformed
+ * rows are skipped and surfaced; they are never converted into a job.
+ */
+export function selectActiveCreators(rows, { config = DEFAULT_SCHEDULER_CONFIG } = {}) {
+  const normalizedConfig = normalizeSchedulerConfig(config);
+  if (!Array.isArray(rows)) fail('CREATOR_ROWS_INVALID');
+  if (!normalizedConfig.enabled) {
+    return Object.freeze({
+      contractVersion: SCHEDULER_CONTRACT_VERSION,
+      status: 'disabled',
+      reason: 'feature_flag_off',
+      selected: Object.freeze([]),
+      skipped: Object.freeze([]),
+    });
+  }
+
+  const selected = [];
+  const skipped = [];
+  const seen = new Set();
+  for (const row of rows) {
+    if (!isRecord(row)) {
+      skipped.push(skip('row_invalid'));
+      continue;
+    }
+    if (row.monitoring_enabled !== true) {
+      skipped.push(skip('monitoring_not_enabled', row));
+      continue;
+    }
+    if (row.identity_state !== 'active' || row.evidence_state !== 'observed') {
+      skipped.push(skip('identity_not_observed_active', row));
+      continue;
+    }
+    let normalizedCreator;
+    let normalizedIdentity;
+    let normalizedProvider;
+    try {
+      normalizedCreator = creatorKey(row.creator_key ?? row.creatorKey);
+      normalizedIdentity = identityKey(row.identity_key ?? row.identityKey);
+      normalizedProvider = providerId(row.provider);
+    } catch {
+      skipped.push(skip('identity_row_invalid', row));
+      continue;
+    }
+    if (seen.has(normalizedCreator)) {
+      skipped.push({ reason: 'duplicate_creator', creatorKey: normalizedCreator });
+      continue;
+    }
+    seen.add(normalizedCreator);
+    const handleValue = row.canonical_handle ?? row.canonicalHandle;
+    let canonicalHandle = null;
+    if (handleValue !== undefined && handleValue !== null && handleValue !== '') {
+      try {
+        canonicalHandle = normalizeCanonicalHandle(handleValue) || null;
+      } catch {
+        skipped.push({ reason: 'canonical_handle_invalid', creatorKey: normalizedCreator });
+        continue;
+      }
+    }
+    selected.push(Object.freeze({
+      creatorKey: normalizedCreator,
+      identityKey: normalizedIdentity,
+      provider: normalizedProvider,
+      ...(canonicalHandle ? { canonicalHandle } : {}),
+    }));
+    if (selected.length >= normalizedConfig.maxCreatorsPerRun) break;
+  }
+  return Object.freeze({
+    contractVersion: SCHEDULER_CONTRACT_VERSION,
+    status: 'ready',
+    reason: null,
+    selected: Object.freeze(selected),
+    skipped: Object.freeze(skipped),
+  });
+}
+
+function requestKeys(operation, creator, bucket) {
+  const fingerprint = hash({ operation, creatorKey: creator.creatorKey, bucket });
+  return {
+    idempotencyKey: `ii:${operation.replace(/_/g, '-')}:${fingerprint.slice(0, 48)}`,
+    runKey: `ii:run:${operation.replace(/_/g, '-')}:${fingerprint.slice(0, 48)}`,
+  };
+}
+
+/**
+ * Produces two service jobs per selected creator. The same IDs are reused on a
+ * replay, so a timeout cannot create a second historical observation.
+ */
+export function buildSnapshotJobs(selection, {
+  config = DEFAULT_SCHEDULER_CONFIG,
+  now,
+} = {}) {
+  const normalizedConfig = normalizeSchedulerConfig(config);
+  if (!isRecord(selection) || !Array.isArray(selection.selected)) fail('SELECTION_INVALID');
+  const requestedAt = isoTimestamp(now, 'requestedAt');
+  const bucket = bucketStart(requestedAt, normalizedConfig.bucketSeconds);
+  const schedulerRunKey = `ii:scheduler:${hash({ bucket, mode: normalizedConfig.mode }).slice(0, 48)}`;
+  if (!normalizedConfig.enabled) {
+    return Object.freeze({
+      contractVersion: SCHEDULER_CONTRACT_VERSION,
+      schedulerRunKey,
+      status: 'disabled',
+      bucket,
+      jobs: Object.freeze([]),
+    });
+  }
+
+  const jobs = [];
+  for (const creator of selection.selected) {
+    for (const operation of SNAPSHOT_OPERATIONS) {
+      const keys = requestKeys(operation, creator, bucket);
+      jobs.push(Object.freeze({
+        contractVersion: SCHEDULER_CONTRACT_VERSION,
+        workflowVersion: SCHEDULER_WORKFLOW_VERSION,
+        schedulerRunKey,
+        operation,
+        creatorKey: creator.creatorKey,
+        identityKey: creator.identityKey,
+        ...(creator.canonicalHandle ? { canonicalHandle: creator.canonicalHandle } : {}),
+        mode: normalizedConfig.mode,
+        bucketSeconds: normalizedConfig.bucketSeconds,
+        limit: operation === 'snapshot_creator_media' ? normalizedConfig.mediaLimit : 1,
+        timeoutMs: normalizedConfig.timeoutMs,
+        maxAttempts: normalizedConfig.maxAttempts,
+        idempotencyKey: keys.idempotencyKey,
+        runKey: keys.runKey,
+        internalService: {
+          method: 'POST',
+          path: SNAPSHOT_SERVICE_PATH,
+          providerTransport: false,
+          credentialSource: 'service-runtime-token-vault',
+        },
+        retryPolicy: {
+          maxAttempts: normalizedConfig.maxAttempts,
+          sameIdempotencyKey: true,
+          retryableClasses: [...RETRYABLE_FAILURE_CLASSES],
+        },
+      }));
+    }
+  }
+  return Object.freeze({
+    contractVersion: SCHEDULER_CONTRACT_VERSION,
+    schedulerRunKey,
+    status: 'ready',
+    bucket,
+    jobs: Object.freeze(jobs),
+  });
+}
+
+function normalizedFailureClass(value) {
+  return String(value || '').trim().toLowerCase().replace(/[-\s]+/g, '_');
+}
+
+export function classifySnapshotFailure(input = {}) {
+  if (!isRecord(input)) fail('FAILURE_INVALID');
+  const statusCode = Number(input.statusCode ?? input.status_code ?? 0);
+  const explicit = normalizedFailureClass(input.classification ?? input.failure_class);
+  const code = normalizedFailureClass(input.code ?? input.reasonCode ?? input.reason_code);
+  const alias = (value) => {
+    if (FAILURE_CLASSES.has(value)) return value;
+    if (/timeout|deadline_exceeded|timed_out/.test(value)) return 'timeout';
+    if (/rate[_-]?limit|throttl/.test(value)) return 'rate_limited';
+    if (/5xx|upstream[_-]?error|bad_gateway|service_unavailable/.test(value)) return 'upstream_5xx';
+    if (/network|econnreset|eai_again|connection_reset/.test(value)) return 'network_transient';
+    return null;
+  };
+  const classification = alias(explicit)
+    || alias(code)
+    || (SAFE_STATUS_CODES.has(statusCode)
+      ? statusCode === 408 ? 'timeout' : statusCode === 429 ? 'rate_limited' : 'upstream_5xx'
+      : 'permanent');
+  const attempt = boundedInteger(input.attempt, 'attempt', { fallback: 1, minimum: 1, maximum: 100 });
+  const maxAttempts = boundedInteger(input.maxAttempts, 'maxAttempts', { fallback: DEFAULT_SCHEDULER_CONFIG.maxAttempts, minimum: 1, maximum: 3 });
+  return Object.freeze({
+    classification,
+    retryable: FAILURE_CLASSES.has(classification) && attempt < maxAttempts,
+    attempt,
+    maxAttempts,
+    sameIdempotencyKey: FAILURE_CLASSES.has(classification),
+  });
+}
+
+function safeStatus(value) {
+  const status = String(value || '').trim().toLowerCase();
+  return ['completed', 'partial', 'unavailable', 'failed', 'skipped'].includes(status) ? status : 'failed';
+}
+
+function safeCoverage(value) {
+  if (!isRecord(value)) return { state: 'unavailable', available: null, expected: null, ratio: null };
+  const available = value.available ?? value.availableMetrics ?? null;
+  const expected = value.expected ?? value.expectedMetrics ?? null;
+  const ratio = value.ratio === undefined || value.ratio === null ? null : Number(value.ratio);
+  if (available !== null && (!Number.isInteger(available) || available < 0)) return { state: 'unavailable', available: null, expected: null, ratio: null };
+  if (expected !== null && (!Number.isInteger(expected) || expected < 0)) return { state: 'unavailable', available: null, expected: null, ratio: null };
+  if (ratio !== null && (!Number.isFinite(ratio) || ratio < 0 || ratio > 1)) return { state: 'unavailable', available: null, expected: null, ratio: null };
+  return {
+    state: value.state || (available === null || expected === null ? 'unavailable' : 'available'),
+    available,
+    expected,
+    ratio,
+  };
+}
+
+function safeFreshness(value) {
+  if (!isRecord(value)) return { status: 'unknown', observedAt: null, retrievedAt: null, ageSeconds: null };
+  return {
+    status: ['fresh', 'stale', 'unknown'].includes(value.status) ? value.status : 'unknown',
+    observedAt: value.observedAt ?? value.observed_at ?? null,
+    retrievedAt: value.retrievedAt ?? value.retrieved_at ?? null,
+    ageSeconds: Number.isInteger(value.ageSeconds ?? value.age_seconds) ? (value.ageSeconds ?? value.age_seconds) : null,
+  };
+}
+
+function safeFailures(value) {
+  if (!Array.isArray(value)) return [];
+  return value.slice(0, 50).map((failure) => ({
+    code: safeCode(failure?.code || failure?.reasonCode, 'provider_failure'),
+    classification: safeCode(failure?.classification, 'permanent'),
+    retryable: failure?.retryable === true,
+  }));
+}
+
+function safeCode(value, fallback) {
+  const normalized = String(value || '').trim().toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 80);
+  return normalized || fallback;
+}
+
+/**
+ * Reduces the internal service response to a bounded workflow receipt. No
+ * provider payload, metric, credential, or raw error is copied into the log.
+ */
+export function normalizeSnapshotResult(result, job) {
+  if (!isRecord(result) || !isRecord(job)) fail('RESULT_INVALID');
+  const status = safeStatus(result.status ?? result.collectorRun?.status);
+  const failures = safeFailures(result.failures ?? result.collectorRun?.failures);
+  return Object.freeze({
+    contractVersion: SCHEDULER_CONTRACT_VERSION,
+    operation: job.operation,
+    creatorKey: job.creatorKey,
+    schedulerRunKey: job.schedulerRunKey,
+    idempotencyKey: job.idempotencyKey,
+    runKey: job.runKey,
+    status,
+    collectorRunStatus: String(result.collectorRun?.status || status).slice(0, 32),
+    coverage: safeCoverage(result.coverage ?? result.collectorRun?.coverage),
+    freshness: safeFreshness(result.freshness ?? result.collectorRun?.freshness),
+    failures,
+    failureCount: failures.length,
+    deduplicated: result.deduplicated === true,
+    limitations: Array.isArray(result.limitations) ? result.limitations.map((item) => safeCode(item, 'limitation')).slice(0, 20) : [],
+  });
+}
+
+export function buildResultRegistrationEvent(job, result, { attempt = 1 } = {}) {
+  const normalizedResult = normalizeSnapshotResult(result, job);
+  const retry = classifySnapshotFailure({
+    classification: normalizedResult.failures[0]?.classification,
+    attempt,
+    maxAttempts: job.maxAttempts,
+  });
+  return Object.freeze({
+    eventVersion: 'influencer-intelligence/snapshot-result/v1',
+    eventType: 'snapshot_result_registered',
+    eventId: `ii:result:${hash({ idempotencyKey: job.idempotencyKey, status: normalizedResult.status }).slice(0, 48)}`,
+    idempotencyKey: `${job.idempotencyKey}:result`,
+    schedulerRunKey: job.schedulerRunKey,
+    operation: job.operation,
+    creatorKey: job.creatorKey,
+    attempt,
+    status: normalizedResult.status,
+    coverage: normalizedResult.coverage,
+    freshness: normalizedResult.freshness,
+    failureCount: normalizedResult.failureCount,
+    retry: {
+      classification: retry.classification,
+      retryable: normalizedResult.status === 'failed' && retry.retryable,
+      sameIdempotencyKey: retry.sameIdempotencyKey,
+    },
+  });
+}

--- a/social/influencer-intelligence/tests/architecture.test.mjs
+++ b/social/influencer-intelligence/tests/architecture.test.mjs
@@ -120,8 +120,11 @@ test('requires deterministic score identity, coverage, and structured signals', 
   assert.equal(PRIVACY_CONTRACT.neverPersisted.includes('raw comment text by default'), true);
 });
 
-test('keeps API and MCP contracts read-only and bounded', () => {
-  assert.ok(API_CONTRACT.routes.every(({ readOnly }) => readOnly === true));
+test('keeps API reads and MCP tools read-only while isolating Orb collection', () => {
+  const snapshotRoute = API_CONTRACT.routes.find(({ path }) => path.endsWith('/snapshots'));
+  assert.equal(snapshotRoute?.readOnly, false);
+  assert.equal(snapshotRoute?.caller, 'Orb-only controlled collection operation');
+  assert.ok(API_CONTRACT.routes.filter(({ path }) => !path.endsWith('/snapshots')).every(({ readOnly }) => readOnly === true));
   assert.equal(API_CONTRACT.requestRules.maxCreatorsPerRequest, 20);
   assert.equal(API_CONTRACT.requestRules.maxWindowDays, 365);
   for (const control of ['authentication', 'server-side grant', 'schema sanitization', 'rate limit', 'timeout and abort', 'audit event', 'read-only database role']) {
@@ -141,7 +144,7 @@ test('keeps this architecture milestone off and runtime-free', () => {
   assert.equal(RELEASE_CONTRACT.architecturePrScope.providerCalls, false);
   assert.equal(RELEASE_CONTRACT.architecturePrScope.crmRegistered, false);
   assert.equal(RELEASE_CONTRACT.architecturePrScope.mcpRegistered, false);
-  assert.equal(RELEASE_CONTRACT.architecturePrScope.orbWorkflowChanged, false);
+  assert.equal(RELEASE_CONTRACT.architecturePrScope.orbWorkflowChanged, true);
 
   const source = fs.readFileSync(architecturePath, 'utf8');
   assert.doesNotMatch(source, /\b(?:fetch|spawn|exec|execFile|createServer|listen)\s*\(/i);

--- a/social/influencer-intelligence/tests/scheduler.test.mjs
+++ b/social/influencer-intelligence/tests/scheduler.test.mjs
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  DEFAULT_SCHEDULER_CONFIG,
+  RETRYABLE_FAILURE_CLASSES,
+  SNAPSHOT_SERVICE_PATH,
+  SCHEDULER_CONTRACT_VERSION,
+  buildResultRegistrationEvent,
+  buildSnapshotJobs,
+  classifySnapshotFailure,
+  normalizeSchedulerConfig,
+  normalizeSnapshotResult,
+  selectActiveCreators,
+} from '../scheduler.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const domainRoot = path.resolve(here, '..');
+const workflowPath = path.resolve(domainRoot, '..', '..', 'orb', 'engine', 'workflows', 'influencer-intelligence-snapshot.json');
+const migrationPath = path.join(domainRoot, 'migrations', '20260811_influencer_intelligence_scheduler_v1.up.sql');
+
+const baseConfig = {
+  ...DEFAULT_SCHEDULER_CONFIG,
+  enabled: true,
+};
+
+function creatorRow(overrides = {}) {
+  return {
+    creator_key: 'creator:synthetic-001',
+    identity_key: 'identity:synthetic-001',
+    provider: 'meta-graph',
+    canonical_handle: 'synthetic.creator',
+    identity_state: 'active',
+    evidence_state: 'observed',
+    monitoring_enabled: true,
+    ...overrides,
+  };
+}
+
+test('scheduler defaults are conservative and fail closed', () => {
+  const config = normalizeSchedulerConfig();
+  assert.equal(config.enabled, false);
+  assert.equal(config.mode, 'shadow');
+  assert.equal(config.intervalHours, 6);
+  assert.equal(config.maxCreatorsPerRun, 25);
+  assert.equal(config.concurrency, 1);
+  assert.equal(config.maxAttempts, 2);
+  assert.equal(config.timeoutMs, 30_000);
+  assert.equal(config.mediaLimit, 20);
+});
+
+test('selection requires explicit monitoring opt-in and observed active identity', () => {
+  const result = selectActiveCreators([
+    creatorRow(),
+    creatorRow({ creator_key: 'creator:disabled', monitoring_enabled: false }),
+    creatorRow({ creator_key: 'creator:private', identity_state: 'unavailable' }),
+    creatorRow({ creator_key: 'creator:gap', evidence_state: 'unavailable' }),
+    creatorRow({ creator_key: 'creator:external', provider: 'modash' }),
+    creatorRow(),
+  ], { config: baseConfig });
+
+  assert.equal(result.status, 'ready');
+  assert.deepEqual(result.selected.map((item) => item.creatorKey), ['creator:synthetic-001']);
+  assert.equal(result.skipped.length, 5);
+  assert.equal(result.skipped.some((item) => item.reason === 'monitoring_not_enabled'), true);
+  assert.equal(result.skipped.some((item) => item.reason === 'identity_not_observed_active'), true);
+  assert.equal(result.skipped.some((item) => item.reason === 'identity_row_invalid'), true);
+  assert.equal(result.skipped.some((item) => item.reason === 'duplicate_creator'), true);
+});
+
+test('selection is bounded and disabled selection performs no work', () => {
+  const rows = Array.from({ length: 30 }, (_, index) => creatorRow({
+    creator_key: `creator:synthetic-${String(index).padStart(3, '0')}`,
+    identity_key: `identity:synthetic-${String(index).padStart(3, '0')}`,
+  }));
+  const bounded = selectActiveCreators(rows, {
+    config: { ...baseConfig, maxCreatorsPerRun: 3 },
+  });
+  assert.equal(bounded.selected.length, 3);
+
+  const disabled = selectActiveCreators(rows, { config: { ...baseConfig, enabled: false } });
+  assert.equal(disabled.status, 'disabled');
+  assert.deepEqual(disabled.selected, []);
+
+  const partialConfig = selectActiveCreators([creatorRow()], { config: { enabled: true } });
+  assert.equal(partialConfig.status, 'ready');
+  assert.equal(partialConfig.selected.length, 1);
+});
+
+test('jobs cover both snapshot operations and are deterministic across replay', () => {
+  const selection = selectActiveCreators([creatorRow()], { config: baseConfig });
+  const first = buildSnapshotJobs(selection, {
+    config: baseConfig,
+    now: '2026-08-11T14:23:00.000Z',
+  });
+  const replay = buildSnapshotJobs(selection, {
+    config: baseConfig,
+    now: '2026-08-11T14:59:00.000Z',
+  });
+
+  assert.equal(first.contractVersion, SCHEDULER_CONTRACT_VERSION);
+  assert.equal(first.jobs.length, 2);
+  assert.deepEqual(first.jobs.map((job) => job.operation), ['snapshot_creator', 'snapshot_creator_media']);
+  assert.equal(first.jobs[1].limit, 20);
+  assert.equal(first.jobs[0].limit, 1);
+  assert.equal(first.jobs[0].internalService.path, SNAPSHOT_SERVICE_PATH);
+  assert.equal(first.jobs[0].internalService.providerTransport, false);
+  assert.deepEqual(first.jobs.map((job) => job.idempotencyKey), replay.jobs.map((job) => job.idempotencyKey));
+  assert.deepEqual(first.jobs.map((job) => job.runKey), replay.jobs.map((job) => job.runKey));
+  assert.deepEqual(first.jobs[0].retryPolicy.retryableClasses, [...RETRYABLE_FAILURE_CLASSES]);
+  assert.equal(/access[_-]?token|api[_-]?key|secret|password|cookie|session|authorization/i.test(JSON.stringify(first.jobs)), false);
+});
+
+test('retry policy retries only bounded transient classes with the same identity', () => {
+  assert.deepEqual(classifySnapshotFailure({ code: 'timeout', attempt: 1, maxAttempts: 2 }), {
+    classification: 'timeout',
+    retryable: true,
+    attempt: 1,
+    maxAttempts: 2,
+    sameIdempotencyKey: true,
+  });
+  assert.equal(classifySnapshotFailure({ statusCode: 429, attempt: 2, maxAttempts: 2 }).retryable, false);
+  assert.equal(classifySnapshotFailure({ code: 'not_found', attempt: 1, maxAttempts: 2 }).retryable, false);
+  assert.equal(classifySnapshotFailure({ code: 'provider_timeout', attempt: 1, maxAttempts: 2 }).classification, 'timeout');
+});
+
+test('result receipts preserve unavailable coverage and never synthesize zero', () => {
+  const selection = selectActiveCreators([creatorRow()], { config: baseConfig });
+  const jobs = buildSnapshotJobs(selection, { config: baseConfig, now: '2026-08-11T14:23:00Z' });
+  const job = jobs.jobs[1];
+  const result = normalizeSnapshotResult({
+    status: 'partial',
+    collectorRun: { status: 'partial' },
+    freshness: { status: 'stale' },
+    failures: [{ code: 'views_unavailable', classification: 'permanent' }],
+  }, job);
+  assert.equal(result.coverage.state, 'unavailable');
+  assert.equal(result.coverage.available, null);
+  assert.equal(result.coverage.expected, null);
+  assert.equal(result.coverage.ratio, null);
+  assert.equal(result.failureCount, 1);
+
+  const event = buildResultRegistrationEvent(job, { status: 'failed' }, { attempt: 2 });
+  assert.equal(event.status, 'failed');
+  assert.equal(event.retry.retryable, false);
+  assert.equal(event.coverage.available, null);
+  assert.equal(event.coverage.ratio, null);
+});
+
+test('workflow is inactive, internal-only, bounded, and contains no provider credentials or write action', () => {
+  const raw = fs.readFileSync(workflowPath, 'utf8');
+  const workflow = JSON.parse(raw);
+  assert.equal(workflow.active, false);
+  assert.equal(workflow.meta.active_default, false);
+  assert.equal(workflow.meta.max_concurrency, 1);
+  assert.equal(workflow.meta.publish_allowed, false);
+  assert.equal(workflow.meta.instagram_write, false);
+  assert.equal(workflow.meta.provider_transport, false);
+  assert.equal(workflow.nodes.some((node) => node.credentials), false);
+  assert.equal(workflow.nodes.some((node) => /graph\.facebook|graph\.instagram|instaloader/i.test(JSON.stringify(node))), false);
+  assert.equal(workflow.nodes.some((node) => /follow|like|comment|direct.message|publish|scrap/i.test(JSON.stringify(node.parameters))), false);
+  assert.equal(workflow.nodes.filter((node) => node.type === 'n8n-nodes-base.httpRequest').length, 1);
+  assert.equal(workflow.nodes.find((node) => node.name === '01_Cron_6h').parameters.triggerTimes.item[0].value, 6);
+  assert.equal(workflow.nodes.find((node) => node.name === '06_Dispatch_And_Register_Snapshot').parameters.options.timeout, 30_000);
+});
+
+test('scheduler migration is additive and defaults monitoring off', () => {
+  const sql = fs.readFileSync(migrationPath, 'utf8');
+  assert.match(sql, /BEGIN;/);
+  assert.match(sql, /COMMIT;/);
+  assert.match(sql, /ADD COLUMN IF NOT EXISTS monitoring_enabled boolean NOT NULL DEFAULT false/i);
+  assert.match(sql, /ADD COLUMN IF NOT EXISTS monitoring_interval_hours integer NOT NULL DEFAULT 6/i);
+  assert.match(sql, /CREATE INDEX IF NOT EXISTS/i);
+  assert.doesNotMatch(sql, /\bDROP\s+(TABLE|COLUMN|SCHEMA)|\bTRUNCATE\b|\bDELETE\s+FROM\b/i);
+});


### PR DESCRIPTION
## Summary
- add a versioned, inactive Orb workflow for bounded snapshot orchestration
- add explicit monitoring opt-in migration (default false) and pure scheduler/retry/result contracts
- keep provider transport, Token Vault, persistence, analytics, scoring, and service auth outside Orb
- extend architecture and CI tests without importing or activating the workflow

## Safety
- six-hour conservative trigger, shadow mode, max 25 creators, concurrency 1, 30s timeout, two attempts
- transient retry classes only, same idempotency key; no provider URLs, credentials, scraping, or Instagram writes
- missing coverage remains unavailable/null

## Validation
- Influencer Intelligence suite: 93/93 passed
- scheduler tests: 8/8 passed
- n8n workflow validator: 6/6 passed
- architecture, module catalog, and domain boundary validators passed
- migration is source-only and unapplied; workflow is active=false

## Operational gates
- do not import/activate workflow, apply migration, mount route, enable flag, or collect real data in this PR.