### PR TITLE
feat(influencer-intelligence): add read-only MCP adapter

### DIFF
--- a/.github/workflows/architecture-governance.yml
+++ b/.github/workflows/architecture-governance.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Validate domain import boundaries
         run: node .github/scripts/validate-domain-boundaries.mjs
       - name: Test Influencer Intelligence contracts, providers and snapshots
-        run: node --test social/influencer-intelligence/tests/contracts.test.mjs social/influencer-intelligence/tests/registry.test.mjs social/influencer-intelligence/tests/providers.test.mjs social/influencer-intelligence/tests/provider-router-contract.test.mjs social/influencer-intelligence/tests/architecture.test.mjs social/influencer-intelligence/tests/data-model.test.mjs social/influencer-intelligence/tests/snapshots.test.mjs social/influencer-intelligence/tests/analytics.test.mjs social/influencer-intelligence/tests/scoring.test.mjs social/influencer-intelligence/tests/scheduler.test.mjs
+        run: node --test social/influencer-intelligence/tests/contracts.test.mjs social/influencer-intelligence/tests/registry.test.mjs social/influencer-intelligence/tests/providers.test.mjs social/influencer-intelligence/tests/provider-router-contract.test.mjs social/influencer-intelligence/tests/architecture.test.mjs social/influencer-intelligence/tests/data-model.test.mjs social/influencer-intelligence/tests/snapshots.test.mjs social/influencer-intelligence/tests/analytics.test.mjs social/influencer-intelligence/tests/scoring.test.mjs social/influencer-intelligence/tests/scheduler.test.mjs social/influencer-intelligence/tests/mcp-readonly.test.mjs
       - name: Validate reproducible staging manifest
         run: node .github/scripts/validate-staging-manifest.mjs
       - name: Validate staging bootstrap safety guards

--- a/docs/decisions/adr-influencer-intelligence-architecture.md
+++ b/docs/decisions/adr-influencer-intelligence-architecture.md
@@ -279,15 +279,23 @@ provider-debug endpoint in this contract.
 
 ## 9. MCP read-only contract
 
-M6 will expose four bounded tools through the existing
-`orb/engine/mcp-readonly-gateway` security pattern:
+M6 adds a source-only domain adapter for the existing
+`orb/engine/mcp-readonly-gateway` security pattern. The current tool registry
+is intentionally limited to artifacts that already exist and delegates to an
+authenticated internal read service:
 
 | Tool | Input | Output |
 | --- | --- | --- |
-| `influencer_intelligence_get_creator_analysis` | creator key, window, metric set | Analysis envelope |
-| `influencer_intelligence_compare_creators` | up to 20 creator keys, window, metric set | Comparison envelope |
-| `influencer_intelligence_get_campaign_fit` | creator keys, structured campaign criteria, window | Campaign Fit envelope |
-| `influencer_intelligence_get_data_coverage` | creator key, window | Coverage/provenance envelope |
+| `search_creators` | bounded query, provider/state filter, page | Creator registry projection |
+| `get_creator_profile` | creator key | Latest profile envelope |
+| `get_creator_snapshots` | creator key, optional bounded window/page | Historical snapshot envelope |
+| `get_creator_media` | creator key, optional bounded window/page | Media metrics envelope |
+| `get_creator_analytics` | creator key, optional bounded window | Persisted deterministic analytics envelope |
+| `get_creator_score` | creator key | Persisted deterministic score envelope |
+| `compare_creators` | up to 20 creator keys, optional bounded window | Comparison envelope |
+
+`get_campaign_fit` is deliberately deferred and is not registered before M11,
+when the Campaign Fit artifact and its separate confidence contract exist.
 
 Each tool requires authentication and the domain grant. Tool input uses a
 closed JSON schema with `additionalProperties: false`, bounded sizes, bounded
@@ -296,7 +304,9 @@ sanitization, a domain rate limit, a 12-second timeout/abort path, an audit
 event, and a read-only database role. The response is sanitized again before
 leaving the gateway.
 
-MCP delegates to the internal service. It cannot call Meta Graph or
+MCP delegates to the internal service. The M6 adapter is not a live transport
+registration; the existing gateway remains the owner of transport and
+upstream-authentication integration. The adapter cannot call Meta Graph or
 instagrapi, retrieve Token Vault material, run arbitrary SQL or shell, scrape,
 publish, engage, or mutate Orb/n8n workflows. Errors are reduced to stable
 codes and never include raw upstream payloads.
@@ -400,7 +410,7 @@ source-controlled migration artifacts; they do not apply them.
 | M3 | Append-only snapshots, retention policy, and Orb job contract | Snapshots merged in PR #1331; inactive scheduler source merged in #1335; import/runtime pending |
 | M4 | Robust analytics and outlier-resistant metrics | Merged in PR #1333; synthetic time-series fixtures and explicit unavailable coverage |
 | M5 | Deterministic score/confidence/provenance engine | Merged in PR #1334; versioned algorithms and golden evidence |
-| M6 | Hardened authenticated read-only MCP | Tool schema, auth/grant, sanitization, limits, timeout, audit, read-only role |
+| M6 | Hardened authenticated read-only MCP domain adapter | Tool schema, auth/grant, sanitization, limits, timeout, audit contract, read-only service delegation; runtime registration remains pending |
 | M7 | `skincos-influencer-intelligence` skill | Skill uses only the approved MCP contract and cannot bypass boundaries |
 | M8 | Read-only CRM API/dashboard | Server-side flag/grant, module catalog, shadow UI, direct-provider negative tests |
 | M9 | Minimized comments intelligence | Aggregate-only topics/sentiment/safety/spam signals and retention evidence |

--- a/social/influencer-intelligence/MCP_READONLY.md
+++ b/social/influencer-intelligence/MCP_READONLY.md
@@ -1,0 +1,78 @@
+# Influencer Intelligence MCP read-only adapter
+
+M6 defines the domain adapter for the existing
+`orb/engine/mcp-readonly-gateway` security pattern. It is source-controlled but
+not registered in a live transport, imported into Orb, or enabled for users.
+The adapter accepts an already authenticated context and an injected internal
+read service. It never opens a provider connection, reads PostgreSQL directly,
+executes SQL or shell, calls Token Vault, or starts a collection job.
+
+## Boundary
+
+The existing gateway owns transport, upstream authentication, local request
+limits, process isolation, and JSONL audit conventions. This adapter owns the
+Influencer Intelligence tool registry, closed input schemas, domain grant
+check, bounded output contract, provider-neutral provenance, and fail-closed
+sanitization. Keeping the adapter free of transport and provider imports
+prevents UI/Codex callers from bypassing the internal service or the official-
+first provider router.
+
+The factory requires a read service with these read-only methods:
+
+| MCP tool | Internal service method |
+| --- | --- |
+| `search_creators` | `searchCreators` |
+| `get_creator_profile` | `getCreatorProfile` |
+| `get_creator_snapshots` | `getCreatorSnapshots` |
+| `get_creator_media` | `getCreatorMedia` |
+| `get_creator_analytics` | `getCreatorAnalytics` |
+| `get_creator_score` | `getCreatorScore` |
+| `compare_creators` | `compareCreators` |
+
+`get_campaign_fit` is deliberately not registered until M11 has a concrete
+Campaign Fit artifact and contract.
+
+## Request controls
+
+Every request requires `authenticated: true`, the server-side grant
+`module.influencer-intelligence.access`, and an opaque `actor_scope`. Tool
+arguments reject unknown properties and sensitive fields. Creator keys are
+opaque internal identifiers; provider ids, tokens, sessions, raw comments, and
+free-form provider payloads are not accepted.
+
+The adapter enforces a 64 KiB request limit, 512 KiB sanitized response limit,
+50-item pages, at most 20 creators per comparison, at most a 365-day window,
+four concurrent calls, a 12-second timeout/abort, and a fixed 60 requests per
+minute per actor scope. Audit is mandatory and audit failure is fail-closed.
+The injected service receives an abort signal and correlation/request id.
+
+## Response contract
+
+The service must return an envelope with `data`, `data_classification`,
+`freshness`, `retrieved_at`, `confidence` or `confidence_score`, `coverage`,
+`providers`, `provenance`, and `limitations`. The adapter normalizes the
+envelope and emits `confidence_score` and `data_coverage` from bounded values.
+`observed`, `derived`, `inferred`, and `unavailable` remain explicit. Missing
+data is `null`, never numeric zero; unavailable results have zero confidence
+and an explicit limitation. `stale` is represented by the freshness field and
+must not be hidden by a successful response state.
+
+Provenance is restricted to bounded provider/source references with timestamps
+and evidence state. Raw payloads, credentials, authorization material, PII,
+sessions, query-string URLs, and diagnostic upstream bodies are rejected or
+removed before a result leaves the adapter. Provider-specific evidence is
+therefore an opaque, bounded reference rather than a raw provider response.
+
+The adapter only returns persisted or service-owned read projections. It does
+not recalculate analytics, scores, weights, benchmarks, or campaign fit, and it
+does not upgrade an inferred signal to observed.
+
+## Runtime status and rollback
+
+This milestone adds no migration, route, systemd unit, Orb import, provider
+call, credential access, grant assignment, or feature-flag change. Keep
+`INFLUENCER_INTELLIGENCE_ENABLED=false`, `mcpRuntimeRegistered=false`, and the
+domain in `off` until the internal service and later M7/M8 gates are proven.
+
+Rollback is a revert or closure of the single-purpose M6 change. No database,
+provider session, workflow, or user-visible state is created by this adapter.

--- a/social/influencer-intelligence/README.md
+++ b/social/influencer-intelligence/README.md
@@ -1,9 +1,10 @@
 # Influencer Intelligence
 
 Status: architecture v1 defined; M2 provider boundary, M4 deterministic
-analytics, and M5 deterministic scoring are implemented in source control, and
-data model v1 plus scoring metadata remain additive, unapplied artifacts in
-this milestone. The domain remains
+analytics, M5 deterministic scoring, and the M6 read-only MCP domain adapter
+are implemented in source control. Data model v1 plus scoring metadata remain
+additive, unapplied artifacts, and M6 runtime registration is still deferred.
+The domain remains
 experimental, not exposed, and off by default.
 
 This domain provides read-only intelligence about Instagram creators for
@@ -20,10 +21,10 @@ boundary, append-only data model, provenance and score envelopes, internal API,
 read-only MCP tools, release/flag model, privacy rules, observability, and the
 M0--M13 implementation gates.
 
-The architecture milestone itself does not add routes, migrations, provider
-transports, CRM registration, MCP registration, Orb workflow changes, or flag
-wiring. `INFLUENCER_INTELLIGENCE_ENABLED` remains `false` and the domain stays
-off until a later milestone proves its own gates.
+The architecture and M6 source milestones do not add routes, migrations,
+provider transports, CRM registration, live MCP registration, Orb workflow
+imports, or flag wiring. `INFLUENCER_INTELLIGENCE_ENABLED` remains `false` and
+the domain stays off until later milestones prove their own gates.
 
 ## M0 decision
 
@@ -196,6 +197,27 @@ under `social/instagram/module/api/` must not be exposed as the domain API
 without independent authentication, input, timeout, rate-limit, audit, and
 deployment hardening.
 
+## M6 decision: read-only MCP adapter
+
+[`mcp-readonly.mjs`](./mcp-readonly.mjs) implements the domain-side adapter for
+the existing `orb/engine/mcp-readonly-gateway` pattern. It exposes bounded
+`search_creators`, `get_creator_profile`, `get_creator_snapshots`,
+`get_creator_media`, `get_creator_analytics`, `get_creator_score`, and
+`compare_creators` tools through an injected internal read service. Campaign Fit
+is intentionally deferred from the tool registry until M11.
+
+The adapter requires authentication, the server-side domain grant, opaque
+actor scope, closed input schemas, bounded windows/pages/comparisons, timeout,
+abort propagation, concurrency control, rate limiting, sanitized output, and
+mandatory audit. It returns explicit classification, freshness, provenance,
+confidence, coverage, limitations, and unavailable/null states. It never calls
+Meta, instagrapi, Token Vault, PostgreSQL, SQL, shell, Orb, or a scoring engine;
+it cannot mutate Instagram, workflows, or persisted scores. The source and
+protocol tests are present, while runtime registration remains pending.
+
+See [`MCP_READONLY.md`](./MCP_READONLY.md) for the internal service contract,
+limits, sanitization boundary, and rollback posture.
+
 ### Incumbent integrations to reuse
 
 - Official-first collection will wrap the existing CRM Graph adapter in
@@ -296,7 +318,7 @@ production configuration.
 | M3 | Append-only snapshots, retention, and Orb scheduling | Data model #1322, snapshots #1331, and inactive Orb scheduler #1335; artifacts/import/runtime pending |
 | M4 | Robust analytics and outlier-resistant metrics | Merged in #1333; pure deterministic engine, golden fixtures, and formula documentation |
 | M5 | Deterministic score, confidence, coverage, and provenance | Merged in #1334; versioned weights, confidence factors, explanations, additive persistence metadata, and golden tests |
-| M6 | Authenticated, sanitized, rate-limited read-only MCP | Pending |
+| M6 | Authenticated, sanitized, rate-limited read-only MCP | Source adapter and protocol tests implemented; runtime registration pending |
 | M7 | `skincos-influencer-intelligence` Codex skill | Pending |
 | M8 | Read-only CRM contracts and dashboard | Pending |
 | M9 | Minimized comments intelligence | Pending |
@@ -319,6 +341,22 @@ production configuration.
 - Rollback: close or revert the single-purpose change to merge SHA
   `f0dcab87d5348941d5c28e690c8a689a3bad8a3d`. No user data, provider session,
   network state, or remote database state is created by this milestone.
+
+## M6 risk, validation, and rollback
+
+- Risk: high because the adapter is a security boundary, but the change is
+  source-only and has no transport or runtime registration.
+- Surfaces: `social/influencer-intelligence/mcp-readonly.mjs`, its protocol
+  tests, architecture manifest/docs, and the architecture governance test
+  list; no provider, database, CRM, Orb, systemd, or user-facing surface.
+- Migration: none; existing additive migration artifacts remain unapplied.
+- Flag/grant: `INFLUENCER_INTELLIGENCE_ENABLED=false`; the grant is validated
+  by the adapter but not assigned to users and `mcpRuntimeRegistered=false`.
+- Validation: protocol/security tests, architecture/domain-boundary validators,
+  focused M0--M5 regression tests, diff hygiene, and terminal hosted CI on the
+  exact PR SHA.
+- Rollback: revert or close the single-purpose change. No database, credential,
+  provider session, workflow, or external business effect is created by M6.
 
 ## Data model risk, validation, and rollback
 

--- a/social/influencer-intelligence/architecture.mjs
+++ b/social/influencer-intelligence/architecture.mjs
@@ -286,17 +286,21 @@ export const API_CONTRACT = deepFreeze({
 
 export const MCP_CONTRACT = deepFreeze({
   contractVersion: 'influencer-intelligence/mcp/v1',
-  transport: 'reuse the authenticated read-only gateway pattern; MCP is not a provider transport',
+  transport: 'domain adapter for the authenticated orb/engine/mcp-readonly-gateway pattern; MCP is not a provider transport',
   controls: ['authentication', 'server-side grant', 'schema sanitization', 'bounded input', 'rate limit', 'timeout and abort', 'audit event', 'read-only database role', 'redacted output'],
-  limits: { maxCreatorsPerRequest: 20, maxWindowDays: 365, timeoutMs: 12000, rateLimitPerMinute: 60 },
+  limits: { maxRequestBytes: 65536, maxResponseBytes: 524288, maxPageSize: 50, maxCreatorsPerRequest: 20, maxWindowDays: 365, maxConcurrentRequests: 4, timeoutMs: 12000, rateLimitPerMinute: 60 },
   tools: [
-    { name: 'influencer_intelligence_get_creator_analysis', readOnly: true, input: ['creatorKey', 'window', 'metricSet'] },
-    { name: 'influencer_intelligence_compare_creators', readOnly: true, input: ['creatorKeys', 'window', 'metricSet'] },
-    { name: 'influencer_intelligence_get_campaign_fit', readOnly: true, input: ['creatorKeys', 'campaignCriteria', 'window'] },
-    { name: 'influencer_intelligence_get_data_coverage', readOnly: true, input: ['creatorKey', 'window'] },
+    { name: 'search_creators', readOnly: true, input: ['query', 'provider', 'registry_state', 'page', 'page_size'] },
+    { name: 'get_creator_profile', readOnly: true, input: ['creator_key'] },
+    { name: 'get_creator_snapshots', readOnly: true, input: ['creator_key', 'window', 'page', 'page_size'] },
+    { name: 'get_creator_media', readOnly: true, input: ['creator_key', 'window', 'page', 'page_size'] },
+    { name: 'get_creator_analytics', readOnly: true, input: ['creator_key', 'window'] },
+    { name: 'get_creator_score', readOnly: true, input: ['creator_key'] },
+    { name: 'compare_creators', readOnly: true, input: ['creator_keys', 'window'] },
   ],
+  deferredTools: [{ name: 'get_campaign_fit', unavailableUntil: 'M11', rule: 'not registered before Campaign Fit exists' }],
   forbidden: ['arbitrary SQL', 'arbitrary shell', 'scraping', 'provider credential retrieval', 'publication', 'engagement', 'workflow mutation', 'raw comment or media output'],
-  output: ['versioned response envelope', 'coverage', 'provenance', 'requestId', 'sanitized errors'],
+  output: ['versioned response envelope', 'data classification', 'freshness', 'confidence', 'coverage', 'provenance', 'requestId', 'sanitized errors'],
 });
 
 export const RELEASE_CONTRACT = deepFreeze({
@@ -322,6 +326,8 @@ export const RELEASE_CONTRACT = deepFreeze({
     schedulerWorkflowImported: false,
     schedulerWorkflowActive: false,
     schedulerMigrationArtifactAdded: true,
+    mcpSourceAdded: true,
+    mcpRuntimeRegistered: false,
   },
 });
 
@@ -350,7 +356,7 @@ export const IMPLEMENTATION_PLAN = deepFreeze([
   { id: 'M3', title: 'Append-only snapshots, retention, and Orb job contract', status: 'data model #1322, snapshots #1331, and scheduler #1335 merged; artifacts/import/runtime pending', acceptance: ['new additive tables', 'immutable evidence lifecycle', 'bounded snapshot_creator and snapshot_creator_media operations', 'inactive dry-run/shadow scheduling', 'resume/recovery with idempotent service calls', 'no live workflow import'] },
   { id: 'M4', title: 'Robust analytics', status: 'merged #1333; synthetic source/tests only', acceptance: ['time windows', 'viral-outlier resistance', 'explicit unavailable coverage'] },
   { id: 'M5', title: 'Deterministic scores and confidence', status: 'merged #1334; synthetic source/tests only', acceptance: ['versioned algorithms', 'score/confidence/coverage/provenance completeness', 'calibration fixtures'] },
-  { id: 'M6', title: 'Hardened read-only MCP', status: 'pending', acceptance: ['auth', 'sanitization', 'rate limit', 'timeout', 'audit', 'bounded tools', 'read-only role'] },
+  { id: 'M6', title: 'Hardened read-only MCP', status: 'source adapter and protocol tests implemented; runtime registration pending', acceptance: ['auth', 'sanitization', 'rate limit', 'timeout', 'audit', 'bounded tools', 'read-only role'] },
   { id: 'M7', title: 'Codex skill', status: 'pending', acceptance: ['read-only tool use', 'safe question routing', 'no provider or shell bypass'] },
   { id: 'M8', title: 'CRM read-only surface', status: 'pending', acceptance: ['internal API only', 'server grant and flag', 'shadow UI', 'no direct provider access'] },
   { id: 'M9', title: 'Comments intelligence', status: 'pending', acceptance: ['aggregate-only signals', 'privacy and model provenance', 'bounded retention'] },

--- a/social/influencer-intelligence/mcp-readonly.mjs
+++ b/social/influencer-intelligence/mcp-readonly.mjs
@@ -1,0 +1,625 @@
+/**
+ * Authenticated, bounded, read-only MCP adapter for Influencer Intelligence.
+ *
+ * The transport gateway owns bearer validation. This adapter accepts only the
+ * resulting authentication context and delegates to an injected internal read
+ * service. It never calls a provider, opens a database, executes shell, or
+ * constructs a query. The same gateway conventions used by
+ * orb/engine/mcp-readonly-gateway are enforced here so M8 can mount the
+ * service without widening this boundary.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import {
+  assertNoSensitiveFields,
+  normalizeCreatorKey,
+  normalizeProviderId,
+} from './contracts.mjs';
+
+export const MCP_READONLY_CONTRACT_VERSION = 'influencer-intelligence/mcp/v1';
+export const MCP_READONLY_SERVER_VERSION = 'influencer-intelligence-mcp/v1';
+
+export const MCP_READONLY_LIMITS = Object.freeze({
+  maxRequestBytes: 64 * 1024,
+  maxResponseBytes: 512 * 1024,
+  maxPageSize: 50,
+  maxCreatorsPerRequest: 20,
+  maxWindowDays: 365,
+  maxConcurrentRequests: 4,
+  timeoutMs: 12_000,
+  rateLimitPerMinute: 60,
+  maxStringLength: 160,
+});
+
+export const MCP_ERROR_CODES = Object.freeze([
+  'AUTH_REQUIRED',
+  'GRANT_REQUIRED',
+  'INVALID_INPUT',
+  'INVALID_SERVICE_RESPONSE',
+  'NOT_FOUND',
+  'UNAVAILABLE',
+  'RATE_LIMITED',
+  'TOO_MANY_CONCURRENT_REQUESTS',
+  'TIMEOUT',
+  'AUDIT_UNAVAILABLE',
+  'SANITIZATION_FAILED',
+  'INTERNAL',
+]);
+
+const DATA_CLASSIFICATIONS = new Set(['observed', 'derived', 'inferred', 'unavailable']);
+const FRESHNESS_STATES = new Set(['fresh', 'stale', 'unknown']);
+const REGISTRY_STATES = new Set(['candidate', 'paused', 'unavailable']);
+const SUPPORTED_SOURCE_TYPES = new Set([
+  'registry',
+  'profile',
+  'media',
+  'analysis',
+  'score',
+  'comparison',
+  'comments-aggregate',
+  'content-features',
+  'campaign-fit',
+]);
+const SAFE_LIMITATION_PATTERN = /^[A-Za-z0-9._:/ -]{1,240}$/;
+const SAFE_SEARCH_PATTERN = /^[A-Za-z0-9._@ -]{1,80}$/;
+const SAFE_ACTOR_SCOPE_PATTERN = /^[A-Za-z0-9._:-]{1,160}$/;
+const SAFE_SOURCE_REF_PATTERN = /^[A-Za-z0-9._:/-]{1,240}$/;
+const SENSITIVE_OUTPUT_KEY = /(?:access[_-]?token|refresh[_-]?token|id[_-]?token|authorization|cookie|credential|secret|client.?secret|password|api[_-]?key|session|session.?id|provider.?account|raw.?provider|raw.?payload|raw.?comment|comment.?text|caption|media.?url|image.?url|video.?url|binary|private.?key|email|phone|telephone|cpf|sql|shell|command|prompt|completion)/i;
+const SENSITIVE_OUTPUT_TEXT = /(?:bearer\s+[A-Za-z0-9._-]{8,}|(?:access[_-]?token|refresh[_-]?token|api[_-]?key|password|client[_ -]?secret|authorization|cookie)\s*[:=]|[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}|\b\d{3}\.\d{3}\.\d{3}-?\d{2}\b)/i;
+const FIXED_ERROR_MESSAGES = Object.freeze({
+  AUTH_REQUIRED: 'authentication is required',
+  GRANT_REQUIRED: 'the Influencer Intelligence grant is required',
+  INVALID_INPUT: 'request arguments are invalid',
+  INVALID_SERVICE_RESPONSE: 'the internal service returned an invalid response',
+  NOT_FOUND: 'creator was not found',
+  UNAVAILABLE: 'the requested analysis is unavailable',
+  RATE_LIMITED: 'rate limit exceeded',
+  TOO_MANY_CONCURRENT_REQUESTS: 'too many concurrent requests',
+  TIMEOUT: 'the read operation timed out',
+  AUDIT_UNAVAILABLE: 'audit storage is unavailable',
+  SANITIZATION_FAILED: 'response sanitization failed',
+  INTERNAL: 'internal read failure',
+});
+
+const STORE_METHODS = Object.freeze({
+  search_creators: 'searchCreators',
+  get_creator_profile: 'getCreatorProfile',
+  get_creator_snapshots: 'getCreatorSnapshots',
+  get_creator_media: 'getCreatorMedia',
+  get_creator_analytics: 'getCreatorAnalytics',
+  get_creator_score: 'getCreatorScore',
+  compare_creators: 'compareCreators',
+});
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function fail(code, message = FIXED_ERROR_MESSAGES[code] || FIXED_ERROR_MESSAGES.INTERNAL) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function assertCondition(condition, code, message) {
+  if (!condition) throw fail(code, message);
+}
+
+function finiteNumber(value, label, { minimum = 0, maximum = Number.POSITIVE_INFINITY } = {}) {
+  assertCondition(typeof value === 'number' && Number.isFinite(value), 'INVALID_SERVICE_RESPONSE', `${label} must be finite`);
+  assertCondition(value >= minimum && value <= maximum, 'INVALID_SERVICE_RESPONSE', `${label} is outside its range`);
+  return Number(value.toFixed(6));
+}
+
+function finiteInteger(value, label, { minimum = 0, maximum = Number.POSITIVE_INFINITY } = {}) {
+  assertCondition(Number.isInteger(value), 'INVALID_SERVICE_RESPONSE', `${label} must be an integer`);
+  assertCondition(value >= minimum && value <= maximum, 'INVALID_SERVICE_RESPONSE', `${label} is outside its range`);
+  return value;
+}
+
+function normalizedTimestamp(value, label, code = 'INVALID_SERVICE_RESPONSE') {
+  assertCondition(typeof value === 'string' && value.length <= 40, code, `${label} must be an ISO timestamp`);
+  const parsed = new Date(value);
+  assertCondition(!Number.isNaN(parsed.getTime()), code, `${label} must be an ISO timestamp`);
+  return parsed.toISOString();
+}
+
+function normalizedString(value, label, { maximum = MCP_READONLY_LIMITS.maxStringLength, pattern = null } = {}) {
+  assertCondition(typeof value === 'string', 'INVALID_INPUT', `${label} must be a string`);
+  const result = value.trim();
+  assertCondition(result.length > 0 && result.length <= maximum, 'INVALID_INPUT', `${label} is invalid`);
+  assertCondition(!/[\u0000-\u001f\u007f]/.test(result), 'INVALID_INPUT', `${label} contains a control character`);
+  if (pattern) assertCondition(pattern.test(result), 'INVALID_INPUT', `${label} contains unsupported characters`);
+  return result;
+}
+
+function optionalString(value, label, options = {}) {
+  if (value === undefined || value === null || value === '') return undefined;
+  return normalizedString(value, label, options);
+}
+
+function pageValue(value, label, fallback, maximum) {
+  if (value === undefined) return fallback;
+  assertCondition(Number.isInteger(value) && value >= 1 && value <= maximum, 'INVALID_INPUT', `${label} is invalid`);
+  return value;
+}
+
+function normalizeWindow(value) {
+  if (value === undefined || value === null) return undefined;
+  assertCondition(isRecord(value), 'INVALID_INPUT', 'window must be an object');
+  const keys = Object.keys(value);
+  assertCondition(keys.every((key) => key === 'start' || key === 'end'), 'INVALID_INPUT', 'window contains unsupported fields');
+  assertCondition(typeof value.start === 'string' && typeof value.end === 'string', 'INVALID_INPUT', 'window requires start and end');
+  const start = normalizedTimestamp(value.start, 'window.start', 'INVALID_INPUT');
+  const end = normalizedTimestamp(value.end, 'window.end', 'INVALID_INPUT');
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  assertCondition(endMs > startMs, 'INVALID_INPUT', 'window.end must follow window.start');
+  assertCondition(endMs - startMs <= MCP_READONLY_LIMITS.maxWindowDays * 24 * 60 * 60 * 1000, 'INVALID_INPUT', 'window exceeds the maximum duration');
+  return { start, end };
+}
+
+function normalizeCreatorKeys(value) {
+  assertCondition(Array.isArray(value), 'INVALID_INPUT', 'creator_keys must be an array');
+  assertCondition(value.length >= 1 && value.length <= MCP_READONLY_LIMITS.maxCreatorsPerRequest, 'INVALID_INPUT', 'creator_keys count is outside the allowed range');
+  const keys = value.map((item) => normalizeCreatorKey(item));
+  assertCondition(new Set(keys).size === keys.length, 'INVALID_INPUT', 'creator_keys must be unique');
+  return keys;
+}
+
+function normalizeInput(toolName, input = {}) {
+  assertCondition(isRecord(input), 'INVALID_INPUT', 'tool arguments must be an object');
+  const allowed = {
+    search_creators: new Set(['query', 'provider', 'registry_state', 'page', 'page_size']),
+    get_creator_profile: new Set(['creator_key']),
+    get_creator_snapshots: new Set(['creator_key', 'window', 'page', 'page_size']),
+    get_creator_media: new Set(['creator_key', 'window', 'page', 'page_size']),
+    get_creator_analytics: new Set(['creator_key', 'window']),
+    get_creator_score: new Set(['creator_key']),
+    compare_creators: new Set(['creator_keys', 'window']),
+  }[toolName];
+  assertCondition(allowed, 'INVALID_INPUT', 'tool is not registered');
+  assertCondition(Object.keys(input).every((key) => allowed.has(key)), 'INVALID_INPUT', 'additional tool arguments are not allowed');
+  assertNoSensitiveFields(input, `tools.call.${toolName}`);
+
+  if (toolName === 'search_creators') {
+    const query = optionalString(input.query, 'query', { maximum: 80, pattern: SAFE_SEARCH_PATTERN });
+    const provider = input.provider === undefined ? undefined : normalizeProviderId(input.provider);
+    const registryState = input.registry_state === undefined ? undefined : normalizedString(input.registry_state, 'registry_state', { maximum: 32 });
+    assertCondition(registryState === undefined || REGISTRY_STATES.has(registryState), 'INVALID_INPUT', 'registry_state is invalid');
+    return {
+      ...(query ? { query } : {}),
+      ...(provider ? { provider } : {}),
+      ...(registryState ? { registry_state: registryState } : {}),
+      page: pageValue(input.page, 'page', 1, 100000),
+      page_size: pageValue(input.page_size, 'page_size', 25, MCP_READONLY_LIMITS.maxPageSize),
+    };
+  }
+
+  if (toolName === 'compare_creators') {
+    const window = normalizeWindow(input.window);
+    return { creator_keys: normalizeCreatorKeys(input.creator_keys), ...(window ? { window } : {}) };
+  }
+
+  const creatorKey = normalizeCreatorKey(input.creator_key);
+  if (toolName === 'get_creator_profile' || toolName === 'get_creator_score') return { creator_key: creatorKey };
+  const window = normalizeWindow(input.window);
+  if (toolName === 'get_creator_analytics') return { creator_key: creatorKey, ...(window ? { window } : {}) };
+  return {
+    creator_key: creatorKey,
+    ...(window ? { window } : {}),
+    page: pageValue(input.page, 'page', 1, 100000),
+    page_size: pageValue(input.page_size, 'page_size', 25, MCP_READONLY_LIMITS.maxPageSize),
+  };
+}
+
+function safeRpcId(value) {
+  if (value === undefined || value === null) return null;
+  if (Number.isInteger(value) && value >= 0) return value;
+  if (typeof value === 'string' && /^[A-Za-z0-9._:-]{1,80}$/.test(value)) return value;
+  return null;
+}
+
+function validateRpc(rpc) {
+  assertCondition(isRecord(rpc), 'INVALID_INPUT', 'JSON-RPC request must be an object');
+  assertCondition(rpc.jsonrpc === '2.0', 'INVALID_INPUT', 'JSON-RPC version is unsupported');
+  assertCondition(typeof rpc.method === 'string' && /^[A-Za-z0-9_./:-]{1,80}$/.test(rpc.method), 'INVALID_INPUT', 'JSON-RPC method is invalid');
+  return safeRpcId(rpc.id);
+}
+
+function normalizeAuthContext(context) {
+  try {
+    assertNoSensitiveFields(context, 'auth_context');
+  } catch {
+    throw fail('AUTH_REQUIRED');
+  }
+  assertCondition(isRecord(context) && context.authenticated === true, 'AUTH_REQUIRED');
+  const grants = Array.isArray(context.grants) ? context.grants : [];
+  const hasGrant = context.grant === 'module.influencer-intelligence.access'
+    || grants.includes('module.influencer-intelligence.access');
+  assertCondition(hasGrant, 'GRANT_REQUIRED');
+  const actorScope = normalizedString(context.actor_scope, 'actor_scope', { maximum: 160, pattern: SAFE_ACTOR_SCOPE_PATTERN });
+  const dataScope = context.data_scope === undefined
+    ? null
+    : normalizedString(context.data_scope, 'data_scope', { maximum: 160, pattern: SAFE_ACTOR_SCOPE_PATTERN });
+  return { actor_scope: actorScope, data_scope: dataScope };
+}
+
+function createDefaultClock() {
+  return () => Date.now();
+}
+
+export function createFixedWindowRateLimiter({
+  limit = MCP_READONLY_LIMITS.rateLimitPerMinute,
+  windowMs = 60_000,
+  clock = createDefaultClock(),
+  maxKeys = 10_000,
+} = {}) {
+  assertCondition(Number.isInteger(limit) && limit > 0, 'INVALID_INPUT', 'rate limit must be positive');
+  assertCondition(Number.isInteger(windowMs) && windowMs > 0, 'INVALID_INPUT', 'rate window must be positive');
+  const windows = new Map();
+  return Object.freeze({
+    allow(key) {
+      const now = clock();
+      const normalizedKey = normalizedString(key, 'rate_limit_key', { maximum: 160, pattern: SAFE_ACTOR_SCOPE_PATTERN });
+      for (const [entryKey, stamps] of windows) {
+        const active = stamps.filter((stamp) => now - stamp < windowMs);
+        if (active.length === 0) windows.delete(entryKey);
+        else windows.set(entryKey, active);
+      }
+      const current = windows.get(normalizedKey) || [];
+      if (current.length >= limit) return false;
+      if (!windows.has(normalizedKey) && windows.size >= maxKeys) {
+        const oldest = windows.keys().next().value;
+        if (oldest !== undefined) windows.delete(oldest);
+      }
+      current.push(now);
+      windows.set(normalizedKey, current);
+      return true;
+    },
+    reset() {
+      windows.clear();
+    },
+  });
+}
+
+function normalizeCoverage(value) {
+  assertCondition(isRecord(value), 'INVALID_SERVICE_RESPONSE', 'coverage is required');
+  const available = value.available_metrics ?? value.availableMetrics;
+  const expected = value.expected_metrics ?? value.expectedMetrics;
+  finiteInteger(available, 'coverage.available_metrics');
+  finiteInteger(expected, 'coverage.expected_metrics', { minimum: 1 });
+  assertCondition(available <= expected, 'INVALID_SERVICE_RESPONSE', 'coverage.available_metrics exceeds expected_metrics');
+  const ratio = Number((available / expected).toFixed(6));
+  return {
+    available_metrics: available,
+    expected_metrics: expected,
+    ratio,
+    score: Number((ratio * 100).toFixed(2)),
+  };
+}
+
+function assertResponseSize(value) {
+  let serialized;
+  try { serialized = JSON.stringify(value); } catch { throw fail('SANITIZATION_FAILED'); }
+  assertCondition(typeof serialized === 'string', 'SANITIZATION_FAILED', 'response is not serializable');
+  const bytes = new TextEncoder().encode(serialized).byteLength;
+  assertCondition(bytes <= MCP_READONLY_LIMITS.maxResponseBytes, 'SANITIZATION_FAILED', 'response exceeds the limit');
+  return value;
+}
+
+function normalizeProvenance(value) {
+  assertCondition(Array.isArray(value), 'INVALID_SERVICE_RESPONSE', 'provenance is required');
+  assertCondition(value.length <= 32, 'INVALID_SERVICE_RESPONSE', 'provenance is too large');
+  return value.map((entry, index) => {
+    assertCondition(isRecord(entry), 'INVALID_SERVICE_RESPONSE', `provenance[${index}] is invalid`);
+    const provider = entry.provider === null || entry.provider === undefined
+      ? null
+      : normalizeProviderId(entry.provider, `provenance[${index}].provider`);
+    const sourceType = normalizedString(entry.source_type ?? entry.sourceType, `provenance[${index}].source_type`, { maximum: 40 });
+    assertCondition(SUPPORTED_SOURCE_TYPES.has(sourceType), 'INVALID_SERVICE_RESPONSE', `provenance[${index}].source_type is invalid`);
+    const sourceRef = normalizedString(entry.source_ref ?? entry.sourceRef, `provenance[${index}].source_ref`, { maximum: 240, pattern: SAFE_SOURCE_REF_PATTERN });
+    const observedAt = normalizedTimestamp(entry.observed_at ?? entry.observedAt, `provenance[${index}].observed_at`);
+    const retrievedAt = normalizedTimestamp(entry.retrieved_at ?? entry.retrievedAt, `provenance[${index}].retrieved_at`);
+    assertCondition(Date.parse(retrievedAt) >= Date.parse(observedAt), 'INVALID_SERVICE_RESPONSE', 'retrieved_at cannot precede observed_at');
+    const evidenceState = normalizedString(entry.evidence_state ?? entry.evidenceState, `provenance[${index}].evidence_state`, { maximum: 16 });
+    assertCondition(DATA_CLASSIFICATIONS.has(evidenceState), 'INVALID_SERVICE_RESPONSE', 'provenance evidence_state is invalid');
+    return { provider, source_type: sourceType, source_ref: sourceRef, observed_at: observedAt, retrieved_at: retrievedAt, evidence_state: evidenceState };
+  });
+}
+
+function normalizeLimitations(value) {
+  assertCondition(Array.isArray(value), 'INVALID_SERVICE_RESPONSE', 'limitations are required');
+  assertCondition(value.length <= 32, 'INVALID_SERVICE_RESPONSE', 'limitations are too large');
+  return value.map((item, index) => normalizedString(item, `limitations[${index}]`, { maximum: 240, pattern: SAFE_LIMITATION_PATTERN }));
+}
+
+function normalizeProviders(value) {
+  assertCondition(Array.isArray(value), 'INVALID_SERVICE_RESPONSE', 'providers are required');
+  assertCondition(value.length <= 8, 'INVALID_SERVICE_RESPONSE', 'providers are too large');
+  const providers = value.map((item, index) => normalizeProviderId(item, `providers[${index}]`));
+  return [...new Set(providers)].sort();
+}
+
+function normalizeDataClassification(value) {
+  const state = normalizedString(value, 'data_classification', { maximum: 16 });
+  assertCondition(DATA_CLASSIFICATIONS.has(state), 'INVALID_SERVICE_RESPONSE', 'data_classification is invalid');
+  return state;
+}
+
+function normalizeFreshness(value) {
+  const freshness = normalizedString(value, 'freshness', { maximum: 16 });
+  assertCondition(FRESHNESS_STATES.has(freshness), 'INVALID_SERVICE_RESPONSE', 'freshness is invalid');
+  return freshness;
+}
+
+function sanitizeText(value) {
+  let text = String(value)
+    .replace(/https?:\/\/[^\s"']*(?:[?&](?:signature|sig|token|access_token|x-amz-signature)=[^\s"']*)/gi, '[redacted-signed-url]')
+    .replace(/\b(?:bearer\s+|basic\s+|access[_-]?token\s*[=:]\s*|refresh[_-]?token\s*[=:]\s*|api[_-]?key\s*[=:]\s*|password\s*[=:]\s*)[^\s,;"']+/gi, '[redacted-secret]')
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[redacted-email]')
+    .replace(/\b\d{3}\.?\d{3}\.?\d{3}-?\d{2}\b/g, '[redacted-cpf]');
+  return text.length > 800 ? `${text.slice(0, 800)}…[truncated]` : text;
+}
+
+function sanitizeValue(value, depth = 0, seen = new Set()) {
+  if (depth > 8) return '[truncated-depth]';
+  if (typeof value === 'string') return sanitizeText(value);
+  if (typeof value === 'number' || typeof value === 'boolean' || value === null) return value;
+  if (value === undefined) return null;
+  if (typeof value !== 'object') return '[unsupported]';
+  if (seen.has(value)) throw fail('SANITIZATION_FAILED');
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) return value.slice(0, 100).map((item) => sanitizeValue(item, depth + 1, seen));
+    const output = {};
+    for (const [key, child] of Object.entries(value).slice(0, 100)) {
+      if (SENSITIVE_OUTPUT_KEY.test(key)) continue;
+      const safeKey = sanitizeText(key).replace(/[^A-Za-z0-9_.-]/g, '_').slice(0, 120);
+      output[safeKey] = sanitizeValue(child, depth + 1, seen);
+    }
+    return output;
+  } finally {
+    seen.delete(value);
+  }
+}
+
+function assertNoSensitiveOutput(value) {
+  let serialized;
+  try { serialized = JSON.stringify(value); } catch { throw fail('SANITIZATION_FAILED'); }
+  assertCondition(!SENSITIVE_OUTPUT_TEXT.test(serialized), 'SANITIZATION_FAILED');
+  return value;
+}
+
+function normalizeServiceResult(raw, requestId, clock) {
+  assertCondition(isRecord(raw), 'INVALID_SERVICE_RESPONSE');
+  assertCondition(Object.prototype.hasOwnProperty.call(raw, 'data'), 'INVALID_SERVICE_RESPONSE');
+  const dataClassification = normalizeDataClassification(raw.data_classification ?? raw.dataClassification);
+  const freshness = normalizeFreshness(raw.freshness);
+  const retrievedAt = normalizedTimestamp(raw.retrieved_at ?? raw.retrievedAt, 'retrieved_at');
+  const coverage = normalizeCoverage(raw.coverage);
+  const confidenceScore = raw.confidence_score === undefined
+    ? Number((finiteNumber(raw.confidence, 'confidence', { maximum: 1 }) * 100).toFixed(2))
+    : finiteNumber(raw.confidence_score, 'confidence_score', { maximum: 100 });
+  if (dataClassification === 'unavailable') {
+    assertCondition(raw.data === null, 'INVALID_SERVICE_RESPONSE', 'unavailable data must be null');
+    assertCondition(confidenceScore === 0, 'INVALID_SERVICE_RESPONSE', 'unavailable data must have zero confidence');
+    assertCondition((raw.coverage.available_metrics ?? raw.coverage.availableMetrics) === 0, 'INVALID_SERVICE_RESPONSE', 'unavailable data must have zero available metrics');
+  } else {
+    assertCondition(raw.data !== undefined && raw.data !== null, 'INVALID_SERVICE_RESPONSE', 'available data must be present');
+  }
+  const providers = normalizeProviders(raw.providers);
+  const provenance = normalizeProvenance(raw.provenance);
+  const limitations = normalizeLimitations(raw.limitations);
+  const errors = raw.errors === undefined ? [] : normalizeLimitations(raw.errors);
+  const data = sanitizeValue(raw.data);
+  assertNoSensitiveOutput(data);
+  const generatedAt = new Date(clock()).toISOString();
+  return {
+    contract_version: MCP_READONLY_CONTRACT_VERSION,
+    request_id: requestId,
+    generated_at: generatedAt,
+    data_classification: dataClassification,
+    freshness,
+    retrieved_at: retrievedAt,
+    data,
+    confidence_score: confidenceScore,
+    data_coverage: coverage.score,
+    coverage,
+    providers,
+    provenance,
+    limitations,
+    errors,
+  };
+}
+
+function rpcResult(id, result) {
+  return { jsonrpc: '2.0', id, result };
+}
+
+function rpcError(id, code) {
+  const numeric = {
+    AUTH_REQUIRED: -32001,
+    GRANT_REQUIRED: -32003,
+    RATE_LIMITED: -32029,
+    TOO_MANY_CONCURRENT_REQUESTS: -32030,
+    TIMEOUT: -32012,
+    AUDIT_UNAVAILABLE: -32070,
+    SANITIZATION_FAILED: -32071,
+  }[code] || -32602;
+  return { jsonrpc: '2.0', id, error: { code: numeric, message: FIXED_ERROR_MESSAGES[code] || FIXED_ERROR_MESSAGES.INTERNAL, data: { error_code: code } } };
+}
+
+function errorCode(error) {
+  return MCP_ERROR_CODES.includes(error?.code) ? error.code : 'INTERNAL';
+}
+
+function toolDefinitions() {
+  return [
+    { name: 'search_creators', description: 'Search bounded creator registry projections without contacting a provider.', inputSchema: { type: 'object', properties: { query: { type: 'string', maxLength: 80 }, provider: { type: 'string', enum: ['meta-graph', 'instagrapi'] }, registry_state: { type: 'string', enum: ['candidate', 'paused', 'unavailable'] }, page: { type: 'integer', minimum: 1 }, page_size: { type: 'integer', minimum: 1, maximum: 50 } }, additionalProperties: false } },
+    { name: 'get_creator_profile', description: 'Return the latest sanitized creator profile projection.', inputSchema: { type: 'object', properties: { creator_key: { type: 'string', minLength: 1, maxLength: 128 } }, required: ['creator_key'], additionalProperties: false } },
+    { name: 'get_creator_snapshots', description: 'Return bounded historical profile snapshots with freshness and provenance.', inputSchema: { type: 'object', properties: { creator_key: { type: 'string', minLength: 1, maxLength: 128 }, window: { type: 'object', properties: { start: { type: 'string', format: 'date-time' }, end: { type: 'string', format: 'date-time' } }, required: ['start', 'end'], additionalProperties: false }, page: { type: 'integer', minimum: 1 }, page_size: { type: 'integer', minimum: 1, maximum: 50 } }, required: ['creator_key'], additionalProperties: false } },
+    { name: 'get_creator_media', description: 'Return bounded creator media metrics without media binaries or raw captions.', inputSchema: { type: 'object', properties: { creator_key: { type: 'string', minLength: 1, maxLength: 128 }, window: { type: 'object', properties: { start: { type: 'string', format: 'date-time' }, end: { type: 'string', format: 'date-time' } }, required: ['start', 'end'], additionalProperties: false }, page: { type: 'integer', minimum: 1 }, page_size: { type: 'integer', minimum: 1, maximum: 50 } }, required: ['creator_key'], additionalProperties: false } },
+    { name: 'get_creator_analytics', description: 'Return the latest deterministic analytics artifact; never computes a new analysis.', inputSchema: { type: 'object', properties: { creator_key: { type: 'string', minLength: 1, maxLength: 128 }, window: { type: 'object', properties: { start: { type: 'string', format: 'date-time' }, end: { type: 'string', format: 'date-time' } }, required: ['start', 'end'], additionalProperties: false } }, required: ['creator_key'], additionalProperties: false } },
+    { name: 'get_creator_score', description: 'Return the latest persisted deterministic Influencer Score artifact.', inputSchema: { type: 'object', properties: { creator_key: { type: 'string', minLength: 1, maxLength: 128 } }, required: ['creator_key'], additionalProperties: false } },
+    { name: 'compare_creators', description: 'Return a bounded comparison from existing artifacts without recalculating scores.', inputSchema: { type: 'object', properties: { creator_keys: { type: 'array', minItems: 1, maxItems: 20, items: { type: 'string', minLength: 1, maxLength: 128 } }, window: { type: 'object', properties: { start: { type: 'string', format: 'date-time' }, end: { type: 'string', format: 'date-time' } }, required: ['start', 'end'], additionalProperties: false } }, required: ['creator_keys'], additionalProperties: false } },
+  ].map((definition) => Object.freeze(definition));
+}
+
+export const MCP_READONLY_TOOLS = Object.freeze(toolDefinitions());
+
+function protocolResult(id, method) {
+  if (method === 'initialize') return rpcResult(id, { protocolVersion: '2025-03-26', capabilities: { tools: {} }, serverInfo: { name: MCP_READONLY_SERVER_VERSION, version: MCP_READONLY_SERVER_VERSION } });
+  if (method === 'ping') return rpcResult(id, {});
+  if (method === 'notifications/initialized') return { jsonrpc: '2.0', id: null, result: {} };
+  return null;
+}
+
+function requireReadService(readService) {
+  assertCondition(isRecord(readService), 'INVALID_INPUT', 'read service is required');
+  for (const method of Object.values(STORE_METHODS)) assertCondition(typeof readService[method] === 'function', 'INVALID_INPUT', `read service method ${method} is required`);
+}
+
+export function createInfluencerIntelligenceMcpGateway({
+  readService,
+  audit,
+  clock = createDefaultClock(),
+  rateLimiter = createFixedWindowRateLimiter({ clock }),
+  maxConcurrentRequests = MCP_READONLY_LIMITS.maxConcurrentRequests,
+  timeoutMs = MCP_READONLY_LIMITS.timeoutMs,
+} = {}) {
+  requireReadService(readService);
+  assertCondition(typeof audit === 'function', 'INVALID_INPUT', 'audit function is required');
+  assertCondition(Number.isInteger(maxConcurrentRequests) && maxConcurrentRequests > 0, 'INVALID_INPUT', 'maxConcurrentRequests is invalid');
+  assertCondition(Number.isInteger(timeoutMs) && timeoutMs > 0 && timeoutMs <= MCP_READONLY_LIMITS.timeoutMs, 'INVALID_INPUT', 'timeoutMs is invalid');
+  let concurrent = 0;
+
+  async function recordAudit({ requestId, tool, ok, code, context, startedAt }) {
+    const event = {
+      request_id: requestId,
+      tool: tool || 'protocol',
+      ok: Boolean(ok),
+      error_code: code || null,
+      actor_scope: context?.actor_scope || null,
+      duration_ms: Math.max(0, clock() - startedAt),
+      at: new Date(clock()).toISOString(),
+    };
+    try {
+      await audit(event);
+    } catch {
+      throw fail('AUDIT_UNAVAILABLE');
+    }
+  }
+
+  async function invoke(toolName, input, context, requestId, signal) {
+    let normalized;
+    try {
+      normalized = normalizeInput(toolName, input);
+    } catch (error) {
+      if (error?.code === 'INVALID_INPUT') throw error;
+      throw fail('INVALID_INPUT');
+    }
+    const method = STORE_METHODS[toolName];
+    const controller = new AbortController();
+    const forwardAbort = () => controller.abort();
+    if (signal) signal.addEventListener('abort', forwardAbort, { once: true });
+    if (signal?.aborted) controller.abort();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const resultPromise = Promise.resolve().then(() => readService[method](normalized, {
+        signal: controller.signal,
+        request_id: requestId,
+        actor_scope: context.actor_scope,
+        data_scope: context.data_scope,
+      }));
+      const timeoutPromise = new Promise((_, reject) => {
+        const onAbort = () => reject(fail('TIMEOUT'));
+        if (controller.signal.aborted) onAbort();
+        else controller.signal.addEventListener('abort', onAbort, { once: true });
+      });
+      const raw = await Promise.race([resultPromise, timeoutPromise]);
+      try {
+        return normalizeServiceResult(raw, requestId, clock);
+      } catch (error) {
+        if (error?.code === 'INVALID_SERVICE_RESPONSE') throw error;
+        throw fail('INVALID_SERVICE_RESPONSE');
+      }
+    } catch (error) {
+      if (error?.code === 'NOT_FOUND' || error?.code === 'UNAVAILABLE') throw fail(error.code);
+      if (error?.code === 'TIMEOUT' || controller.signal.aborted) throw fail('TIMEOUT');
+      if (error?.code === 'INVALID_INPUT') throw fail('INVALID_INPUT');
+      throw fail(error?.code && MCP_ERROR_CODES.includes(error.code) ? error.code : 'INTERNAL');
+    } finally {
+      clearTimeout(timer);
+      if (signal) signal.removeEventListener('abort', forwardAbort);
+    }
+  }
+
+  async function handleRpc({ rpc, context, requestBytes, signal } = {}) {
+    const startedAt = clock();
+    const id = safeRpcId(rpc?.id);
+    const requestId = id === null ? randomUUID() : id;
+    const toolName = typeof rpc?.params?.name === 'string' ? rpc.params.name : null;
+    let normalizedContext = null;
+    let outcome;
+    let outcomeCode = null;
+    try {
+      assertCondition(requestBytes === undefined || (Number.isInteger(requestBytes) && requestBytes >= 0 && requestBytes <= MCP_READONLY_LIMITS.maxRequestBytes), 'INVALID_INPUT', 'request body exceeds the limit');
+      validateRpc(rpc);
+      normalizedContext = normalizeAuthContext(context);
+      let allowed;
+      try { allowed = rateLimiter.allow(normalizedContext.actor_scope); } catch { throw fail('RATE_LIMITED'); }
+      assertCondition(allowed, 'RATE_LIMITED');
+
+      const protocol = protocolResult(id, rpc.method);
+      if (protocol) {
+        outcome = protocol;
+      } else if (rpc.method === 'tools/list') {
+        outcome = rpcResult(id, { tools: MCP_READONLY_TOOLS });
+      } else if (rpc.method === 'tools/call') {
+        assertCondition(typeof toolName === 'string' && Object.hasOwn(STORE_METHODS, toolName), 'INVALID_INPUT', 'tool is not registered');
+        assertCondition(concurrent < maxConcurrentRequests, 'TOO_MANY_CONCURRENT_REQUESTS');
+        concurrent += 1;
+        try {
+          const data = await invoke(toolName, rpc.params.arguments || {}, normalizedContext, requestId, signal);
+          outcome = rpcResult(id, { content: [{ type: 'text', text: JSON.stringify(data) }], structuredContent: data });
+        } finally {
+          concurrent -= 1;
+        }
+      } else {
+        throw fail('INVALID_INPUT');
+      }
+      const safe = sanitizeValue(outcome);
+      assertNoSensitiveOutput(safe);
+      assertResponseSize(safe);
+      outcome = safe;
+    } catch (error) {
+      outcomeCode = errorCode(error);
+      outcome = rpcError(id, outcomeCode);
+    }
+
+    try {
+      await recordAudit({ requestId: id, tool: toolName, ok: outcomeCode === null, code: outcomeCode, context: normalizedContext, startedAt });
+    } catch (error) {
+      return rpcError(id, errorCode(error));
+    }
+    return outcome;
+  }
+
+  return Object.freeze({
+    handleRpc,
+    tools: MCP_READONLY_TOOLS,
+    limits: MCP_READONLY_LIMITS,
+    contractVersion: MCP_READONLY_CONTRACT_VERSION,
+  });
+}
+
+export const __testing = Object.freeze({
+  normalizeInput,
+  normalizeServiceResult,
+  sanitizeValue,
+  assertNoSensitiveOutput,
+  assertResponseSize,
+  normalizeWindow,
+});

--- a/social/influencer-intelligence/tests/architecture.test.mjs
+++ b/social/influencer-intelligence/tests/architecture.test.mjs
@@ -131,6 +131,27 @@ test('keeps API reads and MCP tools read-only while isolating Orb collection', (
     assert.ok(MCP_CONTRACT.controls.includes(control), `missing MCP control: ${control}`);
   }
   assert.ok(MCP_CONTRACT.tools.every(({ readOnly }) => readOnly === true));
+  assert.deepEqual(MCP_CONTRACT.tools.map(({ name }) => name), [
+    'search_creators',
+    'get_creator_profile',
+    'get_creator_snapshots',
+    'get_creator_media',
+    'get_creator_analytics',
+    'get_creator_score',
+    'compare_creators',
+  ]);
+  assert.equal(MCP_CONTRACT.deferredTools[0].name, 'get_campaign_fit');
+  assert.equal(MCP_CONTRACT.deferredTools[0].unavailableUntil, 'M11');
+  assert.deepEqual(MCP_CONTRACT.limits, {
+    maxRequestBytes: 65536,
+    maxResponseBytes: 524288,
+    maxPageSize: 50,
+    maxCreatorsPerRequest: 20,
+    maxWindowDays: 365,
+    maxConcurrentRequests: 4,
+    timeoutMs: 12000,
+    rateLimitPerMinute: 60,
+  });
   assert.equal(MCP_CONTRACT.limits.timeoutMs, 12000);
   assert.match(MCP_CONTRACT.forbidden.join('\n'), /arbitrary SQL/i);
 });
@@ -148,6 +169,8 @@ test('keeps this architecture milestone off and runtime-free', () => {
   assert.equal(RELEASE_CONTRACT.currentSourceScope.schedulerSourceAdded, true);
   assert.equal(RELEASE_CONTRACT.currentSourceScope.schedulerWorkflowImported, false);
   assert.equal(RELEASE_CONTRACT.currentSourceScope.schedulerWorkflowActive, false);
+  assert.equal(RELEASE_CONTRACT.currentSourceScope.mcpSourceAdded, true);
+  assert.equal(RELEASE_CONTRACT.currentSourceScope.mcpRuntimeRegistered, false);
 
   const source = fs.readFileSync(architecturePath, 'utf8');
   assert.doesNotMatch(source, /\b(?:fetch|spawn|exec|execFile|createServer|listen)\s*\(/i);

--- a/social/influencer-intelligence/tests/mcp-readonly.test.mjs
+++ b/social/influencer-intelligence/tests/mcp-readonly.test.mjs
@@ -1,0 +1,270 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+import {
+  MCP_READONLY_LIMITS,
+  MCP_READONLY_TOOLS,
+  __testing,
+  createFixedWindowRateLimiter,
+  createInfluencerIntelligenceMcpGateway,
+} from '../mcp-readonly.mjs';
+
+const AUTH = Object.freeze({
+  authenticated: true,
+  grants: ['module.influencer-intelligence.access'],
+  actor_scope: 'synthetic:operator',
+  data_scope: 'synthetic:workspace',
+});
+
+const NOW = '2026-08-11T12:00:00.000Z';
+const OBSERVED = '2026-08-11T11:55:00.000Z';
+
+function provenance(sourceType = 'profile', provider = 'meta-graph') {
+  return [{
+    provider,
+    source_type: sourceType,
+    source_ref: `fixture:${sourceType}:creator-1`,
+    observed_at: OBSERVED,
+    retrieved_at: NOW,
+    evidence_state: sourceType === 'score' || sourceType === 'analysis' ? 'derived' : 'observed',
+  }];
+}
+
+function envelope(data, overrides = {}) {
+  return {
+    data_classification: 'observed',
+    freshness: 'fresh',
+    retrieved_at: NOW,
+    data,
+    confidence_score: 84,
+    coverage: { available_metrics: 4, expected_metrics: 5 },
+    providers: ['meta-graph'],
+    provenance: provenance(overrides.source_type || 'profile'),
+    limitations: [],
+    ...overrides,
+  };
+}
+
+function unavailableEnvelope(overrides = {}) {
+  return {
+    data_classification: 'unavailable',
+    freshness: 'unknown',
+    retrieved_at: NOW,
+    data: null,
+    confidence_score: 0,
+    coverage: { available_metrics: 0, expected_metrics: 5 },
+    providers: [],
+    provenance: [],
+    limitations: ['analysis_not_computed'],
+    ...overrides,
+  };
+}
+
+function fixtureService(overrides = {}) {
+  const calls = [];
+  const service = {
+    calls,
+    async searchCreators(input) { calls.push(['searchCreators', input]); return envelope({ creators: [{ creator_key: 'creator-1', canonical_handle: 'synthetic_creator' }] }, { source_type: 'registry', providers: [], provenance: [] }); },
+    async getCreatorProfile(input) { calls.push(['getCreatorProfile', input]); return envelope({ creator_key: input.creator_key, followers_count: 100, following_count: 20, media_count: 10 }); },
+    async getCreatorSnapshots(input) { calls.push(['getCreatorSnapshots', input]); return envelope({ snapshots: [{ observed_at: OBSERVED, followers_count: 100 }] }); },
+    async getCreatorMedia(input) { calls.push(['getCreatorMedia', input]); return envelope({ media: [{ media_key: 'media-1', likes_count: 10, comments_count: 2 }] }, { source_type: 'media' }); },
+    async getCreatorAnalytics(input) { calls.push(['getCreatorAnalytics', input]); return envelope({ creator_key: input.creator_key, engagement: { median: 0.12 } }, { source_type: 'analysis', data_classification: 'derived', confidence_score: 70 }); },
+    async getCreatorScore(input) { calls.push(['getCreatorScore', input]); return envelope({ creator_key: input.creator_key, overall_score: 72, confidence_score: 65, data_coverage: 80 }, { source_type: 'score', data_classification: 'derived', confidence_score: 65 }); },
+    async compareCreators(input) { calls.push(['compareCreators', input]); return envelope({ creators: input.creator_keys.map((creator_key) => ({ creator_key })) }, { source_type: 'comparison', data_classification: 'derived', confidence_score: 60 }); },
+    ...overrides,
+  };
+  return service;
+}
+
+function createHarness({ service = fixtureService(), audit = [], ...options } = {}) {
+  return {
+    service,
+    audit,
+    gateway: createInfluencerIntelligenceMcpGateway({
+      readService: service,
+      audit: async (event) => audit.push(event),
+      clock: () => Date.parse(NOW),
+      ...options,
+    }),
+  };
+}
+
+async function call(gateway, name, args = {}, context = AUTH, id = 'request-1', requestBytes) {
+  return gateway.handleRpc({
+    rpc: { jsonrpc: '2.0', id, method: 'tools/call', params: { name, arguments: args } },
+    context,
+    requestBytes,
+  });
+}
+
+function errorCode(response) {
+  return response.error?.data?.error_code;
+}
+
+test('registers only bounded read-only tools and defers campaign fit', async () => {
+  const { gateway } = createHarness();
+  const response = await gateway.handleRpc({ rpc: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }, context: AUTH });
+  const names = response.result.tools.map((tool) => tool.name);
+  assert.deepEqual(names, ['search_creators', 'get_creator_profile', 'get_creator_snapshots', 'get_creator_media', 'get_creator_analytics', 'get_creator_score', 'compare_creators']);
+  assert.equal(names.includes('get_campaign_fit'), false);
+  assert.ok(response.result.tools.every((tool) => tool.inputSchema.additionalProperties === false));
+  assert.ok(names.every((name) => !/follow|like|dm|post|publish|scrap|sql|shell/i.test(name)));
+});
+
+test('requires authenticated context and the server-side grant', async () => {
+  const { gateway, audit } = createHarness();
+  const unauthenticated = await call(gateway, 'get_creator_profile', { creator_key: 'creator-1' }, null);
+  assert.equal(errorCode(unauthenticated), 'AUTH_REQUIRED');
+  const withoutGrant = await call(gateway, 'get_creator_profile', { creator_key: 'creator-1' }, { authenticated: true, grants: [], actor_scope: 'synthetic:operator' });
+  assert.equal(errorCode(withoutGrant), 'GRANT_REQUIRED');
+  assert.equal(audit.length, 2);
+  assert.equal(audit.every((event) => !Object.hasOwn(event, 'authorization')), true);
+});
+
+test('rejects arbitrary arguments, provider account material and oversized requests', async () => {
+  const { gateway } = createHarness();
+  const extra = await call(gateway, 'get_creator_profile', { creator_key: 'creator-1', sql: 'select 1' });
+  assert.equal(errorCode(extra), 'INVALID_INPUT');
+  const secret = await call(gateway, 'get_creator_profile', { creator_key: 'creator-1', provider_account_id: 'real-id' });
+  assert.equal(errorCode(secret), 'INVALID_INPUT');
+  const oversized = await call(gateway, 'get_creator_profile', { creator_key: 'creator-1' }, AUTH, 'request-2', MCP_READONLY_LIMITS.maxRequestBytes + 1);
+  assert.equal(errorCode(oversized), 'INVALID_INPUT');
+});
+
+test('validates bounded windows, paging and comparison cardinality before the store', async () => {
+  const { gateway, service } = createHarness();
+  const tooLong = await call(gateway, 'get_creator_snapshots', { creator_key: 'creator-1', window: { start: '2024-01-01T00:00:00.000Z', end: NOW } });
+  assert.equal(errorCode(tooLong), 'INVALID_INPUT');
+  const duplicate = await call(gateway, 'compare_creators', { creator_keys: ['creator-1', 'creator-1'] });
+  assert.equal(errorCode(duplicate), 'INVALID_INPUT');
+  const valid = await call(gateway, 'get_creator_snapshots', { creator_key: 'creator-1', window: { start: OBSERVED, end: NOW }, page: 2, page_size: 10 });
+  assert.equal(valid.result.structuredContent.data.snapshots[0].followers_count, 100);
+  assert.deepEqual(service.calls.at(-1), ['getCreatorSnapshots', { creator_key: 'creator-1', window: { start: OBSERVED, end: NOW }, page: 2, page_size: 10 }]);
+});
+
+test('returns provenance, freshness, confidence and coverage without recalculating the score', async () => {
+  const { gateway, service } = createHarness();
+  const response = await call(gateway, 'get_creator_score', { creator_key: 'creator-1' });
+  const content = response.result.structuredContent;
+  assert.equal(content.contract_version, 'influencer-intelligence/mcp/v1');
+  assert.equal(content.data_classification, 'derived');
+  assert.equal(content.freshness, 'fresh');
+  assert.equal(content.confidence_score, 65);
+  assert.equal(content.data_coverage, 80);
+  assert.equal(content.coverage.available_metrics, 4);
+  assert.equal(content.provenance[0].source_type, 'score');
+  assert.equal(service.calls[0][0], 'getCreatorScore');
+  assert.equal(JSON.stringify(content).includes('weights'), false);
+});
+
+test('preserves unavailable as null and never substitutes zero metrics', async () => {
+  const service = fixtureService({ async getCreatorAnalytics(input) { return unavailableEnvelope(); } });
+  const { gateway } = createHarness({ service });
+  const response = await call(gateway, 'get_creator_analytics', { creator_key: 'creator-1' });
+  const content = response.result.structuredContent;
+  assert.equal(content.data, null);
+  assert.equal(content.data_classification, 'unavailable');
+  assert.equal(content.confidence_score, 0);
+  assert.equal(content.data_coverage, 0);
+  assert.equal(content.limitations[0], 'analysis_not_computed');
+});
+
+test('rejects an unavailable envelope that claims available metrics', async () => {
+  const service = fixtureService({
+    async getCreatorAnalytics() {
+      return unavailableEnvelope({ coverage: { available_metrics: 1, expected_metrics: 5 } });
+    },
+  });
+  const { gateway } = createHarness({ service });
+  const response = await call(gateway, 'get_creator_analytics', { creator_key: 'creator-1' });
+  assert.equal(errorCode(response), 'INVALID_SERVICE_RESPONSE');
+});
+
+test('sanitizes raw payload, PII and credential-like output before returning it', async () => {
+  const service = fixtureService({
+    async getCreatorProfile() {
+      return envelope({ creator_key: 'creator-1', followers_count: 3, email: 'person@example.test', raw_comment_text: 'hello', nested: { access_token: 'Bearer fake-token-value' }, safe: 'kept' });
+    },
+  });
+  const { gateway } = createHarness({ service });
+  const response = await call(gateway, 'get_creator_profile', { creator_key: 'creator-1' });
+  const data = response.result.structuredContent.data;
+  assert.equal(data.safe, 'kept');
+  assert.equal(Object.hasOwn(data, 'email'), false);
+  assert.equal(Object.hasOwn(data, 'raw_comment_text'), false);
+  assert.equal(Object.hasOwn(data.nested, 'access_token'), false);
+  assert.equal(JSON.stringify(response).includes('person@example.test'), false);
+  assert.equal(JSON.stringify(response).includes('fake-token-value'), false);
+});
+
+test('rate limits by opaque actor scope and emits sanitized audit events', async () => {
+  const audit = [];
+  const { gateway } = createHarness({ audit, rateLimiter: createFixedWindowRateLimiter({ limit: 1, clock: () => Date.parse(NOW) }) });
+  const first = await call(gateway, 'get_creator_profile', { creator_key: 'creator-1' }, AUTH, 'one');
+  const second = await call(gateway, 'get_creator_profile', { creator_key: 'creator-1' }, AUTH, 'two');
+  assert.equal(first.error, undefined);
+  assert.equal(errorCode(second), 'RATE_LIMITED');
+  assert.equal(audit[1].error_code, 'RATE_LIMITED');
+  assert.equal(audit.every((event) => Object.keys(event).every((key) => !/token|cookie|query|creator_key/i.test(key))), true);
+});
+
+test('times out a slow internal read and does not expose the service error', async () => {
+  const service = fixtureService({ async getCreatorAnalytics() { return new Promise(() => {}); } });
+  const { gateway } = createHarness({ service, timeoutMs: 20 });
+  const response = await call(gateway, 'get_creator_analytics', { creator_key: 'creator-1' });
+  assert.equal(errorCode(response), 'TIMEOUT');
+});
+
+test('propagates an already-aborted request without invoking an unbounded read', async () => {
+  let called = false;
+  const service = fixtureService({
+    async getCreatorAnalytics(_input, { signal }) {
+      called = true;
+      return signal.aborted ? new Promise(() => {}) : envelope({ ok: true });
+    },
+  });
+  const { gateway } = createHarness({ service });
+  const signalController = new AbortController();
+  signalController.abort();
+  const response = await gateway.handleRpc({
+    rpc: { jsonrpc: '2.0', id: 'aborted', method: 'tools/call', params: { name: 'get_creator_analytics', arguments: { creator_key: 'creator-1' } } },
+    context: AUTH,
+    signal: signalController.signal,
+  });
+  assert.equal(called, true);
+  assert.equal(errorCode(response), 'TIMEOUT');
+});
+
+test('enforces the sanitized response byte limit', () => {
+  assert.throws(() => __testing.assertResponseSize({ data: 'x'.repeat(MCP_READONLY_LIMITS.maxResponseBytes) }), /response exceeds the limit/);
+});
+
+test('enforces concurrency without queueing unbounded work', async () => {
+  let release;
+  const service = fixtureService({
+    async getCreatorProfile() { return new Promise((resolve) => { release = () => resolve(envelope({ creator_key: 'creator-1' })); }); },
+  });
+  const { gateway } = createHarness({ service, maxConcurrentRequests: 1, timeoutMs: 1000 });
+  const first = call(gateway, 'get_creator_profile', { creator_key: 'creator-1' }, AUTH, 'first');
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  const second = await call(gateway, 'get_creator_profile', { creator_key: 'creator-1' }, AUTH, 'second');
+  assert.equal(errorCode(second), 'TOO_MANY_CONCURRENT_REQUESTS');
+  release();
+  assert.equal((await first).error, undefined);
+});
+
+test('audit failure fails closed instead of returning a successful result', async () => {
+  const gateway = createInfluencerIntelligenceMcpGateway({ readService: fixtureService(), audit: async () => { throw new Error('disk unavailable'); } });
+  const response = await call(gateway, 'get_creator_profile', { creator_key: 'creator-1' });
+  assert.equal(errorCode(response), 'AUDIT_UNAVAILABLE');
+});
+
+test('MCP adapter has no transport, provider, shell or write surface', async () => {
+  const source = await readFile(new URL('../mcp-readonly.mjs', import.meta.url), 'utf8');
+  assert.doesNotMatch(source, /\b(?:fetch|spawn|exec|execFile|createServer|listen)\s*\(/i);
+  assert.doesNotMatch(source, /\b(?:execute_workflow|follow_creator|like_creator|send_dm|publish_post|scrape_profile|arbitrary_sql)\b/i);
+  assert.doesNotMatch(source, /from\s+['"](?:node:)?(?:http|https|net|tls|child_process|pg)['"]/i);
+  assert.match(source, /additionalProperties: false/);
+  assert.match(source, /AUDIT_UNAVAILABLE/);
+});


### PR DESCRIPTION
## Objective
Add the M6 domain-side read-only MCP adapter for Influencer Intelligence, aligned with orb/engine/mcp-readonly-gateway conventions.

## Scope
- seven bounded read-only tools delegated to an injected internal service
- authentication, server-side grant, closed schemas, request/response limits, rate limiting, concurrency and timeout/abort
- sanitized, provenance-aware envelopes with explicit observed/derived/inferred/unavailable, freshness, confidence and coverage
- audit fail-closed and negative tests for credentials, PII, arbitrary SQL/shell/scraping and engagement writes
- architecture/ADR/workflow test synchronization

## Risk and controls
- Risk: high security boundary; source-only adapter with no transport or runtime registration.
- Migration: none; existing artifacts remain unapplied.
- Flag/grant: INFLUENCER_INTELLIGENCE_ENABLED=false; no user grant assignment; mcpRuntimeRegistered=false.
- Provider/runtime: no Meta, instagrapi, Token Vault, PostgreSQL, Orb, shell or network call.
- Rollback: revert or close this single-purpose PR; no external state is created.

## Validation
- focused M6 and architecture tests: 24 passed
- full Influencer Intelligence regression suite: 108 passed
- validate-architecture: passed
- validate-module-catalog: passed
- validate-domain-boundaries: passed with existing legacy-import warnings
- git diff --check: passed

Runtime registration and deployment are intentionally deferred to later milestones/gates.