### PR TITLE
fix(ponto): retain immutable release candidates

### DIFF
--- a/.github/scripts/ponto-dispatch-workflow.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.mjs
@@ -35,10 +35,27 @@ import {
   releaseTagFor,
 } from "./ponto-release-identity.mjs";
 
+const FULL_SHA = /^[0-9a-f]{40}$/;
+
 export const isBodylessResponseStatus = (status) => status === 202 || status === 204;
 export const readGitHubResponse = (response) => (
   isBodylessResponseStatus(response.status) ? null : response.json()
 );
+
+export function resolvePontoCoordinatorIdentity({ releaseSha, workflowSha } = {}) {
+  const immutableReleaseSha = String(releaseSha || "").trim().toLowerCase();
+  const immutableWorkflowSha = String(workflowSha || "").trim().toLowerCase();
+  if (!FULL_SHA.test(immutableReleaseSha)) {
+    throw new Error("RELEASE_SHA must be a full immutable Ponto release SHA");
+  }
+  if (!FULL_SHA.test(immutableWorkflowSha)) {
+    throw new Error("GITHUB_SHA must be a full immutable Ponto coordinator workflow SHA");
+  }
+  return {
+    releaseSha: immutableReleaseSha,
+    workflowSha: immutableWorkflowSha,
+  };
+}
 
 export const minimumDispatchTimeoutMsByWorkflow = Object.freeze({
   "timekeeping-staging-journey.yml": 35 * 60 * 1000,
@@ -312,7 +329,8 @@ const token = String(process.env.GH_TOKEN || "").trim();
 const repository = String(process.env.GITHUB_REPOSITORY || "").trim();
 const output = String(process.env.GITHUB_OUTPUT || "").trim();
 const apiBase = String(process.env.GITHUB_API_URL || "https://api.github.com").replace(/\/$/, "");
-const orchestratorHeadSha = String(process.env.GITHUB_SHA || "").trim().toLowerCase();
+const workflowSourceSha = String(process.env.GITHUB_SHA || "").trim().toLowerCase();
+const configuredReleaseSha = String(process.env.RELEASE_SHA || "").trim().toLowerCase();
 const repositoryId = String(process.env.GITHUB_REPOSITORY_ID || "").trim();
 const capabilityPrivateKey = String(process.env.PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY || "");
 const capabilityPublicKeysJson = String(
@@ -327,11 +345,23 @@ const timeoutMs = dispatchTimeoutMsFor(workflow, configuredTimeoutMs);
 if (!workflow || !/^[0-9]+$/.test(correlation || "") || !inputsFile || !outputFile) {
   throw new Error("usage: ponto-dispatch-workflow.mjs <workflow> <correlation-run-id> <inputs.json> <output.json>");
 }
+const {
+  releaseSha: orchestratorHeadSha,
+  workflowSha: coordinatorWorkflowSha,
+} = resolvePontoCoordinatorIdentity({
+  releaseSha: configuredReleaseSha,
+  workflowSha: workflowSourceSha,
+});
 if (!Number.isFinite(configuredTimeoutMs) || configuredTimeoutMs < 5 * 60 * 1000 || configuredTimeoutMs > 90 * 60 * 1000) {
   throw new Error("PONTO_DISPATCH_TIMEOUT_MS must be between 5 and 90 minutes");
 }
-if (!token || !repository.includes("/") || !/^[0-9a-f]{40}$/.test(orchestratorHeadSha)) {
-  throw new Error("GH_TOKEN, GITHUB_REPOSITORY, and immutable orchestrator GITHUB_SHA are required");
+if (!token || !repository.includes("/")) {
+  throw new Error("GH_TOKEN and GITHUB_REPOSITORY are required for immutable Ponto child dispatch");
+}
+try {
+  assertPontoSourceClosureUnchanged(orchestratorHeadSha, coordinatorWorkflowSha);
+} catch {
+  throw new Error("Ponto coordinator workflow source is outside the immutable release dependency closure");
 }
 
 const request = async (pathname, init = {}) => {
@@ -492,7 +522,7 @@ if (leaseKey) {
     || parentRun?.conclusion != null
     || parentRun?.event !== "workflow_dispatch"
     || parentRun?.head_branch !== "main"
-    || parentRun?.head_sha !== orchestratorHeadSha
+    || String(parentRun?.head_sha || "").trim().toLowerCase() !== coordinatorWorkflowSha
     || String(parentRun?.repository?.id || "") !== repositoryId
     || parentRun?.repository?.full_name !== repository
     || parentRun?.head_repository?.full_name !== repository

--- a/.github/scripts/ponto-dispatch-workflow.test.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.test.mjs
@@ -8,6 +8,7 @@ import {
   governedLeaseKeyFor,
   isBodylessResponseStatus,
   readGitHubResponse,
+  resolvePontoCoordinatorIdentity,
   verifyConsumedCapabilityCheck,
 } from "./ponto-dispatch-workflow.mjs";
 import {
@@ -83,6 +84,35 @@ test("child dispatch keeps an immutable release valid across unrelated main chan
     () => assertPontoDependencyClosureUnchanged(digest, "d".repeat(64)),
     /relevant dependency-closure input changed/,
   );
+});
+
+test("child dispatch separates the immutable release identity from the main workflow revision", () => {
+  const releaseSha = "a".repeat(40);
+  const workflowSha = "b".repeat(40);
+  assert.deepEqual(
+    resolvePontoCoordinatorIdentity({ releaseSha, workflowSha }),
+    { releaseSha, workflowSha },
+  );
+  assert.throws(
+    () => resolvePontoCoordinatorIdentity({ releaseSha, workflowSha: "not-a-sha" }),
+    /GITHUB_SHA must be a full immutable Ponto coordinator workflow SHA/,
+  );
+});
+
+test("Ponto recovery keeps provenance fail-closed while accepting a closure-equivalent coordinator revision", () => {
+  const read = (relative) => fs.readFileSync(new URL(relative, import.meta.url), "utf8");
+  const progressive = read("../workflows/ponto-progressive-release.yml");
+  const orchestratorLease = read("./ponto-orchestrator-lease.mjs");
+  const watchdogJournal = read("./ponto-watchdog-journal.mjs");
+  const recovery = read("../workflows/ponto-staging-recovery-rollback.yml");
+  assert.match(progressive, /PONTO_WORKFLOW_SHA=.*assertPontoSourceClosureUnchanged/s);
+  assert.doesNotMatch(progressive, /release_sha must equal the immutable main coordinator SHA/);
+  assert.match(orchestratorLease, /assertObservedPontoSource\(releaseSha, String\(run\?\.head_sha \|\| ""\)\.trim\(\)\.toLowerCase\(\)\)/);
+  assert.doesNotMatch(orchestratorLease, /run\?\.head_sha !== releaseSha/);
+  assert.match(watchdogJournal, /pontoSourceClosureMatches\(releaseSha, String\(coordinator\?\.head_sha \|\| ""\)\.trim\(\)\.toLowerCase\(\)\)/);
+  assert.doesNotMatch(watchdogJournal, /coordinator\?\.head_sha.*!== releaseSha/);
+  assert.match(recovery, /pontoSourceClosureMatches\(releaseSha, String\(coordinator\.head_sha \|\| ""\)\.toLowerCase\(\)\)/);
+  assert.doesNotMatch(recovery, /coordinator\.head_sha !== releaseSha/);
 });
 
 test("Ponto child mutations expose the canonical global resource and conflict scope", () => {

--- a/.github/scripts/ponto-orchestrator-lease.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.mjs
@@ -655,6 +655,7 @@ const canonicalOrchestrator = async ({ orchestratorRunId, releaseSha, stage }) =
       }
       continue;
     }
+    assertObservedPontoSource(releaseSha, String(run?.head_sha || "").trim().toLowerCase());
     if (
       workflow?.state !== "active"
       || workflow?.path !== ".github/workflows/ponto-progressive-release.yml"
@@ -666,7 +667,6 @@ const canonicalOrchestrator = async ({ orchestratorRunId, releaseSha, stage }) =
       || run?.conclusion != null
       || run?.event !== "workflow_dispatch"
       || run?.head_branch !== "main"
-      || run?.head_sha !== releaseSha
       || run?.name !== `Ponto ${stage} ${releaseSha} orchestrator=${orchestratorRunId}`
       || run?.repository?.full_name !== repository
       || String(run?.repository?.id || "") !== repositoryId

--- a/.github/scripts/ponto-watchdog-journal.mjs
+++ b/.github/scripts/ponto-watchdog-journal.mjs
@@ -242,7 +242,7 @@ export async function reconstructWatchdogJournal({
     || ![".github/workflows/ponto-progressive-release.yml", ".github/workflows/ponto-progressive-release.yml@refs/heads/main"].includes(coordinator?.path)
     || coordinator?.event !== "workflow_dispatch"
     || coordinator?.head_branch !== "main"
-    || String(coordinator?.head_sha || "").toLowerCase() !== releaseSha
+    || !pontoSourceClosureMatches(releaseSha, String(coordinator?.head_sha || "").trim().toLowerCase())
     || coordinator?.repository?.full_name !== repository
     || coordinator?.head_repository?.full_name !== repository
     || !Number.isFinite(coordinatorCreated)

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -142,10 +142,25 @@ jobs:
         run: |
           set -euo pipefail
           [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'release_sha must be a full SHA'; exit 1; }
-          [[ "$GITHUB_SHA" == "$RELEASE_SHA" ]] || { echo 'release_sha must equal the immutable main coordinator SHA'; exit 1; }
+          [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'immutable Ponto coordinator workflow SHA is invalid'; exit 1; }
           [[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]] || { echo 'checkout differs from release_sha'; exit 1; }
           git fetch --no-tags origin main
           git merge-base --is-ancestor "$RELEASE_SHA" origin/main || { echo 'release_sha is not reachable from main'; exit 1; }
+          current_main_sha="$(git rev-parse origin/main)"
+          PONTO_RELEASE_SHA="$RELEASE_SHA" PONTO_WORKFLOW_SHA="$GITHUB_SHA" PONTO_CURRENT_MAIN_SHA="$current_main_sha" node --input-type=module <<'NODE'
+          import { assertPontoSourceClosureUnchanged } from "./.github/scripts/ponto-source-closure.mjs";
+          const releaseSha = process.env.PONTO_RELEASE_SHA;
+          for (const [label, observedSha] of [
+            ["coordinator workflow", process.env.PONTO_WORKFLOW_SHA],
+            ["current main", process.env.PONTO_CURRENT_MAIN_SHA],
+          ]) {
+            try {
+              assertPontoSourceClosureUnchanged(releaseSha, observedSha);
+            } catch {
+              throw new Error(`${label} differs from the immutable Ponto release dependency closure`);
+            }
+          }
+          NODE
           tree="$(git rev-parse "${RELEASE_SHA}^{tree}")"
           echo "tree=$tree" >> "$GITHUB_OUTPUT"
           mkdir -p "$PONTO_ARTIFACT_DIR/predecessor" "$PONTO_ARTIFACT_DIR/runs" "$PONTO_ARTIFACT_DIR/surfaces" "$PONTO_ARTIFACT_DIR/module-transitions"

--- a/.github/workflows/ponto-staging-recovery-rollback.yml
+++ b/.github/workflows/ponto-staging-recovery-rollback.yml
@@ -84,8 +84,9 @@ jobs:
           [[ "$AUTHORIZATION_REF" =~ ^[A-Za-z0-9][A-Za-z0-9._:/#-]{2,119}$ ]] || { echo 'Authorization reference must be opaque'; exit 1; }
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$COORDINATOR_RUN_ID" > "$RUNNER_TEMP/ponto-coordinator.json"
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$WATCHDOG_RUN_ID" > "$RUNNER_TEMP/ponto-watchdog.json"
-          node - "$RUNNER_TEMP/ponto-coordinator.json" "$RUNNER_TEMP/ponto-watchdog.json" <<'NODE'
-          const fs = require("fs");
+          node --input-type=module - "$RUNNER_TEMP/ponto-coordinator.json" "$RUNNER_TEMP/ponto-watchdog.json" <<'NODE'
+          import fs from "node:fs";
+          import { pontoSourceClosureMatches } from "./.github/scripts/ponto-source-closure.mjs";
           const coordinator = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
           const watchdog = JSON.parse(fs.readFileSync(process.argv[3], "utf8"));
           const repo = process.env.GITHUB_REPOSITORY;
@@ -96,7 +97,7 @@ jobs:
             coordinator.path !== ".github/workflows/ponto-progressive-release.yml"
             || coordinator.event !== "workflow_dispatch"
             || !isCompletedFailure(coordinator)
-            || coordinator.head_sha !== releaseSha
+            || !pontoSourceClosureMatches(releaseSha, String(coordinator.head_sha || "").toLowerCase())
             || coordinator.head_branch !== "main"
             || coordinator.repository?.full_name !== repo
             || watchdog.path !== ".github/workflows/ponto-release-watchdog.yml"
@@ -326,8 +327,9 @@ jobs:
           git merge-base --is-ancestor "$RELEASE_SHA" origin/main || { echo 'Failed release is not reachable from main'; exit 1; }
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$COORDINATOR_RUN_ID" > "$RUNNER_TEMP/ponto-coordinator.json"
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$WATCHDOG_RUN_ID" > "$RUNNER_TEMP/ponto-watchdog.json"
-          node - "$RUNNER_TEMP/ponto-coordinator.json" "$RUNNER_TEMP/ponto-watchdog.json" <<'NODE'
-          const fs = require("fs");
+          node --input-type=module - "$RUNNER_TEMP/ponto-coordinator.json" "$RUNNER_TEMP/ponto-watchdog.json" <<'NODE'
+          import fs from "node:fs";
+          import { pontoSourceClosureMatches } from "./.github/scripts/ponto-source-closure.mjs";
           const coordinator = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
           const watchdog = JSON.parse(fs.readFileSync(process.argv[3], "utf8"));
           const repo = process.env.GITHUB_REPOSITORY;
@@ -338,7 +340,7 @@ jobs:
             coordinator.path !== ".github/workflows/ponto-progressive-release.yml"
             || coordinator.event !== "workflow_dispatch"
             || !isCompletedFailure(coordinator)
-            || coordinator.head_sha !== releaseSha
+            || !pontoSourceClosureMatches(releaseSha, String(coordinator.head_sha || "").toLowerCase())
             || coordinator.head_branch !== "main"
             || coordinator.repository?.full_name !== repo
             || watchdog.path !== ".github/workflows/ponto-release-watchdog.yml"


### PR DESCRIPTION
## What changed

Separates the immutable Ponto release SHA from the `main` workflow revision so an unrelated merge no longer invalidates a governed candidate.

The coordinator, child dispatcher, capability gate, watchdog, and staging recovery now require the Ponto dependency closure to match instead of requiring unrelated workflow SHA equality.

## Why

The existing deterministic release tag and global coordinator already distinguish disjoint from conflicting changes, but the root workflow still rejected every `main` advance before that model could apply.

## Validation

- Targeted Ponto and coordination tests: 84 passing
- Deployment topology validation: passing