### PR TITLE
fix(site): align Beauty Movement table with category motion

### DIFF
--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -110,10 +110,10 @@
   pointer-events: none;
 }
 
-.progressRow:not(.progressRowWaiting) {
+.tableStageShifted {
   /* Reuse the instruction's reserved space once the first hand begins.
-   * Keeping the row in normal flow avoids moving the table surface, while
-   * the visual offset lets the category read as the hero subtitle. */
+   * The category row and the complete table move as one visual group, while
+   * their normal-flow space stays intact to avoid a layout shift. */
   transform: translateY(-38px);
 }
 

--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -1966,7 +1966,7 @@ export default function BeautyMovementExperience({
 
                 <section
                     ref={tableRef}
-                    className={styles.tableStage}
+                    className={`${styles.tableStage} ${waitingForInitialDeal ? "" : styles.tableStageShifted}`.trim()}
                     id="mesa-de-cartas"
                     aria-label={tableDefinition.label}
                     aria-describedby={tablePromptText ? "table-stage-prompt" : undefined}

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -28,7 +28,10 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
         assert.match(route, /<Footer \/>/);
     }
 
-    assert.match(experience, /className=\{styles\.tableStage\}/);
+    assert.match(
+        experience,
+        /className=\{`\$\{styles\.tableStage\} \$\{waitingForInitialDeal \? "" : styles\.tableStageShifted\}`\.trim\(\)\}/,
+    );
     assert.match(experience, /id="mesa-de-cartas"/);
     assert.match(experience, /data-hand-stage=\{handStage\}/);
     assert.match(experience, /const tableIsBusy =/);
@@ -321,7 +324,7 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(styles, /@keyframes deckPromptArrowFloat/);
     assert.match(styles, /\.progressRowWaiting \{[\s\S]*min-height: 52px/);
     assert.match(styles, /\.progressRowWaiting \.progressGroup \{[\s\S]*visibility: hidden[\s\S]*pointer-events: none/);
-    assert.match(styles, /\.progressRow:not\(\.progressRowWaiting\) \{[\s\S]*?transform: translateY\(-38px\);/);
+    assert.match(styles, /\.tableStageShifted \{[\s\S]*?transform: translateY\(-38px\);/);
     assert.doesNotMatch(styles, /\.initialDeckPrompt/);
     assert.match(styles, /\.heroDeckInstruction/);
     assert.doesNotMatch(styles, /\.tableDeckPrompt \{|\.deckPrompt \{|\.deckPromptArrow \{/);


### PR DESCRIPTION
## Resumo
- Move a categoria e toda a mesa de cartas pelo `tableStage`, mantendo categorias, superfície branca, textos, cartas, baralho e elementos decorativos no mesmo grupo visual.
- Preserva o espaço no fluxo normal para evitar layout shift quando a primeira categoria entra em relevância.
- Atualiza o teste contínuo para proteger a classe e a semântica do subtítulo não clicável; o único gatilho inicial continua sendo o baralho.

## Validação local
- Prévia candidata: `http://localhost:3427/beleza-em-movimento/local-preview`
- Listener ativo, HTTP 200 e conteúdo da rota confirmados.
- Desktop: início, entrada da primeira categoria, box/cartas/baralho deslocados juntos, três seleções, avanço automático, fusão final, modal, fechamento e reabertura.
- Mobile 390x844: categorias acima da mesa, cartas em coluna, sem corte; reabertura por Enter e fechamento por Escape.
- Console: 0 erros e 0 warnings.

## Checks
- `website:test`: 134/134
- `website/lint`: passou
- `website:typecheck`: passou; build Next.js e TypeScript sem emissão concluídos
- `git diff --check`: passou

## Escopo e rollback
- Sem APIs, schema, dependências ou deploy.
- Rollback: reverter o commit desta PR.