### PR TITLE
docs(codex): keep CRM shortcut guidance catalog-driven

### DIFF
--- a/docs/codex-shared-workspace.md
+++ b/docs/codex-shared-workspace.md
@@ -129,15 +129,16 @@ atalhos de agrupamento abrem menus curtos por domínio.
 ### CRM – Local
 
 Inicia o CRM completo como Gestor, com build automático por impressão,
-Insumos, Timekeeping, adaptador do WhatsApp, Pages Functions, gate dos 14
-módulos e navegador somente depois da aprovação.
+Insumos, Timekeeping, adaptador do WhatsApp, Pages Functions, gate do catálogo
+CRM e navegador somente depois da aprovação.
 
 ### CRM – Módulos
 
-Permite escolher somente papel e módulo. O instalador também cria 16 atalhos
-diretos na subpasta `CRM – Módulos`: 14 módulos para Gestor e Atendimento/Ponto
-para Consultor. Portas, PIDs, logs, estado, autenticação e perfil de navegador
-são privados por combinação.
+Permite escolher somente papel e módulo conforme o catálogo local e a política
+de papéis. O instalador cria os atalhos diretos correspondentes às combinações
+válidas para Gestor e Consultor; superfícies gated permanecem desativadas até
+que sua dependência e autorização sejam liberadas. Portas, PIDs, logs, estado,
+autenticação e perfil de navegador são privados por combinação.
 
 ### CRM – Prévia da Thread
 


### PR DESCRIPTION
## Objetivo
Atualizar o guia de atalhos CRM para acompanhar o catálogo/política atuais sem fixar contagens obsoletas.

## Mudança
- remove referências rígidas a 14 módulos/16 atalhos;
- documenta que combinações válidas vêm do catálogo e da política de papéis;
- mantém superfícies gated desativadas até dependência e autorização.

## Risco e validação
- somente documentação;
- `git diff --check` passou;
- não altera API, flag, banco, deploy ou runtime.