### PR TITLE
fix(ponto): recover immutable tagged staging rollback

### DIFF
--- a/.github/scripts/ponto-automatic-rollback-safety.test.mjs
+++ b/.github/scripts/ponto-automatic-rollback-safety.test.mjs
@@ -69,3 +69,12 @@ test("Pages recovery skips rollback intent custody when no owned candidate exist
     /const pagesIntentInput = plan\.crmPages && UUID\.test\(plan\.crmPages\.candidateDeploymentId \|\| ""\) \?/,
   );
 });
+
+test("recovery accepts only children from the exact immutable Ponto release tag", () => {
+  assert.match(source, /import \{ releaseTagFor \} from "\.\/ponto-release-identity\.mjs"/);
+  assert.match(source, /const expectedReleaseBranch = releaseTagFor\("ponto", releaseSha\);/);
+  assert.match(source, /const isExactImmutableChildRun = \(run, workflow\) => \(/);
+  assert.match(source, /run\.headBranch === expectedReleaseBranch/);
+  assert.match(source, /String\(run\.headSha \|\| ""\)\.toLowerCase\(\) === releaseSha/);
+  assert.doesNotMatch(source, /run\.headBranch !== "main"/);
+});

--- a/.github/scripts/ponto-automatic-rollback.mjs
+++ b/.github/scripts/ponto-automatic-rollback.mjs
@@ -15,6 +15,7 @@ import {
   classifyPagesRollbackOwnership,
   classifyWorkerRollbackOwnership,
 } from "./ponto-rollback-ownership.mjs";
+import { releaseTagFor } from "./ponto-release-identity.mjs";
 import { attestBrokerFailCloseEvidence } from "./ponto-recovery-evidence.mjs";
 import { readCloudflareKvJson } from "./ponto-kv-readback.mjs";
 
@@ -55,6 +56,7 @@ if (process.env.CF_ACCESS_CLIENT_ID || process.env.CF_ACCESS_CLIENT_SECRET) {
 
 if (!artifactRoot || !reportFile) throw new Error("automatic rollback artifact root and report path are required");
 if (!/^[0-9a-f]{40}$/.test(releaseSha) || !["staging", "pilot", "canary", "production"].includes(stage)) throw new Error("invalid automatic rollback identity");
+const expectedReleaseBranch = releaseTagFor("ponto", releaseSha);
 if (
   !/^[0-9]+$/.test(orchestratorRunId)
   || !repository.includes("/")
@@ -287,6 +289,15 @@ const expectedWeights = {
   canary: { timekeeping: 0, identityWorkforce: 0, coreApi: 0 },
   production: { timekeeping: 100, identityWorkforce: 100, coreApi: 100 },
 };
+const isExactImmutableChildRun = (run, workflow) => (
+  run?.workflow === workflow
+  && run.status === "completed"
+  && ["success", "failure", "cancelled", "timed_out", "action_required", "startup_failure"].includes(String(run.conclusion || ""))
+  && run.event === "workflow_dispatch"
+  && run.headBranch === expectedReleaseBranch
+  && String(run.headSha || "").toLowerCase() === releaseSha
+  && run.repository === repository
+);
 const plan = {};
 const unresolved = [];
 const untouched = {};
@@ -300,14 +311,7 @@ for (const [name, spec] of Object.entries(surfaceSpecs)) {
     continue;
   }
   const run = readJson(runFile);
-  if (
-    run.workflow !== spec.workflow
-    || run.status !== "completed"
-    || !["success", "failure", "cancelled", "timed_out", "action_required", "startup_failure"].includes(String(run.conclusion || ""))
-    || run.event !== "workflow_dispatch"
-    || run.headBranch !== "main"
-    || run.repository !== repository
-  ) {
+  if (!isExactImmutableChildRun(run, spec.workflow)) {
     unresolved.push({ surface: name, reason: "child-run-provenance-invalid" });
     continue;
   }
@@ -422,12 +426,7 @@ const pagesProvisionRunFile = path.join(artifactRoot, "runs/provision-pages.json
 if (fs.existsSync(pagesProvisionRunFile)) {
   const run = readJson(pagesProvisionRunFile);
   const journalFile = path.join(artifactRoot, "provisioning/pages/pages-release-probe-evidence.json");
-  const runValid = run.workflow === "cloudflare-pages-sync-ponto.yml"
-    && run.status === "completed"
-    && ["success", "failure", "cancelled", "timed_out", "action_required", "startup_failure"].includes(String(run.conclusion || ""))
-    && run.event === "workflow_dispatch"
-    && run.headBranch === "main"
-    && run.repository === repository;
+  const runValid = isExactImmutableChildRun(run, "cloudflare-pages-sync-ponto.yml");
   if (!runValid) {
     unresolved.push({ surface: "pagesEnvironmentSecrets", reason: "child-run-provenance-invalid" });
   } else if (!fs.existsSync(journalFile)) {
@@ -509,12 +508,7 @@ const drillRunFile = path.join(artifactRoot, "runs/staging-rollback-drill.json")
 if (staging && fs.existsSync(drillRunFile)) {
   const run = readJson(drillRunFile);
   const drillFile = path.join(artifactRoot, "staging-rollback-drill/ponto-staging-rollback-drill.json");
-  const runValid = run.workflow === "ponto-staging-rollback-drill.yml"
-    && run.status === "completed"
-    && ["success", "failure", "cancelled", "timed_out", "action_required", "startup_failure"].includes(String(run.conclusion || ""))
-    && run.event === "workflow_dispatch"
-    && run.headBranch === "main"
-    && run.repository === repository;
+  const runValid = isExactImmutableChildRun(run, "ponto-staging-rollback-drill.yml");
   if (!runValid || !fs.existsSync(drillFile)) {
     drillOwnershipResolved = false;
     unresolved.push({ surface: "stagingRollbackDrill", reason: "drill-run-or-evidence-provenance-invalid" });

--- a/.github/scripts/ponto-staging-rollback-drill.mjs
+++ b/.github/scripts/ponto-staging-rollback-drill.mjs
@@ -99,6 +99,11 @@ export function classifyIncumbentBundle(evidence) {
 }
 
 export function isFailClosedIncumbentHealth({ status, payload, headers, expected }) {
+  return classifyIncumbentCompatibilityHealth({ status, payload, headers, expected })
+    === "heterogeneous-fail-closed-health";
+}
+
+export function classifyIncumbentCompatibilityHealth({ status, payload, headers, expected }) {
   const header = (name) => {
     if (typeof headers?.get === "function") return String(headers.get(name) || "").trim().toLowerCase();
     const lower = name.toLowerCase();
@@ -107,24 +112,48 @@ export function isFailClosedIncumbentHealth({ status, payload, headers, expected
   const metadata = payload?.versionMetadata || {};
   const moduleControlState = String(payload?.dependencies?.module_control?.state || "").toLowerCase();
   const gatewayAffinity = payload?.dependencies?.gateway_affinity || {};
-  return status === 200
+  const timekeepingSourceSha = String(expected?.timekeepingSourceSha || "").toLowerCase();
+  const timekeepingVersionId = String(expected?.timekeepingVersionId || "").toLowerCase();
+  const coreSourceSha = String(expected?.coreSourceSha || "").toLowerCase();
+  const coreVersionId = String(expected?.coreVersionId || "").toLowerCase();
+  const sourceShas = [
+    expected?.pagesSourceSha,
+    expected?.identitySourceSha,
+    expected?.coreSourceSha,
+    expected?.timekeepingSourceSha,
+  ].map((value) => String(value || "").toLowerCase());
+  const coherent = sourceShas.every((value) => SHA.test(value))
+    && new Set(sourceShas).size === 1;
+  const baseline = status === 200
     && payload?.ok === false
     && payload?.ready === false
     && payload?.service === "workforce-timekeeping"
     && payload?.unit === "timekeeping"
     && payload?.environment === "staging"
     && payload?.database === true
-    && ["healthy", "unavailable"].includes(moduleControlState)
-    && gatewayAffinity.state === "unavailable"
-    && gatewayAffinity.reason === "RELEASE_AFFINITY_MISMATCH"
-    && String(metadata.releaseSha || "").toLowerCase() === String(expected.timekeepingSourceSha || "").toLowerCase()
-    && String(metadata.workerVersionId || "").toLowerCase() === String(expected.timekeepingVersionId || "").toLowerCase()
+    && String(metadata.releaseSha || "").toLowerCase() === timekeepingSourceSha
+    && String(metadata.workerVersionId || "").toLowerCase() === timekeepingVersionId
     && SHA.test(String(metadata.gatewayReleaseSha || ""))
     && UUID.test(String(metadata.gatewayVersionId || ""))
     && String(metadata.gatewayEnvironment || "").toLowerCase() === "staging"
-    && header("x-skincos-timekeeping-release-sha") === String(expected.timekeepingSourceSha || "").toLowerCase()
+    && header("x-skincos-timekeeping-release-sha") === timekeepingSourceSha
     && header("x-skincos-timekeeping-environment") === "staging"
-    && header("x-skincos-timekeeping-version-id") === String(expected.timekeepingVersionId || "").toLowerCase();
+    && header("x-skincos-timekeeping-version-id") === timekeepingVersionId;
+  if (!baseline) return null;
+  if (
+    !coherent
+    && ["healthy", "unavailable"].includes(moduleControlState)
+    && gatewayAffinity.state === "unavailable"
+    && gatewayAffinity.reason === "RELEASE_AFFINITY_MISMATCH"
+  ) return "heterogeneous-fail-closed-health";
+  if (
+    coherent
+    && moduleControlState === "unavailable"
+    && gatewayAffinity.state === "healthy"
+    && String(metadata.gatewayReleaseSha || "").toLowerCase() === coreSourceSha
+    && String(metadata.gatewayVersionId || "").toLowerCase() === coreVersionId
+  ) return "coherent-maintenance-health";
+  return null;
 }
 
 const versionSet = (ids, side) => ({
@@ -178,6 +207,24 @@ const safeFailureDetail = (value) => String(value || "")
   .replaceAll(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "<email>")
   .replaceAll(/\b(password|pin|token|secret|authorization|cookie)\s*[:=]\s*[^,\s}]+/gi, "$1=<redacted>")
   .slice(0, 500);
+
+const isRetryableTimekeepingPropagationFailure = (error) => {
+  const detail = String(error?.details || "");
+  return String(error?.code || "") === "AUTHENTICATED_JOURNEY_FAILED"
+    && detail.includes("invalid PIN did not fail closed (503/domain_service_degraded")
+    && detail.includes('"timekeepingReleaseSha":""')
+    && detail.includes('"timekeepingVersionId":""');
+};
+
+const isCoherentIncumbentExpectation = (expected) => {
+  const sourceShas = [
+    expected?.pagesSourceSha,
+    expected?.identitySourceSha,
+    expected?.coreSourceSha,
+    expected?.timekeepingSourceSha,
+  ].map((value) => String(value || "").toLowerCase());
+  return sourceShas.every((value) => SHA.test(value)) && new Set(sourceShas).size === 1;
+};
 
 const recordFailure = (report, phase, error) => {
   const failure = { phase, code: publicFailureCode(error) };
@@ -245,6 +292,7 @@ async function validateFixture({
   let handle;
   let fixtureReady = false;
   let affinityReady = !includeProtectedContract;
+  let legacyIncumbentCompatibilityRequired = false;
   if (includeProtectedContract) {
     report.functionalValidation.candidateAffinity.attempted = true;
     try {
@@ -295,7 +343,22 @@ async function validateFixture({
         ...await runtime.runJourney(handle, pages.url, expected),
       };
     } catch (error) {
-      recordFailure(report, `${label}.journey`, error);
+      if (
+        label === "incumbent"
+        && isCoherentIncumbentExpectation(expected)
+        && isRetryableTimekeepingPropagationFailure(error)
+      ) {
+        legacyIncumbentCompatibilityRequired = true;
+        report.functionalValidation[journeyKey] = {
+          attempted: true,
+          passed: false,
+          skipped: true,
+          blocking: true,
+          reason: "legacy-incumbent-timekeeping-contract-unavailable",
+        };
+      } else {
+        recordFailure(report, `${label}.journey`, error);
+      }
     }
   }
 
@@ -313,6 +376,7 @@ async function validateFixture({
       recordFailure(report, `${label}.teardown`, error);
     }
   }
+  return { legacyIncumbentCompatibilityRequired };
 }
 
 export async function runStagingRollbackDrill(config, runtime) {
@@ -321,6 +385,24 @@ export async function runStagingRollbackDrill(config, runtime) {
   let restoredPages = null;
   let mutationStarted = false;
   let incumbentProvenance = null;
+  let incumbentCompatibilityExpected = null;
+  let incumbentCompatibilityNeedsMaintenance = false;
+
+  const setPreRestorationMaintenance = async () => {
+    if (report.moduleControl.preRestorationMaintenance.attempted) {
+      return report.moduleControl.preRestorationMaintenance;
+    }
+    report.moduleControl.preRestorationMaintenance.attempted = true;
+    try {
+      report.moduleControl.preRestorationMaintenance = {
+        attempted: true,
+        ...await runtime.setModuleState("maintenance", {}, "pre-restoration-maintenance"),
+      };
+    } catch (error) {
+      recordFailure(report, "module-control.pre-restoration-maintenance", error);
+    }
+    return report.moduleControl.preRestorationMaintenance;
+  };
 
   report.preflight.attempted = true;
   try {
@@ -364,6 +446,16 @@ export async function runStagingRollbackDrill(config, runtime) {
   }
 
   if (report.preflight.passed) {
+    incumbentCompatibilityExpected = {
+      pagesSourceSha: incumbentProvenance.crmPages.sourceSha,
+      identitySourceSha: incumbentProvenance.identityWorkforce.sourceSha,
+      coreSourceSha: incumbentProvenance.coreApi.sourceSha,
+      timekeepingSourceSha: incumbentProvenance.timekeeping.sourceSha,
+      pagesDeploymentId: null,
+      identityVersionId: config.ids.identityWorkforce.incumbent,
+      coreVersionId: config.ids.coreApi.incumbent,
+      timekeepingVersionId: config.ids.timekeeping.incumbent,
+    };
     mutationStarted = true;
     rollbackPages = await mutateEverySurface({
       config,
@@ -396,21 +488,15 @@ export async function runStagingRollbackDrill(config, runtime) {
           report.functionalValidation.incumbentCompatibility = {
             attempted: true,
             ...await runtime.proveIncumbentCompatibility(rollbackPages, {
-              pagesSourceSha: incumbentProvenance.crmPages.sourceSha,
-              identitySourceSha: incumbentProvenance.identityWorkforce.sourceSha,
-              coreSourceSha: incumbentProvenance.coreApi.sourceSha,
-              timekeepingSourceSha: incumbentProvenance.timekeeping.sourceSha,
+              ...incumbentCompatibilityExpected,
               pagesDeploymentId: rollbackPages.activeDeploymentId,
-              identityVersionId: config.ids.identityWorkforce.incumbent,
-              coreVersionId: config.ids.coreApi.incumbent,
-              timekeepingVersionId: config.ids.timekeeping.incumbent,
             }),
           };
         } catch (error) {
           recordFailure(report, "incumbent.compatibility", error);
         }
       } else if (report.moduleControl.incumbentActive.passed) {
-        await validateFixture({
+        const validation = await validateFixture({
           label: "incumbent",
           pages: rollbackPages,
           expected: {
@@ -420,25 +506,40 @@ export async function runStagingRollbackDrill(config, runtime) {
             timekeepingVersionId: config.ids.timekeeping.incumbent,
             identityVersionId: config.ids.identityWorkforce.incumbent,
             coreVersionId: config.ids.coreApi.incumbent,
+            pagesSourceSha: incumbentProvenance.crmPages.sourceSha,
+            identitySourceSha: incumbentProvenance.identityWorkforce.sourceSha,
+            coreSourceSha: incumbentProvenance.coreApi.sourceSha,
+            timekeepingSourceSha: incumbentProvenance.timekeeping.sourceSha,
           },
           includeProtectedContract: false,
           runtime,
           report,
         });
+        incumbentCompatibilityNeedsMaintenance = validation.legacyIncumbentCompatibilityRequired;
+      }
+    }
+  }
+
+  if (incumbentCompatibilityNeedsMaintenance) {
+    await setPreRestorationMaintenance();
+    if (report.moduleControl.preRestorationMaintenance.passed && incumbentCompatibilityExpected) {
+      report.functionalValidation.incumbentCompatibility.attempted = true;
+      try {
+        report.functionalValidation.incumbentCompatibility = {
+          attempted: true,
+          ...await runtime.proveIncumbentCompatibility(rollbackPages, {
+            ...incumbentCompatibilityExpected,
+            pagesDeploymentId: rollbackPages?.activeDeploymentId || null,
+          }),
+        };
+      } catch (error) {
+        recordFailure(report, "incumbent.compatibility", error);
       }
     }
   }
 
   if (mutationStarted) {
-    report.moduleControl.preRestorationMaintenance.attempted = true;
-    try {
-      report.moduleControl.preRestorationMaintenance = {
-        attempted: true,
-        ...await runtime.setModuleState("maintenance", {}, "pre-restoration-maintenance"),
-      };
-    } catch (error) {
-      recordFailure(report, "module-control.pre-restoration-maintenance", error);
-    }
+    await setPreRestorationMaintenance();
 
     restoredPages = await mutateEverySurface({
       config,
@@ -499,10 +600,12 @@ export async function runStagingRollbackDrill(config, runtime) {
       && report.functionalValidation.incumbentJourney.passed === false
       && report.functionalValidation.incumbentJourney.blocking === true
       && report.functionalValidation.incumbentCompatibility.passed === true
-      && report.functionalValidation.incumbentCompatibility.mode === "heterogeneous-fail-closed-health"
+      && ["heterogeneous-fail-closed-health", "coherent-maintenance-health"].includes(
+        report.functionalValidation.incumbentCompatibility.mode,
+      )
     );
   const incumbentTeardownPassed = report.functionalValidation.incumbentJourney.skipped === true
-    ? report.teardown.incumbent.notRequired === true
+    ? report.teardown.incumbent.notRequired === true || report.teardown.incumbent.passed === true
     : report.teardown.incumbent.passed;
   const normalPassed = report.failures.length === 0
     && report.preflight.passed
@@ -1240,7 +1343,7 @@ function createRealRuntime(config, env = process.env) {
           },
         });
         payload = await response.json().catch(() => null);
-        const pagesPassed = isFailClosedIncumbentHealth({
+        const compatibilityMode = classifyIncumbentCompatibilityHealth({
           status: response.status,
           payload,
           headers: response.headers,
@@ -1269,7 +1372,8 @@ function createRealRuntime(config, env = process.env) {
           attempt,
           pages: {
             status: response.status,
-            passed: pagesPassed,
+            passed: Boolean(compatibilityMode),
+            compatibilityMode: compatibilityMode || "none",
             ready: payload?.ready === true,
             moduleControl: payload?.dependencies?.module_control?.state || "unknown",
             affinity: payload?.dependencies?.gateway_affinity?.state || "unknown",
@@ -1283,16 +1387,18 @@ function createRealRuntime(config, env = process.env) {
             ready: identityPayload?.ready === true,
           },
         };
-        if (pagesPassed && identityPassed) {
+        if (compatibilityMode && identityPassed) {
           return {
             passed: true,
-            mode: "heterogeneous-fail-closed-health",
+            mode: compatibilityMode,
             attempts: attempt,
             pagesHealth: {
               status: response.status,
               ready: false,
               moduleControl: payload?.dependencies?.module_control?.state || "unknown",
-              affinity: "RELEASE_AFFINITY_MISMATCH",
+              affinity: compatibilityMode === "heterogeneous-fail-closed-health"
+                ? "RELEASE_AFFINITY_MISMATCH"
+                : "HEALTHY_UNDER_MAINTENANCE",
             },
             identityHealth: {
               status: identityResponse.status,
@@ -1400,13 +1506,8 @@ function createRealRuntime(config, env = process.env) {
     try {
       runJourneyCommand();
     } catch (error) {
-      const detail = String(error?.details || "");
-      const retryablePropagationFailure = error instanceof DrillFailure
-        && detail.includes("invalid PIN did not fail closed (503/domain_service_degraded")
-        && detail.includes('"timekeepingReleaseSha":""')
-        && detail.includes('"timekeepingVersionId":""');
-      if (!retryablePropagationFailure) throw error;
-      await proveCandidateAffinity(pages, expected);
+      if (!isRetryableTimekeepingPropagationFailure(error) || handle.label !== "candidate") throw error;
+      await proveCandidateAffinity({ url: origin.href }, expected);
       runJourneyCommand();
     }
     const raw = fs.readFileSync(handle.journeyReportPath, "utf8");

--- a/.github/scripts/ponto-staging-rollback-drill.test.mjs
+++ b/.github/scripts/ponto-staging-rollback-drill.test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 
 import {
   loadConfig,
+  classifyIncumbentCompatibilityHealth,
   classifyIncumbentBundle,
   isFailClosedIncumbentHealth,
   runStagingRollbackDrill,
@@ -219,6 +220,56 @@ test("heterogeneous incumbent health accepts a safe affinity mismatch without tr
   }), false);
 });
 
+test("a coherent incumbent can be accepted only while maintenance is fail-closed", () => {
+  const expected = {
+    pagesSourceSha: "b".repeat(40),
+    identitySourceSha: "b".repeat(40),
+    coreSourceSha: "b".repeat(40),
+    timekeepingSourceSha: "b".repeat(40),
+    coreVersionId: ids.coreApi.incumbent,
+    timekeepingVersionId: ids.timekeeping.incumbent,
+  };
+  const payload = {
+    ok: false,
+    ready: false,
+    service: "workforce-timekeeping",
+    unit: "timekeeping",
+    environment: "staging",
+    database: true,
+    dependencies: {
+      module_control: { state: "unavailable" },
+      gateway_affinity: { state: "healthy" },
+    },
+    versionMetadata: {
+      releaseSha: expected.timekeepingSourceSha,
+      workerVersionId: expected.timekeepingVersionId,
+      gatewayReleaseSha: expected.coreSourceSha,
+      gatewayEnvironment: "staging",
+      gatewayVersionId: expected.coreVersionId,
+    },
+  };
+  const headers = new Map([
+    ["x-skincos-timekeeping-release-sha", expected.timekeepingSourceSha],
+    ["x-skincos-timekeeping-environment", "staging"],
+    ["x-skincos-timekeeping-version-id", expected.timekeepingVersionId],
+  ]);
+
+  assert.equal(
+    classifyIncumbentCompatibilityHealth({ status: 200, payload, headers, expected }),
+    "coherent-maintenance-health",
+  );
+  assert.equal(isFailClosedIncumbentHealth({ status: 200, payload, headers, expected }), false);
+  assert.equal(
+    classifyIncumbentCompatibilityHealth({
+      status: 200,
+      payload: { ...payload, dependencies: { ...payload.dependencies, module_control: { state: "healthy" } } },
+      headers,
+      expected,
+    }),
+    null,
+  );
+});
+
 class FakeRuntime {
   constructor(failAt = "", candidateSourceSha = config.releaseSha, incumbents = incumbentEvidence) {
     this.calls = [];
@@ -307,7 +358,9 @@ class FakeRuntime {
     this.maybeFail(call);
     return {
       passed: true,
-      mode: "heterogeneous-fail-closed-health",
+      mode: this.failAt === "fixture:incumbent:legacy"
+        ? "coherent-maintenance-health"
+        : "heterogeneous-fail-closed-health",
       credentialsIncluded: false,
       piiIncluded: false,
     };
@@ -345,6 +398,12 @@ class FakeRuntime {
     const call = `fixture:${handle.label}:journey`;
     this.calls.push(call);
     this.journeyExpected.set(handle.label, { ...expected });
+    if (this.failAt === "fixture:incumbent:legacy" && handle.label === "incumbent") {
+      const error = new Error("legacy incumbent timekeeping contract is unavailable");
+      error.code = "AUTHENTICATED_JOURNEY_FAILED";
+      error.details = '[ponto-staging-journey] FAILED: invalid PIN did not fail closed (503/domain_service_degraded; {"timekeepingReleaseSha":"","timekeepingVersionId":""})';
+      throw error;
+    }
     this.maybeFail(call);
     return {
       passed: true,
@@ -490,6 +549,22 @@ test("a coherent incumbent bundle receives the authenticated rollback journey", 
   assert.equal(runtime.journeyExpected.get("incumbent").sourceSha, "b".repeat(40));
 });
 
+test("a coherent historical incumbent with an unavailable timekeeping contract is verified only under maintenance", async () => {
+  const runtime = new FakeRuntime("fixture:incumbent:legacy", config.releaseSha, coherentIncumbentEvidence);
+  const report = await runStagingRollbackDrill(config, runtime);
+
+  assert.equal(report.passed, true);
+  assert.equal(report.functionalValidation.incumbentJourney.skipped, true);
+  assert.equal(report.functionalValidation.incumbentJourney.reason, "legacy-incumbent-timekeeping-contract-unavailable");
+  assert.equal(report.functionalValidation.incumbentCompatibility.passed, true);
+  assert.equal(report.functionalValidation.incumbentCompatibility.mode, "coherent-maintenance-health");
+  assert.equal(report.teardown.incumbent.passed, true);
+  assert.ok(
+    runtime.calls.indexOf("module:pre-restoration-maintenance:maintenance")
+      < runtime.calls.indexOf("incumbent:compatibility"),
+  );
+});
+
 test("a restoration failure attempts every remaining compensation and does not open the candidate", async () => {
   const runtime = new FakeRuntime("worker:restoration:identityWorkforce");
   const report = await runStagingRollbackDrill(config, runtime);
@@ -583,6 +658,9 @@ test("the executable and workflow retain no unimplemented hard-stop and require 
   assert.match(script, /ponto-release-probe\/v1\./);
   assert.match(script, /"x-skincos-release-probe-sig":\s*signature/);
   assert.match(script, /incumbentCompatibility/);
+  assert.match(script, /coherent-maintenance-health/);
+  assert.match(script, /handle\.label !== "candidate"/);
+  assert.match(script, /await proveCandidateAffinity\(\{ url: origin\.href \}, expected\);/);
   assert.match(script, /journeyFence/);
   assert.match(script, /journeyAttempts/);
   assert.match(script, /dependencies\?\.gateway_affinity\?\.state === "healthy"/);


### PR DESCRIPTION
## Objetivo

Restaurar a recuperação de staging do Ponto sem aceitar proveniência ampla:

- aceita somente filhos do release tag imutável exato e do SHA correspondente;
- recupera o drill quando o incumbente histórico não oferece o contrato atual, exigindo manutenção fail-closed e afinidade coerente antes de restaurar o candidato.

## Risco e rollback

A mudança toca apenas scripts de governança e seus testes. Sem alteração de dados, flags ou segredos. Reverter este commit restaura a lógica anterior; a execução continua fail-closed se qualquer identidade, saúde ou contrato divergir.

## Validação

- testes focados de rollback, reconciliação e recuperação: 31/31;
- `npm run codex:global-coordination:test`: 196/196;
- `npm run codex:preflight`: aprovado, com somente o aviso conhecido do OAuth local do Wrangler expirado.