### PR TITLE
feat(influencer): add staging Meta shadow transport

### DIFF
--- a/.github/governance/cloudflare-single-writer-policy.json
+++ b/.github/governance/cloudflare-single-writer-policy.json
@@ -69,6 +69,11 @@
       "purpose": "Shared synthetic/staging D1 mutation authority."
     },
     {
+      "id": "token-vault-staging-writer",
+      "resource": "global:token-vault-staging",
+      "purpose": "Serializes staging Token Vault Worker version and dedicated analytics-secret custody for the read-only Influencer Intelligence shadow transport."
+    },
+    {
       "id": "global-coordinator-writer",
       "resource": "global:global-coordinator-writer",
       "purpose": "Canonical bootstrap/update writer for the coordination plane itself; the one-time production bootstrap is allowed only before that endpoint exists, and every later update requires its remote lease."
@@ -208,6 +213,15 @@
       "mutationWorkflows": [
         ".github/workflows/insumos-staging-rbac-smoke.yml",
         ".github/workflows/timekeeping-staging-journey.yml"
+      ]
+    },
+    {
+      "id": "token-vault-staging-shadow",
+      "platform": "cloudflare-worker",
+      "canonicalDeployWorkflow": ".github/workflows/influencer-intelligence-staging-shadow.yml",
+      "coordinationGroup": "token-vault-staging-writer",
+      "mutationWorkflows": [
+        ".github/workflows/influencer-intelligence-staging-shadow.yml"
       ]
     },
     {

--- a/.github/workflows/influencer-intelligence-staging-shadow.yml
+++ b/.github/workflows/influencer-intelligence-staging-shadow.yml
@@ -1,0 +1,502 @@
+name: Influencer Intelligence Staging Shadow
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_real_router_smoke:
+        description: Run the single approved Meta-only router journey when private inputs are configured
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: influencer-intelligence-token-vault-staging-shadow
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  shadow:
+    runs-on: ubuntu-latest
+    environment: staging
+    permissions:
+      contents: read
+
+    steps:
+      - name: Guard Cloudflare deployment custody
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          [[ -n "${CLOUDFLARE_API_TOKEN:-}" && -n "${CLOUDFLARE_ACCOUNT_ID:-}" ]] || {
+            echo 'Cloudflare deployment custody is unavailable.' >&2
+            exit 1
+          }
+
+      - name: Guard private real-read inputs
+        if: ${{ inputs.run_real_router_smoke == true }}
+        env:
+          INFLUENCER_INTELLIGENCE_SHADOW_CREDENTIAL_REF: ${{ secrets.INFLUENCER_INTELLIGENCE_SHADOW_CREDENTIAL_REF }}
+          INFLUENCER_INTELLIGENCE_SHADOW_CREATOR_HANDLE: ${{ secrets.INFLUENCER_INTELLIGENCE_SHADOW_CREATOR_HANDLE }}
+        run: |
+          set -euo pipefail
+          [[ -n "${INFLUENCER_INTELLIGENCE_SHADOW_CREDENTIAL_REF:-}" ]] || {
+            echo 'Private Token Vault credential reference is unavailable; refusing the real Meta read.' >&2
+            exit 1
+          }
+          [[ -n "${INFLUENCER_INTELLIGENCE_SHADOW_CREATOR_HANDLE:-}" ]] || {
+            echo 'Approved creator handle is unavailable; refusing the real Meta read.' >&2
+            exit 1
+          }
+
+      - name: Checkout exact main source
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Pin manual dispatch to the current main source
+        env:
+          EXPECTED_REF: refs/heads/main
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_REF" == "$EXPECTED_REF" ]] || { echo 'Staging shadow can run only from main.' >&2; exit 1; }
+          [[ "$(git rev-parse HEAD)" == "$SOURCE_SHA" ]] || { echo 'Checkout does not match the dispatched source SHA.' >&2; exit 1; }
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          [[ "$(git rev-parse refs/remotes/origin/main)" == "$SOURCE_SHA" ]] || { echo 'main advanced before the staging shadow run; redispatch the current source.' >&2; exit 1; }
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: '22.23.1'
+
+      - name: Verify staging-only source fence
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import assert from 'node:assert/strict';
+          import fs from 'node:fs';
+
+          const config = fs.readFileSync('platform/security/token-vault/wrangler.toml', 'utf8');
+          const section = (name) => {
+            const marker = `[${name}]`;
+            const start = config.indexOf(marker);
+            assert.notEqual(start, -1, `missing ${marker}`);
+            const next = config.indexOf('\n[', start + marker.length);
+            return config.slice(start, next === -1 ? config.length : next);
+          };
+          assert.match(section('vars'), /INFLUENCER_INTELLIGENCE_ANALYTICS_MODE\s*=\s*"off"/);
+          assert.match(section('env.staging.vars'), /INFLUENCER_INTELLIGENCE_ANALYTICS_MODE\s*=\s*"shadow"/);
+          assert.doesNotMatch(config, /^INFLUENCER_INTELLIGENCE_ENABLED\s*=\s*"true"/m);
+          NODE
+
+      - name: Acquire staging Token Vault coordination lease
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || '' }}
+          resource: global:token-vault-staging
+          module: influencer-intelligence
+          source_sha: ${{ github.sha }}
+          proof_file: ${{ runner.temp }}/influencer-intelligence-staging-shadow-lease.json
+          inputs_json: '{"target":"staging","mode":"shadow"}'
+
+      - name: Revalidate coordination before staging mutation
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/influencer-intelligence-staging-shadow-lease.json
+          resource: global:token-vault-staging
+          module: influencer-intelligence
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || '' }}
+
+      - name: Promote bounded staging shadow and validate its contract
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          cd platform/security/token-vault
+          config='wrangler.toml'
+          worker='skincos-token-vault-staging'
+          base_url='https://api-staging.skincos.com.br/internal/token-vault'
+          message="influencer-intelligence:staging-shadow:${GITHUB_SHA}"
+          secret_message="influencer-intelligence:analytics-readonly-staging:${GITHUB_SHA}"
+          output_root="$RUNNER_TEMP/influencer-intelligence-staging-shadow"
+          mkdir -p "$output_root"
+
+          wrangler() {
+            npx --yes wrangler@4.123.0 "$@"
+          }
+
+          wrangler deploy --dry-run --config "$config" --env staging >/dev/null
+          git -C "$GITHUB_WORKSPACE" fetch --no-tags origin main:refs/remotes/origin/main
+          [[ "$(git -C "$GITHUB_WORKSPACE" rev-parse refs/remotes/origin/main)" == "$GITHUB_SHA" ]] || {
+            echo 'main advanced before the staging mutation; refusing a stale source promotion.' >&2
+            exit 1
+          }
+          wrangler deployments status --json --config "$config" --env staging > "$output_root/incumbent.json"
+          incumbent="$(node - "$output_root/incumbent.json" <<'NODE'
+          const fs = require('fs');
+          const value = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          const versions = value.versions || value.latest?.versions || [];
+          if (versions.length !== 1 || Number(versions[0]?.percentage) !== 100) {
+            throw new Error('staging Token Vault must have exactly one 100-percent incumbent before shadow promotion');
+          }
+          process.stdout.write(String(versions[0]?.version_id || versions[0]?.id || ''));
+          NODE
+          )"
+          [[ "$incumbent" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo 'Unable to resolve the staging Token Vault incumbent.' >&2; exit 1; }
+          echo "INFLUENCER_INTELLIGENCE_STAGING_INCUMBENT=$incumbent" >> "$GITHUB_ENV"
+          printf '%s\n' "$incumbent" > "$output_root/incumbent-version.txt"
+
+          analytics_token="$(node --input-type=module -e "import { randomBytes } from 'node:crypto'; process.stdout.write(randomBytes(32).toString('base64url'));")"
+          trap 'unset analytics_token' EXIT
+          printf '%s' "$analytics_token" | wrangler versions secret put TOKEN_VAULT_ANALYTICS_API_TOKEN \
+            --config "$config" \
+            --env staging \
+            --message "$secret_message" >/dev/null
+          umask 077
+          printf '%s' "$analytics_token" > "$output_root/analytics-token"
+          chmod 600 "$output_root/analytics-token"
+
+          WRANGLER_OUTPUT_FILE_PATH="$output_root/source-upload.ndjson" wrangler versions upload \
+            --config "$config" \
+            --env staging \
+            --keep-vars \
+            --strict \
+            --message "$message" \
+            --tag "influencer-intelligence-shadow-${GITHUB_SHA:0:12}"
+          candidate="$(node - "$output_root/source-upload.ndjson" <<'NODE'
+          const fs = require('fs');
+          const rows = fs.readFileSync(process.argv[2], 'utf8').trim().split(/\r?\n/).filter(Boolean).map(JSON.parse);
+          const result = rows.filter((row) => row.type === 'version-upload').at(-1);
+          process.stdout.write(String(result?.version_id || ''));
+          NODE
+          )"
+          [[ "$candidate" =~ ^[0-9a-fA-F-]{36}$ && "$candidate" != "$incumbent" ]] || { echo 'Invalid staging shadow candidate.' >&2; exit 1; }
+          echo "INFLUENCER_INTELLIGENCE_STAGING_CANDIDATE=$candidate" >> "$GITHUB_ENV"
+          printf '%s\n' "$candidate" > "$output_root/candidate-version.txt"
+
+          touch "$output_root/traffic-mutation-started"
+          WRANGLER_OUTPUT_FILE_PATH="$output_root/version-deploy.ndjson" wrangler versions deploy "$candidate@100%" \
+            --yes \
+            --config "$config" \
+            --env staging \
+            --message "$message"
+          wrangler deployments status --json --config "$config" --env staging > "$output_root/candidate-active.json"
+          CANDIDATE="$candidate" node - "$output_root/candidate-active.json" <<'NODE'
+          const fs = require('fs');
+          const value = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          const versions = value.versions || value.latest?.versions || [];
+          if (
+            versions.length !== 1
+            || Number(versions[0]?.percentage) !== 100
+            || String(versions[0]?.version_id || versions[0]?.id || '').toLowerCase() !== process.env.CANDIDATE.toLowerCase()
+          ) throw new Error('staging shadow candidate is not the exact active deployment');
+          NODE
+
+          ANALYTICS_TOKEN="$analytics_token" \
+          BASE_URL="$base_url" \
+          SOURCE_SHA="$GITHUB_SHA" \
+          INCUMBENT="$incumbent" \
+          CANDIDATE="$candidate" \
+          EVIDENCE_FILE="$output_root/evidence.json" \
+          node --input-type=module <<'NODE'
+          import assert from 'node:assert/strict';
+          import { randomUUID } from 'node:crypto';
+          import fs from 'node:fs';
+
+          const baseUrl = process.env.BASE_URL;
+          const token = process.env.ANALYTICS_TOKEN;
+          const deadline = Date.now() + 45_000;
+          let health;
+          let healthStatus = 0;
+          while (Date.now() <= deadline) {
+            const response = await fetch(`${baseUrl}/health`, {
+              headers: { authorization: `Bearer ${token}`, accept: 'application/json' },
+              signal: AbortSignal.timeout(12_000),
+            });
+            healthStatus = response.status;
+            health = await response.json().catch(() => null);
+            if (response.status === 200 && health?.ok === true && health?.environment === 'staging' && health?.analytics_mode === 'shadow' && health?.analytics_ready === true) break;
+            await new Promise((resolve) => setTimeout(resolve, 3_000));
+          }
+          assert.equal(healthStatus, 200, 'staging Token Vault health did not become reachable');
+          assert.equal(health?.ok, true, 'staging Token Vault is unhealthy');
+          assert.equal(health?.environment, 'staging');
+          assert.equal(health?.analytics_mode, 'shadow');
+          assert.equal(health?.analytics_ready, true);
+
+          const contractResponse = await fetch(`${baseUrl}/contract`, {
+            headers: { authorization: `Bearer ${token}`, accept: 'application/json' },
+            signal: AbortSignal.timeout(12_000),
+          });
+          const contract = await contractResponse.json().catch(() => null);
+          assert.equal(contractResponse.status, 200, 'staging Token Vault contract is not reachable');
+          assert.equal(contract?.ok, true);
+          assert.equal(contract?.service, 'skincos-token-vault');
+          assert.equal(contract?.endpoints?.analyticsOperation, 'POST /internal/token-vault/v1/analytics/operations');
+          assert.equal(contract?.auth?.analytics_secret, 'TOKEN_VAULT_ANALYTICS_API_TOKEN');
+
+          const negativeCorrelation = `ii-shadow-negative-${randomUUID()}`;
+          const negativeResponse = await fetch(`${baseUrl}/v1/analytics/operations`, {
+            method: 'POST',
+            headers: {
+              authorization: `Bearer ${token}`,
+              accept: 'application/json',
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify({
+              provider: 'meta-graph',
+              operation: 'resolve_creator',
+              credential_ref: 'shadow-invalid-credential',
+              canonical_handle: 'shadow.invalid',
+              observed_at: new Date().toISOString(),
+              retrieved_at: new Date().toISOString(),
+              correlation_id: negativeCorrelation,
+              limit: 1,
+            }),
+            signal: AbortSignal.timeout(12_000),
+          });
+          const negative = await negativeResponse.json().catch(() => null);
+          assert.equal(negativeResponse.status, 403, 'invalid credential must fail closed');
+          assert.equal(negative?.error, 'permission_gap');
+          assert.equal(typeof negative?.requestId, 'string');
+
+          const evidence = {
+            schema_version: 'influencer-intelligence/staging-shadow-evidence/v1',
+            generated_at: new Date().toISOString(),
+            source_sha: process.env.SOURCE_SHA,
+            environment: 'staging',
+            mode: 'shadow',
+            worker: 'skincos-token-vault-staging',
+            incumbent_version: process.env.INCUMBENT,
+            candidate_version: process.env.CANDIDATE,
+            health: {
+              status: healthStatus,
+              environment: health.environment,
+              analytics_mode: health.analytics_mode,
+              analytics_ready: health.analytics_ready,
+              request_id: health.requestId,
+            },
+            contract: {
+              status: contractResponse.status,
+              analytics_operation: contract.endpoints.analyticsOperation,
+              analytics_secret_name: contract.auth.analytics_secret,
+              analytics_scope: contract.auth.analytics_scope,
+              request_id: contract.requestId,
+            },
+            negative_request: {
+              status: negativeResponse.status,
+              error: negative.error,
+              correlation_id: negativeCorrelation,
+              request_id: negative.requestId,
+            },
+          };
+          fs.writeFileSync(process.env.EVIDENCE_FILE, `${JSON.stringify(evidence, null, 2)}\n`, { mode: 0o600 });
+          process.stdout.write(`staging shadow ready: ${JSON.stringify({ worker: evidence.worker, incumbent: evidence.incumbent_version, candidate: evidence.candidate_version, negative: evidence.negative_request.error })}\n`);
+          NODE
+
+          negative_correlation="$(node -e "const v=require(process.argv[1]);process.stdout.write(v.negative_request.correlation_id)" "$output_root/evidence.json")"
+          wrangler d1 execute skincos-token-vault-staging --remote --config "$config" --env staging --json \
+            --command "SELECT request_id, status, json_extract(metadata_json, '$.operation') AS operation, json_extract(metadata_json, '$.correlation_id') AS correlation_id FROM credential_token_audit WHERE event = 'analytics.meta_graph.operation' AND json_extract(metadata_json, '$.correlation_id') = '$negative_correlation' ORDER BY created_at DESC LIMIT 1" \
+            > "$output_root/negative-audit.json"
+          EVIDENCE_FILE="$output_root/evidence.json" AUDIT_FILE="$output_root/negative-audit.json" node --input-type=module <<'NODE'
+          import assert from 'node:assert/strict';
+          import fs from 'node:fs';
+
+          const evidence = JSON.parse(fs.readFileSync(process.env.EVIDENCE_FILE, 'utf8'));
+          const response = JSON.parse(fs.readFileSync(process.env.AUDIT_FILE, 'utf8'));
+          const rows = Array.isArray(response)
+            ? response.flatMap((entry) => entry?.results || [])
+            : (response?.results || []);
+          assert.equal(rows.length, 1, 'negative request audit entry is missing');
+          assert.equal(rows[0].status, 'permission_gap');
+          assert.equal(rows[0].operation, 'resolve_creator');
+          assert.equal(rows[0].correlation_id, evidence.negative_request.correlation_id);
+          evidence.negative_request.audit_status = rows[0].status;
+          fs.writeFileSync(process.env.EVIDENCE_FILE, `${JSON.stringify(evidence, null, 2)}\n`, { mode: 0o600 });
+          NODE
+
+      - name: Run one approved Meta-only router smoke
+        if: ${{ inputs.run_real_router_smoke == true }}
+        env:
+          INFLUENCER_INTELLIGENCE_SHADOW_CREDENTIAL_REF: ${{ secrets.INFLUENCER_INTELLIGENCE_SHADOW_CREDENTIAL_REF }}
+          INFLUENCER_INTELLIGENCE_SHADOW_CREATOR_HANDLE: ${{ secrets.INFLUENCER_INTELLIGENCE_SHADOW_CREATOR_HANDLE }}
+        run: |
+          set -euo pipefail
+          cd platform/security/token-vault
+          output_root="$RUNNER_TEMP/influencer-intelligence-staging-shadow"
+          analytics_token_file="$output_root/analytics-token"
+          [[ -s "$analytics_token_file" ]] || { echo 'Workflow-only analytics credential is unavailable.' >&2; exit 1; }
+          analytics_token="$(<"$analytics_token_file")"
+          trap 'unset analytics_token' EXIT
+          TOKEN_VAULT_ANALYTICS_API_TOKEN="$analytics_token" \
+            node ../../../social/influencer-intelligence/staging-shadow-router.mjs > "$output_root/router-smoke.json"
+          EVIDENCE_FILE="$output_root/evidence.json" SMOKE_FILE="$output_root/router-smoke.json" node --input-type=module <<'NODE'
+          import assert from 'node:assert/strict';
+          import fs from 'node:fs';
+
+          const evidence = JSON.parse(fs.readFileSync(process.env.EVIDENCE_FILE, 'utf8'));
+          const smoke = JSON.parse(fs.readFileSync(process.env.SMOKE_FILE, 'utf8'));
+          assert.deepEqual(smoke.provider_order, ['meta-graph']);
+          assert.ok(['ok', 'unavailable'].includes(smoke.status));
+          assert.ok(smoke.operations.every((operation) => operation.attempts.every((attempt) => attempt.provider === 'meta-graph')));
+          assert.ok(Number.isInteger(smoke.operation_count) && smoke.operation_count >= 1 && smoke.operation_count <= 2);
+          assert.ok(
+            Number.isInteger(smoke.recorded_transport_attempts)
+            && smoke.recorded_transport_attempts >= smoke.operation_count
+            && smoke.recorded_transport_attempts <= smoke.operation_count * 2,
+          );
+          assert.equal(JSON.stringify(smoke).includes('source_ref'), false, 'router smoke must not expose raw provenance references');
+          evidence.router_smoke = smoke;
+          fs.writeFileSync(process.env.EVIDENCE_FILE, `${JSON.stringify(evidence, null, 2)}\n`, { mode: 0o600 });
+          NODE
+
+      - name: Validate correlated Meta router audit
+        if: ${{ inputs.run_real_router_smoke == true }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          cd platform/security/token-vault
+          output_root="$RUNNER_TEMP/influencer-intelligence-staging-shadow"
+          correlation="$(node -e "const v=require(process.argv[1]);process.stdout.write(v.router_smoke.correlation_id)" "$output_root/evidence.json")"
+          max_attempts="$(node -e "const v=require(process.argv[1]);process.stdout.write(String(v.router_smoke.recorded_transport_attempts))" "$output_root/evidence.json")"
+          npx --yes wrangler@4.123.0 d1 execute skincos-token-vault-staging --remote --config wrangler.toml --env staging --json \
+            --command "SELECT request_id, status, json_extract(metadata_json, '$.operation') AS operation, json_extract(metadata_json, '$.correlation_id') AS correlation_id FROM credential_token_audit WHERE event = 'analytics.meta_graph.operation' AND json_extract(metadata_json, '$.correlation_id') = '$correlation' ORDER BY created_at ASC" \
+            > "$output_root/router-audit.json"
+          EVIDENCE_FILE="$output_root/evidence.json" AUDIT_FILE="$output_root/router-audit.json" MAX_ATTEMPTS="$max_attempts" node --input-type=module <<'NODE'
+          import assert from 'node:assert/strict';
+          import fs from 'node:fs';
+
+          const evidence = JSON.parse(fs.readFileSync(process.env.EVIDENCE_FILE, 'utf8'));
+          const response = JSON.parse(fs.readFileSync(process.env.AUDIT_FILE, 'utf8'));
+          const rows = Array.isArray(response)
+            ? response.flatMap((entry) => entry?.results || [])
+            : (response?.results || []);
+          const maxAttempts = Number(process.env.MAX_ATTEMPTS);
+          assert.ok(rows.length <= maxAttempts, 'router audit exceeds the bounded router attempts');
+          assert.ok(rows.every((row) => row.correlation_id === evidence.router_smoke.correlation_id));
+          assert.ok(rows.every((row) => ['ok', 'permission_gap', 'coverage_gap', 'timeout', 'provider_unavailable', 'rate_limited', 'invalid_response'].includes(row.status)));
+          assert.ok(rows.every((row) => ['resolve_creator', 'get_profile'].includes(row.operation)));
+          const hasTransportGap = evidence.router_smoke.operations.some((operation) => operation.attempts.some((attempt) => (
+            attempt.classification === 'timeout' || attempt.classification === 'provider_unavailable' || attempt.classification === 'retry_exhausted'
+          )));
+          if (evidence.router_smoke.status === 'ok') {
+            assert.equal(rows.length, maxAttempts, 'an observed Meta result requires one audit row per recorded transport attempt');
+          } else if (rows.length === 0) {
+            assert.equal(hasTransportGap, true, 'an unavailable result without an audit row must be a bounded transport gap');
+          }
+          evidence.router_smoke.audit_event_count = rows.length;
+          evidence.router_smoke.audit_statuses = rows.map((row) => row.status);
+          evidence.router_smoke.audit_correlation = rows.length > 0 ? 'correlated' : 'not_observed_after_transport_gap';
+          fs.writeFileSync(process.env.EVIDENCE_FILE, `${JSON.stringify(evidence, null, 2)}\n`, { mode: 0o600 });
+          NODE
+
+      - name: Verify staging candidate after validation
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          cd platform/security/token-vault
+          output_root="$RUNNER_TEMP/influencer-intelligence-staging-shadow"
+          candidate="$(<"$output_root/candidate-version.txt")"
+          [[ "$candidate" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo 'Candidate version is unavailable for final verification.' >&2; exit 1; }
+          npx --yes wrangler@4.123.0 deployments status --json --config wrangler.toml --env staging > "$output_root/candidate-active-after-validation.json"
+          EVIDENCE_FILE="$output_root/evidence.json" CANDIDATE="$candidate" node - "$output_root/candidate-active-after-validation.json" <<'NODE'
+          import assert from 'node:assert/strict';
+          import fs from 'node:fs';
+
+          const value = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          const versions = value.versions || value.latest?.versions || [];
+          assert.equal(versions.length, 1, 'staging shadow must retain a single active version');
+          assert.equal(Number(versions[0]?.percentage), 100, 'staging shadow candidate must retain all traffic');
+          assert.equal(String(versions[0]?.version_id || versions[0]?.id || '').toLowerCase(), process.env.CANDIDATE.toLowerCase());
+          const evidence = JSON.parse(fs.readFileSync(process.env.EVIDENCE_FILE, 'utf8'));
+          evidence.candidate_active_after_validation = true;
+          fs.writeFileSync(process.env.EVIDENCE_FILE, `${JSON.stringify(evidence, null, 2)}\n`, { mode: 0o600 });
+          NODE
+
+      - name: Restore staging incumbent if validation fails or the run is cancelled
+        if: ${{ always() && (failure() || cancelled()) && env.INFLUENCER_INTELLIGENCE_STAGING_INCUMBENT != '' && env.INFLUENCER_INTELLIGENCE_STAGING_CANDIDATE != '' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          INCUMBENT: ${{ env.INFLUENCER_INTELLIGENCE_STAGING_INCUMBENT }}
+          CANDIDATE: ${{ env.INFLUENCER_INTELLIGENCE_STAGING_CANDIDATE }}
+        run: |
+          set -euo pipefail
+          cd platform/security/token-vault
+          output_root="$RUNNER_TEMP/influencer-intelligence-staging-shadow"
+          [[ -f "$output_root/traffic-mutation-started" ]] || { echo 'No staging traffic mutation started; compensation is a no-op.'; exit 0; }
+          npx --yes wrangler@4.123.0 deployments status --json --config wrangler.toml --env staging > "$output_root/rollback-before.json"
+          ownership="$(node - "$output_root/rollback-before.json" <<'NODE'
+          const fs = require('fs');
+          const value = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          const versions = value.versions || value.latest?.versions || [];
+          const selected = [...versions].sort((a, b) => Number(b.percentage || 0) - Number(a.percentage || 0))[0];
+          const id = String(selected?.version_id || selected?.id || '').toLowerCase();
+          const percentage = Number(selected?.percentage || 0);
+          const incumbent = String(process.env.INCUMBENT).toLowerCase();
+          const candidate = String(process.env.CANDIDATE).toLowerCase();
+          if (id === incumbent && percentage === 100) process.stdout.write('already-incumbent');
+          else if (id === candidate && percentage === 100) process.stdout.write('candidate-owned');
+          else process.stdout.write('ownership-conflict');
+          NODE
+          )"
+          case "$ownership" in
+            already-incumbent) echo 'Staging Token Vault was already restored.' ;;
+            candidate-owned)
+              npx --yes wrangler@4.123.0 versions deploy "$INCUMBENT@100%" --yes --config wrangler.toml --env staging --message "influencer-intelligence:staging-shadow-rollback:${GITHUB_SHA}"
+              npx --yes wrangler@4.123.0 deployments status --json --config wrangler.toml --env staging > "$output_root/rollback-after.json"
+              INCUMBENT="$INCUMBENT" node - "$output_root/rollback-after.json" <<'NODE'
+              const fs = require('fs');
+              const value = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+              const versions = value.versions || value.latest?.versions || [];
+              if (versions.length !== 1 || Number(versions[0]?.percentage) !== 100 || String(versions[0]?.version_id || versions[0]?.id || '').toLowerCase() !== process.env.INCUMBENT.toLowerCase()) {
+                throw new Error('rollback did not restore the exact staging incumbent');
+              }
+          NODE
+              ;;
+            *) echo 'Staging Token Vault ownership changed; refusing an unsafe rollback.' >&2; exit 1 ;;
+          esac
+
+      - name: Remove workflow-only analytics credential
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          output_root="$RUNNER_TEMP/influencer-intelligence-staging-shadow"
+          rm -f -- "$output_root/analytics-token"
+
+      - name: Publish redacted staging shadow evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: influencer-intelligence-staging-shadow-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/influencer-intelligence-staging-shadow/evidence.json
+            ${{ runner.temp }}/influencer-intelligence-staging-shadow/router-smoke.json
+            ${{ runner.temp }}/influencer-intelligence-staging-shadow/rollback-after.json
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Release staging Token Vault coordination lease
+        if: ${{ always() }}
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || '' }}
+          proof_file: ${{ runner.temp }}/influencer-intelligence-staging-shadow-lease.json

--- a/platform/security/token-vault/src/analytics-readonly.js
+++ b/platform/security/token-vault/src/analytics-readonly.js
@@ -749,6 +749,7 @@ async function audit(writeAudit, env, input, row, status, requestId, metadata = 
     metadata: {
       scope: 'influencer-intelligence',
       operation: input?.operation || null,
+      correlation_id: input?.correlation_id || null,
       endpoint_family: 'instagram-graph-read-only',
       ...(input?.limit !== undefined ? { limit: input.limit } : {}),
       ...metadata,

--- a/platform/security/token-vault/tests/analytics-readonly.test.js
+++ b/platform/security/token-vault/tests/analytics-readonly.test.js
@@ -189,6 +189,7 @@ test('analytics role can read a bounded Meta profile without returning credentia
     assert.equal(new URL(calls[0].url).searchParams.has('access_token'), false);
     assert.equal(calls[0].url, 'https://graph.facebook.com/v20.0/17841400000000001?fields=business_discovery.username%28synthetic.creator%29%7Bid%2Cusername%2Cfollowers_count%2Cmedia_count%7D');
     assert.equal(db.audit.length, 1);
+    assert.equal(JSON.parse(db.audit[0][8]).correlation_id, 'ii:get_profile:creator:synthetic-001');
     assert.equal(JSON.stringify(db.audit).includes(GRAPH_TOKEN), false);
   });
 });

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -28,6 +28,12 @@ test("Cloudflare mutators have one fail-closed writer group and no unclassified 
   assert.equal(crm.resource, "global:crm-cloudflare-writer");
   const pontoWorkers = policy.coordinationGroups.find((group) => group.id === "ponto-workers-writer");
   assert.equal(pontoWorkers.resource, "global:ponto-workers-writer");
+  const tokenVaultStaging = policy.coordinationGroups.find((group) => group.id === "token-vault-staging-writer");
+  assert.equal(tokenVaultStaging.resource, "global:token-vault-staging");
+  const tokenVaultShadow = policy.surfaces.find((surface) => surface.id === "token-vault-staging-shadow");
+  assert.equal(tokenVaultShadow.canonicalDeployWorkflow, ".github/workflows/influencer-intelligence-staging-shadow.yml");
+  assert.equal(tokenVaultShadow.coordinationGroup, "token-vault-staging-writer");
+  assert.match(read(".github/workflows/influencer-intelligence-staging-shadow.yml"), /resource: global:token-vault-staging/);
   assert.match(read(".github/workflows/deploy-crm-pages.yml"), /resource: global:crm-cloudflare-writer/);
   assert.match(read(".github/workflows/cloudflare-pages-sync-ponto.yml"), /global_resource: global:crm-cloudflare-writer/);
   assert.match(read(".github/workflows/cloudflare-workers-sync-ponto-secrets.yml"), /global_resource: global:ponto-workers-writer/);

--- a/social/influencer-intelligence/staging-shadow-router.mjs
+++ b/social/influencer-intelligence/staging-shadow-router.mjs
@@ -1,0 +1,172 @@
+import { randomUUID } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
+import { createInfluencerIntelligenceProviderRouter } from './provider-runtime.mjs';
+
+const STAGING_TOKEN_VAULT_BASE_URL = 'https://api-staging.skincos.com.br/internal/token-vault';
+const META_PROVIDER = 'meta-graph';
+const SHADOW_TIMEOUT_MS = 12_000;
+
+function boundedText(value, label, { maxLength = 160 } = {}) {
+  if (typeof value !== 'string' || !value.trim() || value.length > maxLength || /[\u0000-\u001f\u007f]/.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value.trim();
+}
+
+function normalizeHandle(value) {
+  const handle = boundedText(value, 'canonicalHandle', { maxLength: 31 }).replace(/^@/, '').toLowerCase();
+  if (!/^[a-z0-9._]{1,30}$/.test(handle)) throw new TypeError('canonicalHandle is invalid');
+  return handle;
+}
+
+function normalizedTimestamp(value) {
+  const date = value === undefined ? new Date() : new Date(value);
+  if (Number.isNaN(date.getTime())) throw new TypeError('now is invalid');
+  return date.toISOString();
+}
+
+function arrayOfText(value) {
+  return Array.isArray(value) ? value.filter((entry) => typeof entry === 'string') : [];
+}
+
+function summarizeAttempt(value) {
+  return {
+    provider: typeof value?.provider === 'string' ? value.provider : null,
+    status: typeof value?.status === 'string' ? value.status : 'unknown',
+    ...(typeof value?.classification === 'string' ? { classification: value.classification } : {}),
+    ...(Number.isInteger(value?.retry_count) ? { retry_count: value.retry_count } : {}),
+  };
+}
+
+/**
+ * Produces operational evidence only. It intentionally omits creator identity,
+ * credential references, creator keys, raw source references and every observed
+ * metric value.
+ */
+export function redactProviderResult(result) {
+  const evidence = result?.provider_specific_evidence || {};
+  const freshness = result?.freshness || {};
+  return Object.freeze({
+    operation: typeof result?.operation === 'string' ? result.operation : 'unknown',
+    status: typeof result?.status === 'string' ? result.status : 'unavailable',
+    provider: typeof result?.provider === 'string' ? result.provider : null,
+    data_classification: typeof result?.data_classification === 'string'
+      ? result.data_classification
+      : 'unavailable',
+    freshness: Object.freeze({
+      ...(Number.isInteger(freshness.max_age_seconds) ? { max_age_seconds: freshness.max_age_seconds } : {}),
+    }),
+    limitations: Object.freeze(arrayOfText(result?.limitations)),
+    provider_specific_evidence: Object.freeze({
+      ...(typeof evidence.adapter_version === 'string' ? { adapter_version: evidence.adapter_version } : {}),
+      ...(typeof evidence.endpoint_family === 'string' ? { endpoint_family: evidence.endpoint_family } : {}),
+      fields: Object.freeze(arrayOfText(evidence.fields)),
+      ...(typeof evidence.correlation_id === 'string' ? { correlation_id: evidence.correlation_id } : {}),
+    }),
+    attempts: Object.freeze((Array.isArray(result?.attempts) ? result.attempts : []).map(summarizeAttempt)),
+  });
+}
+
+function assertMetaOnlyRouter(router) {
+  if (!router || typeof router.resolve_creator !== 'function' || typeof router.get_profile !== 'function') {
+    throw new TypeError('router must implement the Meta read-only operations');
+  }
+  const providerOrder = Array.isArray(router.providerOrder) ? router.providerOrder : [];
+  if (providerOrder.length !== 1 || providerOrder[0] !== META_PROVIDER) {
+    throw new TypeError('shadow router must contain only the Meta official provider');
+  }
+}
+
+function recordedTransportAttempts(operations) {
+  return operations.reduce((total, operation) => total + operation.attempts.reduce((attempts, attempt) => {
+    if (attempt.provider !== META_PROVIDER || attempt.status === 'skipped') return attempts;
+    return attempts + Math.max(1, Number.isInteger(attempt.retry_count) ? attempt.retry_count + 1 : 1);
+  }, 0), 0);
+}
+
+/**
+ * Runs the smallest permitted real transport journey: resolution followed by a
+ * profile request only when resolution succeeds. The temporary creator key is
+ * an internal request key, never a claimed Meta identifier and never persisted.
+ */
+export async function runStagingShadowRouter({
+  router,
+  canonicalHandle,
+  correlationId = `ii-shadow-${randomUUID()}`,
+  now,
+} = {}) {
+  assertMetaOnlyRouter(router);
+  const handle = normalizeHandle(canonicalHandle);
+  const timestamp = normalizedTimestamp(now);
+  const correlation = boundedText(correlationId, 'correlationId', { maxLength: 160 });
+  const requestBase = Object.freeze({
+    observed_at: timestamp,
+    retrieved_at: timestamp,
+    correlation_id: correlation,
+    limit: 1,
+  });
+
+  const resolved = await router.resolve_creator({
+    ...requestBase,
+    canonical_handle: handle,
+  });
+  const operations = [redactProviderResult(resolved)];
+  if (resolved?.status !== 'ok' || resolved?.data?.resolved !== true) {
+    return Object.freeze({
+      contract_version: 'influencer-intelligence/staging-shadow-router/v1',
+      status: 'unavailable',
+      provider_order: Object.freeze([...router.providerOrder]),
+      correlation_id: correlation,
+      operation_count: 1,
+      recorded_transport_attempts: recordedTransportAttempts(operations),
+      operations: Object.freeze(operations),
+    });
+  }
+
+  const resolvedHandle = normalizeHandle(resolved.data.canonical_handle || handle);
+  const profile = await router.get_profile({
+    ...requestBase,
+    creator_key: `shadow:${resolvedHandle}`,
+    canonical_handle: resolvedHandle,
+  });
+  operations.push(redactProviderResult(profile));
+  return Object.freeze({
+    contract_version: 'influencer-intelligence/staging-shadow-router/v1',
+    status: profile?.status === 'ok' ? 'ok' : 'unavailable',
+    provider_order: Object.freeze([...router.providerOrder]),
+    correlation_id: correlation,
+    operation_count: 2,
+    recorded_transport_attempts: recordedTransportAttempts(operations),
+    operations: Object.freeze(operations),
+  });
+}
+
+export async function runStagingShadowRouterFromEnvironment(environment = process.env) {
+  const router = createInfluencerIntelligenceProviderRouter({
+    tokenVaultBaseUrl: STAGING_TOKEN_VAULT_BASE_URL,
+    tokenVaultApiToken: boundedText(environment.TOKEN_VAULT_ANALYTICS_API_TOKEN, 'TOKEN_VAULT_ANALYTICS_API_TOKEN', { maxLength: 512 }),
+    tokenVaultCredentialRef: boundedText(environment.INFLUENCER_INTELLIGENCE_SHADOW_CREDENTIAL_REF, 'INFLUENCER_INTELLIGENCE_SHADOW_CREDENTIAL_REF'),
+    timeoutMs: SHADOW_TIMEOUT_MS,
+    retryPolicy: Object.freeze({ maxAttempts: 2, baseDelayMs: 25 }),
+  });
+  return runStagingShadowRouter({
+    router,
+    canonicalHandle: environment.INFLUENCER_INTELLIGENCE_SHADOW_CREATOR_HANDLE,
+  });
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  try {
+    const result = await runStagingShadowRouterFromEnvironment();
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  } catch (error) {
+    const code = typeof error?.code === 'string' ? error.code : 'shadow_router_error';
+    process.stdout.write(`${JSON.stringify({
+      contract_version: 'influencer-intelligence/staging-shadow-router/v1',
+      status: 'error',
+      error: code,
+    })}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/social/influencer-intelligence/tests/staging-shadow-router.test.mjs
+++ b/social/influencer-intelligence/tests/staging-shadow-router.test.mjs
@@ -1,0 +1,154 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { redactProviderResult, runStagingShadowRouter } from '../staging-shadow-router.mjs';
+
+function result(operation, overrides = {}) {
+  return {
+    operation,
+    status: 'ok',
+    provider: 'meta-graph',
+    data_classification: 'observed',
+    freshness: { max_age_seconds: 3600 },
+    limitations: [],
+    provider_specific_evidence: {
+      adapter_version: 'token-vault-meta-graph-v1',
+      source_ref: `meta-graph:${operation}`,
+      endpoint_family: 'instagram-graph-read-only',
+      fields: ['username'],
+      correlation_id: 'ii-shadow-test',
+    },
+    attempts: [{ provider: 'meta-graph', status: 'ok', retry_count: 0 }],
+    data: {},
+    ...overrides,
+  };
+}
+
+test('shadow router runs Meta resolve then profile sequentially and redacts creator data', async () => {
+  const calls = [];
+  const router = {
+    providerOrder: ['meta-graph'],
+    async resolve_creator(input) {
+      calls.push(['resolve_creator', input]);
+      return result('resolve_creator', {
+        data: { resolved: true, canonical_handle: 'approved.creator', private_value: 'must-not-escape' },
+      });
+    },
+    async get_profile(input) {
+      calls.push(['get_profile', input]);
+      return result('get_profile', {
+        data: { followers_count: 12345, canonical_handle: 'approved.creator' },
+      });
+    },
+  };
+
+  const summary = await runStagingShadowRouter({
+    router,
+    canonicalHandle: '@approved.creator',
+    correlationId: 'ii-shadow-test',
+    now: '2026-08-13T18:00:00.000Z',
+  });
+
+  assert.equal(summary.status, 'ok');
+  assert.equal(summary.operation_count, 2);
+  assert.equal(summary.recorded_transport_attempts, 2);
+  assert.deepEqual(calls.map(([operation]) => operation), ['resolve_creator', 'get_profile']);
+  assert.equal(calls[1][1].creator_key, 'shadow:approved.creator');
+  const encoded = JSON.stringify(summary);
+  assert.equal(encoded.includes('approved.creator'), false);
+  assert.equal(encoded.includes('12345'), false);
+  assert.equal(encoded.includes('private_value'), false);
+  assert.deepEqual(summary.provider_order, ['meta-graph']);
+});
+
+test('shadow router records unavailable resolution without inventing a profile request', async () => {
+  const calls = [];
+  const router = {
+    providerOrder: ['meta-graph'],
+    async resolve_creator(input) {
+      calls.push(input);
+      return result('resolve_creator', {
+        status: 'unavailable',
+        data: null,
+        limitations: ['permission_gap'],
+      });
+    },
+    async get_profile() {
+      throw new Error('get_profile must not run');
+    },
+  };
+
+  const summary = await runStagingShadowRouter({
+    router,
+    canonicalHandle: 'approved.creator',
+    correlationId: 'ii-shadow-test',
+  });
+
+  assert.equal(summary.status, 'unavailable');
+  assert.equal(summary.operation_count, 1);
+  assert.equal(summary.recorded_transport_attempts, 1);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(summary.operations[0].limitations, ['permission_gap']);
+});
+
+test('shadow router records at most one safe retry for correlated audit bounds', async () => {
+  const router = {
+    providerOrder: ['meta-graph'],
+    async resolve_creator() {
+      return result('resolve_creator', {
+        status: 'unavailable',
+        data: null,
+        limitations: ['timeout'],
+        attempts: [{ provider: 'meta-graph', status: 'gap', classification: 'retry_exhausted', retry_count: 1 }],
+      });
+    },
+    async get_profile() {
+      throw new Error('get_profile must not run');
+    },
+  };
+
+  const summary = await runStagingShadowRouter({
+    router,
+    canonicalHandle: 'approved.creator',
+    correlationId: 'ii-shadow-retry-test',
+  });
+
+  assert.equal(summary.operation_count, 1);
+  assert.equal(summary.recorded_transport_attempts, 2);
+});
+
+test('shadow runner rejects an injected fallback provider', async () => {
+  const router = {
+    providerOrder: ['meta-graph', 'instagrapi'],
+    async resolve_creator() {},
+    async get_profile() {},
+  };
+  await assert.rejects(
+    () => runStagingShadowRouter({ router, canonicalHandle: 'approved.creator' }),
+    /only the Meta official provider/,
+  );
+});
+
+test('redaction preserves only transport provenance needed for evidence', () => {
+  const summary = redactProviderResult(result('get_profile', {
+    data: { followers_count: 5, secret: 'never-report' },
+    credential_ref: 'ig_analytics_001',
+    creator_key: 'creator:approved',
+    canonical_handle: 'approved.creator',
+    provider_specific_evidence: {
+      adapter_version: 'token-vault-meta-graph-v1',
+      source_ref: 'meta-graph:get_profile:shadow:approved.creator',
+      endpoint_family: 'instagram-graph-read-only',
+      fields: ['username'],
+      correlation_id: 'ii-shadow-test',
+    },
+  }));
+  const encoded = JSON.stringify(summary);
+  assert.equal(encoded.includes('never-report'), false);
+  assert.equal(encoded.includes('ig_analytics_001'), false);
+  assert.equal(encoded.includes('approved.creator'), false);
+  assert.equal(encoded.includes('creator:approved'), false);
+  assert.equal(encoded.includes('source_ref'), false);
+  assert.equal(encoded.includes('shadow:'), false);
+  assert.equal(summary.provider, 'meta-graph');
+  assert.equal(summary.provider_specific_evidence.correlation_id, 'ii-shadow-test');
+});

--- a/social/influencer-intelligence/tests/staging-shadow-workflow.test.mjs
+++ b/social/influencer-intelligence/tests/staging-shadow-workflow.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const workflow = fs.readFileSync(path.resolve(here, '../../../.github/workflows/influencer-intelligence-staging-shadow.yml'), 'utf8');
+
+test('staging shadow workflow is manual, staging-only, and forbids the fallback bridge', () => {
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /run_real_router_smoke:/);
+  assert.match(workflow, /default:\s*false/);
+  assert.match(workflow, /environment:\s*staging/);
+  assert.match(workflow, /refs\/heads\/main/);
+  assert.match(workflow, /--env staging/);
+  assert.match(workflow, /--strict/);
+  assert.match(workflow, /INFLUENCER_INTELLIGENCE_ANALYTICS_MODE/);
+  assert.match(workflow, /TOKEN_VAULT_ANALYTICS_API_TOKEN/);
+  assert.match(workflow, /candidate_active_after_validation/);
+  assert.match(workflow, /versions\.length\s*!==\s*1/);
+  assert.match(workflow, /Number\(versions\[0\]\?\.percentage\)\s*!==\s*100/);
+  assert.match(workflow, /name:\s*Guard private real-read inputs/);
+  assert.match(workflow, /if:\s*\$\{\{\s*inputs\.run_real_router_smoke\s*==\s*true\s*\}\}/);
+  assert.match(workflow, /name:\s*Remove workflow-only analytics credential/);
+  assert.doesNotMatch(workflow, /instagrapi/i);
+  assert.doesNotMatch(workflow, /TOKEN_VAULT_API_TOKEN:\s*\$\{\{\s*secrets\./);
+
+  const promoteStep = workflow.match(/- name: Promote bounded staging shadow and validate its contract([\s\S]*?)(?=\n\s*- name: Run one approved Meta-only router smoke)/)?.[1] || '';
+  assert.notEqual(promoteStep, '');
+  assert.doesNotMatch(promoteStep, /INFLUENCER_INTELLIGENCE_SHADOW_(CREDENTIAL_REF|CREATOR_HANDLE)/);
+});
+
+test('staging shadow workflow shell blocks remain parseable, including nested heredocs', () => {
+  const lines = workflow.split(/\r?\n/);
+  const blocks = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    if (lines[index] !== '        run: |') continue;
+    const block = [];
+    for (index += 1; index < lines.length; index += 1) {
+      const line = lines[index];
+      if (line.length > 0 && !line.startsWith('          ')) {
+        index -= 1;
+        break;
+      }
+      block.push(line.startsWith('          ') ? line.slice(10) : line);
+    }
+    blocks.push(block.join('\n'));
+  }
+
+  assert.ok(blocks.length >= 5);
+  for (const [index, block] of blocks.entries()) {
+    const parsed = spawnSync('bash', ['-n'], { input: block, encoding: 'utf8' });
+    assert.equal(parsed.status, 0, `workflow shell block ${index + 1} is invalid: ${parsed.stderr}`);
+  }
+});


### PR DESCRIPTION
# Summary

Adds the staging-only Meta Graph shadow transport for Influencer Intelligence. The Worker remains off outside staging; the workflow is manual, main-pinned, Meta-only, and preserves a fail-closed rollback path.

It provisions the dedicated analytics credential only through private stdin, verifies authenticated health/contract plus a negative request, and permits the single real router journey only when private inputs are configured. Creator identity, raw source references, observed metrics, and credential references are excluded from retained evidence.

## Type of change

- [x] Feature
- [x] Security
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [ ] Breaking change

## Checklist

- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (README, API refs, diagrams) — workflow source is the operational contract; no public runtime surface changes
- [x] Security review (CodeQL, gitleaks) — focused diff review completed; CI remains required
- [ ] Performance impact measured — no user-facing runtime is activated

## Links

- Issue: Influencer Intelligence staging shadow transport milestone
- Design/ADR: Existing Token Vault / Influencer Intelligence contracts
- Migration steps: None

## Screenshots / Evidence

Local validation:

- 49 focused Node tests passed.
- `wrangler deploy --dry-run --env staging` passed with `INFLUENCER_INTELLIGENCE_ANALYTICS_MODE=shadow`.
- Workflow test parses every shell block, including heredocs.
- Corrected two low-risk review findings before publication: raw provenance evidence is now omitted and promotion refuses a pre-existing split incumbent.

No real Meta request, CRM/MCP/Orb activation, instagrapi bridge, production change, or migration is included in this PR.