### PR TITLE
fix(influencer-intelligence): harden additive migrations

### DIFF
--- a/social/influencer-intelligence/migrations/20260811_influencer_intelligence_data_model_v1.up.sql
+++ b/social/influencer-intelligence/migrations/20260811_influencer_intelligence_data_model_v1.up.sql
@@ -454,10 +454,30 @@ BEGIN
     'creator_score_component',
     'campaign_creator_fit'
   ] LOOP
-    EXECUTE format('DROP TRIGGER IF EXISTS %I_append_only ON influencer_intelligence.%I', table_name, table_name);
-    EXECUTE format('CREATE TRIGGER %I_append_only BEFORE UPDATE OR DELETE ON influencer_intelligence.%I FOR EACH ROW EXECUTE FUNCTION influencer_intelligence.prevent_append_only_mutation()', table_name, table_name);
-    EXECUTE format('DROP TRIGGER IF EXISTS %I_no_truncate ON influencer_intelligence.%I', table_name, table_name);
-    EXECUTE format('CREATE TRIGGER %I_no_truncate BEFORE TRUNCATE ON influencer_intelligence.%I FOR EACH STATEMENT EXECUTE FUNCTION influencer_intelligence.prevent_append_only_mutation()', table_name, table_name);
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_trigger trigger_row
+      JOIN pg_class relation ON relation.oid = trigger_row.tgrelid
+      JOIN pg_namespace namespace_row ON namespace_row.oid = relation.relnamespace
+      WHERE trigger_row.tgname = table_name || '_append_only'
+        AND relation.relname = table_name
+        AND namespace_row.nspname = 'influencer_intelligence'
+        AND NOT trigger_row.tgisinternal
+    ) THEN
+      EXECUTE format('CREATE TRIGGER %I BEFORE UPDATE OR DELETE ON influencer_intelligence.%I FOR EACH ROW EXECUTE FUNCTION influencer_intelligence.prevent_append_only_mutation()', table_name || '_append_only', table_name);
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_trigger trigger_row
+      JOIN pg_class relation ON relation.oid = trigger_row.tgrelid
+      JOIN pg_namespace namespace_row ON namespace_row.oid = relation.relnamespace
+      WHERE trigger_row.tgname = table_name || '_no_truncate'
+        AND relation.relname = table_name
+        AND namespace_row.nspname = 'influencer_intelligence'
+        AND NOT trigger_row.tgisinternal
+    ) THEN
+      EXECUTE format('CREATE TRIGGER %I BEFORE TRUNCATE ON influencer_intelligence.%I FOR EACH STATEMENT EXECUTE FUNCTION influencer_intelligence.prevent_append_only_mutation()', table_name || '_no_truncate', table_name);
+    END IF;
   END LOOP;
 END
 $$;

--- a/social/influencer-intelligence/migrations/20260811_influencer_intelligence_scoring_v0.up.sql
+++ b/social/influencer-intelligence/migrations/20260811_influencer_intelligence_scoring_v0.up.sql
@@ -17,8 +17,4 @@ ALTER TABLE influencer_intelligence.creator_score
 COMMENT ON COLUMN influencer_intelligence.creator_score.weights_version IS
   'Immutable identifier for the versioned deterministic scoring weights/configuration.';
 
-INSERT INTO public.schema_migrations (version, applied_at)
-VALUES ('20260811_influencer_intelligence_scoring_v0', now())
-ON CONFLICT (version) DO NOTHING;
-
 COMMIT;

--- a/social/influencer-intelligence/tests/data-model.test.mjs
+++ b/social/influencer-intelligence/tests/data-model.test.mjs
@@ -96,7 +96,7 @@ test('defines the complete additive PostgreSQL model with immutable evidence', (
   assert.match(migration, /creator_key, observed_at DESC/);
   assert.match(migration, /creator_key, computed_at DESC/);
   assert.match(migration, /provider ~ '\^\[a-z\]/);
-  assert.doesNotMatch(migration, /DROP\s+(?:TABLE|SCHEMA|COLUMN)/i);
+  assert.doesNotMatch(migration, /\bDROP\s+/i);
   assert.doesNotMatch(migration, /GRANT\s+PUBLIC/i);
   assert.doesNotMatch(migration, /\b(?:access_token|refresh_token|password|secret|email|phone|caption|biography|raw_text)\b/i);
 });
@@ -119,7 +119,8 @@ test('defines additive score weights version metadata without destructive DDL', 
   assert.match(scoringMigration, /BEGIN;[\s\S]*SET LOCAL TIME ZONE 'UTC'/);
   assert.match(scoringMigration, /ADD COLUMN IF NOT EXISTS weights_version/);
   assert.match(scoringMigration, /creator_score/);
-  assert.doesNotMatch(scoringMigration, /DROP\s+(?:TABLE|SCHEMA|COLUMN)/i);
+  assert.doesNotMatch(scoringMigration, /\bDROP\s+/i);
+  assert.doesNotMatch(scoringMigration, /INSERT\s+INTO\s+public\.schema_migrations/i);
   assert.doesNotMatch(scoringMigration, /TRUNCATE\s+/i);
   assert.match(scoringMigration, /COMMIT;\s*$/);
 });


### PR DESCRIPTION
## Objective
Harden the existing Influencer Intelligence PostgreSQL migration artifacts found during audit.

## Risk and surfaces
- Risk: high, migration safety and append-only enforcement.
- Surfaces: social/influencer-intelligence PostgreSQL migrations and contract tests.
- Feature flag: unchanged and remains OFF.
- Runtime/provider/CRM/Orb/MCP: unchanged.

## Changes
- Replace destructive DROP TRIGGER/recreate behavior with idempotent create-if-missing checks.
- Correct dynamic trigger identifier quoting.
- Remove the scoring migration write to unrelated public.schema_migrations; the canonical runner owns migration ledgering.
- Strengthen tests against destructive DDL and wrong-ledger writes.

## Validation
- node --test social/influencer-intelligence/tests/data-model.test.mjs
- git diff --check

## Rollback
Revert this single-purpose commit before any migration application; no database migration has been applied by this PR.