### PR TITLE
fix(ponto): preserve readiness maintenance contract

### DIFF
--- a/api/test/gateway.test.mjs
+++ b/api/test/gateway.test.mjs
@@ -191,6 +191,45 @@ test('dedicated Ponto entrypoint gives authenticated Timekeeping writes a bounde
     resetBoundServiceResilienceForTest();
 });
 
+test('dedicated Ponto readiness preserves the authoritative maintenance contract', async () => {
+    resetBoundServiceResilienceForTest();
+    let bindingCalls = 0;
+    const response = await pontoCoreWorker.fetch(new Request('https://ponto-core.invalid/api/ponto/readiness'), {
+        PONTO_ROUTE_ONLY: 'true',
+        TIMEKEEPING: {
+            fetch: async () => {
+                bindingCalls += 1;
+                return new Response(JSON.stringify({
+                    service: 'workforce-timekeeping',
+                    ok: false,
+                    ready: false,
+                    code: 'MODULE_MAINTENANCE',
+                    availability: { state: 'maintenance', source: 'control' },
+                    versionMetadata: { releaseSha: 'a'.repeat(40) },
+                }), {
+                    status: 503,
+                    headers: { 'content-type': 'application/json; charset=utf-8' },
+                });
+            },
+        },
+        APP_VERSION: 'a'.repeat(40),
+        ENVIRONMENT: 'staging',
+        TIMEKEEPING_VERSION_ID: '33333333-3333-4333-8333-333333333333',
+        CF_VERSION_METADATA: { id: '22222222-2222-4222-8222-222222222222' },
+    }, {});
+
+    assert.equal(response.status, 503);
+    assert.equal(response.headers.get('x-skincos-dependency-status'), 'live');
+    const body = await response.json();
+    assert.equal(body.service, 'workforce-timekeeping');
+    assert.equal(body.ready, false);
+    assert.equal(body.code, 'MODULE_MAINTENANCE');
+    assert.equal(body.availability.state, 'maintenance');
+    assert.equal(body.versionMetadata.releaseSha, 'a'.repeat(40));
+    assert.equal(bindingCalls, 1);
+    resetBoundServiceResilienceForTest();
+});
+
 test('dedicated Ponto Wrangler config has private, independent staging and production services', async () => {
     const config = await readFile(new URL('../wrangler.ponto.toml', import.meta.url), 'utf8');
     assert.match(config, /^name = "skincos-ponto-core"$/m);

--- a/api/workers/ponto.js
+++ b/api/workers/ponto.js
@@ -22,6 +22,10 @@ function timekeepingTimeout(request) {
         : TIMEKEEPING_WRITE_TIMEOUT_MS;
 }
 
+function isPontoReadiness(request) {
+    return request.method === 'GET' && new URL(request.url).pathname === '/api/ponto/readiness';
+}
+
 const handlePontoCoreRequest = createGatewayHandler({
     // The route-only guard makes this handler unreachable. Keeping an explicit
     // fail-closed implementation also prevents a future router refactor from
@@ -40,7 +44,13 @@ const handlePontoCoreRequest = createGatewayHandler({
         prepareTimekeepingRequest(request, env),
         env,
         'TIMEKEEPING',
-        { timeoutMs: timekeepingTimeout(request) },
+        {
+            timeoutMs: timekeepingTimeout(request),
+            // A 503 from the Timekeeping readiness route is the authoritative
+            // fail-closed Ponto contract, not a transport outage. Preserve its
+            // release identity, dependencies and maintenance reason end-to-end.
+            passThroughErrorStatuses: isPontoReadiness(request) ? [503] : [],
+        },
     ),
 });
 

--- a/shared/service-adapters/cloudflare-service-binding.js
+++ b/shared/service-adapters/cloudflare-service-binding.js
@@ -7,10 +7,21 @@ function degradedResponse(bindingName, mode) {
   return new Response(JSON.stringify({ ok: false, error: 'domain_service_degraded', dependency: bindingName, mode, pendingSynchronization: true }), { status: 503, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', 'x-skincos-dependency-status': mode, 'x-skincos-sync-state': 'pending' } });
 }
 
-export async function fetchBoundService(request, env, bindingName, { timeoutMs = 800, failureThreshold = 2, cooldownMs = 15_000, cacheTtlMs = 0 } = {}) {
+export async function fetchBoundService(request, env, bindingName, {
+  timeoutMs = 800,
+  failureThreshold = 2,
+  cooldownMs = 15_000,
+  cacheTtlMs = 0,
+  passThroughErrorStatuses = [],
+} = {}) {
   const binding = env?.[bindingName]; if (!binding || typeof binding.fetch !== 'function') return degradedResponse(bindingName, 'unavailable');
+  const passThroughStatuses = new Set(
+    Array.isArray(passThroughErrorStatuses)
+      ? passThroughErrorStatuses.filter((status) => Number.isInteger(status) && status >= 400 && status <= 599)
+      : [],
+  );
   const cacheKey = request.method === 'GET' && cacheTtlMs > 0 ? `${bindingName}:${request.url}` : null;
-  const result = await callOptionalDependency({ dependency: bindingName, state: serviceDependencyState, cache: safeResponseCache, cacheKey, cacheTtlMs, timeoutMs, failureThreshold, cooldownMs, invoke: async (signal) => { const response = await binding.fetch(new Request(request, { signal })); if (response.status >= 500) throw new Error(`upstream status ${response.status}`); return cacheKey ? response.clone() : response; }, fallback: ({ mode }) => degradedResponse(bindingName, mode) });
+  const result = await callOptionalDependency({ dependency: bindingName, state: serviceDependencyState, cache: safeResponseCache, cacheKey, cacheTtlMs, timeoutMs, failureThreshold, cooldownMs, invoke: async (signal) => { const response = await binding.fetch(new Request(request, { signal })); if (response.status >= 500 && !passThroughStatuses.has(response.status)) throw new Error(`upstream status ${response.status}`); return cacheKey ? response.clone() : response; }, fallback: ({ mode }) => degradedResponse(bindingName, mode) });
   const response = result.mode === 'live' ? result.value : result.value.clone ? result.value.clone() : result.value;
   const headers = new Headers(response.headers); headers.set('x-skincos-dependency-status', result.mode); headers.set('x-skincos-sync-state', result.pendingSynchronization ? 'pending' : 'current');
   return new Response(response.body, { status: response.status, statusText: response.statusText, headers });


### PR DESCRIPTION
## Objetivo
Preservar o contrato autoritativo de GET /api/ponto/readiness quando o Ponto está em manutenção. O endpoint continua retornando HTTP 503 e ready:false, mas passa a devolver o JSON completo do Timekeeping (identidade de release, dependências e motivo de manutenção), sem conversão para uma resposta genérica do adaptador.

## Superfícies e risco
- Ponto Core Worker e adaptador de service binding.
- Sem migration, flag, grant, coorte ou escrita de dados.
- Risco alto de contrato operacional, reduzido por alteração limitada ao readiness do Ponto. Outros 5xx de serviços continuam degradando fail-closed.

## Validação
- node --test api/test/gateway.test.mjs workforce/timekeeping/worker.test.js
- 73 testes aprovados, incluindo o novo caso de preservação de MODULE_MAINTENANCE.

## Rollback
Reverter este PR ou restaurar o candidato imutável anterior. A mudança não altera dados, controle de módulo nem permissões.

## Próximo gate
Após merge, criar um novo candidato imutável e repetir preview + staging, pois esta mudança pertence à closure do Ponto.