### PR TITLE
fix(ponto): accept closure-equivalent coordinator drift

### DIFF
--- a/.github/scripts/ponto-dispatch-workflow.test.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.test.mjs
@@ -145,6 +145,21 @@ test("Ponto recovery keeps provenance fail-closed while accepting a closure-equi
   assert.doesNotMatch(recovery, /coordinator\.head_sha !== releaseSha/);
 });
 
+test("Ponto coordinator accepts only closure-equivalent main drift after pinning the exact release checkout", () => {
+  const progressive = fs.readFileSync(
+    new URL("../workflows/ponto-progressive-release.yml", import.meta.url),
+    "utf8",
+  );
+  const source = progressive.slice(
+    progressive.indexOf("Verify immutable source and ordered predecessor provenance"),
+    progressive.indexOf("Acquire the composite Ponto release lease before gate settlement"),
+  );
+  assert.match(source, /\[\[ "\$\(git rev-parse HEAD\)" == "\$RELEASE_SHA" \]\]/);
+  assert.match(source, /current_main_sha="\$\(git rev-parse origin\/main\)"/);
+  assert.match(source, /\["current main", process\.env\.PONTO_CURRENT_MAIN_SHA\]/);
+  assert.doesNotMatch(source, /\[\[ "\$\(git rev-parse origin\/main\)" == "\$RELEASE_SHA" \]\]/);
+});
+
 test("Ponto child mutations expose the canonical global resource and conflict scope", () => {
   assert.equal(globalResourceFor("deploy-timekeeping.yml", { release_scope: "ponto", target: "preview" }), "global:ponto-workers-writer");
   assert.equal(globalResourceFor("deploy-core-workers.yml", { release_scope: "ponto", unit: "inventory", target: "preview" }), "global:ponto-workers-writer");

--- a/.github/scripts/ponto-production-baseline.test.mjs
+++ b/.github/scripts/ponto-production-baseline.test.mjs
@@ -256,17 +256,16 @@ test("baseline workflow, reusable gate, and coordinator retain every exported Wo
   ]) assert.ok(reuse.includes(required), `baseline reuse misses strict provenance: ${required}`);
 });
 
-test("coordinator and reusable release gate require the exact current main SHA", () => {
+test("coordinator and reusable release gate accept only closure-equivalent current main drift", () => {
   for (const name of [
     "ponto-progressive-release.yml",
     "ponto-release-gate.yml",
   ]) {
     const source = fs.readFileSync(new URL(`../workflows/${name}`, import.meta.url), "utf8");
-    assert.match(
-      source,
-      /\[\[ "\$\(git rev-parse origin\/main\)" == "\$RELEASE_SHA" \]\] \|\| \{ echo 'release_sha must equal current origin\/main'; exit 1; \}/,
-      name,
-    );
+    assert.match(source, /\[\[ "\$\(git rev-parse HEAD\)" == "\$RELEASE_SHA" \]\]/, name);
+    assert.match(source, /current_main_sha="\$\(git rev-parse origin\/main\)"/, name);
+    assert.match(source, /assertPontoSourceClosureUnchanged/, name);
+    assert.doesNotMatch(source, /\[\[ "\$\(git rev-parse origin\/main\)" == "\$RELEASE_SHA" \]\]/, name);
     assert.doesNotMatch(
       source,
       /git merge-base --is-ancestor "\$RELEASE_SHA" origin\/main/,

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -148,7 +148,6 @@ jobs:
           [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'immutable Ponto coordinator workflow SHA is invalid'; exit 1; }
           [[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]] || { echo 'checkout differs from release_sha'; exit 1; }
           git fetch --no-tags origin main
-          [[ "$(git rev-parse origin/main)" == "$RELEASE_SHA" ]] || { echo 'release_sha must equal current origin/main'; exit 1; }
           current_main_sha="$(git rev-parse origin/main)"
           PONTO_RELEASE_SHA="$RELEASE_SHA" PONTO_WORKFLOW_SHA="$GITHUB_SHA" PONTO_CURRENT_MAIN_SHA="$current_main_sha" node --input-type=module <<'NODE'
           import { assertPontoSourceClosureUnchanged } from "./.github/scripts/ponto-source-closure.mjs";

--- a/.github/workflows/ponto-release-gate.yml
+++ b/.github/workflows/ponto-release-gate.yml
@@ -128,7 +128,18 @@ jobs:
           [[ "$PREDECESSOR_RUN_ID" =~ ^[0-9]+$ ]] || { echo 'predecessor_run_id must be numeric'; exit 1; }
           [[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]] || { echo 'checkout differs from release_sha'; exit 1; }
           git fetch --no-tags origin main
-          [[ "$(git rev-parse origin/main)" == "$RELEASE_SHA" ]] || { echo 'release_sha must equal current origin/main'; exit 1; }
+          current_main_sha="$(git rev-parse origin/main)"
+          PONTO_RELEASE_SHA="$RELEASE_SHA" PONTO_CURRENT_MAIN_SHA="$current_main_sha" node --input-type=module <<'NODE'
+          import { assertPontoSourceClosureUnchanged } from "./.github/scripts/ponto-source-closure.mjs";
+          try {
+            assertPontoSourceClosureUnchanged(
+              process.env.PONTO_RELEASE_SHA,
+              process.env.PONTO_CURRENT_MAIN_SHA,
+            );
+          } catch {
+            throw new Error("current main differs from the immutable Ponto release dependency closure");
+          }
+          NODE
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PREDECESSOR_RUN_ID" > "$RUNNER_TEMP/predecessor-run.json"
           gh api "repos/$GITHUB_REPOSITORY/actions/workflows/ponto-progressive-release.yml" > "$RUNNER_TEMP/predecessor-workflow.json"
           node - "$RUNNER_TEMP/predecessor-run.json" "$RUNNER_TEMP/predecessor-workflow.json" <<'NODE'


### PR DESCRIPTION
## Context
A Ponto staging coordinator failed before mutation in run 31744702017 because its root workflow still required `release_sha` to equal the moving `origin/main`, even though the dispatcher already allows a closure-equivalent main revision.

## Change
Keep the exact immutable checkout requirement, then attest the observed `main` through the existing Ponto dependency-closure guard. A relevant Ponto closure change remains fail-closed. Add a regression assertion for the root workflow.

## Validation
- `node --test .github/scripts/ponto-dispatch-workflow.test.mjs .github/scripts/ponto-reconcile-children.test.mjs scripts/tests/global-concurrency-governance-static.test.mjs` (37 passing)
- `git diff --check`