### PR TITLE
fix(site): refine Beauty Movement final flow

### DIFF
--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -110,6 +110,13 @@
   pointer-events: none;
 }
 
+.progressRow:not(.progressRowWaiting) {
+  /* Reuse the instruction's reserved space once the first hand begins.
+   * Keeping the row in normal flow avoids moving the table surface, while
+   * the visual offset lets the category read as the hero subtitle. */
+  transform: translateY(-38px);
+}
+
 .progressGroup {
   display: grid;
   justify-items: stretch;
@@ -398,7 +405,7 @@
 .tableStage,
 .resultStage {
   width: min(100%, 1040px);
-  margin: clamp(16px, 2.4vw, 26px) auto 0;
+  margin: clamp(8px, 1.2vw, 12px) auto 0;
   scroll-margin-top: 32px;
 }
 
@@ -584,10 +591,6 @@
 .tableStage[data-hand-stage="deal"] .deckStage {
   animation: deckStageDeal var(--bm-hand-deal-ms) cubic-bezier(0.4, 0, 0.2, 1) both;
   will-change: transform;
-}
-
-.tableStage[data-hand-stage="reveal"] .deckCardTop {
-  animation: deckReceivePulse 680ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
 }
 
 .tableStage[data-hand-stage="collect"] .deckStage {
@@ -790,22 +793,6 @@
   min-height: 430px;
 }
 
-.specialCardReopenCard {
-  cursor: pointer;
-  outline: none;
-  transition: transform 180ms ease, filter 180ms ease;
-}
-
-.specialCardReopenCard:hover {
-  filter: brightness(1.04);
-  transform: translateY(-4px);
-}
-
-.specialCardReopenCard:focus-visible {
-  outline: 3px solid var(--bm-yellow);
-  outline-offset: 4px;
-}
-
 .specialCardModalOverlay {
   --bm-bg: #fafafa;
   --bm-surface: #ffffff;
@@ -921,8 +908,9 @@
 }
 
 .specialCardBackWithAction {
+  justify-content: flex-start;
   gap: 10px;
-  padding: 24px;
+  padding: 32px 24px 20px;
 }
 
 .specialCardBackWithAction .specialCardBrand {
@@ -936,6 +924,15 @@
   background: var(--bm-yellow);
   color: var(--bm-ink);
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.18);
+}
+
+.specialCardWhatsappAction {
+  width: min(100%, 282px);
+  min-height: 50px;
+  border-color: var(--bm-yellow);
+  background: var(--bm-yellow);
+  color: var(--bm-ink);
+  box-shadow: 0 10px 20px rgba(48, 48, 48, 0.14);
 }
 
 .specialCardRevealError {
@@ -1371,17 +1368,6 @@
 
   72% {
     transform: rotate(2deg) translateY(0) scale(0.98);
-  }
-}
-
-@keyframes deckReceivePulse {
-  0%,
-  100% {
-    transform: rotate(1deg) translateY(0);
-  }
-
-  48% {
-    transform: rotate(-3deg) translateY(4px) scale(1.03);
   }
 }
 

--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -134,6 +134,7 @@ type HandStage =
 type IntroStage = "hidden" | "entering" | "holding" | "exiting";
 type FinaleStage = "hidden" | "assembling" | "collecting" | "merging" | "confirmation" | "result";
 type SpecialCardKind = "velocity" | "discount" | "free_procedure" | "reserved";
+type SpecialCardAction = "none" | "confirm" | "reopen";
 type ProgressRect = {
     left: number;
     top: number;
@@ -679,7 +680,7 @@ export default function BeautyMovementExperience({
     const finaleRef = useRef<HTMLElement | null>(null);
     const confirmationActionRef = useRef<HTMLElement | null>(null);
     const specialCardModalCloseRef = useRef<HTMLButtonElement | null>(null);
-    const specialCardReopenCardRef = useRef<HTMLElement | null>(null);
+    const specialCardReopenActionRef = useRef<HTMLButtonElement | null>(null);
     const selectionsRef = useRef(selections);
     const displayedActIndexRef = useRef(displayedActIndex);
     const introStageRef = useRef(introStage);
@@ -699,20 +700,13 @@ export default function BeautyMovementExperience({
     const closeSpecialCardModal = useCallback(() => {
         setIsSpecialCardModalOpen(false);
         window.requestAnimationFrame(() => {
-            specialCardReopenCardRef.current?.focus({ preventScroll: true });
+            specialCardReopenActionRef.current?.focus({ preventScroll: true });
         });
     }, []);
 
     const openSpecialCardModal = useCallback(() => {
         setIsSpecialCardModalOpen(true);
     }, []);
-
-    function handleSpecialCardReopenKeyDown(event: ReactKeyboardEvent<HTMLElement>) {
-        if (event.key !== "Enter" && event.key !== " " && event.key !== "Spacebar") return;
-
-        event.preventDefault();
-        openSpecialCardModal();
-    }
 
     const motionCssVariables = useMemo(
         () =>
@@ -1551,6 +1545,35 @@ export default function BeautyMovementExperience({
         }
     }
 
+    function renderWhatsappAction(className: string, label = primaryWhatsappLabel) {
+        if (isLocalPreview) {
+            return (
+                <button className={className} type="button" onClick={handleWhatsappClick}>
+                    {label}
+                </button>
+            );
+        }
+
+        if (initialState.campaign.whatsappMessage?.trim()) {
+            return (
+                <BeautyMovementWhatsappLink
+                    className={className}
+                    message={initialState.campaign.whatsappMessage.trim()}
+                    placement="result"
+                    onClick={handleWhatsappClick}
+                >
+                    {label}
+                </BeautyMovementWhatsappLink>
+            );
+        }
+
+        return (
+            <button className={className} type="button" disabled>
+                {label}
+            </button>
+        );
+    }
+
     function handleConditionsClick() {
         if (conditionsOpenedRef.current) return;
         conditionsOpenedRef.current = true;
@@ -1708,7 +1731,8 @@ export default function BeautyMovementExperience({
         );
     }
 
-    function renderSpecialCard(revealed: boolean, showRevealAction = false, interactive = false) {
+    function renderSpecialCard(revealed: boolean, action: SpecialCardAction = "none") {
+        const showRevealAction = action !== "none";
         const kind: SpecialCardKind = revealed
             ? hasCourtesyClass
                 ? "velocity"
@@ -1744,29 +1768,19 @@ export default function BeautyMovementExperience({
                   : "Seu presente está reservado";
         const description =
             kind === "velocity"
-                ? velocity?.text || "Sua aula será confirmada pela equipe da unidade após o contato."
+                ? "Seu movimento também faz parte da celebração."
                 : kind === "discount" || kind === "free_procedure"
                   ? benefit?.displayText || "Um cuidado especial para celebrar o seu momento."
-                  : "Confirme sua entrada para revelar a condição preparada para você.";
-        const meta =
-            kind === "discount" && benefit?.discount
-                ? formatRewardDiscount(benefit.discount)
-                : kind === "free_procedure"
-                  ? "Procedimento gratuito"
-                  : kind === "velocity"
-                    ? "Seu movimento também faz parte da celebração"
-                    : "Carta final da celebração";
+                  : "Um presente preparado para acompanhar o seu momento.";
+        const specialCardWhatsappLabel = /whatsapp/i.test(primaryWhatsappLabel)
+            ? primaryWhatsappLabel
+            : `${primaryWhatsappLabel} no WhatsApp`;
 
         return (
             <article
-                ref={interactive ? specialCardReopenCardRef : undefined}
-                className={`${styles.specialCard} ${interactive ? styles.specialCardReopenCard : ""}`.trim()}
+                className={styles.specialCard}
                 data-special-state={revealed ? "revealed" : "locked"}
-                role={interactive ? "button" : undefined}
-                tabIndex={interactive ? 0 : undefined}
-                aria-label={interactive ? "Revelar sua carta especial" : revealed ? `Carta especial: ${title}` : "Carta especial reservada"}
-                onClick={interactive ? openSpecialCardModal : undefined}
-                onKeyDown={interactive ? handleSpecialCardReopenKeyDown : undefined}
+                aria-label={revealed ? `Carta especial: ${title}` : "Carta especial reservada"}
             >
                 <div className={styles.specialCardInner}>
                     <div
@@ -1780,22 +1794,22 @@ export default function BeautyMovementExperience({
                         <BrandMark className={styles.specialCardBrand} loading="eager" tone="light" title="" />
                         <span className={styles.specialCardBackLabel}>CARTA ESPECIAL</span>
                         <strong>A soma da sua leitura está pronta.</strong>
-                        <span>Confirme sua entrada para revelar a sua carta especial.</span>
                         {showRevealAction ? (
                             <div
                                 className={styles.specialCardRevealAction}
                                 ref={(node) => {
-                                    confirmationActionRef.current = node;
+                                    if (action === "confirm") confirmationActionRef.current = node;
                                 }}
                             >
-                                {actionError ? <p className={styles.specialCardRevealError} role="alert">{actionError}</p> : null}
+                                {action === "confirm" && actionError ? <p className={styles.specialCardRevealError} role="alert">{actionError}</p> : null}
                                 <button
+                                    ref={action === "reopen" ? specialCardReopenActionRef : undefined}
                                     className={styles.primaryButton}
                                     type="button"
-                                    onClick={() => void handleConfirm()}
-                                    disabled={isConfirming}
+                                    onClick={action === "confirm" ? () => void handleConfirm() : openSpecialCardModal}
+                                    disabled={action === "confirm" ? isConfirming : undefined}
                                 >
-                                    {isConfirming ? "Revelando…" : "Clique aqui para revelar sua carta especial"}
+                                    {action === "confirm" && isConfirming ? "Revelando…" : "Clique aqui para revelar sua carta especial"}
                                 </button>
                             </div>
                         ) : null}
@@ -1810,7 +1824,12 @@ export default function BeautyMovementExperience({
                         </span>
                         <strong>{title}</strong>
                         <span className={styles.specialCardCopy}>{description}</span>
-                        <span className={styles.specialCardMeta}>{meta}</span>
+                        {revealed
+                            ? renderWhatsappAction(
+                                `${styles.primaryButton} ${styles.specialCardWhatsappAction}`,
+                                specialCardWhatsappLabel,
+                            )
+                            : null}
                     </div>
                 </div>
             </article>
@@ -1916,24 +1935,7 @@ export default function BeautyMovementExperience({
                 ) : null}
 
                 <div className={styles.resultActions}>
-                    {isLocalPreview ? (
-                        <button className={styles.primaryButton} type="button" onClick={handleWhatsappClick}>
-                            {primaryWhatsappLabel}
-                        </button>
-                    ) : initialState.campaign.whatsappMessage?.trim() ? (
-                        <BeautyMovementWhatsappLink
-                            className={styles.primaryButton}
-                            message={initialState.campaign.whatsappMessage.trim()}
-                            placement="result"
-                            onClick={handleWhatsappClick}
-                        >
-                            {primaryWhatsappLabel}
-                        </BeautyMovementWhatsappLink>
-                    ) : (
-                        <button className={styles.primaryButton} type="button" disabled>
-                            {primaryWhatsappLabel}
-                        </button>
-                    )}
+                    {renderWhatsappAction(styles.primaryButton)}
                     <button className={styles.secondaryButton} type="button" onClick={() => void handleShare()}>
                         Preparar Story para compartilhar
                     </button>
@@ -1955,6 +1957,7 @@ export default function BeautyMovementExperience({
                     <h1 id="beauty-movement-title">{initialState.campaign.title?.trim() || "Beleza que se move com você."}</h1>
                     <p
                         className={`${styles.heroDeckInstruction} ${waitingForInitialDeal ? "" : styles.heroDeckInstructionHidden}`.trim()}
+                        id="beauty-movement-deck-prompt"
                         aria-hidden={!waitingForInitialDeal || undefined}
                     >
                         Clique no baralho para começar a sua leitura
@@ -2144,7 +2147,7 @@ export default function BeautyMovementExperience({
                                 aria-label="Carta especial da celebração"
                             >
                                 {!isLocalPreview ? renderConfirmationAction() : null}
-                                {renderSpecialCard(false, isLocalPreview)}
+                                {renderSpecialCard(false, isLocalPreview ? "confirm" : "none")}
                             </div>
                         ) : finaleStage === "result" ? (
                             <div
@@ -2152,7 +2155,7 @@ export default function BeautyMovementExperience({
                                 role="group"
                                 aria-label="Carta especial do benefício"
                             >
-                                {renderSpecialCard(false, false, !isSpecialCardModalOpen)}
+                                {renderSpecialCard(false, "reopen")}
                             </div>
                         ) : finaleStage === "hidden" && introStage === "hidden" && handStage !== "waiting" && handStage !== "prompt" && handStage !== "prompt-out" ? (
                             <div className={styles.cardGrid} role="group" aria-label={`Cartas da etapa ${tableDefinition.label}`}>

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -190,7 +190,7 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(heroInstructionMarkup, /<p\s+className=\{`\$\{styles\.heroDeckInstruction\} \$\{waitingForInitialDeal \? "" : styles\.heroDeckInstructionHidden\}`\.trim\(\)\}/);
     assert.match(heroInstructionMarkup, /aria-hidden=\{!waitingForInitialDeal \|\| undefined\}/);
     assert.doesNotMatch(heroInstructionMarkup, /<(?:button|a)\b|onClick=|onKeyDown=|tabIndex=|aria-label=/);
-    assert.doesNotMatch(experience, /id="beauty-movement-deck-prompt"/);
+    assert.match(heroInstructionMarkup, /id="beauty-movement-deck-prompt"/);
     assert.equal((experience.match(/onClick=\{startInitialDeal\}/g) ?? []).length, 1);
     assert.match(experience, /Clique no baralho para começar a sua leitura/);
     assert.match(experience, /className=\{styles\.tableDeckPromptArrow\}/);
@@ -210,7 +210,7 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(experience, /setIsSpecialCardModalOpen\(confirmed\)/);
     assert.match(experience, /function closeSpecialCardModal|const closeSpecialCardModal/);
     assert.match(experience, /Fechar carta especial/);
-    assert.match(experience, /Revelar sua carta especial/);
+    assert.match(experience, /Clique aqui para revelar sua carta especial/);
     assert.match(experience, /key=\{introStage !== "hidden" \? "experience-intro" : tableDefinition\.id\}/);
     assert.match(experience, /styles\.tablePromptIntro/);
     assert.match(experience, /styles\.tablePromptIntroHolding/);
@@ -239,7 +239,7 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(styles, /@keyframes cardFlipAndSettle/);
     assert.match(styles, /@keyframes cardSparkle/);
     assert.match(styles, /@keyframes deckDealPulse/);
-    assert.match(styles, /@keyframes deckReceivePulse/);
+    assert.doesNotMatch(styles, /@keyframes deckReceivePulse/);
     assert.match(styles, /@keyframes deckStageDeal/);
     assert.match(styles, /@keyframes deckStageExpand/);
     assert.match(styles, /@keyframes deckStageCollect/);
@@ -259,6 +259,10 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.doesNotMatch(
         styles,
         /\.tableStage\[data-hand-stage="reveal"\] \.cardButton:not\(\.cardButtonSelected\)[^}]*animation:\s*cardReturnToDeck/,
+    );
+    assert.doesNotMatch(
+        styles,
+        /\.tableStage\[data-hand-stage="reveal"\] \.deck(?:Stage|CardTop)\s*\{[^}]*animation:/,
     );
     assert.doesNotMatch(
         styles,
@@ -317,6 +321,7 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(styles, /@keyframes deckPromptArrowFloat/);
     assert.match(styles, /\.progressRowWaiting \{[\s\S]*min-height: 52px/);
     assert.match(styles, /\.progressRowWaiting \.progressGroup \{[\s\S]*visibility: hidden[\s\S]*pointer-events: none/);
+    assert.match(styles, /\.progressRow:not\(\.progressRowWaiting\) \{[\s\S]*?transform: translateY\(-38px\);/);
     assert.doesNotMatch(styles, /\.initialDeckPrompt/);
     assert.match(styles, /\.heroDeckInstruction/);
     assert.doesNotMatch(styles, /\.tableDeckPrompt \{|\.deckPrompt \{|\.deckPromptArrow \{/);
@@ -333,13 +338,14 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(styles, /\.tablePrompt \{[\s\S]*padding: 0;[\s\S]*border: 0;[\s\S]*background: transparent;[\s\S]*box-shadow: none;/);
     assert.match(styles, /\.specialCardStage \{[\s\S]*gap: 0;/);
     assert.match(styles, /\.specialCardStageReopen \{[\s\S]*min-height: 430px/);
-    assert.match(styles, /\.specialCardReopenCard \{[\s\S]*cursor: pointer/);
+    assert.doesNotMatch(styles, /\.specialCardReopenCard/);
     assert.match(styles, /\.specialCardModalOverlay \{[\s\S]*--bm-ink: #303030[\s\S]*position: fixed[\s\S]*backdrop-filter: blur\(10px\)/);
     assert.match(styles, /\.specialCardModalDialog \{[\s\S]*place-items: center/);
     assert.match(styles, /\.specialCardModalClose \{[\s\S]*position: absolute/);
     assert.match(styles, /@keyframes specialCardModalBackdropEnter/);
     assert.match(styles, /\.specialCardRevealAction \{[\s\S]*gap: 7px;[\s\S]*width: min\(100%, 282px\)/);
-    assert.match(styles, /\.specialCardBackWithAction \{[\s\S]*padding: 24px/);
+    assert.match(styles, /\.specialCardBackWithAction \{[\s\S]*justify-content: flex-start[\s\S]*padding: 32px 24px 20px/);
+    assert.match(styles, /\.specialCardWhatsappAction \{[\s\S]*background: var\(--bm-yellow\)/);
     assert.match(styles, /\.promptWord \{[\s\S]*animation: promptWordMaterialize/);
     assert.match(styles, /\.promptTitle,[\s\S]*\.promptSubtitle \{[\s\S]*display: block/);
     assert.match(styles, /@keyframes promptWordMaterialize/);
@@ -392,20 +398,26 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(experience, /aria-hidden=\{!isSelected\}/);
     assert.match(experience, /BeautyMovementCardIllustration/);
     assert.match(experience, /function renderSpecialCard/);
-    assert.match(experience, /function renderSpecialCard\(revealed: boolean, showRevealAction = false, interactive = false\)/);
+    assert.match(experience, /type SpecialCardAction = "none" \| "confirm" \| "reopen"/);
+    assert.match(experience, /function renderSpecialCard\(revealed: boolean, action: SpecialCardAction = "none"\)/);
     assert.match(experience, /className=\{styles\.specialCardRevealAction\}/);
     assert.match(experience, /Garantir presente e confirmar presença/);
     assert.match(experience, /if \(!operationalConsent && !isLocalPreview\) return;/);
-    assert.match(experience, /Confirme sua entrada para revelar a sua carta especial/);
+    assert.doesNotMatch(experience, /Confirme sua entrada para revelar a sua carta especial/);
+    assert.doesNotMatch(experience, /Sua aula será confirmada pela equipe da unidade após o contato/);
+    assert.match(experience, /Seu movimento também faz parte da celebração/);
+    assert.match(experience, /styles\.specialCardWhatsappAction/);
     assert.match(experience, /finaleStage === "confirmation" \?/);
     assert.match(experience, /!isLocalPreview \? renderConfirmationAction\(\) : null/);
-    assert.match(experience, /renderSpecialCard\(false, isLocalPreview\)/);
-    assert.match(experience, /renderSpecialCard\(false, false, !isSpecialCardModalOpen\)/);
+    assert.match(experience, /renderSpecialCard\(false, isLocalPreview \? "confirm" : "none"\)/);
+    assert.match(experience, /renderSpecialCard\(false, "reopen"\)/);
     assert.doesNotMatch(experience, /specialCardPrompt|Sua carta especial está pronta\./);
     assert.match(experience, /Clique aqui para revelar sua carta especial/);
     assert.match(experience, /finaleCardGridMerging/);
     assert.match(experience, /Carta especial do benefício/);
-    assert.match(experience, /role=\{interactive \? "button" : undefined\}/);
+    assert.match(experience, /ref=\{action === "reopen" \? specialCardReopenActionRef : undefined\}/);
+    assert.match(experience, /onClick=\{action === "confirm" \? \(\) => void handleConfirm\(\) : openSpecialCardModal\}/);
+    assert.doesNotMatch(experience, /role=\{interactive \? "button" : undefined\}/);
     assert.doesNotMatch(experience, /aria-label="Cartas finais"/);
     assert.match(experience, /function drawStoryCardIllustration/);
     assert.match(experience, /drawStoryCardIllustration\(context, line\.cardId/);

--- a/website/tests/beautyMovementLocalPreview.test.ts
+++ b/website/tests/beautyMovementLocalPreview.test.ts
@@ -16,6 +16,7 @@ test("local preview is synthetic, blocks production, and cannot open the real Wh
     assert.match(preview, /isLocalPreview/);
     assert.doesNotMatch(preview, /\/api\/beleza-em-movimento/);
     assert.doesNotMatch(preview, /trackEvent|trackSiteBehaviorEvent/);
-    assert.match(experience, /isLocalPreview \? \(/);
+    assert.match(experience, /if \(isLocalPreview\) \{/);
+    assert.match(experience, /<button className=\{className\} type="button" onClick=\{handleWhatsappClick\}>/);
     assert.match(experience, /Prévia local: a abertura do WhatsApp foi simulada\./);
 });


### PR DESCRIPTION
# Summary
- transforma a instrução inicial da hero em subtítulo estático; o baralho permanece como único gatilho da leitura;
- remove a repetição da animação de distribuição ao revelar uma carta e aproxima as categorias do título sem deslocar a mesa;
- refina a carta especial: CTA amarelo persistente para reabertura, composição mais limpa e modal com CTA de WhatsApp e copy de celebração.

## Type of change
- [x] Bug fix
- [x] Enhancement
- [ ] Breaking change
- [ ] Documentation update

## Validation
- `npm run website:test` — 133 testes aprovados
- lint, TypeScript sem emissão e build do website aprovados
- `git diff --check` aprovado
- prévia local isolada: listener na porta 3417, HTTP 200 e conteúdo da rota confirmados
- jornada desktop e mobile: início, primeira mão sem layout shift, três escolhas, avanço automático, fusão final, modal, fechamento e reabertura por clique e teclado
- console da jornada: 0 erros e 0 avisos

## Risk and rollback
- Escopo somente de interface da experiência Beauty Movement; sem APIs, schema, flags, dados, dependências ou deploy.
- Rollback: reverter o commit squash desta PR em uma nova branch governada.

## Links
- Issue: N/A
- Migration: N/A
- Deploy: não solicitado