### PR TITLE
fix(influencer-intelligence): enforce evidence state integrity

### DIFF
--- a/social/influencer-intelligence/contracts.mjs
+++ b/social/influencer-intelligence/contracts.mjs
@@ -39,6 +39,7 @@ const evidenceStateSet = new Set(EVIDENCE_STATES);
 const providerSet = new Set(SUPPORTED_PROVIDER_IDS);
 const sourceTypeSet = new Set(SOURCE_TYPES);
 const scoreKindSet = new Set(SCORE_KINDS);
+const snapshotEvidenceRank = Object.freeze({ observed: 0, derived: 1, inferred: 2 });
 const forbiddenKeySet = new Set([
   'accesstoken',
   'refreshtoken',
@@ -325,6 +326,22 @@ export function normalizeProviderSnapshot(input) {
   for (const observation of observations) {
     if (observation.provenance.provider !== provider) fail('all snapshot observations must use the snapshot provider');
     if (observation.provenance.observedAt !== observedAt) fail('all snapshot observations must use the snapshot observedAt');
+  }
+  const availableObservations = observations.filter((observation) => observation.evidenceState !== 'unavailable');
+  if (availableObservations.length === 0) {
+    if (evidenceState !== 'unavailable') {
+      fail('providerSnapshot with no available observations must be unavailable');
+    }
+  } else {
+    if (evidenceState === 'unavailable') {
+      fail('providerSnapshot with available observations cannot be unavailable');
+    }
+    const snapshotRank = snapshotEvidenceRank[evidenceState];
+    for (const observation of availableObservations) {
+      if (snapshotEvidenceRank[observation.evidenceState] > snapshotRank) {
+        fail('providerSnapshot.evidenceState cannot be more optimistic than contained observation evidenceState');
+      }
+    }
   }
   const provenance = normalizeProvenance({
     ...input.provenance,

--- a/social/influencer-intelligence/scoring.mjs
+++ b/social/influencer-intelligence/scoring.mjs
@@ -375,7 +375,20 @@ function normalizeAnalytics(analytics) {
   assertRecord(analytics.coverage, 'analytics.coverage');
   const coverageRatio = finite(analytics.coverage.ratio, 'analytics.coverage.ratio', { minimum: 0, maximum: 1 });
   const providers = unique(Array.isArray(analytics.providers) ? analytics.providers : []);
-  const provenance = Array.isArray(analytics.provenance) ? analytics.provenance : [];
+  const rawProvenance = analytics.provenance === undefined ? [] : analytics.provenance;
+  if (!Array.isArray(rawProvenance)) fail('INVALID_ANALYTICS_EVIDENCE', 'analytics.provenance must be an array');
+  const provenance = rawProvenance.map((item, index) => {
+    assertRecord(item, `analytics.provenance[${index}]`);
+    boundedString(item.sourceRef, `analytics.provenance[${index}].sourceRef`);
+    return item;
+  });
+  const rawSnapshotKeys = analytics.inputSnapshotKeys === undefined ? [] : analytics.inputSnapshotKeys;
+  if (!Array.isArray(rawSnapshotKeys)) fail('INVALID_ANALYTICS_EVIDENCE', 'analytics.inputSnapshotKeys must be an array');
+  if (rawSnapshotKeys.length > 128) fail('INVALID_ANALYTICS_EVIDENCE', 'analytics.inputSnapshotKeys may contain at most 128 references');
+  const inputSnapshotKeys = rawSnapshotKeys.map((value, index) => boundedString(value, `analytics.inputSnapshotKeys[${index}]`));
+  if (evidenceState === 'derived' && inputSnapshotKeys.length === 0 && provenance.length === 0) {
+    fail('INVALID_ANALYTICS_EVIDENCE', 'derived analytics require at least one input snapshot or provenance reference');
+  }
   const history = analytics.history === undefined || analytics.history === null
     ? legacyHistorySummary(analytics)
     : (() => {
@@ -387,7 +400,7 @@ function normalizeAnalytics(analytics) {
         mediaMetricObservationCount: boundedInteger(analytics.history.mediaMetricObservationCount ?? 0, 'analytics.history.mediaMetricObservationCount', { maximum: 100000 }),
       };
     })();
-  return { ...analytics, creatorKey, calculatedAt, evidenceState, coverageRatio, providers, provenance, history };
+  return { ...analytics, creatorKey, calculatedAt, evidenceState, coverageRatio, providers, provenance, inputSnapshotKeys, history };
 }
 
 function legacyCount(value) {

--- a/social/influencer-intelligence/tests/contracts.test.mjs
+++ b/social/influencer-intelligence/tests/contracts.test.mjs
@@ -82,6 +82,44 @@ test('normalizes a provider snapshot without carrying raw profile payloads', () 
   assert.equal(Object.isFrozen(snapshot.observations[0]), true);
 });
 
+test('does not allow an observed snapshot to contain derived observations', () => {
+  assertContractError(() => normalizeProviderSnapshot({
+    creatorKey: 'creator:synthetic-001',
+    provider: 'meta-graph',
+    observedAt,
+    evidenceState: 'observed',
+    provenance: provenance(),
+    observations: [
+      {
+        key: 'engagement_rate',
+        unit: 'ratio',
+        value: 0.04,
+        evidenceState: 'derived',
+        provenance: provenance({ evidenceState: 'derived' }),
+      },
+    ],
+  }), /cannot be more optimistic/);
+});
+
+test('does not allow an observed snapshot when every observation is unavailable', () => {
+  assertContractError(() => normalizeProviderSnapshot({
+    creatorKey: 'creator:synthetic-001',
+    provider: 'meta-graph',
+    observedAt,
+    evidenceState: 'observed',
+    provenance: provenance(),
+    observations: [
+      {
+        key: 'reach',
+        unit: 'count',
+        value: null,
+        evidenceState: 'unavailable',
+        provenance: provenance({ sourceType: 'insights', evidenceState: 'unavailable' }),
+      },
+    ],
+  }), /no available observations/);
+});
+
 test('rejects credentials and direct contact identifiers at the contract boundary', () => {
   assertContractError(() => normalizeProviderSnapshot({
     creatorKey: 'creator:synthetic-001',

--- a/social/influencer-intelligence/tests/scoring.test.mjs
+++ b/social/influencer-intelligence/tests/scoring.test.mjs
@@ -144,6 +144,14 @@ test('same inputs and calculated timestamp are bit-for-bit deterministic', () =>
   assert.deepEqual(computeInfluencerScore(input), computeInfluencerScore(structuredClone(input)));
 });
 
+test('rejects derived analytics without input evidence references', () => {
+  const analytics = structuredClone(analyticsFor(GOLDEN_FIXTURES.smallStable));
+  analytics.provenance = [];
+  analytics.inputSnapshotKeys = [];
+
+  assert.throws(() => computeInfluencerScore({ analytics }), (error) => error.code === 'INVALID_ANALYTICS_EVIDENCE');
+});
+
 test('input fingerprint binds confidence and evidence metadata, not only component values', () => {
   const fixture = GOLDEN_FIXTURES.smallStable;
   const base = scoreFor(fixture, {


### PR DESCRIPTION
## Summary\n- require derived analytics to carry input snapshot or provenance references\n- reject provider snapshot envelopes that overstate evidence state or hide total unavailability\n- add regression tests for both auditability boundaries\n\n## Scope\n- pure Influencer Intelligence contracts and scoring validation only\n- no migrations, runtime registration, provider calls, credentials, scheduling, CRM flags, or activation changes\n\n## Validation\n- node --test social/influencer-intelligence/tests/*.test.mjs (190 passing)\n- git diff --check\n\n## Rollback\nRevert this single commit; no data or runtime state is changed.