### PR TITLE
fix(ponto): ignore preflight-cancelled watchdog roots

### DIFF
--- a/.github/scripts/ponto-watchdog-context.mjs
+++ b/.github/scripts/ponto-watchdog-context.mjs
@@ -58,9 +58,10 @@ export async function validateWatchdogContext({
   });
   const eventRun = event?.workflow_run;
   if (!Number.isInteger(eventRun?.id)) throw new Error("workflow_run event is absent");
-  const [workflow, run] = await Promise.all([
+  const [workflow, run, jobs] = await Promise.all([
     request(`/repos/${repository}/actions/workflows/ponto-progressive-release.yml`),
     request(`/repos/${repository}/actions/runs/${eventRun.id}`),
+    request(`/repos/${repository}/actions/runs/${eventRun.id}/jobs?per_page=100`),
   ]);
   const match = TITLE.exec(String(run?.display_title || ""));
   const sourceMatchesRelease = sourceMatchesImmutableRelease(
@@ -105,7 +106,14 @@ export async function validateWatchdogContext({
     || eventRun.conclusion !== run.conclusion
   ) throw new Error("failed coordinator provenance is invalid");
   const stage = match[1];
+  // Only an entered orchestrate job can acquire the composite release lease or
+  // dispatch mutable child capabilities.  An explicit empty job inventory is
+  // therefore safe to ignore; an unavailable or malformed inventory remains
+  // fail-closed and preserves the existing recovery behavior.
+  const coordinatorStarted = !Array.isArray(jobs?.jobs)
+    || jobs.jobs.some((job) => job?.name === "orchestrate");
   const requiresClose = stage !== "preview"
+    && coordinatorStarted
     && (unauthorizedReplay || FAILURE_CONCLUSIONS.has(run.conclusion));
   return {
     schemaVersion: 1,

--- a/.github/scripts/ponto-watchdog-context.test.mjs
+++ b/.github/scripts/ponto-watchdog-context.test.mjs
@@ -36,7 +36,12 @@ const event = {
     conclusion: "failure",
   },
 };
-const request = async (pathname) => pathname.endsWith("ponto-progressive-release.yml") ? workflow : run;
+const jobs = { total_count: 1, jobs: [{ name: "orchestrate" }] };
+const request = async (pathname) => {
+  if (pathname.endsWith("ponto-progressive-release.yml")) return workflow;
+  if (pathname.endsWith("/jobs?per_page=100")) return jobs;
+  return run;
+};
 const input = (overrides = {}) => ({
   event,
   repository,
@@ -62,9 +67,11 @@ test("watchdog accepts a closure-compatible main revision for an immutable relea
   const sourceChecks = [];
   const context = await validateWatchdogContext(input({
     event: { workflow_run: { ...event.workflow_run, head_sha: observedSha } },
-    request: async (pathname) => pathname.endsWith("ponto-progressive-release.yml")
-      ? workflow
-      : { ...run, head_sha: observedSha },
+    request: async (pathname) => {
+      if (pathname.endsWith("ponto-progressive-release.yml")) return workflow;
+      if (pathname.endsWith("/jobs?per_page=100")) return jobs;
+      return { ...run, head_sha: observedSha };
+    },
     assertReleaseSource: (releaseSha, currentSha) => {
       sourceChecks.push([releaseSha, currentSha]);
     },
@@ -84,9 +91,11 @@ test("watchdog closes both successful and failed unauthorized reruns", async () 
           conclusion,
         },
       },
-      request: async (pathname) => pathname.endsWith("ponto-progressive-release.yml")
-        ? workflow
-        : replay,
+      request: async (pathname) => {
+        if (pathname.endsWith("ponto-progressive-release.yml")) return workflow;
+        if (pathname.endsWith("/jobs?per_page=100")) return jobs;
+        return replay;
+      },
     }));
     assert.equal(context.unauthorizedReplay, true);
     assert.equal(context.runAttempt, 2);
@@ -111,9 +120,11 @@ test("watchdog audits a preview rerun without assigning a live target or closing
           conclusion,
         },
       },
-      request: async (pathname) => pathname.endsWith("ponto-progressive-release.yml")
-        ? workflow
-        : replay,
+      request: async (pathname) => {
+        if (pathname.endsWith("ponto-progressive-release.yml")) return workflow;
+        if (pathname.endsWith("/jobs?per_page=100")) return jobs;
+        return replay;
+      },
     }));
     assert.equal(context.stage, "preview");
     assert.equal(context.unauthorizedReplay, true);
@@ -131,9 +142,11 @@ test("watchdog treats first-attempt success as a no-op and rejects provenance dr
           conclusion: "success",
         },
       },
-      request: async (pathname) => pathname.endsWith("ponto-progressive-release.yml")
-        ? workflow
-        : { ...run, conclusion: "success" },
+      request: async (pathname) => {
+        if (pathname.endsWith("ponto-progressive-release.yml")) return workflow;
+        if (pathname.endsWith("/jobs?per_page=100")) return jobs;
+        return { ...run, conclusion: "success" };
+      },
     }));
     assert.equal(context.conclusion, "success");
     assert.equal(context.requiresClose, false);
@@ -141,9 +154,11 @@ test("watchdog treats first-attempt success as a no-op and rejects provenance dr
   });
   await t.test("wrong path", async () => {
     await assert.rejects(validateWatchdogContext(input({
-      request: async (pathname) => pathname.endsWith("ponto-progressive-release.yml")
-        ? workflow
-        : { ...run, path: ".github/workflows/other.yml@refs/heads/main" },
+      request: async (pathname) => {
+        if (pathname.endsWith("ponto-progressive-release.yml")) return workflow;
+        if (pathname.endsWith("/jobs?per_page=100")) return jobs;
+        return { ...run, path: ".github/workflows/other.yml@refs/heads/main" };
+      },
     })));
   });
   await assert.rejects(validateWatchdogContext(input({ gitRef: "refs/heads/feature" })));
@@ -154,6 +169,30 @@ test("watchdog treats first-attempt success as a no-op and rejects provenance dr
   await assert.rejects(validateWatchdogContext(input({
     event: { workflow_run: { ...event.workflow_run, run_attempt: 2 } },
   })));
+});
+
+test("watchdog does not close a coordinator cancelled before orchestrate started", async () => {
+  const context = await validateWatchdogContext(input({
+    request: async (pathname) => {
+      if (pathname.endsWith("ponto-progressive-release.yml")) return workflow;
+      if (pathname.endsWith("/jobs?per_page=100")) return { total_count: 0, jobs: [] };
+      return { ...run, conclusion: "cancelled" };
+    },
+    event: { workflow_run: { ...event.workflow_run, conclusion: "cancelled" } },
+  }));
+  assert.equal(context.requiresClose, false);
+  assert.equal(context.passed, true);
+});
+
+test("watchdog preserves fail-close when the coordinator job inventory is ambiguous", async () => {
+  const context = await validateWatchdogContext(input({
+    request: async (pathname) => {
+      if (pathname.endsWith("ponto-progressive-release.yml")) return workflow;
+      if (pathname.endsWith("/jobs?per_page=100")) return {};
+      return run;
+    },
+  }));
+  assert.equal(context.requiresClose, true);
 });
 
 test("watchdog never rolls back after failed child reconciliation", () => {


### PR DESCRIPTION
# Summary

Fix the Ponto release watchdog so a duplicate coordinator cancelled before any jobs exist cannot emergency-close a different valid release root.

## Type of change
- [x] Fix

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (not needed: behavior is covered by the focused regression test)
- [x] Security behavior preserved: ambiguous GitHub job inventories remain fail-closed

## Evidence

- `node --test .github/scripts/ponto-watchdog-context.test.mjs .github/scripts/ponto-emergency-stop.test.mjs`
- `npm run codex:deploy-topology:test`
- Remote evidence: cancelled duplicate run `31630767315` returned an explicit empty jobs inventory.