### PR TITLE
fix(site): reuse selected cards in Beauty Movement finale

### DIFF
--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -642,7 +642,7 @@
   gap: clamp(14px, 2.8vw, 30px);
   width: min(100%, 920px);
   margin: 2px auto 0;
-  --finale-card-height: 360px;
+  --finale-card-height: clamp(280px, 25vw, 304px);
   --finale-special-card-height: 430px;
 }
 
@@ -735,9 +735,9 @@
   min-height: inherit;
   align-items: stretch;
   flex-direction: column;
-  gap: 14px;
+  gap: 10px;
   overflow: hidden;
-  padding: 28px;
+  padding: 22px;
   border: 1px solid var(--bm-line-strong);
   border-top: 3px solid var(--bm-yellow);
   border-radius: 12px;
@@ -747,8 +747,8 @@
 
 .finaleCardIllustration {
   display: grid;
-  width: 126px;
-  height: 126px;
+  width: 110px;
+  height: 110px;
   place-items: center;
   align-self: center;
   margin: 0 auto 2px;
@@ -774,10 +774,17 @@
 .finaleCardFace strong {
   color: var(--bm-ink);
   font-family: var(--font-brand-ui);
-  font-size: clamp(1.85rem, 3.5vw, 2.8rem);
+  font-size: clamp(1.55rem, 3vw, 2.35rem);
   font-weight: 700;
   letter-spacing: -0.06em;
   line-height: 0.95;
+}
+
+.finaleCardMessage {
+  color: var(--bm-muted);
+  font-family: var(--font-brand-text);
+  font-size: 0.95rem;
+  line-height: 1.55;
 }
 
 .specialCardStage {
@@ -2479,7 +2486,7 @@
   .finaleCardGrid {
     grid-template-columns: 1fr;
     width: min(100%, 420px);
-    --finale-card-height: 334px;
+    --finale-card-height: 280px;
     --finale-special-card-height: 410px;
   }
 

--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -1725,7 +1725,8 @@ export default function BeautyMovementExperience({
                         <BeautyMovementCardIllustration cardId={card.id} />
                     </span>
                     <span className={styles.finaleCardAct}>{line.actLabel}</span>
-                    <strong>{line.title}</strong>
+                    <strong>{card.title}</strong>
+                    <span className={styles.finaleCardMessage}>{card.shortMessage}</span>
                 </div>
             </article>
         );

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -155,6 +155,10 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(experience, /className=\{styles\.cardSparkles\}/);
     assert.match(experience, /className=\{styles\.deckStage\}/);
     assert.match(experience, /className=\{styles\.finaleSpecialCardTransform\}/);
+    assert.match(experience, /function renderFinaleCard\(line: ReturnType<typeof getBeautyMovementReading>\[number\]\)/);
+    assert.match(experience, /<BeautyMovementCardIllustration cardId=\{card\.id\} \/>/);
+    assert.match(experience, /<strong>\{card\.title\}<\/strong>/);
+    assert.match(experience, /<span className=\{styles\.finaleCardMessage\}>\{card\.shortMessage\}<\/span>/);
     assert.match(experience, /type HandStage =\s*\|\s*"waiting"/);
     assert.match(experience, /"expand"\s*\|\s*"deal"/);
     assert.match(experience, /function scheduleDealSequence\(token: number, onReady: \(\) => void\)/);
@@ -290,6 +294,8 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(styles, /@keyframes finaleIllustrationPulse/);
     assert.match(styles, /@keyframes finaleIllustrationPulse[\s\S]*100%[\s\S]*opacity: 1/);
     assert.match(styles, /\.finaleCardGrid/);
+    assert.match(styles, /--finale-card-height: clamp\(280px, 25vw, 304px\)/);
+    assert.match(styles, /\.finaleCardMessage/);
     assert.match(styles, /\.finaleSpecialCardTransform \{/);
     assert.match(styles, /\.tableStage\[data-hand-stage="finale"\] \.deckStage[\s\S]*pointer-events: none/);
     assert.match(styles, /\.tableStage\[data-finale-stage="confirmation"\] \.deckStage,[\s\S]*visibility: hidden/);


### PR DESCRIPTION
## Resumo\n- reutiliza os dados, ilustrações, títulos e mensagens das três cartas escolhidas na reunião final\n- alinha a proporção e a tipografia das cartas finais à carta revelada\n- adiciona cobertura focada para a composição final\n\n## Validação\n- 134 testes do website\n- lint\n- typecheck sem emissão\n- build do website\n- prévia local candidata em :3429: jornada de três seleções até a carta especial, sem erros de console\n- git diff --check\n\nSem deploy; rollback por revert do commit da PR.