### PR TITLE
fix(ponto): recover closure-equivalent staging

### DIFF
--- a/.github/scripts/ponto-reconcile-children.test.mjs
+++ b/.github/scripts/ponto-reconcile-children.test.mjs
@@ -130,12 +130,20 @@ test("failure recovery latches before reconciliation and mutexes maintenance plu
   const reconciliationJob = workflow.slice(reconcile, close);
   const closeJob = workflow.slice(close, rollback);
   const rollbackJob = workflow.slice(rollback);
+  const initialization = workflow.slice(
+    workflow.indexOf("Initialize private release artifact directory"),
+    workflow.indexOf("Verify immutable source and ordered predecessor provenance"),
+  );
+  assert.match(initialization, /recovery-intent\.json/);
+  assert.match(initialization, /phase: "pre-mutation"/);
   assert.match(latchJob, /ponto-emergency-latch-write\.mjs/);
   assert.match(latchJob, /Attempt external overlay propagation before reconciliation/);
   assert.match(latchJob, /PONTO_MODULE_EXPECTED_SOURCE=emergency-latch-active/);
   assert.match(latchJob, /pendingPrimaryClose: propagation\.passed !== true/);
   assert.doesNotMatch(latchJob, /concurrency:\s*\n\s*group:\s*ponto-surface-mutation/);
   assert.match(reconciliationJob, /Cancel and reconcile children without waiting on the surface mutex/);
+  assert.match(reconciliationJob, /Download the durable recovery journal/);
+  assert.match(reconciliationJob, /id: rollback_requirement/);
   assert.doesNotMatch(reconciliationJob, /concurrency:\s*\n\s*group:\s*ponto-surface-mutation/);
   assert.match(closeJob, /concurrency:\s*\n\s*group:\s*ponto-surface-mutation[\s\S]*ponto-emergency-maintenance-write\.mjs/);
   assert.match(closeJob, /Prove external fail-close through overlay or exact incumbent control/);
@@ -144,6 +152,7 @@ test("failure recovery latches before reconciliation and mutexes maintenance plu
   assert.match(closeJob, /\["control", "emergency-latch-active"\]\.includes\(availability\?\.source\)/);
   assert.match(rollbackJob, /needs:\s*\[orchestrate, recovery-reconcile, recovery-close\]/);
   assert.match(rollbackJob, /needs\.recovery-reconcile\.result == 'success'/);
+  assert.match(rollbackJob, /needs\.recovery-reconcile\.outputs\.rollback_required == 'true'/);
   assert.match(rollbackJob, /concurrency:\s*\n\s*group:\s*ponto-surface-mutation[\s\S]*ponto-automatic-rollback\.mjs/);
   const reconciliationStep = reconciliationJob;
   assert.doesNotMatch(reconciliationStep, /continue-on-error:\s*true/);
@@ -192,6 +201,7 @@ test("ordered predecessor provenance is exact and replay resistant before artifa
     workflow.indexOf("Refuse a latched Ponto emergency stop before issuing capabilities"),
   );
   const download = provenance.indexOf("gh run download");
+  assert.doesNotMatch(provenance, /release_sha must equal current origin\/main/);
   for (const contract of [
     /workflow\?\.state !== "active"/,
     /workflow\?\.path !== "\.github\/workflows\/ponto-progressive-release\.yml"/,

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -133,11 +133,32 @@ jobs:
           fetch-depth: 0
       - name: Initialize private release artifact directory
         run: |
-          echo "PONTO_ARTIFACT_DIR=$RUNNER_TEMP/ponto-release" >> "$GITHUB_ENV"
+          artifact_dir="$RUNNER_TEMP/ponto-release"
+          echo "PONTO_ARTIFACT_DIR=$artifact_dir" >> "$GITHUB_ENV"
           if [[ "$STAGE" != "preview" ]]; then
             echo "PONTO_ORCHESTRATOR_COORDINATION_PROOF_FILE=$RUNNER_TEMP/ponto-release/global-coordination-release-ponto.json" >> "$GITHUB_ENV"
           fi
-          mkdir -p "$RUNNER_TEMP/ponto-release"
+          mkdir -p "$artifact_dir"
+          node - "$artifact_dir/recovery-intent.json" <<'NODE'
+          const fs = require("fs");
+          const stage = String(process.env.STAGE || "");
+          const releaseSha = String(process.env.RELEASE_SHA || "").toLowerCase();
+          const coordinatorRunId = String(process.env.GITHUB_RUN_ID || "");
+          if (
+            !["preview", "staging", "pilot", "canary", "production", "rollback"].includes(stage)
+            || !/^[0-9a-f]{40}$/.test(releaseSha)
+            || !/^[1-9][0-9]*$/.test(coordinatorRunId)
+          ) throw new Error("recovery intent identity is invalid");
+          fs.writeFileSync(process.argv[2], `${JSON.stringify({
+            schemaVersion: 1,
+            phase: "pre-mutation",
+            stage,
+            releaseSha,
+            coordinatorRunId,
+            credentialsIncluded: false,
+            piiIncluded: false,
+          })}\n`, { mode: 0o600 });
+          NODE
       - name: Verify immutable source and ordered predecessor provenance
         id: source
         env:
@@ -2011,6 +2032,8 @@ jobs:
   recovery-reconcile:
     needs: [orchestrate, recovery-latch]
     if: ${{ always() && needs.recovery-latch.result == 'success' }}
+    outputs:
+      rollback_required: ${{ steps.rollback_requirement.outputs.required }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -2101,6 +2124,23 @@ jobs:
             fi
             rm -rf "$download_dir"
           done
+      - name: Classify whether exact rollback is required
+        id: rollback_requirement
+        run: |
+          set -euo pipefail
+          node - "$PONTO_RECOVERY_ARTIFACT_ROOT/watchdog-journal.json" <<'NODE'
+          const fs = require("fs");
+          const report = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          if (
+            report?.passed !== true
+            || !Number.isInteger(report?.discoveredChildren)
+            || report.discoveredChildren < 0
+          ) throw new Error("watchdog did not prove the recovery child set");
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `required=${report.discoveredChildren > 0 ? "true" : "false"}\n`,
+          );
+          NODE
       - name: Upload immutable ordinary-recovery reconciliation
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -2256,7 +2296,7 @@ jobs:
 
   recovery-rollback:
     needs: [orchestrate, recovery-reconcile, recovery-close]
-    if: ${{ always() && needs.recovery-reconcile.result == 'success' && needs.recovery-close.result == 'success' && contains(fromJSON('["staging","pilot","canary","production"]'), inputs.stage) }}
+    if: ${{ always() && needs.recovery-reconcile.result == 'success' && needs.recovery-reconcile.outputs.rollback_required == 'true' && needs.recovery-close.result == 'success' && contains(fromJSON('["staging","pilot","canary","production"]'), inputs.stage) }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:


### PR DESCRIPTION
## Objetivo
Restaurar o caminho de staging do Ponto quando `main` avança apenas fora da closure Ponto e tornar a recuperação pré-mutation reprodutível.

## Alterações
- remove a igualdade literal `origin/main == release_sha` e mantém a atestação de closure para o workflow, `main` e predecessor;
- cria um journal mínimo, sem segredos ou PII, antes do preflight;
- classifica rollback somente após o watchdog provar o conjunto de filhos governados; nenhum filho significa manutenção comprovada, sem rollback inventado.

## Risco e rollback
Workflow de release Ponto; defaults permanecem fail-closed. O rollback operacional continua sendo o broker/latch e as versões incumbentes. Reverter esta PR restaura o gate anterior, mas não é necessário para recuperar o estado de manutenção atual.

## Validação local
- `node --test` focal: 47/47
- `npm run architecture:validate`
- `npm run codex:deploy-topology:test`
- digest de closure Ponto idêntico entre `e4d6096` e `695767a` antes deste patch.

## Evidência operacional
O staging `31744702017` falhou antes de qualquer mutação pela igualdade residual; o latch e a manutenção externa foram confirmados pelo recovery automático.