### PR TITLE
fix(ponto): accept closure-compatible root issuers

### DIFF
--- a/.github/scripts/ponto-orchestrator-lease.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.mjs
@@ -795,7 +795,11 @@ async function consumeCheck([leaseKey, stage, target, releaseShaRaw, orchestrato
     || issuer?.conclusion != null
     || issuer?.event !== "workflow_dispatch"
     || issuer?.head_branch !== (delegatedIssuer ? releaseTag : "main")
-    || issuer?.head_sha !== releaseSha
+    // The direct issuer is the canonical root on main. It was already
+    // attested through assertObservedPontoSource by canonicalOrchestrator,
+    // which permits a documented disjoint main advance. A delegated issuer
+    // is itself tag-pinned and must remain exact.
+    || (delegatedIssuer && issuer?.head_sha !== releaseSha)
     || issuer?.repository?.full_name !== repository
     || String(issuer?.repository?.id || "") !== repositoryId
     || issuer?.head_repository?.full_name !== repository

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -606,6 +606,13 @@ test("consume-check maps the direct parent issuer into the delegated snapshot sh
   );
 });
 
+test("direct root issuers rely on the closure attestation while delegated issuers stay SHA-pinned", () => {
+  const source = fs.readFileSync(script, "utf8");
+  assert.match(source, /assertObservedPontoSource\(releaseSha, String\(run\?\.head_sha/);
+  assert.match(source, /\(delegatedIssuer && issuer\?\.head_sha !== releaseSha\)/);
+  assert.doesNotMatch(source, /\|\| issuer\?\.head_sha !== releaseSha/);
+});
+
 test("every orchestrated secret or mutation job revalidates the coordinator after checkout and before secrets", () => {
   const guardedJobs = [
     ["deploy-timekeeping.yml", "release"],

--- a/.github/scripts/ponto-watchdog-context.mjs
+++ b/.github/scripts/ponto-watchdog-context.mjs
@@ -1,9 +1,23 @@
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { assertPontoSourceClosureUnchanged } from "./ponto-source-closure.mjs";
 
 const TITLE = /^Ponto (preview|staging|pilot|canary|production|rollback) ([0-9a-f]{40}) orchestrator=([1-9][0-9]*)$/;
 const FAILURE_CONCLUSIONS = new Set(["failure", "cancelled", "timed_out"]);
+
+function sourceMatchesImmutableRelease(releaseSha, observedSha, assertSource) {
+  const release = String(releaseSha || "").trim().toLowerCase();
+  const observed = String(observedSha || "").trim().toLowerCase();
+  if (!release || !observed) return false;
+  if (release === observed) return true;
+  try {
+    assertSource(release, observed);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export const targetForStage = (stage) => {
   if (stage === "preview") return null;
@@ -20,6 +34,7 @@ export async function validateWatchdogContext({
   gitRef,
   watchdogRunAttempt,
   request: requestOverride,
+  assertReleaseSource = assertPontoSourceClosureUnchanged,
 }) {
   if (
     !repository?.includes("/")
@@ -48,6 +63,11 @@ export async function validateWatchdogContext({
     request(`/repos/${repository}/actions/runs/${eventRun.id}`),
   ]);
   const match = TITLE.exec(String(run?.display_title || ""));
+  const sourceMatchesRelease = sourceMatchesImmutableRelease(
+    match?.[2],
+    run?.head_sha,
+    assertReleaseSource,
+  );
   const runAttempt = Number(run?.run_attempt);
   const eventAttempt = Number(eventRun?.run_attempt);
   const unauthorizedReplay = Number.isInteger(runAttempt) && runAttempt > 1;
@@ -77,7 +97,7 @@ export async function validateWatchdogContext({
     || String(run?.head_repository?.id || "") !== String(repositoryId)
     || !match
     || String(run.id) !== match[3]
-    || String(run.head_sha || "").toLowerCase() !== match[2]
+    || !sourceMatchesRelease
     || eventRun.workflow_id !== workflow.id
     || eventRun.path !== run.path
     || eventRun.head_sha !== run.head_sha

--- a/.github/scripts/ponto-watchdog-context.test.mjs
+++ b/.github/scripts/ponto-watchdog-context.test.mjs
@@ -57,6 +57,22 @@ test("watchdog accepts only an exact failed first-attempt coordinator from main"
   assert.equal(context.releaseSha, sha);
 });
 
+test("watchdog accepts a closure-compatible main revision for an immutable release", async () => {
+  const observedSha = "b".repeat(40);
+  const sourceChecks = [];
+  const context = await validateWatchdogContext(input({
+    event: { workflow_run: { ...event.workflow_run, head_sha: observedSha } },
+    request: async (pathname) => pathname.endsWith("ponto-progressive-release.yml")
+      ? workflow
+      : { ...run, head_sha: observedSha },
+    assertReleaseSource: (releaseSha, currentSha) => {
+      sourceChecks.push([releaseSha, currentSha]);
+    },
+  }));
+  assert.equal(context.releaseSha, sha);
+  assert.deepEqual(sourceChecks, [[sha, observedSha]]);
+});
+
 test("watchdog closes both successful and failed unauthorized reruns", async () => {
   for (const conclusion of ["success", "failure"]) {
     const replay = { ...run, run_attempt: 2, conclusion };


### PR DESCRIPTION
## Causa
O staging `31621165553` falhou antes de mutar o alvo porque o child de custódia exigia que o SHA do coordenador em `main` fosse literalmente igual ao SHA da release. Isso contradizia o contrato já validado de aceitar avanço disjunto de `main` quando a dependency closure Ponto é idêntica. O watchdog tinha a mesma comparação estrita.

## Correção
- O emissor raiz continua validado pelo attest de closure canônico; somente emissores delegados pela tag permanecem exigindo SHA exato.
- O watchdog aceita a mesma equivalência de closure e mantém falha fechada quando ela divergir.

## Validação
- `node --test .github/scripts/ponto-orchestrator-lease.test.mjs .github/scripts/ponto-watchdog-context.test.mjs` (42 testes verdes)