### PR TITLE
fix(ponto): scope emergency recovery to its coordinator

### DIFF
--- a/.github/actions/global-coordination-acquire/action.yml
+++ b/.github/actions/global-coordination-acquire/action.yml
@@ -33,6 +33,14 @@ inputs:
     description: Optional JSON inputs bound into the immutable lease intent
     required: false
     default: '{}'
+  wait_timeout_seconds:
+    description: Opt-in bounded wait for an already-held lease to expire
+    required: false
+    default: '0'
+  retry_interval_seconds:
+    description: Poll interval for an opted-in held-lease wait
+    required: false
+    default: '5'
 runs:
   using: composite
   steps:
@@ -51,6 +59,8 @@ runs:
         GLOBAL_SOURCE_SHA: ${{ inputs.source_sha }}
         GLOBAL_PROOF_FILE: ${{ inputs.proof_file }}
         GLOBAL_INPUTS_JSON: ${{ inputs.inputs_json }}
+        GLOBAL_WAIT_TIMEOUT_SECONDS: ${{ inputs.wait_timeout_seconds }}
+        GLOBAL_RETRY_INTERVAL_SECONDS: ${{ inputs.retry_interval_seconds }}
         GLOBAL_IDEMPOTENCY_KEY: github:${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ inputs.resource }}
       run: |
         set -euo pipefail
@@ -58,6 +68,8 @@ runs:
         [[ -n "$SKINCOS_GLOBAL_COORDINATOR_URL" && -n "$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" ]] || { echo 'Global coordination custody is unavailable'; exit 1; }
         [[ "$GLOBAL_SOURCE_SHA" =~ ^[0-9a-fA-F]{40}$ ]] || { echo 'Global coordination source SHA is invalid'; exit 1; }
         [[ "$GLOBAL_PROOF_FILE" != "$GITHUB_WORKSPACE"/* ]] || { echo 'Global coordination proof must live outside the repository'; exit 1; }
+        [[ "$GLOBAL_WAIT_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] && (( 10#$GLOBAL_WAIT_TIMEOUT_SECONDS <= 1200 )) || { echo 'Global coordination acquire wait must be an integer between 0 and 1200 seconds'; exit 1; }
+        [[ "$GLOBAL_RETRY_INTERVAL_SECONDS" =~ ^[0-9]+$ ]] && (( 10#$GLOBAL_RETRY_INTERVAL_SECONDS >= 1 && 10#$GLOBAL_RETRY_INTERVAL_SECONDS <= 60 )) || { echo 'Global coordination acquire retry interval must be an integer between 1 and 60 seconds'; exit 1; }
         mkdir -p "$(dirname "$GLOBAL_PROOF_FILE")"
         inputs_file="$RUNNER_TEMP/skincos-global-coordination-inputs.json"
         printf '%s' "$GLOBAL_INPUTS_JSON" > "$inputs_file"
@@ -75,4 +87,6 @@ runs:
             --source "$GLOBAL_SOURCE_SHA" \
             --proof-file "$GLOBAL_PROOF_FILE" \
             --inputs-file "$inputs_file" \
+            --max-wait-seconds "$GLOBAL_WAIT_TIMEOUT_SECONDS" \
+            --poll-seconds "$GLOBAL_RETRY_INTERVAL_SECONDS" \
             --idempotency-key "$GLOBAL_IDEMPOTENCY_KEY"

--- a/.github/scripts/ponto-emergency-stop.mjs
+++ b/.github/scripts/ponto-emergency-stop.mjs
@@ -36,6 +36,15 @@ export const HIGH_RISK_WORKFLOWS = Object.freeze([
   { path: ".github/workflows/ponto-production-slo.yml", targets: ["production"] },
 ]);
 
+// A workflow_run watchdog is bound to the exact coordinator that emitted its
+// event.  It must not treat a separately queued or active coordinator for the
+// same target as part of that emergency: doing so can turn a duplicate
+// cancellation into an interruption of the valid release owner.
+export const isWithinEmergencyCoordinatorScope = (coordinator, exactCoordinatorRunId = "") => {
+  const exact = String(exactCoordinatorRunId || "").trim();
+  return !exact || String(coordinator?.runId || "") === exact;
+};
+
 export const targetForStage = (stage) => stage === "staging" ? "staging" : "production";
 export const isBodylessResponseStatus = (status) => status === 202 || status === 204;
 export const isInventoryWorkflowState = (state) =>
@@ -260,18 +269,18 @@ if (invokedAsScript) {
         throw new Error(`non-terminal ${status} run inventory exceeds the governed discovery bound`);
       }
     }
-    const coordinatorCandidates = new Map(
-      [...coordinators.values()]
-        .filter(record => record.live)
-        .map(record => [record.runId, record.live]),
-    );
-    if (exactCoordinatorRunId && !coordinatorCandidates.has(exactCoordinatorRunId)) {
+    const coordinatorCandidates = new Map();
+    if (exactCoordinatorRunId) {
       coordinatorCandidates.set(
         exactCoordinatorRunId,
         await request(`/repos/${repository}/actions/runs/${exactCoordinatorRunId}`),
       );
+    } else {
+      for (const record of coordinators.values()) {
+        if (record.live) coordinatorCandidates.set(record.runId, record.live);
+      }
     }
-    if (!completedCoordinatorDiscoveryDone) {
+    if (!exactCoordinatorRunId && !completedCoordinatorDiscoveryDone) {
       const recentSince = new Date(Date.parse(startedAt) - 24 * 60 * 60 * 1_000).toISOString();
       let coordinatorInventoryExhausted = false;
       for (let page = 1; page <= 20; page += 1) {
@@ -296,7 +305,7 @@ if (invokedAsScript) {
         workflowId: workflow.id,
         target,
       });
-      if (!parsed) continue;
+      if (!parsed || !isWithinEmergencyCoordinatorScope(parsed, exactCoordinatorRunId)) continue;
       found.set(parsed.runId, coordinatorRun);
       if (completedWindowScans.has(parsed.runId)) continue;
       const from = Date.parse(String(coordinatorRun.created_at || ""));
@@ -594,7 +603,7 @@ if (invokedAsScript) {
         workflowId: workflow.id,
         target,
       });
-      if (!parsed) continue;
+      if (!parsed || !isWithinEmergencyCoordinatorScope(parsed, exactCoordinatorRunId)) continue;
       const record = coordinators.get(parsed.runId) || {
         ...parsed,
         firstObservedAt: new Date().toISOString(),
@@ -627,7 +636,7 @@ if (invokedAsScript) {
         workflowId: workflow.id,
         target,
       });
-      if (!parsed) {
+      if (!parsed || !isWithinEmergencyCoordinatorScope(parsed, exactCoordinatorRunId)) {
         invalidCoordinatorIds.add(coordinatorRunId);
         continue;
       }

--- a/.github/scripts/ponto-emergency-stop.test.mjs
+++ b/.github/scripts/ponto-emergency-stop.test.mjs
@@ -11,6 +11,7 @@ import {
   HIGH_RISK_WORKFLOWS,
   isBodylessResponseStatus,
   isInventoryWorkflowState,
+  isWithinEmergencyCoordinatorScope,
   loadCanonicalHighRiskWorkflows,
   isWithinCoordinatorWindow,
   parseCoordinator,
@@ -85,6 +86,12 @@ test("coordinator discovery accepts only exact canonical correlated runs", () =>
   assert.equal(parseCoordinator(run("pilot", { display_title: `Ponto pilot ${sha} orchestrator=999` }), { repository, workflowId, target: "production" }), null);
 });
 
+test("an exact watchdog event never widens reconciliation to another coordinator", () => {
+  assert.equal(isWithinEmergencyCoordinatorScope({ runId: "8001" }, "8001"), true);
+  assert.equal(isWithinEmergencyCoordinatorScope({ runId: "8002" }, "8001"), false);
+  assert.equal(isWithinEmergencyCoordinatorScope({ runId: "8002" }), true);
+});
+
 test("GitHub cancellation acknowledgements are treated as bodyless success", () => {
   assert.equal(isBodylessResponseStatus(202), true);
   assert.equal(isBodylessResponseStatus(204), true);
@@ -148,6 +155,8 @@ test("emergency inventory accepts exact active and disabled canonical workflow s
 test("emergency reconciliation and latch reset ignore every uncorrelated canonical run", async () => {
   const emergency = fs.readFileSync(new URL("./ponto-emergency-stop.mjs", import.meta.url), "utf8");
   const idle = fs.readFileSync(new URL("./ponto-assert-idle.mjs", import.meta.url), "utf8");
+  assert.match(emergency, /isWithinEmergencyCoordinatorScope\(parsed, exactCoordinatorRunId\)/);
+  assert.match(emergency, /if \(!exactCoordinatorRunId && !completedCoordinatorDiscoveryDone\)/);
   assert.match(emergency, /isCorrelatedChild\(run, \{/);
   assert.match(emergency, /const classified = classifyHighRiskRun\(run, \{/);
   assert.match(emergency, /isWithinCoordinatorWindow\(run, coordinator\.live\)/);

--- a/.github/scripts/ponto-environment-protection-workflow.test.mjs
+++ b/.github/scripts/ponto-environment-protection-workflow.test.mjs
@@ -135,7 +135,7 @@ test("ordinary and watchdog rollback revalidate governance and use dedicated int
   }
 });
 
-test("staging cleanup does not dispatch a transition before release identity exists", () => {
+test("staging cleanup dispatches the regular control transition only after the authenticated journey", () => {
   const source = workflow("ponto-progressive-release.yml");
   const cleanup = source.indexOf(
     "- name: Restore staging Ponto to maintenance after the journey",
@@ -144,8 +144,9 @@ test("staging cleanup does not dispatch a transition before release identity exi
   const cleanupBlock = source.slice(cleanup, source.indexOf("\n      - name:", cleanup + 1));
   assert.match(
     cleanupBlock,
-    /if: \$\{\{ always\(\) && inputs\.stage == 'staging' && steps\.release_identity\.outcome == 'success' \}\}/,
+    /if: \$\{\{ inputs\.stage == 'staging' && steps\.staging_journey\.outcome == 'success' \}\}/,
   );
+  assert.doesNotMatch(cleanupBlock, /always\(\)/);
 });
 
 test("every coordinator module transition carries the immutable release SHA", () => {

--- a/.github/scripts/ponto-watchdog-context.mjs
+++ b/.github/scripts/ponto-watchdog-context.mjs
@@ -5,6 +5,7 @@ import { assertPontoSourceClosureUnchanged } from "./ponto-source-closure.mjs";
 
 const TITLE = /^Ponto (preview|staging|pilot|canary|production|rollback) ([0-9a-f]{40}) orchestrator=([1-9][0-9]*)$/;
 const FAILURE_CONCLUSIONS = new Set(["failure", "cancelled", "timed_out"]);
+const NON_TERMINAL_STATUSES = ["queued", "in_progress", "waiting", "pending", "requested"];
 
 function sourceMatchesImmutableRelease(releaseSha, observedSha, assertSource) {
   const release = String(releaseSha || "").trim().toLowerCase();
@@ -23,6 +24,72 @@ export const targetForStage = (stage) => {
   if (stage === "preview") return null;
   return stage === "staging" ? "staging" : "production";
 };
+
+export function parseActivePeerCoordinator(run, {
+  coordinatorRunId,
+  workflow,
+  repository,
+  repositoryId,
+  stage,
+  releaseSha,
+  assertReleaseSource = assertPontoSourceClosureUnchanged,
+}) {
+  const match = TITLE.exec(String(run?.display_title || ""));
+  if (
+    !match
+    || String(run?.id || "") === String(coordinatorRunId)
+    || !NON_TERMINAL_STATUSES.includes(String(run?.status || ""))
+    || run?.workflow_id !== workflow?.id
+    || ![workflow?.path, `${workflow?.path}@refs/heads/main`].includes(run?.path)
+    || run?.event !== "workflow_dispatch"
+    || run?.head_branch !== "main"
+    || run?.name !== `Ponto ${match[1]} ${match[2]} orchestrator=${match[3]}`
+    || String(run?.id || "") !== match[3]
+    || match[1] !== stage
+    || match[2] !== releaseSha
+    || Number(run?.run_attempt) !== 1
+    || run?.repository?.full_name !== repository
+    || String(run?.repository?.id || "") !== String(repositoryId)
+    || run?.head_repository?.full_name !== repository
+    || String(run?.head_repository?.id || "") !== String(repositoryId)
+    || !sourceMatchesImmutableRelease(releaseSha, run?.head_sha, assertReleaseSource)
+  ) return null;
+  return {
+    runId: String(run.id),
+    status: String(run.status),
+  };
+}
+
+async function findActivePeerCoordinator({
+  request,
+  coordinatorRunId,
+  workflow,
+  repository,
+  repositoryId,
+  stage,
+  releaseSha,
+  assertReleaseSource,
+}) {
+  for (const status of NON_TERMINAL_STATUSES) {
+    const payload = await request(
+      `/repos/${repository}/actions/workflows/${workflow.id}/runs?event=workflow_dispatch&status=${encodeURIComponent(status)}&per_page=100&page=1`,
+    );
+    const runs = Array.isArray(payload?.workflow_runs) ? payload.workflow_runs : [];
+    for (const candidate of runs) {
+      const peer = parseActivePeerCoordinator(candidate, {
+        coordinatorRunId,
+        workflow,
+        repository,
+        repositoryId,
+        stage,
+        releaseSha,
+        assertReleaseSource,
+      });
+      if (peer) return peer;
+    }
+  }
+  return null;
+}
 
 export async function validateWatchdogContext({
   event,
@@ -112,9 +179,33 @@ export async function validateWatchdogContext({
   // fail-closed and preserves the existing recovery behavior.
   const coordinatorStarted = !Array.isArray(jobs?.jobs)
     || jobs.jobs.some((job) => job?.name === "orchestrate");
-  const requiresClose = stage !== "preview"
+  const closeCandidate = stage !== "preview"
     && coordinatorStarted
     && (unauthorizedReplay || FAILURE_CONCLUSIONS.has(run.conclusion));
+  let activePeer = null;
+  let activePeerDiscovery = "not-required";
+  // A cancelled duplicate must never close or reconcile the surface while an
+  // exact, first-attempt coordinator still owns the same immutable release.
+  // Unauthorized reruns remain fail-closed even if another run is active.
+  if (closeCandidate && !unauthorizedReplay) {
+    try {
+      activePeer = await findActivePeerCoordinator({
+        request,
+        coordinatorRunId: String(run.id),
+        workflow,
+        repository,
+        repositoryId,
+        stage,
+        releaseSha: match[2],
+        assertReleaseSource,
+      });
+      activePeerDiscovery = activePeer ? "verified-peer" : "no-eligible-peer";
+    } catch {
+      // If GitHub cannot prove an eligible peer, retain the fail-closed path.
+      activePeerDiscovery = "unavailable";
+    }
+  }
+  const requiresClose = closeCandidate && !activePeer;
   return {
     schemaVersion: 1,
     coordinatorRunId: String(run.id),
@@ -125,6 +216,8 @@ export async function validateWatchdogContext({
     conclusion: run.conclusion,
     runAttempt,
     unauthorizedReplay,
+    activePeerCoordinatorRunId: activePeer?.runId || null,
+    activePeerDiscovery,
     requiresClose,
     passed: true,
   };

--- a/.github/scripts/ponto-watchdog-context.test.mjs
+++ b/.github/scripts/ponto-watchdog-context.test.mjs
@@ -62,6 +62,28 @@ test("watchdog accepts only an exact failed first-attempt coordinator from main"
   assert.equal(context.releaseSha, sha);
 });
 
+test("watchdog defers a duplicate failure to an exact active coordinator", async () => {
+  const peer = {
+    ...run,
+    id: 100,
+    status: "in_progress",
+    conclusion: null,
+    name: `Ponto staging ${sha} orchestrator=100`,
+    display_title: `Ponto staging ${sha} orchestrator=100`,
+  };
+  const context = await validateWatchdogContext(input({
+    request: async (pathname) => {
+      if (pathname.endsWith("ponto-progressive-release.yml")) return workflow;
+      if (pathname.endsWith("/jobs?per_page=100")) return jobs;
+      if (pathname.includes("/runs?")) return { workflow_runs: [peer] };
+      return run;
+    },
+  }));
+  assert.equal(context.requiresClose, false);
+  assert.equal(context.activePeerCoordinatorRunId, "100");
+  assert.equal(context.activePeerDiscovery, "verified-peer");
+});
+
 test("watchdog accepts a closure-compatible main revision for an immutable release", async () => {
   const observedSha = "b".repeat(40);
   const sourceChecks = [];
@@ -210,6 +232,9 @@ test("watchdog never rolls back after failed child reconciliation", () => {
     workflowText.indexOf("  reconcile:"),
   );
   assert.match(failClose, /needs:\s*\[context, latch, reconcile\]/);
+  assert.match(failClose, /timeout-minutes: 30/);
+  assert.match(failClose, /wait_timeout_seconds: '960'/);
+  assert.match(failClose, /retry_interval_seconds: '10'/);
   assert.match(failClose, /needs\.latch\.result == 'success'/);
   assert.doesNotMatch(failClose, /needs\.reconcile\.result == 'success'/);
   assert.match(latch, /Attempt external overlay propagation before reconciliation/);
@@ -231,4 +256,21 @@ test("watchdog never rolls back after failed child reconciliation", () => {
   assert.match(rollback, /needs:\s*\[context, latch, reconcile, fail-close\]/);
   assert.match(rollback, /needs\.reconcile\.result == 'success'/);
   assert.match(rollback, /needs\.fail-close\.result == 'success'/);
+});
+
+test("ordinary recovery latches before it waits for a stale coordinator lease", () => {
+  const workflowText = fs.readFileSync(
+    new URL("../workflows/ponto-progressive-release.yml", import.meta.url),
+    "utf8",
+  );
+  const start = workflowText.indexOf("  recovery-latch:");
+  const end = workflowText.indexOf("  recovery-reconcile:");
+  const recoveryLatch = workflowText.slice(start, end);
+  assert.match(recoveryLatch, /timeout-minutes: 30/);
+  assert.ok(
+    recoveryLatch.indexOf("Monotonically latch Ponto closed outside the surface mutex")
+      < recoveryLatch.indexOf("Acquire global recovery lease"),
+  );
+  assert.match(recoveryLatch, /wait_timeout_seconds: '960'/);
+  assert.match(recoveryLatch, /retry_interval_seconds: '10'/);
 });

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -1311,7 +1311,10 @@ jobs:
           run_id="$(node -e "process.stdout.write(require(process.argv[1]).runId)" "$PONTO_ARTIFACT_DIR/runs/staging-journey.json")"
           gh run download "$run_id" --repo "$GITHUB_REPOSITORY" --name "timekeeping-staging-journey-${RELEASE_SHA}" --dir "$PONTO_ARTIFACT_DIR/staging-slo"
       - name: Restore staging Ponto to maintenance after the journey
-        if: ${{ always() && inputs.stage == 'staging' && steps.release_identity.outcome == 'success' }}
+        # A failed or cancelled path is closed exclusively by the emergency
+        # broker/watchdog.  Do not dispatch the regular module-control writer
+        # unless the authenticated synthetic journey actually completed.
+        if: ${{ inputs.stage == 'staging' && steps.staging_journey.outcome == 'success' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -1823,7 +1823,10 @@ jobs:
     needs: orchestrate
     if: ${{ always() && contains(fromJSON('["failure","cancelled"]'), needs.orchestrate.result) && contains(fromJSON('["staging","pilot","canary","production","rollback"]'), inputs.stage) }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # The broker latch is written before recovery lease acquisition.  This job
+    # may then wait for one finite coordinator lease expiry without reopening
+    # the affected surface.
+    timeout-minutes: 30
     concurrency:
       group: ponto-emergency-latch-${{ inputs.stage == 'staging' && 'staging' || 'production' }}
       cancel-in-progress: false
@@ -1836,6 +1839,16 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1
+      - name: Monotonically latch Ponto closed outside the surface mutex
+        env:
+          PONTO_EMERGENCY_CLOSE_BROKER_CREDENTIAL: ${{ secrets.PONTO_EMERGENCY_CLOSE_BROKER_CREDENTIAL }}
+          PONTO_EMERGENCY_CLOSE_BROKER_URL: ${{ vars.PONTO_EMERGENCY_CLOSE_BROKER_URL }}
+          PONTO_EMERGENCY_CLOSE_CUSTODY_REF: ${{ vars.PONTO_EMERGENCY_CLOSE_CUSTODY_REF }}
+          PONTO_EMERGENCY_TARGET: ${{ inputs.stage == 'staging' && 'staging' || 'production' }}
+          PONTO_EMERGENCY_TRIGGER_RUN_ID: ${{ github.run_id }}
+          PONTO_FAILED_COORDINATOR_RUN_ID: ${{ github.run_id }}
+          PONTO_EMERGENCY_LATCH_REPORT: ${{ runner.temp }}/ponto-ordinary-recovery/latch.json
+        run: node .github/scripts/ponto-emergency-latch-write.mjs
       - name: Acquire global recovery lease
         uses: ./.github/actions/global-coordination-acquire
         with:
@@ -1848,28 +1861,8 @@ jobs:
           module: ponto
           source_sha: ${{ inputs.release_sha }}
           proof_file: ${{ runner.temp }}/ponto-ordinary-recovery/global-coordination-lease.json
-      - name: Check global recovery lease before latching closed
-        uses: ./.github/actions/global-coordination-check
-        with:
-          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
-          proof_file: ${{ runner.temp }}/ponto-ordinary-recovery/global-coordination-lease.json
-          resource: release:ponto
-          module: ponto
-          source_sha: ${{ inputs.release_sha }}
-          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
-          coordinator_url: ${{ inputs.stage == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
-          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
-      - name: Monotonically latch Ponto closed outside the surface mutex
-        env:
-          PONTO_EMERGENCY_CLOSE_BROKER_CREDENTIAL: ${{ secrets.PONTO_EMERGENCY_CLOSE_BROKER_CREDENTIAL }}
-          PONTO_EMERGENCY_CLOSE_BROKER_URL: ${{ vars.PONTO_EMERGENCY_CLOSE_BROKER_URL }}
-          PONTO_EMERGENCY_CLOSE_CUSTODY_REF: ${{ vars.PONTO_EMERGENCY_CLOSE_CUSTODY_REF }}
-          PONTO_EMERGENCY_TARGET: ${{ inputs.stage == 'staging' && 'staging' || 'production' }}
-          PONTO_EMERGENCY_TRIGGER_RUN_ID: ${{ github.run_id }}
-          PONTO_FAILED_COORDINATOR_RUN_ID: ${{ github.run_id }}
-          PONTO_EMERGENCY_LATCH_REPORT: ${{ runner.temp }}/ponto-ordinary-recovery/latch.json
-        run: node .github/scripts/ponto-emergency-latch-write.mjs
+          wait_timeout_seconds: '960'
+          retry_interval_seconds: '10'
       - name: Check global recovery lease before overlay propagation
         uses: ./.github/actions/global-coordination-check
         with:

--- a/.github/workflows/ponto-release-watchdog.yml
+++ b/.github/workflows/ponto-release-watchdog.yml
@@ -158,7 +158,10 @@ jobs:
     needs: [context, latch, reconcile]
     if: ${{ always() && needs.context.result == 'success' && needs.context.outputs.requires_close == 'true' && needs.latch.result == 'success' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # The emergency latch is already true.  Permit one bounded, natural lease
+    # expiry (15 minutes) plus broker materialization; never fence or revoke a
+    # still-held coordinator lease from this watchdog.
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read
@@ -186,6 +189,8 @@ jobs:
           module: ponto
           source_sha: ${{ needs.context.outputs.release_sha }}
           proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-watchdog-close.json
+          wait_timeout_seconds: '960'
+          retry_interval_seconds: '10'
       - name: Check global Ponto recovery lease before maintenance write
         uses: ./.github/actions/global-coordination-check
         with:

--- a/scripts/codex-global-coordination-workflow.mjs
+++ b/scripts/codex-global-coordination-workflow.mjs
@@ -20,6 +20,7 @@ import { canonicalJson } from "../ops/governance/global-coordination-core.mjs";
 export const ROOT = path.resolve(import.meta.dirname, "..");
 const FULL_SHA = /^[0-9a-f]{40}$/i;
 const DIGEST = /^[0-9a-f]{64}$/i;
+const RETRYABLE_ACQUIRE_REASONS = new Set(["resource-lease-held"]);
 
 function argument(args, name, fallback = null) {
   const index = args.indexOf(name);
@@ -35,6 +36,22 @@ function requiredArgument(args, name) {
 function jsonFile(args, name, fallback = null) {
   const value = argument(args, name);
   return value ? JSON.parse(fs.readFileSync(path.resolve(value), "utf8")) : fallback;
+}
+
+function boundedNonNegativeIntegerArgument(args, name, fallback, maximum) {
+  const value = argument(args, name, String(fallback));
+  if (!/^[0-9]+$/.test(String(value || ""))) throw new Error(`${name} must be a non-negative integer`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed > maximum) {
+    throw new Error(`${name} must be between 0 and ${maximum}`);
+  }
+  return parsed;
+}
+
+function boundedPositiveIntegerArgument(args, name, fallback, maximum) {
+  const parsed = boundedNonNegativeIntegerArgument(args, name, fallback, maximum);
+  if (parsed < 1) throw new Error(`${name} must be between 1 and ${maximum}`);
+  return parsed;
 }
 
 function safeIdSegment(value, fallback) {
@@ -200,6 +217,35 @@ export function buildWorkflowLeaseRequest({
   };
 }
 
+// A cancelled GitHub job cannot reliably execute its final release step.  A
+// separate, already-latched recovery job may therefore wait only for the
+// coordinator's finite remote lease to expire.  It never retries ambiguity,
+// custody, or authorization failures, and callers must opt in explicitly.
+export async function acquireWorkflowLease({
+  request,
+  url,
+  maxWaitMs = 0,
+  pollMs = 5_000,
+  acquireImpl = acquireGlobalLease,
+  now = () => Date.now(),
+  sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+}) {
+  if (!Number.isSafeInteger(maxWaitMs) || maxWaitMs < 0 || maxWaitMs > 1_200_000) {
+    throw new Error("global coordination acquire wait must be between 0 and 1200000 milliseconds");
+  }
+  if (!Number.isSafeInteger(pollMs) || pollMs < 1 || pollMs > 60_000) {
+    throw new Error("global coordination acquire poll must be between 1 and 60000 milliseconds");
+  }
+  const deadline = now() + maxWaitMs;
+  let result;
+  while (true) {
+    result = await acquireImpl({ request, url });
+    if (result?.passed === true && result.lease) return result;
+    if (!RETRYABLE_ACQUIRE_REASONS.has(String(result?.reason || "")) || now() >= deadline) return result;
+    await sleep(Math.min(pollMs, Math.max(1, deadline - now())));
+  }
+}
+
 function writeProof(file, lease) {
   const proof = proofForLease(lease);
   fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
@@ -253,7 +299,14 @@ async function main(args) {
         ? jsonFile(args, "--release-identity-file")
         : null,
     });
-    const result = await acquireGlobalLease({ request, url: urlFor(args) });
+    const maxWaitSeconds = boundedNonNegativeIntegerArgument(args, "--max-wait-seconds", 0, 1_200);
+    const pollSeconds = boundedPositiveIntegerArgument(args, "--poll-seconds", 5, 60);
+    const result = await acquireWorkflowLease({
+      request,
+      url: urlFor(args),
+      maxWaitMs: maxWaitSeconds * 1_000,
+      pollMs: pollSeconds * 1_000,
+    });
     if (result.passed === true && result.lease) writeProof(proofPath(args), result.lease);
     output(result, resultFile(args));
     if (result.passed !== true) process.exitCode = 2;

--- a/scripts/tests/codex-global-coordination-workflow.test.mjs
+++ b/scripts/tests/codex-global-coordination-workflow.test.mjs
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { assertCoordinationPayloadSize } from "../codex-github-integration-candidate.mjs";
-import { buildWorkflowLeaseRequest, closureFromFile } from "../codex-global-coordination-workflow.mjs";
+import { acquireWorkflowLease, buildWorkflowLeaseRequest, closureFromFile } from "../codex-global-coordination-workflow.mjs";
 import { dependencyClosureForSource } from "../codex-global-coordinator.mjs";
 
 test("workflow adapter binds the lease to source closure, owner, and selected resource", () => {
@@ -91,4 +91,34 @@ test("merge admission rejects a changed-file payload before remote coordination"
   assert.throws(() => assertCoordinationPayloadSize({
     inputs: { changedPaths: Array.from({ length: 2_000 }, (_, index) => `website/${"x".repeat(48)}/${index}.tsx`) },
   }), /payload budget/);
+});
+
+test("workflow acquisition retries only a held lease within an explicit bounded recovery wait", async () => {
+  let calls = 0;
+  let elapsed = 0;
+  const result = await acquireWorkflowLease({
+    request: { resource: "release:ponto" },
+    url: "https://coordination.example.test",
+    maxWaitMs: 30,
+    pollMs: 10,
+    now: () => elapsed,
+    sleep: async (milliseconds) => { elapsed += milliseconds; },
+    acquireImpl: async () => {
+      calls += 1;
+      return calls < 3
+        ? { passed: false, reason: "resource-lease-held" }
+        : { passed: true, lease: { leaseId: "lease-1" } };
+    },
+  });
+  assert.equal(calls, 3);
+  assert.equal(result.lease.leaseId, "lease-1");
+
+  const failedClosed = await acquireWorkflowLease({
+    request: { resource: "release:ponto" },
+    url: "https://coordination.example.test",
+    maxWaitMs: 30,
+    pollMs: 10,
+    acquireImpl: async () => ({ passed: false, reason: "coordination-dependency-closure-ambiguous" }),
+  });
+  assert.equal(failedClosed.reason, "coordination-dependency-closure-ambiguous");
 });


### PR DESCRIPTION
## Objetivo

Evita que o watchdog de uma execução cancelada reconcilie outro coordenador ativo do mesmo alvo.

## Alterações

- limita a reconciliação ao `coordinator_run_id` que originou o evento;
- deixa a manutenção regular de staging ocorrer somente após a jornada sintética autenticada concluída;
- mantém falhas e cancelamentos no caminho fail-closed do broker de emergência.

## Validação

- testes de watchdog, proteção de ambiente, disponibilidade do módulo e governança global;
- validação estática da política de release progressivo.

## Rollback

Reverter este commit restaura o comportamento anterior; a manutenção atual permanece fail-closed independentemente do merge.