### PR TITLE
feat(codex): add canonical CRM and ORB worktree topology

### DIFF
--- a/docs/multi-chat-worktree-runbook.md
+++ b/docs/multi-chat-worktree-runbook.md
@@ -48,6 +48,53 @@ git push
 - Evitar dois chats alterando o mesmo arquivo ao mesmo tempo.
 - Se precisar do mesmo arquivo, encadear PR (B parte da branch de A) ou serializar.
 
+## Topologia canônica híbrida
+
+O arquivo `ops/codex/worktree-topology.json` define um slot canônico por
+superfície CRM do catálogo local, pela exceção explícita `users` e por família
+operacional de workflow ORB. Workflows principais e subworkflows são mapeados
+na família; subworkflows não recebem slots físicos independentes. O slot
+canônico é destinado a preview, qualificação e leitura estável; alterações
+continuam em worktrees temporários por tarefa/PR.
+
+Os slots ficam em:
+
+```text
+C:\CodexShared\Worktrees\skincos\admin\canonical\crm\<module>
+C:\CodexShared\Worktrees\skincos\admin\canonical\orb\<workflow-family>
+```
+
+Inventário e plano não alteram Git:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\manage-canonical-worktrees.ps1 -Action inventory
+powershell -ExecutionPolicy Bypass -File .\scripts\manage-canonical-worktrees.ps1 -Action plan
+```
+
+Criar ou reivindicar um slot exige SHA explícito e `-Apply`; não existe
+fallback automático para outro worktree:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\manage-canonical-worktrees.ps1 `
+  -Action ensure-canonical -SurfaceType crm-module -SurfaceId users `
+  -TargetCommit <sha> -Apply
+powershell -ExecutionPolicy Bypass -File .\scripts\manage-canonical-worktrees.ps1 `
+  -Action claim -SurfaceType crm-module -SurfaceId users -Apply
+```
+
+O estado de owners e leases fica no runtime privado em
+`C:\CodexRuntime\operator\admin\skincos\worktree-registry`, nunca no clone
+compartilhado. `claim` não substitui branch/PR de uma tarefa.
+
+“Mesclar worktrees” significa integrar commits por PR, merge ou cherry-pick
+explícito. Diretórios não são combinados. Worktrees sujos, detached, com PR,
+manifesto, processo ou lease permanecem preservados. A aposentadoria usa
+somente `git worktree remove` e depois `git worktree prune`.
+
+O ORB continua executando apenas releases imutáveis sob `/opt/skincos`; o
+worktree canônico de uma família serve para edição e qualificação e não pode
+ser usado como `cwd` de serviço.
+
 ## Checklist de encerramento por chat
 - Branch/worktree limpos (`git status` sem alteracoes locais).
 - PR aberto e rastreavel.

--- a/ops/codex/worktree-topology.json
+++ b/ops/codex/worktree-topology.json
@@ -1,0 +1,86 @@
+{
+  "schemaVersion": 1,
+  "topologyId": "skincos-canonical-worktrees",
+  "operator": "admin",
+  "worktree": {
+    "canonicalRelativeRoot": "admin\\canonical",
+    "pathTemplate": "admin\\canonical\\{surfaceType}\\{surfaceId}",
+    "registryRelativeRoot": "worktree-registry",
+    "canonicalRole": "stable-preview-or-qualification",
+    "ephemeralRole": "task-or-pr"
+  },
+  "crm": {
+    "unit": "local-launch-catalog-plus-explicit-registry-exceptions",
+    "catalogSource": "crm/console/modules/localLaunchCatalog.json",
+    "registrySource": "crm/console/modules/registry.tsx",
+    "pilot": ["users", "atendimento", "clientes"],
+    "surfaces": [
+      { "id": "insumos", "label": "Insumos", "route": "/?module=insumos", "source": "local-launch-catalog" },
+      { "id": "conversa", "label": "Conversa", "route": "/?module=conversa", "source": "local-launch-catalog" },
+      { "id": "atendimento", "label": "Atendimento", "route": "/?module=atendimento", "source": "local-launch-catalog" },
+      { "id": "ponto", "label": "Ponto", "route": "/?module=ponto", "source": "local-launch-catalog" },
+      { "id": "clientes", "label": "Clientes", "route": "/?module=clientes", "source": "local-launch-catalog" },
+      { "id": "caixa", "label": "Caixa", "route": "/?module=caixa", "source": "local-launch-catalog" },
+      { "id": "faturamento", "label": "Faturamento", "route": "/?module=faturamento", "source": "local-launch-catalog" },
+      { "id": "procedimentos", "label": "Procedimentos", "route": "/?module=procedimentos", "source": "local-launch-catalog" },
+      { "id": "unit-monitor", "label": "Unit Monitor", "route": "/?module=unit-monitor", "source": "local-launch-catalog" },
+      { "id": "instagram-studio", "label": "Redes Sociais", "route": "/?module=instagram-studio", "source": "local-launch-catalog" },
+      { "id": "meta-pages-review", "label": "Meta Review", "route": "/?module=meta-pages-review", "source": "local-launch-catalog" },
+      { "id": "meta-ads", "label": "Meta Ads", "route": "/?module=meta-ads", "source": "local-launch-catalog" },
+      { "id": "site-tracking", "label": "Site EF", "route": "/?module=site-tracking", "source": "local-launch-catalog" },
+      { "id": "escala-profissionais", "label": "Escala", "route": "/?module=escala-profissionais", "source": "local-launch-catalog" },
+      {
+        "id": "users",
+        "label": "Usuários",
+        "route": "/?module=users",
+        "source": "registry-exception",
+        "reason": "registry surface has a validated local preview but is absent from localLaunchCatalog"
+      }
+    ]
+  },
+  "orb": {
+    "unit": "workflow-family",
+    "sourceRoot": "orb/engine",
+    "subworkflowPolicy": "map-to-family-without-independent-physical-slot",
+    "pilot": ["livia", "meta-ads-publish"],
+    "families": [
+      {
+        "id": "livia",
+        "label": "Livia",
+        "mainWorkflowIds": ["WGXr4vYkv9UoJ8zc"],
+        "subworkflowIds": [],
+        "subworkflowDiscovery": "active-workflow-entity-and-runtime-manifest",
+        "sourceFiles": ["orb/engine/compose2-current.js", "orb/engine/scripts/livia"],
+        "runtimeSource": "immutable-release-manifest",
+        "status": "active"
+      },
+      {
+        "id": "meta-ads-publish",
+        "label": "Meta Ads Publish",
+        "mainWorkflowIds": ["eFJhFg79lyaycjlm"],
+        "subworkflowIds": [],
+        "relatedWorkflowIds": ["xN8juRoQBMa4JKOd", "yTatSnzUqtKuAjuM"],
+        "subworkflowDiscovery": "active-workflow-entity-and-runtime-manifest",
+        "sourceFiles": ["orb/engine/workflows/meta-ads-publish.current.json"],
+        "runtimeSource": "immutable-release-manifest",
+        "status": "inactive-candidate"
+      },
+      {
+        "id": "clinic-scheduling",
+        "label": "Clinic Scheduling",
+        "mainWorkflowIds": [],
+        "subworkflowIds": [],
+        "subworkflowDiscovery": "workflow-files-and-live-workflow-entity",
+        "sourceFiles": ["orb/engine/workflows/WORKFLOW_01_INBOUND_TRIAGEM.json", "orb/engine/workflows/WORKFLOW_02_AGENDAMENTO.json", "orb/engine/workflows/WORKFLOW_03_LEMBRETES_E_CONFIRMACAO.json", "orb/engine/workflows/WORKFLOW_04_NOSHOW_REATIVACAO.json"],
+        "runtimeSource": "immutable-release-manifest",
+        "status": "catalogued-not-pilot"
+      }
+    ]
+  },
+  "retention": {
+    "manualWorktreeRemoval": "git-worktree-remove-only",
+    "runtimeSourceRemoval": "source-in-use-lease-manifest-quarantine",
+    "orbReleaseGuard": "scripts/runtime/assert-workflow-runtime-retention.sh",
+    "protectedStates": ["dirty", "detached", "open-pr", "manifest-reference", "active-process", "active-lease", "unproven"]
+  }
+}

--- a/scripts/audit-skincos-footprint.ps1
+++ b/scripts/audit-skincos-footprint.ps1
@@ -5,6 +5,7 @@ param(
     [string]$OperatorRuntimeRoot = "C:\CodexRuntime\operator\admin\skincos",
     [string]$Repository = "jubenitogarcia/skincos",
     [string]$ReportPath,
+    [string]$TopologyPath,
     [string[]]$ProtectedPath = @(),
     [switch]$SkipGitHub,
     [switch]$SkipHealth,
@@ -580,10 +581,236 @@ function Get-WorktreeAudit {
             openPullRequest = $openPullRequest
             protected = $protected
             manifestReferences = @($manifestReferences | ForEach-Object { $_.runtimeId })
+            manifestFiles = @($manifestReferences | ForEach-Object { $_.manifestPath })
+            manifestProcesses = @($manifestReferences | ForEach-Object { $_.pids })
             classification = $classification
         }
     }
     return @($records)
+}
+
+function Get-TopologyDocument {
+    param([string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return [pscustomobject]@{ status = "not_configured"; path = $null; document = $null }
+    }
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return [pscustomobject]@{ status = "missing"; path = $Path; document = $null }
+    }
+
+    try {
+        $document = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+    }
+    catch {
+        return [pscustomobject]@{ status = "invalid"; path = $Path; document = $null; error = $_.Exception.Message }
+    }
+
+    if ([int]$document.schemaVersion -ne 1 -or [string]$document.topologyId -ne "skincos-canonical-worktrees") {
+        return [pscustomobject]@{ status = "invalid"; path = $Path; document = $null; error = "unsupported_schema" }
+    }
+    $surfaceIds = @($document.crm.surfaces | ForEach-Object { [string]$_.id }) + @($document.orb.families | ForEach-Object { [string]$_.id })
+    if (@($surfaceIds | Where-Object { $_ -notmatch '^[a-z0-9][a-z0-9-]*$' }).Count -gt 0) {
+        return [pscustomobject]@{ status = "invalid"; path = $Path; document = $null; error = "invalid_surface_id" }
+    }
+    if (@($surfaceIds | Group-Object | Where-Object { $_.Count -gt 1 }).Count -gt 0) {
+        return [pscustomobject]@{ status = "invalid"; path = $Path; document = $null; error = "duplicate_surface_id" }
+    }
+    return [pscustomobject]@{ status = "ok"; path = $Path; document = $document }
+}
+
+function Get-TopologySurfaceDefinitions {
+    param(
+        [object]$Topology,
+        [string]$WorktreeRoot
+    )
+
+    if ($null -eq $Topology) {
+        return @()
+    }
+
+    $definitions = @()
+    foreach ($surface in @($Topology.crm.surfaces)) {
+        $id = [string]$surface.id
+        $definitions += [pscustomobject]@{
+            surfaceType = "crm-module"
+            surfaceId = $id
+            label = [string]$surface.label
+            pilot = @($Topology.crm.pilot) -contains $id
+            expectedPath = Join-Path $WorktreeRoot (Join-Path ([string]$Topology.worktree.canonicalRelativeRoot) ("crm\$id"))
+            workflowIds = @()
+        }
+    }
+    foreach ($family in @($Topology.orb.families)) {
+        $id = [string]$family.id
+        $definitions += [pscustomobject]@{
+            surfaceType = "orb-workflow-family"
+            surfaceId = $id
+            label = [string]$family.label
+            pilot = @($Topology.orb.pilot) -contains $id
+            expectedPath = Join-Path $WorktreeRoot (Join-Path ([string]$Topology.worktree.canonicalRelativeRoot) ("orb\$id"))
+            workflowIds = @($family.mainWorkflowIds) + @($family.subworkflowIds) + @($family.relatedWorkflowIds)
+        }
+    }
+    return @($definitions)
+}
+
+function Get-CanonicalRegistrySnapshot {
+    param([string]$RegistryRoot)
+
+    $path = Join-Path $RegistryRoot "canonical-registry.json"
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        return [pscustomobject]@{ status = "missing"; path = $path; surfaces = @() }
+    }
+    try {
+        $value = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json
+    }
+    catch {
+        return [pscustomobject]@{ status = "invalid"; path = $path; surfaces = @(); error = $_.Exception.Message }
+    }
+    if ($null -eq $value -or [int]$value.schemaVersion -ne 1) {
+        return [pscustomobject]@{ status = "invalid"; path = $path; surfaces = @(); error = "unsupported_schema" }
+    }
+    return [pscustomobject]@{ status = "ok"; path = $path; surfaces = @($value.surfaces) }
+}
+
+function Get-CanonicalLeaseSnapshot {
+    param(
+        [string]$RegistryRoot,
+        [string]$SurfaceType,
+        [string]$SurfaceId
+    )
+
+    $leasePath = Join-Path $RegistryRoot (Join-Path "leases" "$SurfaceType--$SurfaceId")
+    $ownerPath = Join-Path $leasePath "owner.json"
+    if (-not (Test-Path -LiteralPath $ownerPath -PathType Leaf)) {
+        return [pscustomobject]@{ status = "free"; path = $leasePath; owner = $null }
+    }
+    try {
+        $owner = Get-Content -LiteralPath $ownerPath -Raw | ConvertFrom-Json
+        return [pscustomobject]@{ status = "claimed"; path = $leasePath; owner = $owner }
+    }
+    catch {
+        return [pscustomobject]@{ status = "invalid"; path = $leasePath; owner = $null; error = $_.Exception.Message }
+    }
+}
+
+function Get-CanonicalTopologyAudit {
+    param(
+        [object]$TopologyState,
+        [string]$WorktreeRoot,
+        [string]$OperatorRuntimeRoot,
+        [object[]]$Worktrees
+    )
+
+    if ($TopologyState.status -ne "ok") {
+        return [pscustomobject]@{
+            status = $TopologyState.status
+            topologyPath = $TopologyState.path
+            surfaceCount = 0
+            presentCount = 0
+            missingCount = 0
+            duplicateCount = 0
+            claimedCount = 0
+            surfaces = @()
+            unmappedCanonicalWorktrees = @()
+            registry = Get-CanonicalRegistrySnapshot -RegistryRoot (Join-Path $OperatorRuntimeRoot "worktree-registry")
+        }
+    }
+
+    $registry = Get-CanonicalRegistrySnapshot -RegistryRoot (Join-Path $OperatorRuntimeRoot "worktree-registry")
+    $definitions = @(Get-TopologySurfaceDefinitions -Topology $TopologyState.document -WorktreeRoot $WorktreeRoot)
+    $canonicalRows = @()
+    foreach ($definition in $definitions) {
+        $expected = Normalize-PathString -Path $definition.expectedPath
+        $matches = @($Worktrees | Where-Object { (Normalize-PathString -Path $_.path) -eq $expected })
+        $registryRows = @($registry.surfaces | Where-Object { $_.surfaceType -eq $definition.surfaceType -and $_.surfaceId -eq $definition.surfaceId })
+        $lease = Get-CanonicalLeaseSnapshot -RegistryRoot (Join-Path $OperatorRuntimeRoot "worktree-registry") -SurfaceType $definition.surfaceType -SurfaceId $definition.surfaceId
+        $registryMismatch = $false
+        if ($matches.Count -eq 1 -and $registryRows.Count -eq 1) {
+            $registryMismatch = (Normalize-PathString -Path ([string]$registryRows[0].path)) -ne $expected -or
+                ([string]$registryRows[0].targetCommit).ToLowerInvariant() -ne ([string]$matches[0].head).ToLowerInvariant()
+        }
+        $status = "missing"
+        if ($registry.status -eq "invalid") {
+            $status = "invalid_registry"
+        }
+        elseif ($matches.Count -gt 1 -or $registryRows.Count -gt 1) {
+            $status = "duplicate"
+        }
+        elseif ($matches.Count -eq 0 -and $registryRows.Count -gt 0) {
+            $status = "registry_without_worktree"
+        }
+        elseif ($matches.Count -eq 1 -and $matches[0].dirtyCount -gt 0) {
+            $status = "blocked_dirty"
+        }
+        elseif ($matches.Count -eq 1 -and $registryMismatch) {
+            $status = "registry_mismatch"
+        }
+        elseif ($matches.Count -eq 1 -and $lease.status -eq "claimed") {
+            $status = "claimed"
+        }
+        elseif ($matches.Count -eq 1 -and $registryRows.Count -eq 1) {
+            $status = "ready"
+        }
+        elseif ($matches.Count -eq 1) {
+            $status = "unregistered_worktree"
+        }
+
+        $canonicalRows += [pscustomobject]@{
+            surfaceType = $definition.surfaceType
+            surfaceId = $definition.surfaceId
+            label = $definition.label
+            pilot = [bool]$definition.pilot
+            expectedPath = $definition.expectedPath
+            status = $status
+            worktreeCount = $matches.Count
+            worktrees = @($matches | ForEach-Object {
+                [pscustomobject]@{
+                    path = $_.path
+                    head = $_.head
+                    branch = $_.branch
+                    detached = [bool]$_.detached
+                    dirtyCount = $_.dirtyCount
+                    prunable = [bool]$_.prunable
+                }
+            })
+            registryCount = $registryRows.Count
+            registry = @($registryRows)
+            registryMismatch = $registryMismatch
+            lease = $lease
+            manifestReferences = @($matches | ForEach-Object { $_.manifestReferences })
+            manifestFiles = @($matches | ForEach-Object { $_.manifestFiles })
+            manifestProcesses = @($matches | ForEach-Object { $_.manifestProcesses })
+            preservationReason = if ($status -eq "missing") { "canonical_slot_missing" } elseif ($status -eq "duplicate") { "duplicate_slot" } elseif ($status -eq "registry_mismatch") { "registry_mismatch" } elseif ($status -eq "blocked_dirty") { "dirty" } elseif ($status -eq "claimed") { "active_lease" } elseif (@($matches | ForEach-Object { $_.manifestReferences } | Where-Object { $_ }).Count -gt 0) { "manifest_reference" } else { "ready" }
+            workflowIds = @($definition.workflowIds)
+        }
+    }
+
+    $canonicalRoot = Join-Path $WorktreeRoot ([string]$TopologyState.document.worktree.canonicalRelativeRoot)
+    $expectedPaths = @($canonicalRows | ForEach-Object { Normalize-PathString -Path $_.expectedPath })
+    $unmapped = @($Worktrees | Where-Object {
+        $path = Normalize-PathString -Path $_.path
+        (Test-PathWithinRoot -Path $_.path -Root $canonicalRoot) -and ($expectedPaths -notcontains $path)
+    } | ForEach-Object {
+        [pscustomobject]@{ path = $_.path; head = $_.head; branch = $_.branch; dirtyCount = $_.dirtyCount }
+    })
+
+    $driftStatuses = @("invalid_registry", "duplicate", "registry_without_worktree", "registry_mismatch")
+    return [pscustomobject]@{
+        status = if (@($canonicalRows | Where-Object { $driftStatuses -contains $_.status }).Count -gt 0) { "drift" } else { "ok" }
+        topologyPath = $TopologyState.path
+        canonicalRoot = $canonicalRoot
+        surfaceCount = $canonicalRows.Count
+        presentCount = @($canonicalRows | Where-Object { $_.worktreeCount -eq 1 }).Count
+        missingCount = @($canonicalRows | Where-Object { $_.status -eq "missing" }).Count
+        duplicateCount = @($canonicalRows | Where-Object { $_.status -eq "duplicate" }).Count
+        claimedCount = @($canonicalRows | Where-Object { $_.status -eq "claimed" }).Count
+        pilot = @($canonicalRows | Where-Object { $_.pilot })
+        surfaces = @($canonicalRows)
+        unmappedCanonicalWorktrees = $unmapped
+        registry = $registry
+    }
 }
 
 function Get-Health {
@@ -632,6 +859,7 @@ function Get-GitIntegrity {
 
 $normalizedProjectRoot = Normalize-PathString -Path $ProjectRoot
 $scriptCheckoutRoot = Split-Path -Parent $PSScriptRoot
+$effectiveTopologyPath = if ([string]::IsNullOrWhiteSpace($TopologyPath)) { Join-Path $ProjectRoot "ops\codex\worktree-topology.json" } else { $TopologyPath }
 $effectiveProtectedPaths = @($ProtectedPath)
 if (Test-PathWithinRoot -Path $scriptCheckoutRoot -Root $WorktreeRoot -or $normalizedProjectRoot -eq (Normalize-PathString -Path $scriptCheckoutRoot)) {
     $effectiveProtectedPaths += $scriptCheckoutRoot
@@ -642,6 +870,8 @@ $originMain = ((Get-GitOutput -RepoPath $ProjectRoot -Arguments @("rev-parse", "
 $pullRequestIndex = Get-PullRequestIndex -RepositoryName $Repository -Skip:$SkipGitHub
 $manifestIndex = Get-RuntimeManifestIndex -RuntimePath (Join-Path $OperatorRuntimeRoot "runtime\crm-local")
 $worktrees = @(Get-WorktreeAudit -RepoPath $ProjectRoot -SharedWorktreePath $WorktreeRoot -RuntimePath $RuntimeRoot -OperatorPath $OperatorRuntimeRoot -OriginMain $originMain -PullRequestIndex $pullRequestIndex -ManifestIndex $manifestIndex -ProtectedPaths $effectiveProtectedPaths)
+$topologyState = Get-TopologyDocument -Path $effectiveTopologyPath
+$canonicalTopology = Get-CanonicalTopologyAudit -TopologyState $topologyState -WorktreeRoot $WorktreeRoot -OperatorRuntimeRoot $OperatorRuntimeRoot -Worktrees $worktrees
 $gitIntegrity = Get-GitIntegrity -RepoPath $ProjectRoot
 
 $retiredPaths = @(
@@ -698,6 +928,11 @@ $result = [pscustomobject]@{
         privateSourceWorktreeCount = $privateSourceWorktrees.Count
         privateSourceMetadataCount = $sourceMetadataCount
         runtimeManifestCount = $runtimeManifests.Count
+        canonicalSurfaceCount = $canonicalTopology.surfaceCount
+        canonicalPresentCount = $canonicalTopology.presentCount
+        canonicalMissingCount = $canonicalTopology.missingCount
+        canonicalDuplicateCount = $canonicalTopology.duplicateCount
+        canonicalClaimedCount = $canonicalTopology.claimedCount
         classificationCounts = $classificationCounts
         runtimeStateCounts = $runtimeStateCounts
     }
@@ -707,6 +942,7 @@ $result = [pscustomobject]@{
         count = @($pullRequestIndex.pullRequests).Count
     }
     worktrees = @($worktrees)
+    canonicalTopology = $canonicalTopology
     runtimeManifests = @($runtimeManifests)
     retiredPaths = @($retiredPaths | ForEach-Object { [pscustomobject]@{ path = $_; exists = Test-Path -LiteralPath $_ } })
     orphanScheduledTaskPresent = $null -ne $orphanTask
@@ -742,7 +978,8 @@ Write-Output $json
 if ($FailOnDrift) {
     $retiredPresent = @($result.retiredPaths | Where-Object { $_.exists }).Count -gt 0
     $prunablePresent = @($result.worktrees | Where-Object { $_.prunable }).Count -gt 0
-    if ($retiredPresent -or $result.orphanScheduledTaskPresent -or $prunablePresent -or $result.project.gitIntegrity.state -ne "ok") {
+    $canonicalDrift = $result.canonicalTopology.status -in @("invalid", "drift")
+    if ($retiredPresent -or $result.orphanScheduledTaskPresent -or $prunablePresent -or $result.project.gitIntegrity.state -ne "ok" -or $canonicalDrift) {
         exit 1
     }
 }

--- a/scripts/manage-canonical-worktrees.ps1
+++ b/scripts/manage-canonical-worktrees.ps1
@@ -1,0 +1,664 @@
+param(
+    [ValidateSet('inventory', 'plan', 'ensure-canonical', 'claim', 'release', 'retire')]
+    [string]$Action = 'inventory',
+    [string]$ProjectRoot = 'C:\CodexShared\Projetos\skincos',
+    [string]$WorktreeRoot = 'C:\CodexShared\Worktrees\skincos',
+    [string]$TopologyPath,
+    [string]$RuntimeRegistryRoot = 'C:\CodexRuntime\operator\admin\skincos\worktree-registry',
+    [string]$Repository = 'jubenitogarcia/skincos',
+    [ValidateSet('crm-module', 'orb-workflow-family')]
+    [string]$SurfaceType,
+    [string]$SurfaceId,
+    [string]$TargetCommit,
+    [string]$WorktreePath,
+    [string]$Owner = $env:USERNAME,
+    [string]$LeaseToken,
+    [switch]$Apply,
+    [switch]$SkipGitHub
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ([string]::IsNullOrWhiteSpace($TopologyPath)) {
+    $TopologyPath = Join-Path $ProjectRoot 'ops\codex\worktree-topology.json'
+}
+
+function Normalize-PathString {
+    param([string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return ''
+    }
+
+    try {
+        $fullPath = [System.IO.Path]::GetFullPath($Path)
+    }
+    catch {
+        $fullPath = $Path
+    }
+
+    return $fullPath.Replace('/', '\').TrimEnd([char[]]'\/').ToLowerInvariant()
+}
+
+function Test-PathWithinRoot {
+    param(
+        [string]$Path,
+        [string]$Root
+    )
+
+    $normalizedPath = Normalize-PathString -Path $Path
+    $normalizedRoot = Normalize-PathString -Path $Root
+    return $normalizedPath -eq $normalizedRoot -or $normalizedPath.StartsWith("$normalizedRoot\")
+}
+
+function Convert-ToWslPath {
+    param([string]$Path)
+
+    if ($Path -match '^([A-Za-z]):\\(.*)$') {
+        return "/mnt/$($Matches[1].ToLowerInvariant())/$($Matches[2].Replace('\', '/'))"
+    }
+    return $Path.Replace('\', '/')
+}
+
+function Read-JsonFile {
+    param([string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return $null
+    }
+
+    try {
+        return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+    }
+    catch {
+        throw "JSON inválido em '$Path': $($_.Exception.Message)"
+    }
+}
+
+function Write-JsonAtomic {
+    param(
+        [string]$Path,
+        [object]$Value
+    )
+
+    $parent = Split-Path -Parent $Path
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    $temporary = "$Path.$PID.tmp"
+    $Value | ConvertTo-Json -Depth 16 | Set-Content -LiteralPath $temporary -Encoding utf8
+    Move-Item -LiteralPath $temporary -Destination $Path -Force
+}
+
+function Invoke-Git {
+    param(
+        [string]$RepoPath,
+        [string[]]$Arguments
+    )
+
+    $oldPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    $output = @()
+    $exitCode = 1
+    try {
+        $output = @(& git -C $RepoPath @Arguments 2>&1 | ForEach-Object { [string]$_ })
+        $exitCode = $LASTEXITCODE
+    }
+    catch {
+        $output = @([string]$_.Exception.Message)
+        $exitCode = 1
+    }
+    finally {
+        $ErrorActionPreference = $oldPreference
+    }
+
+    return [pscustomobject]@{
+        output = @($output)
+        exitCode = $exitCode
+    }
+}
+
+function Get-WorktreeRecords {
+    param(
+        [string]$RepoPath,
+        [switch]$IncludeStatus
+    )
+
+    $result = Invoke-Git -RepoPath $RepoPath -Arguments @('worktree', 'list', '--porcelain')
+    if ($result.exitCode -ne 0) {
+        throw "git worktree list falhou: $($result.output -join ' ')"
+    }
+
+    $records = @()
+    $current = $null
+    foreach ($line in @($result.output + '')) {
+        if ($line -like 'worktree *') {
+            if ($null -ne $current) {
+                $records += [pscustomobject]$current
+            }
+            $current = [ordered]@{
+                path = $line.Substring(9)
+                head = $null
+                branch = $null
+                detached = $false
+                locked = $false
+                lockReason = $null
+                prunable = $false
+                prunableReason = $null
+            }
+            continue
+        }
+
+        if ($null -eq $current) {
+            continue
+        }
+
+        if ($line -like 'HEAD *') {
+            $current.head = $line.Substring(5)
+        }
+        elseif ($line -match '^branch refs/heads/(.*)$') {
+            $current.branch = $Matches[1]
+        }
+        elseif ($line -eq 'detached') {
+            $current.detached = $true
+        }
+        elseif ($line -eq 'locked') {
+            $current.locked = $true
+        }
+        elseif ($line -like 'locked *') {
+            $current.locked = $true
+            $current.lockReason = $line.Substring(7)
+        }
+        elseif ($line -eq 'prunable') {
+            $current.prunable = $true
+        }
+        elseif ($line -like 'prunable *') {
+            $current.prunable = $true
+            $current.prunableReason = $line.Substring(9)
+        }
+    }
+
+    if ($null -ne $current) {
+        $records += [pscustomobject]$current
+    }
+
+    foreach ($record in $records) {
+        $exists = Test-Path -LiteralPath $record.path -PathType Container
+        $status = @()
+        if ($exists -and $IncludeStatus) {
+            $status = @(Invoke-Git -RepoPath $record.path -Arguments @('status', '--porcelain=v1')).output
+        }
+        $dirtyCount = $null
+        if ($IncludeStatus) {
+            $dirtyCount = @($status | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }).Count
+        }
+        Add-Member -InputObject $record -NotePropertyName exists -NotePropertyValue $exists
+        Add-Member -InputObject $record -NotePropertyName dirtyCount -NotePropertyValue $dirtyCount
+        Add-Member -InputObject $record -NotePropertyName dirtySample -NotePropertyValue @($status | Select-Object -First 10)
+    }
+
+    return @($records)
+}
+
+function Get-Topology {
+    $topology = Read-JsonFile -Path $TopologyPath
+    if ($null -eq $topology) {
+        throw "Topologia não encontrada em '$TopologyPath'."
+    }
+    if ([int]$topology.schemaVersion -ne 1 -or [string]$topology.topologyId -ne 'skincos-canonical-worktrees') {
+        throw "Topologia incompatível em '$TopologyPath'."
+    }
+
+    $allIds = @()
+    $allIds += @($topology.crm.surfaces | ForEach-Object { [string]$_.id })
+    $allIds += @($topology.orb.families | ForEach-Object { [string]$_.id })
+    if (@($allIds | Where-Object { $_ -notmatch '^[a-z0-9][a-z0-9-]*$' }).Count -gt 0) {
+        throw 'A topologia contém identificador de superfície inválido.'
+    }
+    if (@($allIds | Group-Object | Where-Object { $_.Count -gt 1 }).Count -gt 0) {
+        throw 'A topologia contém identificadores de superfície duplicados.'
+    }
+    return $topology
+}
+
+function Get-SurfaceDefinitions {
+    param([object]$Topology)
+
+    $definitions = @()
+    foreach ($surface in @($Topology.crm.surfaces)) {
+        $id = [string]$surface.id
+        $definitions += [pscustomobject]@{
+            surfaceType = 'crm-module'
+            surfaceId = $id
+            label = [string]$surface.label
+            route = [string]$surface.route
+            source = [string]$surface.source
+            pilot = @($Topology.crm.pilot) -contains $id
+            expectedPath = Join-Path $WorktreeRoot (Join-Path ([string]$Topology.worktree.canonicalRelativeRoot) ("crm\$id"))
+            workflowIds = @()
+        }
+    }
+    foreach ($family in @($Topology.orb.families)) {
+        $id = [string]$family.id
+        $definitions += [pscustomobject]@{
+            surfaceType = 'orb-workflow-family'
+            surfaceId = $id
+            label = [string]$family.label
+            route = $null
+            source = 'workflow-family'
+            pilot = @($Topology.orb.pilot) -contains $id
+            expectedPath = Join-Path $WorktreeRoot (Join-Path ([string]$Topology.worktree.canonicalRelativeRoot) ("orb\$id"))
+            workflowIds = @($family.mainWorkflowIds) + @($family.subworkflowIds) + @($family.relatedWorkflowIds)
+        }
+    }
+    return @($definitions)
+}
+
+function Get-RegistryState {
+    $path = Join-Path $RuntimeRegistryRoot 'canonical-registry.json'
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        return [pscustomobject]@{
+            status = 'missing'
+            path = $path
+            surfaces = @()
+        }
+    }
+
+    $value = Read-JsonFile -Path $path
+    if ($null -eq $value -or [int]$value.schemaVersion -ne 1) {
+        return [pscustomobject]@{
+            status = 'invalid'
+            path = $path
+            surfaces = @()
+        }
+    }
+    return [pscustomobject]@{
+        status = 'ok'
+        path = $path
+        surfaces = @($value.surfaces)
+    }
+}
+
+function Get-Lease {
+    param(
+        [string]$SurfaceType,
+        [string]$SurfaceId
+    )
+
+    $key = "$SurfaceType--$SurfaceId"
+    $leasePath = Join-Path $RuntimeRegistryRoot (Join-Path 'leases' $key)
+    $ownerPath = Join-Path $leasePath 'owner.json'
+    if (-not (Test-Path -LiteralPath $ownerPath -PathType Leaf)) {
+        return [pscustomobject]@{ status = 'free'; path = $leasePath; owner = $null }
+    }
+    return [pscustomobject]@{ status = 'claimed'; path = $leasePath; owner = Read-JsonFile -Path $ownerPath }
+}
+
+function Get-SurfaceDefinition {
+    param(
+        [object[]]$Definitions,
+        [string]$RequestedType,
+        [string]$RequestedId
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RequestedType) -or [string]::IsNullOrWhiteSpace($RequestedId)) {
+        throw '-SurfaceType e -SurfaceId são obrigatórios para esta ação.'
+    }
+    $matches = @($Definitions | Where-Object { $_.surfaceType -eq $RequestedType -and $_.surfaceId -eq $RequestedId })
+    if ($matches.Count -ne 1) {
+        throw "Superfície não encontrada ou ambígua: $RequestedType/$RequestedId."
+    }
+    return $matches[0]
+}
+
+function Get-ManifestReferences {
+    $root = Join-Path $RuntimeRegistryRoot '..\runtime\crm-local'
+    $manifestRoot = [System.IO.Path]::GetFullPath($root)
+    if (-not (Test-Path -LiteralPath $manifestRoot -PathType Container)) {
+        return @()
+    }
+
+    $references = @()
+    foreach ($file in @(Get-ChildItem -LiteralPath $manifestRoot -Filter 'current.json' -File -Recurse -Force -ErrorAction SilentlyContinue)) {
+        try { $manifest = Get-Content -LiteralPath $file.FullName -Raw | ConvertFrom-Json } catch { continue }
+        foreach ($propertyName in @('worktree', 'sourceOrigin')) {
+            if ($null -eq $manifest.PSObject.Properties[$propertyName]) { continue }
+            $value = [string]$manifest.$propertyName
+            if ([string]::IsNullOrWhiteSpace($value)) { continue }
+            $references += [pscustomobject]@{ manifestPath = $file.FullName; property = $propertyName; value = $value }
+        }
+    }
+    return @($references)
+}
+
+function Get-CanonicalInventory {
+    param(
+        [object]$Topology,
+        [object[]]$Definitions,
+        [object[]]$Worktrees,
+        [object]$Registry
+    )
+
+    $manifestReferences = @(Get-ManifestReferences)
+    $surfaceRows = @()
+    foreach ($definition in $Definitions) {
+        $expected = Normalize-PathString -Path $definition.expectedPath
+        $matches = @($Worktrees | Where-Object { (Normalize-PathString -Path $_.path) -eq $expected })
+        $registryRows = @($Registry.surfaces | Where-Object { $_.surfaceType -eq $definition.surfaceType -and $_.surfaceId -eq $definition.surfaceId })
+        $lease = Get-Lease -SurfaceType $definition.surfaceType -SurfaceId $definition.surfaceId
+        $manifestRows = @($manifestReferences | Where-Object { Test-PathWithinRoot -Path $_.value -Root $definition.expectedPath })
+        $registryMismatch = $false
+        if ($matches.Count -eq 1 -and $registryRows.Count -eq 1) {
+            $registryMismatch = (Normalize-PathString -Path ([string]$registryRows[0].path)) -ne $expected -or
+                ([string]$registryRows[0].targetCommit).ToLowerInvariant() -ne ([string]$matches[0].head).ToLowerInvariant()
+        }
+
+        $status = 'missing'
+        if ($Registry.status -eq 'invalid') {
+            $status = 'invalid_registry'
+        }
+        elseif ($matches.Count -gt 1 -or $registryRows.Count -gt 1) {
+            $status = 'duplicate'
+        }
+        elseif ($matches.Count -eq 0 -and $registryRows.Count -gt 0) {
+            $status = 'registry_without_worktree'
+        }
+        elseif ($matches.Count -eq 1 -and $matches[0].dirtyCount -gt 0) {
+            $status = 'blocked_dirty'
+        }
+        elseif ($matches.Count -eq 1 -and $manifestRows.Count -gt 0) {
+            $status = 'protected_manifest_reference'
+        }
+        elseif ($matches.Count -eq 1 -and $lease.status -eq 'claimed') {
+            $status = 'claimed'
+        }
+        elseif ($matches.Count -eq 1 -and $registryMismatch) {
+            $status = 'registry_mismatch'
+        }
+        elseif ($matches.Count -eq 1 -and $registryRows.Count -eq 1) {
+            $status = 'ready'
+        }
+        elseif ($matches.Count -eq 1) {
+            $status = 'unregistered_worktree'
+        }
+
+        $row = [ordered]@{
+            surfaceType = $definition.surfaceType
+            surfaceId = $definition.surfaceId
+            label = $definition.label
+            pilot = [bool]$definition.pilot
+            expectedPath = $definition.expectedPath
+            status = $status
+            worktreeCount = $matches.Count
+            worktrees = @($matches | ForEach-Object {
+                [pscustomobject]@{
+                    path = $_.path
+                    head = $_.head
+                    branch = $_.branch
+                    detached = [bool]$_.detached
+                    dirtyCount = $_.dirtyCount
+                    prunable = [bool]$_.prunable
+                }
+            })
+            registryCount = $registryRows.Count
+            registry = @($registryRows)
+            registryMismatch = $registryMismatch
+            lease = $lease
+            manifestReferences = @($manifestRows)
+            workflowIds = @($definition.workflowIds)
+        }
+        $surfaceRows += [pscustomobject]$row
+    }
+
+    $canonicalRoot = Join-Path $WorktreeRoot ([string]$Topology.worktree.canonicalRelativeRoot)
+    $expectedPaths = @($surfaceRows | ForEach-Object { Normalize-PathString -Path $_.expectedPath })
+    $extra = @()
+    foreach ($worktree in $Worktrees) {
+        $worktreePath = Normalize-PathString -Path $worktree.path
+        if ((Test-PathWithinRoot -Path $worktree.path -Root $canonicalRoot) -and ($expectedPaths -notcontains $worktreePath)) {
+            $extra += [pscustomobject]@{ path = $worktree.path; head = $worktree.head; branch = $worktree.branch; dirtyCount = $worktree.dirtyCount }
+        }
+    }
+
+    return [pscustomobject]@{
+        status = if (@($surfaceRows | Where-Object { $_.status -in @('invalid_registry', 'duplicate', 'registry_mismatch') }).Count -gt 0) { 'drift' } else { 'ok' }
+        topologyPath = $TopologyPath
+        canonicalRoot = $canonicalRoot
+        surfaceCount = $surfaceRows.Count
+        presentCount = @($surfaceRows | Where-Object { $_.worktreeCount -eq 1 }).Count
+        missingCount = @($surfaceRows | Where-Object { $_.status -eq 'missing' }).Count
+        duplicateCount = @($surfaceRows | Where-Object { $_.status -eq 'duplicate' }).Count
+        claimedCount = @($surfaceRows | Where-Object { $_.status -eq 'claimed' }).Count
+        pilot = @($surfaceRows | Where-Object { $_.pilot })
+        surfaces = @($surfaceRows)
+        unmappedCanonicalWorktrees = $extra
+        registry = $Registry
+    }
+}
+
+function Write-RegistryEntry {
+    param([object]$Entry)
+
+    $registryPath = Join-Path $RuntimeRegistryRoot 'canonical-registry.json'
+    $registry = Get-RegistryState
+    $surfaces = @($registry.surfaces | Where-Object { $_.surfaceType -ne $Entry.surfaceType -or $_.surfaceId -ne $Entry.surfaceId })
+    $surfaces += $Entry
+    Write-JsonAtomic -Path $registryPath -Value ([pscustomobject]@{ schemaVersion = 1; updatedAtUtc = (Get-Date).ToUniversalTime().ToString('o'); surfaces = @($surfaces) })
+}
+
+function Update-RegistryLease {
+    param(
+        [string]$RequestedType,
+        [string]$RequestedId,
+        [object]$Lease
+    )
+
+    $registry = Get-RegistryState
+    $rows = @($registry.surfaces | ForEach-Object {
+        if ($_.surfaceType -eq $RequestedType -and $_.surfaceId -eq $RequestedId) {
+            $copy = [ordered]@{}
+            foreach ($property in $_.PSObject.Properties) { $copy[$property.Name] = $property.Value }
+            if ($null -eq $Lease) {
+                $copy.Remove('lease')
+            }
+            else {
+                $copy.lease = $Lease
+            }
+            [pscustomobject]$copy
+        }
+        else { $_ }
+    })
+    Write-JsonAtomic -Path (Join-Path $RuntimeRegistryRoot 'canonical-registry.json') -Value ([pscustomobject]@{ schemaVersion = 1; updatedAtUtc = (Get-Date).ToUniversalTime().ToString('o'); surfaces = @($rows) })
+}
+
+function Ensure-Canonical {
+    param(
+        [object]$Definition,
+        [object[]]$Worktrees
+    )
+
+    if (-not $Apply) { throw 'ensure-canonical exige -Apply.' }
+    if ($TargetCommit -notmatch '^[0-9a-fA-F]{40}$') { throw 'ensure-canonical exige -TargetCommit com SHA completo de 40 caracteres.' }
+
+    $matches = @($Worktrees | Where-Object { (Normalize-PathString -Path $_.path) -eq (Normalize-PathString -Path $Definition.expectedPath) })
+    if ($matches.Count -gt 1) { throw "Slot canônico duplicado: $($Definition.surfaceType)/$($Definition.surfaceId)." }
+    if ($matches.Count -eq 1) {
+        $status = @(Invoke-Git -RepoPath $matches[0].path -Arguments @('status', '--porcelain=v1')).output
+        if (@($status | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }).Count -gt 0) { throw 'O slot canônico existente está sujo.' }
+        if ([string]$matches[0].head -ne $TargetCommit) { throw "Slot canônico já existe em $($matches[0].head), esperado $TargetCommit." }
+        $action = 'reused'
+    }
+    else {
+        if (Test-Path -LiteralPath $Definition.expectedPath) { throw "O caminho canônico existe mas não está registrado: $($Definition.expectedPath)." }
+        $commitCheck = Invoke-Git -RepoPath $ProjectRoot -Arguments @('cat-file', '-e', "$TargetCommit^{commit}")
+        if ($commitCheck.exitCode -ne 0) { throw "SHA alvo não existe no repositório: $TargetCommit." }
+        New-Item -ItemType Directory -Path (Split-Path -Parent $Definition.expectedPath) -Force | Out-Null
+        $add = Invoke-Git -RepoPath $ProjectRoot -Arguments @('worktree', 'add', '--detach', $Definition.expectedPath, $TargetCommit)
+        if ($add.exitCode -ne 0) { throw "Não foi possível criar o slot canônico: $($add.output -join ' ')" }
+        $action = 'created'
+    }
+
+    $entry = [pscustomobject]@{
+        surfaceType = $Definition.surfaceType
+        surfaceId = $Definition.surfaceId
+        label = $Definition.label
+        role = 'canonical'
+        path = $Definition.expectedPath
+        targetCommit = $TargetCommit.ToLowerInvariant()
+        source = $Definition.source
+        updatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+    }
+    Write-RegistryEntry -Entry $entry
+    return [pscustomobject]@{ action = $action; surfaceType = $Definition.surfaceType; surfaceId = $Definition.surfaceId; path = $Definition.expectedPath; targetCommit = $TargetCommit.ToLowerInvariant() }
+}
+
+function Claim-Canonical {
+    param([object]$Surface)
+
+    if (-not $Apply) { throw 'claim exige -Apply.' }
+    if ($Surface.status -notin @('ready', 'claimed')) { throw "Slot não está pronto para claim: $($Surface.status)." }
+    if ($Surface.worktreeCount -ne 1) { throw 'Claim exige exatamente um worktree canônico.' }
+    if (@($Surface.worktrees | Where-Object { $_.dirtyCount -gt 0 }).Count -gt 0) { throw 'Claim recusado para worktree sujo.' }
+    if ($Surface.lease.status -eq 'claimed') { throw "Slot já possui lease de $($Surface.lease.owner.owner)." }
+
+    $leasePath = $Surface.lease.path
+    New-Item -ItemType Directory -Path (Split-Path -Parent $leasePath) -Force | Out-Null
+    New-Item -ItemType Directory -Path $leasePath -Force:$false | Out-Null
+    $token = [guid]::NewGuid().ToString('N')
+    $ownerRecord = [pscustomobject]@{
+        schemaVersion = 1
+        token = $token
+        owner = $Owner
+        pid = $PID
+        claimedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+        surfaceType = $Surface.surfaceType
+        surfaceId = $Surface.surfaceId
+        path = $Surface.expectedPath
+    }
+    Write-JsonAtomic -Path (Join-Path $leasePath 'owner.json') -Value $ownerRecord
+    Update-RegistryLease -RequestedType $Surface.surfaceType -RequestedId $Surface.surfaceId -Lease ([pscustomobject]@{ owner = $Owner; token = $token; claimedAtUtc = $ownerRecord.claimedAtUtc })
+    return [pscustomobject]@{ action = 'claimed'; surfaceType = $Surface.surfaceType; surfaceId = $Surface.surfaceId; owner = $Owner; token = $token; path = $Surface.expectedPath }
+}
+
+function Release-Canonical {
+    param([object]$Surface)
+
+    if (-not $Apply) { throw 'release exige -Apply.' }
+    if ($Surface.lease.status -ne 'claimed') { return [pscustomobject]@{ action = 'already-free'; surfaceType = $Surface.surfaceType; surfaceId = $Surface.surfaceId } }
+    $record = $Surface.lease.owner
+    if ($record.owner -ne $Owner -and ([string]::IsNullOrWhiteSpace($LeaseToken) -or $record.token -ne $LeaseToken)) {
+        throw 'Release recusado: owner/token não corresponde ao lease.'
+    }
+    Remove-Item -LiteralPath $Surface.lease.path -Recurse -Force
+    Update-RegistryLease -RequestedType $Surface.surfaceType -RequestedId $Surface.surfaceId -Lease $null
+    return [pscustomobject]@{ action = 'released'; surfaceType = $Surface.surfaceType; surfaceId = $Surface.surfaceId; path = $Surface.expectedPath }
+}
+
+function Test-OpenPullRequest {
+    param([string]$Branch)
+
+    if ($SkipGitHub) { return [pscustomobject]@{ status = 'skipped'; open = $null } }
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { return [pscustomobject]@{ status = 'gh_missing'; open = $null } }
+    $oldPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    $raw = @(& gh pr list --repo $Repository --head $Branch --state open --json number,title 2>&1 | ForEach-Object { [string]$_ })
+    $exitCode = $LASTEXITCODE
+    $ErrorActionPreference = $oldPreference
+    if ($exitCode -ne 0) { return [pscustomobject]@{ status = 'error'; open = $null; output = $raw } }
+    try { $rows = @($raw -join "`n" | ConvertFrom-Json) } catch { return [pscustomobject]@{ status = 'error'; open = $null; output = $raw } }
+    return [pscustomobject]@{ status = 'ok'; open = $rows.Count -gt 0; pullRequests = @($rows) }
+}
+
+function Test-SourceInUse {
+    param([string]$Path)
+
+    $wrapper = Join-Path $ProjectRoot 'scripts\invoke-skincos-wsl.ps1'
+    if (-not (Test-Path -LiteralPath $wrapper -PathType Leaf)) { return [pscustomobject]@{ status = 'wrapper_missing'; inUse = $null } }
+    $oldPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    & $wrapper -ProjectRoot $ProjectRoot -Executable 'bash' -Argument @('scripts/crm-local-process-control.sh', 'source-in-use', (Convert-ToWslPath -Path $Path)) -SkipBootstrapCheck -SkipNodeCheck -SkipNpmCheck *> $null
+    $exitCode = $LASTEXITCODE
+    $ErrorActionPreference = $oldPreference
+    if ($exitCode -eq 0) { return [pscustomobject]@{ status = 'checked'; inUse = $true } }
+    if ($exitCode -eq 1) { return [pscustomobject]@{ status = 'checked'; inUse = $false } }
+    return [pscustomobject]@{ status = 'error'; inUse = $null; exitCode = $exitCode }
+}
+
+function Retire-Worktree {
+    if (-not $Apply) { throw 'retire exige -Apply.' }
+    if ([string]::IsNullOrWhiteSpace($WorktreePath)) { throw 'retire exige -WorktreePath explícito.' }
+    $normalized = Normalize-PathString -Path $WorktreePath
+    if ((Normalize-PathString -Path $ProjectRoot) -eq $normalized) { throw 'O clone compartilhado nunca pode ser aposentado.' }
+    $topology = Get-Topology
+    $canonicalRoot = Join-Path $WorktreeRoot ([string]$topology.worktree.canonicalRelativeRoot)
+    if (Test-PathWithinRoot -Path $WorktreePath -Root $canonicalRoot) { throw 'Slots canônicos não podem ser aposentados por esta ação.' }
+
+    $records = @(Get-WorktreeRecords -RepoPath $ProjectRoot -IncludeStatus | Where-Object { (Normalize-PathString -Path $_.path) -eq $normalized })
+    if ($records.Count -ne 1) { throw "Worktree não encontrado ou ambíguo: $WorktreePath." }
+    $record = $records[0]
+    if (-not $record.exists) { throw 'Worktree não existe no filesystem.' }
+    if ($record.dirtyCount -gt 0) { throw 'Worktree sujo: preservação obrigatória.' }
+    if ($record.detached) { throw 'Worktree detached: confirmação manual obrigatória.' }
+    if ($record.prunable) { throw 'Worktree já prunable: resolver estado Git antes da remoção.' }
+    if ([string]::IsNullOrWhiteSpace($record.branch)) { throw 'Worktree sem branch não pode ser aposentado automaticamente.' }
+
+    $remote = Invoke-Git -RepoPath $ProjectRoot -Arguments @('show-ref', '--verify', '--quiet', "refs/remotes/origin/$($record.branch)")
+    if ($remote.exitCode -eq 0) { throw 'Branch possui tracking remoto; revisão manual obrigatória.' }
+    $ancestor = Invoke-Git -RepoPath $ProjectRoot -Arguments @('merge-base', '--is-ancestor', $record.head, 'origin/main')
+    if ($ancestor.exitCode -ne 0) { throw 'Worktree não é ancestral de origin/main.' }
+
+    $pr = Test-OpenPullRequest -Branch $record.branch
+    if ($pr.status -ne 'ok' -or $pr.open) { throw "PR não foi comprovadamente encerrado: $($pr | ConvertTo-Json -Compress -Depth 6)" }
+
+    $manifestReferences = @(Get-ManifestReferences | Where-Object { Test-PathWithinRoot -Path $_.value -Root $record.path })
+    if ($manifestReferences.Count -gt 0) { throw 'Manifesto de runtime referencia o worktree.' }
+    $leaseKey = @((Get-RegistryState).surfaces | Where-Object { (Normalize-PathString -Path $_.path) -eq $normalized })
+    if ($leaseKey.Count -gt 0 -and $leaseKey[0].lease) { throw 'Lease de runtime referencia o worktree.' }
+    $sourceUse = Test-SourceInUse -Path $record.path
+    if ($sourceUse.status -ne 'checked' -or $sourceUse.inUse) { throw "source-in-use não confirmou ausência de processo: $($sourceUse | ConvertTo-Json -Compress)" }
+
+    $removed = Invoke-Git -RepoPath $ProjectRoot -Arguments @('worktree', 'remove', '--', $record.path)
+    if ($removed.exitCode -ne 0) { throw "git worktree remove falhou: $($removed.output -join ' ')" }
+    $prune = Invoke-Git -RepoPath $ProjectRoot -Arguments @('worktree', 'prune')
+    if ($prune.exitCode -ne 0) { throw "git worktree prune falhou: $($prune.output -join ' ')" }
+    return [pscustomobject]@{ action = 'retired'; path = $record.path; branch = $record.branch; head = $record.head; sourceInUse = $sourceUse }
+}
+
+$topology = Get-Topology
+$definitions = @(Get-SurfaceDefinitions -Topology $topology)
+$requiresInventory = $Action -in @('inventory', 'plan', 'claim', 'release')
+$worktrees = @(Get-WorktreeRecords -RepoPath $ProjectRoot -IncludeStatus:$requiresInventory)
+$registry = Get-RegistryState
+$inventory = if ($requiresInventory) { Get-CanonicalInventory -Topology $topology -Definitions $definitions -Worktrees $worktrees -Registry $registry } else { $null }
+
+switch ($Action) {
+    'inventory' {
+        $inventory | ConvertTo-Json -Depth 16
+    }
+    'plan' {
+        $actions = @($inventory.surfaces | ForEach-Object {
+            switch ($_.status) {
+                'missing' { [pscustomobject]@{ action = 'ensure-canonical'; surfaceType = $_.surfaceType; surfaceId = $_.surfaceId; required = $true; reason = 'canonical_slot_missing'; mutation = 'requires -Apply and explicit -TargetCommit' } }
+                'ready' { [pscustomobject]@{ action = 'none'; surfaceType = $_.surfaceType; surfaceId = $_.surfaceId; required = $false; reason = 'canonical_slot_ready'; mutation = 'none' } }
+                'claimed' { [pscustomobject]@{ action = 'none'; surfaceType = $_.surfaceType; surfaceId = $_.surfaceId; required = $false; reason = 'canonical_slot_claimed'; mutation = 'none' } }
+                default { [pscustomobject]@{ action = 'review'; surfaceType = $_.surfaceType; surfaceId = $_.surfaceId; required = $true; reason = $_.status; mutation = 'blocked_fail_closed' } }
+            }
+        })
+        [pscustomobject]@{ inventory = $inventory; actions = $actions } | ConvertTo-Json -Depth 16
+    }
+    'ensure-canonical' {
+        $definition = Get-SurfaceDefinition -Definitions $definitions -RequestedType $SurfaceType -RequestedId $SurfaceId
+        Ensure-Canonical -Definition $definition -Worktrees $worktrees | ConvertTo-Json -Depth 12
+    }
+    'claim' {
+        $surface = Get-SurfaceDefinition -Definitions $definitions -RequestedType $SurfaceType -RequestedId $SurfaceId
+        $row = @($inventory.surfaces | Where-Object { $_.surfaceType -eq $surface.surfaceType -and $_.surfaceId -eq $surface.surfaceId })[0]
+        Claim-Canonical -Surface $row | ConvertTo-Json -Depth 12
+    }
+    'release' {
+        $surface = Get-SurfaceDefinition -Definitions $definitions -RequestedType $SurfaceType -RequestedId $SurfaceId
+        $row = @($inventory.surfaces | Where-Object { $_.surfaceType -eq $surface.surfaceType -and $_.surfaceId -eq $surface.surfaceId })[0]
+        Release-Canonical -Surface $row | ConvertTo-Json -Depth 12
+    }
+    'retire' {
+        Retire-Worktree | ConvertTo-Json -Depth 12
+    }
+}

--- a/scripts/tests/test-canonical-worktree-topology.ps1
+++ b/scripts/tests/test-canonical-worktree-topology.ps1
@@ -1,0 +1,126 @@
+$ErrorActionPreference = 'Stop'
+
+$scriptRoot = Split-Path -Parent $PSScriptRoot
+$repositoryRoot = Split-Path -Parent $scriptRoot
+$coordinator = Join-Path $repositoryRoot 'scripts\manage-canonical-worktrees.ps1'
+$topologySource = Join-Path $repositoryRoot 'ops\codex\worktree-topology.json'
+$fixtureRoot = Join-Path ([System.IO.Path]::GetTempPath()) "skincos-canonical-topology-$PID"
+$fixtureRepo = Join-Path $fixtureRoot 'repo'
+$fixtureWorktrees = Join-Path $fixtureRoot 'worktrees'
+$fixtureRegistry = Join-Path $fixtureRoot 'registry'
+$fixtureTopology = Join-Path $fixtureRoot 'topology.json'
+
+function Invoke-GitFixture {
+    param([string[]]$Arguments)
+    $oldPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    & git @Arguments 2>$null | Out-Null
+    $exitCode = $LASTEXITCODE
+    $ErrorActionPreference = $oldPreference
+    if ($exitCode -ne 0) { throw "Fixture git failed: git $($Arguments -join ' ')" }
+}
+
+function Invoke-Coordinator {
+    param([hashtable]$Parameters)
+    $arguments = @{
+        ProjectRoot = $fixtureRepo
+        WorktreeRoot = $fixtureWorktrees
+        TopologyPath = $fixtureTopology
+        RuntimeRegistryRoot = $fixtureRegistry
+        SkipGitHub = $true
+    }
+    foreach ($key in $Parameters.Keys) { $arguments[$key] = $Parameters[$key] }
+    $output = @(& $coordinator @arguments 2>&1 | ForEach-Object { [string]$_ })
+    if ($LASTEXITCODE -ne 0) { throw "Coordinator failed: $($output -join ' ')" }
+    return ($output -join "`n" | ConvertFrom-Json)
+}
+
+try {
+    New-Item -ItemType Directory -Path $fixtureRepo, $fixtureWorktrees, $fixtureRegistry -Force | Out-Null
+    Invoke-GitFixture @('-C', $fixtureRepo, 'init', '--quiet')
+    Invoke-GitFixture @('-C', $fixtureRepo, 'config', 'user.email', 'fixture@example.invalid')
+    Invoke-GitFixture @('-C', $fixtureRepo, 'config', 'user.name', 'Fixture')
+    Set-Content -LiteralPath (Join-Path $fixtureRepo 'README.md') -Value "fixture`n" -Encoding utf8
+    Invoke-GitFixture @('-C', $fixtureRepo, 'add', 'README.md')
+    Invoke-GitFixture @('-C', $fixtureRepo, 'commit', '--quiet', '-m', 'fixture')
+    $target = (& git -C $fixtureRepo rev-parse HEAD).Trim()
+
+    $topology = [ordered]@{
+        schemaVersion = 1
+        topologyId = 'skincos-canonical-worktrees'
+        worktree = [ordered]@{ canonicalRelativeRoot = 'admin\canonical'; pathTemplate = 'admin\canonical\{surfaceType}\{surfaceId}' }
+        crm = [ordered]@{
+            pilot = @('users')
+            surfaces = @([ordered]@{ id = 'users'; label = 'Usuários'; route = '/?module=users'; source = 'fixture' })
+        }
+        orb = [ordered]@{ pilot = @(); families = @() }
+    }
+    $topology | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $fixtureTopology -Encoding utf8
+
+    $common = @('-ProjectRoot', $fixtureRepo, '-WorktreeRoot', $fixtureWorktrees, '-TopologyPath', $fixtureTopology, '-RuntimeRegistryRoot', $fixtureRegistry, '-SkipGitHub')
+    $initial = Invoke-Coordinator @{ Action = 'inventory' }
+    if ($initial.missingCount -ne 1 -or $initial.presentCount -ne 0) { throw 'Initial inventory did not report one missing canonical slot.' }
+
+    $plan = Invoke-Coordinator @{ Action = 'plan' }
+    if ($plan.actions[0].action -ne 'ensure-canonical' -or $plan.actions[0].mutation -notmatch 'Apply') { throw 'Read-only plan did not require explicit ensure apply.' }
+
+    $created = Invoke-Coordinator @{ Action = 'ensure-canonical'; SurfaceType = 'crm-module'; SurfaceId = 'users'; TargetCommit = $target; Apply = $true }
+    if ($created.action -ne 'created' -or $created.targetCommit -ne $target) { throw 'Canonical slot was not created at the explicit target SHA.' }
+
+    $ready = Invoke-Coordinator @{ Action = 'inventory' }
+    if ($ready.surfaces[0].status -ne 'ready' -or $ready.presentCount -ne 1 -or -not $ready.surfaces[0].worktrees[0].detached) { throw 'Created canonical slot was not reported ready and detached.' }
+
+    $registryPath = Join-Path $fixtureRegistry 'canonical-registry.json'
+    $registry = Get-Content -Raw -LiteralPath $registryPath | ConvertFrom-Json
+    $registry.surfaces[0].targetCommit = ('0' * 40)
+    $registry | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $registryPath -Encoding utf8
+    $mismatch = Invoke-Coordinator @{ Action = 'inventory' }
+    if ($mismatch.surfaces[0].status -ne 'registry_mismatch' -or -not $mismatch.surfaces[0].registryMismatch) { throw 'Registry/SHA mismatch was not reported.' }
+    $repaired = Invoke-Coordinator @{ Action = 'ensure-canonical'; SurfaceType = 'crm-module'; SurfaceId = 'users'; TargetCommit = $target; Apply = $true }
+    if ($repaired.action -ne 'reused') { throw 'Existing canonical slot was not safely reused after registry repair.' }
+
+    $claimed = Invoke-Coordinator @{ Action = 'claim'; SurfaceType = 'crm-module'; SurfaceId = 'users'; Owner = 'fixture-owner'; Apply = $true }
+    if ($claimed.action -ne 'claimed' -or [string]::IsNullOrWhiteSpace($claimed.token)) { throw 'Canonical claim did not create a lease token.' }
+
+    $secondClaimParameters = @{
+        Action = 'claim'
+        SurfaceType = 'crm-module'
+        SurfaceId = 'users'
+        Owner = 'other-owner'
+        Apply = $true
+        ProjectRoot = $fixtureRepo
+        WorktreeRoot = $fixtureWorktrees
+        TopologyPath = $fixtureTopology
+        RuntimeRegistryRoot = $fixtureRegistry
+        SkipGitHub = $true
+    }
+    $oldPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    $secondClaimExitCode = 0
+    $secondClaim = @()
+    try {
+        $secondClaim = @(& $coordinator @secondClaimParameters 2>&1)
+        $secondClaimExitCode = $LASTEXITCODE
+    }
+    catch {
+        $secondClaimExitCode = 1
+        $secondClaim += [string]$_.Exception.Message
+    }
+    $ErrorActionPreference = $oldPreference
+    if ($secondClaimExitCode -eq 0 -or (($secondClaim -join ' ') -notmatch 'já possui lease|lease')) { throw 'Duplicate canonical claim was not rejected.' }
+
+    $released = Invoke-Coordinator @{ Action = 'release'; SurfaceType = 'crm-module'; SurfaceId = 'users'; Owner = 'fixture-owner'; LeaseToken = $claimed.token; Apply = $true }
+    if ($released.action -ne 'released') { throw 'Canonical release did not remove the lease.' }
+
+    $canonicalPath = Join-Path $fixtureWorktrees 'admin\canonical\crm\users'
+    Add-Content -LiteralPath (Join-Path $canonicalPath 'README.md') -Value "dirty`n"
+    $dirty = Invoke-Coordinator @{ Action = 'inventory' }
+    if ($dirty.surfaces[0].status -ne 'blocked_dirty') { throw 'Dirty canonical slot was not preserved as blocked.' }
+
+    Write-Output 'Canonical worktree topology fixture tests: PASS'
+}
+finally {
+    if (Test-Path -LiteralPath $fixtureRoot) {
+        Remove-Item -LiteralPath $fixtureRoot -Recurse -Force
+    }
+}


### PR DESCRIPTION
## Objetivo

Adiciona a topologia canônica híbrida para CRM e ORB, com um slot estável por superfície/família e worktrees temporários preservados para tarefas e PRs.

Este PR depende de #1337 (`codex/admin/worktree-safety-audit-20260811`) e deve ser revisado/mesclado após essa base.

## Entregas

- `ops/codex/worktree-topology.json` com 14 módulos do catálogo, a exceção explícita `users`, famílias ORB e política de subworkflows sem slots físicos independentes.
- `scripts/manage-canonical-worktrees.ps1` com `inventory`, `plan`, `ensure-canonical`, `claim`, `release` e `retire`, registro/leases privados e remoção somente via Git.
- Auditoria de footprint com slot esperado/encontrado, duplicidade, SHA/registro, leases, manifestos/processos e motivo de preservação.
- Runbook e fixture Git do lifecycle.

## Slots-piloto materializados

- CRM `users` em `ca1e1dab82616f1804b91d0ecd87e355f065e2d2`.
- CRM `atendimento` e `clientes` em `45cfd807d1b0d48f955990b851c4e53dcbeccb3e`.
- ORB `livia` e `meta-ads-publish` em `45cfd807d1b0d48f955990b851c4e53dcbeccb3e`.

## Validação

- Parser PowerShell e JSON: pass.
- Fixture do coordenador: pass, incluindo detached, mismatch de registro/SHA, dirty, claim duplicado e release.
- `crm-local-dual-persona.test.mjs`: 23/23.
- Retenção de runtime ORB: pass.
- Livia QA: 34/34; Meta Ads: 11/11.
- APIs locais autenticadas de Usuários e rotas CRM Users/Atendimento/Clientes: HTTP 200, sem `route_not_found`; 6 membros e 2 unidades listados.
- Auditoria offline final: 519 worktrees, 18 superfícies, 5 presentes, 13 ausentes, 0 duplicados, 0 leases, Git íntegro e `git worktree prune --dry-run` limpo.

A suíte E2E Playwright não iniciou neste worktree porque o executável `playwright` não está instalado no ambiente WSL do checkout; nenhuma instalação foi feita e nenhum runtime foi alterado.

Não houve deploy, alteração de flag, banco remoto, API pública ou remoção de worktree preexistente. O único checkout removido foi um auxiliar limpo criado acidentalmente durante esta implementação, usando `git worktree remove`.