### PR TITLE
fix(ci): preserve Core coordination outputs

### DIFF
--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -243,7 +243,8 @@ jobs:
           retention-days: 90
           if-no-files-found: error
   ponto-identity-staging:
-    needs: promotion
+    # This job consumes the reusable coordination outputs below.
+    needs: [coordination, promotion]
     if: ${{ github.run_attempt == 1 && inputs.release_scope == 'ponto' && inputs.unit == 'inventory' && inputs.target == 'staging' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -1078,7 +1079,8 @@ jobs:
           if-no-files-found: error
 
   ponto-progressive-release:
-    needs: progressive
+    # This job consumes the reusable coordination outputs below.
+    needs: [coordination, progressive]
     if: ${{ github.run_attempt == 1 && inputs.release_scope == 'ponto' && inputs.unit == 'api' && contains(fromJSON('["pilot","canary","production","rollback"]'), inputs.target) }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -1482,7 +1484,8 @@ jobs:
           retention-days: 90
           if-no-files-found: error
   ponto-identity-progressive-release:
-    needs: progressive
+    # This job consumes the reusable coordination outputs below.
+    needs: [coordination, progressive]
     if: ${{ github.run_attempt == 1 && inputs.release_scope == 'ponto' && inputs.unit == 'inventory' && contains(fromJSON('["pilot","canary","production","rollback"]'), inputs.target) }}
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -444,3 +444,17 @@ test("CRM Pages deploy declares coordination as a direct dependency for lease ou
 
   assert.match(workflow, /\n  deploy:\n    # The deploy job reads lease outputs from the reusable coordination job\.[\s\S]*?\n    needs: \[coordination, promotion\]/);
 });
+
+test("Core Worker jobs declare coordination before consuming its lease outputs", () => {
+  const workflow = read(".github/workflows/deploy-core-workers.yml");
+
+  for (const jobName of [
+    "ponto-identity-staging",
+    "ponto-progressive-release",
+    "ponto-identity-progressive-release",
+  ]) {
+    const block = jobBlock(workflow, jobName);
+    assert.match(block, /needs: \[(?:coordination, (?:promotion|progressive))\]/);
+    assert.match(block, /needs\.coordination\.outputs\.(?:global_coordinator_url|global_proof_b64)/);
+  }
+});


### PR DESCRIPTION
## Objetivo
Corrigir a perda de outputs do reusable global coordination gate nos jobs Core Ponto.

## Causa
Os jobs `ponto-identity-staging`, `ponto-progressive-release` e `ponto-identity-progressive-release` consumiam `needs.coordination.outputs.*` sem declarar `coordination` como dependência direta. O run `31537122961` comprovou URL/proof vazios no gate de Identity.

## Mudança
Adicionar `coordination` aos `needs` desses três jobs e um teste estático focal contra regressão. Nenhuma superfície de produto, segredo, flag ou dado foi alterado.

## Validação
`node --test scripts/tests/global-concurrency-governance-static.test.mjs` via Ubuntu-24.04 WSL: 15/15 verdes; `git diff --check` verde.

## Rollback
Reverter este commit; o fluxo continua fail-closed quando a coordenação não estiver disponível.