### PR TITLE
fix(ponto): harden cancelled Core rollback proof

### DIFF
--- a/.github/scripts/ponto-automatic-rollback-safety.test.mjs
+++ b/.github/scripts/ponto-automatic-rollback-safety.test.mjs
@@ -79,14 +79,13 @@ test("recovery accepts only children from the exact immutable Ponto release tag"
   assert.doesNotMatch(source, /run\.headBranch !== "main"/);
 });
 
-test("a cancelled Core child is untouched only when GitHub attests that deploy never started", () => {
+test("a cancelled staging Core child is untouched only with runner and live-incumbent proof", () => {
   assert.match(source, /const preMutationJobNames = Object\.freeze\(\{\s*coreApi: "deploy",/s);
-  assert.match(source, /run\.conclusion !== "cancelled"/);
   assert.match(source, /actions\/runs\/\$\{encodeURIComponent\(childRunId\)\}\/jobs\?filter=latest&per_page=100/);
-  assert.match(source, /expectedJob\?\.status === "completed"/);
-  assert.match(source, /expectedJob\?\.conclusion === "cancelled"/);
-  assert.match(source, /Array\.isArray\(expectedJob\?\.steps\)/);
-  assert.match(source, /expectedJob\.steps\.length === 0/);
-  assert.match(source, /untouched\[candidate\.surface\] = proof\.disposition/);
-  assert.match(source, /pre-mutation-job-attestation-unavailable/);
+  assert.match(source, /inspectCancelledBeforeRunnerDeployJob/);
+  assert.match(source, /resolveStagingCorePrecondition/);
+  assert.match(source, /validateAttestedStagingCorePredecessor/);
+  assert.match(source, /cancelled-before-runner-no-worker-mutation/);
+  assert.match(source, /fs\.existsSync\(surfaceFile\)/);
+  assert.match(source, /fs\.existsSync\(journalFile\)/);
 });

--- a/.github/scripts/ponto-automatic-rollback.mjs
+++ b/.github/scripts/ponto-automatic-rollback.mjs
@@ -18,6 +18,11 @@ import {
 import { releaseTagFor } from "./ponto-release-identity.mjs";
 import { attestBrokerFailCloseEvidence } from "./ponto-recovery-evidence.mjs";
 import { readCloudflareKvJson } from "./ponto-kv-readback.mjs";
+import { resolveStagingCorePrecondition } from "./ponto-core-staging-precondition.mjs";
+import {
+  inspectCancelledBeforeRunnerDeployJob,
+  validateAttestedStagingCorePredecessor,
+} from "./ponto-cancelled-core-before-mutation.mjs";
 
 const [artifactRoot, reportFile] = process.argv.slice(2);
 const releaseSha = String(process.env.RELEASE_SHA || "").trim().toLowerCase();
@@ -331,6 +336,9 @@ for (const [name, spec] of Object.entries(surfaceSpecs)) {
       surface: name,
       childRunId: String(run.runId),
       run,
+      surfaceFile,
+      journalFile,
+      spec,
     });
   }
   const migrationStarted = journalValid && journal.migrationStarted === true;
@@ -735,33 +743,67 @@ const github = async (pathname, init = {}) => {
 const preMutationJobNames = Object.freeze({
   coreApi: "deploy",
 });
-const attestCancelledBeforeMutation = async ({ surface, childRunId, run }) => {
+const attestCancelledBeforeMutation = async ({
+  surface,
+  childRunId,
+  run,
+  surfaceFile,
+  journalFile,
+  spec,
+}) => {
   const expectedJobName = preMutationJobNames[surface];
-  if (!expectedJobName || run.conclusion !== "cancelled" || !/^[1-9][0-9]*$/.test(childRunId)) {
+  if (
+    !staging
+    || !expectedJobName
+    || run.conclusion !== "cancelled"
+    || !/^[1-9][0-9]*$/.test(childRunId)
+    || fs.existsSync(surfaceFile)
+    || fs.existsSync(journalFile)
+  ) {
     return { passed: false, reason: "mutation-journal-missing-or-invalid" };
   }
+
+  let jobProof;
   try {
     const payload = await github(
       `/repos/${repository}/actions/runs/${encodeURIComponent(childRunId)}/jobs?filter=latest&per_page=100`,
     );
-    const jobs = Array.isArray(payload?.jobs) ? payload.jobs : null;
-    const totalCount = Number(payload?.total_count);
-    const expectedJobs = jobs?.filter((job) => job?.name === expectedJobName) || [];
-    const expectedJob = expectedJobs[0];
-    const neverStarted = Array.isArray(jobs)
-      && Number.isSafeInteger(totalCount)
-      && totalCount === jobs.length
-      && expectedJobs.length === 1
-      && expectedJob?.status === "completed"
-      && expectedJob?.conclusion === "cancelled"
-      && Array.isArray(expectedJob?.steps)
-      && expectedJob.steps.length === 0;
-    return neverStarted
-      ? { passed: true, jobName: expectedJobName, disposition: "cancelled-before-mutation" }
-      : { passed: false, reason: "mutation-journal-missing-or-invalid" };
+    jobProof = inspectCancelledBeforeRunnerDeployJob(payload);
   } catch {
     return { passed: false, reason: "pre-mutation-job-attestation-unavailable" };
   }
+  if (!jobProof.passed) return { passed: false, reason: "mutation-journal-missing-or-invalid" };
+
+  let predecessorProof;
+  try {
+    const catalogPath = path.resolve("platform/deploy/operational-units.json");
+    if (!fs.existsSync(catalogPath)) {
+      return { passed: false, reason: "staging-core-predecessor-catalog-missing" };
+    }
+    predecessorProof = await resolveStagingCorePrecondition({
+      catalog: readJson(catalogPath),
+      accountId,
+      apiToken,
+      repository,
+      catalogPath,
+    });
+  } catch {
+    return { passed: false, reason: "staging-core-predecessor-proof-unavailable" };
+  }
+  const incumbent = validateAttestedStagingCorePredecessor({
+    proof: predecessorProof,
+    releaseSha,
+    workerName: spec.workerName,
+  });
+  if (!incumbent.passed) return { passed: false, reason: incumbent.reason };
+
+  return {
+    passed: true,
+    jobName: expectedJobName,
+    disposition: "cancelled-before-runner-no-worker-mutation",
+    deployJob: jobProof.job,
+    predecessor: incumbent.predecessor,
+  };
 };
 const preMutationCancellations = {};
 for (const candidate of preMutationCancellationCandidates) {
@@ -773,6 +815,8 @@ for (const candidate of preMutationCancellationCandidates) {
       childRunId: candidate.childRunId,
       jobName: proof.jobName,
       disposition: proof.disposition,
+      deployJob: proof.deployJob,
+      predecessor: proof.predecessor,
     };
     continue;
   }

--- a/.github/scripts/ponto-cancelled-core-before-mutation.mjs
+++ b/.github/scripts/ponto-cancelled-core-before-mutation.mjs
@@ -1,0 +1,82 @@
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const rejected = reason => ({ passed: false, reason });
+
+export function inspectCancelledBeforeRunnerDeployJob(payload) {
+  const jobs = payload?.jobs;
+  if (!Array.isArray(jobs) || Number(payload?.total_count) !== jobs.length) {
+    return rejected("github-jobs-list-incomplete");
+  }
+
+  const deployJobs = jobs.filter(job => job?.name === "deploy");
+  if (deployJobs.length !== 1) return rejected("deploy-job-not-unique");
+
+  const deploy = deployJobs[0];
+  if (deploy.status !== "completed" || deploy.conclusion !== "cancelled") {
+    return rejected("deploy-job-not-cancelled");
+  }
+  if (!Array.isArray(deploy.steps) || deploy.steps.length !== 0) {
+    return rejected("deploy-job-has-steps");
+  }
+
+  const runnerFields = [
+    "runner_id",
+    "runner_name",
+    "runner_group_id",
+    "runner_group_name",
+  ];
+  if (!runnerFields.every(field => deploy[field] == null)) {
+    return rejected("deploy-job-had-runner");
+  }
+
+  const startedAt = Date.parse(String(deploy.started_at || ""));
+  const completedAt = Date.parse(String(deploy.completed_at || ""));
+  if (
+    Number.isFinite(startedAt)
+    && Number.isFinite(completedAt)
+    && completedAt > startedAt
+  ) {
+    return rejected("deploy-job-has-execution-window");
+  }
+
+  return {
+    passed: true,
+    job: {
+      conclusion: "cancelled",
+      runnerAllocated: false,
+      stepCount: 0,
+      timing: Number.isFinite(startedAt) && Number.isFinite(completedAt)
+        ? "completed-not-after-started"
+        : "no-credible-execution-timestamp",
+    },
+  };
+}
+
+export function validateAttestedStagingCorePredecessor({ proof, releaseSha, workerName }) {
+  if (
+    proof?.schemaVersion !== 1
+    || proof?.target !== "staging"
+    || proof?.liveAttested !== true
+    || proof?.worker !== workerName
+    || !SHA_PATTERN.test(String(proof?.sourceSha || ""))
+    || String(proof.sourceSha).toLowerCase() === String(releaseSha).toLowerCase()
+    || !UUID_PATTERN.test(String(proof?.versionId || ""))
+    || !UUID_PATTERN.test(String(proof?.deploymentId || ""))
+    || proof?.credentialsIncluded !== false
+    || proof?.piiIncluded !== false
+  ) {
+    return rejected("staging-core-predecessor-not-attested");
+  }
+
+  return {
+    passed: true,
+    predecessor: {
+      mode: String(proof.predecessorMode || ""),
+      sourceSha: String(proof.sourceSha).toLowerCase(),
+      versionId: String(proof.versionId).toLowerCase(),
+      deploymentId: String(proof.deploymentId).toLowerCase(),
+      worker: String(proof.worker),
+    },
+  };
+}

--- a/.github/scripts/ponto-cancelled-core-before-mutation.test.mjs
+++ b/.github/scripts/ponto-cancelled-core-before-mutation.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  inspectCancelledBeforeRunnerDeployJob,
+  validateAttestedStagingCorePredecessor,
+} from "./ponto-cancelled-core-before-mutation.mjs";
+
+const releaseSha = "a".repeat(40);
+const predecessorSha = "b".repeat(40);
+const workerName = "skincos-ponto-core-staging";
+const deployJob = {
+  name: "deploy",
+  status: "completed",
+  conclusion: "cancelled",
+  steps: [],
+  runner_id: null,
+  runner_name: null,
+  runner_group_id: null,
+  runner_group_name: null,
+  started_at: "2026-08-13T17:34:47Z",
+  completed_at: "2026-08-13T17:34:46Z",
+};
+
+test("accepts only a deploy job cancelled before runner allocation", () => {
+  const result = inspectCancelledBeforeRunnerDeployJob({
+    total_count: 1,
+    jobs: [deployJob],
+  });
+  assert.deepEqual(result, {
+    passed: true,
+    job: {
+      conclusion: "cancelled",
+      runnerAllocated: false,
+      stepCount: 0,
+      timing: "completed-not-after-started",
+    },
+  });
+});
+
+test("rejects a cancelled deploy that received a runner, steps, or an execution window", () => {
+  assert.equal(
+    inspectCancelledBeforeRunnerDeployJob({
+      total_count: 1,
+      jobs: [{ ...deployJob, runner_id: 12 }],
+    }).reason,
+    "deploy-job-had-runner",
+  );
+  assert.equal(
+    inspectCancelledBeforeRunnerDeployJob({
+      total_count: 1,
+      jobs: [{ ...deployJob, steps: [{ name: "checkout" }] }],
+    }).reason,
+    "deploy-job-has-steps",
+  );
+  assert.equal(
+    inspectCancelledBeforeRunnerDeployJob({
+      total_count: 1,
+      jobs: [{ ...deployJob, completed_at: "2026-08-13T17:35:47Z" }],
+    }).reason,
+    "deploy-job-has-execution-window",
+  );
+});
+
+test("requires a fresh, different, private staging Core predecessor attestation", () => {
+  const proof = {
+    schemaVersion: 1,
+    target: "staging",
+    predecessorMode: "staging-incumbent",
+    sourceSha: predecessorSha,
+    versionId: "b71704e3-0d6d-4327-83cf-3121010995b1",
+    deploymentId: "e6845b49-0d6d-4327-83cf-3121010995b1",
+    worker: workerName,
+    liveAttested: true,
+    credentialsIncluded: false,
+    piiIncluded: false,
+  };
+  assert.equal(
+    validateAttestedStagingCorePredecessor({ proof, releaseSha, workerName }).passed,
+    true,
+  );
+  assert.equal(
+    validateAttestedStagingCorePredecessor({
+      proof: { ...proof, sourceSha: releaseSha },
+      releaseSha,
+      workerName,
+    }).reason,
+    "staging-core-predecessor-not-attested",
+  );
+  assert.equal(
+    validateAttestedStagingCorePredecessor({
+      proof: { ...proof, liveAttested: false },
+      releaseSha,
+      workerName,
+    }).reason,
+    "staging-core-predecessor-not-attested",
+  );
+});

--- a/.github/workflows/architecture-governance.yml
+++ b/.github/workflows/architecture-governance.yml
@@ -54,6 +54,8 @@ jobs:
         run: node --test .github/scripts/ponto-core-baseline-publisher.test.mjs
       - name: Test Ponto Core staging predecessor attestation
         run: node --test .github/scripts/ponto-core-staging-precondition.test.mjs
+      - name: Test Ponto cancelled Core rollback guard
+        run: node --test .github/scripts/ponto-cancelled-core-before-mutation.test.mjs .github/scripts/ponto-automatic-rollback-safety.test.mjs
       - name: Validate module catalog, maturity and dependency graph
         run: node .github/scripts/validate-module-catalog.mjs && node .github/scripts/validate-module-maturity.mjs
       - name: Validate domain import boundaries


### PR DESCRIPTION
## Resumo
- endurece a exceção de rollback para um filho Core cancelado antes de qualquer mutação;
- exige job `deploy` cancelado sem runner, sem steps e sem janela de execução;
- exige predecessor Core de staging recém-atestado, privado e diferente do SHA tentado;
- mantém qualquer evidência ausente ou ambígua em fail-closed.

## Validação
- `node --check .github/scripts/ponto-automatic-rollback.mjs`
- testes direcionados de rollback, predecessor e dispatch
- `npm run codex:global-coordination:test`
- validadores de release e arquitetura