### PR TITLE
fix(escala): restore coordinated auth secret sync

### DIFF
--- a/.github/scripts/validate-deploy-topology.mjs
+++ b/.github/scripts/validate-deploy-topology.mjs
@@ -217,6 +217,7 @@ const pagesSecretWriters = [
   '.github/workflows/cloudflare-pages-sync-meta-ads-report-secret.yml',
   '.github/workflows/cloudflare-sync-integrations-encryption-secret.yml',
 ];
+const escalaSecretSync = read('.github/workflows/cloudflare-pages-sync-escala.yml');
 const trustedGateCheckout = [
   'ref: ${{ github.sha }}',
   'ref: ${{ github.workflow_sha }}',
@@ -610,6 +611,14 @@ for (const workflow of pagesSecretWriters) {
   ) {
     fail(`${workflow} must serialize every CRM Pages secret mutation with the global Ponto surface mutex and never dispatch the retired auxiliary publisher`);
   }
+}
+const activeCoordinationKey = "shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY || secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}";
+const activeCoordinationKeyId = "key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || 'legacy-v1' }}";
+if (
+  escalaSecretSync.split(activeCoordinationKey).length - 1 !== 5
+  || escalaSecretSync.split(activeCoordinationKeyId).length - 1 !== 5
+) {
+  fail('Escala secret synchronization must use the active global coordination key and key ID at every lease boundary');
 }
 if (
   !timekeepingPublisher.includes('default: ponto')

--- a/.github/workflows/cloudflare-pages-sync-escala.yml
+++ b/.github/workflows/cloudflare-pages-sync-escala.yml
@@ -50,7 +50,8 @@ jobs:
           required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY || secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || 'legacy-v1' }}
           resource: global:crm-cloudflare-writer
           module: escala-api
           source_sha: ${{ github.sha }}
@@ -66,7 +67,8 @@ jobs:
           source_sha: ${{ github.sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY || secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || 'legacy-v1' }}
 
       - name: Sync Pages secret (Escala) by environment
         env:
@@ -91,7 +93,8 @@ jobs:
           source_sha: ${{ github.sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY || secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || 'legacy-v1' }}
 
       - name: Cleanup duplicate production secret binding (Escala target)
         env:
@@ -116,7 +119,8 @@ jobs:
           source_sha: ${{ github.sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY || secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || 'legacy-v1' }}
 
       - name: Sync Worker secret (Escala API) by environment
         if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -168,5 +172,6 @@ jobs:
         with:
           required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY || secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || 'legacy-v1' }}
           proof_file: ${{ runner.temp }}/skincos-global-coordination-escala-api-sync.json


### PR DESCRIPTION
## Diagnosis\nThe scheduled Escala auth-secret synchronization failed before any Cloudflare mutation because its global coordination calls omitted the active key identifier and used the legacy shared-secret path. The production coordinator rejected the acquire request fail-closed.\n\n## Change\n- Pass the active coordination key with the legacy fallback at every Escala lease boundary.\n- Pass the active coordination key ID with the legacy fallback at acquire, checks, and release.\n- Add a regression test that covers all five boundaries.\n\n## Validation\n- git diff --check\n- hosted CI will run the Ponto dispatcher contract test, architecture validation, security audit, and Timekeeping CI.\n\n## Safety\nThis PR changes workflow custody wiring only; it does not write any Cloudflare secret or deploy a runtime.