### PR TITLE
fix(crm): reconcile Workforce before invite resend

### DIFF
--- a/crm/api/server.js
+++ b/crm/api/server.js
@@ -2060,7 +2060,12 @@ if (DEV_AUTH_ENABLED) {
         const hierarchyError = localTeamHierarchyError(session, member.profile, member.units)
         if (hierarchyError) return res.status(403).json({ success: false, error: 'Hierarquia não permite reenviar este convite', code: hierarchyError })
         if (!['INVITED', 'PENDING_ACCESS'].includes(String(member.accountStatus || '').toUpperCase())) return res.status(409).json({ success: false, error: 'Somente convites pendentes podem ser reenviados', code: 'TEAM_INVITE_NOT_PENDING' })
-        if (!String(member.workforceEmployeeId || '').trim()) return res.status(409).json({ success: false, error: 'Reconcilie o vínculo Workforce antes de reenviar o convite', code: 'TEAM_WORKFORCE_BINDING_REQUIRED' })
+        if (!String(member.workforceEmployeeId || '').trim()) {
+            member.workforceEmployeeId = `local-wf-${randomUUID()}`
+            member.provisioningState = 'INVITE_PENDING'
+            localAudit(store, session, 'EMPLOYEE_TEAM_WORKFORCE_RECONCILED', id, { workforceEmployeeId: member.workforceEmployeeId, automaticBeforeInviteResend: true, inviteDeliveryChanged: false, localPreview: true }, null)
+            localTeamTelemetry(store, session, 'EMPLOYEE_TEAM_WORKFORCE_RECONCILED', 'SUCCESS', 1, member.units.length)
+        }
         store.invites.forEach((invite) => { if (invite.id === member.inviteId && !invite.revoked) invite.revoked = true })
         const at = new Date().toISOString()
         const inviteId = `local-invite-${randomUUID()}`

--- a/inventory/src/routes/admin.js
+++ b/inventory/src/routes/admin.js
@@ -43,6 +43,60 @@ function isOnboardingDependencyError(value) {
     || code === 'SERVICE_DEGRADED';
 }
 
+// Rebuild a missing server-side Workforce projection before an already
+// authorized pending-onboarding operation. This never creates, revokes, or
+// delivers an invite; callers retain those distinct state transitions.
+async function reconcilePendingWorkforceOnboarding({ env, onboarding, onboardingId, auth, units, accountStatus, requestId }) {
+  const existingEmployeeId = String(onboarding.workforce_employee_id || '').trim();
+  let workforceEmployeeId = existingEmployeeId;
+  let workforceReconciled = false;
+  if (!workforceEmployeeId) {
+    const workforce = await syncIdentityWorkforceOnboarding(env, {
+      onboardingId,
+      fullName: String(onboarding.full_name || '').trim(),
+      corporateEmail: String(onboarding.corporate_email || '').trim(),
+      mobilePhoneHash: String(onboarding.mobile_phone_hash || '').trim(),
+      units,
+      profile: String(onboarding.profile || '').trim().toUpperCase(),
+      accountStatus,
+      jobTitle: String(onboarding.job_title || displayJobTitle(onboarding.profile)).trim(),
+      department: String(onboarding.department_name || '').trim(),
+      createdBy: String(auth?.user?.username || ''),
+    }, requestId);
+    workforceEmployeeId = String(workforce?.employeeId || '').trim();
+    if (!workforceEmployeeId) throw new Error('WORKFORCE_EMPLOYEE_ID_REQUIRED');
+    workforceReconciled = true;
+  }
+
+  const existingTeam = await env.DB.prepare('SELECT workforce_employee_id FROM crm_employee_team WHERE onboarding_id=? LIMIT 1').bind(onboardingId).first();
+  if (existingTeam?.workforce_employee_id && String(existingTeam.workforce_employee_id).trim() !== workforceEmployeeId) {
+    throw new Error('TEAM_WORKFORCE_BINDING_CONFLICT');
+  }
+  const existingEmployeeOwner = await env.DB.prepare('SELECT onboarding_id FROM crm_employee_team WHERE workforce_employee_id=? LIMIT 1').bind(workforceEmployeeId).first();
+  if (existingEmployeeOwner?.onboarding_id && String(existingEmployeeOwner.onboarding_id).trim() !== onboardingId) {
+    throw new Error('TEAM_WORKFORCE_BINDING_CONFLICT');
+  }
+
+  const now = new Date().toISOString();
+  const provisioningState = accountStatus === 'INVITED' ? 'INVITE_PENDING' : 'WORKFORCE_SYNCED';
+  const localStatements = [
+    env.DB.prepare('UPDATE crm_employee_onboarding SET workforce_employee_id=?, provisioning_state=?, compensation_state=NULL, last_error_code=NULL, updated_at=? WHERE id=?').bind(workforceEmployeeId, provisioningState, now, onboardingId),
+  ];
+  if (!existingTeam?.workforce_employee_id) {
+    localStatements.push(
+      env.DB.prepare(`INSERT INTO crm_employee_team
+        (workforce_employee_id, onboarding_id, schedule_professional_id, schedule_status, schedule_role, schedule_shift, schedule_nickname, schedule_instagram, schedule_color, units_json, created_by, created_at, updated_at)
+        VALUES (?, ?, NULL, NULL, NULL, NULL, NULL, NULL, NULL, ?, ?, ?, ?)`)
+        .bind(workforceEmployeeId, onboardingId, JSON.stringify(units), String(auth?.user?.username || ''), now, now)
+    );
+  }
+  await env.DB.batch(localStatements);
+
+  const updated = await env.DB.prepare('SELECT * FROM crm_employee_onboarding WHERE id=? LIMIT 1').bind(onboardingId).first();
+  if (String(updated?.workforce_employee_id || '').trim() !== workforceEmployeeId) throw new Error('TEAM_WORKFORCE_BINDING_CONFLICT');
+  return { updated, existingEmployeeId, workforceEmployeeId, workforceReconciled, provisioningState };
+}
+
 function unifiedTeamEnabled(env) {
   const value = String(env?.UNIFIED_TEAM_ENABLED || '').trim().toLowerCase();
   return ['1', 'true', 'yes', 'on'].includes(value);
@@ -1319,53 +1373,15 @@ export async function handleAdminRoutes({
       if (!['INVITED', 'PENDING_ACCESS'].includes(accountStatus)) return withCORS(JSON.stringify({ success: false, error: 'Somente acessos pendentes podem reconciliar o Workforce', code: 'TEAM_WORKFORCE_RECONCILE_NOT_PENDING' }), { status: 409 }, appOrigin);
 
       requestId = String(request.headers.get('x-request-id') || `identity-workforce-reconcile-${onboardingId}`).slice(0, 180);
-      const existingEmployeeId = String(onboarding.workforce_employee_id || '').trim();
-      let workforceEmployeeId = existingEmployeeId;
-      let workforceReconciled = false;
-      if (!workforceEmployeeId) {
-        const workforce = await syncIdentityWorkforceOnboarding(env, {
-          onboardingId,
-          fullName: String(onboarding.full_name || '').trim(),
-          corporateEmail: String(onboarding.corporate_email || '').trim(),
-          mobilePhoneHash: String(onboarding.mobile_phone_hash || '').trim(),
-          units,
-          profile: String(onboarding.profile || '').trim().toUpperCase(),
-          accountStatus,
-          jobTitle: String(onboarding.job_title || displayJobTitle(onboarding.profile)).trim(),
-          department: String(onboarding.department_name || '').trim(),
-          createdBy: String(auth?.user?.username || ''),
-        }, requestId);
-        workforceEmployeeId = String(workforce?.employeeId || '').trim();
-        if (!workforceEmployeeId) throw new Error('WORKFORCE_EMPLOYEE_ID_REQUIRED');
-        workforceReconciled = true;
-      }
-
-      const existingTeam = await env.DB.prepare('SELECT workforce_employee_id FROM crm_employee_team WHERE onboarding_id=? LIMIT 1').bind(onboardingId).first();
-      if (existingTeam?.workforce_employee_id && String(existingTeam.workforce_employee_id).trim() !== workforceEmployeeId) {
-        return withCORS(JSON.stringify({ success: false, error: 'O vínculo Workforce existente diverge do onboarding', code: 'TEAM_WORKFORCE_BINDING_CONFLICT' }), { status: 409 }, appOrigin);
-      }
-      const existingEmployeeOwner = await env.DB.prepare('SELECT onboarding_id FROM crm_employee_team WHERE workforce_employee_id=? LIMIT 1').bind(workforceEmployeeId).first();
-      if (existingEmployeeOwner?.onboarding_id && String(existingEmployeeOwner.onboarding_id).trim() !== onboardingId) {
-        return withCORS(JSON.stringify({ success: false, error: 'A identidade Workforce já pertence a outro onboarding', code: 'TEAM_WORKFORCE_BINDING_CONFLICT' }), { status: 409 }, appOrigin);
-      }
-
-      const now = new Date().toISOString();
-      const provisioningState = accountStatus === 'INVITED' ? 'INVITE_PENDING' : 'WORKFORCE_SYNCED';
-      const localStatements = [
-        env.DB.prepare('UPDATE crm_employee_onboarding SET workforce_employee_id=?, provisioning_state=?, compensation_state=NULL, last_error_code=NULL, updated_at=? WHERE id=?').bind(workforceEmployeeId, provisioningState, now, onboardingId),
-      ];
-      if (!existingTeam?.workforce_employee_id) {
-        localStatements.push(
-          env.DB.prepare(`INSERT INTO crm_employee_team
-            (workforce_employee_id, onboarding_id, schedule_professional_id, schedule_status, schedule_role, schedule_shift, schedule_nickname, schedule_instagram, schedule_color, units_json, created_by, created_at, updated_at)
-            VALUES (?, ?, NULL, NULL, NULL, NULL, NULL, NULL, NULL, ?, ?, ?, ?)`)
-            .bind(workforceEmployeeId, onboardingId, JSON.stringify(units), String(auth?.user?.username || ''), now, now)
-        );
-      }
-      await env.DB.batch(localStatements);
-
-      const updated = await env.DB.prepare('SELECT * FROM crm_employee_onboarding WHERE id=? LIMIT 1').bind(onboardingId).first();
-      if (String(updated?.workforce_employee_id || '').trim() !== workforceEmployeeId) throw new Error('TEAM_WORKFORCE_BINDING_CONFLICT');
+      const { updated, existingEmployeeId, workforceEmployeeId, workforceReconciled, provisioningState } = await reconcilePendingWorkforceOnboarding({
+        env,
+        onboarding,
+        onboardingId,
+        auth,
+        units,
+        accountStatus,
+        requestId,
+      });
       await appendAuditLog?.({ env, actor: auth.user.username, role: auth.user.role, ip, userAgent, action: 'EMPLOYEE_TEAM_WORKFORCE_RECONCILED', entity: 'EMPLOYEE_ONBOARDING', entityId: onboardingId, unidade: units.join(','), before: { workforceEmployeeId: existingEmployeeId || null, accountStatus }, after: { workforceEmployeeId, accountStatus, provisioningState, workforceReconciled, inviteDeliveryChanged: false, requestId } });
       await recordTeamTelemetry({ env, eventName: 'EMPLOYEE_TEAM_WORKFORCE_RECONCILED', actorRole: auth.user.role, itemCount: 1, unitCount: units.length });
       return withCORS(JSON.stringify({ success: true, data: publicOnboarding(updated), replayed: !workforceReconciled }), { status: 200 }, appOrigin);
@@ -1386,25 +1402,42 @@ export async function handleAdminRoutes({
     try {
       if (!onboardingHasSaga || !invitesHasInviteeEmail || !invitesHasUsername) return withCORS(JSON.stringify({ success: false, error: 'Migração de convites pendente', code: 'INVITE_MIGRATION_REQUIRED' }), { status: 503 }, appOrigin);
       const onboardingId = decodeURIComponent(resendInviteMatch[1] || '').trim();
-      const onboarding = await env.DB.prepare('SELECT * FROM crm_employee_onboarding WHERE id=? LIMIT 1').bind(onboardingId).first();
+      let onboarding = await env.DB.prepare('SELECT * FROM crm_employee_onboarding WHERE id=? LIMIT 1').bind(onboardingId).first();
       if (!onboarding) return withCORS(JSON.stringify({ success: false, error: 'Membro da equipe não encontrado', code: 'TEAM_MEMBER_NOT_FOUND' }), { status: 404 }, appOrigin);
       if (!teamUnitsVisible(auth, onboarding.units_json)) return withCORS(JSON.stringify({ success: false, error: 'Unidade fora do escopo do gestor', code: 'TEAM_UNITS_DENIED' }), { status: 403 }, appOrigin);
-      const hierarchyDenied = canCreateEmployee({ actorRole: auth?.user?.role, actorAllowedUnits: auth?.user?.allowedUnits, targetProfile: onboarding.profile, units: normalizeAllowedUnits(onboarding.units_json) });
+      const units = normalizeAllowedUnits(onboarding.units_json);
+      const hierarchyDenied = canCreateEmployee({ actorRole: auth?.user?.role, actorAllowedUnits: auth?.user?.allowedUnits, targetProfile: onboarding.profile, units });
       if (hierarchyDenied) return withCORS(JSON.stringify({ success: false, error: 'Hierarquia não permite reenviar este convite', code: hierarchyDenied }), { status: 403 }, appOrigin);
-      if (!['INVITED', 'PENDING_ACCESS'].includes(normalizeAccountState(onboarding.account_status))) return withCORS(JSON.stringify({ success: false, error: 'Somente convites pendentes podem ser reenviados', code: 'TEAM_INVITE_NOT_PENDING' }), { status: 409 }, appOrigin);
-      if (!String(onboarding.workforce_employee_id || '').trim()) return withCORS(JSON.stringify({ success: false, error: 'Reconcilie o vínculo Workforce antes de reenviar o convite', code: 'TEAM_WORKFORCE_BINDING_REQUIRED' }), { status: 409 }, appOrigin);
+      const accountStatus = normalizeAccountState(onboarding.account_status);
+      if (!['INVITED', 'PENDING_ACCESS'].includes(accountStatus)) return withCORS(JSON.stringify({ success: false, error: 'Somente convites pendentes podem ser reenviados', code: 'TEAM_INVITE_NOT_PENDING' }), { status: 409 }, appOrigin);
+      const requestId = String(request.headers.get('x-request-id') || `identity-invite-resend-${onboardingId}`).slice(0, 180);
+      if (!String(onboarding.workforce_employee_id || '').trim()) {
+        try {
+          const reconciliation = await reconcilePendingWorkforceOnboarding({ env, onboarding, onboardingId, auth, units, accountStatus, requestId });
+          onboarding = reconciliation.updated;
+          await appendAuditLog?.({ env, actor: auth.user.username, role: auth.user.role, ip, userAgent, action: 'EMPLOYEE_TEAM_WORKFORCE_RECONCILED', entity: 'EMPLOYEE_ONBOARDING', entityId: onboardingId, unidade: units.join(','), before: { workforceEmployeeId: reconciliation.existingEmployeeId || null, accountStatus }, after: { workforceEmployeeId: reconciliation.workforceEmployeeId, accountStatus, provisioningState: reconciliation.provisioningState, workforceReconciled: reconciliation.workforceReconciled, automaticBeforeInviteResend: true, inviteDeliveryChanged: false, requestId } });
+          await recordTeamTelemetry({ env, eventName: 'EMPLOYEE_TEAM_WORKFORCE_RECONCILED', actorRole: auth.user.role, itemCount: 1, unitCount: units.length });
+        } catch (error) {
+          const code = String(error?.message || 'TEAM_WORKFORCE_RECONCILE_FAILED').slice(0, 120);
+          const dependencyFailure = isOnboardingDependencyError(code) || /^(WORKFORCE_|IDENTITY_WORKFORCE_|TIMEKEEPING_|RELEASE_AFFINITY_|RUNTIME_BINDINGS_)/.test(code);
+          if (dependencyFailure) {
+            await env.DB.prepare("UPDATE crm_employee_onboarding SET provisioning_state='FAILED', last_error_code=?, updated_at=? WHERE id=?").bind(code, new Date().toISOString(), onboardingId).run().catch(() => {});
+          }
+          await Promise.resolve(appendAuditLog?.({ env, actor: auth.user.username, role: auth.user.role, ip, userAgent, action: 'EMPLOYEE_TEAM_WORKFORCE_RECONCILE_FAILED', entity: 'EMPLOYEE_ONBOARDING', entityId: onboardingId, unidade: units.join(','), after: { code, requestId, automaticBeforeInviteResend: true, failClosed: true, inviteDeliveryChanged: false } })).catch(() => {});
+          const status = dependencyFailure ? 503 : (/(CONFLICT|REQUIRED|INVALID)/.test(code) ? 409 : 500);
+          return withCORS(JSON.stringify({ success: false, error: dependencyFailure ? 'Vínculo Workforce pendente' : 'Não foi possível reconciliar o vínculo Workforce', code }), { status }, appOrigin);
+        }
+      }
 
       const personalEmail = await decryptOnboardingToken(env, onboarding.personal_email_encrypted);
       if (!personalEmail) return withCORS(JSON.stringify({ success: false, error: 'E-mail pessoal indisponível para o convite', code: 'INVITEE_EMAIL_UNAVAILABLE' }), { status: 503 }, appOrigin);
       const now = new Date().toISOString();
-      const requestId = String(request.headers.get('x-request-id') || `identity-invite-resend-${onboardingId}`).slice(0, 180);
       if (onboarding.invite_id) await env.DB.prepare(`UPDATE ${invitesTable} SET revoked=1 WHERE id=? AND uses_count=0`).bind(onboarding.invite_id).run();
 
       const token = randomInviteToken();
       const tokenHash = await sha256Hex(token);
       const inviteId = crypto.randomUUID();
       const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
-      const units = normalizeAllowedUnits(onboarding.units_json);
       const modules = resolveEmployeeProfile(onboarding.profile, { unified: true })?.modules || ['ponto'];
       const columns = ['id', 'token_hash', 'token_hint', 'invitee_email', 'corporate_email', 'role', 'allowed_units_json', 'allowed_modules_json', 'max_uses', 'uses_count', 'expires_at', 'revoked', 'note', 'created_by', 'created_at', 'requested_username'];
       const values = [inviteId, tokenHash, `${token.slice(0, 4)}…${token.slice(-4)}`, personalEmail, onboarding.corporate_email, onboarding.profile, JSON.stringify(units), JSON.stringify(modules), 1, 0, expiresAt, 0, `Reenvio de onboarding ${onboarding.department_name || ''}`.trim(), String(auth?.user?.username || ''), now, onboarding.requested_username];

--- a/inventory/tests/onboardingConsistency.test.mjs
+++ b/inventory/tests/onboardingConsistency.test.mjs
@@ -117,7 +117,7 @@ test('invite activation has an audited retry boundary and does not mint a second
   assert.doesNotMatch(activationBlock, /randomInviteToken\(\)/);
 });
 
-test('Workforce recovery is backend-only and invitation delivery fails closed without a binding', async () => {
+test('Workforce recovery is backend-only and invitation delivery auto-reconciles before any invite mutation', async () => {
   const admin = await readFile(new URL('../src/routes/admin.js', import.meta.url), 'utf8');
   const localApi = await readFile(new URL('../../crm/api/server.js', import.meta.url), 'utf8');
   const reconcileBlock = admin.slice(
@@ -135,19 +135,22 @@ test('Workforce recovery is backend-only and invitation delivery fails closed wi
   const updateBlock = admin.slice(admin.indexOf('const teamMemberMatch'), admin.indexOf("if (url.pathname === '/admin/team' && request.method === 'GET')"));
 
   assert.match(reconcileBlock, /workforce.*reconcile/);
-  assert.match(reconcileBlock, /syncIdentityWorkforceOnboarding\(env/);
+  assert.match(reconcileBlock, /reconcilePendingWorkforceOnboarding/);
+  assert.match(admin, /syncIdentityWorkforceOnboarding\(env/);
   assert.match(reconcileBlock, /EMPLOYEE_TEAM_WORKFORCE_RECONCILED/);
   assert.match(reconcileBlock, /inviteDeliveryChanged: false/);
   assert.doesNotMatch(reconcileBlock, /sendAccountInviteEmail/);
-  assert.match(resendBlock, /TEAM_WORKFORCE_BINDING_REQUIRED/);
+  assert.match(resendBlock, /reconcilePendingWorkforceOnboarding/);
+  assert.doesNotMatch(resendBlock, /TEAM_WORKFORCE_BINDING_REQUIRED/);
   assert.ok(
-    resendBlock.indexOf('TEAM_WORKFORCE_BINDING_REQUIRED') < resendBlock.indexOf('UPDATE ${invitesTable} SET revoked=1'),
-    'the resend guard must run before any invite revocation',
+    resendBlock.indexOf('reconcilePendingWorkforceOnboarding') < resendBlock.indexOf('UPDATE ${invitesTable} SET revoked=1'),
+    'automatic Workforce reconciliation must finish before any invite revocation',
   );
-  assert.match(localResendBlock, /TEAM_WORKFORCE_BINDING_REQUIRED/);
+  assert.match(localResendBlock, /automaticBeforeInviteResend/);
+  assert.doesNotMatch(localResendBlock, /TEAM_WORKFORCE_BINDING_REQUIRED/);
   assert.ok(
-    localResendBlock.indexOf('TEAM_WORKFORCE_BINDING_REQUIRED') < localResendBlock.indexOf('store.invites.forEach'),
-    'the local preview guard must run before any invite revocation',
+    localResendBlock.indexOf('automaticBeforeInviteResend') < localResendBlock.indexOf('store.invites.forEach'),
+    'the local preview reconciliation must run before any invite revocation',
   );
   assert.match(updateBlock, /const workforce = await syncIdentityWorkforceOnboarding\(env/);
   assert.match(updateBlock, /sets\.push\('workforce_employee_id=\?'\)/);

--- a/inventory/tests/unifiedTeamAccountScope.test.mjs
+++ b/inventory/tests/unifiedTeamAccountScope.test.mjs
@@ -307,11 +307,51 @@ test('backend Workforce reconciliation repairs a pending invite without activati
   assert.equal(Number(crmUser.ativo), 0);
 });
 
-test('resend refuses a missing Workforce binding before mutating a pending invite', async () => {
+test('resend automatically reconciles a missing Workforce binding before guarded delivery', async () => {
+  await env.DB.batch([
+    env.DB.prepare("UPDATE crm_employee_onboarding SET account_status='INVITED', workforce_employee_id=NULL, invite_id='pending-hellen-invite', provisioning_state='FAILED' WHERE id=?").bind('hellenmelo-employee'),
+    env.DB.prepare('DELETE FROM crm_employee_team WHERE onboarding_id=?').bind('hellenmelo-employee'),
+  ]);
+  const result = await callRoute('/admin/team/hellenmelo-employee/invite/resend', {
+    method: 'POST',
+    envOverride: { workforce: workforceBindingWithEmployee('wf-hellen-recovered') },
+  });
+  assert.equal(result.response.status, 503);
+  assert.equal(result.body.code, 'INVITEE_EMAIL_UNAVAILABLE');
+  const onboarding = await env.DB.prepare('SELECT account_status, workforce_employee_id, invite_id, provisioning_state, last_error_code FROM crm_employee_onboarding WHERE id=?').bind('hellenmelo-employee').first();
+  const team = await env.DB.prepare('SELECT workforce_employee_id FROM crm_employee_team WHERE onboarding_id=?').bind('hellenmelo-employee').first();
+  assert.equal(onboarding.account_status, 'INVITED');
+  assert.equal(onboarding.workforce_employee_id, 'wf-hellen-recovered');
+  assert.equal(onboarding.invite_id, 'pending-hellen-invite');
+  assert.equal(onboarding.provisioning_state, 'INVITE_PENDING');
+  assert.equal(onboarding.last_error_code, null);
+  assert.equal(team.workforce_employee_id, 'wf-hellen-recovered');
+});
+
+test('resend keeps the prior invite untouched when automatic Workforce reconciliation fails', async () => {
   await env.DB.prepare("UPDATE crm_employee_onboarding SET account_status='INVITED', workforce_employee_id=NULL, invite_id='pending-hellen-invite', provisioning_state='FAILED' WHERE id=?").bind('hellenmelo-employee').run();
-  const result = await callRoute('/admin/team/hellenmelo-employee/invite/resend', { method: 'POST' });
+  const result = await callRoute('/admin/team/hellenmelo-employee/invite/resend', {
+    method: 'POST',
+    envOverride: { workforce: workforceBinding(false) },
+  });
+  assert.equal(result.response.status, 503);
+  assert.equal(result.body.code, 'WORKFORCE_TEST_FAILURE');
+  const onboarding = await env.DB.prepare('SELECT account_status, workforce_employee_id, invite_id, provisioning_state, last_error_code FROM crm_employee_onboarding WHERE id=?').bind('hellenmelo-employee').first();
+  assert.equal(onboarding.account_status, 'INVITED');
+  assert.equal(onboarding.workforce_employee_id, null);
+  assert.equal(onboarding.invite_id, 'pending-hellen-invite');
+  assert.equal(onboarding.provisioning_state, 'FAILED');
+  assert.equal(onboarding.last_error_code, 'WORKFORCE_TEST_FAILURE');
+});
+
+test('resend rejects a conflicting automatic Workforce binding before invitation mutation', async () => {
+  await env.DB.prepare("UPDATE crm_employee_onboarding SET account_status='INVITED', workforce_employee_id=NULL, invite_id='pending-hellen-invite', provisioning_state='FAILED' WHERE id=?").bind('hellenmelo-employee').run();
+  const result = await callRoute('/admin/team/hellenmelo-employee/invite/resend', {
+    method: 'POST',
+    envOverride: { workforce: workforceBindingWithEmployee('wf-unlinked') },
+  });
   assert.equal(result.response.status, 409);
-  assert.equal(result.body.code, 'TEAM_WORKFORCE_BINDING_REQUIRED');
+  assert.equal(result.body.code, 'TEAM_WORKFORCE_BINDING_CONFLICT');
   const onboarding = await env.DB.prepare('SELECT account_status, workforce_employee_id, invite_id FROM crm_employee_onboarding WHERE id=?').bind('hellenmelo-employee').first();
   assert.equal(onboarding.account_status, 'INVITED');
   assert.equal(onboarding.workforce_employee_id, null);


### PR DESCRIPTION
# Summary

Automatically reconcile a missing Workforce binding on the server before an authorized CRM invitation resend. The recovery does not activate the user, expose technical bindings in the UI, revoke the existing invitation, or alter email delivery. A Workforce outage or conflicting identity fails closed before any invite mutation.

## Type of change
- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [x] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (README, API refs, diagrams)
- [x] Security review (CodeQL, gitleaks)
- [ ] Performance impact measured

## Links
- Issue: CRM Usuarios / convite pendente
- Design/ADR: server-derived Workforce onboarding
- Migration steps: none

## Screenshots / Evidence
- 41 focused CRM identity, onboarding, invitation and Workforce tests passed.
- Deployment topology validation passed.
- No database migration or production deployment is included; rollback is the preceding Inventory Worker/Pages artifact.