### PR TITLE
fix(crm): default influencer intelligence panel to off

### DIFF
--- a/crm/console/InfluencerIntelligenceModule.tsx
+++ b/crm/console/InfluencerIntelligenceModule.tsx
@@ -266,7 +266,7 @@ function getUiError(error: unknown): string {
   return 'Não foi possível consultar o serviço interno. Nenhum valor foi inferido.'
 }
 
-export function InfluencerIntelligencePanel({ client = createInfluencerIntelligenceApi(), enabled = true, granted = true }: PanelProps) {
+export function InfluencerIntelligencePanel({ client = createInfluencerIntelligenceApi(), enabled = false, granted = false }: PanelProps) {
   const [query, setQuery] = React.useState('')
   const [results, setResults] = React.useState<InfluencerCreatorSummary[]>([])
   const [selectedKeys, setSelectedKeys] = React.useState<string[]>([])

--- a/crm/console/tests/components/influencerIntelligence.component.test.tsx
+++ b/crm/console/tests/components/influencerIntelligence.component.test.tsx
@@ -52,8 +52,8 @@ describe('Influencer Intelligence CRM panel', () => {
     expect(screen.getByText('0', { exact: true })).toBeVisible()
   })
 
-  it('keeps the module closed when its gates are absent', () => {
-    render(<InfluencerIntelligencePanel client={client()} enabled={false} granted={false} />)
+  it('keeps the module closed when its gates are absent, including direct embedding defaults', () => {
+    render(<InfluencerIntelligencePanel client={client()} />)
     expect(screen.getByTestId('influencer-module-off')).toHaveTextContent(/desligado/i)
     expect(screen.queryByRole('button', { name: 'Buscar' })).not.toBeInTheDocument()
   })


### PR DESCRIPTION
## Scope
Close a fail-open direct-embedding path in the Influencer Intelligence CRM panel.

## Risk and surfaces
- Risk: low; UI defaults only.
- Surfaces: crm/console panel and component test.
- Migration: none.
- Feature flag/grant: module wrapper unchanged; direct panel embedding now also fails closed.
- External effects: none.

## Changes
- Default enabled and granted to false when the panel is embedded without explicit server-derived gates.
- Strengthen the component test to cover omitted gates.

## Validation
- git diff --check.
- Targeted Vitest was attempted through the canonical WSL wrapper but this isolated worktree has no 
ode_modules/Vitest; no install was performed. CI is required for the full component test.

## Rollback
Revert this commit; no data or runtime configuration changes.