### PR TITLE
fix(ponto): attest protected staging affinity

### DIFF
--- a/.github/scripts/ponto-automatic-rollback-safety.test.mjs
+++ b/.github/scripts/ponto-automatic-rollback-safety.test.mjs
@@ -63,17 +63,16 @@ test("zero-surface recovery uses a fresh external maintenance probe instead of f
   assert.match(source, /no-dispatched-surface-noop/);
 });
 
-test("composite rollback attestation waits for public propagation while maintenance remains required", () => {
-  const start = source.indexOf("const compositeHealthUrl = staging");
-  const end = source.indexOf("// Re-read after every mutation", start);
-  assert.ok(start >= 0 && end > start, "composite rollback attestation block is absent");
-  const block = source.slice(start, end);
-  assert.match(block, /const maxCompositeAttempts = 36/);
-  assert.match(block, /for \(let attempt = 1; attempt <= maxCompositeAttempts; attempt \+= 1\)/);
-  assert.match(block, /availability\?\.state === "maintenance"/);
-  assert.match(block, /x-skincos-gateway-version-id/);
-  assert.match(block, /x-skincos-timekeeping-version-id/);
-  assert.match(block, /await new Promise\(\(resolve\) => setTimeout\(resolve, 5_000\)\)/);
+test("external composite recovery readback waits for bounded edge propagation before failing", () => {
+  assert.match(source, /const EXTERNAL_COMPOSITE_MAX_ATTEMPTS = 36/);
+  assert.match(source, /const EXTERNAL_COMPOSITE_RETRY_DELAY_MS = 5_000/);
+  assert.match(source, /automatic_rollback_readback/);
+  assert.match(source, /cache-control": "no-store"/);
+  assert.match(source, /await waitForPropagation\(EXTERNAL_COMPOSITE_RETRY_DELAY_MS\)/);
+  assert.match(source, /propagationTimedOut: true/);
+  assert.match(source, /external\.composite = await attestExternalComposite\(\)/);
+  assert.match(source, /plan\.coreApi\.incumbentVersionId/);
+  assert.match(source, /plan\.timekeeping\.incumbentVersionId/);
 });
 
 test("Pages recovery skips rollback intent custody when no owned candidate exists", () => {

--- a/.github/scripts/ponto-automatic-rollback.mjs
+++ b/.github/scripts/ponto-automatic-rollback.mjs
@@ -1096,6 +1096,49 @@ for (const name of ["coreApi", "identityWorkforce", "timekeeping"]) {
 }
 
 const external = {};
+const EXTERNAL_COMPOSITE_MAX_ATTEMPTS = 36;
+const EXTERNAL_COMPOSITE_RETRY_DELAY_MS = 5_000;
+const waitForPropagation = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+const attestExternalComposite = async () => {
+  const origin = staging
+    ? "https://crm-staging.skincos.com.br/api/ponto/health"
+    : "https://crm.skincos.com.br/api/ponto/health";
+  let latest = { passed: false, status: 0, reason: "external-composite-probe-not-attempted" };
+  for (let attempt = 1; attempt <= EXTERNAL_COMPOSITE_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      const probe = new URL(origin);
+      probe.searchParams.set("automatic_rollback_readback", `${recoveryRunId}-${attempt}`);
+      const response = await fetch(probe, {
+        redirect: "manual",
+        signal: AbortSignal.timeout(15_000),
+        headers: { accept: "application/json", "cache-control": "no-store", ...accessHeaders },
+      });
+      const json = await response.json().catch(() => null);
+      const dependencies = json?.dependencies && typeof json.dependencies === "object" ? Object.entries(json.dependencies) : [];
+      const maintenanceOnly = json?.ok === false
+        && json?.ready === false
+        && json?.availability?.state === "maintenance"
+        && json?.dependencies?.module_control?.state === "unavailable"
+        && json?.dependencies?.module_control?.reason === "MODULE_MAINTENANCE"
+        && dependencies.every(([name, dependency]) => name === "module_control" || dependency?.required !== true || dependency?.state === "healthy");
+      latest = {
+        passed: response.status === 200
+          && maintenanceOnly
+          && String(response.headers.get("x-skincos-gateway-version-id") || "").toLowerCase() === plan.coreApi.incumbentVersionId.toLowerCase()
+          && String(response.headers.get("x-skincos-timekeeping-version-id") || "").toLowerCase() === plan.timekeeping.incumbentVersionId.toLowerCase(),
+        status: response.status,
+        coreVersionId: String(response.headers.get("x-skincos-gateway-version-id") || ""),
+        timekeepingVersionId: String(response.headers.get("x-skincos-timekeeping-version-id") || ""),
+        attempt,
+      };
+    } catch {
+      latest = { passed: false, status: 0, reason: "external-composite-probe-failed", attempt };
+    }
+    if (latest.passed) return latest;
+    if (attempt < EXTERNAL_COMPOSITE_MAX_ATTEMPTS) await waitForPropagation(EXTERNAL_COMPOSITE_RETRY_DELAY_MS);
+  }
+  return { ...latest, propagationTimedOut: true, attempts: EXTERNAL_COMPOSITE_MAX_ATTEMPTS };
+};
 if (plan.identityWorkforce && proofs.identityWorkforce?.passed) {
   try {
     const response = await fetch(staging
@@ -1118,41 +1161,7 @@ if (plan.identityWorkforce && proofs.identityWorkforce?.passed) {
   }
 }
 if (plan.coreApi && plan.timekeeping && proofs.coreApi?.passed && proofs.timekeeping?.passed) {
-  const compositeHealthUrl = staging
-    ? "https://crm-staging.skincos.com.br/api/ponto/health"
-    : "https://crm.skincos.com.br/api/ponto/health";
-  const maxCompositeAttempts = 36;
-  for (let attempt = 1; attempt <= maxCompositeAttempts; attempt += 1) {
-    try {
-      const response = await fetch(compositeHealthUrl, {
-        redirect: "manual",
-        signal: AbortSignal.timeout(15_000),
-        headers: { accept: "application/json", ...accessHeaders },
-      });
-      const json = await response.json().catch(() => null);
-      const dependencies = json?.dependencies && typeof json.dependencies === "object" ? Object.entries(json.dependencies) : [];
-      const maintenanceOnly = json?.ok === false
-        && json?.ready === false
-        && json?.availability?.state === "maintenance"
-        && json?.dependencies?.module_control?.state === "unavailable"
-        && json?.dependencies?.module_control?.reason === "MODULE_MAINTENANCE"
-        && dependencies.every(([name, dependency]) => name === "module_control" || dependency?.required !== true || dependency?.state === "healthy");
-      external.composite = {
-        passed: response.status === 200
-          && maintenanceOnly
-          && String(response.headers.get("x-skincos-gateway-version-id") || "").toLowerCase() === plan.coreApi.incumbentVersionId.toLowerCase()
-          && String(response.headers.get("x-skincos-timekeeping-version-id") || "").toLowerCase() === plan.timekeeping.incumbentVersionId.toLowerCase(),
-        status: response.status,
-        coreVersionId: String(response.headers.get("x-skincos-gateway-version-id") || ""),
-        timekeepingVersionId: String(response.headers.get("x-skincos-timekeeping-version-id") || ""),
-        attempts: attempt,
-      };
-    } catch {
-      external.composite = { passed: false, status: 0, attempts: attempt };
-    }
-    if (external.composite.passed || attempt === maxCompositeAttempts) break;
-    await new Promise((resolve) => setTimeout(resolve, 5_000));
-  }
+  external.composite = await attestExternalComposite();
 }
 
 // Re-read after every mutation while still holding the surface mutex. A reset,

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -803,16 +803,18 @@ test("staging waits for exact Pages-to-Timekeeping affinity before the authentic
   const end = source.indexOf("- name: Execute authenticated synthetic staging journey", start);
   assert.ok(start >= 0 && end > start, "staging affinity probe block is absent or misplaced");
   const block = source.slice(start, end);
-  assert.match(block, /for attempt in \{1\.\.36\}; do/);
-  assert.match(block, /\/api\/ponto\/health\?staging_affinity_probe=\$GITHUB_RUN_ID/);
+  assert.match(block, /PONTO_IDEMPOTENCY_KEY: \$\{\{ secrets\.PONTO_IDEMPOTENCY_KEY \}\}/);
+  assert.match(block, /const maxAttempts = 36/);
+  assert.match(block, /\/api\/ponto\/_release-readiness/);
+  assert.match(block, /ponto-release-probe\/v1\.\$\{timestamp\}\.\$\{nonce\}\.GET/);
   assert.match(block, /x-skincos-pages-release-sha/);
-  assert.match(block, /x-skincos-gateway-environment/);
-  assert.match(block, /x-skincos-timekeeping-release-sha/);
-  assert.match(block, /x-skincos-timekeeping-version-id/);
-  assert.doesNotMatch(block, /x-skincos-gateway-release-sha/);
-  assert.doesNotMatch(block, /x-skincos-gateway-version-id/);
-  assert.match(block, /Unable to attest exact staging Pages-to-Timekeeping affinity/);
-  assert.doesNotMatch(block, /PONTO_IDEMPOTENCY_KEY/);
+  assert.match(block, /body\?\.coreVersionId/);
+  assert.match(block, /body\?\.timekeepingVersionId/);
+  assert.match(block, /protected-pages-service-binding/);
+  assert.match(block, /publicVersionOverrideUsed: false/);
+  assert.match(block, /releaseProbeNonceReserved: true/);
+  assert.match(block, /bounded propagation/);
+  assert.doesNotMatch(block, /PONTO_RELEASE_PROBE_HMAC_KEY/);
 });
 
 test("staging retries the protected Identity contract during bounded propagation", () => {

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -1228,57 +1228,135 @@ jobs:
             --dir "$PONTO_ARTIFACT_DIR/module-transitions/staging-active"
       - name: Prove exact staging Pages-to-Timekeeping affinity before authenticated journey
         if: inputs.stage == 'staging'
+        env:
+          # The protected Pages endpoint derives and verifies the same scoped
+          # release-probe key.  The root remains environment-scoped and is
+          # never written to output, artifacts, or an external request.
+          PONTO_IDEMPOTENCY_KEY: ${{ secrets.PONTO_IDEMPOTENCY_KEY }}
         run: |
           set -euo pipefail
           pages_url="$(node -e "process.stdout.write(require(process.argv[1]).url)" "$PONTO_ARTIFACT_DIR/surfaces/pages/surface.json")"
           timekeeping_id="$(node -e "process.stdout.write(require(process.argv[1]).candidateVersionId)" "$PONTO_ARTIFACT_DIR/surfaces/timekeeping/surface.json")"
+          core_id="$(node -e "process.stdout.write(require(process.argv[1]).candidateVersionId)" "$PONTO_ARTIFACT_DIR/surfaces/core/surface.json")"
           [[ "$pages_url" =~ ^https://[a-z0-9-]+\.skincos-staging\.pages\.dev/?$ ]] || { echo 'staging Pages affinity probe requires the immutable Pages origin'; exit 1; }
-          [[ "$timekeeping_id" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo 'staging Pages affinity probe requires the exact Timekeeping version identity'; exit 1; }
-          affinity_attested=false
-          for attempt in {1..36}; do
-            http_status="000"
-            curl_status=0
-            http_status="$(curl --silent --show-error --retry 3 --retry-all-errors --retry-delay 2 \
-              --connect-timeout 10 --max-time 30 \
-              --dump-header "$RUNNER_TEMP/staging-affinity.headers" \
-              --output "$RUNNER_TEMP/staging-affinity.json" \
-              --write-out '%{http_code}' \
-              "${pages_url%/}/api/ponto/health?staging_affinity_probe=$GITHUB_RUN_ID" \
-            )" || curl_status=$?
-            if [[ "$http_status" == "200" && "$curl_status" == "0" ]]; then
-              affinity_status=0
-            RELEASE_SHA="$RELEASE_SHA" \
-            TIMEKEEPING_VERSION_ID="$timekeeping_id" \
-            node - "$RUNNER_TEMP/staging-affinity.json" "$RUNNER_TEMP/staging-affinity.headers" <<'NODE' || affinity_status=$?
-          const fs = require("fs");
-          let body;
-          try {
-            body = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
-          } catch {
-            process.exit(2);
+          [[ "$timekeeping_id" =~ ^[0-9a-fA-F-]{36}$ && "$core_id" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo 'staging Pages affinity probe requires exact Worker version identities'; exit 1; }
+          [[ -n "${PONTO_IDEMPOTENCY_KEY:-}" ]] || { echo 'Staging PONTO_IDEMPOTENCY_KEY is required for the protected affinity probe'; exit 1; }
+          PAGES_URL="$pages_url" \
+          TIMEKEEPING_VERSION_ID="$timekeeping_id" \
+          CORE_VERSION_ID="$core_id" \
+          AFFINITY_REPORT="$PONTO_ARTIFACT_DIR/staging-affinity.json" \
+          node --input-type=module <<'NODE'
+          import crypto from "node:crypto";
+          import fs from "node:fs";
+
+          const releaseSha = String(process.env.RELEASE_SHA || "").toLowerCase();
+          const timekeepingVersionId = String(process.env.TIMEKEEPING_VERSION_ID || "").toLowerCase();
+          const coreVersionId = String(process.env.CORE_VERSION_ID || "").toLowerCase();
+          const origin = new URL(process.env.PAGES_URL);
+          if (
+            !/^[0-9a-f]{40}$/.test(releaseSha)
+            || !/^[0-9a-f-]{36}$/.test(timekeepingVersionId)
+            || !/^[0-9a-f-]{36}$/.test(coreVersionId)
+            || origin.protocol !== "https:"
+            || !origin.hostname.endsWith(".skincos-staging.pages.dev")
+            || origin.pathname !== "/"
+            || origin.search
+            || origin.hash
+          ) throw new Error("protected staging affinity inputs are invalid");
+
+          const pathname = "/api/ponto/_release-readiness";
+          const bodyHash = crypto.createHash("sha256").update("").digest("hex");
+          const releaseProbeKey = crypto.createHmac("sha256", process.env.PONTO_IDEMPOTENCY_KEY)
+            .update("skincos/ponto/release-probe/v1")
+            .digest("base64url");
+          const maxAttempts = 36;
+          const retryDelayMs = 5_000;
+          let lastObservation = { attempt: 0, status: 0, error: "not attempted" };
+
+          for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+            const timestamp = String(Date.now());
+            const nonce = crypto.randomBytes(32).toString("base64url");
+            const signature = crypto.createHmac("sha256", releaseProbeKey)
+              .update(`ponto-release-probe/v1.${timestamp}.${nonce}.GET.${pathname}.${bodyHash}.${releaseSha}`)
+              .digest("base64url");
+            const probe = new URL(pathname, origin);
+            probe.searchParams.set("staging_affinity_probe", `${process.env.GITHUB_RUN_ID}-${attempt}`);
+            let response = null;
+            let body = null;
+            try {
+              response = await fetch(probe, {
+                method: "GET",
+                redirect: "manual",
+                headers: {
+                  accept: "application/json",
+                  "cache-control": "no-store",
+                  "x-skincos-release-probe-ts": timestamp,
+                  "x-skincos-release-probe-nonce": nonce,
+                  "x-skincos-release-probe-signature-version": "1",
+                  "x-skincos-release-probe-sig": signature,
+                },
+                signal: AbortSignal.timeout(30_000),
+              });
+              body = await response.json().catch(() => null);
+            } catch {
+              // The report intentionally keeps only a bounded condition code.
+            }
+            const pagesReleaseSha = String(response?.headers.get("x-skincos-pages-release-sha") || "").toLowerCase();
+            const pagesEnvironment = String(response?.headers.get("x-skincos-pages-environment") || "").toLowerCase();
+            const exact = response?.status === 200
+              && pagesReleaseSha === releaseSha
+              && pagesEnvironment === "staging"
+              && body?.ok === true
+              && body?.ready === true
+              && String(body?.releaseSha || "").toLowerCase() === releaseSha
+              && String(body?.coreVersionId || "").toLowerCase() === coreVersionId
+              && String(body?.timekeepingVersionId || "").toLowerCase() === timekeepingVersionId;
+            if (exact) {
+              fs.writeFileSync(process.env.AFFINITY_REPORT, `${JSON.stringify({
+                schemaVersion: 1,
+                passed: true,
+                sourceSha: releaseSha,
+                environment: "staging",
+                pagesOrigin: origin.origin,
+                coreVersionId,
+                timekeepingVersionId,
+                contractMode: "protected-pages-service-binding",
+                publicVersionOverrideUsed: false,
+                releaseProbeNonceReserved: true,
+                credentialsIncluded: false,
+                piiIncluded: false,
+              }, null, 2)}\n`, { mode: 0o600 });
+              process.exit(0);
+            }
+            lastObservation = {
+              attempt,
+              status: Number(response?.status || 0),
+              error: response ? String(body?.error || "RELEASE_READINESS_VERSION_MISMATCH") : "RELEASE_READINESS_UNAVAILABLE",
+              releaseSha: String(body?.releaseSha || ""),
+              coreVersionId: String(body?.coreVersionId || ""),
+              timekeepingVersionId: String(body?.timekeepingVersionId || ""),
+              pagesReleaseSha,
+              pagesEnvironment,
+            };
+            if (attempt < maxAttempts) await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
           }
-          const headers = fs.readFileSync(process.argv[3], "utf8").toLowerCase();
-          if (!body || typeof body !== "object") process.exit(2);
-          const required = [
-            `x-skincos-pages-release-sha: ${process.env.RELEASE_SHA}`,
-            "x-skincos-pages-environment: staging",
-            "x-skincos-gateway-environment: staging",
-            `x-skincos-timekeeping-release-sha: ${process.env.RELEASE_SHA}`,
-            "x-skincos-timekeeping-environment: staging",
-            `x-skincos-timekeeping-version-id: ${process.env.TIMEKEEPING_VERSION_ID}`,
-          ];
-          if (required.some((value) => !headers.includes(value.toLowerCase()))) process.exit(2);
+          throw new Error(`protected staging Pages-to-Timekeeping affinity did not match the exact release after bounded propagation; last=${JSON.stringify(lastObservation)}`);
           NODE
-              if [[ "$affinity_status" == "0" ]]; then affinity_attested=true; break; fi
-              [[ "$affinity_status" == "2" ]] || exit "$affinity_status"
-            elif [[ "$http_status" != "404" && "$http_status" != "502" && "$http_status" != "503" && "$http_status" != "504" && "$http_status" != "000" ]]; then
-              echo "staging Pages affinity probe returned HTTP $http_status"
-              exit 1
-            fi
-            if [[ "$attempt" != 36 ]]; then sleep 5; fi
-          done
-          [[ "$affinity_attested" == true ]] || { echo 'Unable to attest exact staging Pages-to-Timekeeping affinity before the authenticated journey'; exit 1; }
-          rm -f "$RUNNER_TEMP/staging-affinity.json" "$RUNNER_TEMP/staging-affinity.headers"
+          node - "$PONTO_ARTIFACT_DIR/staging-affinity.json" <<'NODE'
+          const fs = require("fs");
+          const report = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          if (
+            report.schemaVersion !== 1
+            || report.passed !== true
+            || report.sourceSha !== process.env.RELEASE_SHA
+            || report.environment !== "staging"
+            || report.contractMode !== "protected-pages-service-binding"
+            || report.publicVersionOverrideUsed !== false
+            || report.releaseProbeNonceReserved !== true
+            || report.credentialsIncluded !== false
+            || report.piiIncluded !== false
+          ) throw new Error("protected staging affinity evidence is invalid");
+          NODE
       - name: Execute authenticated synthetic staging journey
         id: staging_journey
         if: inputs.stage == 'staging'


### PR DESCRIPTION
## Motivo

O `health` público foi corretamente endurecido para consultar o gateway canônico, mas a checagem de afinidade de staging ainda exigia que esse endpoint público refletisse as versões candidatas. Isso é estruturalmente incompatível: a versão candidata só é válida dentro do binding protegido de Pages.

## Mudança

- atesta Core e Timekeeping candidatos por `/_release-readiness`, com HMAC de probe derivado localmente do segredo de staging;
- preserva `health` e `readiness` públicos no contrato canônico, sem override público;
- mantém evidência sanitizada, sem segredo, token ou PII;
- torna a leitura pós-rollback resistente à propagação de edge usando `no-store`, nonce de URL e janela limitada.

## Validação local

- `node --test .github/scripts/ponto-orchestrator-lease.test.mjs .github/scripts/ponto-automatic-rollback-safety.test.mjs .github/scripts/ponto-dispatch-workflow.test.mjs` (54/54)
- `npm run codex:global-coordination:test` (197/197)
- `npm run codex:cloudflare:single-writer:test`
- `npm run architecture:validate`
- sintaxe extraída do bloco de workflow validada com `bash -n`