### PR TITLE
fix(ponto): recover coherent staging rollback

### DIFF
--- a/.github/scripts/ponto-watchdog-journal.mjs
+++ b/.github/scripts/ponto-watchdog-journal.mjs
@@ -36,7 +36,7 @@ const SURFACES = Object.freeze({
   identityWorkforce: {
     workflowPath: ".github/workflows/deploy-core-workers.yml",
     titlePrefix: (stage, sha, runId) =>
-      `Core inventory ${stage} ${sha} orchestrator=${runId}`,
+      `Core inventory ${stage} team=true ${sha} orchestrator=${runId}`,
     runFile: "runs/identity.json",
     artifacts: (stage, sha) => [
       [`ponto-surface-identity-workforce-${stage}-${sha}`, "surfaces/identity"],
@@ -46,7 +46,7 @@ const SURFACES = Object.freeze({
   coreApi: {
     workflowPath: ".github/workflows/deploy-core-workers.yml",
     titlePrefix: (stage, sha, runId) =>
-      `Core api ${stage} ${sha} orchestrator=${runId}`,
+      `Core api ${stage} team=false ${sha} orchestrator=${runId}`,
     runFile: "runs/core.json",
     artifacts: (stage, sha) => [
       [`ponto-surface-core-api-${stage}-${sha}`, "surfaces/core"],

--- a/.github/scripts/ponto-watchdog-journal.test.mjs
+++ b/.github/scripts/ponto-watchdog-journal.test.mjs
@@ -115,8 +115,8 @@ test("watchdog reconstructs exact surface run files and a bounded artifact manif
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "ponto-watchdog-journal-"));
   const rows = [
     run(10, "deploy-timekeeping.yml", `Timekeeping staging ${sha} orchestrator=99 nonce=${"1".repeat(32)}`),
-    run(11, "deploy-core-workers.yml", `Core inventory staging ${sha} orchestrator=99 nonce=${"2".repeat(32)}`),
-    run(12, "deploy-core-workers.yml", `Core api staging ${sha} orchestrator=99 nonce=${"3".repeat(32)}`),
+    run(11, "deploy-core-workers.yml", `Core inventory staging team=true ${sha} orchestrator=99 nonce=${"2".repeat(32)}`),
+    run(12, "deploy-core-workers.yml", `Core api staging team=false ${sha} orchestrator=99 nonce=${"3".repeat(32)}`),
     run(13, "deploy-crm-pages.yml", `CRM Pages staging ${sha} orchestrator=99 nonce=${"4".repeat(32)}`),
   ];
   anchor(root, "timekeeping.json", "deploy-timekeeping.yml", 501, 10);
@@ -314,7 +314,7 @@ test("watchdog accepts an exact terminal coordination-gate failure with no mutat
   const child = run(
     10,
     "deploy-core-workers.yml",
-    `Core inventory staging ${sha} orchestrator=99 nonce=${"1".repeat(32)}`,
+    `Core inventory staging team=true ${sha} orchestrator=99 nonce=${"1".repeat(32)}`,
   );
   child.conclusion = "failure";
   const request = scopedRequest([child], async (pathname) => {


### PR DESCRIPTION
## Summary
- recognize the exact Core child titles, including team=true and team=false, during durable watchdog recovery
- cover the recovery reconstruction regression with focused tests

## Validation
- node --test ponto-staging-rollback-drill.test.mjs ponto-watchdog-journal.test.mjs (19/19)
- npm run codex:global-coordination:test (196/196)

## Operational context
The failed staging drill restored all incumbents under maintenance but recovery journal reconstruction could not match the actual Core child titles. The incumbent affinity repair is already merged separately in #1392. This PR is code-only; a new immutable preview and full governed staging run are required before any further promotion. Reverting this commit restores the previous behavior.