### PR TITLE
fix(ponto): pin prepared JIT runner identity

### DIFF
--- a/.github/governance/progressive-release-policy.json
+++ b/.github/governance/progressive-release-policy.json
@@ -97,7 +97,7 @@
       "jitCleanupHookCustodyRef": null
     },
       "production": {
-        "runnerId": 23,
+        "runnerId": 25,
         "runnerName": "ponto-jit-e307a5ad92b34cbc8d8d1d3c",
         "runnerIsolationRef": "vault:v1:ponto-jit-runner-production-e307a5ad92b34cbc8d8d1d3c",
         "requiredLabels": ["self-hosted", "Linux", "X64", "ponto-jit-e307a5ad92b34cbc8d8d1d3c"],


### PR DESCRIPTION
# Summary

Pins the governed Ponto pilot-runner policy to the freshly registered GitHub runner identity. The registration was prepared on the isolated native host with the service kept stopped; this PR is the immutable policy-to-runtime binding required before it can accept any job.

## Type of change
- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [x] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (README, API refs, diagrams)
- [x] Security review (CodeQL, gitleaks)
- [ ] Performance impact measured

## Links
- Issue: Workforce/Ponto restoration
- Design/ADR: governed JIT pilot runner custody
- Migration steps: none

## Screenshots / Evidence
- The runner was prepared and remains stopped pending this policy merge.
- 61 JIT custody, coordinator and journey tests passed.
- Deployment topology validation passed.
- Rollback before service start: runner remains inactive; no production Ponto traffic is enabled.