### PR TITLE
feat(site): close Beauty Movement UX iteration

### DIFF
--- a/website/src/components/BeautyMovementCardIllustration.tsx
+++ b/website/src/components/BeautyMovementCardIllustration.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { memo, type ReactNode } from "react";
 
 type BeautyMovementCardIllustrationProps = {
     cardId: string;
@@ -47,7 +47,7 @@ function DefaultArt() {
 }
 
 /** Original, monochrome editorial drawings for the card concepts. */
-export default function BeautyMovementCardIllustration({ cardId }: BeautyMovementCardIllustrationProps) {
+const BeautyMovementCardIllustration = memo(function BeautyMovementCardIllustration({ cardId }: BeautyMovementCardIllustrationProps) {
     let art: ReactNode;
 
     switch (cardId) {
@@ -310,4 +310,8 @@ export default function BeautyMovementCardIllustration({ cardId }: BeautyMovemen
             {art}
         </svg>
     );
-}
+});
+
+BeautyMovementCardIllustration.displayName = "BeautyMovementCardIllustration";
+
+export default BeautyMovementCardIllustration;

--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -36,66 +36,43 @@
 .hero {
   display: grid;
   justify-items: center;
+  gap: clamp(12px, 1.8vw, 18px);
   max-width: 830px;
   margin: 0 auto;
   text-align: center;
 }
 
-.heroDeckPrompt {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  width: min(100%, 220px);
+.heroDeckInstruction {
+  display: block;
   max-width: 100%;
-  min-height: 40px;
-  margin: 0 0 clamp(14px, 2.4vw, 22px);
-  padding: 9px 18px;
-  border: 1px solid var(--bm-yellow-ink);
-  border-radius: 999px;
-  background: var(--bm-yellow-soft);
-  color: var(--bm-ink);
-  cursor: pointer;
-  font-family: var(--font-brand-ui);
-  font-size: clamp(0.76rem, 1vw, 0.86rem);
-  font-weight: 700;
-  letter-spacing: 0.025em;
-  line-height: 1.25;
+  margin: 0 auto;
+  color: var(--bm-muted);
+  font-family: var(--font-brand-text);
+  font-size: clamp(0.94rem, 1.35vw, 1.08rem);
+  font-weight: 400;
+  letter-spacing: 0.01em;
+  line-height: 1.4;
   text-align: center;
-  white-space: nowrap;
-  box-shadow: 0 8px 18px rgba(48, 48, 48, 0.1);
-  transition: background 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+  text-wrap: balance;
 }
 
-.heroDeckPrompt::before {
-  flex: 0 0 auto;
-  width: 7px;
-  height: 7px;
-  border-radius: 999px;
-  background: var(--bm-yellow);
-  content: "";
-}
-
-.heroDeckPrompt:hover {
-  background: #ffe9a0;
-  box-shadow: 0 12px 24px rgba(48, 48, 48, 0.14);
-  transform: translateY(-2px);
-}
-
-.heroDeckPrompt:focus-visible {
-  outline: 3px solid var(--bm-yellow);
-  outline-offset: 4px;
-}
-
-.heroDeckPromptArrow {
+.tableDeckPromptArrow {
+  position: absolute;
+  z-index: 3;
+  bottom: calc(32px + 106px + 8px);
+  left: 50%;
+  display: block;
   color: var(--bm-yellow-ink);
-  font-size: 1.15rem;
+  font-size: 1.35rem;
+  font-weight: 700;
   line-height: 1;
-  transition: transform 180ms ease;
+  pointer-events: none;
+  transform: translateX(-50%);
+  animation: deckPromptArrowFloat 1200ms cubic-bezier(0.22, 1, 0.36, 1) infinite alternate;
 }
 
-.heroDeckPrompt:hover .heroDeckPromptArrow {
-  transform: translateY(3px);
+.tableSurface[data-deck-state="waiting"] .tableDeckPromptArrow {
+  bottom: 35px;
 }
 
 .hero h1 {
@@ -111,12 +88,22 @@
 }
 
 .progressRow {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  align-items: center;
-  gap: clamp(16px, 3vw, 42px);
+  position: relative;
+  display: flex;
+  justify-content: center;
   width: min(100%, 930px);
-  margin: -4px auto 0;
+  min-height: 38px;
+  margin: -4px auto 2px;
+}
+
+.progressRowWaiting {
+  min-height: 52px;
+  align-items: start;
+}
+
+.progressRowWaiting .progressGroup {
+  visibility: hidden;
+  pointer-events: none;
 }
 
 .progressGroup {
@@ -128,12 +115,21 @@
 }
 
 .tablePrompt {
-  max-width: 560px;
-  margin: 0;
+  display: grid;
+  justify-items: center;
+  width: min(100%, 680px);
+  max-width: 100%;
+  margin: 0 auto clamp(8px, 1.4vw, 14px);
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
   color: var(--bm-muted);
   font-family: var(--font-brand-text);
   font-size: clamp(0.9rem, 1.25vw, 1.02rem);
   line-height: 1.45;
+  text-align: center;
   text-wrap: pretty;
   overflow: visible;
 }
@@ -161,17 +157,6 @@
   color: var(--bm-muted);
   font-size: 0.96em;
   line-height: 1.4;
-}
-
-.tablePromptIntro .promptTitle,
-.tablePromptIntroHolding .promptTitle,
-.tablePromptIntroExit .promptTitle {
-  color: inherit;
-  font-family: var(--font-brand-text);
-  font-size: inherit;
-  font-weight: 400;
-  letter-spacing: normal;
-  line-height: inherit;
 }
 
 .tablePromptIntro {
@@ -246,8 +231,9 @@
   background: var(--bm-yellow);
   box-shadow: 0 8px 18px rgba(245, 179, 1, 0.18);
   pointer-events: none;
-  animation: progressHighlightTransfer var(--bm-progress-total-ms) cubic-bezier(0.22, 1, 0.36, 1) both;
-  will-change: left, top, width, height;
+  transform-origin: center;
+  animation: progressHighlightTransfer var(--bm-progress-total-ms) cubic-bezier(0.4, 0, 0.2, 1) both;
+  will-change: left, top, width, height, transform;
 }
 
 .progressItem {
@@ -266,8 +252,8 @@
   justify-items: center;
   gap: 0;
   width: 100%;
-  min-height: 44px;
-  padding: 8px 2px 10px;
+  min-height: 38px;
+  padding: 5px 2px 7px;
   border: 0;
   border-bottom: 2px solid transparent;
   background: transparent;
@@ -317,17 +303,31 @@
 }
 
 .progressItemCurrent .progressButton {
+  grid-template-rows: 25px 5px;
   border-bottom-color: var(--bm-yellow);
   border-radius: 8px;
   background: var(--bm-yellow);
   color: var(--bm-ink);
-  min-height: 50px;
-  padding: 10px 18px;
+  height: 38px;
+  min-height: 38px;
+  align-self: start;
+  padding: 4px 14px 1px;
 }
 
 .progressItemCurrent .progressButton strong {
   font-size: clamp(1rem, 1.5vw, 1.18rem);
   font-size: var(--bm-progress-active-label-size);
+}
+
+.progressItemEntering .progressButton {
+  transform-origin: center;
+  animation: progressButtonEnter var(--bm-progress-enter-ms) cubic-bezier(0.18, 0.86, 0.24, 1) both;
+  will-change: min-height, padding, transform, background, color, opacity;
+}
+
+.progressItemEntering strong {
+  animation: progressLabelEnter var(--bm-progress-enter-ms) cubic-bezier(0.18, 0.86, 0.24, 1) both;
+  will-change: font-size;
 }
 
 .progressItemCurrent .progressButton:hover {
@@ -355,8 +355,10 @@
 
 .progressItemTransferFrom .progressButton {
   color: var(--bm-ink);
-  min-height: 50px;
-  padding: 10px 18px;
+  height: 38px;
+  min-height: 38px;
+  align-self: start;
+  padding: 4px 14px 1px;
   border-radius: 8px;
   animation: progressButtonCollapse var(--bm-progress-collapse-ms) cubic-bezier(0.4, 0, 0.2, 1) both;
   will-change: min-height, padding, transform;
@@ -375,16 +377,16 @@
 .progressItemTransferTo .progressButton {
   color: var(--bm-muted);
   opacity: 1;
-  min-height: 44px;
-  padding: 8px 2px 10px;
-  animation: progressButtonExpand var(--bm-progress-expand-ms) cubic-bezier(0.22, 1, 0.36, 1) both;
+  min-height: 38px;
+  padding: 5px 2px 7px;
+  animation: progressButtonExpand var(--bm-progress-expand-ms) cubic-bezier(0.4, 0, 0.2, 1) both;
   animation-delay: calc(var(--bm-progress-collapse-ms) + var(--bm-progress-transfer-ms));
   will-change: min-height, padding, transform;
 }
 
 .progressItemTransferTo strong {
   font-size: 0.78rem;
-  animation: progressLabelExpand var(--bm-progress-expand-ms) cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: progressLabelExpand var(--bm-progress-expand-ms) cubic-bezier(0.4, 0, 0.2, 1) both;
   animation-delay: calc(var(--bm-progress-collapse-ms) + var(--bm-progress-transfer-ms));
   will-change: font-size;
 }
@@ -399,10 +401,14 @@
 .tableStage {
   position: relative;
   display: grid;
-  gap: 8px;
+  gap: 4px;
   padding: clamp(4px, 0.8vw, 8px) 0 clamp(8px, 1vw, 12px);
   overflow-anchor: none;
   isolation: isolate;
+}
+
+.tableStage[data-finale-stage="hidden"] {
+  padding-bottom: clamp(86px, 9vw, 96px);
 }
 
 .tableStage::before,
@@ -434,7 +440,7 @@
   position: relative;
   width: min(100%, 920px);
   margin: 0 auto;
-  padding: clamp(10px, 1.5vw, 16px) clamp(10px, 1.4vw, 16px) clamp(126px, 10vw, 136px);
+  padding: clamp(10px, 1.5vw, 16px) clamp(10px, 1.4vw, 16px) clamp(32px, 3vw, 44px);
   border: 1px solid var(--bm-line);
   border-radius: 14px;
   background: rgba(255, 255, 255, 0.48);
@@ -442,14 +448,45 @@
 }
 
 .tableSurface[data-deck-state="waiting"] {
-  min-height: 220px;
+  height: 0;
+  min-height: 0;
+  padding: 0;
+  border-color: transparent;
+  background: transparent;
+  box-shadow: none;
+  overflow: visible;
+}
+
+.tableSurface[data-deck-state="intro"],
+.tableSurface[data-deck-state="prompt"] {
+  padding-bottom: clamp(10px, 1.5vw, 16px);
+  overflow: visible;
+}
+
+.tableSurface[data-deck-state="intro"] {
+  height: var(--bm-table-intro-height, 0px);
+  min-height: 0;
+  transition: height var(--bm-hand-expand-ms) cubic-bezier(0.4, 0, 0.2, 1);
+  will-change: height;
+}
+
+.tableSurface[data-deck-state="prompt"] {
+  min-height: 112px;
+}
+
+.tableSurface[data-deck-state="waiting"] .deckStage,
+.tableSurface[data-deck-state="intro"] .deckStage,
+.tableSurface[data-deck-state="prompt"] .deckStage,
+.tableSurface[data-deck-state="expanding"] .deckStage,
+.tableSurface[data-deck-state="ready"] .deckStage {
+  bottom: -79px;
 }
 
 .deckStage {
   appearance: none;
   position: absolute;
   z-index: 2;
-  bottom: 14px;
+  bottom: 32px;
   left: 50%;
   width: 82px;
   height: 106px;
@@ -459,7 +496,6 @@
   color: inherit;
   cursor: pointer;
   transform: translateX(-50%);
-  will-change: auto;
 }
 
 .deckStage .deckCard,
@@ -525,14 +561,14 @@
 }
 
 .tableStage[data-hand-stage="expand"] .tableSurface {
-  height: var(--bm-table-expand-height, 220px);
-  overflow: hidden;
-  transition: height var(--bm-hand-expand-ms) cubic-bezier(0.22, 1, 0.36, 1);
+  height: var(--bm-table-expand-height, 112px);
+  overflow: visible;
+  transition: height var(--bm-hand-expand-ms) cubic-bezier(0.4, 0, 0.2, 1);
   will-change: height;
 }
 
 .tableStage[data-hand-stage="expand"] .deckStage {
-  animation: deckStageExpand var(--bm-hand-expand-ms) cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: deckStageExpand var(--bm-hand-expand-ms) cubic-bezier(0.4, 0, 0.2, 1) both;
   will-change: transform;
 }
 
@@ -542,7 +578,7 @@
 }
 
 .tableStage[data-hand-stage="deal"] .deckStage {
-  animation: deckStageDeal var(--bm-hand-deal-ms) cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: deckStageDeal var(--bm-hand-deal-ms) cubic-bezier(0.4, 0, 0.2, 1) both;
   will-change: transform;
 }
 
@@ -593,16 +629,19 @@
 }
 
 .finaleCardGrid {
+  position: relative;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: clamp(14px, 2.8vw, 30px);
   width: min(100%, 920px);
   margin: 2px auto 0;
+  --finale-card-height: 360px;
+  --finale-special-card-height: 430px;
 }
 
 .finaleCard {
   position: relative;
-  min-height: 360px;
+  min-height: var(--finale-card-height);
   perspective: 1200px;
   pointer-events: none;
   --finale-x: 0px;
@@ -618,6 +657,41 @@
 .finaleCard:nth-child(3) {
   --finale-x: clamp(-320px, -23vw, -170px);
   --finale-rotate: 8deg;
+}
+
+.tableStage[data-hand-stage="finale"] .deckStage,
+.tableStage[data-finale-stage="confirmation"] .deckStage,
+.tableStage[data-finale-stage="result"] .deckStage {
+  pointer-events: none;
+}
+
+.tableStage[data-finale-stage="confirmation"] .deckStage,
+.tableStage[data-finale-stage="result"] .deckStage {
+  visibility: hidden;
+}
+
+.finaleSpecialCardTransform {
+  position: absolute;
+  z-index: 6;
+  top: calc((var(--finale-card-height) - var(--finale-special-card-height)) / 2);
+  left: 50%;
+  width: min(100%, 360px);
+  height: var(--finale-special-card-height);
+  pointer-events: none;
+  opacity: 0;
+  transform: translate3d(-50%, 0, 0) scale(0.16);
+  transform-origin: center;
+}
+
+.finaleSpecialCardTransform .specialCard {
+  width: 100%;
+  min-height: 100%;
+  animation: none;
+}
+
+.tableStage[data-hand-stage="finale"] .finaleCardGridMerging .finaleSpecialCardTransform {
+  animation: finaleSpecialCardTransform var(--bm-finale-merge-ms) cubic-bezier(0.18, 0.86, 0.24, 1) both;
+  will-change: transform, opacity;
 }
 
 .tableStage[data-hand-stage="finale"][data-finale-stage="merging"] .deckCardTop {
@@ -639,12 +713,14 @@
   will-change: transform, opacity;
 }
 
-.tableStage[data-hand-stage="finale"] .finaleCardGridMerging .finaleCard:nth-child(2) {
-  animation-delay: var(--bm-finale-merge-stagger-ms);
+.tableStage[data-hand-stage="finale"] .finaleCardGridMerging .finaleCard:nth-child(1),
+.tableStage[data-hand-stage="finale"] .finaleCardGridMerging .finaleCard:nth-child(3) {
+  animation-delay: 0ms;
 }
 
-.tableStage[data-hand-stage="finale"] .finaleCardGridMerging .finaleCard:nth-child(3) {
-  animation-delay: calc(var(--bm-finale-merge-stagger-ms) * 2);
+.tableStage[data-hand-stage="finale"] .finaleCardGridMerging .finaleCard:nth-child(2) {
+  animation: finaleCenterCardTransform var(--bm-finale-card-merge-ms) cubic-bezier(0.18, 0.86, 0.24, 1) both;
+  animation-delay: 0ms;
 }
 
 .finaleCardFace {
@@ -699,11 +775,102 @@
 
 .specialCardStage {
   display: grid;
-  gap: 18px;
+  gap: 0;
   width: min(100%, 520px);
   min-height: 430px;
   place-items: center;
   margin: 2px auto 0;
+}
+
+.specialCardStageReopen {
+  min-height: 430px;
+}
+
+.specialCardReopenCard {
+  cursor: pointer;
+  outline: none;
+  transition: transform 180ms ease, filter 180ms ease;
+}
+
+.specialCardReopenCard:hover {
+  filter: brightness(1.04);
+  transform: translateY(-4px);
+}
+
+.specialCardReopenCard:focus-visible {
+  outline: 3px solid var(--bm-yellow);
+  outline-offset: 4px;
+}
+
+.specialCardModalOverlay {
+  --bm-bg: #fafafa;
+  --bm-surface: #ffffff;
+  --bm-surface-soft: #f5f5f5;
+  --bm-ink: #303030;
+  --bm-muted: #505050;
+  --bm-line: #d0d0d0;
+  --bm-line-strong: #a8a8a8;
+  --bm-yellow: #f5b301;
+  --bm-yellow-soft: #fff2bd;
+  --bm-yellow-ink: #825900;
+  --bm-shadow: 0 10px 24px rgba(48, 48, 48, 0.08);
+  position: fixed;
+  z-index: 80;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: clamp(16px, 4vw, 32px);
+  background: rgba(10, 10, 11, 0.64);
+  backdrop-filter: blur(10px) saturate(0.84);
+  -webkit-backdrop-filter: blur(10px) saturate(0.84);
+  animation: specialCardModalBackdropEnter 260ms ease-out both;
+}
+
+.specialCardModalDialog {
+  position: relative;
+  display: grid;
+  width: min(400px, 100%);
+  max-height: min(94vh, 720px);
+  place-items: center;
+  padding-top: 22px;
+}
+
+.specialCardModalDialog .specialCard {
+  width: min(360px, 100%);
+  max-height: calc(94vh - 22px);
+}
+
+.specialCardModalClose {
+  position: absolute;
+  z-index: 2;
+  top: 0;
+  right: 0;
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  background: rgba(15, 15, 16, 0.7);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.2);
+  color: var(--bm-surface);
+  cursor: pointer;
+  font-size: 1.65rem;
+  line-height: 1;
+  transition: transform 180ms ease, background 180ms ease, border-color 180ms ease;
+}
+
+.specialCardModalClose:hover,
+.specialCardModalClose:focus-visible {
+  border-color: var(--bm-yellow);
+  background: var(--bm-yellow);
+  color: var(--bm-ink);
+  transform: translateY(-1px);
+}
+
+.specialCardModalClose:focus-visible {
+  outline: 3px solid var(--bm-yellow);
+  outline-offset: 4px;
 }
 
 .specialCardConfirmation {
@@ -742,32 +909,39 @@
   width: 100%;
 }
 
-.finaleHoldStatus {
+.specialCardRevealAction {
   display: grid;
   justify-items: center;
-  gap: 3px;
-  margin: -4px auto 0;
-  color: var(--bm-muted);
-  text-align: center;
+  gap: 7px;
+  width: min(100%, 282px);
 }
 
-.finaleHoldStatus span {
-  font-family: var(--font-brand-ui);
-  font-size: 0.76rem;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+.specialCardBackWithAction {
+  gap: 10px;
+  padding: 24px;
 }
 
-.finaleHoldStatus strong {
+.specialCardBackWithAction .specialCardBrand {
+  width: 76px;
+  height: 68px;
+}
+
+.specialCardRevealAction .primaryButton {
+  width: 100%;
+  border-color: var(--bm-yellow);
+  background: var(--bm-yellow);
   color: var(--bm-ink);
-  font-family: var(--font-brand-ui);
-  font-size: 1.35rem;
-  line-height: 1;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.18);
 }
 
-.finaleHoldStatus small {
-  font-size: 0.82rem;
+.specialCardRevealError {
+  max-width: 270px;
+  margin: 0;
+  color: rgba(250, 250, 250, 0.88);
+  font-family: var(--font-brand-text);
+  font-size: 0.76rem;
+  line-height: 1.35;
+  text-align: center;
 }
 
 .specialCard {
@@ -775,6 +949,10 @@
   min-height: 430px;
   perspective: 1200px;
   animation: specialCardEnter 820ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
+}
+
+.specialCardStageReopen .specialCard {
+  width: min(100%, 360px);
 }
 
 .specialCardInner {
@@ -935,7 +1113,6 @@
   perspective: 1200px;
   text-align: left;
   transition: transform 320ms cubic-bezier(0.22, 1, 0.36, 1), filter 320ms ease;
-  will-change: auto;
   --deal-x: 0px;
   --deal-y: 106px;
   --deal-rotate: 0deg;
@@ -987,17 +1164,19 @@
   transform-origin: center center;
   transform-style: preserve-3d;
   transition: transform 860ms cubic-bezier(0.16, 1, 0.3, 1);
-  will-change: transform;
 }
 
 .cardButtonSelected .cardInner {
   animation: cardFlipAndSettle var(--bm-hand-reveal-ms) cubic-bezier(0.18, 0.86, 0.24, 1) both;
-  will-change: transform;
 }
 
 .cardButtonSelected {
   z-index: 3;
   animation: cardLiftAndSettle var(--bm-hand-reveal-ms) cubic-bezier(0.18, 0.86, 0.24, 1) both;
+}
+
+.tableStage[data-hand-stage="reveal"] .cardButtonSelected,
+.tableStage[data-hand-stage="reveal"] .cardButtonSelected .cardInner {
   will-change: transform;
 }
 
@@ -1103,6 +1282,16 @@
 
 .cardButtonSelected .cardSparkles > span:nth-child(5) {
   animation-delay: 300ms;
+}
+
+@keyframes deckPromptArrowFloat {
+  from {
+    transform: translate(-50%, 0);
+  }
+
+  to {
+    transform: translate(-50%, 5px);
+  }
 }
 
 @keyframes cardLiftAndSettle {
@@ -1258,24 +1447,6 @@
   }
 }
 
-@keyframes finaleCardsReappear {
-  from {
-    opacity: 0;
-    transform: translate3d(var(--finale-x), var(--finale-y), 0) rotate(var(--finale-rotate)) scale(0.58);
-  }
-
-  62% {
-    opacity: 1;
-    transform: translate3d(calc(var(--finale-x) * 0.08), calc(var(--finale-y) * 0.08), 0)
-      rotate(calc(var(--finale-rotate) * 0.12)) scale(1.04);
-  }
-
-  to {
-    opacity: 1;
-    transform: translate3d(0, 0, 0) rotate(0deg) scale(1);
-  }
-}
-
 @keyframes finaleCardsMerge {
   0% {
     opacity: 1;
@@ -1297,6 +1468,52 @@
   100% {
     opacity: 0;
     transform: translate3d(var(--finale-x), var(--finale-merge-y, 0px), 0) rotate(0deg) scale(0.24);
+  }
+}
+
+@keyframes finaleCenterCardTransform {
+  0%,
+  52% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1) rotate(0deg);
+  }
+
+  68% {
+    opacity: 1;
+    transform: translate3d(0, -3px, 0) scale(1.04) rotate(-1deg);
+  }
+
+  84% {
+    opacity: 0.62;
+    transform: translate3d(0, 0, 0) scale(0.64) rotate(0deg);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translate3d(0, 0, 0) scale(0.2) rotate(0deg);
+  }
+}
+
+@keyframes finaleSpecialCardTransform {
+  0%,
+  52% {
+    opacity: 0;
+    transform: translate3d(-50%, 0, 0) scale(0.16);
+  }
+
+  68% {
+    opacity: 0.18;
+    transform: translate3d(-50%, 0, 0) scale(0.32);
+  }
+
+  84% {
+    opacity: 0.78;
+    transform: translate3d(-50%, 0, 0) scale(0.84);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translate3d(-50%, 0, 0) scale(1);
   }
 }
 
@@ -1327,6 +1544,16 @@
   to {
     opacity: 1;
     transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes specialCardModalBackdropEnter {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
   }
 }
 
@@ -1604,20 +1831,19 @@
   line-height: 1.55;
 }
 
-.actAdvance {
-  display: grid;
-  justify-items: center;
-  gap: 12px;
-}
-
 .autoAdvance {
   display: block;
   width: 100%;
   height: 4px;
-  margin-top: 8px;
+  margin-top: 1px;
   border-radius: 999px;
   background: rgba(48, 48, 48, 0.16);
   overflow: hidden;
+  visibility: hidden;
+}
+
+.autoAdvanceVisible {
+  visibility: visible;
 }
 
 .autoAdvance::after {
@@ -1628,6 +1854,10 @@
   background: var(--bm-ink);
   content: "";
   transform-origin: left center;
+  animation: none;
+}
+
+.autoAdvanceVisible::after {
   animation: autoAdvanceProgress var(--bm-auto-advance-ms) linear both;
 }
 
@@ -1669,53 +1899,84 @@
   }
 }
 
-@keyframes progressHighlightTransfer {
-  0%,
-  23% {
-    top: var(--progress-from-top);
-    left: var(--progress-from-left);
-    width: var(--progress-from-width);
-    height: var(--progress-from-height);
-  }
-
-  73% {
-    top: var(--progress-to-top);
-    left: var(--progress-from-left);
-    width: calc(var(--progress-to-left) + var(--progress-to-width) - var(--progress-from-left));
-    height: var(--progress-to-height);
-  }
-
-  100% {
-    top: var(--progress-to-top);
-    left: var(--progress-to-left);
-    width: var(--progress-to-width);
-    height: var(--progress-to-height);
-  }
-}
-
 @keyframes progressButtonCollapse {
   from {
-    min-height: 50px;
-    padding: 10px 18px;
+    min-height: 38px;
+    padding: 4px 14px 1px;
+    background: var(--bm-yellow);
   }
 
   to {
-    min-height: 44px;
-    padding: 8px 2px 10px;
+    min-height: 38px;
+    padding: 5px 2px 7px;
+    background: transparent;
+  }
+}
+
+@keyframes progressButtonEnter {
+  0% {
+    min-height: 38px;
+    padding: 5px 2px 7px;
+    background: transparent;
+    color: var(--bm-muted);
+    opacity: 0.65;
+    transform: translate3d(0, 2px, 0) scale(0.92);
+  }
+
+  42% {
+    min-height: 38px;
+    padding: 4px 14px 1px;
+    background: var(--bm-yellow);
+    color: var(--bm-ink);
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1.04);
+  }
+
+  72% {
+    transform: translate3d(0, 0, 0) scale(0.985);
+  }
+
+  100% {
+    min-height: 38px;
+    padding: 4px 14px 1px;
+    background: var(--bm-yellow);
+    color: var(--bm-ink);
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+
+@keyframes progressLabelEnter {
+  0% {
+    font-size: 0.78rem;
+  }
+
+  42% {
+    font-size: var(--bm-progress-active-label-size);
+  }
+
+  72% {
+    font-size: calc(var(--bm-progress-active-label-size) * 0.985);
+  }
+
+  100% {
+    font-size: var(--bm-progress-active-label-size);
   }
 }
 
 @keyframes progressButtonExpand {
   from {
-    min-height: 44px;
-    padding: 8px 2px 10px;
+    min-height: 38px;
+    padding: 5px 2px 7px;
     color: var(--bm-muted);
+    background: transparent;
   }
 
   to {
-    min-height: 50px;
-    padding: 10px 18px;
+    min-height: 38px;
+    padding: 4px 14px 1px;
     color: var(--bm-ink);
+    background: var(--bm-yellow);
   }
 }
 
@@ -1739,17 +2000,78 @@
   }
 }
 
+@keyframes progressHighlightTransfer {
+  0% {
+    top: var(--progress-from-top);
+    left: var(--progress-from-left);
+    width: var(--progress-from-width);
+    height: var(--progress-from-height);
+    border-radius: 8px;
+    transform: translateZ(0) scale(1);
+  }
+
+  16% {
+    top: var(--progress-from-top);
+    left: var(--progress-from-left);
+    width: var(--progress-from-width);
+    height: var(--progress-from-height);
+    border-radius: 10px;
+    transform: translateZ(0) scale(1.04, 0.94);
+  }
+
+  48% {
+    top: var(--progress-to-top);
+    left: var(--progress-from-left);
+    width: calc(var(--progress-to-left) + var(--progress-to-width) - var(--progress-from-left));
+    height: var(--progress-to-height);
+    border-radius: 12px;
+    transform: translateZ(0) scale(1.02, 0.98);
+  }
+
+  70% {
+    top: var(--progress-to-top);
+    left: var(--progress-from-left);
+    width: calc(var(--progress-to-left) + var(--progress-to-width) - var(--progress-from-left));
+    height: var(--progress-to-height);
+    border-radius: 12px;
+    transform: translateZ(0) scale(1.06, 0.93);
+  }
+
+  82% {
+    top: var(--progress-to-top);
+    left: var(--progress-to-left);
+    width: var(--progress-to-width);
+    height: var(--progress-to-height);
+    border-radius: 8px;
+    transform: translateZ(0) scale(0.98, 1.04);
+  }
+
+  92% {
+    top: var(--progress-to-top);
+    left: var(--progress-to-left);
+    width: var(--progress-to-width);
+    height: var(--progress-to-height);
+    border-radius: 8px;
+    transform: translateZ(0) scale(1.02, 0.98);
+  }
+
+  100% {
+    top: var(--progress-to-top);
+    left: var(--progress-to-left);
+    width: var(--progress-to-width);
+    height: var(--progress-to-height);
+    border-radius: 8px;
+    transform: translateZ(0) scale(1);
+  }
+}
+
 @keyframes deckStageDeal {
   0% {
     transform: translateX(-50%) translateY(0) scale(1) rotate(0deg);
   }
 
-  34% {
-    transform: translateX(-50%) translateY(8px) scale(0.97) rotate(-1deg);
-  }
-
-  68% {
-    transform: translateX(-50%) translateY(4px) scale(0.99) rotate(0.5deg);
+  50% {
+    transform: translateX(-50%) translateY(2px) scale(0.995) rotate(-0.15deg);
   }
 
   100% {
@@ -1759,15 +2081,11 @@
 
 @keyframes deckStageExpand {
   0% {
-    transform: translateX(-50%) translateY(-24px) scale(0.96) rotate(-1deg);
+    transform: translateX(-50%) translateY(0) scale(0.985) rotate(-0.35deg);
   }
 
-  42% {
-    transform: translateX(-50%) translateY(-10px) scale(1.015) rotate(0.6deg);
-  }
-
-  76% {
-    transform: translateX(-50%) translateY(3px) scale(0.99) rotate(-0.25deg);
+  55% {
+    transform: translateX(-50%) translateY(0) scale(1.005) rotate(0.15deg);
   }
 
   100% {
@@ -1809,13 +2127,6 @@
   100% {
     transform: translateX(-50%) translateY(0) scale(1) rotate(0deg);
   }
-}
-
-.advanceNote {
-  margin: 0;
-  color: var(--bm-muted);
-  font-size: 0.86rem;
-  text-align: center;
 }
 
 .inlineError,
@@ -1886,7 +2197,6 @@
   }
 }
 
-.continueButton,
 .primaryButton,
 .secondaryButton {
   display: inline-flex;
@@ -1902,17 +2212,11 @@
   transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease, border-color 180ms ease;
 }
 
-.continueButton,
 .primaryButton {
   border: 1px solid var(--bm-ink);
   background: var(--bm-ink);
   color: var(--bm-surface);
   box-shadow: var(--bm-shadow);
-}
-
-.continueButton {
-  justify-self: center;
-  padding: 0 24px;
 }
 
 .primaryButton {
@@ -1926,9 +2230,7 @@
   color: var(--bm-ink);
 }
 
-.continueButton:hover,
 .primaryButton:hover,
-.continueButton:focus-visible,
 .primaryButton:focus-visible {
   background: var(--bm-yellow);
   border-color: var(--bm-yellow);
@@ -1945,7 +2247,6 @@
 }
 
 .primaryButton:disabled,
-.continueButton:disabled,
 .secondaryButton:disabled {
   opacity: 0.58;
   box-shadow: none;
@@ -2168,8 +2469,8 @@
   }
 
   .progressButton {
-    min-height: 44px;
-    padding: 7px 10px 9px;
+    min-height: 38px;
+    padding: 5px 10px 7px;
   }
 
   .progressItem strong {
@@ -2188,31 +2489,37 @@
   .finaleCardGrid {
     grid-template-columns: 1fr;
     width: min(100%, 420px);
+    --finale-card-height: 334px;
+    --finale-special-card-height: 410px;
   }
 
   .finaleCard {
-    min-height: 334px;
+    min-height: var(--finale-card-height);
   }
 
   .finaleCard:nth-child(1) {
     --finale-x: 0px;
     --finale-y: 122px;
-    --finale-merge-y: 0px;
+    --finale-merge-y: 348px;
     --finale-rotate: 0deg;
   }
 
   .finaleCard:nth-child(2) {
     --finale-x: 0px;
     --finale-y: 470px;
-    --finale-merge-y: -348px;
+    --finale-merge-y: 0px;
     --finale-rotate: 0deg;
   }
 
   .finaleCard:nth-child(3) {
     --finale-x: 0px;
     --finale-y: 818px;
-    --finale-merge-y: -696px;
+    --finale-merge-y: -348px;
     --finale-rotate: 0deg;
+  }
+
+  .finaleSpecialCardTransform {
+    top: calc(var(--finale-card-height) + clamp(14px, 2.8vw, 30px) + (var(--finale-card-height) - var(--finale-special-card-height)) / 2);
   }
 
   .specialCardStage,
@@ -2294,7 +2601,7 @@
   }
 
   .tableSurface {
-    padding-bottom: 130px;
+    padding-bottom: 40px;
   }
 
   .cardButton {
@@ -2342,6 +2649,10 @@
   .progressItemTransferFrom strong,
   .progressItemTransferTo .progressButton,
   .progressItemTransferTo strong,
+  .progressItemEntering .progressButton,
+  .progressItemEntering strong,
+  .specialCard,
+  .specialCardModalOverlay,
   .cardBack .cardIllustration,
   .cardBack .cardIllustration svg,
   .cardBack .cardIllustration svg > * {
@@ -2355,5 +2666,17 @@
 
   .cardButtonSelected .cardBack {
     display: flex;
+  }
+
+  .finaleSpecialCardTransform {
+    opacity: 1;
+    transform: translate3d(-50%, 0, 0) scale(1);
+    animation: none !important;
+  }
+
+  .tableStage[data-hand-stage="finale"] .finaleCardGridMerging .finaleCard {
+    opacity: 0;
+    transform: translate3d(0, 0, 0) scale(0.2);
+    animation: none !important;
   }
 }

--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -56,6 +56,10 @@
   text-wrap: balance;
 }
 
+.heroDeckInstructionHidden {
+  visibility: hidden;
+}
+
 .tableDeckPromptArrow {
   position: absolute;
   z-index: 3;
@@ -92,13 +96,13 @@
   display: flex;
   justify-content: center;
   width: min(100%, 930px);
-  min-height: 38px;
+  min-height: 52px;
+  align-items: flex-start;
   margin: -4px auto 2px;
 }
 
 .progressRowWaiting {
   min-height: 52px;
-  align-items: start;
 }
 
 .progressRowWaiting .progressGroup {

--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -1953,11 +1953,12 @@ export default function BeautyMovementExperience({
             <section className={styles.shell} aria-labelledby="beauty-movement-title">
                 <header className={styles.hero}>
                     <h1 id="beauty-movement-title">{initialState.campaign.title?.trim() || "Beleza que se move com você."}</h1>
-                    {waitingForInitialDeal ? (
-                        <p className={styles.heroDeckInstruction}>
-                            Clique no baralho para começar a sua leitura
-                        </p>
-                    ) : null}
+                    <p
+                        className={`${styles.heroDeckInstruction} ${waitingForInitialDeal ? "" : styles.heroDeckInstructionHidden}`.trim()}
+                        aria-hidden={!waitingForInitialDeal || undefined}
+                    >
+                        Clique no baralho para começar a sua leitura
+                    </p>
                 </header>
 
                 <section

--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -155,9 +155,32 @@ type ShareNavigator = Navigator & {
 
 const STORY_WIDTH = 1080;
 const STORY_HEIGHT = 1920;
-const INITIAL_TABLE_HEIGHT = 220;
+// Keep the intro/prompt compact while preserving enough room for the deck to
+// cross the lower edge of the surface without being visually detached from the copy.
+const INITIAL_TABLE_HEIGHT = 112;
 const AUTO_ADVANCE_SECONDS = BEAUTY_MOVEMENT_MOTION.autoAdvanceMs / 1_000;
-const FINALE_HOLD_SECONDS = BEAUTY_MOVEMENT_MOTION.finaleHoldMs / 1_000;
+const INITIAL_EXPERIENCE_TITLE = "3 anos. 3 cartas.";
+const INITIAL_EXPERIENCE_SUBTITLE = "Um novo movimento para celebrar tudo o que ainda vem pela frente.";
+
+type InitialExperienceCopy = {
+    title: string;
+    subtitle: string;
+};
+
+function getInitialExperienceCopy(description?: string | null): InitialExperienceCopy {
+    const text = description?.trim();
+    const fallback = `${INITIAL_EXPERIENCE_TITLE} ${INITIAL_EXPERIENCE_SUBTITLE}`;
+    const fullText = text || fallback;
+
+    if (fullText.startsWith(`${INITIAL_EXPERIENCE_TITLE} `)) {
+        return {
+            title: INITIAL_EXPERIENCE_TITLE,
+            subtitle: fullText.slice(INITIAL_EXPERIENCE_TITLE.length).trim(),
+        };
+    }
+
+    return { title: fullText, subtitle: "" };
+}
 
 function motionDuration(durationMs: number, reducedMotion: boolean, preserveTiming = false): number {
     return reducedMotion && !preserveTiming ? 0 : durationMs;
@@ -632,8 +655,9 @@ export default function BeautyMovementExperience({
     const [finaleStage, setFinaleStage] = useState<FinaleStage>(() =>
         initialState.confirmed ? "result" : initialReadingComplete ? "confirmation" : "hidden",
     );
-    const [finaleHoldRemaining, setFinaleHoldRemaining] = useState(0);
+    const [isSpecialCardModalOpen, setIsSpecialCardModalOpen] = useState(initialState.confirmed);
     const [tableExpansionHeight, setTableExpansionHeight] = useState<number | null>(null);
+    const [tableIntroHeight, setTableIntroHeight] = useState(0);
     const [autoAdvanceActive, setAutoAdvanceActive] = useState(false);
     const [progressMotion, setProgressMotion] = useState<ProgressMotion | null>(null);
     const openedRef = useRef(false);
@@ -654,6 +678,8 @@ export default function BeautyMovementExperience({
     const progressButtonRefs = useRef<Array<HTMLButtonElement | null>>([]);
     const finaleRef = useRef<HTMLElement | null>(null);
     const confirmationActionRef = useRef<HTMLElement | null>(null);
+    const specialCardModalCloseRef = useRef<HTMLButtonElement | null>(null);
+    const specialCardReopenCardRef = useRef<HTMLElement | null>(null);
     const selectionsRef = useRef(selections);
     const displayedActIndexRef = useRef(displayedActIndex);
     const introStageRef = useRef(introStage);
@@ -670,6 +696,24 @@ export default function BeautyMovementExperience({
     const introTransitionGateRef = useRef(createBeautyMovementMotionGate());
     const progressMotionKeyRef = useRef(0);
 
+    const closeSpecialCardModal = useCallback(() => {
+        setIsSpecialCardModalOpen(false);
+        window.requestAnimationFrame(() => {
+            specialCardReopenCardRef.current?.focus({ preventScroll: true });
+        });
+    }, []);
+
+    const openSpecialCardModal = useCallback(() => {
+        setIsSpecialCardModalOpen(true);
+    }, []);
+
+    function handleSpecialCardReopenKeyDown(event: ReactKeyboardEvent<HTMLElement>) {
+        if (event.key !== "Enter" && event.key !== " " && event.key !== "Spacebar") return;
+
+        event.preventDefault();
+        openSpecialCardModal();
+    }
+
     const motionCssVariables = useMemo(
         () =>
             ({
@@ -679,20 +723,21 @@ export default function BeautyMovementExperience({
                 "--bm-hand-expand-ms": `${BEAUTY_MOVEMENT_MOTION.handExpandMs}ms`,
                 "--bm-hand-deal-ms": `${BEAUTY_MOVEMENT_MOTION.handDealMs}ms`,
                 "--bm-table-expand-height": `${tableExpansionHeight ?? INITIAL_TABLE_HEIGHT}px`,
+                "--bm-table-intro-height": `${tableIntroHeight}px`,
                 "--bm-progress-collapse-ms": `${BEAUTY_MOVEMENT_MOTION.progressCollapseMs}ms`,
+                "--bm-progress-enter-ms": `${BEAUTY_MOVEMENT_MOTION.progressEnterMs}ms`,
                 "--bm-progress-transfer-ms": `${BEAUTY_MOVEMENT_MOTION.progressTransferMs}ms`,
                 "--bm-progress-expand-ms": `${BEAUTY_MOVEMENT_MOTION.progressExpandMs}ms`,
                 "--bm-progress-total-ms": `${BEAUTY_MOVEMENT_MOTION.progressTransitionMs}ms`,
                 "--bm-finale-enter-ms": `${BEAUTY_MOVEMENT_MOTION.finaleCardsEnterMs}ms`,
                 "--bm-finale-merge-ms": `${BEAUTY_MOVEMENT_MOTION.finaleMergeMs}ms`,
                 "--bm-finale-card-merge-ms": `${BEAUTY_MOVEMENT_MOTION.finaleCardMergeMs}ms`,
-                "--bm-finale-merge-stagger-ms": `${BEAUTY_MOVEMENT_MOTION.finaleMergeStaggerMs}ms`,
                 "--bm-prompt-word-delay-ms": `${BEAUTY_MOVEMENT_MOTION.promptWordDelayMs}ms`,
                 "--bm-prompt-word-animation-ms": `${BEAUTY_MOVEMENT_MOTION.promptWordAnimationMs}ms`,
                 "--bm-prompt-exit-ms": `${BEAUTY_MOVEMENT_MOTION.promptExitBaseMs}ms`,
                 "--bm-prompt-exit-delay-ms": `${BEAUTY_MOVEMENT_MOTION.promptExitWordDelayMs}ms`,
             }) as CSSProperties,
-        [tableExpansionHeight],
+        [tableExpansionHeight, tableIntroHeight],
     );
 
     useEffect(() => {
@@ -728,6 +773,7 @@ export default function BeautyMovementExperience({
         if (initialState.confirmed) {
             setConfirmed(true);
             setCurrentFinaleStage("result");
+            setIsSpecialCardModalOpen(true);
         }
     }, [initialState.confirmed]);
 
@@ -752,7 +798,11 @@ export default function BeautyMovementExperience({
     useEffect(() => {
         if (finaleStage === "confirmation") {
             window.requestAnimationFrame(() => {
-                confirmationActionRef.current?.focus({ preventScroll: true });
+                const confirmationAction = confirmationActionRef.current;
+                const focusTarget = isLocalPreview
+                    ? confirmationAction?.querySelector<HTMLButtonElement>("button")
+                    : confirmationAction;
+                focusTarget?.focus({ preventScroll: true });
             });
             return;
         }
@@ -760,18 +810,28 @@ export default function BeautyMovementExperience({
         window.requestAnimationFrame(() => {
             finaleRef.current?.focus({ preventScroll: true });
         });
-    }, [finaleStage]);
+    }, [finaleStage, isLocalPreview]);
 
     useEffect(() => {
-        if (finaleStage !== "collecting") return;
+        if (finaleStage !== "result" || !isSpecialCardModalOpen) return;
 
-        setFinaleHoldRemaining(FINALE_HOLD_SECONDS);
-        const countdownTimer = window.setInterval(() => {
-            setFinaleHoldRemaining((current) => Math.max(0, current - 1));
-        }, 1000);
+        const previousBodyOverflow = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
 
-        return () => window.clearInterval(countdownTimer);
-    }, [finaleStage]);
+        const closeOnEscape = (event: KeyboardEvent) => {
+            if (event.key === "Escape") closeSpecialCardModal();
+        };
+        window.addEventListener("keydown", closeOnEscape);
+        const focusFrame = window.requestAnimationFrame(() => {
+            specialCardModalCloseRef.current?.focus({ preventScroll: true });
+        });
+
+        return () => {
+            window.cancelAnimationFrame(focusFrame);
+            window.removeEventListener("keydown", closeOnEscape);
+            document.body.style.overflow = previousBodyOverflow;
+        };
+    }, [closeSpecialCardModal, finaleStage, isSpecialCardModalOpen]);
 
     useEffect(() => {
         mountedRef.current = true;
@@ -843,19 +903,45 @@ export default function BeautyMovementExperience({
         };
     }
 
-    function startProgressMotion(fromIndex: number, toIndex: number) {
+    function measureProgressTransition(fromIndex: number, toIndex: number): { from: ProgressRect; to: ProgressRect } | null {
+        const from = measureProgressButton(fromIndex);
+        const sourceButton = progressButtonRefs.current[fromIndex];
+        const targetButton = progressButtonRefs.current[toIndex];
+        const sourceItem = sourceButton?.closest("li");
+        const targetItem = targetButton?.closest("li");
+        if (!from || !sourceItem || !targetItem) return null;
+
+        const sourceWasCurrent = sourceItem.classList.contains(styles.progressItemCurrent);
+        const targetWasCurrent = targetItem.classList.contains(styles.progressItemCurrent);
+        let to: ProgressRect | null = null;
+
+        // Measure the destination in the layout it will have after React commits
+        // the new active index: the source collapses while the destination grows.
+        sourceItem.classList.remove(styles.progressItemCurrent);
+        targetItem.classList.add(styles.progressItemCurrent);
+        try {
+            to = measureProgressButton(toIndex);
+        } finally {
+            sourceItem.classList.toggle(styles.progressItemCurrent, sourceWasCurrent);
+            targetItem.classList.toggle(styles.progressItemCurrent, targetWasCurrent);
+        }
+
+        return to ? { from, to } : null;
+    }
+
+    function startProgressMotion(fromIndex: number, toIndex: number): boolean {
         if (fromIndex === toIndex || reducedMotionRef.current) {
             if (progressMotionTimerRef.current !== null) {
                 window.clearTimeout(progressMotionTimerRef.current);
                 progressMotionTimerRef.current = null;
             }
             setProgressMotion(null);
-            return;
+            return false;
         }
 
-        const from = measureProgressButton(fromIndex);
-        const to = measureProgressButton(toIndex);
-        if (!from || !to) return;
+        const measuredTransition = measureProgressTransition(fromIndex, toIndex);
+        if (!measuredTransition) return false;
+        const { from, to } = measuredTransition;
 
         if (progressMotionTimerRef.current !== null) {
             window.clearTimeout(progressMotionTimerRef.current);
@@ -870,13 +956,16 @@ export default function BeautyMovementExperience({
                 setProgressMotion(null);
             }
         }, BEAUTY_MOVEMENT_MOTION.progressTransitionMs);
+
+        return true;
     }
 
-    function setCurrentActIndex(next: number) {
+    function setCurrentActIndex(next: number): boolean {
         const previous = displayedActIndexRef.current;
-        startProgressMotion(previous, next);
+        const progressMotionStarted = startProgressMotion(previous, next);
         displayedActIndexRef.current = next;
         setDisplayedActIndex(next);
+        return progressMotionStarted;
     }
 
     function setCurrentHandStage(next: HandStage) {
@@ -1107,12 +1196,13 @@ export default function BeautyMovementExperience({
         transitionInFlightRef.current = true;
         const handToken = beginHandTransition();
         const introToken = beginIntroTransition();
+        setTableIntroHeight(0);
         setCurrentIntroStage("entering");
-        scheduleIntroTransition(introToken, promptEntryDuration(initialExperienceCopy), () => {
+        scheduleIntroTransition(introToken, promptEntryDuration(initialExperienceText), () => {
             setCurrentIntroStage("holding");
             scheduleIntroTransition(introToken, BEAUTY_MOVEMENT_MOTION.initialIntroHoldMs, () => {
                 setCurrentIntroStage("exiting");
-                scheduleIntroTransition(introToken, promptExitTransitionDuration(initialExperienceCopy), () => {
+                scheduleIntroTransition(introToken, promptExitTransitionDuration(initialExperienceText), () => {
                     setCurrentIntroStage("hidden");
                     setCurrentHandStage("prompt");
                     scheduleHandTransition(handToken, promptReadingDelay(tableDefinition.prompt, reducedMotionRef.current), () => {
@@ -1152,7 +1242,6 @@ export default function BeautyMovementExperience({
             scheduleHandTransition(handToken, BEAUTY_MOVEMENT_MOTION.finaleCardsEnterMs, () => {
                 setCurrentFinaleStage("collecting");
                 scheduleHandTransition(handToken, BEAUTY_MOVEMENT_MOTION.finaleHoldMs, () => {
-                    setFinaleHoldRemaining(0);
                     setCurrentFinaleStage("merging");
                     scheduleHandTransition(
                         handToken,
@@ -1161,13 +1250,18 @@ export default function BeautyMovementExperience({
                             transitionInFlightRef.current = false;
                             setCurrentHandStage("ready");
                             setCurrentFinaleStage(confirmed ? "result" : "confirmation");
+                            setIsSpecialCardModalOpen(confirmed);
                             if (confirmed) {
                                 window.requestAnimationFrame(() => {
                                     window.requestAnimationFrame(scrollToFinale);
                                 });
                             } else {
                                 window.requestAnimationFrame(() => {
-                                    confirmationActionRef.current?.focus({ preventScroll: true });
+                                    const confirmationAction = confirmationActionRef.current;
+                                    const focusTarget = isLocalPreview
+                                        ? confirmationAction?.querySelector<HTMLButtonElement>("button")
+                                        : confirmationAction;
+                                    focusTarget?.focus({ preventScroll: true });
                                 });
                             }
                         },
@@ -1190,26 +1284,32 @@ export default function BeautyMovementExperience({
         const handToken = beginHandTransition();
         setCurrentHandStage("collect");
         scheduleHandTransition(handToken, BEAUTY_MOVEMENT_MOTION.handCollectMs, () => {
-            setCurrentActIndex(nextIndex);
             setCurrentHandStage("prompt");
+            const progressMotionStarted = setCurrentActIndex(nextIndex);
             scheduleHandTransition(
                 handToken,
-                promptReadingDelay(BEAUTY_MOVEMENT_ACT_DEFINITIONS[nextIndex]?.prompt || "", reducedMotionRef.current),
+                progressMotionStarted ? BEAUTY_MOVEMENT_MOTION.progressTransitionMs : 0,
                 () => {
-                    setCurrentHandStage("prompt-out");
                     scheduleHandTransition(
                         handToken,
-                        promptExitTransitionDuration(BEAUTY_MOVEMENT_ACT_DEFINITIONS[nextIndex]?.prompt || ""),
+                        promptReadingDelay(BEAUTY_MOVEMENT_ACT_DEFINITIONS[nextIndex]?.prompt || "", reducedMotionRef.current),
                         () => {
-                            scheduleDealSequence(handToken, () => {
-                                transitionInFlightRef.current = false;
-                                setCurrentHandStage("ready");
-                                window.requestAnimationFrame(scrollToTable);
-                            });
+                            setCurrentHandStage("prompt-out");
+                            scheduleHandTransition(
+                                handToken,
+                                promptExitTransitionDuration(BEAUTY_MOVEMENT_ACT_DEFINITIONS[nextIndex]?.prompt || ""),
+                                () => {
+                                    scheduleDealSequence(handToken, () => {
+                                        transitionInFlightRef.current = false;
+                                        setCurrentHandStage("ready");
+                                        window.requestAnimationFrame(scrollToTable);
+                                    });
+                                },
+                            );
                         },
+                        true,
                     );
                 },
-                true,
             );
         });
     }
@@ -1281,7 +1381,7 @@ export default function BeautyMovementExperience({
                 resizeFrame = null;
                 const surface = tableSurfaceRef.current;
                 if (!surface || handStageRef.current !== "expand") return;
-                setTableExpansionHeight(Math.max(220, surface.scrollHeight));
+                setTableExpansionHeight(Math.max(INITIAL_TABLE_HEIGHT, surface.scrollHeight));
             });
         };
 
@@ -1294,6 +1394,30 @@ export default function BeautyMovementExperience({
             if (resizeFrame !== null) window.cancelAnimationFrame(resizeFrame);
         };
     }, [handStage]);
+
+    useEffect(() => {
+        if (introStage !== "entering" || handStage !== "waiting") return;
+
+        let measureFrame: number | null = window.requestAnimationFrame(() => {
+            measureFrame = null;
+            const surface = tableSurfaceRef.current;
+            if (!surface || surface.dataset.deckState !== "intro") return;
+
+            // The deck intentionally crosses the surface boundary. Exclude it
+            // from this one intrinsic-content measurement so later intro
+            // phases cannot measure their own overflow and grow the table
+            // repeatedly.
+            const deck = surface.querySelector<HTMLElement>(`.${styles.deckStage}`);
+            const previousDisplay = deck?.style.display;
+            if (deck) deck.style.display = "none";
+            setTableIntroHeight(Math.max(INITIAL_TABLE_HEIGHT, Math.ceil(surface.scrollHeight)));
+            if (deck) deck.style.display = previousDisplay ?? "";
+        });
+
+        return () => {
+            if (measureFrame !== null) window.cancelAnimationFrame(measureFrame);
+        };
+    }, [handStage, introStage]);
 
     useEffect(() => {
         const cancelWhenBackgrounded = () => {
@@ -1335,7 +1459,11 @@ export default function BeautyMovementExperience({
     }
 
     function handleSelectedCardAnimationEnd(event: ReactAnimationEvent<HTMLButtonElement>, actIndex: number) {
-        if (event.currentTarget !== event.target || event.animationName !== "cardLiftAndSettle") return;
+        // CSS Modules scopes keyframe names (for example, `cardLiftAndSettle__hash`),
+        // so comparing against the source name would silently ignore the event.
+        // The stage/token guards in settleReveal already make this handler idempotent
+        // and keep collect/deal animations from advancing the hand accidentally.
+        if (event.currentTarget !== event.target) return;
         const token = revealTransitionTokenRef.current;
         if (token === null) return;
         settleReveal(actIndex, token);
@@ -1392,7 +1520,7 @@ export default function BeautyMovementExperience({
         setConfirmationAttempted(true);
         setActionError(null);
 
-        if (!operationalConsent) return;
+        if (!operationalConsent && !isLocalPreview) return;
 
         confirmInFlightRef.current = true;
         setIsConfirming(true);
@@ -1404,6 +1532,7 @@ export default function BeautyMovementExperience({
             if (!mountedRef.current) return;
             setConfirmed(true);
             setCurrentFinaleStage("result");
+            setIsSpecialCardModalOpen(true);
             onTrack?.("beauty_movement_confirmed", { stage: "confirmation" });
         } catch {
             if (mountedRef.current) {
@@ -1471,9 +1600,8 @@ export default function BeautyMovementExperience({
 
     const tableAct = BEAUTY_MOVEMENT_ACTS[displayedActIndex] ?? BEAUTY_MOVEMENT_ACTS[0];
     const tableDefinition = BEAUTY_MOVEMENT_ACT_DEFINITIONS[displayedActIndex] ?? BEAUTY_MOVEMENT_ACT_DEFINITIONS[0];
-    const initialExperienceCopy =
-        initialState.campaign.description?.trim() ||
-        "3 anos. 3 cartas. Um novo movimento para celebrar tudo o que ainda vem pela frente.";
+    const initialExperienceCopy = getInitialExperienceCopy(initialState.campaign.description);
+    const initialExperienceText = [initialExperienceCopy.title, initialExperienceCopy.subtitle].filter(Boolean).join(" ");
     const tableCards = getBeautyMovementCardsForAct(initialState.palette, tableAct);
     const tableSelectedCardId = selections[tableAct];
     const tableSelected = Boolean(tableSelectedCardId);
@@ -1482,7 +1610,7 @@ export default function BeautyMovementExperience({
     const waitingForInitialDeal = handStage === "waiting" && introStage === "hidden" && finaleStage === "hidden";
     const tablePromptCopy =
         introStage !== "hidden"
-            ? { title: initialExperienceCopy, subtitle: "" }
+            ? initialExperienceCopy
             : handStage === "prompt" || handStage === "prompt-out"
               ? { title: tableDefinition.promptTitle, subtitle: tableDefinition.promptSubtitle }
               : null;
@@ -1498,6 +1626,18 @@ export default function BeautyMovementExperience({
                 : handStage === "prompt-out"
                   ? styles.tablePromptExit
                   : "";
+    const tableIsBusy =
+        introStage !== "hidden" ||
+        handStage === "prompt" ||
+        handStage === "prompt-out" ||
+        handStage === "reveal" ||
+        handStage === "collect" ||
+        handStage === "expand" ||
+        handStage === "deal" ||
+        handStage === "finale" ||
+        finaleStage === "assembling" ||
+        finaleStage === "collecting" ||
+        finaleStage === "merging";
 
     function renderCard(card: BeautyMovementCard, cardIndex: number) {
         const pendingKey = `${displayedActIndex}:${card.id}`;
@@ -1525,7 +1665,7 @@ export default function BeautyMovementExperience({
                 <span className={styles.cardInner}>
                     <span className={`${styles.cardFace} ${styles.cardFront}`}>
                         <span className={styles.cardBrandMark} aria-hidden="true">
-                            <BrandMark className={styles.cardBrandLogo} tone="light" title="" />
+                            <BrandMark className={styles.cardBrandLogo} loading="eager" tone="light" title="" />
                         </span>
                         <span className={styles.cardPrompt}>
                             {isPending ? "Guardando escolha" : tableIsUnlocked ? "Revelar carta" : "Bloqueada"}
@@ -1568,7 +1708,7 @@ export default function BeautyMovementExperience({
         );
     }
 
-    function renderSpecialCard(revealed: boolean) {
+    function renderSpecialCard(revealed: boolean, showRevealAction = false, interactive = false) {
         const kind: SpecialCardKind = revealed
             ? hasCourtesyClass
                 ? "velocity"
@@ -1619,16 +1759,46 @@ export default function BeautyMovementExperience({
 
         return (
             <article
-                className={styles.specialCard}
+                ref={interactive ? specialCardReopenCardRef : undefined}
+                className={`${styles.specialCard} ${interactive ? styles.specialCardReopenCard : ""}`.trim()}
                 data-special-state={revealed ? "revealed" : "locked"}
-                aria-label={revealed ? `Carta especial: ${title}` : "Carta especial reservada"}
+                role={interactive ? "button" : undefined}
+                tabIndex={interactive ? 0 : undefined}
+                aria-label={interactive ? "Revelar sua carta especial" : revealed ? `Carta especial: ${title}` : "Carta especial reservada"}
+                onClick={interactive ? openSpecialCardModal : undefined}
+                onKeyDown={interactive ? handleSpecialCardReopenKeyDown : undefined}
             >
                 <div className={styles.specialCardInner}>
-                    <div className={`${styles.specialCardFace} ${styles.specialCardBack}`} aria-hidden={revealed}>
-                        <BrandMark className={styles.specialCardBrand} tone="light" title="" />
+                    <div
+                        className={[
+                            styles.specialCardFace,
+                            styles.specialCardBack,
+                            showRevealAction ? styles.specialCardBackWithAction : "",
+                        ].filter(Boolean).join(" ")}
+                        aria-hidden={revealed}
+                    >
+                        <BrandMark className={styles.specialCardBrand} loading="eager" tone="light" title="" />
                         <span className={styles.specialCardBackLabel}>CARTA ESPECIAL</span>
                         <strong>A soma da sua leitura está pronta.</strong>
-                        <span>Confirme sua entrada para revelar o presente reservado.</span>
+                        <span>Confirme sua entrada para revelar a sua carta especial.</span>
+                        {showRevealAction ? (
+                            <div
+                                className={styles.specialCardRevealAction}
+                                ref={(node) => {
+                                    confirmationActionRef.current = node;
+                                }}
+                            >
+                                {actionError ? <p className={styles.specialCardRevealError} role="alert">{actionError}</p> : null}
+                                <button
+                                    className={styles.primaryButton}
+                                    type="button"
+                                    onClick={() => void handleConfirm()}
+                                    disabled={isConfirming}
+                                >
+                                    {isConfirming ? "Revelando…" : "Clique aqui para revelar sua carta especial"}
+                                </button>
+                            </div>
+                        ) : null}
                         <span className={styles.specialCardSeal} aria-hidden="true">
                             ✦
                         </span>
@@ -1775,27 +1945,19 @@ export default function BeautyMovementExperience({
     }
 
     return (
-        <main className={styles.page}>
+        <>
+        <main className={styles.page} aria-hidden={isSpecialCardModalOpen || undefined}>
             <div className={styles.backgroundOrbOne} aria-hidden="true" />
             <div className={styles.backgroundOrbTwo} aria-hidden="true" />
 
             <section className={styles.shell} aria-labelledby="beauty-movement-title">
                 <header className={styles.hero}>
-                    {waitingForInitialDeal ? (
-                        <button
-                            className={styles.heroDeckPrompt}
-                            id="beauty-movement-deck-prompt"
-                            type="button"
-                            onClick={scrollToTable}
-                            aria-label="Ir ao baralho e começar sua leitura"
-                        >
-                            <span>Começar a leitura</span>
-                            <span className={styles.heroDeckPromptArrow} aria-hidden="true">
-                                ↓
-                            </span>
-                        </button>
-                    ) : null}
                     <h1 id="beauty-movement-title">{initialState.campaign.title?.trim() || "Beleza que se move com você."}</h1>
+                    {waitingForInitialDeal ? (
+                        <p className={styles.heroDeckInstruction}>
+                            Clique no baralho para começar a sua leitura
+                        </p>
+                    ) : null}
                 </header>
 
                 <section
@@ -1807,10 +1969,13 @@ export default function BeautyMovementExperience({
                     data-hand-stage={handStage}
                     data-act-index={displayedActIndex}
                     data-finale-stage={finaleStage}
+                    aria-busy={tableIsBusy || undefined}
                     style={motionCssVariables}
                 >
-                    <div className={styles.progressRow}>
-                        <div className={styles.progressGroup}>
+                    <div
+                        className={`${styles.progressRow} ${waitingForInitialDeal ? styles.progressRowWaiting : ""}`.trim()}
+                    >
+                        <div className={styles.progressGroup} aria-hidden={waitingForInitialDeal || undefined}>
                             <ol
                                 ref={progressListRef}
                                 className={`${styles.progress} ${progressMotion ? styles.progressMotionActive : ""}`.trim()}
@@ -1836,11 +2001,21 @@ export default function BeautyMovementExperience({
                                 ) : null}
                                 {BEAUTY_MOVEMENT_ACT_DEFINITIONS.map((act, index) => {
                                     const isDone = Boolean(selections[act.id]);
-                                    const isCurrent = introStage === "hidden" && !waitingForInitialDeal && index === displayedActIndex;
+                                    const isCurrent =
+                                        finaleStage === "hidden" &&
+                                        introStage === "hidden" &&
+                                        !waitingForInitialDeal &&
+                                        index === displayedActIndex;
+                                    const isInitialCategoryEntering =
+                                        isCurrent &&
+                                        !progressMotion &&
+                                        displayedActIndex === 0 &&
+                                        (handStage === "prompt" || handStage === "prompt-out");
                                     const isLocked = !isActUnlocked(index);
                                     const isProgressSource = progressMotion?.fromIndex === index;
                                     const isProgressTarget = progressMotion?.toIndex === index;
                                     const isAdvanceReady = isCurrent && isDone && handStage === "held";
+                                    const isAutoAdvanceVisible = isCurrent && !progressMotion && autoAdvanceActive;
                                     const nextAct = BEAUTY_MOVEMENT_ACT_DEFINITIONS[index + 1];
                                     const progressActionLabel = isAdvanceReady
                                         ? index === BEAUTY_MOVEMENT_ACTS.length - 1
@@ -1853,29 +2028,39 @@ export default function BeautyMovementExperience({
                                                 styles.progressItem,
                                                 isDone ? styles.progressItemDone : "",
                                                 isCurrent && !progressMotion ? styles.progressItemCurrent : "",
+                                                isInitialCategoryEntering ? styles.progressItemEntering : "",
                                                 isProgressSource ? styles.progressItemTransferFrom : "",
                                                 isProgressTarget ? styles.progressItemTransferTo : "",
                                             ].filter(Boolean).join(" ")}
                                             key={act.id}
                                         >
-                                            <button
-                                                className={styles.progressButton}
-                                                type="button"
-                                                onClick={() => handleProgressClick(index)}
-                                                ref={(element) => {
-                                                    progressButtonRefs.current[index] = element;
-                                                }}
-                                                disabled={!isCurrent || Boolean(progressMotion)}
+                                                <button
+                                                    className={styles.progressButton}
+                                                    type="button"
+                                                    onClick={() => handleProgressClick(index)}
+                                                    ref={(element) => {
+                                                        progressButtonRefs.current[index] = element;
+                                                    }}
+                                                    disabled={!isCurrent || Boolean(progressMotion)}
                                                 aria-current={isCurrent ? "step" : undefined}
                                                 aria-label={progressActionLabel}
                                             >
                                                 <span className={styles.progressCopy}>
                                                     <strong>{act.label}</strong>
                                                 </span>
-                                                {isCurrent && !progressMotion && autoAdvanceActive ? (
-                                                    <span className={styles.autoAdvance} role="status" aria-live="polite">
+                                                {isCurrent && !progressMotion ? (
+                                                    <span
+                                                        className={`${styles.autoAdvance} ${isAutoAdvanceVisible ? styles.autoAdvanceVisible : ""}`.trim()}
+                                                        role="status"
+                                                        aria-live={isAutoAdvanceVisible ? "polite" : undefined}
+                                                        aria-hidden={isAutoAdvanceVisible ? undefined : true}
+                                                    >
                                                         <span className={styles.srOnly}>
-                                                            {nextDefinition ? "Próxima mão" : "Confirmação"} automática em {AUTO_ADVANCE_SECONDS} segundos.
+                                                            {isAutoAdvanceVisible ? (
+                                                                <>
+                                                                    {nextDefinition ? "Próxima mão" : "Confirmação"} automática em {AUTO_ADVANCE_SECONDS} segundos.
+                                                                </>
+                                                            ) : null}
                                                         </span>
                                                     </span>
                                                 ) : null}
@@ -1886,6 +2071,30 @@ export default function BeautyMovementExperience({
                             </ol>
                         </div>
 
+                    </div>
+
+                    <div
+                        ref={tableSurfaceRef}
+                        className={styles.tableSurface}
+                        data-deck-state={
+                            waitingForInitialDeal
+                                ? "waiting"
+                                : introStage !== "hidden"
+                                  ? "intro"
+                                  : handStage === "prompt" || handStage === "prompt-out"
+                                    ? "prompt"
+                                    : handStage === "expand"
+                                      ? "expanding"
+                                      : finaleStage === "confirmation" || finaleStage === "result"
+                                        ? "final"
+                                        : "ready"
+                        }
+                    >
+                        {waitingForInitialDeal ? (
+                            <span className={styles.tableDeckPromptArrow} aria-hidden="true">
+                                ↓
+                            </span>
+                        ) : null}
                         {tablePromptCopy ? (
                             <p
                                 className={`${styles.tablePrompt} ${tablePromptClassName}`.trim()}
@@ -1900,34 +2109,19 @@ export default function BeautyMovementExperience({
                                 ) : null}
                             </p>
                         ) : null}
-                    </div>
-
-                    <div
-                        ref={tableSurfaceRef}
-                        className={styles.tableSurface}
-                        data-deck-state={
-                            waitingForInitialDeal || introStage !== "hidden" || handStage === "prompt" || handStage === "prompt-out"
-                                ? "waiting"
-                                : handStage === "expand"
-                                  ? "expanding"
-                                : finaleStage === "confirmation" || finaleStage === "result"
-                                  ? "final"
-                                  : "ready"
-                        }
-                    >
                         <button
                             className={styles.deckStage}
                             type="button"
                             onClick={startInitialDeal}
                             onKeyDown={handleDeckKeyDown}
                             disabled={!waitingForInitialDeal}
-                            aria-describedby={waitingForInitialDeal ? "beauty-movement-deck-prompt" : undefined}
-                            aria-label="Clique no baralho para distribuir as cartas"
+                            aria-hidden={finaleStage !== "hidden" ? true : undefined}
+                            aria-label="Clique no baralho para começar a sua leitura"
                         >
                             <span className={`${styles.deckCard} ${styles.deckCardUnder}`} />
                             <span className={`${styles.deckCard} ${styles.deckCardMiddle}`} />
                             <span className={`${styles.deckCard} ${styles.deckCardTop}`}>
-                                <BrandMark className={styles.deckBrandLogo} tone="light" title="" />
+                                <BrandMark className={styles.deckBrandLogo} loading="eager" tone="light" title="" />
                             </span>
                         </button>
                         {finaleStage === "assembling" || finaleStage === "collecting" || finaleStage === "merging" ? (
@@ -1936,26 +2130,32 @@ export default function BeautyMovementExperience({
                                 aria-hidden="true"
                             >
                                 {reading.map(renderFinaleCard)}
+                                {finaleStage === "merging" ? (
+                                    <div className={styles.finaleSpecialCardTransform}>
+                                        {renderSpecialCard(false)}
+                                    </div>
+                                ) : null}
                             </div>
-                        ) : finaleStage === "confirmation" || finaleStage === "result" ? (
+                        ) : finaleStage === "confirmation" ? (
                             <div
                                 className={styles.specialCardStage}
                                 role="group"
-                                aria-label={finaleStage === "result" ? "Carta especial do benefício" : "Carta especial da celebração"}
+                                aria-label="Carta especial da celebração"
                             >
-                                {finaleStage === "confirmation" ? renderConfirmationAction() : null}
-                                {renderSpecialCard(finaleStage === "result")}
+                                {!isLocalPreview ? renderConfirmationAction() : null}
+                                {renderSpecialCard(false, isLocalPreview)}
+                            </div>
+                        ) : finaleStage === "result" ? (
+                            <div
+                                className={`${styles.specialCardStage} ${styles.specialCardStageReopen}`}
+                                role="group"
+                                aria-label="Carta especial do benefício"
+                            >
+                                {renderSpecialCard(false, false, !isSpecialCardModalOpen)}
                             </div>
                         ) : finaleStage === "hidden" && introStage === "hidden" && handStage !== "waiting" && handStage !== "prompt" && handStage !== "prompt-out" ? (
                             <div className={styles.cardGrid} role="group" aria-label={`Cartas da etapa ${tableDefinition.label}`}>
                                 {tableCards.map(renderCard)}
-                            </div>
-                        ) : null}
-                        {finaleStage === "collecting" ? (
-                            <div className={styles.finaleHoldStatus} role="status" aria-live="polite">
-                                <span>Leitura reunida</span>
-                                <strong>{finaleHoldRemaining}s</strong>
-                                <small>A carta especial se forma em seguida.</small>
                             </div>
                         ) : null}
                     </div>
@@ -1988,5 +2188,33 @@ export default function BeautyMovementExperience({
 
             </section>
         </main>
+            {finaleStage === "result" && isSpecialCardModalOpen ? (
+                <div
+                    className={styles.specialCardModalOverlay}
+                    role="presentation"
+                    onClick={(event) => {
+                        if (event.target === event.currentTarget) closeSpecialCardModal();
+                    }}
+                >
+                    <section
+                        className={styles.specialCardModalDialog}
+                        role="dialog"
+                        aria-modal="true"
+                        aria-label="Carta especial"
+                    >
+                        <button
+                            ref={specialCardModalCloseRef}
+                            className={styles.specialCardModalClose}
+                            type="button"
+                            aria-label="Fechar carta especial"
+                            onClick={closeSpecialCardModal}
+                        >
+                            ×
+                        </button>
+                        {renderSpecialCard(true)}
+                    </section>
+                </div>
+            ) : null}
+        </>
     );
 }

--- a/website/src/components/BrandMark.tsx
+++ b/website/src/components/BrandMark.tsx
@@ -5,11 +5,12 @@ import Image from "next/image";
 
 type Props = {
     className?: string;
+    loading?: "eager" | "lazy";
     title?: string;
     tone?: "dark" | "light";
 };
 
-export default function BrandMark({ className, title = "Espaço Facial", tone = "dark" }: Props) {
+export default function BrandMark({ className, loading = "lazy", title = "Espaço Facial", tone = "dark" }: Props) {
     const candidates = useMemo(() => {
         if (tone === "light") {
             return ["/mark-white.png", "/mark.png"] as const;
@@ -34,6 +35,7 @@ export default function BrandMark({ className, title = "Espaço Facial", tone = 
                 width={484}
                 height={432}
                 sizes="64px"
+                loading={loading}
                 draggable={false}
                 style={shouldInvert ? { filter: "invert(1)" } : undefined}
                 onError={() => {

--- a/website/src/lib/beautyMovementMotion.ts
+++ b/website/src/lib/beautyMovementMotion.ts
@@ -15,14 +15,14 @@ export const BEAUTY_MOVEMENT_MOTION = {
     /** A short settle window keeps the freshly dealt cards fully at rest before clicks are enabled. */
     handDealSettleMs: 120,
     progressCollapseMs: 220,
+    progressEnterMs: 620,
     progressTransferMs: 480,
     progressExpandMs: 260,
     progressTransitionMs: 960,
     finaleCardsEnterMs: 880,
     finaleMergeMs: 1_200,
     finaleCardMergeMs: 1_120,
-    finaleMergeStaggerMs: 40,
-    /** The third finale card has a stagger; let its last frame land before swapping the DOM. */
+    /** Let the last merge frame land before swapping the DOM. */
     finaleMergeSettleMs: 120,
     initialIntroHoldMs: 2_600,
     promptWordDelayMs: 48,

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -108,11 +108,11 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.doesNotMatch(experience, /className=\{styles\.progressCopy\}>\s*<small>/);
     assert.match(experience, /styles\.progressRowWaiting/);
     assert.match(experience, /className=\{styles\.progressGroup\}/);
-    assert.match(experience, /className=\{styles\.heroDeckInstruction\}/);
+    assert.match(experience, /styles\.heroDeckInstructionHidden/);
     assert.match(experience, /aria-hidden=\{waitingForInitialDeal \|\| undefined\}/);
     assert.match(experience, /\$\{styles\.tablePrompt\}/);
     assert.match(experience, /key=\{introStage !== "hidden" \? "experience-intro" : tableDefinition\.id\}/);
-    assert.match(experience, /waitingForInitialDeal \? \(/);
+    assert.doesNotMatch(experience, /waitingForInitialDeal \? \(\s*<p/);
     assert.doesNotMatch(experience, /className=\{styles\.autoAdvanceLabel\}/);
     assert.doesNotMatch(experience, /className=\{styles\.autoAdvanceHint\}/);
     assert.doesNotMatch(experience, /className=\{styles\.brandLine\}/);
@@ -181,13 +181,14 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(experience, /function handleDeckKeyDown\(event: ReactKeyboardEvent<HTMLButtonElement>\)/);
     assert.match(experience, /event\.key !== "Enter" && event\.key !== " " && event\.key !== "Spacebar"/);
     assert.equal((experience.match(/onKeyDown=\{handleDeckKeyDown\}/g) ?? []).length, 1);
-    const heroInstructionClass = experience.indexOf("className={styles.heroDeckInstruction}");
+    const heroInstructionClass = experience.indexOf("styles.heroDeckInstruction");
     const heroInstructionMarkup = experience.slice(
         experience.lastIndexOf("<p", heroInstructionClass),
         experience.indexOf("</p>", heroInstructionClass) + "</p>".length,
     );
     assert.ok(heroInstructionClass >= 0);
-    assert.match(heroInstructionMarkup, /<p\s+className=\{styles\.heroDeckInstruction\}>/);
+    assert.match(heroInstructionMarkup, /<p\s+className=\{`\$\{styles\.heroDeckInstruction\} \$\{waitingForInitialDeal \? "" : styles\.heroDeckInstructionHidden\}`\.trim\(\)\}/);
+    assert.match(heroInstructionMarkup, /aria-hidden=\{!waitingForInitialDeal \|\| undefined\}/);
     assert.doesNotMatch(heroInstructionMarkup, /<(?:button|a)\b|onClick=|onKeyDown=|tabIndex=|aria-label=/);
     assert.doesNotMatch(experience, /id="beauty-movement-deck-prompt"/);
     assert.equal((experience.match(/onClick=\{startInitialDeal\}/g) ?? []).length, 1);
@@ -298,6 +299,8 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
         styles.indexOf(".tableDeckPromptArrow {"),
     );
     assert.match(heroInstructionStyles, /display: block[\s\S]*font-family: var\(--font-brand-text\)/);
+    assert.match(styles, /\.heroDeckInstructionHidden \{\s*visibility: hidden;/);
+    assert.match(styles, /\.progressRow \{[\s\S]*min-height: 52px;[\s\S]*align-items: flex-start;/);
     assert.doesNotMatch(heroInstructionStyles, /cursor: pointer|:hover|:focus-visible|appearance:|background:/);
     assert.match(styles, /\.tableDeckPromptArrow \{[\s\S]*position: absolute[\s\S]*bottom: calc\(32px \+ 106px \+ 8px\)[\s\S]*font-size: 1\.35rem/);
     assert.match(styles, /\.tableSurface \{[\s\S]*padding: clamp\(10px, 1\.5vw, 16px\) clamp\(10px, 1\.4vw, 16px\) clamp\(32px, 3vw, 44px\)/);

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -5,7 +5,7 @@ import test from "node:test";
 const sourceUrl = (relativePath: string) => new URL(`../${relativePath}`, import.meta.url);
 
 test("continuous experience reuses the real shell and keeps the inline finale flow", async () => {
-    const [page, localPage, experience, styles, campaignStyles, illustrations, header, headerScrollBehavior, globalStyles, cards] = await Promise.all([
+    const [page, localPage, experience, styles, campaignStyles, illustrations, header, headerScrollBehavior, globalStyles, cards, brandMark] = await Promise.all([
         readFile(sourceUrl("src/app/beleza-em-movimento/page.tsx"), "utf8"),
         readFile(sourceUrl("src/app/beleza-em-movimento/local-preview/page.tsx"), "utf8"),
         readFile(sourceUrl("src/components/BeautyMovementExperience.tsx"), "utf8"),
@@ -16,6 +16,7 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
         readFile(sourceUrl("src/components/HeaderScrollBehavior.tsx"), "utf8"),
         readFile(sourceUrl("src/styles/globals.css"), "utf8"),
         readFile(sourceUrl("src/lib/beautyMovementCards.ts"), "utf8"),
+        readFile(sourceUrl("src/components/BrandMark.tsx"), "utf8"),
     ]);
 
     for (const route of [page, localPage]) {
@@ -30,12 +31,15 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(experience, /className=\{styles\.tableStage\}/);
     assert.match(experience, /id="mesa-de-cartas"/);
     assert.match(experience, /data-hand-stage=\{handStage\}/);
+    assert.match(experience, /const tableIsBusy =/);
+    assert.match(experience, /aria-busy=\{tableIsBusy \|\| undefined\}/);
     assert.match(experience, /beauty_movement_act_view/);
     assert.match(experience, /requestAnimationFrame\(animate\)/);
     assert.match(experience, /scrollIntoView\(\{ behavior: "auto"/);
     assert.match(experience, /prefers-reduced-motion/);
     assert.match(experience, /import \{ BEAUTY_MOVEMENT_MOTION, createBeautyMovementMotionGate \}/);
     assert.match(experience, /AUTO_ADVANCE_SECONDS = BEAUTY_MOVEMENT_MOTION\.autoAdvanceMs \/ 1_000/);
+    assert.match(experience, /const INITIAL_TABLE_HEIGHT = 112/);
     assert.match(experience, /type IntroStage = "hidden" \| "entering" \| "holding" \| "exiting"/);
     assert.match(experience, /BEAUTY_MOVEMENT_MOTION\.initialIntroHoldMs/);
     assert.match(experience, /BEAUTY_MOVEMENT_MOTION\.promptWordDelayMs/);
@@ -55,6 +59,8 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(experience, /motionDuration\(delayMs, reducedMotionRef\.current, preserveTiming\)/);
     assert.match(experience, /if \(reducedMotion\) return;/);
     assert.match(experience, /handleSelectedCardAnimationEnd/);
+    assert.match(experience, /if \(event\.currentTarget !== event\.target\) return/);
+    assert.doesNotMatch(experience, /event\.animationName !== "cardLiftAndSettle"/);
     assert.match(experience, /handRevealFallbackMs/);
     assert.match(experience, /autoAdvanceActive/);
     assert.match(experience, /function beginFinale\(\)/);
@@ -64,8 +70,7 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(experience, /confirmInFlightRef/);
     assert.match(experience, /setCurrentFinaleStage\("collecting"\)/);
     assert.match(experience, /setCurrentFinaleStage\("merging"\)/);
-    assert.match(experience, /FINALE_HOLD_SECONDS = BEAUTY_MOVEMENT_MOTION\.finaleHoldMs \/ 1_000/);
-    assert.match(experience, /finaleHoldRemaining/);
+    assert.doesNotMatch(experience, /FINALE_HOLD_SECONDS|finaleHoldRemaining|Leitura reunida|A carta especial se forma em seguida/);
     assert.match(experience, /setCurrentFinaleStage\("assembling"\)/);
     assert.match(experience, /BEAUTY_MOVEMENT_MOTION\.finaleCardsEnterMs/);
     assert.match(experience, /BEAUTY_MOVEMENT_MOTION\.finaleMergeMs/);
@@ -78,15 +83,33 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(experience, /disabled=\{!isCurrent \|\| Boolean\(progressMotion\)\}/);
     assert.match(experience, /onClick=\{\(\) => handleProgressClick\(index\)\}/);
     assert.match(experience, /className=\{styles\.progressCopy\}/);
+    assert.match(experience, /className=\{styles\.progressTransfer\}/);
+    assert.match(experience, /function measureProgressTransition\(fromIndex: number, toIndex: number\)/);
+    assert.match(experience, /sourceItem\.classList\.remove\(styles\.progressItemCurrent\)/);
+    assert.match(experience, /targetItem\.classList\.add\(styles\.progressItemCurrent\)/);
+    assert.ok(experience.indexOf("measureProgressTransition(fromIndex, toIndex)") < experience.indexOf("setProgressMotion({ fromIndex"));
+    const progressMarkup = experience.slice(experience.indexOf("className={styles.progressButton}"));
+    assert.ok(progressMarkup.indexOf("styles.autoAdvance") < progressMarkup.indexOf("</button>"));
     assert.match(
         experience,
-        /<\/span>\s*\{isCurrent && !progressMotion && autoAdvanceActive \? \(\s*<span className=\{styles\.autoAdvance\}/,
+        /\{isCurrent && !progressMotion \? \(\s*<span\s+className=\{`\$\{styles\.autoAdvance\}/,
     );
-    assert.doesNotMatch(experience, /<\/button>\s*\{isCurrent && autoAdvanceActive/);
+    assert.match(experience, /const isAutoAdvanceVisible = isCurrent && !progressMotion && autoAdvanceActive/);
+    assert.match(experience, /styles\.autoAdvanceVisible/);
+    assert.match(experience, /aria-hidden=\{isAutoAdvanceVisible \? undefined : true\}/);
+    const nextHandTransition = experience.slice(experience.indexOf("function moveToNextHand"));
+    assert.match(nextHandTransition, /setCurrentHandStage\("prompt"\);\s*const progressMotionStarted = setCurrentActIndex\(nextIndex\)/);
+    assert.match(nextHandTransition, /progressMotionStarted \? BEAUTY_MOVEMENT_MOTION\.progressTransitionMs : 0/);
+    assert.ok(
+        nextHandTransition.indexOf('setCurrentHandStage("prompt")') <
+            nextHandTransition.indexOf("const progressMotionStarted = setCurrentActIndex(nextIndex)"),
+    );
     assert.doesNotMatch(experience, /<\/ol>\s*\{autoAdvanceActive \? \(/);
     assert.doesNotMatch(experience, /className=\{styles\.progressCopy\}>\s*<small>/);
-    assert.match(experience, /className=\{styles\.progressRow\}/);
+    assert.match(experience, /styles\.progressRowWaiting/);
     assert.match(experience, /className=\{styles\.progressGroup\}/);
+    assert.match(experience, /className=\{styles\.heroDeckInstruction\}/);
+    assert.match(experience, /aria-hidden=\{waitingForInitialDeal \|\| undefined\}/);
     assert.match(experience, /\$\{styles\.tablePrompt\}/);
     assert.match(experience, /key=\{introStage !== "hidden" \? "experience-intro" : tableDefinition\.id\}/);
     assert.match(experience, /waitingForInitialDeal \? \(/);
@@ -95,8 +118,16 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.doesNotMatch(experience, /className=\{styles\.brandLine\}/);
     assert.doesNotMatch(experience, /id="table-stage-title"/);
     assert.match(experience, /aria-label=\{tableDefinition\.label\}/);
-    assert.match(experience, /3 anos\. 3 cartas\. Um novo movimento/);
+    assert.match(experience, /const INITIAL_EXPERIENCE_TITLE = "3 anos\. 3 cartas\."/);
+    assert.match(experience, /const INITIAL_EXPERIENCE_SUBTITLE = "Um novo movimento para celebrar tudo o que ainda vem pela frente\."/);
+    assert.match(experience, /function getInitialExperienceCopy\(description\?: string \| null\)/);
+    assert.match(experience, /initialExperienceCopy\.title/);
+    assert.match(experience, /initialExperienceCopy\.subtitle/);
     assert.match(experience, /className=\{styles\.specialCardStage\}/);
+    assert.match(experience, /styles\.specialCardStageReopen/);
+    assert.match(experience, /className=\{styles\.specialCardModalOverlay\}/);
+    assert.match(experience, /role="dialog"/);
+    assert.match(experience, /aria-modal="true"/);
     assert.match(experience, /role="group" aria-label=\{`Cartas da etapa \$\{tableDefinition\.label\}`\}/);
     assert.doesNotMatch(experience, /role="list" aria-label="Cartas finais"/);
     assert.doesNotMatch(experience, /className=\{styles\.progressNumber\}/);
@@ -117,9 +148,10 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.doesNotMatch(experience, /actsStack|revealedStrip/);
     assert.doesNotMatch(experience, /BeautyMovementModalReading/);
     assert.doesNotMatch(experience, /finaleCardGridSettled/);
-    assert.match(experience, /aria-label=\{finaleStage === "result" \? "Carta especial do benefício"/);
+    assert.match(experience, /aria-label="Carta especial"/);
     assert.match(experience, /className=\{styles\.cardSparkles\}/);
     assert.match(experience, /className=\{styles\.deckStage\}/);
+    assert.match(experience, /className=\{styles\.finaleSpecialCardTransform\}/);
     assert.match(experience, /type HandStage =\s*\|\s*"waiting"/);
     assert.match(experience, /"expand"\s*\|\s*"deal"/);
     assert.match(experience, /function scheduleDealSequence\(token: number, onReady: \(\) => void\)/);
@@ -131,27 +163,53 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(experience, /if \(handStage !== "expand"\) return;/);
     assert.match(experience, /window\.addEventListener\("resize", syncExpansionHeight\)/);
     assert.match(experience, /new ResizeObserver\(syncExpansionHeight\)/);
-    assert.match(experience, /setTableExpansionHeight\(Math\.max\(220, surface\.scrollHeight\)\)/);
+    assert.match(experience, /setTableExpansionHeight\(Math\.max\(INITIAL_TABLE_HEIGHT, surface\.scrollHeight\)\)/);
+    assert.match(experience, /const \[tableIntroHeight, setTableIntroHeight\] = useState\(0\)/);
+    assert.match(experience, /if \(introStage !== "entering" \|\| handStage !== "waiting"\) return;/);
+    assert.match(experience, /surface\.dataset\.deckState !== "intro"/);
+    assert.match(experience, /const deck = surface\.querySelector<HTMLElement>\(`\.\$\{styles\.deckStage\}`\)/);
+    assert.match(experience, /const previousDisplay = deck\?\.style\.display/);
+    assert.match(experience, /deck\.style\.display = "none"/);
+    assert.match(experience, /setTableIntroHeight\(Math\.max\(INITIAL_TABLE_HEIGHT, Math\.ceil\(surface\.scrollHeight\)\)\)/);
     assert.match(experience, /getBoundingClientRect\(\)\.height/);
     assert.match(experience, /setTableExpansionHeight\(startHeight\)/);
+    assert.match(experience, /const isInitialCategoryEntering =/);
+    assert.match(experience, /styles\.progressItemEntering/);
     assert.match(experience, /const targetHeight = Math\.max\(\s*startHeight,/);
     assert.match(experience, /"held"/);
     assert.match(experience, /function startInitialDeal\(\)/);
     assert.match(experience, /function handleDeckKeyDown\(event: ReactKeyboardEvent<HTMLButtonElement>\)/);
     assert.match(experience, /event\.key !== "Enter" && event\.key !== " " && event\.key !== "Spacebar"/);
-    assert.match(experience, /onKeyDown=\{handleDeckKeyDown\}/);
-    assert.match(experience, /className=\{styles\.heroDeckPrompt\}/);
-    assert.match(experience, /id="beauty-movement-deck-prompt"/);
-    assert.match(experience, /onClick=\{scrollToTable\}/);
-    assert.match(experience, /Ir ao baralho e começar sua leitura/);
-    assert.match(experience, /Começar a leitura/);
-    assert.match(experience, /className=\{styles\.heroDeckPromptArrow\}/);
+    assert.equal((experience.match(/onKeyDown=\{handleDeckKeyDown\}/g) ?? []).length, 1);
+    const heroInstructionClass = experience.indexOf("className={styles.heroDeckInstruction}");
+    const heroInstructionMarkup = experience.slice(
+        experience.lastIndexOf("<p", heroInstructionClass),
+        experience.indexOf("</p>", heroInstructionClass) + "</p>".length,
+    );
+    assert.ok(heroInstructionClass >= 0);
+    assert.match(heroInstructionMarkup, /<p\s+className=\{styles\.heroDeckInstruction\}>/);
+    assert.doesNotMatch(heroInstructionMarkup, /<(?:button|a)\b|onClick=|onKeyDown=|tabIndex=|aria-label=/);
+    assert.doesNotMatch(experience, /id="beauty-movement-deck-prompt"/);
+    assert.equal((experience.match(/onClick=\{startInitialDeal\}/g) ?? []).length, 1);
+    assert.match(experience, /Clique no baralho para começar a sua leitura/);
+    assert.match(experience, /className=\{styles\.tableDeckPromptArrow\}/);
     assert.doesNotMatch(experience, /Clique no baralho <span aria-hidden="true">↗<\/span>/);
+    assert.doesNotMatch(experience, /className=\{styles\.tableDeckPrompt\}/);
     assert.doesNotMatch(experience, /className=\{styles\.deckPrompt\}/);
-    assert.ok(experience.indexOf("className={styles.heroDeckPrompt}") < experience.indexOf('<h1 id="beauty-movement-title">'));
+    assert.ok(heroInstructionClass < experience.indexOf("className={styles.tableSurface}"));
+    assert.ok(experience.indexOf("className={styles.tableSurface}") < experience.indexOf("className={styles.tableDeckPromptArrow}"));
+    assert.ok(experience.indexOf("className={styles.tableDeckPromptArrow}") < experience.indexOf("className={styles.deckStage}"));
     assert.match(experience, /data-deck-state=\{/);
+    assert.match(experience, /\? "intro"/);
+    assert.match(experience, /\? "prompt"/);
     assert.match(experience, /finaleStage === "confirmation" \|\| finaleStage === "result"/);
-    assert.match(experience, /const isCurrent = introStage === "hidden" && !waitingForInitialDeal && index === displayedActIndex/);
+    assert.match(experience, /const isCurrent =\s*finaleStage === "hidden" &&\s*introStage === "hidden" &&\s*!waitingForInitialDeal &&\s*index === displayedActIndex/);
+    assert.match(experience, /const \[isSpecialCardModalOpen, setIsSpecialCardModalOpen\] = useState\(initialState\.confirmed\)/);
+    assert.match(experience, /setIsSpecialCardModalOpen\(true\)/);
+    assert.match(experience, /setIsSpecialCardModalOpen\(confirmed\)/);
+    assert.match(experience, /function closeSpecialCardModal|const closeSpecialCardModal/);
+    assert.match(experience, /Fechar carta especial/);
+    assert.match(experience, /Revelar sua carta especial/);
     assert.match(experience, /key=\{introStage !== "hidden" \? "experience-intro" : tableDefinition\.id\}/);
     assert.match(experience, /styles\.tablePromptIntro/);
     assert.match(experience, /styles\.tablePromptIntroHolding/);
@@ -163,8 +221,8 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(experience, /setCurrentHandStage\("prompt"\)/);
     assert.doesNotMatch(experience, /className=\{styles\.actCount\}/);
     assert.match(experience, /styles\.deckCardTop/);
-    assert.doesNotMatch(experience, /role="dialog"/);
-    assert.doesNotMatch(experience, /aria-modal="true"/);
+    assert.match(experience, /role="dialog"/);
+    assert.match(experience, /aria-modal="true"/);
 
     assert.match(styles, /--bm-bg: #fafafa/i);
     assert.match(styles, /--bm-ink: #303030/i);
@@ -210,6 +268,8 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.doesNotMatch(styles, /@keyframes finaleReturnToDeck/);
     assert.match(styles, /@keyframes finaleCardsMerge/);
     assert.match(styles, /@keyframes finaleCardsHold/);
+    assert.match(styles, /@keyframes finaleCenterCardTransform/);
+    assert.match(styles, /@keyframes finaleSpecialCardTransform/);
     assert.match(styles, /finaleCardGridHolding/);
     assert.match(styles, /data-finale-stage="assembling"/);
     assert.match(styles, /animation: finaleCardsHold var\(--bm-finale-enter-ms\)/);
@@ -222,45 +282,100 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(styles, /@keyframes finaleIllustrationPulse/);
     assert.match(styles, /@keyframes finaleIllustrationPulse[\s\S]*100%[\s\S]*opacity: 1/);
     assert.match(styles, /\.finaleCardGrid/);
+    assert.match(styles, /\.finaleSpecialCardTransform \{/);
+    assert.match(styles, /\.tableStage\[data-hand-stage="finale"\] \.deckStage[\s\S]*pointer-events: none/);
+    assert.match(styles, /\.tableStage\[data-finale-stage="confirmation"\] \.deckStage,[\s\S]*visibility: hidden/);
     assert.match(styles, /\.specialCardStage/);
     assert.match(styles, /\.specialCardConfirmation/);
-    assert.match(styles, /\.finaleHoldStatus/);
+    assert.match(styles, /\.specialCardRevealAction/);
+    assert.doesNotMatch(styles, /\.specialCardPrompt|\.finaleHoldStatus/);
     assert.match(styles, /\.specialCard/);
     assert.match(styles, /@keyframes specialCardFlip/);
     assert.match(styles, /@keyframes specialCardIconFloat/);
     assert.match(styles, /\.inlineFinale/);
-    assert.match(styles, /\.heroDeckPrompt \{[\s\S]*cursor: pointer/);
-    assert.match(styles, /\.heroDeckPromptArrow[\s\S]*font-size: 1\.15rem/);
-    assert.doesNotMatch(styles, /\.deckPrompt|\.deckPromptArrow/);
-    assert.match(styles, /\.deckStage[\s\S]*bottom: 14px/);
+    const heroInstructionStyles = styles.slice(
+        styles.indexOf(".heroDeckInstruction {"),
+        styles.indexOf(".tableDeckPromptArrow {"),
+    );
+    assert.match(heroInstructionStyles, /display: block[\s\S]*font-family: var\(--font-brand-text\)/);
+    assert.doesNotMatch(heroInstructionStyles, /cursor: pointer|:hover|:focus-visible|appearance:|background:/);
+    assert.match(styles, /\.tableDeckPromptArrow \{[\s\S]*position: absolute[\s\S]*bottom: calc\(32px \+ 106px \+ 8px\)[\s\S]*font-size: 1\.35rem/);
+    assert.match(styles, /\.tableSurface \{[\s\S]*padding: clamp\(10px, 1\.5vw, 16px\) clamp\(10px, 1\.4vw, 16px\) clamp\(32px, 3vw, 44px\)/);
+    assert.match(styles, /\.tableSurface\[data-deck-state="waiting"\] \{[\s\S]*height: 0[\s\S]*min-height: 0[\s\S]*padding: 0[\s\S]*border-color: transparent[\s\S]*background: transparent[\s\S]*box-shadow: none[\s\S]*overflow: visible/);
+    assert.match(styles, /\.tableSurface\[data-deck-state="intro"\] \{[\s\S]*height: var\(--bm-table-intro-height, 0px\)[\s\S]*transition: height var\(--bm-hand-expand-ms\)/);
+    assert.match(
+        styles,
+        /\.tableSurface\[data-deck-state="intro"\],[\s\S]*\.tableSurface\[data-deck-state="prompt"\] \{[\s\S]*padding-bottom: clamp\(10px, 1\.5vw, 16px\)[\s\S]*overflow: visible/,
+    );
+    assert.match(styles, /\.tableSurface\[data-deck-state="prompt"\] \{[\s\S]*min-height: 112px/);
+    assert.match(styles, /\.tableSurface\[data-deck-state="waiting"\] \.deckStage,[\s\S]*\.tableSurface\[data-deck-state="intro"\] \.deckStage,[\s\S]*\.tableSurface\[data-deck-state="prompt"\] \.deckStage,[\s\S]*\.tableSurface\[data-deck-state="expanding"\] \.deckStage,[\s\S]*\.tableSurface\[data-deck-state="ready"\] \.deckStage[\s\S]*bottom: -79px/);
+    assert.match(styles, /\.tableSurface\[data-deck-state="waiting"\] \.tableDeckPromptArrow \{[\s\S]*bottom: 35px/);
+    assert.match(styles, /\.tableStage\[data-finale-stage="hidden"\] \{[\s\S]*padding-bottom: clamp\(86px, 9vw, 96px\)/);
+    assert.match(styles, /@keyframes deckPromptArrowFloat/);
+    assert.match(styles, /\.progressRowWaiting \{[\s\S]*min-height: 52px/);
+    assert.match(styles, /\.progressRowWaiting \.progressGroup \{[\s\S]*visibility: hidden[\s\S]*pointer-events: none/);
+    assert.doesNotMatch(styles, /\.initialDeckPrompt/);
+    assert.match(styles, /\.heroDeckInstruction/);
+    assert.doesNotMatch(styles, /\.tableDeckPrompt \{|\.deckPrompt \{|\.deckPromptArrow \{/);
+    assert.doesNotMatch(styles, /\.actAdvance|\.advanceNote|\.continueButton|@keyframes finaleCardsReappear/);
+    assert.match(styles, /\.deckStage[\s\S]*bottom: 32px/);
     assert.match(styles, /\.deckStage \.(?:deckCard|deckBrandLogo)[\s\S]*cursor: pointer/);
     assert.match(styles, /\.deckStage:disabled,[\s\S]*\.deckStage:disabled \.deckBrandLogo[\s\S]*cursor: default/);
     assert.match(styles, /--deal-y: 106px/);
     assert.match(styles, /\.progressItemCurrent \.progressButton[\s\S]*background: var\(--bm-yellow\)/);
-    assert.match(styles, /\.progressRow \{[\s\S]*grid-template-columns: auto minmax\(0, 1fr\)/);
+    assert.match(styles, /\.progressRow \{[\s\S]*display: flex[\s\S]*justify-content: center/);
+    assert.match(styles, /\.progressRow \{[\s\S]*min-height: 38px/);
     assert.match(styles, /\.progressGroup \{[\s\S]*width: max-content/);
     assert.match(styles, /\.tablePrompt \{[\s\S]*font-size: clamp\(0\.9rem/);
+    assert.match(styles, /\.tablePrompt \{[\s\S]*padding: 0;[\s\S]*border: 0;[\s\S]*background: transparent;[\s\S]*box-shadow: none;/);
+    assert.match(styles, /\.specialCardStage \{[\s\S]*gap: 0;/);
+    assert.match(styles, /\.specialCardStageReopen \{[\s\S]*min-height: 430px/);
+    assert.match(styles, /\.specialCardReopenCard \{[\s\S]*cursor: pointer/);
+    assert.match(styles, /\.specialCardModalOverlay \{[\s\S]*--bm-ink: #303030[\s\S]*position: fixed[\s\S]*backdrop-filter: blur\(10px\)/);
+    assert.match(styles, /\.specialCardModalDialog \{[\s\S]*place-items: center/);
+    assert.match(styles, /\.specialCardModalClose \{[\s\S]*position: absolute/);
+    assert.match(styles, /@keyframes specialCardModalBackdropEnter/);
+    assert.match(styles, /\.specialCardRevealAction \{[\s\S]*gap: 7px;[\s\S]*width: min\(100%, 282px\)/);
+    assert.match(styles, /\.specialCardBackWithAction \{[\s\S]*padding: 24px/);
     assert.match(styles, /\.promptWord \{[\s\S]*animation: promptWordMaterialize/);
     assert.match(styles, /\.promptTitle,[\s\S]*\.promptSubtitle \{[\s\S]*display: block/);
     assert.match(styles, /@keyframes promptWordMaterialize/);
     assert.match(styles, /@keyframes promptWordDissolve/);
     assert.match(styles, /\.tablePromptIntroHolding \{[\s\S]*animation: none/);
     assert.match(styles, /\.tablePromptIntroExit,[\s\S]*\.tablePromptExit/);
-    assert.match(styles, /\.tablePromptIntro \.promptTitle,[\s\S]*\.tablePromptIntroHolding \.promptTitle,[\s\S]*\.tablePromptIntroExit \.promptTitle[\s\S]*font-weight: 400/);
+    assert.doesNotMatch(styles, /\.tablePromptIntro \.promptTitle,[\s\S]*font-weight: 400/);
     assert.match(styles, /\.progressItemCurrent \.progressButton strong \{[\s\S]*font-size: clamp\(1rem/);
     assert.doesNotMatch(styles, /\.tableStage\s*\{[^}]*border-top/);
-    assert.match(styles, /\.progressButton \{[\s\S]*min-height: 44px/);
-    assert.match(styles, /\.progressItem \{[\s\S]*display: grid[\s\S]*justify-items: stretch/);
+    assert.match(styles, /\.progressButton \{[\s\S]*min-height: 38px/);
     assert.match(styles, /\.progressButton \{[\s\S]*width: 100%/);
-    assert.match(styles, /\.autoAdvance \{[\s\S]*width: 100%[\s\S]*height: 4px[\s\S]*margin-top: 8px/);
+    assert.match(styles, /\.progressItemCurrent \.progressButton \{[\s\S]*grid-template-rows: 25px 5px[\s\S]*height: 38px[\s\S]*min-height: 38px[\s\S]*padding: 4px 14px 1px/);
+    assert.match(styles, /\.autoAdvance \{[\s\S]*width: 100%[\s\S]*height: 4px[\s\S]*margin-top: 1px/);
+    assert.match(styles, /\.autoAdvance \{[\s\S]*visibility: hidden/);
+    assert.match(styles, /\.autoAdvanceVisible \{[\s\S]*visibility: visible/);
+    assert.match(styles, /\.autoAdvance::after \{[\s\S]*animation: none/);
+    assert.match(styles, /\.autoAdvanceVisible::after \{[\s\S]*animation: autoAdvanceProgress var\(--bm-auto-advance-ms\) linear both/);
+    assert.match(styles, /\.progressTransfer \{[\s\S]*background: var\(--bm-yellow\)/);
+    assert.match(styles, /\.progressMotionActive \.progressButton \{[\s\S]*background: transparent !important/);
+    assert.match(styles, /@keyframes progressButtonCollapse[\s\S]*background: transparent/);
+    assert.match(styles, /@keyframes progressButtonExpand[\s\S]*background: var\(--bm-yellow\)/);
+    assert.match(styles, /\.progressItemEntering \.progressButton[\s\S]*animation: progressButtonEnter var\(--bm-progress-enter-ms\)/);
+    assert.match(styles, /\.progressItemEntering strong[\s\S]*animation: progressLabelEnter var\(--bm-progress-enter-ms\)/);
+    assert.match(styles, /@keyframes progressButtonEnter/);
+    assert.match(styles, /@keyframes progressLabelEnter/);
+    assert.match(styles, /\.progressTransfer \{[\s\S]*animation: progressHighlightTransfer var\(--bm-progress-total-ms\)/);
+    assert.match(styles, /@keyframes progressHighlightTransfer[\s\S]*calc\(var\(--progress-to-left\) \+ var\(--progress-to-width\) - var\(--progress-from-left\)\)/);
     assert.match(styles, /\.autoAdvance::after \{[\s\S]*background: var\(--bm-ink\)/);
-    assert.match(styles, /animation: autoAdvanceProgress var\(--bm-auto-advance-ms\)/);
     assert.match(styles, /animation: cardLiftAndSettle var\(--bm-hand-reveal-ms\)/);
+    assert.match(styles, /\.tableStage\[data-hand-stage="reveal"\] \.cardButtonSelected,\s*\.tableStage\[data-hand-stage="reveal"\] \.cardButtonSelected \.cardInner/);
     assert.match(styles, /animation: deckStageDeal var\(--bm-hand-deal-ms\)/);
-    assert.match(styles, /\.tableStage\[data-hand-stage="expand"\] \.tableSurface[\s\S]*height: var\(--bm-table-expand-height, 220px\)/);
+    assert.match(styles, /\.tableStage\[data-hand-stage="expand"\] \.tableSurface[\s\S]*height: var\(--bm-table-expand-height, 112px\)/);
+    assert.match(styles, /\.tableStage\[data-hand-stage="expand"\] \.tableSurface[\s\S]*overflow: visible/);
     assert.match(styles, /\.tableStage\[data-hand-stage="expand"\] \.cardGrid[\s\S]*visibility: hidden/);
-    assert.match(styles, /transition: height var\(--bm-hand-expand-ms\)/);
-    assert.match(styles, /@keyframes deckStageExpand[\s\S]*0%\s*\{[\s\S]*translateX\(-50%\) translateY\(-24px\)[\s\S]*100%\s*\{[\s\S]*translateX\(-50%\) translateY\(0\)/);
+    assert.match(styles, /transition: height var\(--bm-hand-expand-ms\) cubic-bezier\(0\.4, 0, 0\.2, 1\)/);
+    assert.match(styles, /@keyframes deckStageExpand[\s\S]*0%\s*\{[\s\S]*translateX\(-50%\) translateY\(0\) scale\(0\.985\)[\s\S]*100%\s*\{[\s\S]*translateX\(-50%\) translateY\(0\)/);
+    assert.match(styles, /@keyframes deckStageDeal[\s\S]*50%\s*\{[\s\S]*translateX\(-50%\) translateY\(2px\) scale\(0\.995\)/);
+    assert.doesNotMatch(styles, /@keyframes deckStageExpand[\s\S]*translateY\(-24px\)/);
+    assert.doesNotMatch(styles, /@keyframes deckStageDeal[\s\S]*translateY\(8px\)/);
     assert.match(styles, /animation: deckStageCollect var\(--bm-hand-collect-ms\)/);
     assert.match(styles, /@keyframes finaleCardsMerge[\s\S]*0% \{[\s\S]*opacity: 1[\s\S]*translate3d\(0, 0, 0\)/);
     assert.doesNotMatch(styles, /\.brandLine|\.brandDivider|\.partnerName/);
@@ -268,14 +383,26 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(styles, /\.cardBrandMark/);
     assert.doesNotMatch(styles, /\.actsStack|\.revealedStrip|\.reopenReading/);
     assert.match(experience, /<BrandMark/);
+    assert.match(brandMark, /loading=\{loading\}/);
+    assert.match(experience, /<BrandMark className=\{styles\.cardBrandLogo\} loading="eager"/);
     assert.ok(experience.indexOf("className={styles.tableStage}") < experience.indexOf("${styles.progress}"));
     assert.match(experience, /aria-hidden=\{!isSelected\}/);
     assert.match(experience, /BeautyMovementCardIllustration/);
     assert.match(experience, /function renderSpecialCard/);
-    assert.match(experience, /className=\{styles\.specialCardConfirmation\}/);
+    assert.match(experience, /function renderSpecialCard\(revealed: boolean, showRevealAction = false, interactive = false\)/);
+    assert.match(experience, /className=\{styles\.specialCardRevealAction\}/);
     assert.match(experience, /Garantir presente e confirmar presença/);
+    assert.match(experience, /if \(!operationalConsent && !isLocalPreview\) return;/);
+    assert.match(experience, /Confirme sua entrada para revelar a sua carta especial/);
+    assert.match(experience, /finaleStage === "confirmation" \?/);
+    assert.match(experience, /!isLocalPreview \? renderConfirmationAction\(\) : null/);
+    assert.match(experience, /renderSpecialCard\(false, isLocalPreview\)/);
+    assert.match(experience, /renderSpecialCard\(false, false, !isSpecialCardModalOpen\)/);
+    assert.doesNotMatch(experience, /specialCardPrompt|Sua carta especial está pronta\./);
+    assert.match(experience, /Clique aqui para revelar sua carta especial/);
     assert.match(experience, /finaleCardGridMerging/);
     assert.match(experience, /Carta especial do benefício/);
+    assert.match(experience, /role=\{interactive \? "button" : undefined\}/);
     assert.doesNotMatch(experience, /aria-label="Cartas finais"/);
     assert.match(experience, /function drawStoryCardIllustration/);
     assert.match(experience, /drawStoryCardIllustration\(context, line\.cardId/);

--- a/website/tests/beautyMovementMotion.test.ts
+++ b/website/tests/beautyMovementMotion.test.ts
@@ -11,6 +11,7 @@ test("beauty movement motion keeps its visible stages and reading windows aligne
     assert.ok(BEAUTY_MOVEMENT_MOTION.handDealSettleMs > 0);
     assert.equal(BEAUTY_MOVEMENT_MOTION.handCollectMs, 860);
     assert.equal(BEAUTY_MOVEMENT_MOTION.handExpandMs, 760);
+    assert.equal(BEAUTY_MOVEMENT_MOTION.progressEnterMs, 620);
     assert.equal(
         BEAUTY_MOVEMENT_MOTION.progressCollapseMs +
             BEAUTY_MOVEMENT_MOTION.progressTransferMs +
@@ -18,10 +19,7 @@ test("beauty movement motion keeps its visible stages and reading windows aligne
         BEAUTY_MOVEMENT_MOTION.progressTransitionMs,
     );
     assert.equal(BEAUTY_MOVEMENT_MOTION.finaleCardsEnterMs, 880);
-    assert.equal(
-        BEAUTY_MOVEMENT_MOTION.finaleCardMergeMs + BEAUTY_MOVEMENT_MOTION.finaleMergeStaggerMs * 2,
-        BEAUTY_MOVEMENT_MOTION.finaleMergeMs,
-    );
+    assert.ok(BEAUTY_MOVEMENT_MOTION.finaleCardMergeMs < BEAUTY_MOVEMENT_MOTION.finaleMergeMs);
     assert.ok(BEAUTY_MOVEMENT_MOTION.finaleMergeSettleMs > 0);
     assert.ok(BEAUTY_MOVEMENT_MOTION.handRevealFallbackMs > BEAUTY_MOVEMENT_MOTION.handRevealMs);
 });


### PR DESCRIPTION
# Summary

Finaliza a iteração UX da experiência Beauty Movement.

- Troca a instrução do hero por um subtítulo não interativo; somente o baralho inicia a leitura.
- Estabiliza a geometria do hero, progresso e mesa para eliminar o deslocamento na primeira categoria.
- Mantém a coreografia de categorias, mesa, baralho, fusão final, modal e reabertura da carta especial.
- Atualiza os testes de semântica e de temporização da experiência.

## Type of change
- [x] Feature
- [x] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (README, API refs, diagrams) — não aplicável; não há mudança de contrato.
- [ ] Security review (CodeQL, gitleaks) — coberto pelos checks obrigatórios da PR.
- [ ] Performance impact measured — sem alteração de dependência, API ou superfície de runtime fora do website.

## Links
- Issue: —
- Design/ADR: —
- Migration steps: nenhuma; não há schema, flag, API ou dado novo.

## Screenshots / Evidence
- `git diff --check origin/main...HEAD` passou.
- `npm --prefix website ci --prefer-offline --no-audit --fund=false` concluiu.
- `npm run website:test`: 133/133 passaram.
- `npm run module:site-public:website:lint` passou.
- `npm --prefix website exec -- tsc -p website/tsconfig.json --noEmit --incremental false` passou.
- `npm run module:site-public:website:build` passou, incluindo a rota `/beleza-em-movimento/local-preview`.
- Prévia isolada: listener na porta 3417, HTTP 200 e conteúdo da rota confirmados.
- QA renderizada desktop e 390×844: subtítulo não focável, único gatilho inicial no baralho, ausência de layout shift na primeira mão, três seleções e avanços automáticos, fusão, modal com foco/scroll lock, fechamento e reabertura por clique e teclado; console limpo.

## Rollback
Reverter o commit de squash desta PR (`git revert <merge-sha>`). Nenhum deploy de staging ou produção foi solicitado ou executado.