### PR TITLE
fix(influencer-intelligence): align MCP classifications with evidence

### DIFF
--- a/social/influencer-intelligence/mcp-readonly.mjs
+++ b/social/influencer-intelligence/mcp-readonly.mjs
@@ -48,6 +48,7 @@ export const MCP_ERROR_CODES = Object.freeze([
 ]);
 
 const DATA_CLASSIFICATIONS = new Set(['observed', 'derived', 'inferred', 'unavailable']);
+const EVIDENCE_STATE_RANK = Object.freeze({ observed: 0, derived: 1, inferred: 2, unavailable: -1 });
 const FRESHNESS_STATES = new Set(['fresh', 'stale', 'unknown']);
 const REGISTRY_STATES = new Set(['candidate', 'paused', 'unavailable']);
 const SUPPORTED_SOURCE_TYPES = new Set([
@@ -353,6 +354,35 @@ function normalizeProvenance(value) {
   });
 }
 
+function assertClassificationEvidenceConsistency(dataClassification, provenance) {
+  const evidenceStates = provenance.map((entry) => entry.evidence_state);
+  if (dataClassification === 'unavailable') {
+    assertCondition(
+      evidenceStates.every((state) => state === 'unavailable'),
+      'INVALID_SERVICE_RESPONSE',
+      'unavailable data cannot carry available evidence',
+    );
+    return;
+  }
+
+  const highestEvidenceRank = evidenceStates.reduce(
+    (highest, state) => Math.max(highest, EVIDENCE_STATE_RANK[state]),
+    -1,
+  );
+  assertCondition(
+    highestEvidenceRank <= EVIDENCE_STATE_RANK[dataClassification],
+    'INVALID_SERVICE_RESPONSE',
+    'data_classification cannot be more optimistic than provenance evidence',
+  );
+  if (dataClassification === 'inferred') {
+    assertCondition(
+      evidenceStates.includes('inferred'),
+      'INVALID_SERVICE_RESPONSE',
+      'inferred data requires inferred provenance evidence',
+    );
+  }
+}
+
 function normalizeLimitations(value) {
   assertCondition(Array.isArray(value), 'INVALID_SERVICE_RESPONSE', 'limitations are required');
   assertCondition(value.length <= 32, 'INVALID_SERVICE_RESPONSE', 'limitations are too large');
@@ -436,6 +466,7 @@ function normalizeServiceResult(raw, requestId, clock, { redactPublicNames = fal
   }
   const providers = normalizeProviders(raw.providers);
   const provenance = normalizeProvenance(raw.provenance);
+  assertClassificationEvidenceConsistency(dataClassification, provenance);
   const limitations = normalizeLimitations(raw.limitations);
   const errors = raw.errors === undefined ? [] : normalizeLimitations(raw.errors);
   const data = sanitizeValue(raw.data, 0, new Set(), { redactPublicNames });

--- a/social/influencer-intelligence/tests/mcp-readonly.test.mjs
+++ b/social/influencer-intelligence/tests/mcp-readonly.test.mjs
@@ -217,6 +217,20 @@ test('rejects an unavailable envelope that claims available metrics', async () =
   assert.equal(errorCode(response), 'INVALID_SERVICE_RESPONSE');
 });
 
+test('rejects a classification that hides more optimistic provenance evidence', async () => {
+  const service = fixtureService({
+    async getCreatorProfile() {
+      return envelope({ creator_key: 'creator-1' }, {
+        data_classification: 'observed',
+        provenance: provenance('profile').map((entry) => ({ ...entry, evidence_state: 'inferred' })),
+      });
+    },
+  });
+  const { gateway } = createHarness({ service });
+  const response = await call(gateway, 'get_creator_profile', { creator_key: 'creator-1' });
+  assert.equal(errorCode(response), 'INVALID_SERVICE_RESPONSE');
+});
+
 test('sanitizes raw payload, PII and credential-like output before returning it', async () => {
   const service = fixtureService({
     async getCreatorProfile() {


### PR DESCRIPTION
## Scope\nClose an audit gap at the Influencer Intelligence MCP boundary.\n\n## Change\n- reject top-level observed/derived classifications that hide more optimistic provenance evidence;\n- reject unavailable responses carrying available evidence;\n- require inferred responses to carry inferred provenance;\n- add a regression test for evidence-state downgrade.\n\n## Risk and surfaces\n- Risk: low; read-only response validation only.\n- Surfaces: MCP adapter and contract tests.\n- Migration: none.\n- Feature flag/runtime: unchanged and off by default.\n- Credentials/providers/Orb/CRM: untouched.\n\n## Validation\n- full Influencer Intelligence suite: 195/195;\n- git diff --check: passed.\n\n## Rollback\nRevert this single commit/PR; no data or runtime state is changed.