### PR TITLE
fix(ponto): allow closure-equivalent main drift

### DIFF
--- a/.github/scripts/ponto-dispatch-workflow.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.mjs
@@ -74,13 +74,21 @@ export function assertPontoDependencyClosureUnchanged(orchestratorDigest, mainDi
   return assertDependencyClosureUnchanged(orchestratorDigest, mainDigest);
 }
 
-export function assertPontoReleaseIsCurrentMain(releaseSha, currentMainSha) {
+export function assertPontoReleaseIsCurrentMain(
+  releaseSha,
+  currentMainSha,
+  assertReleaseSource = assertPontoSourceClosureUnchanged,
+) {
   const release = String(releaseSha || "").trim().toLowerCase();
   const currentMain = String(currentMainSha || "").trim().toLowerCase();
   if (!FULL_SHA.test(release)) throw new Error("Ponto release SHA must be a full SHA");
   if (!FULL_SHA.test(currentMain)) throw new Error("current main SHA is unavailable");
   if (release !== currentMain) {
-    throw new Error("Ponto release SHA no longer equals current main");
+    try {
+      assertReleaseSource(release, currentMain);
+    } catch (error) {
+      throw new Error("Ponto release dependency closure no longer matches current main", { cause: error });
+    }
   }
   return { releaseSha: release, currentMainSha: currentMain };
 }

--- a/.github/scripts/ponto-dispatch-workflow.test.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.test.mjs
@@ -87,15 +87,26 @@ test("child dispatch keeps an immutable release valid across unrelated main chan
   );
 });
 
-test("child dispatch refuses a release SHA after main advances", () => {
+test("child dispatch accepts unrelated main drift only with an equivalent Ponto closure", () => {
   const releaseSha = "a".repeat(40);
+  const unrelatedMainSha = "b".repeat(40);
   assert.deepEqual(
     assertPontoReleaseIsCurrentMain(releaseSha, releaseSha),
     { releaseSha, currentMainSha: releaseSha },
   );
+  assert.deepEqual(
+    assertPontoReleaseIsCurrentMain(releaseSha, unrelatedMainSha, (release, currentMain) => {
+      assert.equal(release, releaseSha);
+      assert.equal(currentMain, unrelatedMainSha);
+      return { release, observed: currentMain, digest: "c".repeat(64) };
+    }),
+    { releaseSha, currentMainSha: unrelatedMainSha },
+  );
   assert.throws(
-    () => assertPontoReleaseIsCurrentMain(releaseSha, "b".repeat(40)),
-    /no longer equals current main/,
+    () => assertPontoReleaseIsCurrentMain(releaseSha, unrelatedMainSha, () => {
+      throw new Error("a relevant dependency-closure input changed after the immutable release was selected");
+    }),
+    /dependency closure no longer matches current main/,
   );
 });
 


### PR DESCRIPTION
## Context\nA website-only merge advanced main after an immutable Ponto candidate had passed its publishing gates. The dispatcher then rejected the candidate solely because its SHA no longer exactly matched main, triggering a safe rollback before the authenticated staging journey.\n\n## Change\nAccept a differing main SHA only after the existing Ponto source dependency-closure attestation proves it is equivalent. Any relevant Ponto closure drift remains fail-closed. The immutable release identity is unchanged.\n\n## Validation\n- targeted Ponto dispatcher, lease, and reconciliation tests: 54 passing\n- 
pm run architecture:validate\n- 
pm run codex:global-coordination:test: 197 passing\n- real closure-equivalence and relevant-drift rejection checks against current commits\n\n## Operational safety\nNo production configuration or runtime mutation is included. The completed preview 31740863885 was allowed to reach its terminal state before this PR was opened.