### PR TITLE
fix(token-vault): preserve fail-closed analytics audit

### DIFF
--- a/platform/security/token-vault/src/analytics-readonly.js
+++ b/platform/security/token-vault/src/analytics-readonly.js
@@ -738,8 +738,14 @@ function responseJson(data, status = 200) {
 
 async function audit(writeAudit, env, input, row, status, requestId, metadata = {}) {
   if (typeof writeAudit !== 'function') return;
+  const credentialRefState = row?.id
+    ? 'matched'
+    : (input?.credential_ref ? 'unmatched' : 'not_provided');
   await writeAudit(env, {
-    tokenId: row?.id || input?.credential_ref,
+    // credential_token_audit.token_id is a foreign key. An unresolved,
+    // caller-controlled reference must remain auditable without converting a
+    // deliberate 403 permission_gap into an internal error.
+    tokenId: row?.id || null,
     event: 'analytics.meta_graph.operation',
     provider: 'meta-graph',
     unit: row?.unit,
@@ -750,6 +756,7 @@ async function audit(writeAudit, env, input, row, status, requestId, metadata = 
       scope: 'influencer-intelligence',
       operation: input?.operation || null,
       correlation_id: input?.correlation_id || null,
+      credential_ref_state: credentialRefState,
       endpoint_family: 'instagram-graph-read-only',
       ...(input?.limit !== undefined ? { limit: input.limit } : {}),
       ...metadata,

--- a/platform/security/token-vault/tests/analytics-readonly.test.js
+++ b/platform/security/token-vault/tests/analytics-readonly.test.js
@@ -32,6 +32,10 @@ class FakeStatement {
   async run() {
     if (this.sql.includes('INSERT INTO credential_token_audit')) {
       if (this.db.failAudit) throw new Error('audit unavailable');
+      const tokenId = this.values[1];
+      if (this.db.enforceAuditForeignKey && tokenId && !this.db.tokens.some((row) => row.id === tokenId)) {
+        throw new Error('FOREIGN KEY constraint failed');
+      }
       this.db.audit.push([...this.values]);
       return { success: true };
     }
@@ -44,6 +48,7 @@ class FakeDb {
     this.tokens = [];
     this.audit = [];
     this.failAudit = false;
+    this.enforceAuditForeignKey = false;
   }
 
   prepare(sql) {
@@ -221,6 +226,35 @@ test('operational credentials cannot invoke analytics and missing scope fails cl
   assert.equal(missingScope.status, 403);
   assert.equal((await missingScope.json()).error, 'permission_gap');
   assert.equal(db.audit.length, 1);
+});
+
+test('an unknown analytics credential is audited without violating the token foreign key', async () => {
+  const db = new FakeDb();
+  db.enforceAuditForeignKey = true;
+  const env = environment(db);
+
+  await withFetch(env, async () => {
+    throw new Error('Meta must not be called for an unknown credential');
+  }, async () => {
+    const response = await handleRequest(
+      new Request('https://api-staging.skincos.com.br/internal/token-vault/v1/analytics/operations', {
+        method: 'POST',
+        headers: headers(),
+        body: JSON.stringify(profileRequest({ credential_ref: 'ig_analytics_missing' })),
+      }),
+      env,
+    );
+
+    assert.equal(response.status, 403);
+    assert.equal((await response.json()).error, 'permission_gap');
+  });
+
+  assert.equal(db.audit.length, 1);
+  assert.equal(db.audit[0][1], null);
+  const metadata = JSON.parse(db.audit[0][8]);
+  assert.equal(metadata.credential_ref_state, 'unmatched');
+  assert.equal(metadata.correlation_id, 'ii:get_profile:creator:synthetic-001');
+  assert.equal(JSON.stringify(db.audit).includes('ig_analytics_missing'), false);
 });
 
 test('official transport preserves explicit zero metrics and omits unavailable fields', async () => {


### PR DESCRIPTION
# Summary

Fix the staging shadow transport's negative-request path: an unknown analytics `credential_ref` now writes an audit row with a null foreign-key link plus a non-sensitive match state, so the intended `403 permission_gap` remains fail-closed instead of becoming `500 internal_error`.

## Type of change
- [x] Fix
- [x] Security

## Scope and risk

- Surface: Token Vault's authenticated, read-only Influencer Intelligence analytics endpoint and its audit row.
- Flags/grants: unchanged. Root module remains off; only the existing staging shadow workflow can promote a bounded candidate.
- Migration: none. Existing `credential_token_audit.token_id` foreign key is respected.
- User surfaces: no CRM, MCP, Orb, native runtime, or provider fallback activation.
- Rollback: deploy the incumbent staging Worker version `e902e414-9d86-4a9e-91e5-87c73a76aeaf` through the existing workflow; the workflow already restores it automatically on a failed validation.

## Validation

- `node --test platform/security/token-vault/tests/analytics-readonly.test.js platform/security/token-vault/tests/index.test.js platform/security/token-vault/tests/staging-shadow-config.test.js social/influencer-intelligence/tests/token-vault-transport.test.mjs social/influencer-intelligence/tests/staging-shadow-router.test.mjs social/influencer-intelligence/tests/staging-shadow-workflow.test.mjs scripts/tests/global-concurrency-governance-static.test.mjs scripts/tests/codex-global-coordination-client.test.mjs scripts/tests/codex-global-coordination-workflow.test.mjs` — 70 passing.
- Security diff review completed with no findings for the two-file patch.
- The previous staging run `31735837719` exercised the failure and automatically restored the incumbent before any real Meta smoke ran.

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [x] Docs not needed; behavior is constrained to the existing contract
- [x] Security review completed
- [ ] Performance impact measured (not applicable; removes a failed audit write)

## Links
- Issue: Influencer Intelligence staging shadow transport continuation
- Design/ADR: existing Token Vault analytics read-only transport contract
- Migration steps: none

## Screenshots / Evidence

The next gated staging workflow run will validate authenticated health/contract plus the bounded negative request before any optional one-creator Meta-only read.