### PR TITLE
fix(ponto): preserve Core readiness release identity

### DIFF
--- a/api/src/router.js
+++ b/api/src/router.js
@@ -1,12 +1,12 @@
-const json = (status, payload, requestId) =>
-    new Response(JSON.stringify(payload), {
-        status,
-        headers: {
-            'content-type': 'application/json; charset=utf-8',
-            'cache-control': 'no-store',
-            'x-request-id': requestId,
-        },
+const json = (status, payload, requestId, extraHeaders) => {
+    const headers = new Headers({
+        'content-type': 'application/json; charset=utf-8',
+        'cache-control': 'no-store',
+        'x-request-id': requestId,
     });
+    for (const [name, value] of new Headers(extraHeaders || {})) headers.set(name, value);
+    return new Response(JSON.stringify(payload), { status, headers });
+};
 
 function requestIdFor(request) {
     return String(request.headers.get('x-request-id') || request.headers.get('cf-ray') || crypto.randomUUID()).trim();
@@ -149,10 +149,24 @@ async function pontoReadiness(request, env, ctx, timekeepingHandler, requestId) 
     try {
         const response = await timekeepingHandler(probe, env, ctx);
         const ready = response.ok;
+        const releaseHeaders = new Headers();
+        setGatewayReleaseHeaders(releaseHeaders, env);
+        for (const name of [
+            'x-skincos-timekeeping-release-sha',
+            'x-skincos-timekeeping-version-id',
+        ]) {
+            const value = response.headers.get(name);
+            if (value) releaseHeaders.set(name, value);
+        }
         await response.body?.cancel().catch(() => {});
         const status = ready ? 200 : 503;
         pontoOperationalLog(env, requestId, status, '/readiness');
-        return json(status, pontoOperationalPayload(env, requestId, ready, ready ? 'healthy' : 'degraded'), requestId);
+        return json(
+            status,
+            pontoOperationalPayload(env, requestId, ready, ready ? 'healthy' : 'degraded'),
+            requestId,
+            releaseHeaders,
+        );
     } catch {
         pontoOperationalLog(env, requestId, 503, '/readiness');
         return json(503, pontoOperationalPayload(env, requestId, false, 'unavailable'), requestId);

--- a/api/test/gateway.test.mjs
+++ b/api/test/gateway.test.mjs
@@ -41,19 +41,28 @@ test('readiness proves D1 is available and fails closed when it is not', async (
 
 test('Ponto route-only health and readiness use only the Timekeeping binding', async () => {
     const probePaths = [];
+    const releaseSha = 'a'.repeat(40);
+    const coreVersionId = '22222222-2222-4222-8222-222222222222';
+    const timekeepingVersionId = '33333333-3333-4333-8333-333333333333';
     const isolated = createGatewayHandler({
         inventoryHandler: async () => new Response('must-not-run'),
         timekeepingHandler: async (request) => {
             probePaths.push(new URL(request.url).pathname);
-            return new Response(JSON.stringify({ ok: true, ready: true }), { headers: { 'content-type': 'application/json' } });
+            return new Response(JSON.stringify({ ok: true, ready: true }), {
+                headers: {
+                    'content-type': 'application/json',
+                    'x-skincos-timekeeping-release-sha': releaseSha,
+                    'x-skincos-timekeeping-version-id': timekeepingVersionId,
+                },
+            });
         },
     });
     const env = {
         PONTO_ROUTE_ONLY: 'true',
         TIMEKEEPING: { fetch: async () => new Response('unused') },
-        APP_VERSION: 'baseline-sha',
+        APP_VERSION: releaseSha,
         ENVIRONMENT: 'staging',
-        CF_VERSION_METADATA: { id: 'version-id', tag: 'baseline-tag' },
+        CF_VERSION_METADATA: { id: coreVersionId, tag: 'baseline-tag' },
     };
 
     const health = await isolated(new Request('https://ponto-core.invalid/health', { headers: { 'x-request-id': 'ponto-health-1' } }), env, {});
@@ -63,11 +72,15 @@ test('Ponto route-only health and readiness use only the Timekeeping binding', a
     assert.equal(healthBody.ready, true);
     assert.equal(healthBody.dependencies.timekeeping.state, 'configured');
     assert.equal(healthBody.dependencies.d1, undefined);
-    assert.deepEqual(healthBody.version_metadata, { id: 'version-id', tag: 'baseline-tag' });
+    assert.deepEqual(healthBody.version_metadata, { id: coreVersionId, tag: 'baseline-tag' });
 
     const readiness = await isolated(new Request('https://ponto-core.invalid/readiness?ignored=true'), env, {});
     assert.equal(readiness.status, 200);
     assert.equal((await readiness.json()).dependencies.timekeeping.state, 'healthy');
+    assert.equal(readiness.headers.get('x-skincos-gateway-release-sha'), releaseSha);
+    assert.equal(readiness.headers.get('x-skincos-gateway-version-id'), coreVersionId);
+    assert.equal(readiness.headers.get('x-skincos-timekeeping-release-sha'), releaseSha);
+    assert.equal(readiness.headers.get('x-skincos-timekeeping-version-id'), timekeepingVersionId);
     assert.deepEqual(probePaths, ['/api/ponto/readiness']);
 });
 


### PR DESCRIPTION
## Objetivo
Restabelece o contrato de prontidão privado do Ponto: o Core agora repassa somente as identidades de release do Timekeeping e suas próprias identidades ao Pages protegido.

## Superfícies e risco
- Core Ponto / contrato interno Pages-to-Timekeeping.
- Sem migration, flags, grants ou tráfego de produção.
- O comportamento continua fail-closed quando a dependência não está pronta.

## Validação
- `npm --prefix api test` via Ubuntu-24.04: 32/32.
- Teste focal cobre os quatro cabeçalhos de identidade exigidos pelo Pages.

## Rollback
Reverter este commit restaura o Core anterior; a cadeia Ponto permanece em maintenance até o próximo ciclo canônico validado.