### PR TITLE
fix(ponto): avoid preview recovery lease inversion

### DIFF
--- a/.github/scripts/ponto-dispatch-workflow.test.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.test.mjs
@@ -116,6 +116,9 @@ test("Ponto recovery keeps provenance fail-closed while accepting a closure-equi
 });
 
 test("Ponto child mutations expose the canonical global resource and conflict scope", () => {
+  assert.equal(globalResourceFor("deploy-timekeeping.yml", { release_scope: "ponto", target: "preview" }), "global:ponto-workers-writer");
+  assert.equal(globalResourceFor("deploy-core-workers.yml", { release_scope: "ponto", unit: "inventory", target: "preview" }), "global:ponto-workers-writer");
+  assert.equal(globalResourceFor("deploy-crm-pages.yml", { release_scope: "ponto", target: "preview" }), "global:crm-cloudflare-writer");
   assert.equal(globalResourceFor("deploy-timekeeping.yml", { release_scope: "ponto", target: "staging" }), "global:ponto-workers-writer");
   assert.equal(globalResourceFor("cloudflare-pages-sync-ponto.yml", { target: "staging" }), "global:crm-cloudflare-writer");
   assert.equal(globalResourceFor("deploy-core-workers.yml", { release_scope: "ponto", unit: "api", target: "staging" }), "global:ponto-workers-writer");

--- a/.github/scripts/ponto-environment-protection-workflow.test.mjs
+++ b/.github/scripts/ponto-environment-protection-workflow.test.mjs
@@ -64,7 +64,26 @@ test("coordinator initializes runner-only custody paths inside a step", () => {
   assert.doesNotMatch(jobEnvironment, /\$\{\{\s*runner\./);
   assert.match(
     initialization,
-    /echo "PONTO_ORCHESTRATOR_COORDINATION_PROOF_FILE=\$RUNNER_TEMP\/ponto-release\/global-coordination-release-ponto\.json" >> "\$GITHUB_ENV"/,
+    /if \[\[ "\$STAGE" != "preview" \]\]; then\s+echo "PONTO_ORCHESTRATOR_COORDINATION_PROOF_FILE=\$RUNNER_TEMP\/ponto-release\/global-coordination-release-ponto\.json" >> "\$GITHUB_ENV"/,
+  );
+
+  const acquireStart = coordinator.indexOf(
+    "\n      - name: Acquire the composite Ponto release lease before gate settlement",
+  );
+  const acquireEnd = coordinator.indexOf("\n      - name:", acquireStart + 1);
+  const releaseStart = coordinator.indexOf(
+    "\n      - name: Release the composite Ponto release lease",
+  );
+  const releaseEnd = coordinator.indexOf("\n\n  recovery-latch:", releaseStart);
+  assert.ok(acquireStart >= 0);
+  assert.ok(releaseStart >= 0);
+  assert.match(
+    coordinator.slice(acquireStart, acquireEnd),
+    /if: \$\{\{ inputs\.stage != 'preview' \}\}/,
+  );
+  assert.match(
+    coordinator.slice(releaseStart, releaseEnd),
+    /if: \$\{\{ always\(\) && inputs\.stage != 'preview' \}\}/,
   );
 });
 

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -134,7 +134,9 @@ jobs:
       - name: Initialize private release artifact directory
         run: |
           echo "PONTO_ARTIFACT_DIR=$RUNNER_TEMP/ponto-release" >> "$GITHUB_ENV"
-          echo "PONTO_ORCHESTRATOR_COORDINATION_PROOF_FILE=$RUNNER_TEMP/ponto-release/global-coordination-release-ponto.json" >> "$GITHUB_ENV"
+          if [[ "$STAGE" != "preview" ]]; then
+            echo "PONTO_ORCHESTRATOR_COORDINATION_PROOF_FILE=$RUNNER_TEMP/ponto-release/global-coordination-release-ponto.json" >> "$GITHUB_ENV"
+          fi
           mkdir -p "$RUNNER_TEMP/ponto-release"
       - name: Verify immutable source and ordered predecessor provenance
         id: source
@@ -215,10 +217,13 @@ jobs:
           PONTO_EXPECTED_STAGE="$predecessor" PONTO_EXPECTED_SHA="$RELEASE_SHA" PONTO_EXPECTED_REPOSITORY="$GITHUB_REPOSITORY" \
             node .github/scripts/ponto-release-evidence.mjs verify "$PONTO_ARTIFACT_DIR/predecessor/ponto-release-evidence.json"
           rm -f "$RUNNER_TEMP/ponto-workflow.json" "$RUNNER_TEMP/predecessor-run.json"
-      # Hold the closure-scoped Ponto lease while required checks settle. The
-      # coordinator still admits a documented disjoint main merge, but delays
-      # one that changes the selected Ponto dependency closure.
+      # Preview never holds the composite release lease: its child publishers
+      # already take their individual global writer leases, while the watchdog
+      # must remain able to acquire release:ponto and materialize fail-close.
+      # Staging and live stages retain the closure-scoped composite lease while
+      # their required checks settle.
       - name: Acquire the composite Ponto release lease before gate settlement
+        if: ${{ inputs.stage != 'preview' }}
         uses: ./.github/actions/global-coordination-acquire
         with:
           required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
@@ -1810,7 +1815,7 @@ jobs:
           retention-days: 90
           if-no-files-found: warn
       - name: Release the composite Ponto release lease
-        if: always()
+        if: ${{ always() && inputs.stage != 'preview' }}
         uses: ./.github/actions/global-coordination-release
         with:
           required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -176,13 +176,21 @@ test("the staging RBAC journey recovers synthetic teardown under a fresh lease",
   assert.match(workflow, /refusing a non-staging D1 target/);
 });
 
-test("the Ponto composite lease starts before gate settlement, selects the correct authority, and spans the orchestrator", () => {
+test("the Ponto composite lease protects only non-preview stages while preview keeps separate writer custody", () => {
   const workflow = read(".github/workflows/ponto-progressive-release.yml");
   const acquire = workflow.indexOf("Acquire the composite Ponto release lease before gate settlement");
   const requiredChecks = workflow.indexOf("Attest canonical merged PR and required checks for the immutable SHA");
   const firstDispatch = workflow.indexOf("node .github/scripts/ponto-dispatch-workflow.mjs");
   const release = workflow.indexOf("Release the composite Ponto release lease");
   assert.ok(acquire >= 0 && requiredChecks > acquire && firstDispatch > acquire && release > firstDispatch);
+  const acquireEnd = workflow.indexOf("\n      - name:", acquire + 1);
+  const releaseEnd = workflow.indexOf("\n\n  recovery-latch:", release);
+  assert.match(workflow.slice(acquire, acquireEnd), /if: \$\{\{ inputs\.stage != 'preview' \}\}/);
+  assert.match(workflow.slice(release, releaseEnd), /if: \$\{\{ always\(\) && inputs\.stage != 'preview' \}\}/);
+  assert.match(
+    workflow,
+    /if \[\[ "\$STAGE" != "preview" \]\]; then\s+echo "PONTO_ORCHESTRATOR_COORDINATION_PROOF_FILE=/,
+  );
   assert.match(workflow, /SKINCOS_GLOBAL_COORDINATOR_URL: \$\{\{ contains\(fromJSON\('\["preview","staging"\]'\)/);
   assert.match(workflow, /coordinator_url: \$\{\{ env\.SKINCOS_GLOBAL_COORDINATOR_URL \}\}/);
   assert.match(read(".github/scripts/ponto-dispatch-workflow.mjs"), /revalidatePontoCompositeLease/);


### PR DESCRIPTION
## Summary
- keep preview child writers under their scoped global writer resources
- skip the composite elease:ponto lease and proof for preview runs
- preserve composite release custody for staging and all live stages

## Validation
- codex:global-coordination:test
- codex:deploy-topology:test
- targeted Ponto dispatch and environment-protection tests