### PR TITLE
fix(influencer): use active coordinator key for staging shadow

### DIFF
--- a/.github/workflows/influencer-intelligence-staging-shadow.yml
+++ b/.github/workflows/influencer-intelligence-staging-shadow.yml
@@ -96,7 +96,7 @@ jobs:
           required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
           key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || '' }}
           resource: global:token-vault-staging
           module: influencer-intelligence
@@ -114,7 +114,7 @@ jobs:
           source_sha: ${{ github.sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
           key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || '' }}
 
       - name: Promote bounded staging shadow and validate its contract
@@ -497,6 +497,6 @@ jobs:
         with:
           required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
           key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || '' }}
           proof_file: ${{ runner.temp }}/influencer-intelligence-staging-shadow-lease.json

--- a/social/influencer-intelligence/tests/staging-shadow-workflow.test.mjs
+++ b/social/influencer-intelligence/tests/staging-shadow-workflow.test.mjs
@@ -21,6 +21,12 @@ test('staging shadow workflow is manual, staging-only, and forbids the fallback 
   assert.match(workflow, /candidate_active_after_validation/);
   assert.match(workflow, /versions\.length\s*!==\s*1/);
   assert.match(workflow, /Number\(versions\[0\]\?\.percentage\)\s*!==\s*100/);
+  assert.equal(
+    (workflow.match(/shared_secret:\s*\$\{\{\s*secrets\.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY\s*\}\}/g) || []).length,
+    3,
+    'all staging shadow lease operations must use the active coordinator key',
+  );
+  assert.doesNotMatch(workflow, /secrets\.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET/);
   assert.match(workflow, /name:\s*Guard private real-read inputs/);
   assert.match(workflow, /if:\s*\$\{\{\s*inputs\.run_real_router_smoke\s*==\s*true\s*\}\}/);
   assert.match(workflow, /name:\s*Remove workflow-only analytics credential/);


### PR DESCRIPTION
# Summary

Corrects the staging Token Vault shadow workflow to use the epoch-pinned global coordination active key for acquire, revalidation, and release. The prior manual run stopped at the lease boundary before any Cloudflare mutation because it supplied the legacy custody secret.

The regression test now requires the active key at all three lease boundaries and rejects the legacy secret reference.

## Type of change

- [x] Fix
- [x] Security

## Checklist

- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (README, API refs, diagrams)
- [x] Focused security diff review completed
- [ ] Performance impact measured (not applicable)

## Links

- Issue: None
- Design/ADR: Existing staging shadow transport design
- Migration steps: None

## Screenshots / Evidence

- Focused validation passed: Cloudflare single-writer governance and 33 coordination/workflow tests.
- The failed staging run performed no Worker version, secret, D1, or Meta operation; this PR only repairs its custody wiring.
- Scope remains manual, staging-only, Meta-only when separately enabled, and without instagrapi fallback, CRM/MCP/Orb activation, or production change.