### PR TITLE
fix(ponto): reject release dispatch after main drift

### DIFF
--- a/.github/scripts/ponto-automatic-rollback-safety.test.mjs
+++ b/.github/scripts/ponto-automatic-rollback-safety.test.mjs
@@ -78,3 +78,15 @@ test("recovery accepts only children from the exact immutable Ponto release tag"
   assert.match(source, /String\(run\.headSha \|\| ""\)\.toLowerCase\(\) === releaseSha/);
   assert.doesNotMatch(source, /run\.headBranch !== "main"/);
 });
+
+test("a cancelled Core child is untouched only when GitHub attests that deploy never started", () => {
+  assert.match(source, /const preMutationJobNames = Object\.freeze\(\{\s*coreApi: "deploy",/s);
+  assert.match(source, /run\.conclusion !== "cancelled"/);
+  assert.match(source, /actions\/runs\/\$\{encodeURIComponent\(childRunId\)\}\/jobs\?filter=latest&per_page=100/);
+  assert.match(source, /expectedJob\?\.status === "completed"/);
+  assert.match(source, /expectedJob\?\.conclusion === "cancelled"/);
+  assert.match(source, /Array\.isArray\(expectedJob\?\.steps\)/);
+  assert.match(source, /expectedJob\.steps\.length === 0/);
+  assert.match(source, /untouched\[candidate\.surface\] = proof\.disposition/);
+  assert.match(source, /pre-mutation-job-attestation-unavailable/);
+});

--- a/.github/scripts/ponto-automatic-rollback.mjs
+++ b/.github/scripts/ponto-automatic-rollback.mjs
@@ -302,6 +302,7 @@ const plan = {};
 const unresolved = [];
 const untouched = {};
 const retainedDataChanges = {};
+const preMutationCancellationCandidates = [];
 for (const [name, spec] of Object.entries(surfaceSpecs)) {
   const surfaceFile = path.join(artifactRoot, spec.path);
   const runFile = path.join(artifactRoot, spec.run);
@@ -325,7 +326,13 @@ for (const [name, spec] of Object.entries(surfaceSpecs)) {
     && String(journal.orchestratorRunId) === orchestratorRunId
     && journal.credentialsIncluded === false
     && journal.piiIncluded === false;
-  if (!journalValid) unresolved.push({ surface: name, childRunId: String(run.runId), reason: "mutation-journal-missing-or-invalid" });
+  if (!journalValid) {
+    preMutationCancellationCandidates.push({
+      surface: name,
+      childRunId: String(run.runId),
+      run,
+    });
+  }
   const migrationStarted = journalValid && journal.migrationStarted === true;
   if (migrationStarted) {
     const migrationResolved = journal.migrationCompleted === true
@@ -720,6 +727,62 @@ const github = async (pathname, init = {}) => {
   return payload;
 };
 
+// A cancelled child normally leaves an always-uploaded mutation journal. The
+// one safe exception is the Core staging publisher cancelled before its only
+// mutable `deploy` job ever ran. Resolve that exception from the GitHub job
+// record itself; any unavailable, renamed, started, or otherwise ambiguous
+// job remains unresolved and therefore fail-closed.
+const preMutationJobNames = Object.freeze({
+  coreApi: "deploy",
+});
+const attestCancelledBeforeMutation = async ({ surface, childRunId, run }) => {
+  const expectedJobName = preMutationJobNames[surface];
+  if (!expectedJobName || run.conclusion !== "cancelled" || !/^[1-9][0-9]*$/.test(childRunId)) {
+    return { passed: false, reason: "mutation-journal-missing-or-invalid" };
+  }
+  try {
+    const payload = await github(
+      `/repos/${repository}/actions/runs/${encodeURIComponent(childRunId)}/jobs?filter=latest&per_page=100`,
+    );
+    const jobs = Array.isArray(payload?.jobs) ? payload.jobs : null;
+    const totalCount = Number(payload?.total_count);
+    const expectedJobs = jobs?.filter((job) => job?.name === expectedJobName) || [];
+    const expectedJob = expectedJobs[0];
+    const neverStarted = Array.isArray(jobs)
+      && Number.isSafeInteger(totalCount)
+      && totalCount === jobs.length
+      && expectedJobs.length === 1
+      && expectedJob?.status === "completed"
+      && expectedJob?.conclusion === "cancelled"
+      && Array.isArray(expectedJob?.steps)
+      && expectedJob.steps.length === 0;
+    return neverStarted
+      ? { passed: true, jobName: expectedJobName, disposition: "cancelled-before-mutation" }
+      : { passed: false, reason: "mutation-journal-missing-or-invalid" };
+  } catch {
+    return { passed: false, reason: "pre-mutation-job-attestation-unavailable" };
+  }
+};
+const preMutationCancellations = {};
+for (const candidate of preMutationCancellationCandidates) {
+  const proof = await attestCancelledBeforeMutation(candidate);
+  if (proof.passed) {
+    untouched[candidate.surface] = proof.disposition;
+    preMutationCancellations[candidate.surface] = {
+      passed: true,
+      childRunId: candidate.childRunId,
+      jobName: proof.jobName,
+      disposition: proof.disposition,
+    };
+    continue;
+  }
+  unresolved.push({
+    surface: candidate.surface,
+    childRunId: candidate.childRunId,
+    reason: proof.reason,
+  });
+}
+
 let pagesCreatedDeploymentId = "";
 let pagesMutationAttempted = false;
 let pagesMutationObserved = false;
@@ -1101,6 +1164,7 @@ const report = {
   plannedSurfaces: plannedNames,
   planSource: Object.fromEntries(Object.entries(plan).map(([name, item]) => [name, item.source])),
   untouchedSurfaces: untouched,
+  preMutationCancellations,
   unresolved,
   proofs,
   environmentPrerequisites,

--- a/.github/scripts/ponto-dispatch-workflow.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.mjs
@@ -74,6 +74,17 @@ export function assertPontoDependencyClosureUnchanged(orchestratorDigest, mainDi
   return assertDependencyClosureUnchanged(orchestratorDigest, mainDigest);
 }
 
+export function assertPontoReleaseIsCurrentMain(releaseSha, currentMainSha) {
+  const release = String(releaseSha || "").trim().toLowerCase();
+  const currentMain = String(currentMainSha || "").trim().toLowerCase();
+  if (!FULL_SHA.test(release)) throw new Error("Ponto release SHA must be a full SHA");
+  if (!FULL_SHA.test(currentMain)) throw new Error("current main SHA is unavailable");
+  if (release !== currentMain) {
+    throw new Error("Ponto release SHA no longer equals current main");
+  }
+  return { releaseSha: release, currentMainSha: currentMain };
+}
+
 export function globalResourceFor(workflow, inputs) {
   const target = String(inputs?.target || "").trim().toLowerCase();
   const stage = String(inputs?.stage || inputs?.orchestrator_stage || "").trim().toLowerCase();
@@ -439,14 +450,10 @@ const cancelActiveChildBestEffort = async (candidate) => {
 
 const currentMain = await request(`/repos/${repository}/commits/main`);
 const currentMainSha = String(currentMain?.sha || "").trim().toLowerCase();
-if (!/^[0-9a-f]{40}$/.test(currentMainSha)) throw new Error("current main SHA is unavailable");
+assertPontoReleaseIsCurrentMain(orchestratorHeadSha, currentMainSha);
 ensureCommitAvailable(currentMainSha);
-assertPontoDependencyClosureUnchanged(
-  pontoDependencyClosureDigest(orchestratorHeadSha),
-  pontoDependencyClosureDigest(currentMainSha),
-);
 await revalidatePontoCompositeLease({
-  observedDependencyClosureDigest: pontoDependencyClosureDigest(currentMainSha),
+  observedDependencyClosureDigest: pontoDependencyClosureDigest(orchestratorHeadSha),
 });
 
 const inputs = JSON.parse(fs.readFileSync(inputsFile, "utf8"));
@@ -580,15 +587,11 @@ fs.writeFileSync(outputFile, `${JSON.stringify({
   releaseTag: releaseIdentity.releaseTag,
   releaseIdentityDigest: releaseIdentity.identity.releaseIdentityDigest,
 }, null, 2)}\n`, { mode: 0o600 });
-const dispatchMain = await request(`/repos/${repository}/commits/main`);
-const dispatchMainSha = String(dispatchMain?.sha || "").trim().toLowerCase();
-if (!/^[0-9a-f]{40}$/.test(dispatchMainSha)) throw new Error("current main SHA is unavailable before child dispatch");
-ensureCommitAvailable(dispatchMainSha);
-const dispatchClosureDigest = pontoDependencyClosureDigest(dispatchMainSha);
-assertPontoDependencyClosureUnchanged(
-  pontoDependencyClosureDigest(orchestratorHeadSha),
-  dispatchClosureDigest,
-);
+  const dispatchMain = await request(`/repos/${repository}/commits/main`);
+  const dispatchMainSha = String(dispatchMain?.sha || "").trim().toLowerCase();
+  assertPontoReleaseIsCurrentMain(orchestratorHeadSha, dispatchMainSha);
+  ensureCommitAvailable(dispatchMainSha);
+  const dispatchClosureDigest = pontoDependencyClosureDigest(orchestratorHeadSha);
 await revalidatePontoCompositeLease({ observedDependencyClosureDigest: dispatchClosureDigest });
 compositeLeaseLastRenewedAt = Date.now();
 await revalidateGlobalDispatchLease(globalDispatchLease, {
@@ -625,9 +628,9 @@ while (Date.now() - startedAt < timeoutMs) {
     try {
       const observedMain = await request(`/repos/${repository}/commits/main`);
       const observedMainSha = String(observedMain?.sha || "").trim().toLowerCase();
-      if (!/^[0-9a-f]{40}$/.test(observedMainSha)) throw new Error("current main SHA is unavailable during child dispatch");
+      assertPontoReleaseIsCurrentMain(orchestratorHeadSha, observedMainSha);
       ensureCommitAvailable(observedMainSha);
-      const observedClosureDigest = pontoDependencyClosureDigest(observedMainSha);
+      const observedClosureDigest = pontoDependencyClosureDigest(orchestratorHeadSha);
       await revalidatePontoCompositeLease({ observedDependencyClosureDigest: observedClosureDigest });
       compositeLeaseLastRenewedAt = Date.now();
     } catch (coordinationError) {

--- a/.github/scripts/ponto-dispatch-workflow.test.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.test.mjs
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import test from "node:test";
 import {
   assertPontoDependencyClosureUnchanged,
+  assertPontoReleaseIsCurrentMain,
   dispatchTimeoutMsFor,
   globalResourceFor,
   governedLeaseKeyFor,
@@ -86,6 +87,18 @@ test("child dispatch keeps an immutable release valid across unrelated main chan
   );
 });
 
+test("child dispatch refuses a release SHA after main advances", () => {
+  const releaseSha = "a".repeat(40);
+  assert.deepEqual(
+    assertPontoReleaseIsCurrentMain(releaseSha, releaseSha),
+    { releaseSha, currentMainSha: releaseSha },
+  );
+  assert.throws(
+    () => assertPontoReleaseIsCurrentMain(releaseSha, "b".repeat(40)),
+    /no longer equals current main/,
+  );
+});
+
 test("child dispatch separates the immutable release identity from the main workflow revision", () => {
   const releaseSha = "a".repeat(40);
   const workflowSha = "b".repeat(40);
@@ -102,11 +115,17 @@ test("child dispatch separates the immutable release identity from the main work
 test("Ponto recovery keeps provenance fail-closed while accepting a closure-equivalent coordinator revision", () => {
   const read = (relative) => fs.readFileSync(new URL(relative, import.meta.url), "utf8");
   const progressive = read("../workflows/ponto-progressive-release.yml");
+  const dispatcher = read("./ponto-dispatch-workflow.mjs");
   const orchestratorLease = read("./ponto-orchestrator-lease.mjs");
   const watchdogJournal = read("./ponto-watchdog-journal.mjs");
   const recovery = read("../workflows/ponto-staging-recovery-rollback.yml");
   assert.match(progressive, /PONTO_WORKFLOW_SHA=.*assertPontoSourceClosureUnchanged/s);
   assert.doesNotMatch(progressive, /release_sha must equal the immutable main coordinator SHA/);
+  for (const currentMainCheck of [
+    "assertPontoReleaseIsCurrentMain(orchestratorHeadSha, currentMainSha)",
+    "assertPontoReleaseIsCurrentMain(orchestratorHeadSha, dispatchMainSha)",
+    "assertPontoReleaseIsCurrentMain(orchestratorHeadSha, observedMainSha)",
+  ]) assert.ok(dispatcher.includes(currentMainCheck), `missing current-main guard: ${currentMainCheck}`);
   assert.match(orchestratorLease, /assertObservedPontoSource\(releaseSha, String\(run\?\.head_sha \|\| ""\)\.trim\(\)\.toLowerCase\(\)\)/);
   assert.doesNotMatch(orchestratorLease, /run\?\.head_sha !== releaseSha/);
   assert.match(watchdogJournal, /pontoSourceClosureMatches\(releaseSha, String\(coordinator\?\.head_sha \|\| ""\)\.trim\(\)\.toLowerCase\(\)\)/);

--- a/.github/scripts/ponto-production-baseline.test.mjs
+++ b/.github/scripts/ponto-production-baseline.test.mjs
@@ -255,3 +255,22 @@ test("baseline workflow, reusable gate, and coordinator retain every exported Wo
     "reusableRuns.length > 1",
   ]) assert.ok(reuse.includes(required), `baseline reuse misses strict provenance: ${required}`);
 });
+
+test("coordinator and reusable release gate require the exact current main SHA", () => {
+  for (const name of [
+    "ponto-progressive-release.yml",
+    "ponto-release-gate.yml",
+  ]) {
+    const source = fs.readFileSync(new URL(`../workflows/${name}`, import.meta.url), "utf8");
+    assert.match(
+      source,
+      /\[\[ "\$\(git rev-parse origin\/main\)" == "\$RELEASE_SHA" \]\] \|\| \{ echo 'release_sha must equal current origin\/main'; exit 1; \}/,
+      name,
+    );
+    assert.doesNotMatch(
+      source,
+      /git merge-base --is-ancestor "\$RELEASE_SHA" origin\/main/,
+      name,
+    );
+  }
+});

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -148,7 +148,7 @@ jobs:
           [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'immutable Ponto coordinator workflow SHA is invalid'; exit 1; }
           [[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]] || { echo 'checkout differs from release_sha'; exit 1; }
           git fetch --no-tags origin main
-          git merge-base --is-ancestor "$RELEASE_SHA" origin/main || { echo 'release_sha is not reachable from main'; exit 1; }
+          [[ "$(git rev-parse origin/main)" == "$RELEASE_SHA" ]] || { echo 'release_sha must equal current origin/main'; exit 1; }
           current_main_sha="$(git rev-parse origin/main)"
           PONTO_RELEASE_SHA="$RELEASE_SHA" PONTO_WORKFLOW_SHA="$GITHUB_SHA" PONTO_CURRENT_MAIN_SHA="$current_main_sha" node --input-type=module <<'NODE'
           import { assertPontoSourceClosureUnchanged } from "./.github/scripts/ponto-source-closure.mjs";

--- a/.github/workflows/ponto-release-gate.yml
+++ b/.github/workflows/ponto-release-gate.yml
@@ -128,7 +128,7 @@ jobs:
           [[ "$PREDECESSOR_RUN_ID" =~ ^[0-9]+$ ]] || { echo 'predecessor_run_id must be numeric'; exit 1; }
           [[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]] || { echo 'checkout differs from release_sha'; exit 1; }
           git fetch --no-tags origin main
-          git merge-base --is-ancestor "$RELEASE_SHA" origin/main || { echo 'release_sha is not reachable from main'; exit 1; }
+          [[ "$(git rev-parse origin/main)" == "$RELEASE_SHA" ]] || { echo 'release_sha must equal current origin/main'; exit 1; }
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PREDECESSOR_RUN_ID" > "$RUNNER_TEMP/predecessor-run.json"
           gh api "repos/$GITHUB_REPOSITORY/actions/workflows/ponto-progressive-release.yml" > "$RUNNER_TEMP/predecessor-workflow.json"
           node - "$RUNNER_TEMP/predecessor-run.json" "$RUNNER_TEMP/predecessor-workflow.json" <<'NODE'


### PR DESCRIPTION
## Objective

Keep governed Ponto promotion tied to the exact current `main` SHA and recover a child cancelled before mutation without weakening rollback safety.

## Change

- require exact `origin/main` in the root coordinator and reusable release gate;
- recheck exact `main` before and during child dispatch;
- accept a cancelled Core child as untouched only after GitHub proves its mutable `deploy` job ran zero steps;
- retain closure-compatible watchdog provenance only for fail-closed recovery.

## Validation

- focused Node tests: 42 passing
- deployment topology validation: passing

## Rollback

Revert these workflow-only commits; staging and production remain fail-closed in maintenance until a governed release succeeds.