### PR TITLE
fix(ponto): align staging affinity and rollback recovery

### DIFF
--- a/.github/scripts/ponto-automatic-rollback-safety.test.mjs
+++ b/.github/scripts/ponto-automatic-rollback-safety.test.mjs
@@ -63,6 +63,19 @@ test("zero-surface recovery uses a fresh external maintenance probe instead of f
   assert.match(source, /no-dispatched-surface-noop/);
 });
 
+test("composite rollback attestation waits for public propagation while maintenance remains required", () => {
+  const start = source.indexOf("const compositeHealthUrl = staging");
+  const end = source.indexOf("// Re-read after every mutation", start);
+  assert.ok(start >= 0 && end > start, "composite rollback attestation block is absent");
+  const block = source.slice(start, end);
+  assert.match(block, /const maxCompositeAttempts = 36/);
+  assert.match(block, /for \(let attempt = 1; attempt <= maxCompositeAttempts; attempt \+= 1\)/);
+  assert.match(block, /availability\?\.state === "maintenance"/);
+  assert.match(block, /x-skincos-gateway-version-id/);
+  assert.match(block, /x-skincos-timekeeping-version-id/);
+  assert.match(block, /await new Promise\(\(resolve\) => setTimeout\(resolve, 5_000\)\)/);
+});
+
 test("Pages recovery skips rollback intent custody when no owned candidate exists", () => {
   assert.match(
     source,

--- a/.github/scripts/ponto-automatic-rollback.mjs
+++ b/.github/scripts/ponto-automatic-rollback.mjs
@@ -1118,33 +1118,40 @@ if (plan.identityWorkforce && proofs.identityWorkforce?.passed) {
   }
 }
 if (plan.coreApi && plan.timekeeping && proofs.coreApi?.passed && proofs.timekeeping?.passed) {
-  try {
-    const response = await fetch(staging
-      ? "https://crm-staging.skincos.com.br/api/ponto/health"
-      : "https://crm.skincos.com.br/api/ponto/health", {
-      redirect: "manual",
-      signal: AbortSignal.timeout(15_000),
-      headers: { accept: "application/json", ...accessHeaders },
-    });
-    const json = await response.json().catch(() => null);
-    const dependencies = json?.dependencies && typeof json.dependencies === "object" ? Object.entries(json.dependencies) : [];
-    const maintenanceOnly = json?.ok === false
-      && json?.ready === false
-      && json?.availability?.state === "maintenance"
-      && json?.dependencies?.module_control?.state === "unavailable"
-      && json?.dependencies?.module_control?.reason === "MODULE_MAINTENANCE"
-      && dependencies.every(([name, dependency]) => name === "module_control" || dependency?.required !== true || dependency?.state === "healthy");
-    external.composite = {
-      passed: response.status === 200
-        && maintenanceOnly
-        && String(response.headers.get("x-skincos-gateway-version-id") || "").toLowerCase() === plan.coreApi.incumbentVersionId.toLowerCase()
-        && String(response.headers.get("x-skincos-timekeeping-version-id") || "").toLowerCase() === plan.timekeeping.incumbentVersionId.toLowerCase(),
-      status: response.status,
-      coreVersionId: String(response.headers.get("x-skincos-gateway-version-id") || ""),
-      timekeepingVersionId: String(response.headers.get("x-skincos-timekeeping-version-id") || ""),
-    };
-  } catch {
-    external.composite = { passed: false, status: 0 };
+  const compositeHealthUrl = staging
+    ? "https://crm-staging.skincos.com.br/api/ponto/health"
+    : "https://crm.skincos.com.br/api/ponto/health";
+  const maxCompositeAttempts = 36;
+  for (let attempt = 1; attempt <= maxCompositeAttempts; attempt += 1) {
+    try {
+      const response = await fetch(compositeHealthUrl, {
+        redirect: "manual",
+        signal: AbortSignal.timeout(15_000),
+        headers: { accept: "application/json", ...accessHeaders },
+      });
+      const json = await response.json().catch(() => null);
+      const dependencies = json?.dependencies && typeof json.dependencies === "object" ? Object.entries(json.dependencies) : [];
+      const maintenanceOnly = json?.ok === false
+        && json?.ready === false
+        && json?.availability?.state === "maintenance"
+        && json?.dependencies?.module_control?.state === "unavailable"
+        && json?.dependencies?.module_control?.reason === "MODULE_MAINTENANCE"
+        && dependencies.every(([name, dependency]) => name === "module_control" || dependency?.required !== true || dependency?.state === "healthy");
+      external.composite = {
+        passed: response.status === 200
+          && maintenanceOnly
+          && String(response.headers.get("x-skincos-gateway-version-id") || "").toLowerCase() === plan.coreApi.incumbentVersionId.toLowerCase()
+          && String(response.headers.get("x-skincos-timekeeping-version-id") || "").toLowerCase() === plan.timekeeping.incumbentVersionId.toLowerCase(),
+        status: response.status,
+        coreVersionId: String(response.headers.get("x-skincos-gateway-version-id") || ""),
+        timekeepingVersionId: String(response.headers.get("x-skincos-timekeeping-version-id") || ""),
+        attempts: attempt,
+      };
+    } catch {
+      external.composite = { passed: false, status: 0, attempts: attempt };
+    }
+    if (external.composite.passed || attempt === maxCompositeAttempts) break;
+    await new Promise((resolve) => setTimeout(resolve, 5_000));
   }
 }
 

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -806,9 +806,11 @@ test("staging waits for exact Pages-to-Timekeeping affinity before the authentic
   assert.match(block, /for attempt in \{1\.\.36\}; do/);
   assert.match(block, /\/api\/ponto\/health\?staging_affinity_probe=\$GITHUB_RUN_ID/);
   assert.match(block, /x-skincos-pages-release-sha/);
-  assert.match(block, /x-skincos-gateway-version-id/);
+  assert.match(block, /x-skincos-gateway-environment/);
   assert.match(block, /x-skincos-timekeeping-release-sha/);
   assert.match(block, /x-skincos-timekeeping-version-id/);
+  assert.doesNotMatch(block, /x-skincos-gateway-release-sha/);
+  assert.doesNotMatch(block, /x-skincos-gateway-version-id/);
   assert.match(block, /Unable to attest exact staging Pages-to-Timekeeping affinity/);
   assert.doesNotMatch(block, /PONTO_IDEMPOTENCY_KEY/);
 });

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -1232,9 +1232,8 @@ jobs:
           set -euo pipefail
           pages_url="$(node -e "process.stdout.write(require(process.argv[1]).url)" "$PONTO_ARTIFACT_DIR/surfaces/pages/surface.json")"
           timekeeping_id="$(node -e "process.stdout.write(require(process.argv[1]).candidateVersionId)" "$PONTO_ARTIFACT_DIR/surfaces/timekeeping/surface.json")"
-          core_id="$(node -e "process.stdout.write(require(process.argv[1]).candidateVersionId)" "$PONTO_ARTIFACT_DIR/surfaces/core/surface.json")"
           [[ "$pages_url" =~ ^https://[a-z0-9-]+\.skincos-staging\.pages\.dev/?$ ]] || { echo 'staging Pages affinity probe requires the immutable Pages origin'; exit 1; }
-          [[ "$timekeeping_id" =~ ^[0-9a-fA-F-]{36}$ && "$core_id" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo 'staging Pages affinity probe requires exact Worker version identities'; exit 1; }
+          [[ "$timekeeping_id" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo 'staging Pages affinity probe requires the exact Timekeeping version identity'; exit 1; }
           affinity_attested=false
           for attempt in {1..36}; do
             http_status="000"
@@ -1248,10 +1247,9 @@ jobs:
             )" || curl_status=$?
             if [[ "$http_status" == "200" && "$curl_status" == "0" ]]; then
               affinity_status=0
-              RELEASE_SHA="$RELEASE_SHA" \
-              TIMEKEEPING_VERSION_ID="$timekeeping_id" \
-              CORE_VERSION_ID="$core_id" \
-              node - "$RUNNER_TEMP/staging-affinity.json" "$RUNNER_TEMP/staging-affinity.headers" <<'NODE' || affinity_status=$?
+            RELEASE_SHA="$RELEASE_SHA" \
+            TIMEKEEPING_VERSION_ID="$timekeeping_id" \
+            node - "$RUNNER_TEMP/staging-affinity.json" "$RUNNER_TEMP/staging-affinity.headers" <<'NODE' || affinity_status=$?
           const fs = require("fs");
           let body;
           try {
@@ -1264,9 +1262,7 @@ jobs:
           const required = [
             `x-skincos-pages-release-sha: ${process.env.RELEASE_SHA}`,
             "x-skincos-pages-environment: staging",
-            `x-skincos-gateway-release-sha: ${process.env.RELEASE_SHA}`,
             "x-skincos-gateway-environment: staging",
-            `x-skincos-gateway-version-id: ${process.env.CORE_VERSION_ID}`,
             `x-skincos-timekeeping-release-sha: ${process.env.RELEASE_SHA}`,
             "x-skincos-timekeeping-environment: staging",
             `x-skincos-timekeeping-version-id: ${process.env.TIMEKEEPING_VERSION_ID}`,


### PR DESCRIPTION
Corrige o gate de afinidade de staging para atestar apenas Pages e Timekeeping, e faz a atestacao externa de rollback aguardar a propagacao publica mantendo maintenance. Validacao focal: node --check e 59 testes de orquestracao/recovery verdes.