### PR TITLE
fix(security): update nanoid to 3.3.18

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10063,9 +10063,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/website/package.json
+++ b/website/package.json
@@ -73,7 +73,7 @@
     "form-data": "4.0.6",
     "ip-address": "10.2.0",
     "js-yaml": "4.2.0",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "postcss": "8.5.18",
     "qs": "6.15.2",
     "sharp": "0.35.0",


### PR DESCRIPTION
# Summary

Updates the Website override and lockfile from `nanoid` 3.3.17 to 3.3.18. GitHub Actions began blocking the Ponto predecessor PR because GHSA-2v37-7h3g-55p8 affects versions below 3.3.18; the Ponto change does not modify the Website lockfile.

## Type of change
- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [x] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (not applicable)
- [x] Security review (npm audit gate)
- [ ] Performance impact measured (not applicable)

## Links
- Issue: release gate for PR #1404
- Design/ADR: not applicable
- Migration steps: none

## Screenshots / Evidence
- `node .github/scripts/npm-audit-gate.mjs website` passes.
- Rollback: revert this two-file lockfile/override commit; no runtime or data migration.