### PR TITLE
fix(ponto): terminate pilot preflight heredocs

### DIFF
--- a/.github/scripts/ponto-secret-custody.test.mjs
+++ b/.github/scripts/ponto-secret-custody.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import test from "node:test";
 
@@ -76,6 +77,23 @@ test("release pilot runner preflight keeps its callback inside the YAML run bloc
     step,
     /const matching = runners\.filter\(\(runner\) => \{\r?\n            const labels = \(runner\.labels \|\| \[\]\)\.map\(item => String\(item\?\.name \|\| ""\)\);\r?\n            const normalizedLabels = new Set\(labels\.map\(label => label\.toLowerCase\(\)\)\);\r?\n            return labels\.length === requiredLabels\.length\r?\n              && requiredLabels\.every\(label => normalizedLabels\.has\(label\.toLowerCase\(\)\)\);\r?\n          \}\);/,
   );
+});
+
+test("release pilot runner preflight is syntactically valid Bash", () => {
+  const source = workflow("ponto-progressive-release.yml");
+  const start = source.indexOf(
+    "- name: Preflight production custody, approved cohort, and online pilot runner",
+  );
+  const end = source.indexOf(
+    "- name: Attest unconditional edge blocks before any candidate mutation",
+    start,
+  );
+  const step = source.slice(start, end);
+  const run = step.match(/        run: \|\r?\n([\s\S]*)$/)?.[1];
+  assert.ok(run, "pilot preflight run block must exist");
+  const shell = run.split(/\r?\n/).map(line => line.slice(10)).join("\n");
+  const result = spawnSync("bash", ["-n"], { encoding: "utf8", input: shell });
+  assert.equal(result.status, 0, result.stderr);
 });
 
 test("coordinator refuses repository fallback for both environment-owned roots before mutation", () => {

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -572,7 +572,7 @@ jobs:
               name: "PONTO_PILOT_RUNNER_LABELS_JSON",
               value: process.env.PONTO_PILOT_RUNNER_LABELS_JSON || "",
             }));
-            NODE
+          NODE
           fi
           if ! gh api "repos/$GITHUB_REPOSITORY/actions/variables/PONTO_PILOT_RUNNER_ENCRYPTION_PUBLIC_KEY_PEM" > "$RUNNER_TEMP/ponto-pilot-runner-encryption-repository-variable.json"; then
             node - "$RUNNER_TEMP/ponto-pilot-runner-encryption-repository-variable.json" <<'NODE'
@@ -581,7 +581,7 @@ jobs:
               name: "PONTO_PILOT_RUNNER_ENCRYPTION_PUBLIC_KEY_PEM",
               value: process.env.PONTO_PILOT_RUNNER_ENCRYPTION_PUBLIC_KEY_PEM || "",
             }));
-            NODE
+          NODE
           fi
           gh api "repos/$GITHUB_REPOSITORY/environments/production/variables?per_page=100" > "$RUNNER_TEMP/ponto-pilot-runner-environment-variables.json"
           node - \


### PR DESCRIPTION
Corrige os dois delimitadores de heredoc do preflight de piloto que permaneciam recuados dentro de condicionais. O Bash absorvia o restante do step como heredoc e falhava antes de qualquer mutação de ambiente.

Validação focal:
- `node --test .github/scripts/ponto-secret-custody.test.mjs` (9/9 no WSL)
- o novo teste executa `bash -n` no bloco real do workflow.

Não altera secrets, runners, políticas de produção ou estado de ambiente.