### PR TITLE
fix(site): prevent clipping of Beauty Movement finale card

### DIFF
--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -666,6 +666,19 @@
   --finale-rotate: 8deg;
 }
 
+.tableStage[data-hand-stage="finale"] {
+  overflow: visible;
+}
+
+.tableStage[data-hand-stage="finale"] .tableSurface {
+  overflow: visible;
+}
+
+.tableStage[data-hand-stage="finale"] .finaleCardGridMerging {
+  z-index: 4;
+  overflow: visible;
+}
+
 .tableStage[data-hand-stage="finale"] .deckStage,
 .tableStage[data-finale-stage="confirmation"] .deckStage,
 .tableStage[data-finale-stage="result"] .deckStage {

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -297,6 +297,9 @@ test("continuous experience reuses the real shell and keeps the inline finale fl
     assert.match(styles, /--finale-card-height: clamp\(280px, 25vw, 304px\)/);
     assert.match(styles, /\.finaleCardMessage/);
     assert.match(styles, /\.finaleSpecialCardTransform \{/);
+    assert.match(styles, /\.tableStage\[data-hand-stage="finale"\] \{[\s\S]*overflow: visible;/);
+    assert.match(styles, /\.tableStage\[data-hand-stage="finale"\] \.tableSurface \{[\s\S]*overflow: visible;/);
+    assert.match(styles, /\.tableStage\[data-hand-stage="finale"\] \.finaleCardGridMerging \{[\s\S]*z-index: 4;[\s\S]*overflow: visible;/);
     assert.match(styles, /\.tableStage\[data-hand-stage="finale"\] \.deckStage[\s\S]*pointer-events: none/);
     assert.match(styles, /\.tableStage\[data-finale-stage="confirmation"\] \.deckStage,[\s\S]*visibility: hidden/);
     assert.match(styles, /\.specialCardStage/);


### PR DESCRIPTION
## What changed\n\n- Keep the table stage, white surface, and finale merge grid overflow visible while the special card enters.\n- Raise the merging grid above the deck so the three-card fusion and special-card transform render as one uninterrupted layer.\n- Add focused regression assertions for the finale overflow and stacking contract.\n\n## Root cause\n\nThe special card is absolutely positioned and intentionally grows beyond the table surface during the merge. The finale state did not explicitly preserve overflow visibility or the stacking order needed by that transform, so the white table boundary could clip or paint over the entering card.\n\n## Validation\n\n- git diff --check\n- 
pm test (134 passing)\n- 
pm run lint\n- 
pm run typecheck (production build + TypeScript no emit)\n- Candidate preview on port 3429: listener + HTTP 200 + route content\n- Timed browser flow through all three card selections; captured data-finale-stage=merging, verified visible overflow/z-index, and found no console errors or warnings\n\nRollback: revert commit 4678518a.