### PR TITLE
feat(influencer-intelligence): add bounded comments intelligence

### DIFF
--- a/social/influencer-intelligence/COMMENTS.md
+++ b/social/influencer-intelligence/COMMENTS.md
@@ -1,0 +1,92 @@
+# Comments intelligence v1
+
+M9 adds a bounded, aggregate-only analysis boundary. It does not fetch
+comments, own provider sessions, invoke a provider, schedule a job, or expose
+raw text through the MCP or CRM. An approved collector supplies a temporary
+sample and this module returns minimized aggregates. The PostgreSQL migration
+`20260812_influencer_intelligence_comments_v1.up.sql` is additive and remains
+unapplied until the governed database gate is satisfied.
+
+## Sampling
+
+`sampleCommentRecords` accepts at most 200 candidate records and selects at
+most 100 comments. The default is 50. `bounded_recent` consumes the provider's
+bounded order; `deterministic_uniform` selects evenly spaced records. The
+result includes a versioned audit object with strategy, requested limit,
+candidate count, selected count, truncation, source order, and aggregate-only
+retention. There is no implicit request for all comments.
+
+Comment text exists only for the duration of lexical or semantic analysis. A
+commenter digest, when needed for repeated-commenter metrics, must already be
+a domain-scoped SHA-256 digest. Raw provider IDs, usernames, contact fields,
+and comment text are rejected from the persistence path.
+
+## Deterministic metrics
+
+All ratios use the selected sample as their denominator unless the metric
+requires a labeled subset. A metric that has no usable labels is
+`unavailable` with `value: null`; it is never silently converted to zero.
+
+- `unique_commenter_ratio`: unique commenter digests divided by labeled
+  commenter digests.
+- `emoji_only_ratio`: comments containing only emoji, variation selectors,
+  modifiers, joiners, marks, and whitespace divided by sample size.
+- `duplicate_ratio`: duplicate occurrences after Unicode normalization,
+  case-folding, punctuation normalization, and whitespace collapse divided by
+  sample size.
+- `near_duplicate_ratio`: non-exact comments with a peer at normalized
+  Levenshtein distance at most 0.12 or token Jaccard similarity at least 0.8,
+  divided by sample size. Exact duplicates are not counted again.
+- `generic_short_comment_ratio`: comments of at most 24 characters matching
+  the bounded generic phrase lexicon divided by sample size.
+- `repeated_commenter_ratio`: comments authored by a digest occurring at least
+  twice divided by labeled commenter comments. This is an aggregate pattern,
+  not an individual bot or fraud classification.
+- `comment_length_distribution`: count, mean, median, and fixed length bins.
+- `language_distribution`: labeled language counts and explicit unknown count.
+- `comment_like_distribution`: fixed like-count bins, mean, median, and
+  explicit missing count when like counts are partially available.
+
+## Semantic interface
+
+An optional injected analyzer receives only `sample_index` and ephemeral text.
+It must return the closed schema
+`influencer-intelligence-comments-semantic/v1` with a model version,
+confidence, four aggregate relevance counts (`relevant`, `generic`,
+`spam_like`, `unknown`), bounded evidence codes, and opaque evidence refs.
+Free-form notes, arbitrary scores, raw text, identity labels, and individual
+bot claims are rejected. Semantic output is `inferred`, while lexical metrics
+remain `derived`.
+
+## Comment quality and confidence
+
+`comment_quality_score` is independent from the Influencer Score. Its
+deterministic components are:
+
+```text
+originality = 1 - (0.60 * duplicate_ratio + 0.40 * near_duplicate_ratio)
+substance = 1 - (0.60 * generic_short_comment_ratio + 0.40 * emoji_only_ratio)
+audience_diversity = unique_commenter_ratio (when available)
+semantic_relevance = relevant / sample_size (when the structured analyzer is available)
+```
+
+The configured weights are originality 0.30, substance 0.30, audience
+diversity 0.20, and semantic relevance 0.20. Missing components are excluded
+from the weighted numerator and denominator, while the independent confidence
+falls. Confidence combines sample size (50 comments for the full factor),
+metric coverage, commenter-label coverage, semantic confidence, freshness,
+and the declared provider reliability. Therefore a small or partial sample
+cannot receive high confidence merely because one metric looks favorable.
+
+The persisted row stores `sampling_version`, `sampling_config`,
+`algorithm_version`, `quality_score`, `quality_confidence`, and optional
+`model_version`; the JSON aggregate contains only bounded metrics, factors,
+coverage, freshness, provenance references, and limitations.
+
+## Scope and rollout
+
+This milestone changes no provider adapter, workflow, CRM route, MCP tool, or
+feature flag. It is source-only, synthetic-testable, and compatible with the
+existing append-only `creator_comment_sample` relation. The module remains off
+by default and does not initiate engagement actions.
+

--- a/social/influencer-intelligence/README.md
+++ b/social/influencer-intelligence/README.md
@@ -304,8 +304,10 @@ ratio.
   `suspicious_growth_pattern` with confidence, coverage, provenance, and the
   algorithm/model version.
 - Comments intelligence stores aggregate, minimized signals (for example
-  topic, sentiment, safety, and spam proportions) rather than an unbounded
-  comment archive. Raw text retention requires a separate privacy decision.
+  topic, sentiment, safety, spam proportions, duplicate ratios, language
+  coverage, and bounded comment quality) rather than an unbounded comment
+  archive. Raw text retention requires a separate privacy decision. M9's
+  formulas and semantic schema are documented in [`COMMENTS.md`](./COMMENTS.md).
 - A score is not complete without score, confidence, coverage, provenance,
   timestamp, provider identifiers, evidence state, and algorithm version.
 
@@ -340,7 +342,7 @@ production configuration.
 | M6 | Authenticated, sanitized, rate-limited read-only MCP | Source adapter and protocol tests implemented; runtime registration pending |
 | M7 | `skincos-influencer-intelligence` Codex skill | Versioned skill, UI metadata and contract tests implemented; runtime/user access remains governed |
 | M8 | Read-only CRM contracts and dashboard | Source implemented; gated shadow UI, upstream/runtime off |
-| M9 | Minimized comments intelligence | Pending |
+| M9 | Minimized comments intelligence | Source implemented; additive quality/sampling migration and synthetic tests; runtime/provider wiring remains off |
 | M10 | Semantic content and Reels signals | Pending |
 | M11 | Campaign and brand fit | Pending |
 | M12 | Synthetic validation and calibration | Pending |

--- a/social/influencer-intelligence/architecture.mjs
+++ b/social/influencer-intelligence/architecture.mjs
@@ -161,8 +161,9 @@ export const DATA_MODEL = deepFreeze({
   ],
   persistence: {
     migration: 'migrations/20260811_influencer_intelligence_data_model_v1.up.sql',
+    additiveMigrations: ['migrations/20260812_influencer_intelligence_comments_v1.up.sql'],
     dependsOn: 'migrations/20260810_influencer_intelligence_registry_v1.up.sql',
-    artifactStatus: 'source-controlled additive artifact; not applied by this milestone',
+    artifactStatus: 'source-controlled additive artifacts; not applied by this milestone',
     appendOnlyRelations: [
       'collector_evidence',
       'creator_profile_snapshot',
@@ -340,6 +341,9 @@ export const RELEASE_CONTRACT = deepFreeze({
     crmRuntimeEnabled: false,
     crmUpstreamConfigured: false,
     crmFeatureFlagDefault: false,
+    commentsSourceAdded: true,
+    commentsMigrationArtifactAdded: true,
+    commentsRuntimeWired: false,
   },
 });
 
@@ -371,7 +375,7 @@ export const IMPLEMENTATION_PLAN = deepFreeze([
   { id: 'M6', title: 'Hardened read-only MCP', status: 'source adapter and protocol tests implemented; runtime registration pending', acceptance: ['auth', 'sanitization', 'rate limit', 'timeout', 'audit', 'bounded tools', 'read-only role'] },
   { id: 'M7', title: 'Codex skill', status: 'versioned skill and contract tests implemented; MCP/runtime registration remains governed by later gates', acceptance: ['read-only tool use', 'safe question routing', 'no provider or shell bypass'] },
   { id: 'M8', title: 'CRM read-only surface', status: 'internal proxy, typed client, gated shadow dashboard, and synthetic UI tests implemented; upstream/runtime remains off', acceptance: ['internal API only', 'server grant and flag', 'shadow UI', 'no direct provider access'] },
-  { id: 'M9', title: 'Comments intelligence', status: 'pending', acceptance: ['aggregate-only signals', 'privacy and model provenance', 'bounded retention'] },
+  { id: 'M9', title: 'Comments intelligence', status: 'source implemented; aggregate-only analyzer, additive persistence metadata, and synthetic tests; runtime/provider wiring remains off', acceptance: ['aggregate-only signals', 'privacy and model provenance', 'bounded retention'] },
   { id: 'M10', title: 'Semantic content and Reels signals', status: 'pending', acceptance: ['approved media projection', 'no raw media archive by default', 'versioned inference'] },
   { id: 'M11', title: 'Campaign and brand fit', status: 'pending', acceptance: ['structured criteria', 'explainable deterministic base', 'inferred signals labeled'] },
   { id: 'M12', title: 'Synthetic validation and calibration', status: 'pending', acceptance: ['fixtures', 'outlier tests', 'coverage/confidence calibration', 'negative policy tests'] },

--- a/social/influencer-intelligence/comments.mjs
+++ b/social/influencer-intelligence/comments.mjs
@@ -1,0 +1,810 @@
+import {
+  assertNoSensitiveFields,
+} from './contracts.mjs';
+
+/**
+ * Bounded, aggregate-only comment intelligence.
+ *
+ * The input comment text is an ephemeral analysis input. It is never returned
+ * by this module and is never accepted by the PostgreSQL repository. Provider
+ * adapters must reduce commenter identity to a domain-scoped SHA-256 digest
+ * before calling this boundary.
+ */
+
+export const COMMENT_ANALYSIS_ALGORITHM_VERSION =
+  'influencer-intelligence-comments/v1';
+export const COMMENT_SAMPLING_VERSION =
+  'influencer-intelligence-comments-sampling/v1';
+export const COMMENT_SEMANTIC_SCHEMA_VERSION =
+  'influencer-intelligence-comments-semantic/v1';
+
+export const MAX_COMMENT_SAMPLE_SIZE = 100;
+export const MAX_COMMENT_CANDIDATES = 200;
+export const DEFAULT_COMMENT_SAMPLE_SIZE = 50;
+export const DEFAULT_COMMENT_FRESHNESS_SECONDS = 7 * 24 * 60 * 60;
+
+export const COMMENT_METRIC_KEYS = Object.freeze([
+  'unique_commenter_ratio',
+  'emoji_only_ratio',
+  'duplicate_ratio',
+  'near_duplicate_ratio',
+  'generic_short_comment_ratio',
+  'repeated_commenter_ratio',
+  'comment_length_distribution',
+  'language_distribution',
+  'comment_like_distribution',
+]);
+
+const COMMENT_METRIC_SET = new Set(COMMENT_METRIC_KEYS);
+const QUALITY_WEIGHTS = Object.freeze({
+  originality: 0.30,
+  substance: 0.30,
+  audience_diversity: 0.20,
+  semantic_relevance: 0.20,
+});
+const SAMPLING_STRATEGIES = new Set(['bounded_recent', 'deterministic_uniform']);
+const FRESHNESS_STATUSES = new Set(['fresh', 'stale', 'unknown']);
+const PROVIDER_PATTERN = /^[a-z][a-z0-9._-]{1,63}$/;
+const OPAQUE_PATTERN = /^[A-Za-z0-9._:-]{1,240}$/;
+const SOURCE_REF_PATTERN = /^[A-Za-z0-9._:/-]{1,240}$/;
+const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
+const VERSION_PATTERN = /^[a-z][a-z0-9._/-]{0,79}$/;
+const LANGUAGE_PATTERN = /^[a-z]{2,12}(?:[-_][a-z]{2,8})?$/;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/;
+const COMMENT_FIELDS = new Set([
+  'text',
+  'commenter_digest',
+  'commenterDigest',
+  'language_code',
+  'languageCode',
+  'like_count',
+  'likeCount',
+]);
+const SAMPLING_FIELDS = new Set([
+  'max_comments',
+  'maxComments',
+  'strategy',
+]);
+const GENERIC_SHORT_PHRASES = new Set([
+  'amazing',
+  'awesome',
+  'congrats',
+  'first',
+  'gorgeous',
+  'linda',
+  'lindo',
+  'love it',
+  'nice',
+  'nice post',
+  'perfeito',
+  'top',
+  'wow',
+]);
+const SEMANTIC_EVIDENCE_CODES = new Set([
+  'contextual_relevance',
+  'generic_language',
+  'repeated_promotion',
+  'insufficient_context',
+]);
+const SEMANTIC_BASIS_CODES = new Set([
+  'aggregate_label',
+  'topic_overlap',
+  'generic_pattern',
+  'insufficient_sample_context',
+]);
+
+export class CommentIntelligenceError extends Error {
+  constructor(code, message = code) {
+    super(message);
+    this.name = 'CommentIntelligenceError';
+    this.code = code;
+  }
+}
+
+function fail(code, message = code) {
+  throw new CommentIntelligenceError(code, message);
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function deepFreeze(value, seen = new Set()) {
+  if (!value || typeof value !== 'object' || seen.has(value)) return value;
+  seen.add(value);
+  for (const child of Object.values(value)) deepFreeze(child, seen);
+  return Object.freeze(value);
+}
+
+function round(value, digits = 6) {
+  const factor = 10 ** digits;
+  return Math.round((value + Number.EPSILON) * factor) / factor;
+}
+
+function boundedInteger(value, label, { minimum = 0, maximum = Number.MAX_SAFE_INTEGER, required = true } = {}) {
+  if (value === undefined || value === null) {
+    if (!required) return undefined;
+    fail(`${label.toUpperCase()}_REQUIRED`);
+  }
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    fail(`${label.toUpperCase()}_INVALID`);
+  }
+  return value;
+}
+
+function boundedDecimal(value, label, { minimum = 0, maximum = 1, required = true } = {}) {
+  if (value === undefined || value === null) {
+    if (!required) return undefined;
+    fail(`${label.toUpperCase()}_REQUIRED`);
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < minimum || value > maximum) {
+    fail(`${label.toUpperCase()}_INVALID`);
+  }
+  return round(value);
+}
+
+function boundedString(value, label, { maximum = 240, required = true } = {}) {
+  if (value === undefined || value === null || value === '') {
+    if (!required) return undefined;
+    fail(`${label.toUpperCase()}_REQUIRED`);
+  }
+  if (typeof value !== 'string') fail(`${label.toUpperCase()}_INVALID`);
+  const normalized = value.trim();
+  if (!normalized || normalized.length > maximum || CONTROL_CHARACTER_PATTERN.test(normalized)) {
+    fail(`${label.toUpperCase()}_INVALID`);
+  }
+  return normalized;
+}
+
+function safeOpaque(value, label, { required = true, pattern = OPAQUE_PATTERN } = {}) {
+  const normalized = boundedString(value, label, { maximum: 240, required });
+  if (normalized === undefined) return undefined;
+  if (!pattern.test(normalized)) fail(`${label.toUpperCase()}_INVALID`);
+  return normalized;
+}
+
+function safeVersion(value, label, { required = true } = {}) {
+  const normalized = boundedString(value, label, { maximum: 80, required });
+  if (normalized === undefined) return undefined;
+  if (!VERSION_PATTERN.test(normalized)) fail(`${label.toUpperCase()}_INVALID`);
+  return normalized;
+}
+
+function timestamp(value, label) {
+  const normalized = boundedString(value, label, { maximum: 40 });
+  const parsed = new Date(normalized);
+  if (Number.isNaN(parsed.getTime())) fail(`${label.toUpperCase()}_INVALID`);
+  return parsed.toISOString();
+}
+
+function normalizeProvider(value) {
+  const normalized = boundedString(value, 'provider', { maximum: 64 }).toLowerCase();
+  if (!PROVIDER_PATTERN.test(normalized)) fail('PROVIDER_INVALID');
+  return normalized;
+}
+
+function normalizeLanguage(value) {
+  if (value === undefined || value === null || value === '') return undefined;
+  const normalized = boundedString(value, 'languageCode', { maximum: 24 }).toLowerCase().replace('-', '_');
+  if (!LANGUAGE_PATTERN.test(normalized.replace('_', '-'))) fail('LANGUAGE_CODE_INVALID');
+  return normalized;
+}
+
+function normalizeCommenterDigest(value) {
+  if (value === undefined || value === null || value === '') return undefined;
+  const normalized = boundedString(value, 'commenterDigest', { maximum: 64 }).toLowerCase();
+  if (!DIGEST_PATTERN.test(normalized)) fail('COMMENTER_DIGEST_INVALID');
+  return normalized;
+}
+
+function normalizeComment(value, index) {
+  if (!isRecord(value)) fail('COMMENT_INVALID', `comment[${index}] must be an object`);
+  assertNoSensitiveFields({ ...value, ...('text' in value ? { text: undefined } : {}) }, `comment[${index}]`);
+  for (const key of Object.keys(value)) {
+    if (!COMMENT_FIELDS.has(key)) fail('COMMENT_FIELD_FORBIDDEN', `comment[${index}] contains an unsupported field`);
+  }
+  const text = boundedString(value.text, `comment[${index}].text`, { maximum: 2000 });
+  try {
+    assertNoSensitiveFields(text, `comment[${index}].text`);
+  } catch {
+    fail('COMMENT_TEXT_POLICY_BLOCKED');
+  }
+  const commenterDigest = normalizeCommenterDigest(value.commenter_digest ?? value.commenterDigest);
+  const languageCode = normalizeLanguage(value.language_code ?? value.languageCode);
+  const likeCount = boundedInteger(value.like_count ?? value.likeCount, `comment[${index}].likeCount`, {
+    minimum: 0,
+    required: false,
+  });
+  return Object.freeze({
+    text,
+    ...(commenterDigest ? { commenter_digest: commenterDigest } : {}),
+    ...(languageCode ? { language_code: languageCode } : {}),
+    ...(likeCount !== undefined ? { like_count: likeCount } : {}),
+  });
+}
+
+function normalizeSamplingConfig(value = {}, candidateCount = 0) {
+  if (!isRecord(value)) fail('SAMPLING_CONFIG_INVALID');
+  for (const key of Object.keys(value)) {
+    if (!SAMPLING_FIELDS.has(key)) fail('SAMPLING_CONFIG_FIELD_FORBIDDEN');
+  }
+  const maxComments = boundedInteger(value.max_comments ?? value.maxComments ?? DEFAULT_COMMENT_SAMPLE_SIZE, 'maxComments', {
+    minimum: 1,
+    maximum: MAX_COMMENT_SAMPLE_SIZE,
+  });
+  const strategy = boundedString(value.strategy ?? 'bounded_recent', 'sampling.strategy', { maximum: 40 }).toLowerCase();
+  if (!SAMPLING_STRATEGIES.has(strategy)) fail('SAMPLING_STRATEGY_INVALID');
+  return Object.freeze({
+    sampling_version: COMMENT_SAMPLING_VERSION,
+    strategy,
+    requested_limit: maxComments,
+    candidate_count: candidateCount,
+    selected_count: Math.min(candidateCount, maxComments),
+    truncated: candidateCount > maxComments,
+    source_order: 'provider_bounded',
+    retention: 'aggregate_only',
+  });
+}
+
+export function sampleCommentRecords(comments, config = {}) {
+  if (!Array.isArray(comments) || comments.length > MAX_COMMENT_CANDIDATES) {
+    fail('COMMENT_CANDIDATES_OUT_OF_BOUNDS');
+  }
+  const normalized = comments.map((comment, index) => normalizeComment(comment, index));
+  const sampling = normalizeSamplingConfig(config, normalized.length);
+  const limit = sampling.requested_limit;
+  let selected;
+  if (normalized.length <= limit) {
+    selected = normalized;
+  } else if (sampling.strategy === 'bounded_recent') {
+    selected = normalized.slice(0, limit);
+  } else {
+    selected = limit === 1
+      ? [normalized[0]]
+      : Array.from({ length: limit }, (_, index) => {
+        const sourceIndex = Math.floor((index * (normalized.length - 1)) / (limit - 1));
+        return normalized[sourceIndex];
+      });
+  }
+  return Object.freeze({
+    comments: Object.freeze(selected),
+    sampling: Object.freeze({ ...sampling, selected_count: selected.length }),
+  });
+}
+
+function normalizedText(text) {
+  return text
+    .normalize('NFKC')
+    .toLocaleLowerCase('und')
+    .replace(/[.,!?;:()[\]{}"'`?]+/gu, ' ')
+    .replace(/\s+/gu, ' ')
+    .trim();
+}
+
+function lexicalText(text) {
+  return normalizedText(text).replace(/[^\p{L}\p{N}\s]/gu, '').replace(/\s+/gu, ' ').trim();
+}
+
+function isEmojiOnly(text) {
+  const normalized = text.trim();
+  if (!normalized) return false;
+  let hasEmoji = false;
+  for (const character of normalized) {
+    if (/\p{Extended_Pictographic}|\p{Regional_Indicator}|\p{Emoji_Modifier}/u.test(character)) {
+      hasEmoji = true;
+      continue;
+    }
+    if (/\p{M}|\s|\uFE0F|\u200D/u.test(character)) continue;
+    return false;
+  }
+  return hasEmoji;
+}
+
+function isGenericShort(text) {
+  if (text.length > 24) return false;
+  const lexical = lexicalText(text);
+  if (!lexical) return false;
+  if (GENERIC_SHORT_PHRASES.has(lexical)) return true;
+  const words = lexical.split(' ');
+  return words.length <= 3 && words.every((word) => GENERIC_SHORT_PHRASES.has(word));
+}
+
+function levenshtein(left, right) {
+  const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+  for (let row = 1; row <= left.length; row += 1) {
+    let diagonal = previous[0];
+    previous[0] = row;
+    for (let column = 1; column <= right.length; column += 1) {
+      const above = previous[column];
+      previous[column] = left[row - 1] === right[column - 1]
+        ? diagonal
+        : Math.min(previous[column - 1] + 1, above + 1, diagonal + 1);
+      diagonal = above;
+    }
+  }
+  return previous[right.length];
+}
+
+function tokenJaccard(left, right) {
+  const leftTokens = new Set(left.split(' ').filter(Boolean));
+  const rightTokens = new Set(right.split(' ').filter(Boolean));
+  if (leftTokens.size === 0 || rightTokens.size === 0) return 0;
+  const intersection = [...leftTokens].filter((token) => rightTokens.has(token)).length;
+  const union = new Set([...leftTokens, ...rightTokens]).size;
+  return intersection / union;
+}
+
+function isNearDuplicate(left, right) {
+  if (!left || !right || left === right) return false;
+  const distance = levenshtein(left, right) / Math.max(left.length, right.length);
+  return distance <= 0.12 || tokenJaccard(left, right) >= 0.8;
+}
+
+function median(values) {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return round(sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle]);
+}
+
+function countBins(values, bins) {
+  const counts = Object.fromEntries(bins.map(({ bucket }) => [bucket, 0]));
+  for (const value of values) {
+    const bucket = bins.find(({ minimum, maximum }) => value >= minimum && (maximum === undefined || value <= maximum));
+    counts[bucket?.bucket || bins.at(-1).bucket] += 1;
+  }
+  return counts;
+}
+
+function metric(value, { confidence = 1, limitations = [] } = {}) {
+  return Object.freeze({
+    value: value === null ? null : (typeof value === 'number' ? round(value) : value),
+    evidence_state: value === null ? 'unavailable' : 'derived',
+    confidence: value === null ? 0 : round(confidence),
+    limitations: Object.freeze([...new Set(limitations)]),
+  });
+}
+
+function unavailableMetric(limitation) {
+  return metric(null, { limitations: [limitation] });
+}
+
+function calculateFreshness(observedAt, retrievedAt, now, maxAgeSeconds) {
+  const nowMs = Date.parse(now);
+  const observedMs = Date.parse(observedAt);
+  const ageSeconds = Math.max(0, Math.floor((nowMs - observedMs) / 1000));
+  const status = ageSeconds <= maxAgeSeconds ? 'fresh' : 'stale';
+  return Object.freeze({
+    status,
+    observed_at: observedAt,
+    retrieved_at: retrievedAt,
+    age_seconds: ageSeconds,
+    max_age_seconds: maxAgeSeconds,
+  });
+}
+
+function normalizeSemanticEvidence(value, sampleSize) {
+  if (!Array.isArray(value) || value.length > 8) fail('SEMANTIC_EVIDENCE_INVALID');
+  return Object.freeze(value.map((entry, index) => {
+    if (!isRecord(entry)) fail('SEMANTIC_EVIDENCE_INVALID');
+    const keys = Object.keys(entry);
+    if (keys.some((key) => !['code', 'count', 'basis'].includes(key))) fail('SEMANTIC_FREE_FORM_EVIDENCE_REJECTED');
+    const code = boundedString(entry.code, `semantic.evidence[${index}].code`, { maximum: 64 }).toLowerCase();
+    const basis = boundedString(entry.basis, `semantic.evidence[${index}].basis`, { maximum: 64 }).toLowerCase();
+    if (!SEMANTIC_EVIDENCE_CODES.has(code) || !SEMANTIC_BASIS_CODES.has(basis)) fail('SEMANTIC_EVIDENCE_CODE_INVALID');
+    const count = boundedInteger(entry.count, `semantic.evidence[${index}].count`, { maximum: sampleSize });
+    return Object.freeze({ code, count, basis });
+  }));
+}
+
+function normalizeSemanticResult(value, sampleSize, fallbackRef) {
+  if (!isRecord(value)) fail('SEMANTIC_RESULT_INVALID');
+  const allowed = new Set(['schema_version', 'schemaVersion', 'model_version', 'modelVersion', 'confidence', 'relevance', 'evidence', 'evidence_refs', 'evidenceRefs']);
+  if (Object.keys(value).some((key) => !allowed.has(key))) fail('SEMANTIC_FREE_FORM_OUTPUT_REJECTED');
+  const schemaVersion = boundedString(value.schema_version ?? value.schemaVersion, 'semantic.schemaVersion', { maximum: 80 });
+  if (schemaVersion !== COMMENT_SEMANTIC_SCHEMA_VERSION) fail('SEMANTIC_SCHEMA_VERSION_INVALID');
+  const modelVersion = safeVersion(value.model_version ?? value.modelVersion, 'semantic.modelVersion');
+  const confidence = boundedDecimal(value.confidence, 'semantic.confidence');
+  if (!isRecord(value.relevance)) fail('SEMANTIC_RELEVANCE_INVALID');
+  const relevanceKeys = ['relevant', 'generic', 'spam_like', 'unknown'];
+  if (Object.keys(value.relevance).some((key) => !relevanceKeys.includes(key))) fail('SEMANTIC_RELEVANCE_INVALID');
+  const relevance = Object.fromEntries(relevanceKeys.map((key) => [
+    key,
+    boundedInteger(value.relevance[key], `semantic.relevance.${key}`, { maximum: sampleSize }),
+  ]));
+  if (Object.values(relevance).reduce((total, count) => total + count, 0) !== sampleSize) {
+    fail('SEMANTIC_RELEVANCE_COVERAGE_INVALID');
+  }
+  const evidence = normalizeSemanticEvidence(value.evidence, sampleSize);
+  const evidenceRefsInput = value.evidence_refs ?? value.evidenceRefs ?? [fallbackRef];
+  if (!Array.isArray(evidenceRefsInput) || evidenceRefsInput.length < 1 || evidenceRefsInput.length > 8) fail('SEMANTIC_EVIDENCE_REFS_INVALID');
+  const normalizedEvidenceRefs = evidenceRefsInput.map((ref, index) => safeOpaque(ref, `semantic.evidenceRefs[${index}]`, { pattern: SOURCE_REF_PATTERN }));
+  const evidenceRefs = Object.freeze([...new Set(normalizedEvidenceRefs)]);
+  return Object.freeze({
+    status: 'available',
+    evidence_state: 'inferred',
+    schema_version: schemaVersion,
+    model_version: modelVersion,
+    confidence,
+    relevance,
+    relevant_ratio: round(relevance.relevant / Math.max(1, sampleSize)),
+    evidence,
+    evidence_refs: evidenceRefs,
+  });
+}
+
+function unavailableSemantic(limitation) {
+  return Object.freeze({
+    status: 'unavailable',
+    evidence_state: 'unavailable',
+    schema_version: COMMENT_SEMANTIC_SCHEMA_VERSION,
+    model_version: null,
+    confidence: 0,
+    relevance: null,
+    relevant_ratio: null,
+    evidence: Object.freeze([]),
+    evidence_refs: Object.freeze([]),
+    limitation,
+  });
+}
+
+function buildMetrics(comments) {
+  const sampleSize = comments.length;
+  if (sampleSize === 0) {
+    return Object.freeze(Object.fromEntries(COMMENT_METRIC_KEYS.map((key) => [key, unavailableMetric('empty_sample')])));
+  }
+  const texts = comments.map(({ text }) => normalizedText(text));
+  const frequencies = new Map();
+  for (const text of texts) frequencies.set(text, (frequencies.get(text) || 0) + 1);
+  const uniqueTexts = frequencies.size;
+  const duplicateCount = texts.filter((text) => (frequencies.get(text) || 0) > 1).length;
+  const nearDuplicateCount = texts.reduce((count, text, index) => {
+    if ((frequencies.get(text) || 0) > 1) return count;
+    return count + (texts.some((other, otherIndex) => otherIndex !== index && isNearDuplicate(text, other)) ? 1 : 0);
+  }, 0);
+  const emojiOnlyCount = comments.filter(({ text }) => isEmojiOnly(text)).length;
+  const genericShortCount = comments.filter(({ text }) => isGenericShort(text)).length;
+  const lengths = comments.map(({ text }) => [...text].length);
+  const commenterDigests = comments.map(({ commenter_digest: digest }) => digest).filter(Boolean);
+  const commenterCounts = new Map();
+  for (const digest of commenterDigests) commenterCounts.set(digest, (commenterCounts.get(digest) || 0) + 1);
+  const repeatedCommentCount = commenterDigests.filter((digest) => commenterCounts.get(digest) > 1).length;
+  const languageCounts = new Map();
+  for (const language of comments.map(({ language_code: code }) => code).filter(Boolean)) {
+    languageCounts.set(language, (languageCounts.get(language) || 0) + 1);
+  }
+  const likeCounts = comments.map(({ like_count: count }) => count).filter((count) => count !== undefined);
+  const likeBins = [
+    { bucket: 'none', minimum: 0, maximum: 0 },
+    { bucket: 'low', minimum: 1, maximum: 2 },
+    { bucket: 'medium', minimum: 3, maximum: 9 },
+    { bucket: 'high', minimum: 10, maximum: 49 },
+    { bucket: 'very_high', minimum: 50 },
+  ];
+  const lengthBins = [
+    { bucket: 'empty', minimum: 0, maximum: 0 },
+    { bucket: 'short_1_20', minimum: 1, maximum: 20 },
+    { bucket: 'medium_21_80', minimum: 21, maximum: 80 },
+    { bucket: 'long_81_160', minimum: 81, maximum: 160 },
+    { bucket: 'very_long_161_plus', minimum: 161 },
+  ];
+  return Object.freeze({
+    unique_commenter_ratio: commenterDigests.length === 0
+      ? unavailableMetric('commenter_digest_unavailable')
+      : metric(new Set(commenterDigests).size / commenterDigests.length, {
+        confidence: commenterDigests.length / sampleSize,
+        limitations: commenterDigests.length < sampleSize ? ['partial_commenter_digest_coverage'] : [],
+      }),
+    emoji_only_ratio: metric(emojiOnlyCount / sampleSize),
+    duplicate_ratio: metric((sampleSize - uniqueTexts) / sampleSize),
+    near_duplicate_ratio: metric(nearDuplicateCount / sampleSize),
+    generic_short_comment_ratio: metric(genericShortCount / sampleSize),
+    repeated_commenter_ratio: commenterDigests.length === 0
+      ? unavailableMetric('commenter_digest_unavailable')
+      : metric(repeatedCommentCount / commenterDigests.length, {
+        confidence: commenterDigests.length / sampleSize,
+        limitations: commenterDigests.length < sampleSize ? ['partial_commenter_digest_coverage'] : [],
+      }),
+    comment_length_distribution: metric({
+      count: sampleSize,
+      mean: round(lengths.reduce((total, value) => total + value, 0) / sampleSize),
+      median: median(lengths),
+      bins: countBins(lengths, lengthBins),
+    }),
+    language_distribution: languageCounts.size === 0
+      ? unavailableMetric('language_labels_unavailable')
+      : metric({
+        labeled_count: [...languageCounts.values()].reduce((total, value) => total + value, 0),
+        unknown_count: sampleSize - [...languageCounts.values()].reduce((total, value) => total + value, 0),
+        counts: Object.fromEntries([...languageCounts.entries()].sort(([left], [right]) => left.localeCompare(right))),
+      }, {
+        confidence: [...languageCounts.values()].reduce((total, value) => total + value, 0) / sampleSize,
+        limitations: [...languageCounts.values()].reduce((total, value) => total + value, 0) < sampleSize
+          ? ['partial_language_coverage']
+          : [],
+      }),
+    comment_like_distribution: likeCounts.length === 0
+      ? unavailableMetric('comment_like_counts_unavailable')
+      : metric({
+        available_count: likeCounts.length,
+        missing_count: sampleSize - likeCounts.length,
+        mean: round(likeCounts.reduce((total, value) => total + value, 0) / likeCounts.length),
+        median: median(likeCounts),
+        bins: countBins(likeCounts, likeBins),
+      }, {
+        confidence: likeCounts.length / sampleSize,
+        limitations: likeCounts.length < sampleSize ? ['partial_comment_like_coverage'] : [],
+      }),
+  });
+}
+
+function qualityComponent(value, evidenceRefs, limitations = [], confidence = 1) {
+  return Object.freeze({
+    value: round(value * 100, 4),
+    evidence_state: 'derived',
+    confidence: round(confidence),
+    evidence_refs: Object.freeze([...evidenceRefs]),
+    limitations: Object.freeze([...limitations]),
+  });
+}
+
+function buildQuality(metrics, semantic, evidenceRef) {
+  const components = {};
+  const available = [];
+  const originality = 1 - ((metrics.duplicate_ratio.value * 0.6) + (metrics.near_duplicate_ratio.value * 0.4));
+  components.originality = qualityComponent(originality, [evidenceRef]);
+  available.push(['originality', originality]);
+  const substance = 1 - ((metrics.generic_short_comment_ratio.value * 0.6) + (metrics.emoji_only_ratio.value * 0.4));
+  components.substance = qualityComponent(substance, [evidenceRef]);
+  available.push(['substance', substance]);
+  if (metrics.unique_commenter_ratio.value !== null) {
+    components.audience_diversity = qualityComponent(
+      metrics.unique_commenter_ratio.value,
+      [evidenceRef],
+      metrics.unique_commenter_ratio.limitations,
+      metrics.unique_commenter_ratio.confidence,
+    );
+    available.push(['audience_diversity', metrics.unique_commenter_ratio.value]);
+  } else {
+    components.audience_diversity = Object.freeze({ value: null, evidence_state: 'unavailable', confidence: 0, evidence_refs: Object.freeze([]), limitations: Object.freeze(['commenter_digest_unavailable']) });
+  }
+  if (semantic.status === 'available') {
+    components.semantic_relevance = qualityComponent(semantic.relevant_ratio, semantic.evidence_refs, [], semantic.confidence);
+    available.push(['semantic_relevance', semantic.relevant_ratio]);
+  } else {
+    components.semantic_relevance = Object.freeze({ value: null, evidence_state: 'unavailable', confidence: 0, evidence_refs: Object.freeze([]), limitations: Object.freeze([semantic.limitation]) });
+  }
+  const weightTotal = available.reduce((total, [key]) => total + QUALITY_WEIGHTS[key], 0);
+  const score = available.reduce((total, [key, value]) => total + (QUALITY_WEIGHTS[key] * value), 0) / weightTotal;
+  return Object.freeze({
+    score: round(score * 100, 4),
+    components: Object.freeze(components),
+    used_components: Object.freeze(available.map(([key]) => key)),
+    limitations: Object.freeze(semantic.status === 'unavailable' ? [semantic.limitation] : []),
+  });
+}
+
+function countAvailableMetrics(metrics) {
+  return COMMENT_METRIC_KEYS.reduce((total, key) => total + (metrics[key].value === null ? 0 : 1), 0);
+}
+
+function buildConfidence({ sampleSize, coverage, semantic, metrics, freshness, providerReliability }) {
+  const sampleFactor = Math.min(1, sampleSize / DEFAULT_COMMENT_SAMPLE_SIZE);
+  const commenterCoverage = metrics.unique_commenter_ratio.value === null
+    ? 0
+    : metrics.unique_commenter_ratio.confidence;
+  const semanticFactor = semantic.status === 'available' ? semantic.confidence : 0;
+  const freshnessFactor = freshness.status === 'fresh' ? 1 : 0.5;
+  const factors = {
+    sample_size: round(sampleFactor),
+    metric_coverage: round(coverage.ratio),
+    commenter_coverage: round(commenterCoverage),
+    semantic_confidence: round(semanticFactor),
+    freshness: round(freshnessFactor),
+    provider_reliability: round(providerReliability),
+  };
+  const value = (sampleFactor * 0.30)
+    + (coverage.ratio * 0.20)
+    + (commenterCoverage * 0.15)
+    + (semanticFactor * 0.15)
+    + (freshnessFactor * 0.10)
+    + (providerReliability * 0.10);
+  return Object.freeze({ value: round(value), factors });
+}
+
+function normalizeAnalysisInput(input, clock) {
+  if (!isRecord(input)) fail('ANALYSIS_INPUT_INVALID');
+  const allowed = new Set([
+    'sample_key', 'sampleKey', 'creator_key', 'creatorKey', 'media_key', 'mediaKey',
+    'provider', 'provider_adapter_version', 'providerAdapterVersion', 'source_ref', 'sourceRef',
+    'observed_at', 'observedAt', 'retrieved_at', 'retrievedAt', 'comments', 'sampling',
+    'semantic_analyzer', 'semanticAnalyzer', 'provider_reliability', 'providerReliability',
+    'freshness_max_age_seconds', 'freshnessMaxAgeSeconds',
+  ]);
+  if (Object.keys(input).some((key) => !allowed.has(key))) fail('ANALYSIS_FIELD_FORBIDDEN');
+  const sampleKey = safeOpaque(input.sample_key ?? input.sampleKey, 'sampleKey');
+  const creatorKey = safeOpaque(input.creator_key ?? input.creatorKey, 'creatorKey');
+  const mediaKey = safeOpaque(input.media_key ?? input.mediaKey, 'mediaKey', { required: false });
+  const provider = normalizeProvider(input.provider);
+  const providerAdapterVersion = safeVersion(input.provider_adapter_version ?? input.providerAdapterVersion, 'providerAdapterVersion');
+  const sourceRef = safeOpaque(input.source_ref ?? input.sourceRef, 'sourceRef', { pattern: SOURCE_REF_PATTERN });
+  const observedAt = timestamp(input.observed_at ?? input.observedAt, 'observedAt');
+  const retrievedAt = timestamp(input.retrieved_at ?? input.retrievedAt, 'retrievedAt');
+  if (Date.parse(retrievedAt) < Date.parse(observedAt)) fail('TIMESTAMP_ORDER_INVALID');
+  const nowValue = typeof clock === 'function' ? clock() : clock;
+  const nowDate = nowValue instanceof Date ? nowValue : new Date(nowValue === undefined ? Date.now() : nowValue);
+  if (Number.isNaN(nowDate.getTime())) fail('CLOCK_INVALID');
+  const maxAgeSeconds = boundedInteger(input.freshness_max_age_seconds ?? input.freshnessMaxAgeSeconds ?? DEFAULT_COMMENT_FRESHNESS_SECONDS, 'freshnessMaxAgeSeconds', {
+    minimum: 0,
+    maximum: 315360000,
+  });
+  const providerReliability = boundedDecimal(input.provider_reliability ?? input.providerReliability ?? 0.5, 'providerReliability');
+  const sampled = sampleCommentRecords(input.comments, input.sampling || {});
+  return {
+    sampleKey,
+    creatorKey,
+    mediaKey,
+    provider,
+    providerAdapterVersion,
+    sourceRef,
+    observedAt,
+    retrievedAt,
+    now: nowDate.toISOString(),
+    maxAgeSeconds,
+    providerReliability,
+    sampled,
+    semanticAnalyzer: input.semantic_analyzer ?? input.semanticAnalyzer,
+  };
+}
+
+function aggregateMetricsForPersistence(analysis) {
+  return Object.freeze({
+    sample_size: analysis.sample_size,
+    metrics: Object.fromEntries(Object.entries(analysis.metrics).map(([key, value]) => [key, value.value])),
+    metric_details: analysis.metrics,
+    quality_components: analysis.comment_quality.components,
+    quality_confidence_factors: analysis.comment_quality.confidence_factors,
+    coverage: analysis.coverage,
+    sampling: analysis.sampling,
+    freshness: analysis.freshness,
+    semantic: analysis.semantic.status === 'available'
+      ? analysis.semantic
+      : { status: 'unavailable', limitation: analysis.semantic.limitation },
+    evidence_refs: analysis.evidence_refs,
+    limitations: analysis.limitations,
+  });
+}
+
+export async function analyzeCommentSample(input, { clock = Date.now } = {}) {
+  const normalized = normalizeAnalysisInput(input, clock);
+  const { comments, sampling } = normalized.sampled;
+  const metrics = buildMetrics(comments);
+  const evidenceRefs = Object.freeze([normalized.sourceRef]);
+  let semantic = unavailableSemantic('semantic_analyzer_unavailable');
+  if (comments.length > 0 && normalized.semanticAnalyzer !== undefined && normalized.semanticAnalyzer !== null) {
+    if (!normalized.semanticAnalyzer || typeof normalized.semanticAnalyzer.analyze !== 'function') {
+      fail('SEMANTIC_ANALYZER_INTERFACE_INVALID');
+    }
+    try {
+      const semanticInput = Object.freeze({
+        schema_version: COMMENT_SEMANTIC_SCHEMA_VERSION,
+        comments: Object.freeze(comments.map((comment, index) => Object.freeze({ sample_index: index, text: comment.text }))),
+      });
+      const semanticResult = await normalized.semanticAnalyzer.analyze(semanticInput);
+      semantic = normalizeSemanticResult(semanticResult, comments.length, normalized.sourceRef);
+    } catch (error) {
+      if (error instanceof CommentIntelligenceError) throw error;
+      semantic = unavailableSemantic('semantic_analyzer_failed');
+    }
+  }
+  const freshness = calculateFreshness(normalized.observedAt, normalized.retrievedAt, normalized.now, normalized.maxAgeSeconds);
+  const availableMetrics = countAvailableMetrics(metrics);
+  const coverage = Object.freeze({
+    available_metrics: availableMetrics,
+    expected_metrics: COMMENT_METRIC_KEYS.length,
+    ratio: round(availableMetrics / COMMENT_METRIC_KEYS.length),
+    semantic_available: semantic.status === 'available',
+  });
+  const quality = comments.length === 0
+    ? Object.freeze({
+      score: null,
+      confidence: 0,
+      components: Object.freeze({}),
+      used_components: Object.freeze([]),
+      limitations: Object.freeze(['empty_sample']),
+    })
+    : buildQuality(metrics, semantic, normalized.sourceRef);
+  const confidence = comments.length === 0
+    ? Object.freeze({ value: 0, factors: Object.freeze({}) })
+    : buildConfidence({
+      sampleSize: comments.length,
+      coverage,
+      semantic,
+      metrics,
+      freshness,
+      providerReliability: normalized.providerReliability,
+    });
+  const limitations = new Set();
+  for (const metricValue of Object.values(metrics)) for (const limitation of metricValue.limitations) limitations.add(limitation);
+  for (const limitation of quality.limitations) limitations.add(limitation);
+  if (normalized.providerReliability === 0.5 && input.providerReliability === undefined && input.provider_reliability === undefined) {
+    limitations.add('provider_reliability_unspecified');
+  }
+  if (freshness.status === 'stale') limitations.add('stale_observation');
+  if (semantic.status === 'unavailable') limitations.add(semantic.limitation);
+  const commentQuality = Object.freeze({
+    score: quality.score,
+    confidence: confidence.value,
+    evidence_state: quality.score === null ? 'unavailable' : 'derived',
+    algorithm_version: COMMENT_ANALYSIS_ALGORITHM_VERSION,
+    components: quality.components,
+    used_components: quality.used_components,
+    confidence_factors: confidence.factors,
+  });
+  const analysis = {
+    algorithm_version: COMMENT_ANALYSIS_ALGORITHM_VERSION,
+    sample_key: normalized.sampleKey,
+    creator_key: normalized.creatorKey,
+    ...(normalized.mediaKey ? { media_key: normalized.mediaKey } : {}),
+    provider: normalized.provider,
+    retrieved_at: normalized.retrievedAt,
+    data_classification: comments.length === 0 ? 'observed' : 'derived',
+    evidence_state: comments.length === 0 ? 'unavailable' : 'derived',
+    freshness,
+    limitations: Object.freeze([...limitations]),
+    provider_specific_evidence: Object.freeze({
+      provider: normalized.provider,
+      operation: 'get_comments_sample',
+      adapter_version: normalized.providerAdapterVersion,
+      source_ref: normalized.sourceRef,
+      fields: Object.freeze(['aggregate_metrics', 'sample_size', 'sampling_config']),
+    }),
+    sampling,
+    sample_size: comments.length,
+    metrics,
+    semantic,
+    comment_quality: commentQuality,
+    coverage,
+    evidence_refs: evidenceRefs,
+    provenance: Object.freeze({
+      provider: normalized.provider,
+      source_type: 'comments-aggregate',
+      evidence_state: comments.length === 0 ? 'unavailable' : 'derived',
+      observed_at: normalized.observedAt,
+      retrieved_at: normalized.retrievedAt,
+      source_ref: normalized.sourceRef,
+    }),
+  };
+  return deepFreeze({
+    ...analysis,
+    aggregate_metrics: aggregateMetricsForPersistence(analysis),
+  });
+}
+
+export async function analyzeAndPersistCommentSample({ repository, retentionPolicyVersion, evidenceKey, ingestKey, ...input } = {}, options = {}) {
+  if (!repository || typeof repository.recordCommentSample !== 'function') fail('REPOSITORY_REQUIRED');
+  const analysis = await analyzeCommentSample(input, options);
+  const result = await repository.recordCommentSample({
+    sampleKey: analysis.sample_key,
+    ingestKey: safeOpaque(ingestKey, 'ingestKey'),
+    creatorKey: analysis.creator_key,
+    mediaKey: analysis.media_key,
+    evidenceKey: safeOpaque(evidenceKey, 'evidenceKey'),
+    provider: analysis.provider,
+    providerAdapterVersion: input.providerAdapterVersion ?? input.provider_adapter_version,
+    evidenceState: analysis.evidence_state,
+    observedAt: analysis.provenance.observed_at,
+    retrievedAt: analysis.retrieved_at,
+    sourceRef: analysis.provenance.source_ref,
+    commentCount: analysis.evidence_state === 'unavailable' ? undefined : analysis.sample_size,
+    aggregateMetrics: analysis.evidence_state === 'unavailable' ? {} : analysis.aggregate_metrics,
+    modelVersion: analysis.semantic.status === 'available' ? analysis.semantic.model_version : undefined,
+    algorithmVersion: analysis.algorithm_version,
+    qualityScore: analysis.comment_quality.score,
+    qualityConfidence: analysis.comment_quality.confidence,
+    samplingVersion: analysis.sampling.sampling_version,
+    samplingConfig: analysis.sampling,
+    retentionPolicyVersion: safeVersion(retentionPolicyVersion, 'retentionPolicyVersion'),
+  });
+  return Object.freeze({ analysis, persistence: result });
+}

--- a/social/influencer-intelligence/migrations/20260812_influencer_intelligence_comments_v1.up.sql
+++ b/social/influencer-intelligence/migrations/20260812_influencer_intelligence_comments_v1.up.sql
@@ -1,0 +1,85 @@
+BEGIN;
+
+SET LOCAL TIME ZONE 'UTC';
+
+-- M9 is additive. The base comment relation remains append-only and the
+-- existing immutable trigger also covers these new columns.
+ALTER TABLE influencer_intelligence.creator_comment_sample
+  ADD COLUMN IF NOT EXISTS sampling_version text,
+  ADD COLUMN IF NOT EXISTS sampling_config jsonb NOT NULL DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS algorithm_version text,
+  ADD COLUMN IF NOT EXISTS quality_score numeric(6,2),
+  ADD COLUMN IF NOT EXISTS quality_confidence numeric(5,4);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'creator_comment_sample_sampling_config_check'
+      AND conrelid = 'influencer_intelligence.creator_comment_sample'::regclass
+  ) THEN
+    ALTER TABLE influencer_intelligence.creator_comment_sample
+      ADD CONSTRAINT creator_comment_sample_sampling_config_check
+      CHECK (jsonb_typeof(sampling_config) = 'object');
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'creator_comment_sample_quality_fields_check'
+      AND conrelid = 'influencer_intelligence.creator_comment_sample'::regclass
+  ) THEN
+    ALTER TABLE influencer_intelligence.creator_comment_sample
+      ADD CONSTRAINT creator_comment_sample_quality_fields_check
+      CHECK (
+        (quality_score IS NULL AND quality_confidence IS NULL AND algorithm_version IS NULL)
+        OR (quality_score IS NOT NULL AND quality_confidence IS NOT NULL AND algorithm_version IS NOT NULL)
+      );
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'creator_comment_sample_quality_score_check'
+      AND conrelid = 'influencer_intelligence.creator_comment_sample'::regclass
+  ) THEN
+    ALTER TABLE influencer_intelligence.creator_comment_sample
+      ADD CONSTRAINT creator_comment_sample_quality_score_check
+      CHECK (quality_score IS NULL OR quality_score BETWEEN 0 AND 100);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'creator_comment_sample_quality_confidence_check'
+      AND conrelid = 'influencer_intelligence.creator_comment_sample'::regclass
+  ) THEN
+    ALTER TABLE influencer_intelligence.creator_comment_sample
+      ADD CONSTRAINT creator_comment_sample_quality_confidence_check
+      CHECK (quality_confidence IS NULL OR quality_confidence BETWEEN 0 AND 1);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'creator_comment_sample_algorithm_version_check'
+      AND conrelid = 'influencer_intelligence.creator_comment_sample'::regclass
+  ) THEN
+    ALTER TABLE influencer_intelligence.creator_comment_sample
+      ADD CONSTRAINT creator_comment_sample_algorithm_version_check
+      CHECK (algorithm_version IS NULL OR algorithm_version ~ '^[a-z][a-z0-9._/-]{0,79}$');
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'creator_comment_sample_sampling_version_check'
+      AND conrelid = 'influencer_intelligence.creator_comment_sample'::regclass
+  ) THEN
+    ALTER TABLE influencer_intelligence.creator_comment_sample
+      ADD CONSTRAINT creator_comment_sample_sampling_version_check
+      CHECK (sampling_version IS NULL OR sampling_version ~ '^[a-z][a-z0-9._/-]{0,79}$');
+  END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS creator_comment_sample_algorithm_observed_idx
+  ON influencer_intelligence.creator_comment_sample (algorithm_version, observed_at DESC);
+
+COMMIT;

--- a/social/influencer-intelligence/repository.mjs
+++ b/social/influencer-intelligence/repository.mjs
@@ -298,8 +298,8 @@ export const SQL = Object.freeze({
     returning snapshot_key, ingest_key, media_key, creator_key, provider, evidence_state, observed_at`,
   recordCommentSample: `
     insert into influencer_intelligence.creator_comment_sample
-      (sample_key, ingest_key, creator_key, media_key, evidence_key, provider, provider_adapter_version, evidence_state, observed_at, retrieved_at, source_ref, topic_key, language_code, sentiment_label, safety_label, comment_count, spam_ratio, sentiment_score, aggregate_metrics, model_version, retention_policy_version)
-    values ($1, $2, $3, $4, $5, $6, $7, $8, $9::timestamptz, $10::timestamptz, $11, $12, $13, $14, $15, $16, $17, $18, $19::jsonb, $20, $21)
+      (sample_key, ingest_key, creator_key, media_key, evidence_key, provider, provider_adapter_version, evidence_state, observed_at, retrieved_at, source_ref, topic_key, language_code, sentiment_label, safety_label, comment_count, spam_ratio, sentiment_score, aggregate_metrics, model_version, sampling_version, sampling_config, algorithm_version, quality_score, quality_confidence, retention_policy_version)
+    values ($1, $2, $3, $4, $5, $6, $7, $8, $9::timestamptz, $10::timestamptz, $11, $12, $13, $14, $15, $16, $17, $18, $19::jsonb, $20, $21, $22::jsonb, $23, $24, $25, $26)
     on conflict (ingest_key) do nothing
     returning sample_key, ingest_key, creator_key, provider, evidence_state, observed_at`,
   recordAnalysis: `
@@ -512,10 +512,19 @@ export function createInfluencerIntelligenceRepository({ queryable }) {
     async recordCommentSample(input) {
       const common = commonArtifact(input, 'sample');
       const aggregateMetrics = normalizeSafeJson(input.aggregateMetrics, 'aggregateMetrics');
+      const samplingConfig = normalizeSafeJson(input.samplingConfig, 'samplingConfig');
+      const samplingVersion = optionalString(input.samplingVersion, 'samplingVersion', VERSION_PATTERN);
+      const algorithmVersion = optionalString(input.algorithmVersion, 'algorithmVersion', VERSION_PATTERN);
+      const qualityScore = decimal(input.qualityScore, 'qualityScore', { minimum: 0, maximum: 100 });
+      const qualityConfidence = decimal(input.qualityConfidence, 'qualityConfidence', { minimum: 0, maximum: 1 });
+      const qualityFieldsPresent = qualityScore !== null || qualityConfidence !== null || algorithmVersion !== null;
+      if (qualityFieldsPresent && (qualityScore === null || qualityConfidence === null || algorithmVersion === null)) {
+        fail('COMMENT_SAMPLE_QUALITY_FIELDS_REQUIRED');
+      }
       if (common.evidenceState === 'inferred' && !input.modelVersion) fail('COMMENT_SAMPLE_MODEL_VERSION_REQUIRED');
       if (common.evidenceState === 'unavailable' && (
         input.commentCount !== undefined || input.spamRatio !== undefined || input.sentimentScore !== undefined ||
-        Object.keys(aggregateMetrics).length > 0
+        Object.keys(aggregateMetrics).length > 0 || qualityFieldsPresent
       )) fail('UNAVAILABLE_COMMENT_SAMPLE_MUST_BE_EMPTY');
       const row = await insertReturning(queryable, SQL.recordCommentSample, [
         common.key, common.ingestKey, common.creatorKey, optionalString(input.mediaKey, 'mediaKey'),
@@ -525,7 +534,8 @@ export function createInfluencerIntelligenceRepository({ queryable }) {
         optionalString(input.sentimentLabel, 'sentimentLabel', /^(positive|neutral|negative|mixed|unknown)$/),
         optionalString(input.safetyLabel, 'safetyLabel', /^(safe|flagged|unknown)$/), integer(input.commentCount, 'commentCount'),
         decimal(input.spamRatio, 'spamRatio', { minimum: 0, maximum: 1 }), decimal(input.sentimentScore, 'sentimentScore', { minimum: -1, maximum: 1 }),
-        JSON.stringify(aggregateMetrics), optionalString(input.modelVersion, 'modelVersion', VERSION_PATTERN), common.retentionPolicyVersion,
+        JSON.stringify(aggregateMetrics), optionalString(input.modelVersion, 'modelVersion', VERSION_PATTERN), samplingVersion,
+        JSON.stringify(samplingConfig), algorithmVersion, qualityScore, qualityConfidence, common.retentionPolicyVersion,
       ]);
       return { inserted: Boolean(row), row };
     },

--- a/social/influencer-intelligence/tests/architecture.test.mjs
+++ b/social/influencer-intelligence/tests/architecture.test.mjs
@@ -167,6 +167,18 @@ test('records the M7 skill as source-complete without enabling runtime access', 
   assert.equal(RELEASE_CONTRACT.currentSourceScope.mcpRuntimeRegistered, false);
 });
 
+test('records M9 comments intelligence as source-complete without wiring runtime collection', () => {
+  const milestone = IMPLEMENTATION_PLAN.find(({ id }) => id === 'M9');
+  assert.match(milestone.status, /aggregate-only analyzer/i);
+  assert.match(milestone.status, /runtime\/provider wiring remains off/i);
+  assert.deepEqual(DATA_MODEL.persistence.additiveMigrations, [
+    'migrations/20260812_influencer_intelligence_comments_v1.up.sql',
+  ]);
+  assert.equal(RELEASE_CONTRACT.currentSourceScope.commentsSourceAdded, true);
+  assert.equal(RELEASE_CONTRACT.currentSourceScope.commentsMigrationArtifactAdded, true);
+  assert.equal(RELEASE_CONTRACT.currentSourceScope.commentsRuntimeWired, false);
+});
+
 test('keeps this architecture milestone off and runtime-free', () => {
   assert.equal(FEATURE_ACCESS.defaultValue, false);
   assert.equal(FEATURE_ACCESS.initialMode, 'off');

--- a/social/influencer-intelligence/tests/comments.test.mjs
+++ b/social/influencer-intelligence/tests/comments.test.mjs
@@ -1,0 +1,227 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  COMMENT_ANALYSIS_ALGORITHM_VERSION,
+  COMMENT_METRIC_KEYS,
+  COMMENT_SAMPLING_VERSION,
+  COMMENT_SEMANTIC_SCHEMA_VERSION,
+  CommentIntelligenceError,
+  analyzeCommentSample,
+  analyzeAndPersistCommentSample,
+  sampleCommentRecords,
+} from '../comments.mjs';
+import {
+  COMMENT_FIXTURES,
+  STRUCTURED_SEMANTIC_RESULT,
+} from './fixtures/comments-golden-fixtures.mjs';
+
+const commonInput = {
+  sampleKey: 'sample-comments-1',
+  creatorKey: 'creator-comments-1',
+  mediaKey: 'media-comments-1',
+  provider: 'meta-graph',
+  providerAdapterVersion: 'meta-graph-adapter-v1',
+  sourceRef: 'synthetic-fixture/comments-1',
+  observedAt: '2026-08-11T12:00:00.000Z',
+  retrievedAt: '2026-08-11T12:01:00.000Z',
+  providerReliability: 0.9,
+  freshnessMaxAgeSeconds: 14 * 24 * 60 * 60,
+  sampling: { maxComments: 100, strategy: 'bounded_recent' },
+};
+
+function semanticAnalyzer(result = STRUCTURED_SEMANTIC_RESULT) {
+  return {
+    calls: [],
+    async analyze(input) {
+      this.calls.push(input);
+      return result;
+    },
+  };
+}
+
+test('selects a bounded, auditable sample without an implicit unbounded fetch', () => {
+  const result = sampleCommentRecords(COMMENT_FIXTURES.boundedCandidates, {
+    maxComments: 3,
+    strategy: 'bounded_recent',
+  });
+  assert.equal(result.comments.length, 3);
+  assert.equal(result.sampling.sampling_version, COMMENT_SAMPLING_VERSION);
+  assert.equal(result.sampling.requested_limit, 3);
+  assert.equal(result.sampling.candidate_count, 6);
+  assert.equal(result.sampling.truncated, true);
+  assert.equal(result.sampling.retention, 'aggregate_only');
+  assert.throws(
+    () => sampleCommentRecords(COMMENT_FIXTURES.boundedCandidates, { maxComments: 101 }),
+    (error) => error instanceof CommentIntelligenceError && error.code === 'MAXCOMMENTS_INVALID',
+  );
+  assert.throws(
+    () => sampleCommentRecords(Array.from({ length: 201 }, () => ({ text: 'bounded' }))),
+    (error) => error instanceof CommentIntelligenceError && error.code === 'COMMENT_CANDIDATES_OUT_OF_BOUNDS',
+  );
+});
+
+test('deterministic metrics cover duplicates, near duplicates, emoji, generic text, languages and likes', async () => {
+  const analyzer = semanticAnalyzer();
+  const first = await analyzeCommentSample({
+    ...commonInput,
+    comments: COMMENT_FIXTURES.mixed,
+    semanticAnalyzer: analyzer,
+  }, { clock: '2026-08-11T12:02:00.000Z' });
+  const second = await analyzeCommentSample({
+    ...commonInput,
+    comments: COMMENT_FIXTURES.mixed,
+    semanticAnalyzer: semanticAnalyzer(),
+  }, { clock: '2026-08-11T12:02:00.000Z' });
+
+  assert.deepEqual(first, second);
+  assert.equal(first.algorithm_version, COMMENT_ANALYSIS_ALGORITHM_VERSION);
+  assert.equal(first.sample_size, 7);
+  assert.equal(first.metrics.duplicate_ratio.value, 0.142857);
+  assert.equal(first.metrics.near_duplicate_ratio.value, 0.142857);
+  assert.equal(first.metrics.emoji_only_ratio.value, 0.142857);
+  assert.equal(first.metrics.generic_short_comment_ratio.value, 0.142857);
+  assert.equal(first.metrics.unique_commenter_ratio.value, 0.5);
+  assert.equal(first.metrics.repeated_commenter_ratio.value, 1);
+  assert.equal(first.metrics.language_distribution.value.counts.pt_br, 1);
+  assert.equal(first.metrics.comment_like_distribution.value.missing_count, 1);
+  assert.equal(first.semantic.status, 'available');
+  assert.equal(first.semantic.schema_version, COMMENT_SEMANTIC_SCHEMA_VERSION);
+  assert.equal(first.comment_quality.evidence_state, 'derived');
+  assert.ok(first.comment_quality.score >= 0 && first.comment_quality.score <= 100);
+  assert.ok(first.comment_quality.confidence < 0.8, 'a seven-comment sample must not receive high confidence');
+  assert.equal(first.coverage.expected_metrics, COMMENT_METRIC_KEYS.length);
+  assert.equal(first.freshness.status, 'fresh');
+  assert.equal(JSON.stringify(first).includes('This explanation'), false);
+  assert.equal(Object.keys(first).includes('comments'), false);
+});
+
+test('missing labels remain unavailable instead of becoming zero', async () => {
+  const result = await analyzeCommentSample({
+    ...commonInput,
+    comments: COMMENT_FIXTURES.noLabels,
+  }, { clock: '2026-08-11T12:02:00.000Z' });
+  assert.equal(result.metrics.unique_commenter_ratio.value, null);
+  assert.equal(result.metrics.unique_commenter_ratio.evidence_state, 'unavailable');
+  assert.equal(result.metrics.repeated_commenter_ratio.value, null);
+  assert.equal(result.metrics.language_distribution.value, null);
+  assert.equal(result.metrics.comment_like_distribution.value, null);
+  assert.equal(result.metrics.duplicate_ratio.value, 0);
+  assert.equal(result.metrics.emoji_only_ratio.value, 0);
+  assert.equal(result.semantic.status, 'unavailable');
+  assert.ok(result.limitations.includes('semantic_analyzer_unavailable'));
+  assert.ok(result.comment_quality.confidence < 0.5);
+});
+
+test('empty provider sample is explicit unavailable data, not a zero quality score', async () => {
+  const result = await analyzeCommentSample({
+    ...commonInput,
+    comments: [],
+  }, { clock: '2026-08-11T12:02:00.000Z' });
+  assert.equal(result.sample_size, 0);
+  assert.equal(result.evidence_state, 'unavailable');
+  assert.equal(result.comment_quality.score, null);
+  assert.equal(result.comment_quality.confidence, 0);
+  assert.equal(result.coverage.available_metrics, 0);
+  assert.ok(Object.values(result.metrics).every((metric) => metric.value === null));
+});
+
+test('staleness and provider reliability reduce independent confidence', async () => {
+  const result = await analyzeCommentSample({
+    ...commonInput,
+    providerReliability: 0.4,
+    comments: COMMENT_FIXTURES.genuine,
+  }, { clock: '2026-09-01T12:02:00.000Z' });
+  assert.equal(result.freshness.status, 'stale');
+  assert.ok(result.limitations.includes('stale_observation'));
+  assert.equal(result.comment_quality.confidence_factors.provider_reliability, 0.4);
+  assert.equal(result.comment_quality.confidence_factors.freshness, 0.5);
+  assert.ok(result.comment_quality.confidence < 0.6);
+});
+
+test('semantic analysis accepts only a closed aggregate schema and stores model provenance', async () => {
+  const analyzer = semanticAnalyzer();
+  const result = await analyzeCommentSample({
+    ...commonInput,
+    comments: COMMENT_FIXTURES.mixed,
+    semanticAnalyzer: analyzer,
+  });
+  assert.equal(analyzer.calls.length, 1);
+  assert.equal(analyzer.calls[0].schema_version, COMMENT_SEMANTIC_SCHEMA_VERSION);
+  assert.equal(analyzer.calls[0].comments[0].sample_index, 0);
+  assert.equal(result.semantic.model_version, 'semantic-comments-fixture/v1');
+  assert.equal(result.semantic.relevance.relevant, 4);
+  assert.deepEqual(result.semantic.evidence_refs, ['synthetic-fixture/comments-semantic']);
+  assert.equal('text' in result.semantic, false);
+  await assert.rejects(
+    analyzeCommentSample({
+      ...commonInput,
+      comments: COMMENT_FIXTURES.genuine,
+      semanticAnalyzer: semanticAnalyzer({ ...STRUCTURED_SEMANTIC_RESULT, note: 'free-form score narrative' }),
+    }),
+    (error) => error instanceof CommentIntelligenceError && error.code === 'SEMANTIC_FREE_FORM_OUTPUT_REJECTED',
+  );
+});
+
+test('raw commenter identity and credential-like comment content are rejected at the ephemeral boundary', async () => {
+  const credentialLikeText = ['access', '_token', '=do-not-process'].join('');
+  await assert.rejects(
+    analyzeCommentSample({
+      ...commonInput,
+      comments: [{ text: 'useful feedback', commenterId: 'provider-user-1' }],
+    }),
+    (error) => error instanceof CommentIntelligenceError && error.code === 'COMMENT_FIELD_FORBIDDEN',
+  );
+  await assert.rejects(
+    analyzeCommentSample({
+      ...commonInput,
+      comments: [{ text: credentialLikeText }],
+    }),
+    (error) => error instanceof CommentIntelligenceError && error.code === 'COMMENT_TEXT_POLICY_BLOCKED',
+  );
+});
+
+test('semantic provider failure degrades to unavailable without inventing labels', async () => {
+  const result = await analyzeCommentSample({
+    ...commonInput,
+    comments: COMMENT_FIXTURES.genuine,
+    semanticAnalyzer: { async analyze() { throw new Error('transport'); } },
+  });
+  assert.equal(result.semantic.status, 'unavailable');
+  assert.equal(result.semantic.relevance, null);
+  assert.equal(result.comment_quality.components.semantic_relevance.value, null);
+  assert.ok(result.limitations.includes('semantic_analyzer_failed'));
+});
+
+test('analyze-and-persist sends only aggregate output to the repository', async () => {
+  const writes = [];
+  const repository = {
+    async recordCommentSample(input) {
+      writes.push(input);
+      return { inserted: true, row: { sample_key: input.sampleKey } };
+    },
+  };
+  const result = await analyzeAndPersistCommentSample({
+    repository,
+    ...commonInput,
+    comments: COMMENT_FIXTURES.genuine,
+    semanticAnalyzer: semanticAnalyzer({
+      ...STRUCTURED_SEMANTIC_RESULT,
+      relevance: { relevant: 2, generic: 0, spam_like: 0, unknown: 1 },
+      evidence: [
+        { code: 'contextual_relevance', count: 2, basis: 'aggregate_label' },
+        { code: 'generic_language', count: 1, basis: 'generic_pattern' },
+      ],
+    }),
+    ingestKey: 'comment-ingest-1',
+    evidenceKey: 'comment-evidence-1',
+    retentionPolicyVersion: 'retention/v1',
+  });
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0].algorithmVersion, COMMENT_ANALYSIS_ALGORITHM_VERSION);
+  assert.equal(writes[0].qualityScore, result.analysis.comment_quality.score);
+  assert.equal(writes[0].samplingVersion, COMMENT_SAMPLING_VERSION);
+  assert.equal(writes[0].commentCount, 3);
+  assert.equal(JSON.stringify(writes[0]).includes('Usei por duas semanas'), false);
+  assert.equal(JSON.stringify(writes[0]).includes('commenter_digest'), false);
+});

--- a/social/influencer-intelligence/tests/data-model.test.mjs
+++ b/social/influencer-intelligence/tests/data-model.test.mjs
@@ -15,9 +15,11 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const migrationPath = path.join(here, '..', 'migrations', '20260811_influencer_intelligence_data_model_v1.up.sql');
 const snapshotMetadataMigrationPath = path.join(here, '..', 'migrations', '20260811_influencer_intelligence_snapshots_v1.up.sql');
 const scoringMigrationPath = path.join(here, '..', 'migrations', '20260811_influencer_intelligence_scoring_v0.up.sql');
+const commentsMigrationPath = path.join(here, '..', 'migrations', '20260812_influencer_intelligence_comments_v1.up.sql');
 const migration = fs.readFileSync(migrationPath, 'utf8');
 const snapshotMetadataMigration = fs.readFileSync(snapshotMetadataMigrationPath, 'utf8');
 const scoringMigration = fs.readFileSync(scoringMigrationPath, 'utf8');
+const commentsMigration = fs.readFileSync(commentsMigrationPath, 'utf8');
 const digestA = 'a'.repeat(64);
 const digestB = 'b'.repeat(64);
 const observedAt = '2026-08-11T12:00:00.000Z';
@@ -122,6 +124,18 @@ test('defines additive score weights version metadata without destructive DDL', 
   assert.match(scoringMigration, /COMMIT;\s*$/);
 });
 
+test('defines additive comment sampling, quality, and algorithm metadata without destructive DDL', () => {
+  assert.match(commentsMigration, /BEGIN;[\s\S]*SET LOCAL TIME ZONE 'UTC'/);
+  for (const column of ['sampling_version', 'sampling_config', 'algorithm_version', 'quality_score', 'quality_confidence']) {
+    assert.match(commentsMigration, new RegExp(`ADD COLUMN IF NOT EXISTS ${column}`), column);
+  }
+  assert.match(commentsMigration, /creator_comment_sample_quality_fields_check/);
+  assert.match(commentsMigration, /creator_comment_sample_quality_confidence_check/);
+  assert.doesNotMatch(commentsMigration, /DROP\s+(?:TABLE|SCHEMA|COLUMN)/i);
+  assert.doesNotMatch(commentsMigration, /TRUNCATE\s+/i);
+  assert.match(commentsMigration, /COMMIT;\s*$/);
+});
+
 test('repository exposes a parameterized, injected PostgreSQL boundary', async () => {
   const queryable = fakeQueryable([{ rows: [{ run_key: 'run-1' }] }]);
   const repository = createInfluencerIntelligenceRepository({ queryable });
@@ -217,6 +231,57 @@ test('media identity reconciliation does not rewrite historical metric snapshots
   assert.match(SQL.upsertMedia, /on conflict \(media_key\) do update/i);
   assert.match(SQL.recordMediaSnapshot, /on conflict \(ingest_key\) do nothing/i);
   assert.doesNotMatch(SQL.recordMediaSnapshot, /on conflict \(media_key\) do update/i);
+});
+
+test('comment intelligence persists only bounded aggregates with sampling and algorithm provenance', async () => {
+  const queryable = fakeQueryable([{ rows: [{ sample_key: 'comment-sample-1' }] }]);
+  const repository = createInfluencerIntelligenceRepository({ queryable });
+  const aggregateMetrics = {
+    sample_size: 7,
+    metrics: { duplicate_ratio: 0.14, language_distribution: { counts: { en: 4, pt: 2 } } },
+    quality_components: { originality: { value: 84 } },
+  };
+  await repository.recordCommentSample({
+    sampleKey: 'comment-sample-1',
+    ingestKey: 'comment-ingest-1',
+    creatorKey: 'creator-1',
+    mediaKey: 'media-1',
+    evidenceKey: 'evidence-1',
+    provider: 'meta-graph',
+    providerAdapterVersion: 'meta-graph-adapter-v1',
+    evidenceState: 'derived',
+    observedAt,
+    retrievedAt,
+    sourceRef: 'synthetic-fixture/comments-1',
+    commentCount: 7,
+    aggregateMetrics,
+    samplingVersion: 'influencer-intelligence-comments-sampling/v1',
+    samplingConfig: { requested_limit: 50, selected_count: 7, retention: 'aggregate_only' },
+    algorithmVersion: 'influencer-intelligence-comments/v1',
+    qualityScore: 84,
+    qualityConfidence: 0.42,
+    modelVersion: 'semantic-comments-fixture/v1',
+    retentionPolicyVersion: 'retention/v1',
+  });
+  const call = queryable.calls[0];
+  assert.equal(call.values[2], 'creator-1');
+  assert.equal(call.values[20], 'influencer-intelligence-comments-sampling/v1');
+  assert.deepEqual(JSON.parse(call.values[21]).retention, 'aggregate_only');
+  assert.equal(call.values[22], 'influencer-intelligence-comments/v1');
+  assert.equal(call.values[23], 84);
+  assert.equal(call.values[24], 0.42);
+  assert.doesNotMatch(call.text, /duplicate_ratio|semantic-comments/);
+  assert.doesNotMatch(JSON.stringify(call.values), /raw comment|comment text|commenter/);
+
+  await assert.rejects(
+    repository.recordCommentSample({
+      sampleKey: 'comment-sample-2', ingestKey: 'comment-ingest-2', creatorKey: 'creator-1', evidenceKey: 'evidence-1',
+      provider: 'meta-graph', providerAdapterVersion: 'meta-graph-adapter-v1', evidenceState: 'derived', observedAt, retrievedAt,
+      sourceRef: 'synthetic-fixture/comments-2', aggregateMetrics: {}, algorithmVersion: 'influencer-intelligence-comments/v1',
+      qualityScore: 80, retentionPolicyVersion: 'retention/v1',
+    }),
+    (error) => error.code === 'COMMENT_SAMPLE_QUALITY_FIELDS_REQUIRED',
+  );
 });
 
 test('scores accept future provider slugs but require auditable provenance and versions', async () => {

--- a/social/influencer-intelligence/tests/fixtures/comments-golden-fixtures.mjs
+++ b/social/influencer-intelligence/tests/fixtures/comments-golden-fixtures.mjs
@@ -1,0 +1,45 @@
+const digestA = 'a'.repeat(64);
+const digestB = 'b'.repeat(64);
+const digestC = 'c'.repeat(64);
+
+export const COMMENTER_DIGESTS = Object.freeze({ digestA, digestB, digestC });
+
+export const COMMENT_FIXTURES = Object.freeze({
+  mixed: Object.freeze([
+    { text: 'This explanation helped me understand the ingredient.', commenterDigest: digestA, languageCode: 'en', likeCount: 3 },
+    { text: 'Amei a explica??o e vou testar na rotina.', commenterDigest: digestB, languageCode: 'pt-BR', likeCount: 1 },
+    { text: 'This explanation helped me understand the ingredient.', commenterDigest: digestA, languageCode: 'en', likeCount: 3 },
+    { text: '??', commenterDigest: digestC, languageCode: 'en', likeCount: 0 },
+    { text: 'nice post', commenterDigest: digestC, languageCode: 'en' },
+    { text: 'This explanation helped me understand the ingredients!', commenterDigest: digestB, languageCode: 'en', likeCount: 10 },
+    { text: 'La textura parece ligera para piel sensible.', languageCode: 'es', likeCount: 2 },
+  ]),
+  genuine: Object.freeze([
+    { text: 'Usei por duas semanas e a textura funcionou bem na minha pele seca.', commenterDigest: digestA, languageCode: 'pt', likeCount: 5 },
+    { text: 'The comparison between the two formulas was useful for my routine.', commenterDigest: digestB, languageCode: 'en', likeCount: 4 },
+    { text: 'La explicaci?n del protector solar fue clara y pr?ctica.', commenterDigest: digestC, languageCode: 'es', likeCount: 2 },
+  ]),
+  noLabels: Object.freeze([
+    { text: 'A thoughtful question about the routine.' },
+    { text: 'Another independent response with useful detail.' },
+  ]),
+  boundedCandidates: Object.freeze(Array.from({ length: 6 }, (_, index) => ({
+    text: `bounded sample comment ${index + 1}`,
+    commenterDigest: digestA,
+    languageCode: 'en',
+  }))),
+});
+
+export const STRUCTURED_SEMANTIC_RESULT = Object.freeze({
+  schemaVersion: 'influencer-intelligence-comments-semantic/v1',
+  modelVersion: 'semantic-comments-fixture/v1',
+  confidence: 0.78,
+  relevance: { relevant: 4, generic: 1, spam_like: 1, unknown: 1 },
+  evidence: [
+    { code: 'contextual_relevance', count: 4, basis: 'aggregate_label' },
+    { code: 'generic_language', count: 1, basis: 'generic_pattern' },
+    { code: 'repeated_promotion', count: 1, basis: 'aggregate_label' },
+    { code: 'insufficient_context', count: 1, basis: 'insufficient_sample_context' },
+  ],
+  evidenceRefs: ['synthetic-fixture/comments-semantic'],
+});


### PR DESCRIPTION
## Summary
- add bounded, deterministic aggregate comment intelligence with explicit missing-data states
- add closed structured semantic analyzer contract, quality score/confidence, and provenance
- add additive persistence metadata for sampling, algorithm, quality score, and confidence

## Boundaries
- ephemeral comment text is never returned or persisted
- only domain-scoped commenter digests are accepted; raw identities are rejected
- no provider transport, credentials, scraping, engagement, workflow, CRM, or MCP wiring
- existing append-only creator_comment_sample and injected repository boundary are reused
- module remains off by default; migration is source-controlled and unapplied

## Validation
- focused comments, data model, and architecture tests: 32 passed locally
- full Influencer Intelligence suite: 123 passed locally before the final follow-up assertion; the exact focused suite after the follow-up passed 32/32
- architecture validation: passed
- module catalog validation: passed
- domain boundary validation: passed with the 3 pre-existing tracked legacy warnings
- dependency closure validation: passed
- git diff --check: passed

## Rollback
Revert or close this single-purpose PR. No database, runtime, provider, or user state is changed.