### PR TITLE
fix(onboarding): reconcile Workforce before invite resend

### DIFF
--- a/crm/api/server.js
+++ b/crm/api/server.js
@@ -2060,6 +2060,7 @@ if (DEV_AUTH_ENABLED) {
         const hierarchyError = localTeamHierarchyError(session, member.profile, member.units)
         if (hierarchyError) return res.status(403).json({ success: false, error: 'Hierarquia não permite reenviar este convite', code: hierarchyError })
         if (!['INVITED', 'PENDING_ACCESS'].includes(String(member.accountStatus || '').toUpperCase())) return res.status(409).json({ success: false, error: 'Somente convites pendentes podem ser reenviados', code: 'TEAM_INVITE_NOT_PENDING' })
+        if (!String(member.workforceEmployeeId || '').trim()) return res.status(409).json({ success: false, error: 'Reconcilie o vínculo Workforce antes de reenviar o convite', code: 'TEAM_WORKFORCE_BINDING_REQUIRED' })
         store.invites.forEach((invite) => { if (invite.id === member.inviteId && !invite.revoked) invite.revoked = true })
         const at = new Date().toISOString()
         const inviteId = `local-invite-${randomUUID()}`

--- a/inventory/src/routes/admin.js
+++ b/inventory/src/routes/admin.js
@@ -1297,6 +1297,90 @@ export async function handleAdminRoutes({
     }
   }
 
+  // A retryable, server-only boundary for records that predate a successful
+  // Workforce provisioning. It deliberately does not issue, revoke, or send
+  // an invite: an operator must make the binding healthy before a delivery
+  // action can be attempted.
+  const reconcileWorkforceMatch = url.pathname.match(/^\/admin\/team\/([^/]+)\/workforce\/reconcile$/);
+  if (reconcileWorkforceMatch && request.method === 'POST') {
+    let onboardingId = '';
+    let onboarding = null;
+    let units = [];
+    let requestId = '';
+    try {
+      onboardingId = decodeURIComponent(reconcileWorkforceMatch[1] || '').trim();
+      onboarding = await env.DB.prepare('SELECT * FROM crm_employee_onboarding WHERE id=? LIMIT 1').bind(onboardingId).first();
+      if (!onboarding) return withCORS(JSON.stringify({ success: false, error: 'Membro da equipe não encontrado', code: 'TEAM_MEMBER_NOT_FOUND' }), { status: 404 }, appOrigin);
+      if (!teamUnitsVisible(auth, onboarding.units_json)) return withCORS(JSON.stringify({ success: false, error: 'Unidade fora do escopo do gestor', code: 'TEAM_UNITS_DENIED' }), { status: 403 }, appOrigin);
+      units = normalizeAllowedUnits(onboarding.units_json);
+      const hierarchyDenied = canCreateEmployee({ actorRole: auth?.user?.role, actorAllowedUnits: auth?.user?.allowedUnits, targetProfile: onboarding.profile, units });
+      if (hierarchyDenied) return withCORS(JSON.stringify({ success: false, error: 'Hierarquia não permite reconciliar este vínculo', code: hierarchyDenied }), { status: 403 }, appOrigin);
+      const accountStatus = normalizeAccountState(onboarding.account_status);
+      if (!['INVITED', 'PENDING_ACCESS'].includes(accountStatus)) return withCORS(JSON.stringify({ success: false, error: 'Somente acessos pendentes podem reconciliar o Workforce', code: 'TEAM_WORKFORCE_RECONCILE_NOT_PENDING' }), { status: 409 }, appOrigin);
+
+      requestId = String(request.headers.get('x-request-id') || `identity-workforce-reconcile-${onboardingId}`).slice(0, 180);
+      const existingEmployeeId = String(onboarding.workforce_employee_id || '').trim();
+      let workforceEmployeeId = existingEmployeeId;
+      let workforceReconciled = false;
+      if (!workforceEmployeeId) {
+        const workforce = await syncIdentityWorkforceOnboarding(env, {
+          onboardingId,
+          fullName: String(onboarding.full_name || '').trim(),
+          corporateEmail: String(onboarding.corporate_email || '').trim(),
+          mobilePhoneHash: String(onboarding.mobile_phone_hash || '').trim(),
+          units,
+          profile: String(onboarding.profile || '').trim().toUpperCase(),
+          accountStatus,
+          jobTitle: String(onboarding.job_title || displayJobTitle(onboarding.profile)).trim(),
+          department: String(onboarding.department_name || '').trim(),
+          createdBy: String(auth?.user?.username || ''),
+        }, requestId);
+        workforceEmployeeId = String(workforce?.employeeId || '').trim();
+        if (!workforceEmployeeId) throw new Error('WORKFORCE_EMPLOYEE_ID_REQUIRED');
+        workforceReconciled = true;
+      }
+
+      const existingTeam = await env.DB.prepare('SELECT workforce_employee_id FROM crm_employee_team WHERE onboarding_id=? LIMIT 1').bind(onboardingId).first();
+      if (existingTeam?.workforce_employee_id && String(existingTeam.workforce_employee_id).trim() !== workforceEmployeeId) {
+        return withCORS(JSON.stringify({ success: false, error: 'O vínculo Workforce existente diverge do onboarding', code: 'TEAM_WORKFORCE_BINDING_CONFLICT' }), { status: 409 }, appOrigin);
+      }
+      const existingEmployeeOwner = await env.DB.prepare('SELECT onboarding_id FROM crm_employee_team WHERE workforce_employee_id=? LIMIT 1').bind(workforceEmployeeId).first();
+      if (existingEmployeeOwner?.onboarding_id && String(existingEmployeeOwner.onboarding_id).trim() !== onboardingId) {
+        return withCORS(JSON.stringify({ success: false, error: 'A identidade Workforce já pertence a outro onboarding', code: 'TEAM_WORKFORCE_BINDING_CONFLICT' }), { status: 409 }, appOrigin);
+      }
+
+      const now = new Date().toISOString();
+      const provisioningState = accountStatus === 'INVITED' ? 'INVITE_PENDING' : 'WORKFORCE_SYNCED';
+      const localStatements = [
+        env.DB.prepare('UPDATE crm_employee_onboarding SET workforce_employee_id=?, provisioning_state=?, compensation_state=NULL, last_error_code=NULL, updated_at=? WHERE id=?').bind(workforceEmployeeId, provisioningState, now, onboardingId),
+      ];
+      if (!existingTeam?.workforce_employee_id) {
+        localStatements.push(
+          env.DB.prepare(`INSERT INTO crm_employee_team
+            (workforce_employee_id, onboarding_id, schedule_professional_id, schedule_status, schedule_role, schedule_shift, schedule_nickname, schedule_instagram, schedule_color, units_json, created_by, created_at, updated_at)
+            VALUES (?, ?, NULL, NULL, NULL, NULL, NULL, NULL, NULL, ?, ?, ?, ?)`)
+            .bind(workforceEmployeeId, onboardingId, JSON.stringify(units), String(auth?.user?.username || ''), now, now)
+        );
+      }
+      await env.DB.batch(localStatements);
+
+      const updated = await env.DB.prepare('SELECT * FROM crm_employee_onboarding WHERE id=? LIMIT 1').bind(onboardingId).first();
+      if (String(updated?.workforce_employee_id || '').trim() !== workforceEmployeeId) throw new Error('TEAM_WORKFORCE_BINDING_CONFLICT');
+      await appendAuditLog?.({ env, actor: auth.user.username, role: auth.user.role, ip, userAgent, action: 'EMPLOYEE_TEAM_WORKFORCE_RECONCILED', entity: 'EMPLOYEE_ONBOARDING', entityId: onboardingId, unidade: units.join(','), before: { workforceEmployeeId: existingEmployeeId || null, accountStatus }, after: { workforceEmployeeId, accountStatus, provisioningState, workforceReconciled, inviteDeliveryChanged: false, requestId } });
+      await recordTeamTelemetry({ env, eventName: 'EMPLOYEE_TEAM_WORKFORCE_RECONCILED', actorRole: auth.user.role, itemCount: 1, unitCount: units.length });
+      return withCORS(JSON.stringify({ success: true, data: publicOnboarding(updated), replayed: !workforceReconciled }), { status: 200 }, appOrigin);
+    } catch (error) {
+      const code = String(error?.message || 'TEAM_WORKFORCE_RECONCILE_FAILED').slice(0, 120);
+      const dependencyFailure = isOnboardingDependencyError(code) || /^(WORKFORCE_|IDENTITY_WORKFORCE_|TIMEKEEPING_|RELEASE_AFFINITY_|RUNTIME_BINDINGS_)/.test(code);
+      if (onboardingId && onboarding?.id && dependencyFailure) {
+        await env.DB.prepare("UPDATE crm_employee_onboarding SET provisioning_state='FAILED', last_error_code=?, updated_at=? WHERE id=?").bind(code, new Date().toISOString(), onboardingId).run().catch(() => {});
+      }
+      await Promise.resolve(appendAuditLog?.({ env, actor: auth?.user?.username || '', role: auth?.user?.role || '', ip, userAgent, action: 'EMPLOYEE_TEAM_WORKFORCE_RECONCILE_FAILED', entity: 'EMPLOYEE_ONBOARDING', entityId: onboardingId || null, unidade: units.join(','), after: { code, requestId: requestId || null, failClosed: true, inviteDeliveryChanged: false } })).catch(() => {});
+      const status = dependencyFailure ? 503 : (/(CONFLICT|REQUIRED|INVALID)/.test(code) ? 409 : 500);
+      return withCORS(JSON.stringify({ success: false, error: dependencyFailure ? 'Vínculo Workforce pendente' : 'Não foi possível reconciliar o vínculo Workforce', code }), { status }, appOrigin);
+    }
+  }
+
   const resendInviteMatch = url.pathname.match(/^\/admin\/team\/([^/]+)\/invite\/resend$/);
   if (resendInviteMatch && request.method === 'POST') {
     try {
@@ -1308,6 +1392,7 @@ export async function handleAdminRoutes({
       const hierarchyDenied = canCreateEmployee({ actorRole: auth?.user?.role, actorAllowedUnits: auth?.user?.allowedUnits, targetProfile: onboarding.profile, units: normalizeAllowedUnits(onboarding.units_json) });
       if (hierarchyDenied) return withCORS(JSON.stringify({ success: false, error: 'Hierarquia não permite reenviar este convite', code: hierarchyDenied }), { status: 403 }, appOrigin);
       if (!['INVITED', 'PENDING_ACCESS'].includes(normalizeAccountState(onboarding.account_status))) return withCORS(JSON.stringify({ success: false, error: 'Somente convites pendentes podem ser reenviados', code: 'TEAM_INVITE_NOT_PENDING' }), { status: 409 }, appOrigin);
+      if (!String(onboarding.workforce_employee_id || '').trim()) return withCORS(JSON.stringify({ success: false, error: 'Reconcilie o vínculo Workforce antes de reenviar o convite', code: 'TEAM_WORKFORCE_BINDING_REQUIRED' }), { status: 409 }, appOrigin);
 
       const personalEmail = await decryptOnboardingToken(env, onboarding.personal_email_encrypted);
       if (!personalEmail) return withCORS(JSON.stringify({ success: false, error: 'E-mail pessoal indisponível para o convite', code: 'INVITEE_EMAIL_UNAVAILABLE' }), { status: 503 }, appOrigin);
@@ -1745,7 +1830,7 @@ export async function handleAdminRoutes({
     const requestId = String(request.headers.get('x-request-id') || `identity-team-update-${teamMemberMatch[1] || ''}`).slice(0, 180);
     try {
       onboardingId = decodeURIComponent(teamMemberMatch[1] || '').trim();
-      current = await env.DB.prepare(`SELECT o.*, t.schedule_professional_id, t.schedule_status, t.schedule_role, t.schedule_shift, t.schedule_nickname, t.schedule_instagram, t.schedule_color, t.units_json AS schedule_units_json, a.id AS crm_account_link_id, a.crm_username AS crm_account_username, a.review_status AS crm_account_review_status
+      current = await env.DB.prepare(`SELECT o.*, t.workforce_employee_id AS team_workforce_employee_id, t.schedule_professional_id, t.schedule_status, t.schedule_role, t.schedule_shift, t.schedule_nickname, t.schedule_instagram, t.schedule_color, t.units_json AS schedule_units_json, a.id AS crm_account_link_id, a.crm_username AS crm_account_username, a.review_status AS crm_account_review_status
         FROM crm_employee_onboarding o LEFT JOIN crm_employee_team t ON t.onboarding_id=o.id
         LEFT JOIN crm_employee_account_links a ON a.onboarding_id=o.id WHERE o.id=? LIMIT 1`).bind(onboardingId).first();
       if (!current) return withCORS(JSON.stringify({ success: false, error: 'Membro da equipe não encontrado', code: 'TEAM_MEMBER_NOT_FOUND' }), { status: 404 }, appOrigin);
@@ -1806,7 +1891,7 @@ export async function handleAdminRoutes({
       const accountScopeChanged = accountScope.state === 'CONFIRMED'
         && JSON.stringify(normalizeAllowedUnits(accountScope.crmUser.allowed_units_json)) !== JSON.stringify(nextAccountUnits);
 
-      await syncIdentityWorkforceOnboarding(env, {
+      const workforce = await syncIdentityWorkforceOnboarding(env, {
         onboardingId,
         fullName: nextName,
         corporateEmail: current.corporate_email,
@@ -1818,12 +1903,20 @@ export async function handleAdminRoutes({
         department: nextDepartment,
         createdBy: String(auth?.user?.username || ''),
       }, requestId);
+      const workforceEmployeeId = String(workforce?.employeeId || current.workforce_employee_id || '').trim();
+      if (!workforceEmployeeId) throw new Error('WORKFORCE_EMPLOYEE_ID_REQUIRED');
+      if (String(current.workforce_employee_id || '').trim() && String(current.workforce_employee_id).trim() !== workforceEmployeeId) throw new Error('TEAM_WORKFORCE_BINDING_CONFLICT');
+      if (String(current.team_workforce_employee_id || '').trim() && String(current.team_workforce_employee_id).trim() !== workforceEmployeeId) throw new Error('TEAM_WORKFORCE_BINDING_CONFLICT');
       workforceSynchronized = true;
 
       localPersistenceStage = 'ONBOARDING_TEAM_SCOPE_UPDATE';
       const localAt = new Date().toISOString();
       const sets = ['full_name=?', 'profile=?', 'job_title=?', 'department_name=?', 'units_json=?', 'updated_at=?'];
       const values = [nextName, nextProfile.profile || nextProfile, displayJobTitle(nextProfile.profile || nextProfile), nextDepartment, JSON.stringify(nextUnits), localAt];
+      if (!String(current.workforce_employee_id || '').trim()) {
+        sets.push('workforce_employee_id=?');
+        values.push(workforceEmployeeId);
+      }
       if (nextPersonalEmail) {
         sets.push('personal_email_encrypted=?', 'personal_email_hash=?');
         values.push(nextPersonalEmailEncrypted, nextPersonalEmailHash);
@@ -1837,8 +1930,8 @@ export async function handleAdminRoutes({
       const nextScheduleProfessionalId = scheduleEnabled ? (teamData.professionalId || current.schedule_professional_id || null) : (current.schedule_professional_id || null);
       const localStatements = [
         env.DB.prepare(`UPDATE crm_employee_onboarding SET ${sets.join(', ')} WHERE id=?`).bind(...values),
-        env.DB.prepare(`UPDATE crm_employee_team SET schedule_professional_id=?, schedule_status=?, schedule_role=?, schedule_shift=?, schedule_nickname=?, schedule_instagram=?, schedule_color=?, units_json=?, updated_at=? WHERE onboarding_id=?`).bind(
-        nextScheduleProfessionalId, teamData.status || null, teamData.role || null, teamData.shift || null,
+        env.DB.prepare(`UPDATE crm_employee_team SET workforce_employee_id=?, schedule_professional_id=?, schedule_status=?, schedule_role=?, schedule_shift=?, schedule_nickname=?, schedule_instagram=?, schedule_color=?, units_json=?, updated_at=? WHERE onboarding_id=?`).bind(
+        workforceEmployeeId, nextScheduleProfessionalId, teamData.status || null, teamData.role || null, teamData.shift || null,
         teamData.nickname || null, teamData.instagram || null, teamData.color || null, JSON.stringify(teamData.units), localAt, onboardingId,
         ),
       ];

--- a/inventory/tests/onboardingConsistency.test.mjs
+++ b/inventory/tests/onboardingConsistency.test.mjs
@@ -117,6 +117,43 @@ test('invite activation has an audited retry boundary and does not mint a second
   assert.doesNotMatch(activationBlock, /randomInviteToken\(\)/);
 });
 
+test('Workforce recovery is backend-only and invitation delivery fails closed without a binding', async () => {
+  const admin = await readFile(new URL('../src/routes/admin.js', import.meta.url), 'utf8');
+  const localApi = await readFile(new URL('../../crm/api/server.js', import.meta.url), 'utf8');
+  const reconcileBlock = admin.slice(
+    admin.indexOf('const reconcileWorkforceMatch'),
+    admin.indexOf('const resendInviteMatch'),
+  );
+  const resendBlock = admin.slice(
+    admin.indexOf('const resendInviteMatch'),
+    admin.indexOf('const revokeInviteMatch'),
+  );
+  const localResendBlock = localApi.slice(
+    localApi.indexOf("app.post(['/api/crm/admin/team/:id/invite/resend'"),
+    localApi.indexOf("app.post(['/api/crm/admin/team/:id/invite/revoke'"),
+  );
+  const updateBlock = admin.slice(admin.indexOf('const teamMemberMatch'), admin.indexOf("if (url.pathname === '/admin/team' && request.method === 'GET')"));
+
+  assert.match(reconcileBlock, /workforce.*reconcile/);
+  assert.match(reconcileBlock, /syncIdentityWorkforceOnboarding\(env/);
+  assert.match(reconcileBlock, /EMPLOYEE_TEAM_WORKFORCE_RECONCILED/);
+  assert.match(reconcileBlock, /inviteDeliveryChanged: false/);
+  assert.doesNotMatch(reconcileBlock, /sendAccountInviteEmail/);
+  assert.match(resendBlock, /TEAM_WORKFORCE_BINDING_REQUIRED/);
+  assert.ok(
+    resendBlock.indexOf('TEAM_WORKFORCE_BINDING_REQUIRED') < resendBlock.indexOf('UPDATE ${invitesTable} SET revoked=1'),
+    'the resend guard must run before any invite revocation',
+  );
+  assert.match(localResendBlock, /TEAM_WORKFORCE_BINDING_REQUIRED/);
+  assert.ok(
+    localResendBlock.indexOf('TEAM_WORKFORCE_BINDING_REQUIRED') < localResendBlock.indexOf('store.invites.forEach'),
+    'the local preview guard must run before any invite revocation',
+  );
+  assert.match(updateBlock, /const workforce = await syncIdentityWorkforceOnboarding\(env/);
+  assert.match(updateBlock, /sets\.push\('workforce_employee_id=\?'\)/);
+  assert.match(updateBlock, /UPDATE crm_employee_team SET workforce_employee_id=\?/);
+});
+
 test('onboarding status changes stay hierarchical, synchronized, audited and fail closed', async () => {
   const admin = await readFile(new URL('../src/routes/admin.js', import.meta.url), 'utf8');
   assert.ok(admin.includes("const statusMatch = url.pathname.match(/^\\/admin\\/(onboarding|team)\\/([^/]+)\\/status$/);"));

--- a/inventory/tests/unifiedTeamAccountScope.test.mjs
+++ b/inventory/tests/unifiedTeamAccountScope.test.mjs
@@ -74,6 +74,14 @@ function workforceBinding(ok = true) {
   };
 }
 
+function workforceBindingWithEmployee(employeeId) {
+  return {
+    fetch: async () => new Response(JSON.stringify({ ok: true, data: { employeeId } }), {
+      headers: { 'content-type': 'application/json' },
+    }),
+  };
+}
+
 function routeEnv({ workforce = workforceBinding(true), unifiedTeamEnabled = 'true', DB = env.DB } = {}) {
   return {
     ...env,
@@ -274,4 +282,66 @@ test('workforce failure prevents any local team or account scope write', async (
   assert.deepEqual(state.teamUnits, ['barra-shopping-sul']);
   assert.deepEqual(state.accountUnits, ['barra-shopping-sul']);
   assert.equal(state.sessionVersion, 0);
+});
+
+test('backend Workforce reconciliation repairs a pending invite without activation or delivery', async () => {
+  await env.DB.batch([
+    env.DB.prepare("UPDATE crm_employee_onboarding SET account_status='INVITED', workforce_employee_id=NULL, invite_id='pending-hellen-invite', provisioning_state='FAILED', last_error_code='WORKFORCE_SYNC_FAILED' WHERE id=?").bind('hellenmelo-employee'),
+    env.DB.prepare('DELETE FROM crm_employee_team WHERE onboarding_id=?').bind('hellenmelo-employee'),
+    env.DB.prepare('UPDATE crm_users SET ativo=0 WHERE username=?').bind('hellenmelo'),
+  ]);
+
+  const result = await callRoute('/admin/team/hellenmelo-employee/workforce/reconcile', {
+    method: 'POST',
+    envOverride: { workforce: workforceBindingWithEmployee('wf-hellen-repaired') },
+  });
+  assert.equal(result.response.status, 200);
+  assert.equal(result.body.success, true);
+  const onboarding = await env.DB.prepare('SELECT account_status, workforce_employee_id, provisioning_state FROM crm_employee_onboarding WHERE id=?').bind('hellenmelo-employee').first();
+  const team = await env.DB.prepare('SELECT workforce_employee_id FROM crm_employee_team WHERE onboarding_id=?').bind('hellenmelo-employee').first();
+  const crmUser = await env.DB.prepare('SELECT ativo FROM crm_users WHERE username=?').bind('hellenmelo').first();
+  assert.equal(onboarding.account_status, 'INVITED');
+  assert.equal(onboarding.workforce_employee_id, 'wf-hellen-repaired');
+  assert.equal(onboarding.provisioning_state, 'INVITE_PENDING');
+  assert.equal(team.workforce_employee_id, 'wf-hellen-repaired');
+  assert.equal(Number(crmUser.ativo), 0);
+});
+
+test('resend refuses a missing Workforce binding before mutating a pending invite', async () => {
+  await env.DB.prepare("UPDATE crm_employee_onboarding SET account_status='INVITED', workforce_employee_id=NULL, invite_id='pending-hellen-invite', provisioning_state='FAILED' WHERE id=?").bind('hellenmelo-employee').run();
+  const result = await callRoute('/admin/team/hellenmelo-employee/invite/resend', { method: 'POST' });
+  assert.equal(result.response.status, 409);
+  assert.equal(result.body.code, 'TEAM_WORKFORCE_BINDING_REQUIRED');
+  const onboarding = await env.DB.prepare('SELECT account_status, workforce_employee_id, invite_id FROM crm_employee_onboarding WHERE id=?').bind('hellenmelo-employee').first();
+  assert.equal(onboarding.account_status, 'INVITED');
+  assert.equal(onboarding.workforce_employee_id, null);
+  assert.equal(onboarding.invite_id, 'pending-hellen-invite');
+});
+
+test('Workforce reconciliation fails closed when the returned employee belongs to another onboarding', async () => {
+  await env.DB.batch([
+    env.DB.prepare("UPDATE crm_employee_onboarding SET account_status='INVITED', workforce_employee_id=NULL, provisioning_state='FAILED' WHERE id=?").bind('hellenmelo-employee'),
+    env.DB.prepare('DELETE FROM crm_employee_team WHERE onboarding_id=?').bind('hellenmelo-employee'),
+  ]);
+  const result = await callRoute('/admin/team/hellenmelo-employee/workforce/reconcile', {
+    method: 'POST',
+    envOverride: { workforce: workforceBindingWithEmployee('wf-unlinked') },
+  });
+  assert.equal(result.response.status, 409);
+  assert.equal(result.body.code, 'TEAM_WORKFORCE_BINDING_CONFLICT');
+  const onboarding = await env.DB.prepare('SELECT workforce_employee_id FROM crm_employee_onboarding WHERE id=?').bind('hellenmelo-employee').first();
+  const team = await env.DB.prepare('SELECT onboarding_id FROM crm_employee_team WHERE workforce_employee_id=?').bind('wf-unlinked').first();
+  assert.equal(onboarding.workforce_employee_id, null);
+  assert.equal(team.onboarding_id, 'unlinked-employee');
+});
+
+test('team edits persist the Workforce employee returned by the idempotent backend sync', async () => {
+  await env.DB.prepare('UPDATE crm_employee_onboarding SET workforce_employee_id=NULL WHERE id=?').bind('hellenmelo-employee').run();
+  const result = await callRoute('/admin/team/hellenmelo-employee', {
+    body: { units: ['barra-shopping-sul'] },
+    envOverride: { workforce: workforceBindingWithEmployee('wf-hellenmelo') },
+  });
+  assert.equal(result.response.status, 200);
+  const onboarding = await env.DB.prepare('SELECT workforce_employee_id FROM crm_employee_onboarding WHERE id=?').bind('hellenmelo-employee').first();
+  assert.equal(onboarding.workforce_employee_id, 'wf-hellenmelo');
 });


### PR DESCRIPTION
## Objetivo
Repara o caminho de onboarding que permitia reenviar um convite sem o vínculo obrigatório de Workforce e cria uma reconciliação administrativa idempotente, somente no backend.

## Comportamento
- `POST /admin/team/:id/workforce/reconcile` recompõe somente o vínculo Workforce e a projeção de equipe.
- Não cria senha, não ativa a conta e não envia/revoga convite.
- O reenvio falha fechado com `TEAM_WORKFORCE_BINDING_REQUIRED` antes de qualquer mutação de convite.
- Edições de equipe persistem o `workforce_employee_id` retornado pelo sync idempotente.
- A prévia local aplica a mesma guarda de reenvio.

## Risco e rollback
Mudança de backend de onboarding, sem migration. Reverter este PR remove a rota e restaura o comportamento anterior; enquanto este código estiver ativo, qualquer falha de Workforce mantém o convite sem entrega e a conta inativa.

## Validação
- `pnpm --dir inventory test`: 87 testes aprovados.
- Jornada D1 efêmera: reconciliação pendente, recusa antes de reenvio, colisão de identidade e persistência no PUT.
- `node --check inventory/src/routes/admin.js` e `node --check crm/api/server.js`.