### PR TITLE
fix(ponto): preserve readiness affinity headers

### DIFF
--- a/api/src/router.js
+++ b/api/src/router.js
@@ -105,6 +105,25 @@ function setGatewayReleaseHeaders(headers, env) {
     else headers.delete('x-skincos-gateway-version-tag');
 }
 
+function copyTimekeepingReleaseHeaders(target, upstream) {
+    for (const name of [
+        'x-skincos-timekeeping-release-sha',
+        'x-skincos-timekeeping-version-id',
+        'x-skincos-timekeeping-environment',
+    ]) {
+        const value = String(upstream?.headers?.get(name) || '').trim();
+        if (value) target.set(name, value);
+        else target.delete(name);
+    }
+}
+
+function pontoOperationalResponse(status, env, requestId, ready, dependencyState, upstream) {
+    const response = json(status, pontoOperationalPayload(env, requestId, ready, dependencyState), requestId);
+    setGatewayReleaseHeaders(response.headers, env);
+    copyTimekeepingReleaseHeaders(response.headers, upstream);
+    return response;
+}
+
 function operationalLog(env, requestId, status, route) {
     console.log({
         domain: 'api',
@@ -132,7 +151,7 @@ function pontoOperationalLog(env, requestId, status, route) {
 async function pontoReadiness(request, env, ctx, timekeepingHandler, requestId) {
     if (!hasTimekeepingBinding(env) || typeof timekeepingHandler !== 'function') {
         pontoOperationalLog(env, requestId, 503, '/readiness');
-        return json(503, pontoOperationalPayload(env, requestId, false, 'unavailable'), requestId);
+        return pontoOperationalResponse(503, env, requestId, false, 'unavailable');
     }
 
     const probeUrl = new URL(request.url);
@@ -152,10 +171,10 @@ async function pontoReadiness(request, env, ctx, timekeepingHandler, requestId) 
         await response.body?.cancel().catch(() => {});
         const status = ready ? 200 : 503;
         pontoOperationalLog(env, requestId, status, '/readiness');
-        return json(status, pontoOperationalPayload(env, requestId, ready, ready ? 'healthy' : 'degraded'), requestId);
+        return pontoOperationalResponse(status, env, requestId, ready, ready ? 'healthy' : 'degraded', response);
     } catch {
         pontoOperationalLog(env, requestId, 503, '/readiness');
-        return json(503, pontoOperationalPayload(env, requestId, false, 'unavailable'), requestId);
+        return pontoOperationalResponse(503, env, requestId, false, 'unavailable');
     }
 }
 
@@ -180,7 +199,7 @@ export function createGatewayHandler({ inventoryHandler, timekeepingHandler, fin
             if (request.method === 'GET' && url.pathname === '/health') {
                 const configured = hasTimekeepingBinding(env);
                 pontoOperationalLog(env, requestId, 200, '/health');
-                return json(200, pontoOperationalPayload(env, requestId, configured, configured ? 'configured' : 'unavailable'), requestId);
+                return pontoOperationalResponse(200, env, requestId, configured, configured ? 'configured' : 'unavailable');
             }
 
             if (request.method === 'GET' && url.pathname === '/readiness') {

--- a/api/test/gateway.test.mjs
+++ b/api/test/gateway.test.mjs
@@ -45,15 +45,22 @@ test('Ponto route-only health and readiness use only the Timekeeping binding', a
         inventoryHandler: async () => new Response('must-not-run'),
         timekeepingHandler: async (request) => {
             probePaths.push(new URL(request.url).pathname);
-            return new Response(JSON.stringify({ ok: true, ready: true }), { headers: { 'content-type': 'application/json' } });
+            return new Response(JSON.stringify({ ok: true, ready: true }), {
+                headers: {
+                    'content-type': 'application/json',
+                    'x-skincos-timekeeping-release-sha': 'a'.repeat(40),
+                    'x-skincos-timekeeping-version-id': '33333333-3333-4333-8333-333333333333',
+                    'x-skincos-timekeeping-environment': 'staging',
+                },
+            });
         },
     });
     const env = {
         PONTO_ROUTE_ONLY: 'true',
         TIMEKEEPING: { fetch: async () => new Response('unused') },
-        APP_VERSION: 'baseline-sha',
+        APP_VERSION: 'a'.repeat(40),
         ENVIRONMENT: 'staging',
-        CF_VERSION_METADATA: { id: 'version-id', tag: 'baseline-tag' },
+        CF_VERSION_METADATA: { id: '22222222-2222-4222-8222-222222222222', tag: 'baseline-tag' },
     };
 
     const health = await isolated(new Request('https://ponto-core.invalid/health', { headers: { 'x-request-id': 'ponto-health-1' } }), env, {});
@@ -63,11 +70,19 @@ test('Ponto route-only health and readiness use only the Timekeeping binding', a
     assert.equal(healthBody.ready, true);
     assert.equal(healthBody.dependencies.timekeeping.state, 'configured');
     assert.equal(healthBody.dependencies.d1, undefined);
-    assert.deepEqual(healthBody.version_metadata, { id: 'version-id', tag: 'baseline-tag' });
+    assert.deepEqual(healthBody.version_metadata, { id: '22222222-2222-4222-8222-222222222222', tag: 'baseline-tag' });
+    assert.equal(health.headers.get('x-skincos-gateway-release-sha'), 'a'.repeat(40));
+    assert.equal(health.headers.get('x-skincos-gateway-version-id'), '22222222-2222-4222-8222-222222222222');
 
     const readiness = await isolated(new Request('https://ponto-core.invalid/readiness?ignored=true'), env, {});
     assert.equal(readiness.status, 200);
     assert.equal((await readiness.json()).dependencies.timekeeping.state, 'healthy');
+    assert.equal(readiness.headers.get('x-skincos-gateway-release-sha'), 'a'.repeat(40));
+    assert.equal(readiness.headers.get('x-skincos-gateway-environment'), 'staging');
+    assert.equal(readiness.headers.get('x-skincos-gateway-version-id'), '22222222-2222-4222-8222-222222222222');
+    assert.equal(readiness.headers.get('x-skincos-timekeeping-release-sha'), 'a'.repeat(40));
+    assert.equal(readiness.headers.get('x-skincos-timekeeping-version-id'), '33333333-3333-4333-8333-333333333333');
+    assert.equal(readiness.headers.get('x-skincos-timekeeping-environment'), 'staging');
     assert.deepEqual(probePaths, ['/api/ponto/readiness']);
 });
 


### PR DESCRIPTION
## Summary
- preserve deployment-owned Core release headers on the private Ponto `/health` and `/readiness` probes
- forward only the authoritative Timekeeping release-identity headers from the bound service on readiness
- add a regression test for the exact Core–Timekeeping affinity contract consumed by the protected CRM Pages probe

## Validation
- `api`: `npm test` via the Ubuntu-24.04 wrapper — 32 passing
- `git diff --check`
- the isolated CRM console dependencies were absent; its targeted Vitest run is left to required hosted CI

## Risk and rollback
- probe-response headers only; no runtime flag, migration, account, or route exposure changes
- rollback: `git revert 7b9b9604db144bb5577033ef1b856b4b593f6bfc`
- no secrets or PII included