### PR TITLE
fix(ponto): restore pilot runner preflight indentation

### DIFF
--- a/.github/scripts/ponto-secret-custody.test.mjs
+++ b/.github/scripts/ponto-secret-custody.test.mjs
@@ -61,6 +61,23 @@ test("release preflight proves the repository-scoped runner selector used by run
   );
 });
 
+test("release pilot runner preflight keeps its callback inside the YAML run block", () => {
+  const source = workflow("ponto-progressive-release.yml");
+  const start = source.indexOf(
+    "- name: Preflight production custody, approved cohort, and online pilot runner",
+  );
+  const end = source.indexOf(
+    "- name: Attest unconditional edge blocks before any candidate mutation",
+    start,
+  );
+  const step = source.slice(start, end);
+  assert.ok(start >= 0 && end > start);
+  assert.match(
+    step,
+    /const matching = runners\.filter\(\(runner\) => \{\r?\n            const labels = \(runner\.labels \|\| \[\]\)\.map\(item => String\(item\?\.name \|\| ""\)\);\r?\n            const normalizedLabels = new Set\(labels\.map\(label => label\.toLowerCase\(\)\)\);\r?\n            return labels\.length === requiredLabels\.length\r?\n              && requiredLabels\.every\(label => normalizedLabels\.has\(label\.toLowerCase\(\)\)\);\r?\n          \}\);/,
+  );
+});
+
 test("coordinator refuses repository fallback for both environment-owned roots before mutation", () => {
   const source = workflow("ponto-progressive-release.yml");
   const preflight = source.slice(

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -673,9 +673,9 @@ jobs:
           }
           const matching = runners.filter((runner) => {
             const labels = (runner.labels || []).map(item => String(item?.name || ""));
-          const normalizedLabels = new Set(labels.map(label => label.toLowerCase()));
-          return labels.length === requiredLabels.length
-            && requiredLabels.every(label => normalizedLabels.has(label.toLowerCase()));
+            const normalizedLabels = new Set(labels.map(label => label.toLowerCase()));
+            return labels.length === requiredLabels.length
+              && requiredLabels.every(label => normalizedLabels.has(label.toLowerCase()));
           });
           if (
             matching.length !== 1


### PR DESCRIPTION
Restores the nested runner-selector callback indentation that made the pilot preflight shell heredoc invalid. Adds a focused regression assertion for the generated YAML run block.