### PR TITLE
fix(influencer-intelligence): harden provider timeout evidence

### DIFF
--- a/social/influencer-intelligence/provider-router.mjs
+++ b/social/influencer-intelligence/provider-router.mjs
@@ -393,7 +393,7 @@ export function createProviderRouter({
             handle: request.canonical_handle,
             observedAt: request.observed_at,
             retrievedAt: request.retrieved_at,
-          })
+          }, { signal: controller.signal, attempt })
           : handler(request, { signal: controller.signal, attempt })),
         timeout,
       ]);

--- a/social/influencer-intelligence/providers/profile-provider.mjs
+++ b/social/influencer-intelligence/providers/profile-provider.mjs
@@ -161,7 +161,7 @@ export function createProfileProvider({
     id: providerId,
     officialFirst,
     capabilities: Object.freeze(['profile']),
-    async collect(input = {}) {
+    async collect(input = {}, context = {}) {
       if (!isRecord(input)) throw new ProviderAdapterError('provider collection input must be an object');
       const creatorKey = normalizeCreatorKey(input.creatorKey);
       const requestedHandle = normalizeCanonicalHandle(input.handle);
@@ -181,7 +181,7 @@ export function createProfileProvider({
       });
       let projection;
       try {
-        projection = await readProfile(request);
+        projection = await readProfile(request, context);
       } catch (error) {
         if (error instanceof ProviderGapError || error instanceof ProviderCollectionError) throw error;
         throw new ProviderCollectionError('transport_error');

--- a/social/influencer-intelligence/providers/provider-contracts.d.ts
+++ b/social/influencer-intelligence/providers/provider-contracts.d.ts
@@ -46,6 +46,7 @@ export interface ProviderSpecificEvidence {
   fields?: readonly string[];
   endpoint_family?: string;
   coverage_code?: string;
+  model_version?: string;
 }
 
 export interface ProviderAttempt {

--- a/social/influencer-intelligence/providers/provider-contracts.mjs
+++ b/social/influencer-intelligence/providers/provider-contracts.mjs
@@ -568,7 +568,7 @@ export function normalizeProviderCandidate({
       sourceRef: sourceRef || `${normalizedProvider}:${normalizedOperation}:${request.creator_key || 'unresolved'}`,
     },
   );
-  if (dataClassification === 'inferred' && !evidence.model_version) {
+  if (status === 'ok' && dataClassification === 'inferred' && !evidence.model_version) {
     fail('invalid_response', 'inferred provider data requires model version evidence');
   }
   return deepFreeze({

--- a/social/influencer-intelligence/providers/provider-contracts.mjs
+++ b/social/influencer-intelligence/providers/provider-contracts.mjs
@@ -453,6 +453,8 @@ function normalizeEvidence(value, { provider, operation, request, adapterVersion
     'observed_fields',
     'endpoint_family',
     'coverage_code',
+    'model_version',
+    'modelVersion',
     'provider',
     'operation',
     'correlation_id',
@@ -478,6 +480,12 @@ function normalizeEvidence(value, { provider, operation, request, adapterVersion
   }
   if (input.endpoint_family !== undefined) evidence.endpoint_family = slug(input.endpoint_family, 'endpoint_family');
   if (input.coverage_code !== undefined) evidence.coverage_code = slug(input.coverage_code, 'coverage_code');
+  const modelVersion = input.model_version ?? input.modelVersion;
+  if (modelVersion !== undefined) {
+    const normalizedModelVersion = normalizedString(modelVersion, 'provider_specific_evidence.model_version', { maxLength: 80 });
+    if (!/^[a-z][a-z0-9._/-]{0,79}$/.test(normalizedModelVersion)) fail('invalid_response', 'provider model version is invalid');
+    evidence.model_version = normalizedModelVersion;
+  }
   evidence.provider = provider;
   evidence.operation = operation;
   evidence.correlation_id = request.correlation_id;
@@ -555,6 +563,9 @@ export function normalizeProviderCandidate({
       sourceRef: sourceRef || `${normalizedProvider}:${normalizedOperation}:${request.creator_key || 'unresolved'}`,
     },
   );
+  if (dataClassification === 'inferred' && !evidence.model_version) {
+    fail('invalid_response', 'inferred provider data requires model version evidence');
+  }
   return deepFreeze({
     contract_version: PROVIDER_OPERATION_CONTRACT_VERSION,
     operation: normalizedOperation,

--- a/social/influencer-intelligence/providers/provider-contracts.mjs
+++ b/social/influencer-intelligence/providers/provider-contracts.mjs
@@ -45,7 +45,7 @@ export const PROVIDER_TERMINAL_CODES = Object.freeze([
 ]);
 
 export const PROVIDER_OPERATION_CONTRACT_VERSION =
-  'influencer-intelligence/provider-operation/v1';
+  'influencer-intelligence/provider-operation/v1.1';
 
 const operationSet = new Set(PROVIDER_OPERATIONS);
 const classificationSet = new Set(DATA_CLASSIFICATIONS);
@@ -482,7 +482,12 @@ function normalizeEvidence(value, { provider, operation, request, adapterVersion
   if (input.coverage_code !== undefined) evidence.coverage_code = slug(input.coverage_code, 'coverage_code');
   const modelVersion = input.model_version ?? input.modelVersion;
   if (modelVersion !== undefined) {
-    const normalizedModelVersion = normalizedString(modelVersion, 'provider_specific_evidence.model_version', { maxLength: 80 });
+    let normalizedModelVersion;
+    try {
+      normalizedModelVersion = normalizedString(modelVersion, 'provider_specific_evidence.model_version', { maxLength: 80 });
+    } catch {
+      fail('invalid_response', 'provider model version is malformed');
+    }
     if (!/^[a-z][a-z0-9._/-]{0,79}$/.test(normalizedModelVersion)) fail('invalid_response', 'provider model version is invalid');
     evidence.model_version = normalizedModelVersion;
   }

--- a/social/influencer-intelligence/tests/provider-router-contract.test.mjs
+++ b/social/influencer-intelligence/tests/provider-router-contract.test.mjs
@@ -302,11 +302,14 @@ test('unsupported operation coverage remains unavailable and never fabricates me
 });
 
 test('the router keeps the pre-existing collect-only adapter boundary compatible', async () => {
+  let legacyContext;
   const legacyMeta = {
     id: 'meta-graph',
     officialFirst: true,
     capabilities: ['profile'],
-    collect: async () => ({
+    collect: async (_input, context) => {
+      legacyContext = context;
+      return {
       creatorKey: 'creator:synthetic-001',
       handle: 'synthetic.creator',
       provider: 'meta-graph',
@@ -320,7 +323,8 @@ test('the router keeps the pre-existing collect-only adapter boundary compatible
         { key: 'followers_count', value: 12000 },
         { key: 'media_count', value: 42 },
       ],
-    }),
+      };
+    },
   };
   const router = createProviderRouter({ providers: { 'meta-graph': legacyMeta } });
 
@@ -329,6 +333,42 @@ test('the router keeps the pre-existing collect-only adapter boundary compatible
   assert.equal(result.provider, 'meta-graph');
   assert.equal(result.data.followers_count, 12000);
   assert.equal(result.data.media_count, 42);
+  assert.equal(legacyContext.attempt, 1);
+  assert.equal(legacyContext.signal instanceof AbortSignal, true);
+});
+
+test('inferred provider data requires model-version evidence before acceptance', async () => {
+  const meta = createMetaGraphProvider({
+    operations: {
+      get_profile: async () => ({
+        ...candidateFor('get_profile'),
+        data_classification: 'inferred',
+      }),
+    },
+  });
+  const router = createProviderRouter({ providers: { 'meta-graph': meta } });
+
+  await assert.rejects(
+    router.get_profile(baseRequest),
+    (error) => error instanceof ProviderRouterError && error.reasonCode === 'invalid_response',
+  );
+
+  const withModel = createMetaGraphProvider({
+    operations: {
+      get_profile: async () => ({
+        ...candidateFor('get_profile'),
+        data_classification: 'inferred',
+        provider_specific_evidence: {
+          ...candidateFor('get_profile').provider_specific_evidence,
+          model_version: 'profile-inference/v1',
+        },
+      }),
+    },
+  });
+  const validRouter = createProviderRouter({ providers: { 'meta-graph': withModel } });
+  const result = await validRouter.get_profile(baseRequest);
+  assert.equal(result.data_classification, 'inferred');
+  assert.equal(result.provider_specific_evidence.model_version, 'profile-inference/v1');
 });
 
 test('future external providers require explicit opt-in and still use the same contract', async () => {

--- a/social/influencer-intelligence/tests/provider-router-contract.test.mjs
+++ b/social/influencer-intelligence/tests/provider-router-contract.test.mjs
@@ -371,6 +371,27 @@ test('inferred provider data requires model-version evidence before acceptance',
   assert.equal(result.provider_specific_evidence.model_version, 'profile-inference/v1');
 });
 
+test('malformed provider model-version evidence is classified as invalid response', async () => {
+  const meta = createMetaGraphProvider({
+    operations: {
+      get_profile: async () => ({
+        ...candidateFor('get_profile'),
+        data_classification: 'inferred',
+        provider_specific_evidence: {
+          ...candidateFor('get_profile').provider_specific_evidence,
+          model_version: 7,
+        },
+      }),
+    },
+  });
+  const router = createProviderRouter({ providers: { 'meta-graph': meta } });
+
+  await assert.rejects(
+    router.get_profile(baseRequest),
+    (error) => error instanceof ProviderRouterError && error.reasonCode === 'invalid_response',
+  );
+});
+
 test('future external providers require explicit opt-in and still use the same contract', async () => {
   const meta = createMetaGraphProvider({
     operations: {

--- a/social/influencer-intelligence/tests/provider-router-contract.test.mjs
+++ b/social/influencer-intelligence/tests/provider-router-contract.test.mjs
@@ -392,6 +392,24 @@ test('malformed provider model-version evidence is classified as invalid respons
   );
 });
 
+test('unavailable inferred provider results remain explicit gaps without model evidence', async () => {
+  const meta = createMetaGraphProvider({
+    operations: {
+      get_profile: async () => ({
+        status: 'unavailable',
+        data: null,
+        data_classification: 'inferred',
+      }),
+    },
+  });
+  const router = createProviderRouter({ providers: { 'meta-graph': meta } });
+
+  const result = await router.get_profile(baseRequest);
+  assert.equal(result.status, 'unavailable');
+  assert.equal(result.data, null);
+  assert.equal(result.data_classification, 'observed');
+});
+
 test('future external providers require explicit opt-in and still use the same contract', async () => {
   const meta = createMetaGraphProvider({
     operations: {

--- a/social/influencer-intelligence/tests/providers.test.mjs
+++ b/social/influencer-intelligence/tests/providers.test.mjs
@@ -13,6 +13,7 @@ import {
   META_GRAPH_PROFILE_FIELDS,
 } from '../providers/meta-graph-adapter.mjs';
 import {
+  createProfileProvider,
   ProviderCollectionError,
   ProviderGapError,
 } from '../providers/profile-provider.mjs';
@@ -105,6 +106,29 @@ test('adapter rejects sensitive or raw provider fields before the contract bound
     provider.collect(collectionInput),
     (error) => error instanceof ProviderCollectionError && error.reasonCode === 'policy_block',
   );
+});
+
+test('legacy profile provider receives the router abort signal', async () => {
+  let aborted = false;
+  const controller = new AbortController();
+  const provider = createProfileProvider({
+    provider: 'meta-graph',
+    officialFirst: true,
+    sourceRefPrefix: 'meta-graph',
+    requestFields: ['username'],
+    readProfile: async (_request, { signal }) => new Promise((resolve, reject) => {
+      signal.addEventListener('abort', () => {
+        aborted = true;
+        reject(new Error('legacy transport aborted'));
+      }, { once: true });
+    }),
+  });
+
+  const pending = provider.collect(collectionInput, { signal: controller.signal, attempt: 1 });
+  controller.abort();
+
+  await assert.rejects(pending, (error) => error instanceof ProviderCollectionError && error.reasonCode === 'transport_error');
+  assert.equal(aborted, true);
 });
 
 test('router tries Meta first and falls back only for an explicit coverage gap', async () => {


### PR DESCRIPTION
## Scope
Harden the existing provider router without adding a provider or transport.

## Risk and surfaces
- Risk: low; provider boundary and contract validation only.
- Surfaces: social/influencer-intelligence provider router and typed contract tests.
- Migration: none.
- Feature flag: unchanged; module remains off by default.
- External effects: none; injected mocks only, no credentials or network calls.

## Changes
- Propagate AbortSignal and attempt metadata to the legacy collect adapter so timeout cancellation reaches the provider boundary.
- Require bounded model-version evidence for inferred provider candidates.
- Add contract coverage for both behaviors.

## Validation
- node --test social/influencer-intelligence/tests/providers.test.mjs social/influencer-intelligence/tests/provider-router-contract.test.mjs (20/20).
- git diff --check.

## Rollback
Revert this commit; no data or runtime configuration changes.