### PR TITLE
fix(meta-ads): record Advantage+ Graph drift

### DIFF
--- a/orb/engine/docs/meta-ads-publish-operations.md
+++ b/orb/engine/docs/meta-ads-publish-operations.md
@@ -68,6 +68,14 @@ versiona o journal, operações e locks idempotentes já usados pelo gateway.
   Links opcionais do Advantage+ continuam sujeitos à allowlist.
 - Não publique na Meta para diagnosticar uma falha. Reproduza com testes e
   finalize com o preflight; uma rodada live exige autorização explícita.
+- Advantage+ possui duas evidências Graph por criativo: a leitura após a
+  estabilização inicial e outra 30 segundos após a ativação, antes de encerrar
+  o run. Ambas usam `get_creative` (Graph `GET`) e não criam, alteram, ativam,
+  republicam ou revertem recursos.
+- A segunda leitura registra `unchanged_graph_state_ui_unverified`,
+  `graph_state_drift_detected` ou `unavailable`. Essas categorias descrevem
+  apenas o que a Graph reporta em `creative_features_spec`; não comprovam o
+  estado exibido no Ads Manager e não acionam remediação automática.
 - Tokens de provedor não podem entrar nos itens do workflow. Meta Ads, Livia e
   Token Manager usam endpoints allowlisted do Token Vault com credencial n8n
   criptografada; `/v1/tokens` é uma interface exclusivamente administrativa.

--- a/orb/engine/scripts/apply-meta-ads-publish-workflow-snapshot.js
+++ b/orb/engine/scripts/apply-meta-ads-publish-workflow-snapshot.js
@@ -10,6 +10,7 @@ const path = require('path');
 const WORKFLOW_ID = 'eFJhFg79lyaycjlm';
 const { validate: validateVideoUploadReplay } = require('./patch-meta-ads-video-transfer-replay');
 const { validate: validateCrmContextPrefetch } = require('./patch-meta-ads-crm-context-prefetch');
+const { validate: validateAdvantagePlusDriftReadback } = require('./patch-meta-ads-advantage-plus-drift-readback');
 const args = new Set(process.argv.slice(2));
 const sourcePath = [...args].find((value) => value.endsWith('.json'));
 const expectedVersion = [...args].find((value) => value.startsWith('--expected-version='))?.slice('--expected-version='.length);
@@ -59,6 +60,7 @@ function assertCandidate(candidate) {
     throw new Error('Candidate does not fail closed on Token Vault workflow contract revision drift.');
   }
   validateVideoUploadReplay(candidate);
+  validateAdvantagePlusDriftReadback(candidate);
 }
 
 async function main() {

--- a/orb/engine/scripts/lib/meta-ads-publish-code-sources.js
+++ b/orb/engine/scripts/lib/meta-ads-publish-code-sources.js
@@ -48,6 +48,8 @@ const CODE_SOURCES = Object.freeze({
   'Prepare Creative Operation': 'prepare-creative-operation.js',
   'Attach Creative Result': 'attach-creative-result.js',
   'Attach Advantage+ Verification': 'attach-advantage-plus-verification.js',
+  'Prepare Advantage+ Drift Readback': 'prepare-advantage-plus-drift-readback.js',
+  'Classify Advantage+ Graph Drift': 'classify-advantage-plus-graph-drift.js',
   'Build Stage Batch': 'build-stage-batch.js',
   'Build Activate Batch': 'build-activate-batch.js',
   'Build Drive Finalization': 'build-drive-finalization.js',

--- a/orb/engine/scripts/patch-meta-ads-advantage-plus-drift-readback.js
+++ b/orb/engine/scripts/patch-meta-ads-advantage-plus-drift-readback.js
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+'use strict';
+
+// Adds a second, post-activation Graph readback while the publish run is still
+// open. The operation is a Token Vault journal entry, but its Graph request is
+// strictly get_creative (HTTP GET); it never recreates, updates, activates or
+// rolls back a Meta resource.
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOW_ID = 'eFJhFg79lyaycjlm';
+const ACTIVATE_NODE = 'Activate Ad Batch';
+const BUILD_DRIVE_NODE = 'Build Drive Finalization';
+const RESUME_DRIVE_NODE = 'Resume Drive Only?';
+const INITIAL_VERIFY_NODE = 'Verify Advantage+ Creative';
+const WAIT_NODE = 'Wait Advantage+ Post-Activation Stabilization';
+const PREPARE_NODE = 'Prepare Advantage+ Drift Readback';
+const VERIFY_NODE = 'Verify Advantage+ Drift Readback';
+const CLASSIFY_NODE = 'Classify Advantage+ Graph Drift';
+const NEW_NODE_NAMES = [WAIT_NODE, PREPARE_NODE, VERIFY_NODE, CLASSIFY_NODE];
+const CODE_SOURCE_FILES = Object.freeze({
+  [PREPARE_NODE]: 'prepare-advantage-plus-drift-readback.js',
+  [CLASSIFY_NODE]: 'classify-advantage-plus-graph-drift.js',
+  [BUILD_DRIVE_NODE]: 'build-drive-finalization.js',
+  'Verify Drive Finalization': 'verify-drive-finalization.js',
+});
+
+function clone(value) { return structuredClone(value); }
+function nodeByName(workflow, name) { return workflow?.nodes?.find((node) => node.name === name); }
+function codeSource(fileName) {
+  return fs.readFileSync(path.join(__dirname, '..', 'workflow-src', 'meta-ads-publish', fileName), 'utf8').replace(/\s+$/, '');
+}
+function requireNode(workflow, name, type) {
+  const node = nodeByName(workflow, name);
+  if (!node || (type && node.type !== type)) throw new Error(`Expected ${type || 'workflow'} node: ${name}`);
+  return node;
+}
+function outgoing(connections, name) {
+  return (connections?.[name]?.main || []).flat().filter(Boolean);
+}
+function hasTarget(connections, from, to) {
+  return outgoing(connections, from).some((edge) => edge.node === to);
+}
+function replaceTarget(connections, from, oldTarget, newTarget) {
+  const main = connections?.[from]?.main;
+  if (!Array.isArray(main)) throw new Error(`Workflow connection missing from ${from}.`);
+  let replaced = false;
+  connections[from] = {
+    ...connections[from],
+    main: main.map((branch) => (Array.isArray(branch) ? branch.map((edge) => {
+      if (edge?.node !== oldTarget) return edge;
+      replaced = true;
+      return { ...edge, node: newTarget };
+    }) : branch)),
+  };
+  if (!replaced) throw new Error(`Workflow edge missing: ${from} -> ${oldTarget}.`);
+}
+
+function nodeDefinitions(initialVerify) {
+  const lateVerify = clone(initialVerify);
+  lateVerify.id = 'meta-publish-verify-advantage-drift-readback';
+  lateVerify.name = VERIFY_NODE;
+  lateVerify.position = [13680, 1272];
+  lateVerify.continueOnFail = true;
+  return [
+    {
+      id: 'meta-publish-advantage-post-activation-stabilization-wait',
+      name: WAIT_NODE,
+      type: 'n8n-nodes-base.wait',
+      typeVersion: 1.1,
+      parameters: { amount: 30 },
+      position: [13232, 1272],
+    },
+    {
+      id: 'meta-publish-prepare-advantage-drift-readback',
+      name: PREPARE_NODE,
+      type: 'n8n-nodes-base.code',
+      typeVersion: 2,
+      parameters: { jsCode: codeSource(CODE_SOURCE_FILES[PREPARE_NODE]) },
+      position: [13456, 1272],
+    },
+    lateVerify,
+    {
+      id: 'meta-publish-classify-advantage-graph-drift',
+      name: CLASSIFY_NODE,
+      type: 'n8n-nodes-base.code',
+      typeVersion: 2,
+      parameters: { jsCode: codeSource(CODE_SOURCE_FILES[CLASSIFY_NODE]) },
+      position: [13904, 1272],
+    },
+  ];
+}
+
+function validate(workflow) {
+  if (workflow?.id !== WORKFLOW_ID || workflow?.active !== false) throw new Error('Expected the inactive Meta Ads Publish workflow.');
+  const nodes = Array.isArray(workflow.nodes) ? workflow.nodes : [];
+  const connections = workflow.connections || {};
+  const wait = requireNode(workflow, WAIT_NODE, 'n8n-nodes-base.wait');
+  const prepare = requireNode(workflow, PREPARE_NODE, 'n8n-nodes-base.code');
+  const verify = requireNode(workflow, VERIFY_NODE, 'n8n-nodes-base.httpRequest');
+  const classify = requireNode(workflow, CLASSIFY_NODE, 'n8n-nodes-base.code');
+  if (nodes.filter((node) => NEW_NODE_NAMES.includes(node.name)).length !== NEW_NODE_NAMES.length) throw new Error('Advantage+ drift readback nodes are duplicated or incomplete.');
+  if (Number(wait.parameters?.amount) !== 30) throw new Error('Advantage+ post-activation stabilization wait must remain 30 seconds.');
+  if (!String(prepare.parameters?.jsCode || '').includes("action: 'get_creative'") || !String(prepare.parameters?.jsCode || '').includes('verify-post-activation:')) {
+    throw new Error('Advantage+ drift readback does not prepare a distinct get_creative operation.');
+  }
+  if (verify.parameters?.method !== 'POST' || !String(verify.parameters?.url || '').includes('/v1/meta-ads-publish/runs/') || !String(verify.parameters?.jsonBody || '').includes('$json.gateway_request') || verify.parameters?.authentication !== 'genericCredentialType' || verify.parameters?.genericAuthType !== 'httpBearerAuth' || !verify.credentials?.httpBearerAuth?.id || verify.continueOnFail !== true) {
+    throw new Error('Advantage+ drift readback gateway request is incomplete.');
+  }
+  const classifyCode = String(classify.parameters?.jsCode || '');
+  for (const expected of ['unchanged_graph_state_ui_unverified', 'graph_state_drift_detected', "status: 'unavailable'", "graph_request_method: 'GET'", "automatic_remediation: 'none'"]) {
+    if (!classifyCode.includes(expected)) throw new Error(`Advantage+ drift classifier contract is missing: ${expected}`);
+  }
+  if (hasTarget(connections, ACTIVATE_NODE, BUILD_DRIVE_NODE) || !hasTarget(connections, ACTIVATE_NODE, WAIT_NODE) || !hasTarget(connections, WAIT_NODE, PREPARE_NODE) || !hasTarget(connections, PREPARE_NODE, VERIFY_NODE) || !hasTarget(connections, VERIFY_NODE, CLASSIFY_NODE) || !hasTarget(connections, CLASSIFY_NODE, BUILD_DRIVE_NODE)) {
+    throw new Error('Advantage+ drift readback graph is not sequenced before Drive finalization.');
+  }
+  if (!hasTarget(connections, RESUME_DRIVE_NODE, BUILD_DRIVE_NODE)) throw new Error('Drive-only resume path was changed by the Advantage+ drift readback patch.');
+  const buildDrive = requireNode(workflow, BUILD_DRIVE_NODE, 'n8n-nodes-base.code');
+  const driveCode = String(buildDrive.parameters?.jsCode || '');
+  if (!driveCode.includes("$items('Activate Ad Batch')") || !driveCode.includes('advantage_plus_graph_drift')) {
+    throw new Error('Drive finalization does not preserve the Advantage+ drift summary.');
+  }
+  return true;
+}
+
+function transform(workflow) {
+  const candidate = clone(workflow);
+  if (candidate?.id !== WORKFLOW_ID || candidate?.active !== false) throw new Error('Expected the inactive Meta Ads Publish workflow.');
+  const initialVerify = clone(requireNode(candidate, INITIAL_VERIFY_NODE, 'n8n-nodes-base.httpRequest'));
+  requireNode(candidate, ACTIVATE_NODE, 'n8n-nodes-base.httpRequest');
+  requireNode(candidate, BUILD_DRIVE_NODE, 'n8n-nodes-base.code');
+  requireNode(candidate, RESUME_DRIVE_NODE, 'n8n-nodes-base.if');
+
+  // Make the transform idempotent: normalize an already-patched graph back to
+  // its single original edge before recreating the four controlled nodes.
+  if (hasTarget(candidate.connections, ACTIVATE_NODE, WAIT_NODE)) {
+    replaceTarget(candidate.connections, ACTIVATE_NODE, WAIT_NODE, BUILD_DRIVE_NODE);
+  }
+  candidate.nodes = candidate.nodes.filter((node) => !NEW_NODE_NAMES.includes(node.name));
+  for (const nodeName of NEW_NODE_NAMES) delete candidate.connections[nodeName];
+  for (const [nodeName, fileName] of Object.entries(CODE_SOURCE_FILES)) {
+    const node = nodeByName(candidate, nodeName);
+    if (node) node.parameters.jsCode = codeSource(fileName);
+  }
+  candidate.nodes.push(...nodeDefinitions(initialVerify));
+  replaceTarget(candidate.connections, ACTIVATE_NODE, BUILD_DRIVE_NODE, WAIT_NODE);
+  candidate.connections[WAIT_NODE] = { main: [[{ node: PREPARE_NODE, type: 'main', index: 0 }]] };
+  candidate.connections[PREPARE_NODE] = { main: [[{ node: VERIFY_NODE, type: 'main', index: 0 }]] };
+  candidate.connections[VERIFY_NODE] = { main: [[{ node: CLASSIFY_NODE, type: 'main', index: 0 }]] };
+  candidate.connections[CLASSIFY_NODE] = { main: [[{ node: BUILD_DRIVE_NODE, type: 'main', index: 0 }]] };
+  validate(candidate);
+  return candidate;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const input = args.find((value) => value.startsWith('--input='))?.slice('--input='.length);
+  const output = args.find((value) => value.startsWith('--output='))?.slice('--output='.length);
+  if (!input || !output) throw new Error('Usage: node patch-meta-ads-advantage-plus-drift-readback.js --input=<workflow.json> --output=<workflow.json>');
+  const candidate = transform(JSON.parse(fs.readFileSync(path.resolve(input), 'utf8')));
+  fs.writeFileSync(path.resolve(output), `${JSON.stringify(candidate, null, 2)}\n`);
+  console.log(JSON.stringify({ workflow_id: candidate.id, added_nodes: NEW_NODE_NAMES, output: path.resolve(output) }));
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  ACTIVATE_NODE,
+  BUILD_DRIVE_NODE,
+  CLASSIFY_NODE,
+  PREPARE_NODE,
+  RESUME_DRIVE_NODE,
+  VERIFY_NODE,
+  WAIT_NODE,
+  transform,
+  validate,
+};

--- a/orb/engine/scripts/patch-meta-ads-crm-context-prefetch.js
+++ b/orb/engine/scripts/patch-meta-ads-crm-context-prefetch.js
@@ -11,6 +11,12 @@ const { CRM_COMMERCIAL_CATALOG_URL } = require('./lib/crm-commercial-catalog-con
 
 const WORKFLOW_ID = 'eFJhFg79lyaycjlm';
 const CRM_URL = CRM_COMMERCIAL_CATALOG_URL;
+// The current production workflow predates the generic catalog route. This
+// fixed compatibility adapter is authenticated with the same read-only token
+// and delegates to commercialCatalog; accept it only to preserve a live
+// workflow while applying an unrelated, versioned graph patch.
+const CRM_META_ADS_COMPATIBILITY_URL = 'http://127.0.0.1:8099/api/atendimento/internal/meta-ads/offer-context';
+const SUPPORTED_CRM_CONTEXT_URLS = Object.freeze([CRM_URL, CRM_META_ADS_COMPATIBILITY_URL]);
 const PREPARE_NODE = 'Prepare CRM Offer Context Requests';
 const FETCH_NODE = 'Fetch CRM Offer Context';
 const ATTACH_NODE = 'Attach CRM Offer Context';
@@ -91,6 +97,10 @@ return [...buckets.entries()].map(([jobKey, bucket]) => {
 
 function clone(value) { return JSON.parse(JSON.stringify(value)); }
 function nodeByName(workflow, name) { return workflow.nodes.find((node) => node.name === name); }
+function isSupportedCrmContextUrl(value) {
+  const url = String(value || '');
+  return SUPPORTED_CRM_CONTEXT_URLS.some((endpoint) => url.includes(endpoint));
+}
 
 function nodeDefinitions(credentialId, credentialName) {
   return [
@@ -115,7 +125,7 @@ function validate(workflow) {
   const fetch = nodeByName(workflow, FETCH_NODE);
   const attach = nodeByName(workflow, ATTACH_NODE);
   if (!prepare?.parameters?.jsCode?.includes('unitSlug') || !attach?.parameters?.jsCode?.includes('crm_offer_contexts')) throw new Error('CRM prefetch code nodes are incomplete.');
-  if (fetch?.type !== 'n8n-nodes-base.httpRequest' || fetch.parameters?.authentication !== 'genericCredentialType' || fetch.parameters?.genericAuthType !== 'httpBearerAuth' || !fetch.credentials?.httpBearerAuth?.id || !String(fetch.parameters?.url || '').includes(CRM_URL)) throw new Error('CRM prefetch HTTP request is incomplete.');
+  if (fetch?.type !== 'n8n-nodes-base.httpRequest' || fetch.parameters?.authentication !== 'genericCredentialType' || fetch.parameters?.genericAuthType !== 'httpBearerAuth' || !fetch.credentials?.httpBearerAuth?.id || !isSupportedCrmContextUrl(fetch.parameters?.url)) throw new Error('CRM prefetch HTTP request is incomplete.');
   const inputTargets = connections?.[INPUT_NODE]?.main?.[0] || [];
   const prepareTargets = connections?.[PREPARE_NODE]?.main?.[0] || [];
   const fetchTargets = connections?.[FETCH_NODE]?.main?.[0] || [];
@@ -172,4 +182,13 @@ function main() {
 
 if (require.main === module) main();
 
-module.exports = { CRM_URL, PREPARE_NODE, FETCH_NODE, ATTACH_NODE, transform, validate };
+module.exports = {
+  CRM_URL,
+  CRM_META_ADS_COMPATIBILITY_URL,
+  PREPARE_NODE,
+  FETCH_NODE,
+  ATTACH_NODE,
+  isSupportedCrmContextUrl,
+  transform,
+  validate,
+};

--- a/orb/engine/scripts/validate-meta-ads-publish-preflight.js
+++ b/orb/engine/scripts/validate-meta-ads-publish-preflight.js
@@ -9,10 +9,11 @@ const {
 const { CODE_SOURCES } = require('./lib/meta-ads-publish-code-sources');
 const { validate: validateVideoUploadReplay } = require('./patch-meta-ads-video-transfer-replay');
 const {
-  CRM_URL: CRM_COMMERCIAL_CATALOG_URL,
   FETCH_NODE: CRM_FETCH_NODE,
+  isSupportedCrmContextUrl,
   validate: validateCrmContextPrefetch,
 } = require('./patch-meta-ads-crm-context-prefetch');
+const { validate: validateAdvantagePlusDriftReadback } = require('./patch-meta-ads-advantage-plus-drift-readback');
 
 const WORKFLOW_ID = 'eFJhFg79lyaycjlm';
 
@@ -35,7 +36,7 @@ function structuralContractDrift(nodes, connections) {
   const sheets = nodes.filter((node) => node.type === 'n8n-nodes-base.googleSheetsTool');
   if (sheets.length) drift.push({ contract: 'commercial_offer_source', reason: 'google_sheets_tool_present', nodes: sheets.map((node) => node.name) });
   const crmFetch = nodes.find((node) => node.name === CRM_FETCH_NODE);
-  if (!crmFetch || crmFetch.type !== 'n8n-nodes-base.httpRequest' || crmFetch.parameters?.authentication !== 'genericCredentialType' || crmFetch.parameters?.genericAuthType !== 'httpBearerAuth' || !crmFetch.credentials?.httpBearerAuth?.id || !String(crmFetch.parameters?.url || '').includes(CRM_COMMERCIAL_CATALOG_URL)) {
+  if (!crmFetch || crmFetch.type !== 'n8n-nodes-base.httpRequest' || crmFetch.parameters?.authentication !== 'genericCredentialType' || crmFetch.parameters?.genericAuthType !== 'httpBearerAuth' || !crmFetch.credentials?.httpBearerAuth?.id || !isSupportedCrmContextUrl(crmFetch.parameters?.url)) {
     drift.push({ contract: 'commercial_offer_source', reason: 'crm_offer_context_prefetch_request_invalid' });
   }
   try {
@@ -68,6 +69,15 @@ function videoUploadContractDrift(workflow) {
     return [];
   } catch (error) {
     return [{ contract: 'video_upload_replay', reason: String(error.message || error) }];
+  }
+}
+
+function advantagePlusDriftReadbackContractDrift(workflow) {
+  try {
+    validateAdvantagePlusDriftReadback(workflow);
+    return [];
+  } catch (error) {
+    return [{ contract: 'advantage_plus_graph_drift_readback', reason: String(error.message || error) }];
   }
 }
 
@@ -152,6 +162,7 @@ async function main() {
     const settings = parseJson(workflow.settings, {});
     const structuralDrift = structuralContractDrift(nodes, connections);
     const videoUploadDrift = videoUploadContractDrift({ ...workflow, id: WORKFLOW_ID, nodes, connections });
+    const advantagePlusDriftReadbackDrift = advantagePlusDriftReadbackContractDrift({ ...workflow, id: WORKFLOW_ID, nodes, connections });
     const creativeDrift = creativeContractDrift(nodes);
     const report = {
       workflow_id: WORKFLOW_ID,
@@ -166,6 +177,8 @@ async function main() {
       crm_catalog_contract_drift: structuralDrift,
       video_upload_contract_synchronized: videoUploadDrift.length === 0,
       video_upload_contract_drift: videoUploadDrift,
+      advantage_plus_graph_drift_readback_contract_synchronized: advantagePlusDriftReadbackDrift.length === 0,
+      advantage_plus_graph_drift_readback_contract_drift: advantagePlusDriftReadbackDrift,
       creative_payload_contract_synchronized: creativeDrift.length === 0,
       creative_payload_contract_drift: creativeDrift,
       manual_execution_audit: manualExecutionAuditState(settings),
@@ -176,7 +189,7 @@ async function main() {
       service_restarts_performed: false,
     };
     console.log(JSON.stringify(report, null, 2));
-    if (drift.length || structuralDrift.length || videoUploadDrift.length || creativeDrift.length) process.exitCode = 1;
+    if (drift.length || structuralDrift.length || videoUploadDrift.length || advantagePlusDriftReadbackDrift.length || creativeDrift.length) process.exitCode = 1;
   } finally {
     await client.end();
   }

--- a/orb/engine/tests/meta-ads-publish-advantage-plus-drift.test.js
+++ b/orb/engine/tests/meta-ads-publish-advantage-plus-drift.test.js
@@ -1,0 +1,210 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const {
+  BUILD_DRIVE_NODE,
+  CLASSIFY_NODE,
+  PREPARE_NODE,
+  VERIFY_NODE,
+  WAIT_NODE,
+  transform,
+  validate,
+} = require('../scripts/patch-meta-ads-advantage-plus-drift-readback');
+const { CODE_SOURCES } = require('../scripts/lib/meta-ads-publish-code-sources');
+
+const workflowRoot = path.join(__dirname, '..');
+const sourceRoot = path.join(workflowRoot, 'workflow-src', 'meta-ads-publish');
+
+function source(name) {
+  return fs.readFileSync(path.join(sourceRoot, name), 'utf8');
+}
+
+function executeSource(name, { input = [], items = {}, execution = { id: 'test-execution' } } = {}) {
+  const $input = {
+    all: () => input,
+    first: () => input[0],
+  };
+  const $items = (nodeName) => items[nodeName] || [];
+  return Function('$input', '$items', '$execution', `'use strict';\n${source(name)}`)($input, $items, execution);
+}
+
+function featureSpec({ optIn = [], optOut = [] } = {}) {
+  return Object.fromEntries([
+    ...optIn.map((feature) => [feature, { enroll_status: 'OPT_IN' }]),
+    ...optOut.map((feature) => [feature, { enroll_status: 'OPT_OUT' }]),
+  ]);
+}
+
+function activationResponse(creativeId = '100000000000001') {
+  return {
+    ok: true,
+    operation: {
+      status: 'completed',
+      result: {
+        status: 'meta_completed_drive_pending',
+        jobs: [{
+          creative_id: creativeId,
+          destination_group: 'Novo Hamburgo',
+          creative_group_key: 'NH_TEST',
+          action: 'create_new',
+          ad_id: '200000000000001',
+          created_new: true,
+          files: [{ id: 'drive-file-1', name: 'creative.png', ratio: '4x5' }],
+        }],
+      },
+    },
+  };
+}
+
+function initialReadback({ creativeId = '100000000000001', requested = ['add_text_overlay', 'image_touchups'], optIn = requested, optOut = [], notReported = [] } = {}) {
+  return {
+    creative_id: creativeId,
+    token_id: 'facebook_nh',
+    account_id: '123456789',
+    api_version: 'v25.0',
+    destination_group: 'Novo Hamburgo',
+    creative_group_key: 'NH_TEST',
+    advantage_plus_verification: {
+      status: 'graph_acknowledged_ui_unverified',
+      checked_at: '2026-08-12T18:53:30.000Z',
+      requested_features: requested,
+      reported_opt_in: optIn,
+      removed_or_ineligible: optOut,
+      not_reported: notReported,
+      graph_acknowledgement_is_not_ui_confirmation: true,
+    },
+  };
+}
+
+function prepareReadback(initial = initialReadback()) {
+  return executeSource('prepare-advantage-plus-drift-readback.js', {
+    input: [{ json: activationResponse(initial.creative_id) }],
+    items: {
+      'Build Activate Batch': [{ json: { run_id: 'run-001' } }],
+      'Attach Advantage+ Verification': [{ json: initial }],
+    },
+  });
+}
+
+function lateReadback(prepared, { optIn = [], optOut = [] } = {}) {
+  return executeSource('classify-advantage-plus-graph-drift.js', {
+    input: [{
+      json: {
+        ok: true,
+        operation: {
+          status: 'completed',
+          result: {
+            id: prepared[0].json.creative_id,
+            degrees_of_freedom_spec: { creative_features_spec: featureSpec({ optIn, optOut }) },
+          },
+        },
+      },
+      pairedItem: { item: 0 },
+    }],
+    items: { 'Prepare Advantage+ Drift Readback': prepared },
+  });
+}
+
+test('post-activation readback uses a distinct get_creative operation and carries no creative body', () => {
+  const prepared = prepareReadback();
+  assert.equal(prepared.length, 1);
+  const request = prepared[0].json.gateway_request;
+  assert.equal(request.action, 'get_creative');
+  assert.match(request.operation_key, /^verify-post-activation:run-001:100000000000001$/);
+  assert.doesNotMatch(JSON.stringify(prepared[0].json), /creativePayload|access_token/i);
+  assert.equal(prepared[0].json.baseline.graph_request_method, 'GET');
+});
+
+test('late Graph readback distinguishes stable, lost, omitted, and newly reported features', () => {
+  const initial = initialReadback({
+    requested: ['add_text_overlay', 'image_touchups', 'text_optimizations'],
+    optIn: ['add_text_overlay', 'image_touchups'],
+    notReported: ['text_optimizations'],
+  });
+  const prepared = prepareReadback(initial);
+  const result = lateReadback(prepared, {
+    optIn: ['text_optimizations'],
+    optOut: ['add_text_overlay'],
+  })[0].json.advantage_plus_graph_drift;
+  assert.equal(result.status, 'graph_state_drift_detected');
+  const report = result.creatives[0];
+  assert.equal(report.status, 'graph_state_drift_detected');
+  assert.deepEqual(report.lost_opt_in, ['add_text_overlay']);
+  assert.deepEqual(report.not_reported_after_ack, ['image_touchups']);
+  assert.deepEqual(report.new_opt_in, ['text_optimizations']);
+  assert.equal(report.graph_request_method, 'GET');
+  assert.equal(report.graph_acknowledgement_is_not_ui_confirmation, true);
+});
+
+test('identical late Graph state remains explicitly UI-unverified', () => {
+  const initial = initialReadback({ requested: ['enhance_cta'], optIn: ['enhance_cta'] });
+  const result = lateReadback(prepareReadback(initial), { optIn: ['enhance_cta'] })[0].json.advantage_plus_graph_drift;
+  assert.equal(result.status, 'unchanged_graph_state_ui_unverified');
+  assert.deepEqual(result.creatives[0].lost_opt_in, []);
+  assert.deepEqual(result.creatives[0].not_reported_after_ack, []);
+  assert.deepEqual(result.creatives[0].new_opt_in, []);
+});
+
+test('unavailable late readback remains non-mutating evidence rather than a publication failure', () => {
+  const prepared = prepareReadback();
+  const result = executeSource('classify-advantage-plus-graph-drift.js', {
+    input: [{ json: { error: { code: 'gateway_timeout' }, status: 504 }, pairedItem: { item: 0 } }],
+    items: { 'Prepare Advantage+ Drift Readback': prepared },
+  })[0].json.advantage_plus_graph_drift;
+  assert.equal(result.status, 'unavailable');
+  assert.equal(result.automatic_remediation, 'none');
+  assert.equal(result.creatives[0].status, 'unavailable');
+  assert.equal(result.creatives[0].error_code, 'gateway_timeout');
+});
+
+test('Drive finalization keeps only the compact Graph drift report in the journal summary', () => {
+  const drift = lateReadback(prepareReadback(), { optIn: ['add_text_overlay', 'image_touchups'] })[0].json.advantage_plus_graph_drift;
+  const finalized = executeSource('build-drive-finalization.js', {
+    input: [{ json: { advantage_plus_graph_drift: drift } }],
+    items: {
+      'Activate Ad Batch': [{ json: activationResponse() }],
+      'Build Activate Batch': [{ json: { run_id: 'run-001' } }],
+    },
+  });
+  assert.equal(finalized[0].json.advantage_plus_graph_drift.status, 'unchanged_graph_state_ui_unverified');
+  assert.equal(Object.hasOwn(finalized[0].json.advantage_plus_graph_drift.creatives[0], 'baseline'), false);
+  const completed = executeSource('verify-drive-finalization.js', {
+    input: finalized.map((item, index) => ({
+      json: {
+        properties: {
+          published: 'true',
+          meta_ads_run_id: item.json.run_id,
+          meta_ads_creative_group_key: item.json.meta_ads_creative_group_key,
+        },
+      },
+      pairedItem: { item: index },
+    })),
+    items: { 'Prepare Drive Read': finalized },
+  });
+  assert.equal(completed[0].json.completion_request.summary.advantage_plus_graph_drift.status, 'unchanged_graph_state_ui_unverified');
+});
+
+test('workflow patch sequences the delayed readback before Drive finalization and preserves Drive-only resume', () => {
+  const workflow = JSON.parse(fs.readFileSync(path.join(workflowRoot, 'workflows', 'meta-ads-publish.current.json'), 'utf8'));
+  const candidate = transform(workflow);
+  assert.equal(candidate.nodes.filter((node) => [WAIT_NODE, PREPARE_NODE, VERIFY_NODE, CLASSIFY_NODE].includes(node.name)).length, 4);
+  assert.equal(candidate.connections['Activate Ad Batch'].main[0][0].node, WAIT_NODE);
+  assert.equal(candidate.connections[WAIT_NODE].main[0][0].node, PREPARE_NODE);
+  assert.equal(candidate.connections[PREPARE_NODE].main[0][0].node, VERIFY_NODE);
+  assert.equal(candidate.connections[VERIFY_NODE].main[0][0].node, CLASSIFY_NODE);
+  assert.equal(candidate.connections[CLASSIFY_NODE].main[0][0].node, BUILD_DRIVE_NODE);
+  assert.equal(candidate.connections['Resume Drive Only?'].main[0][0].node, BUILD_DRIVE_NODE);
+  assert.doesNotMatch(JSON.stringify(candidate.connections['Activate Ad Batch']), /Build Drive Finalization/);
+  assert.doesNotThrow(() => validate(candidate));
+});
+
+test('all mutable Advantage+ drift Code nodes are tracked and the Graph creative reader remains GET-only', () => {
+  assert.equal(Object.keys(CODE_SOURCES).length, 51);
+  assert.equal(CODE_SOURCES[PREPARE_NODE], 'prepare-advantage-plus-drift-readback.js');
+  assert.equal(CODE_SOURCES[CLASSIFY_NODE], 'classify-advantage-plus-graph-drift.js');
+  const gateway = fs.readFileSync(path.join(workflowRoot, '..', '..', 'platform', 'security', 'token-vault', 'src', 'meta-ads-publish.js'), 'utf8');
+  assert.match(gateway, /async function getCreative\([\s\S]*?\{ method: 'GET' \}/);
+});

--- a/orb/engine/tests/meta-ads-publish-preflight.test.js
+++ b/orb/engine/tests/meta-ads-publish-preflight.test.js
@@ -11,14 +11,17 @@ const {
 } = require('../scripts/lib/meta-ads-publish-execution-semantics');
 const { CRM_TOOL_NAME, CRM_URL, transform } = require('../scripts/prepare-meta-ads-publish-crm-catalog');
 const { transform: patchVideoUploadReplay } = require('../scripts/patch-meta-ads-video-transfer-replay');
+const { CRM_META_ADS_COMPATIBILITY_URL, isSupportedCrmContextUrl } = require('../scripts/patch-meta-ads-crm-context-prefetch');
 const { CODE_SOURCES } = require('../scripts/lib/meta-ads-publish-code-sources');
 
 test('tracks every live Meta Ads Publish Code node in one shared source map', () => {
-  assert.equal(Object.keys(CODE_SOURCES).length, 49);
+  assert.equal(Object.keys(CODE_SOURCES).length, 51);
   assert.equal(CODE_SOURCES['Build Jobs'], 'build-jobs.js');
   assert.equal(CODE_SOURCES['Validate Visual Grouping'], 'validate-visual-grouping.js');
   assert.equal(CODE_SOURCES['Prepare CRM Offer Context Requests'], 'prepare-crm-offer-context-requests.js');
   assert.equal(CODE_SOURCES['Attach CRM Offer Context'], 'attach-crm-offer-context.js');
+  assert.equal(CODE_SOURCES['Prepare Advantage+ Drift Readback'], 'prepare-advantage-plus-drift-readback.js');
+  assert.equal(CODE_SOURCES['Classify Advantage+ Graph Drift'], 'classify-advantage-plus-graph-drift.js');
 });
 
 test('Responses API uses the n8n 1.3 default when the stored parameter is absent', () => {
@@ -86,6 +89,12 @@ test('replaces the legacy Sheets tool with the authenticated CRM offer-context t
   assert.deepEqual(updatedSchema.properties.analysis.properties.crmPricing.properties.source.enum, ['crm', 'none']);
 });
 
+test('accepts only the fixed legacy Meta Ads compatibility adapter during a versioned workflow patch', () => {
+  assert.equal(isSupportedCrmContextUrl(`${CRM_META_ADS_COMPATIBILITY_URL}?unit=novo-hamburgo`), true);
+  assert.equal(isSupportedCrmContextUrl('http://127.0.0.1:8099/api/atendimento/internal/commercial/catalog?unit=novo-hamburgo'), true);
+  assert.equal(isSupportedCrmContextUrl('https://example.invalid/offer-context'), false);
+});
+
 test('preflight loads workflow connections before validating the CRM tool edge', () => {
   const source = fs.readFileSync(
     path.join(__dirname, '..', 'scripts', 'validate-meta-ads-publish-preflight.js'),
@@ -93,6 +102,7 @@ test('preflight loads workflow connections before validating the CRM tool edge',
   );
   assert.match(source, /SELECT active, nodes, connections, settings,/);
   assert.match(source, /gateway_contract_revision_gate_missing/);
+  assert.match(source, /advantage_plus_graph_drift_readback/);
   assert.doesNotMatch(source, /new RegExp\(/);
 });
 

--- a/orb/engine/workflow-src/meta-ads-publish/build-drive-finalization.js
+++ b/orb/engine/workflow-src/meta-ads-publish/build-drive-finalization.js
@@ -1,23 +1,51 @@
 function text(value) { return String(value ?? '').trim(); }
 function list(value) { return Array.isArray(value) ? value : []; }
+function object(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }
 function unique(values) { return [...new Set(list(values).map(text).filter(Boolean))]; }
+
+function compactDriftReport(value) {
+  const report = object(value);
+  if (!text(report.status)) return null;
+  return {
+    status: text(report.status),
+    graph_request_method: text(report.graph_request_method || 'GET'),
+    comparison_scope: text(report.comparison_scope),
+    graph_acknowledgement_is_not_ui_confirmation: report.graph_acknowledgement_is_not_ui_confirmation === true,
+    ui_confirmation_required: report.ui_confirmation_required === true,
+    automatic_remediation: text(report.automatic_remediation || 'none'),
+    creatives: list(report.creatives).map((creative) => ({
+      creative_id: text(creative && creative.creative_id),
+      destination_group: text(creative && creative.destination_group),
+      creative_group_key: text(creative && creative.creative_group_key),
+      status: text(creative && creative.status),
+      checked_at: text(creative && creative.checked_at),
+      lost_opt_in: unique(creative && creative.lost_opt_in),
+      not_reported_after_ack: unique(creative && creative.not_reported_after_ack),
+      new_opt_in: unique(creative && creative.new_opt_in),
+    })),
+  };
+}
 
 const input = $input.first()?.json || {};
 let runId = text(input.run_id);
 let jobs = [];
+let advantagePlusGraphDrift = null;
 if (input.resume_drive_only === true) {
   runId = text(input.run_id || input.run?.id);
   jobs = list(input.run?.summary?.jobs);
+  advantagePlusGraphDrift = compactDriftReport(input.run?.summary?.advantage_plus_graph_drift);
 } else {
-  if (input.ok !== true || input.operation?.status !== 'completed') {
-    throw new Error(`Activate Ad Batch falhou: ${JSON.stringify(input.detail || input.error || input)}`);
+  const activation = object(($items('Activate Ad Batch')[0] || {}).json || input.activation_response || input);
+  if (activation.ok !== true || activation.operation?.status !== 'completed') {
+    throw new Error(`Activate Ad Batch falhou: ${JSON.stringify(activation.detail || activation.error || activation)}`);
   }
-  const result = input.operation.result || {};
+  const result = activation.operation.result || {};
   if (result.status !== 'meta_completed_drive_pending') {
     throw new Error(`Activate Ad Batch retornou estado inesperado: ${JSON.stringify(result)}`);
   }
   runId = text(($items('Build Activate Batch')[0]?.json || {}).run_id);
   jobs = list(result.jobs);
+  advantagePlusGraphDrift = compactDriftReport(input.advantage_plus_graph_drift);
 }
 if (!runId || !jobs.length) throw new Error('Build Drive Finalization sem run_id ou jobs persistidos.');
 
@@ -50,6 +78,7 @@ const lines = [
   `Run: ${runId}`,
   `Jobs Meta: ${summaries.length}`,
   `Artes: ${byFile.size}`,
+  ...(advantagePlusGraphDrift ? [`Advantage+ Graph pos-ativacao: ${advantagePlusGraphDrift.status} (nao confirma o Ads Manager)`] : []),
   '',
   ...summaries.map((job) => `- ${job.creative_group_key} | ${job.destination_group} | ${job.action} | ad ${job.ad_id}`),
 ];
@@ -70,6 +99,7 @@ return [...byFile.values()].map((file) => ({
     meta_ads_ad_ids: unique(file.ad_ids).join(', '),
     meta_ads_creative_ids: unique(file.creative_ids).join(', '),
     meta_publish_summary: summaries,
+    advantage_plus_graph_drift: advantagePlusGraphDrift,
     whatsapp_message: message,
     telegram_message: message,
   },

--- a/orb/engine/workflow-src/meta-ads-publish/classify-advantage-plus-graph-drift.js
+++ b/orb/engine/workflow-src/meta-ads-publish/classify-advantage-plus-graph-drift.js
@@ -1,0 +1,120 @@
+function text(value) { return String(value ?? '').trim(); }
+function list(value) { return Array.isArray(value) ? value : []; }
+function object(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }
+function unique(values) { return [...new Set(list(values).map(text).filter(Boolean))]; }
+function pairedIndex(item, fallback) {
+  const paired = item && item.pairedItem;
+  if (Array.isArray(paired) && paired.length) return Number(paired[0].item ?? fallback);
+  if (paired && typeof paired === 'object') return Number(paired.item ?? fallback);
+  return Number(fallback);
+}
+
+function featureSnapshot(creative, requested) {
+  const features = object(object(creative.degrees_of_freedom_spec).creative_features_spec);
+  const reportedOptIn = [];
+  const reportedNonOptIn = [];
+  const notReported = [];
+  for (const feature of requested) {
+    if (!Object.prototype.hasOwnProperty.call(features, feature)) {
+      notReported.push(feature);
+    } else if (text(features[feature] && features[feature].enroll_status).toUpperCase() === 'OPT_IN') {
+      reportedOptIn.push(feature);
+    } else {
+      reportedNonOptIn.push(feature);
+    }
+  }
+  return {
+    reported_opt_in: reportedOptIn,
+    reported_non_opt_in: reportedNonOptIn,
+    not_reported: notReported,
+  };
+}
+
+function unavailable(prepared, response) {
+  const detail = object(response && (response.detail || response.error));
+  return {
+    creative_id: text(prepared.creative_id),
+    destination_group: text(prepared.destination_group),
+    creative_group_key: text(prepared.creative_group_key),
+    status: 'unavailable',
+    checked_at: new Date().toISOString(),
+    comparison_scope: 'requested_features_only:degrees_of_freedom_spec.creative_features_spec',
+    graph_request_method: 'GET',
+    graph_acknowledgement_is_not_ui_confirmation: true,
+    baseline: object(prepared.baseline),
+    current: null,
+    error_code: text(detail.code || response?.status || response?.error || 'graph_readback_unavailable'),
+    error_subcode: text(detail.error_subcode),
+    lost_opt_in: [],
+    not_reported_after_ack: [],
+    new_opt_in: [],
+  };
+}
+
+const preparedItems = $items('Prepare Advantage+ Drift Readback') || [];
+const reports = [];
+for (const [index, item] of $input.all().entries()) {
+  const sourceIndex = pairedIndex(item, index);
+  const prepared = object(preparedItems[sourceIndex] && preparedItems[sourceIndex].json);
+  const response = object(item.json);
+  const baseline = object(prepared.baseline);
+  if (!prepared.creative_id || response.ok !== true || response.operation?.status !== 'completed' || !baseline.available) {
+    reports.push(unavailable(prepared, response));
+    continue;
+  }
+  const creative = object(response.operation.result);
+  const requested = unique(baseline.requested_features);
+  const current = featureSnapshot(creative, requested);
+  const baselineOptIn = new Set(unique(baseline.reported_opt_in));
+  const currentOptIn = new Set(current.reported_opt_in);
+  const currentNonOptIn = new Set(current.reported_non_opt_in);
+  const currentNotReported = new Set(current.not_reported);
+  const lostOptIn = requested.filter((feature) => baselineOptIn.has(feature) && currentNonOptIn.has(feature));
+  const notReportedAfterAck = requested.filter((feature) => baselineOptIn.has(feature) && currentNotReported.has(feature));
+  const newOptIn = requested.filter((feature) => !baselineOptIn.has(feature) && currentOptIn.has(feature));
+  const driftDetected = lostOptIn.length || notReportedAfterAck.length || newOptIn.length;
+  reports.push({
+    creative_id: text(prepared.creative_id || creative.id),
+    destination_group: text(prepared.destination_group),
+    creative_group_key: text(prepared.creative_group_key),
+    status: driftDetected ? 'graph_state_drift_detected' : 'unchanged_graph_state_ui_unverified',
+    checked_at: new Date().toISOString(),
+    comparison_scope: 'requested_features_only:degrees_of_freedom_spec.creative_features_spec',
+    graph_request_method: 'GET',
+    graph_acknowledgement_is_not_ui_confirmation: true,
+    baseline: {
+      checked_at: text(baseline.checked_at),
+      requested_features: requested,
+      reported_opt_in: unique(baseline.reported_opt_in),
+      reported_non_opt_in: unique(baseline.reported_non_opt_in),
+      not_reported: unique(baseline.not_reported),
+    },
+    current,
+    lost_opt_in: lostOptIn,
+    not_reported_after_ack: notReportedAfterAck,
+    new_opt_in: newOptIn,
+  });
+}
+
+const hasDrift = reports.some((report) => report.status === 'graph_state_drift_detected');
+const hasUnavailable = reports.some((report) => report.status === 'unavailable');
+const status = hasDrift
+  ? 'graph_state_drift_detected'
+  : hasUnavailable
+    ? 'unavailable'
+    : 'unchanged_graph_state_ui_unverified';
+
+return [{
+  json: {
+    run_id: text((preparedItems[0] || {}).json?.run_id),
+    advantage_plus_graph_drift: {
+      status,
+      graph_request_method: 'GET',
+      comparison_scope: 'requested_features_only:degrees_of_freedom_spec.creative_features_spec',
+      graph_acknowledgement_is_not_ui_confirmation: true,
+      ui_confirmation_required: true,
+      automatic_remediation: 'none',
+      creatives: reports,
+    },
+  },
+}];

--- a/orb/engine/workflow-src/meta-ads-publish/prepare-advantage-plus-drift-readback.js
+++ b/orb/engine/workflow-src/meta-ads-publish/prepare-advantage-plus-drift-readback.js
@@ -1,0 +1,64 @@
+function text(value) { return String(value ?? '').trim(); }
+function list(value) { return Array.isArray(value) ? value : []; }
+function object(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }
+function unique(values) { return [...new Set(list(values).map(text).filter(Boolean))]; }
+function key(value) { return text(value).normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^A-Za-z0-9_.:-]+/g, '_').slice(0, 190); }
+
+function baselineFor(source) {
+  const verification = object(source.advantage_plus_verification);
+  const requested = unique(verification.requested_features || source.advantage_plus_requested_features);
+  const optIn = unique(verification.reported_opt_in || verification.graph_acknowledged_features);
+  const reportedNonOptIn = unique(verification.removed_or_ineligible || verification.removed_features);
+  const notReported = unique(verification.not_reported);
+  const available = verification.graph_acknowledgement_is_not_ui_confirmation === true
+    && Boolean(verification.checked_at)
+    && requested.length > 0;
+  return {
+    available,
+    status: text(verification.status || 'unavailable'),
+    checked_at: text(verification.checked_at),
+    requested_features: requested,
+    reported_opt_in: optIn,
+    reported_non_opt_in: reportedNonOptIn,
+    not_reported: notReported,
+    graph_request_method: 'GET',
+    graph_acknowledgement_is_not_ui_confirmation: true,
+  };
+}
+
+const activation = object($input.first()?.json);
+if (activation.ok !== true || activation.operation?.status !== 'completed' || activation.operation?.result?.status !== 'meta_completed_drive_pending') {
+  throw new Error(`Prepare Advantage+ Drift Readback recebeu ativacao invalida: ${JSON.stringify(activation.detail || activation.error || activation)}`);
+}
+
+const runId = text(($items('Build Activate Batch')[0]?.json || {}).run_id || activation.run_id);
+const jobs = list(activation.operation?.result?.jobs);
+const initialReadbacks = $items('Attach Advantage+ Verification') || [];
+const byCreativeId = new Map(initialReadbacks.map((item) => [text(item?.json?.creative_id), object(item?.json)]).filter(([creativeId]) => creativeId));
+if (!runId || !jobs.length) throw new Error('Prepare Advantage+ Drift Readback sem run_id ou jobs ativados.');
+
+return jobs.map((job, index) => {
+  const creativeId = text(job.creative_id);
+  const source = object(byCreativeId.get(creativeId));
+  if (!creativeId || !text(source.token_id) || !text(source.account_id)) {
+    throw new Error(`Prepare Advantage+ Drift Readback sem contexto seguro para creative ${creativeId || index}.`);
+  }
+  return {
+    json: {
+      run_id: runId,
+      creative_id: creativeId,
+      destination_group: text(job.destination_group || source.destination_group),
+      creative_group_key: text(job.creative_group_key || source.creative_group_key),
+      baseline: baselineFor(source),
+      gateway_request: {
+        action: 'get_creative',
+        operation_key: key(`verify-post-activation:${runId}:${creativeId}`),
+        token_id: text(source.token_id),
+        account_id: text(source.account_id),
+        api_version: text(source.api_version || 'v25.0'),
+        object_id: creativeId,
+      },
+    },
+    pairedItem: { item: index },
+  };
+});

--- a/orb/engine/workflow-src/meta-ads-publish/verify-drive-finalization.js
+++ b/orb/engine/workflow-src/meta-ads-publish/verify-drive-finalization.js
@@ -32,6 +32,7 @@ return [{
     verified_file_count: verified.length,
     files: verified.map((item) => ({ id: text(item.id), name: text(item.fileName) })),
     meta_publish_summary: first.meta_publish_summary,
+    advantage_plus_graph_drift: first.advantage_plus_graph_drift || null,
     whatsapp_message: text(first.whatsapp_message),
     telegram_message: text(first.telegram_message),
     completion_request: {
@@ -39,6 +40,7 @@ return [{
       summary: {
         verified_file_count: verified.length,
         jobs: first.meta_publish_summary,
+        advantage_plus_graph_drift: first.advantage_plus_graph_drift || null,
       },
     },
   },

--- a/orb/engine/workflows/meta-ads-publish.current.json
+++ b/orb/engine/workflows/meta-ads-publish.current.json
@@ -489,7 +489,7 @@
       "typeVersion": 4.3,
       "position": [
         15024,
-        1352
+        1448
       ],
       "id": "e8ac9e77-fbc6-4082-8358-f197ac53cf08",
       "name": "Inform Meta Publish Success (WhatsApp)",
@@ -498,33 +498,6 @@
       "maxTries": 3,
       "waitBetweenTries": 5000,
       "onError": "continueRegularOutput"
-    },
-    {
-      "parameters": {
-        "chatId": "7893126619",
-        "text": "={{ $json.event.payload.telegram_message }}",
-        "additionalFields": {
-          "appendAttribution": false,
-          "disable_web_page_preview": true,
-          "parse_mode": "HTML"
-        }
-      },
-      "type": "n8n-nodes-base.telegram",
-      "typeVersion": 1.2,
-      "position": [
-        15024,
-        1544
-      ],
-      "id": "a64f575a-fcdf-4307-8caa-6f723490fcf9",
-      "name": "Inform Meta Publish Success (Telegram)",
-      "webhookId": "837f6d8f-f5bb-41e6-9323-fb074a1d43c1",
-      "retryOnFail": false,
-      "credentials": {
-        "telegramApi": {
-          "id": "9NlSo0dcxNrKtlWW",
-          "name": "Telegram – @espacofacial_bot"
-        }
-      }
     },
     {
       "parameters": {
@@ -815,7 +788,7 @@
     },
     {
       "parameters": {
-        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction list(value) { return Array.isArray(value) ? value : []; }\nfunction unique(values) { return [...new Set(list(values).map(text).filter(Boolean))]; }\n\nconst input = $input.first()?.json || {};\nlet runId = text(input.run_id);\nlet jobs = [];\nif (input.resume_drive_only === true) {\n  runId = text(input.run_id || input.run?.id);\n  jobs = list(input.run?.summary?.jobs);\n} else {\n  if (input.ok !== true || input.operation?.status !== 'completed') {\n    throw new Error(`Activate Ad Batch falhou: ${JSON.stringify(input.detail || input.error || input)}`);\n  }\n  const result = input.operation.result || {};\n  if (result.status !== 'meta_completed_drive_pending') {\n    throw new Error(`Activate Ad Batch retornou estado inesperado: ${JSON.stringify(result)}`);\n  }\n  runId = text(($items('Build Activate Batch')[0]?.json || {}).run_id);\n  jobs = list(result.jobs);\n}\nif (!runId || !jobs.length) throw new Error('Build Drive Finalization sem run_id ou jobs persistidos.');\n\nconst byFile = new Map();\nfor (const job of jobs) {\n  for (const file of list(job.files)) {\n    const id = text(file.id);\n    if (!id) continue;\n    if (!byFile.has(id)) byFile.set(id, { id, name: text(file.name), ratio: text(file.ratio), units: [], ad_ids: [], creative_ids: [], groups: [] });\n    const row = byFile.get(id);\n    row.units.push(job.destination_group);\n    row.ad_ids.push(job.ad_id);\n    row.creative_ids.push(job.creative_id);\n    row.groups.push(job.creative_group_key);\n  }\n}\nif (!byFile.size) throw new Error('Build Drive Finalization nao recuperou os arquivos do journal.');\n\nconst publishedAt = new Date().toISOString();\nconst summaries = jobs.map((job) => ({\n  creative_group_key: text(job.creative_group_key),\n  destination_group: text(job.destination_group),\n  action: text(job.action),\n  ad_id: text(job.ad_id),\n  creative_id: text(job.creative_id),\n  created_new: job.created_new === true,\n}));\nconst lines = [\n  'Meta Ads Publish concluido',\n  `Run: ${runId}`,\n  `Jobs Meta: ${summaries.length}`,\n  `Artes: ${byFile.size}`,\n  '',\n  ...summaries.map((job) => `- ${job.creative_group_key} | ${job.destination_group} | ${job.action} | ad ${job.ad_id}`),\n];\nconst message = lines.join('\\n');\n\nreturn [...byFile.values()].map((file) => ({\n  json: {\n    id: file.id,\n    fileName: file.name,\n    ratio: file.ratio,\n    run_id: runId,\n    published: true,\n    meta_ads_published_at: publishedAt,\n    meta_ads_execution_id: String($execution.id),\n    meta_ads_run_id: runId,\n    meta_ads_creative_group_key: unique(file.groups).join(', '),\n    meta_ads_units: unique(file.units).join(', '),\n    meta_ads_ad_ids: unique(file.ad_ids).join(', '),\n    meta_ads_creative_ids: unique(file.creative_ids).join(', '),\n    meta_publish_summary: summaries,\n    whatsapp_message: message,\n    telegram_message: message,\n  },\n}));"
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction list(value) { return Array.isArray(value) ? value : []; }\nfunction object(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }\nfunction unique(values) { return [...new Set(list(values).map(text).filter(Boolean))]; }\n\nfunction compactDriftReport(value) {\n  const report = object(value);\n  if (!text(report.status)) return null;\n  return {\n    status: text(report.status),\n    graph_request_method: text(report.graph_request_method || 'GET'),\n    comparison_scope: text(report.comparison_scope),\n    graph_acknowledgement_is_not_ui_confirmation: report.graph_acknowledgement_is_not_ui_confirmation === true,\n    ui_confirmation_required: report.ui_confirmation_required === true,\n    automatic_remediation: text(report.automatic_remediation || 'none'),\n    creatives: list(report.creatives).map((creative) => ({\n      creative_id: text(creative && creative.creative_id),\n      destination_group: text(creative && creative.destination_group),\n      creative_group_key: text(creative && creative.creative_group_key),\n      status: text(creative && creative.status),\n      checked_at: text(creative && creative.checked_at),\n      lost_opt_in: unique(creative && creative.lost_opt_in),\n      not_reported_after_ack: unique(creative && creative.not_reported_after_ack),\n      new_opt_in: unique(creative && creative.new_opt_in),\n    })),\n  };\n}\n\nconst input = $input.first()?.json || {};\nlet runId = text(input.run_id);\nlet jobs = [];\nlet advantagePlusGraphDrift = null;\nif (input.resume_drive_only === true) {\n  runId = text(input.run_id || input.run?.id);\n  jobs = list(input.run?.summary?.jobs);\n  advantagePlusGraphDrift = compactDriftReport(input.run?.summary?.advantage_plus_graph_drift);\n} else {\n  const activation = object(($items('Activate Ad Batch')[0] || {}).json || input.activation_response || input);\n  if (activation.ok !== true || activation.operation?.status !== 'completed') {\n    throw new Error(`Activate Ad Batch falhou: ${JSON.stringify(activation.detail || activation.error || activation)}`);\n  }\n  const result = activation.operation.result || {};\n  if (result.status !== 'meta_completed_drive_pending') {\n    throw new Error(`Activate Ad Batch retornou estado inesperado: ${JSON.stringify(result)}`);\n  }\n  runId = text(($items('Build Activate Batch')[0]?.json || {}).run_id);\n  jobs = list(result.jobs);\n  advantagePlusGraphDrift = compactDriftReport(input.advantage_plus_graph_drift);\n}\nif (!runId || !jobs.length) throw new Error('Build Drive Finalization sem run_id ou jobs persistidos.');\n\nconst byFile = new Map();\nfor (const job of jobs) {\n  for (const file of list(job.files)) {\n    const id = text(file.id);\n    if (!id) continue;\n    if (!byFile.has(id)) byFile.set(id, { id, name: text(file.name), ratio: text(file.ratio), units: [], ad_ids: [], creative_ids: [], groups: [] });\n    const row = byFile.get(id);\n    row.units.push(job.destination_group);\n    row.ad_ids.push(job.ad_id);\n    row.creative_ids.push(job.creative_id);\n    row.groups.push(job.creative_group_key);\n  }\n}\nif (!byFile.size) throw new Error('Build Drive Finalization nao recuperou os arquivos do journal.');\n\nconst publishedAt = new Date().toISOString();\nconst summaries = jobs.map((job) => ({\n  creative_group_key: text(job.creative_group_key),\n  destination_group: text(job.destination_group),\n  action: text(job.action),\n  ad_id: text(job.ad_id),\n  creative_id: text(job.creative_id),\n  created_new: job.created_new === true,\n}));\nconst lines = [\n  'Meta Ads Publish concluido',\n  `Run: ${runId}`,\n  `Jobs Meta: ${summaries.length}`,\n  `Artes: ${byFile.size}`,\n  ...(advantagePlusGraphDrift ? [`Advantage+ Graph pos-ativacao: ${advantagePlusGraphDrift.status} (nao confirma o Ads Manager)`] : []),\n  '',\n  ...summaries.map((job) => `- ${job.creative_group_key} | ${job.destination_group} | ${job.action} | ad ${job.ad_id}`),\n];\nconst message = lines.join('\\n');\n\nreturn [...byFile.values()].map((file) => ({\n  json: {\n    id: file.id,\n    fileName: file.name,\n    ratio: file.ratio,\n    run_id: runId,\n    published: true,\n    meta_ads_published_at: publishedAt,\n    meta_ads_execution_id: String($execution.id),\n    meta_ads_run_id: runId,\n    meta_ads_creative_group_key: unique(file.groups).join(', '),\n    meta_ads_units: unique(file.units).join(', '),\n    meta_ads_ad_ids: unique(file.ad_ids).join(', '),\n    meta_ads_creative_ids: unique(file.creative_ids).join(', '),\n    meta_publish_summary: summaries,\n    advantage_plus_graph_drift: advantagePlusGraphDrift,\n    whatsapp_message: message,\n    telegram_message: message,\n  },\n}));"
       },
       "id": "meta-publish-drive-finalization",
       "name": "Build Drive Finalization",
@@ -875,7 +848,7 @@
     },
     {
       "parameters": {
-        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction pairedIndex(item, fallback) {\n  const paired = item && item.pairedItem;\n  if (Array.isArray(paired) && paired.length) return Number(paired[0].item ?? fallback);\n  if (paired && typeof paired === 'object') return Number(paired.item ?? fallback);\n  return Number(fallback);\n}\n\nconst prepared = $items('Prepare Drive Read') || [];\nconst verified = [];\nfor (const [index, item] of $input.all().entries()) {\n  const sourceIndex = pairedIndex(item, index);\n  const expected = (prepared[sourceIndex] || {}).json || {};\n  const actual = item.json || {};\n  const properties = actual.properties || {};\n  const checks = {\n    published: text(properties.published) === 'true',\n    run_id: text(properties.meta_ads_run_id) === text(expected.run_id),\n    groups: text(properties.meta_ads_creative_group_key) === text(expected.meta_ads_creative_group_key),\n  };\n  if (!checks.published || !checks.run_id || !checks.groups) {\n    throw new Error(`Drive readback falhou para ${expected.id}: ${JSON.stringify(checks)}`);\n  }\n  verified.push(expected);\n}\nif (verified.length !== prepared.length) throw new Error(`Drive readback incompleto: ${verified.length}/${prepared.length}.`);\n\nconst first = verified[0];\nreturn [{\n  json: {\n    run_id: text(first.run_id),\n    verified_file_count: verified.length,\n    files: verified.map((item) => ({ id: text(item.id), name: text(item.fileName) })),\n    meta_publish_summary: first.meta_publish_summary,\n    whatsapp_message: text(first.whatsapp_message),\n    telegram_message: text(first.telegram_message),\n    completion_request: {\n      status: 'completed',\n      summary: {\n        verified_file_count: verified.length,\n        jobs: first.meta_publish_summary,\n      },\n    },\n  },\n}];"
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction pairedIndex(item, fallback) {\n  const paired = item && item.pairedItem;\n  if (Array.isArray(paired) && paired.length) return Number(paired[0].item ?? fallback);\n  if (paired && typeof paired === 'object') return Number(paired.item ?? fallback);\n  return Number(fallback);\n}\n\nconst prepared = $items('Prepare Drive Read') || [];\nconst verified = [];\nfor (const [index, item] of $input.all().entries()) {\n  const sourceIndex = pairedIndex(item, index);\n  const expected = (prepared[sourceIndex] || {}).json || {};\n  const actual = item.json || {};\n  const properties = actual.properties || {};\n  const checks = {\n    published: text(properties.published) === 'true',\n    run_id: text(properties.meta_ads_run_id) === text(expected.run_id),\n    groups: text(properties.meta_ads_creative_group_key) === text(expected.meta_ads_creative_group_key),\n  };\n  if (!checks.published || !checks.run_id || !checks.groups) {\n    throw new Error(`Drive readback falhou para ${expected.id}: ${JSON.stringify(checks)}`);\n  }\n  verified.push(expected);\n}\nif (verified.length !== prepared.length) throw new Error(`Drive readback incompleto: ${verified.length}/${prepared.length}.`);\n\nconst first = verified[0];\nreturn [{\n  json: {\n    run_id: text(first.run_id),\n    verified_file_count: verified.length,\n    files: verified.map((item) => ({ id: text(item.id), name: text(item.fileName) })),\n    meta_publish_summary: first.meta_publish_summary,\n    advantage_plus_graph_drift: first.advantage_plus_graph_drift || null,\n    whatsapp_message: text(first.whatsapp_message),\n    telegram_message: text(first.telegram_message),\n    completion_request: {\n      status: 'completed',\n      summary: {\n        verified_file_count: verified.length,\n        jobs: first.meta_publish_summary,\n        advantage_plus_graph_drift: first.advantage_plus_graph_drift || null,\n      },\n    },\n  },\n}];"
       },
       "id": "meta-publish-verify-drive",
       "name": "Verify Drive Finalization",
@@ -2177,7 +2150,7 @@
     },
     {
       "parameters": {
-        "url": "={{ 'http://127.0.0.1:8099/api/atendimento/internal/commercial/catalog?unit=' + encodeURIComponent($json.crm_unit) }}",
+        "url": "={{ 'http://127.0.0.1:8099/api/atendimento/internal/meta-ads/offer-context?unit=' + encodeURIComponent($json.crm_unit) }}",
         "authentication": "genericCredentialType",
         "genericAuthType": "httpBearerAuth",
         "options": {
@@ -2210,6 +2183,77 @@
       "position": [
         7136,
         1464
+      ]
+    },
+    {
+      "id": "meta-publish-advantage-post-activation-stabilization-wait",
+      "name": "Wait Advantage+ Post-Activation Stabilization",
+      "type": "n8n-nodes-base.wait",
+      "typeVersion": 1.1,
+      "parameters": {
+        "amount": 30
+      },
+      "position": [
+        13232,
+        1272
+      ]
+    },
+    {
+      "id": "meta-publish-prepare-advantage-drift-readback",
+      "name": "Prepare Advantage+ Drift Readback",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction list(value) { return Array.isArray(value) ? value : []; }\nfunction object(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }\nfunction unique(values) { return [...new Set(list(values).map(text).filter(Boolean))]; }\nfunction key(value) { return text(value).normalize('NFD').replace(/[\\u0300-\\u036f]/g, '').replace(/[^A-Za-z0-9_.:-]+/g, '_').slice(0, 190); }\n\nfunction baselineFor(source) {\n  const verification = object(source.advantage_plus_verification);\n  const requested = unique(verification.requested_features || source.advantage_plus_requested_features);\n  const optIn = unique(verification.reported_opt_in || verification.graph_acknowledged_features);\n  const reportedNonOptIn = unique(verification.removed_or_ineligible || verification.removed_features);\n  const notReported = unique(verification.not_reported);\n  const available = verification.graph_acknowledgement_is_not_ui_confirmation === true\n    && Boolean(verification.checked_at)\n    && requested.length > 0;\n  return {\n    available,\n    status: text(verification.status || 'unavailable'),\n    checked_at: text(verification.checked_at),\n    requested_features: requested,\n    reported_opt_in: optIn,\n    reported_non_opt_in: reportedNonOptIn,\n    not_reported: notReported,\n    graph_request_method: 'GET',\n    graph_acknowledgement_is_not_ui_confirmation: true,\n  };\n}\n\nconst activation = object($input.first()?.json);\nif (activation.ok !== true || activation.operation?.status !== 'completed' || activation.operation?.result?.status !== 'meta_completed_drive_pending') {\n  throw new Error(`Prepare Advantage+ Drift Readback recebeu ativacao invalida: ${JSON.stringify(activation.detail || activation.error || activation)}`);\n}\n\nconst runId = text(($items('Build Activate Batch')[0]?.json || {}).run_id || activation.run_id);\nconst jobs = list(activation.operation?.result?.jobs);\nconst initialReadbacks = $items('Attach Advantage+ Verification') || [];\nconst byCreativeId = new Map(initialReadbacks.map((item) => [text(item?.json?.creative_id), object(item?.json)]).filter(([creativeId]) => creativeId));\nif (!runId || !jobs.length) throw new Error('Prepare Advantage+ Drift Readback sem run_id ou jobs ativados.');\n\nreturn jobs.map((job, index) => {\n  const creativeId = text(job.creative_id);\n  const source = object(byCreativeId.get(creativeId));\n  if (!creativeId || !text(source.token_id) || !text(source.account_id)) {\n    throw new Error(`Prepare Advantage+ Drift Readback sem contexto seguro para creative ${creativeId || index}.`);\n  }\n  return {\n    json: {\n      run_id: runId,\n      creative_id: creativeId,\n      destination_group: text(job.destination_group || source.destination_group),\n      creative_group_key: text(job.creative_group_key || source.creative_group_key),\n      baseline: baselineFor(source),\n      gateway_request: {\n        action: 'get_creative',\n        operation_key: key(`verify-post-activation:${runId}:${creativeId}`),\n        token_id: text(source.token_id),\n        account_id: text(source.account_id),\n        api_version: text(source.api_version || 'v25.0'),\n        object_id: creativeId,\n      },\n    },\n    pairedItem: { item: index },\n  };\n});"
+      },
+      "position": [
+        13456,
+        1272
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ ($vars.TOKEN_VAULT_BASE_URL || 'https://api.skincos.com.br/internal/token-vault') + '/v1/meta-ads-publish/runs/' + $json.run_id + '/operations' }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpBearerAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ $json.gateway_request }}",
+        "options": {
+          "timeout": 330000
+        }
+      },
+      "id": "meta-publish-verify-advantage-drift-readback",
+      "name": "Verify Advantage+ Drift Readback",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.3,
+      "position": [
+        13680,
+        1272
+      ],
+      "retryOnFail": true,
+      "maxTries": 4,
+      "waitBetweenTries": 10000,
+      "credentials": {
+        "httpBearerAuth": {
+          "id": "metaPublishGatewayBearer",
+          "name": "Meta Ads Publish - Gateway Bearer"
+        }
+      },
+      "continueOnFail": true
+    },
+    {
+      "id": "meta-publish-classify-advantage-graph-drift",
+      "name": "Classify Advantage+ Graph Drift",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "parameters": {
+        "jsCode": "function text(value) { return String(value ?? '').trim(); }\nfunction list(value) { return Array.isArray(value) ? value : []; }\nfunction object(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : {}; }\nfunction unique(values) { return [...new Set(list(values).map(text).filter(Boolean))]; }\nfunction pairedIndex(item, fallback) {\n  const paired = item && item.pairedItem;\n  if (Array.isArray(paired) && paired.length) return Number(paired[0].item ?? fallback);\n  if (paired && typeof paired === 'object') return Number(paired.item ?? fallback);\n  return Number(fallback);\n}\n\nfunction featureSnapshot(creative, requested) {\n  const features = object(object(creative.degrees_of_freedom_spec).creative_features_spec);\n  const reportedOptIn = [];\n  const reportedNonOptIn = [];\n  const notReported = [];\n  for (const feature of requested) {\n    if (!Object.prototype.hasOwnProperty.call(features, feature)) {\n      notReported.push(feature);\n    } else if (text(features[feature] && features[feature].enroll_status).toUpperCase() === 'OPT_IN') {\n      reportedOptIn.push(feature);\n    } else {\n      reportedNonOptIn.push(feature);\n    }\n  }\n  return {\n    reported_opt_in: reportedOptIn,\n    reported_non_opt_in: reportedNonOptIn,\n    not_reported: notReported,\n  };\n}\n\nfunction unavailable(prepared, response) {\n  const detail = object(response && (response.detail || response.error));\n  return {\n    creative_id: text(prepared.creative_id),\n    destination_group: text(prepared.destination_group),\n    creative_group_key: text(prepared.creative_group_key),\n    status: 'unavailable',\n    checked_at: new Date().toISOString(),\n    comparison_scope: 'requested_features_only:degrees_of_freedom_spec.creative_features_spec',\n    graph_request_method: 'GET',\n    graph_acknowledgement_is_not_ui_confirmation: true,\n    baseline: object(prepared.baseline),\n    current: null,\n    error_code: text(detail.code || response?.status || response?.error || 'graph_readback_unavailable'),\n    error_subcode: text(detail.error_subcode),\n    lost_opt_in: [],\n    not_reported_after_ack: [],\n    new_opt_in: [],\n  };\n}\n\nconst preparedItems = $items('Prepare Advantage+ Drift Readback') || [];\nconst reports = [];\nfor (const [index, item] of $input.all().entries()) {\n  const sourceIndex = pairedIndex(item, index);\n  const prepared = object(preparedItems[sourceIndex] && preparedItems[sourceIndex].json);\n  const response = object(item.json);\n  const baseline = object(prepared.baseline);\n  if (!prepared.creative_id || response.ok !== true || response.operation?.status !== 'completed' || !baseline.available) {\n    reports.push(unavailable(prepared, response));\n    continue;\n  }\n  const creative = object(response.operation.result);\n  const requested = unique(baseline.requested_features);\n  const current = featureSnapshot(creative, requested);\n  const baselineOptIn = new Set(unique(baseline.reported_opt_in));\n  const currentOptIn = new Set(current.reported_opt_in);\n  const currentNonOptIn = new Set(current.reported_non_opt_in);\n  const currentNotReported = new Set(current.not_reported);\n  const lostOptIn = requested.filter((feature) => baselineOptIn.has(feature) && currentNonOptIn.has(feature));\n  const notReportedAfterAck = requested.filter((feature) => baselineOptIn.has(feature) && currentNotReported.has(feature));\n  const newOptIn = requested.filter((feature) => !baselineOptIn.has(feature) && currentOptIn.has(feature));\n  const driftDetected = lostOptIn.length || notReportedAfterAck.length || newOptIn.length;\n  reports.push({\n    creative_id: text(prepared.creative_id || creative.id),\n    destination_group: text(prepared.destination_group),\n    creative_group_key: text(prepared.creative_group_key),\n    status: driftDetected ? 'graph_state_drift_detected' : 'unchanged_graph_state_ui_unverified',\n    checked_at: new Date().toISOString(),\n    comparison_scope: 'requested_features_only:degrees_of_freedom_spec.creative_features_spec',\n    graph_request_method: 'GET',\n    graph_acknowledgement_is_not_ui_confirmation: true,\n    baseline: {\n      checked_at: text(baseline.checked_at),\n      requested_features: requested,\n      reported_opt_in: unique(baseline.reported_opt_in),\n      reported_non_opt_in: unique(baseline.reported_non_opt_in),\n      not_reported: unique(baseline.not_reported),\n    },\n    current,\n    lost_opt_in: lostOptIn,\n    not_reported_after_ack: notReportedAfterAck,\n    new_opt_in: newOptIn,\n  });\n}\n\nconst hasDrift = reports.some((report) => report.status === 'graph_state_drift_detected');\nconst hasUnavailable = reports.some((report) => report.status === 'unavailable');\nconst status = hasDrift\n  ? 'graph_state_drift_detected'\n  : hasUnavailable\n    ? 'unavailable'\n    : 'unchanged_graph_state_ui_unverified';\n\nreturn [{\n  json: {\n    run_id: text((preparedItems[0] || {}).json?.run_id),\n    advantage_plus_graph_drift: {\n      status,\n      graph_request_method: 'GET',\n      comparison_scope: 'requested_features_only:degrees_of_freedom_spec.creative_features_spec',\n      graph_acknowledgement_is_not_ui_confirmation: true,\n      ui_confirmation_required: true,\n      automatic_remediation: 'none',\n      creatives: reports,\n    },\n  },\n}];"
+      },
+      "position": [
+        13904,
+        1272
       ]
     }
   ],
@@ -2594,7 +2638,7 @@
           {
             "type": "main",
             "index": 0,
-            "node": "Build Drive Finalization"
+            "node": "Wait Advantage+ Post-Activation Stabilization"
           }
         ]
       ]
@@ -2683,11 +2727,6 @@
             "type": "main",
             "index": 0,
             "node": "Inform Meta Publish Success (WhatsApp)"
-          },
-          {
-            "type": "main",
-            "index": 0,
-            "node": "Inform Meta Publish Success (Telegram)"
           }
         ],
         []
@@ -3464,6 +3503,50 @@
         [
           {
             "node": "Livia",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Wait Advantage+ Post-Activation Stabilization": {
+      "main": [
+        [
+          {
+            "node": "Prepare Advantage+ Drift Readback",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Advantage+ Drift Readback": {
+      "main": [
+        [
+          {
+            "node": "Verify Advantage+ Drift Readback",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Verify Advantage+ Drift Readback": {
+      "main": [
+        [
+          {
+            "node": "Classify Advantage+ Graph Drift",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Classify Advantage+ Graph Drift": {
+      "main": [
+        [
+          {
+            "node": "Build Drive Finalization",
             "type": "main",
             "index": 0
           }


### PR DESCRIPTION
## Objetivo
Registrar, após a ativação do lote, uma segunda amostra somente-leitura da Graph para separar o estado reconhecido na criação do estado posteriormente exposto pela API. Isto trata a divergência observada em Novo Hamburgo sem assumir que a Graph reproduz a interface do Gerenciador de Anúncios.

## Superfícies e comportamento
- Meta Ads – Publish: adiciona espera de 30 s e uma operação `get_creative` pós-ativação por criativo.
- Token Vault: reutiliza o leitor existente; a chamada à Graph é `GET` e não cria, atualiza, ativa ou publica recursos da Meta.
- O resultado classifica somente as chaves solicitadas como estável, alterado, não reportado ou indisponível. Não há correção automática, reenvio ou alteração de criativo.
- A execução continua manual/inativa; a mudança não dispara publicação por si só.
- O rótulo do Gerenciador “Mostrar destaques” permanece sem mapeamento Graph confirmado e não é inferido.

## Classificação e controles
- Risco médio: é uma extensão isolada de observabilidade em um workflow manual/inativo; o caminho existente de criação/ativação não foi alterado e a nova ação externa é exclusivamente `GET`.
- Não há migration, feature flag, grant ou deployment de Token Vault nesta entrega.
- Risco operacional residual: uma leitura adicional e 30 s adicionais por lote; respostas ausentes ou erros de leitura permanecem evidência inconclusiva, não falha de publicação.
- Privacidade: somente um resumo permitido é gravado no journal; corpos de criativo e credenciais não são encaminhados.
- Compatibilidade: preserva o adaptador CRM Meta Ads já usado no workflow live, com allowlist explícita.
- Não será aberto caso nem enviada comunicação à Meta.

## Validação pré-produção
- Testes focados: 17/17 aprovados (`meta-ads-publish-advantage-plus-drift` e `meta-ads-publish-preflight`).
- Fontes incorporadas dos nós Code sincronizadas.
- `git diff --check` aprovado.
- Candidato gerado a partir do checkpoint live exato (versão `6af5ebfd-1c51-47b8-a775-84c562af3036`, 107 nós) e dry-run de aplicação aprovado para 111 nós. Nenhum anúncio, campanha ou criativo foi alterado durante a validação.

## Rollback e smoke
- Antes da aplicação live, será mantido checkpoint privado da definição atual; o rollback restaura exatamente essa versão e valida novamente o preflight.
- Gatilhos: falha do preflight, topologia divergente ou qualquer indício de mutação Meta fora de `GET`.
- Smoke pós-aplicação: confirmar workflow inativo, 111 nós, arestas pós-ativação, contrato `GET` e ausência de nova execução/publicação.