### PR TITLE
fix(staging): guard runtime grant checks before schema creation

### DIFF
--- a/scripts/staging/influencer-intelligence-migration.mjs
+++ b/scripts/staging/influencer-intelligence-migration.mjs
@@ -390,8 +390,10 @@ async function collectRuntimePrivilegeState(client) {
             $1::name as role_name,
             exists(select 1 from pg_roles where rolname = $1::name) as role_present,
             case when exists(select 1 from pg_roles where rolname = $1::name)
+              and exists(select 1 from pg_namespace where nspname = $2::name)
               then has_schema_privilege($1::name, $2::name, 'USAGE') else false end as schema_usage,
             case when exists(select 1 from pg_roles where rolname = $1::name)
+              and exists(select 1 from pg_namespace where nspname = $2::name)
               then has_schema_privilege($1::name, $2::name, 'CREATE') else false end as schema_create,
             case when exists(select 1 from pg_roles where rolname = $1::name)
               then exists(

--- a/social/influencer-intelligence/tests/migration-runner.test.mjs
+++ b/social/influencer-intelligence/tests/migration-runner.test.mjs
@@ -104,6 +104,7 @@ test('dry-run proves identity, minimum grants, lock and timeout without migratio
     assert.match(roleProofQuery, /\$1::name/)
     const runtimePrivilegeQuery = fake.queries.find(({ sql }) => sql.includes('role_name'))?.sql || ''
     assert.match(runtimePrivilegeQuery, /\$1::name/)
+    assert.match(runtimePrivilegeQuery, /pg_namespace/)
     assert.equal(fake.queries.filter(({ sql }) => sql.includes('insert into')).length, 0)
 })
 


### PR DESCRIPTION
Make the staging migration runner safe on a pristine database by checking schema existence before calling has_schema_privilege. Add a focused regression assertion. This remains staging-only and does not change runtime activation.