### PR TITLE
perf(codex): scope retire checks to target worktree

### DIFF
--- a/scripts/manage-canonical-worktrees.ps1
+++ b/scripts/manage-canonical-worktrees.ps1
@@ -119,7 +119,8 @@ function Invoke-Git {
 function Get-WorktreeRecords {
     param(
         [string]$RepoPath,
-        [switch]$IncludeStatus
+        [switch]$IncludeStatus,
+        [string]$OnlyPath
     )
 
     $result = Invoke-Git -RepoPath $RepoPath -Arguments @('worktree', 'list', '--porcelain')
@@ -178,6 +179,11 @@ function Get-WorktreeRecords {
 
     if ($null -ne $current) {
         $records += [pscustomobject]$current
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($OnlyPath)) {
+        $normalizedOnlyPath = Normalize-PathString -Path $OnlyPath
+        $records = @($records | Where-Object { (Normalize-PathString -Path $_.path) -eq $normalizedOnlyPath })
     }
 
     foreach ($record in $records) {
@@ -591,7 +597,7 @@ function Retire-Worktree {
     $canonicalRoot = Join-Path $WorktreeRoot ([string]$topology.worktree.canonicalRelativeRoot)
     if (Test-PathWithinRoot -Path $WorktreePath -Root $canonicalRoot) { throw 'Slots canônicos não podem ser aposentados por esta ação.' }
 
-    $records = @(Get-WorktreeRecords -RepoPath $ProjectRoot -IncludeStatus | Where-Object { (Normalize-PathString -Path $_.path) -eq $normalized })
+    $records = @(Get-WorktreeRecords -RepoPath $ProjectRoot -IncludeStatus -OnlyPath $WorktreePath)
     if ($records.Count -ne 1) { throw "Worktree não encontrado ou ambíguo: $WorktreePath." }
     $record = $records[0]
     if (-not $record.exists) { throw 'Worktree não existe no filesystem.' }


### PR DESCRIPTION
## Summary\n\n- limits etire status collection to the explicit worktree path\n- preserves all branch, dirty, detached, remote, PR, manifest, lease, source-in-use, and git-worktree-remove gates\n- makes a confirmed candidate batch operationally tractable without broad status rescans\n\n## Validation\n\n- PowerShell parser: pass\n- canonical topology fixture tests: pass\n- diff check: pass\n- no production, API, flag, database, or runtime changes\n\nFollow-up to merged canonical topology work in #1337, #1342, and #1345.