### PR TITLE
fix(codex): treat empty PR listings as closed

### DIFF
--- a/scripts/manage-canonical-worktrees.ps1
+++ b/scripts/manage-canonical-worktrees.ps1
@@ -569,7 +569,12 @@ function Test-OpenPullRequest {
     $exitCode = $LASTEXITCODE
     $ErrorActionPreference = $oldPreference
     if ($exitCode -ne 0) { return [pscustomobject]@{ status = 'error'; open = $null; output = $raw } }
-    try { $rows = @($raw -join "`n" | ConvertFrom-Json) } catch { return [pscustomobject]@{ status = 'error'; open = $null; output = $raw } }
+    try {
+        $jsonText = $raw -join "`n"
+        $document = $jsonText | ConvertFrom-Json
+        $rows = if ($null -eq $document) { @() } else { @($document) }
+    }
+    catch { return [pscustomobject]@{ status = 'error'; open = $null; output = $raw } }
     return [pscustomobject]@{ status = 'ok'; open = $rows.Count -gt 0; pullRequests = @($rows) }
 }
 


### PR DESCRIPTION
## Summary\n\n- parses gh pr list --state open through an explicit JSON document\n- treats the valid empty array [] as zero open PRs\n- keeps GitHub errors fail-closed\n\n## Validation\n\n- first confirmed candidate retirement passed all coordinator gates after the fix\n- no dirty, detached, remote-tracked, manifest-referenced, leased, or active-source worktree was targeted\n- no production, API, flag, database, or runtime changes\n\nFollow-up to #1348 and the canonical topology work.