### PR TITLE
fix(ponto): acquire release lease before gate settlement

### DIFF
--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -215,6 +215,21 @@ jobs:
           PONTO_EXPECTED_STAGE="$predecessor" PONTO_EXPECTED_SHA="$RELEASE_SHA" PONTO_EXPECTED_REPOSITORY="$GITHUB_REPOSITORY" \
             node .github/scripts/ponto-release-evidence.mjs verify "$PONTO_ARTIFACT_DIR/predecessor/ponto-release-evidence.json"
           rm -f "$RUNNER_TEMP/ponto-workflow.json" "$RUNNER_TEMP/predecessor-run.json"
+      # Hold the closure-scoped Ponto lease while required checks settle. The
+      # coordinator still admits a documented disjoint main merge, but delays
+      # one that changes the selected Ponto dependency closure.
+      - name: Acquire the composite Ponto release lease before gate settlement
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ env.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          proof_file: ${{ runner.temp }}/ponto-release/global-coordination-release-ponto.json
       - name: Attest canonical merged PR and required checks for the immutable SHA
         if: ${{ inputs.stage != 'preview' }}
         env:
@@ -810,18 +825,6 @@ jobs:
           }, null, 2)}\n`, { mode: 0o600 });
           NODE
           rm -f "$evidence_dir/artifact.zip"
-      - name: Acquire the composite Ponto release lease before candidate mutation
-        uses: ./.github/actions/global-coordination-acquire
-        with:
-          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
-          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
-          coordinator_url: ${{ env.SKINCOS_GLOBAL_COORDINATOR_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
-          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
-          resource: release:ponto
-          module: ponto
-          source_sha: ${{ inputs.release_sha }}
-          proof_file: ${{ runner.temp }}/ponto-release/global-coordination-release-ponto.json
       - name: Establish immutable Ponto release identity
         id: release_identity
         env:

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -176,12 +176,13 @@ test("the staging RBAC journey recovers synthetic teardown under a fresh lease",
   assert.match(workflow, /refusing a non-staging D1 target/);
 });
 
-test("the Ponto composite lease starts before candidate mutation, selects the correct authority, and spans the orchestrator", () => {
+test("the Ponto composite lease starts before gate settlement, selects the correct authority, and spans the orchestrator", () => {
   const workflow = read(".github/workflows/ponto-progressive-release.yml");
-  const acquire = workflow.indexOf("Acquire the composite Ponto release lease before candidate mutation");
+  const acquire = workflow.indexOf("Acquire the composite Ponto release lease before gate settlement");
+  const requiredChecks = workflow.indexOf("Attest canonical merged PR and required checks for the immutable SHA");
   const firstDispatch = workflow.indexOf("node .github/scripts/ponto-dispatch-workflow.mjs");
   const release = workflow.indexOf("Release the composite Ponto release lease");
-  assert.ok(acquire >= 0 && firstDispatch > acquire && release > firstDispatch);
+  assert.ok(acquire >= 0 && requiredChecks > acquire && firstDispatch > acquire && release > firstDispatch);
   assert.match(workflow, /SKINCOS_GLOBAL_COORDINATOR_URL: \$\{\{ contains\(fromJSON\('\["preview","staging"\]'\)/);
   assert.match(workflow, /coordinator_url: \$\{\{ env\.SKINCOS_GLOBAL_COORDINATOR_URL \}\}/);
   assert.match(read(".github/scripts/ponto-dispatch-workflow.mjs"), /revalidatePontoCompositeLease/);
@@ -203,7 +204,7 @@ test("Ponto child dispatch is pinned to the immutable release identity", () => {
   const workflow = read(".github/workflows/ponto-progressive-release.yml");
   const dispatcher = read(".github/scripts/ponto-dispatch-workflow.mjs");
   const identity = read(".github/scripts/ponto-release-identity.mjs");
-  const acquire = workflow.indexOf("Acquire the composite Ponto release lease before candidate mutation");
+  const acquire = workflow.indexOf("Acquire the composite Ponto release lease before gate settlement");
   const establish = workflow.indexOf("Establish immutable Ponto release identity");
   const dispatch = workflow.indexOf("node .github/scripts/ponto-dispatch-workflow.mjs");
   assert.ok(acquire >= 0 && establish > acquire && dispatch > establish);


### PR DESCRIPTION
## Objetivo
Antecipar a lease composta `release:ponto` para antes da estabilização de checks do coordenador, mantendo a exclusividade apenas para alterações cuja closure dependa do Ponto.

## Risco e rollback
Nenhum novo recurso ou bypass é introduzido. Mudanças disjuntas continuam admissíveis pelo coordenador; uma reversão deste commit restaura a ordem anterior.

## Validação
- `node --test scripts/tests/global-concurrency-governance-static.test.mjs` — 16/16
- `npm run codex:deploy-topology:test` — verde