### PR TITLE
fix(influencer-intelligence): reuse canonical staging migrator custody

### DIFF
--- a/docs/runbooks/influencer-intelligence-staging-migrations.md
+++ b/docs/runbooks/influencer-intelligence-staging-migrations.md
@@ -17,8 +17,10 @@ checkpoint only below
 `/var/backups/skincos/influencer-intelligence/staging/`; callers cannot choose
 the destination. The underlying fixed runner is
 `scripts/staging/influencer-intelligence-migration.mjs`. It reads the database URL only from the native private file
-`/etc/skincos/influencer-intelligence-staging-migrator.env`; the file is not in
-Git and its value is never printed. The URL must point to loopback TLS,
+`/etc/skincos/crm-atendimento-staging-migrator.env`, the canonical staging
+database migrator custody already used by the CRM; no analytics-specific copy
+of the password is created. The file is not in Git and its value is never
+printed. The URL must point to loopback TLS,
 `skincos_staging`, and `skincos_staging_migrator_login`. The runner overrides
 the connection application name to `influencer-intelligence-migration` and
 proves it from PostgreSQL.

--- a/scripts/staging/influencer-intelligence-migration.mjs
+++ b/scripts/staging/influencer-intelligence-migration.mjs
@@ -16,7 +16,11 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const ROOT = path.resolve(import.meta.dirname, '../..')
 const MIGRATIONS_ROOT = path.join(ROOT, 'social/influencer-intelligence/migrations')
-const FIXED_ENV_FILE = '/etc/skincos/influencer-intelligence-staging-migrator.env'
+// Reuse the canonical staging database migrator custody already provisioned
+// for the CRM. Do not duplicate the password into an analytics-specific file;
+// the destination and role assertions below still bind this operation to the
+// exact staging database contract.
+const FIXED_ENV_FILE = '/etc/skincos/crm-atendimento-staging-migrator.env'
 
 export const INFLUENCER_INTELLIGENCE_MIGRATION_RUNNER_VERSION = 'influencer-intelligence/staging-migrations/v1'
 export const INFLUENCER_INTELLIGENCE_STAGING_TARGET = Object.freeze({
@@ -663,6 +667,7 @@ if (isDirectExecution) {
 export const __testables = {
     ROOT,
     MIGRATIONS_ROOT,
+    FIXED_ENV_FILE,
     MIGRATION_PLAN,
     EXPECTED_RELATIONS,
     APPEND_ONLY_RELATIONS,

--- a/social/influencer-intelligence/tests/migration-runner.test.mjs
+++ b/social/influencer-intelligence/tests/migration-runner.test.mjs
@@ -148,3 +148,7 @@ test('native staging wrapper is release-bound and keeps database custody out of 
     assert.doesNotMatch(wrapper, /DATABASE_URL|password|--database-url|--connection-string/)
     assert.match(wrapper, /CHECKPOINT_ROOT='\/var\/backups\/skincos\/influencer-intelligence\/staging'/)
 })
+
+test('runner reuses the canonical CRM staging migrator custody without duplicating a secret', () => {
+    assert.equal(__testables.FIXED_ENV_FILE, '/etc/skincos/crm-atendimento-staging-migrator.env')
+})


### PR DESCRIPTION
## Objective
Close the staging custody gap found after PR #1374: the runner must use the canonical root-owned CRM staging database migrator environment already provisioned on the host, without requiring or duplicating an analytics-specific password file.

## Scope
- reuse /etc/skincos/crm-atendimento-staging-migrator.env as the fixed private input;
- retain exact database, loopback TLS, session user, owner role, timeout, lease, checksum, checkpoint and runtime-grant assertions;
- document that no analytics-specific secret copy is created;
- add a contract test binding the runner to the canonical custody path.

## Risk and rollback
Risk: high, limited to the staging-only migration runner's secret path. No credentials are committed or printed, no database connection is made by CI, and no migration is applied by this PR. Rollback is reverting this source change; the module remains OFF.

## Validation
- migration runner tests: 8 passed
- PR #1374 full domain/architecture/security/E2E checks: passed
- no production or provider runtime activity.

## Operational gate
After merge, the exact merged SHA still must be staged immutably with the module-specific coordination closure. The staging apply remains separate and requires root custody, the existing private migrator file, lease, checkpoint and post-validation.