### PR TITLE
fix(crm): keep Ponto readiness on gateway contract

### DIFF
--- a/crm/console/functions/api/ponto/[[path]].ts
+++ b/crm/console/functions/api/ponto/[[path]].ts
@@ -1105,9 +1105,14 @@ export async function onRequest(context: any): Promise<Response> {
     redirect: 'manual',
   })
 
+  // Health and readiness are public observability contracts. They must be read
+  // from the canonical gateway, rather than a possibly stale Pages service
+  // binding, so a maintenance/degraded response cannot be reintroduced as a
+  // legacy ready=true result through the CRM alias.
+  const useCanonicalGateway = rest === '/health' || rest === '/health/' || rest === '/readiness' || rest === '/readiness/'
   let upstream: Response
   try {
-    upstream = configuration.localDirectTimekeeping
+    upstream = configuration.localDirectTimekeeping || useCanonicalGateway
       ? await fetch(upstreamRequest)
       : await env.PONTO_CORE.fetch(upstreamRequest)
   } catch {

--- a/crm/console/tests/pontoProxy.test.ts
+++ b/crm/console/tests/pontoProxy.test.ts
@@ -196,11 +196,45 @@ describe('Ponto CRM proxy', () => {
   it('keeps health public and preserves query strings', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } }))
     vi.stubGlobal('fetch', fetchMock)
-    const response = await onRequest(context('/api/ponto/health?probe=1'))
+    const ctx = context('/api/ponto/health?probe=1')
+    const coreFetch = vi.fn().mockRejectedValue(new Error('public observability must not use the service binding'))
+    ctx.env.PONTO_CORE = { fetch: coreFetch }
+    const response = await onRequest(ctx)
     expect(response.status).toBe(200); expect(getInsumosUser).not.toHaveBeenCalled()
     expect((fetchMock.mock.calls[0][0] as Request).url).toBe('https://api.skincos.com.br/api/ponto/health?probe=1')
+    expect(coreFetch).not.toHaveBeenCalled()
     expect(response.headers.get('x-skincos-pages-release-sha')).toBe(RELEASE_SHA)
     expect(response.headers.get('x-skincos-pages-environment')).toBe('production')
+  })
+
+  it('keeps readiness on the canonical gateway and preserves its degraded status', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      ok: false,
+      error: 'domain_service_degraded',
+      dependency: 'TIMEKEEPING',
+    }), {
+      status: 503,
+      headers: {
+        'content-type': 'application/json',
+        'x-skincos-gateway-release-sha': 'gateway-release',
+      },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+    const ctx = context('/api/ponto/readiness?probe=maintenance')
+    const coreFetch = vi.fn().mockRejectedValue(new Error('public readiness must not use the service binding'))
+    ctx.env.PONTO_CORE = { fetch: coreFetch }
+
+    const response = await onRequest(ctx)
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: 'domain_service_degraded',
+      dependency: 'TIMEKEEPING',
+    })
+    expect((fetchMock.mock.calls[0][0] as Request).url).toBe('https://api.skincos.com.br/api/ponto/readiness?probe=maintenance')
+    expect(coreFetch).not.toHaveBeenCalled()
+    expect(response.headers.get('x-skincos-gateway-release-sha')).toBe('gateway-release')
   })
 
   it('signs canonical protected routes and strips browser cookies and authorization', async () => {


### PR DESCRIPTION
# Summary

Routes the public CRM Ponto health and readiness endpoints through the canonical API gateway. This prevents a stale private service binding from exposing a legacy ready=true response while the canonical Ponto control plane is in maintenance or degraded.

## Type of change
- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [x] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (README, API refs, diagrams)
- [x] Security review (CodeQL, gitleaks)
- [ ] Performance impact measured

## Links
- Issue: Workforce/Ponto health-readiness contract
- Design/ADR: canonical gateway for public observability
- Migration steps: none

## Screenshots / Evidence
- `pontoProxy` contract suite: 33 passing tests.
- CRM Pages TypeScript check passed.
- The regression test verifies a 503 Timekeeping readiness is preserved and bypasses the stale Pages service binding.
- Rollback is the previous CRM Pages deployment; Ponto stays in maintenance until the governed pilot is complete.