### PR TITLE
fix(livia): preserve visual assertion output envelope

### DIFF
--- a/orb/engine/scripts/patch-livia-commercial-catalog.js
+++ b/orb/engine/scripts/patch-livia-commercial-catalog.js
@@ -202,9 +202,10 @@ function createCatalogTool(credential) {
 function addCommercialGuard(assertNode) {
   const code = String(assertNode?.parameters?.jsCode || '');
   if (code.includes('livia_crm_pricing_guard_v1')) return;
-  const marker = 'return { json: current };';
-  if (!code.includes(marker)) throw new Error('Assert Livia Visual Analysis return contract is missing.');
-  assertNode.parameters.jsCode = code.replace(marker, `${COMMERCIAL_GUARD_CODE}\n${marker}`);
+  const marker = 'return { json: current';
+  const markerIndex = code.lastIndexOf(marker);
+  if (markerIndex < 0) throw new Error('Assert Livia Visual Analysis return contract is missing.');
+  assertNode.parameters.jsCode = `${code.slice(0, markerIndex)}${COMMERCIAL_GUARD_CODE}\n${code.slice(markerIndex)}`;
 }
 
 function validate(workflow) {

--- a/orb/engine/tests/livia-commercial-catalog.test.js
+++ b/orb/engine/tests/livia-commercial-catalog.test.js
@@ -58,3 +58,18 @@ test('Livia commercial catalog patch is idempotent', () => {
   const twice = patchWorkflow(once);
   assert.deepEqual(twice, once);
 });
+
+test('Livia commercial guard preserves the live visual assertion return envelope', () => {
+  const liveShape = fixture();
+  const visualAssert = liveShape.nodes.find((node) => node.name === 'Assert Livia Visual Analysis');
+  visualAssert.parameters.jsCode = visualAssert.parameters.jsCode.replace(
+    'return { json: current };',
+    'return { json: current, binary: $input.item.binary, pairedItem: $input.item.pairedItem };',
+  );
+
+  const candidate = patchWorkflow(liveShape);
+  validate(candidate);
+  const patchedCode = candidate.nodes.find((node) => node.name === 'Assert Livia Visual Analysis').parameters.jsCode;
+  assert.match(patchedCode, /livia_crm_pricing_guard_v1/);
+  assert.match(patchedCode, /return \{ json: current, binary: \$input\.item\.binary, pairedItem: \$input\.item\.pairedItem \};/);
+});


### PR DESCRIPTION
## Objetivo

Follow-up do PR #1339, baseado diretamente no main mergeado. Corrige a promocao do catalogo comercial contra o retorno visual real do workflow live.

## Alteracao

O node Assert Livia Visual Analysis preserva binary e pairedItem; o guard crmPricing agora e inserido antes de qualquer retorno que comece por return { json: current, sem substituir o envelope.

## Validacao

- node --test tests/livia-commercial-catalog.test.js
- regressao especifica para o envelope live
- sem schema, migracao, segredo ou efeito social

## Rollback

Reverter este commit. O PR #1339 e o incumbent funcional.