### PR TITLE
fix(codex): sync topology with gated CRM catalog

### DIFF
--- a/ops/codex/worktree-topology.json
+++ b/ops/codex/worktree-topology.json
@@ -25,6 +25,13 @@
       { "id": "procedimentos", "label": "Procedimentos", "route": "/?module=procedimentos", "source": "local-launch-catalog" },
       { "id": "unit-monitor", "label": "Unit Monitor", "route": "/?module=unit-monitor", "source": "local-launch-catalog" },
       { "id": "instagram-studio", "label": "Redes Sociais", "route": "/?module=instagram-studio", "source": "local-launch-catalog" },
+      {
+        "id": "influencer-intelligence",
+        "label": "Influencer Intelligence",
+        "route": "/?module=influencer-intelligence",
+        "source": "local-launch-catalog",
+        "reason": "gated surface remains disabled online until its internal API dependency is released"
+      },
       { "id": "meta-pages-review", "label": "Meta Review", "route": "/?module=meta-pages-review", "source": "local-launch-catalog" },
       { "id": "meta-ads", "label": "Meta Ads", "route": "/?module=meta-ads", "source": "local-launch-catalog" },
       { "id": "site-tracking", "label": "Site EF", "route": "/?module=site-tracking", "source": "local-launch-catalog" },


### PR DESCRIPTION
## Objetivo
Sincronizar a topologia canônica com o catálogo CRM após o merge do PR #1350.

## Mudança
- adiciona `influencer-intelligence` como slot lógico CRM;
- preserva a superfície gated/desativada online até a dependência de API interna ser liberada;
- não altera API pública, flag, banco, deploy ou runtime ativo.

## Validação
- catálogo local: 17 módulos e topologia: 17 superfícies CRM + 3 famílias ORB;
- fixture `test-canonical-worktree-topology.ps1`: PASS;
- slot canônico detached materializado em `C:\CodexShared\Worktrees\skincos\admin\canonical\crm\influencer-intelligence` no SHA `e5fab7927bf5a44f34d551d587f8b0f9cd7b54a0`;
- rollback: reverter este commit e remover o slot exclusivamente pelo coordenador, se necessário.