### PR TITLE
fix(codex): align canonical topology with CRM catalog

### DIFF
--- a/ops/codex/worktree-topology.json
+++ b/ops/codex/worktree-topology.json
@@ -35,6 +35,13 @@
         "route": "/?module=users",
         "source": "registry-exception",
         "reason": "registry surface has a validated local preview but is absent from localLaunchCatalog"
+      },
+      {
+        "id": "clinical-approvals",
+        "label": "Aprovações clínicas",
+        "route": "/?module=clinical-approvals",
+        "source": "local-launch-catalog",
+        "reason": "disabled online but still defined by the local catalog and registry"
       }
     ]
   },


### PR DESCRIPTION
## Summary\n\n- adds the currently catalogued clinical-approvals CRM surface to the versioned canonical topology\n- keeps it explicitly marked as offline-disabled while preserving a stable canonical slot\n- prevents the coordinator inventory from silently omitting a registry/catalog surface\n\n## Validation\n\n- PowerShell JSON parse\n- canonical worktree topology fixture tests\n- no production, API, flag, database, or runtime changes\n\nThis is a follow-up to merged PRs #1337 and #1342.