### PR TITLE
fix(ponto): avoid redundant fresh lease renewal

### DIFF
--- a/.github/actions/global-coordination-check/action.yml
+++ b/.github/actions/global-coordination-check/action.yml
@@ -55,6 +55,7 @@ runs:
         GLOBAL_OBSERVED_SOURCE_SHA: ${{ inputs.observed_source_sha }}
         GLOBAL_ENABLED: ${{ inputs.enabled }}
         GLOBAL_PROOF_FILE: ${{ runner.temp }}/skincos-global-coordination-proof-check.json
+        GLOBAL_CHECK_RESULT: ${{ runner.temp }}/skincos-global-coordination-check-result.json
       run: |
         set -euo pipefail
         [[ "$GLOBAL_ENABLED" == true ]] || { echo 'Global coordination is not active'; exit 1; }
@@ -80,11 +81,40 @@ runs:
         coordination_attempt=1
         coordination_max_attempts=3
         while (( coordination_attempt <= coordination_max_attempts )); do
+          # The lease was often acquired only seconds before this gate.  The
+          # authorization check is the authoritative fail-closed boundary; do
+          # not add an unnecessary remote state mutation while more than five
+          # minutes of the exact lease remain.  When it is due, renew first
+          # and then authorize again against the renewed proof.
           if SKINCOS_GLOBAL_COORDINATOR_URL="$SKINCOS_GLOBAL_COORDINATOR_URL" \
             SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET="$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" \
             SKINCOS_GLOBAL_COORDINATION_KEY_ID="${SKINCOS_GLOBAL_COORDINATION_KEY_ID:-}" \
-              node scripts/codex-global-coordination-workflow.mjs renew \
-                --proof-file "$GLOBAL_PROOF_FILE" && \
+              node scripts/codex-global-coordination-workflow.mjs check \
+                --proof-file "$GLOBAL_PROOF_FILE" \
+                --resource "$GLOBAL_RESOURCE" \
+                --module "$GLOBAL_MODULE" \
+                --source "$GLOBAL_OBSERVED_SOURCE_SHA" \
+                --candidate-source "$GLOBAL_SOURCE_SHA" \
+                --result-file "$GLOBAL_CHECK_RESULT"; then
+            renew_required="$(node - "$GLOBAL_CHECK_RESULT" <<'NODE'
+          const fs = require("fs");
+          const result = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const expiresAt = Number(result?.lease?.expiresAt);
+          if (result?.passed !== true || !Number.isSafeInteger(expiresAt)) {
+            throw new Error("global coordination authorization did not return an exact lease expiry");
+          }
+          process.stdout.write(expiresAt - Date.now() > 5 * 60 * 1000 ? "false" : "true");
+        NODE
+            )" || renew_required="invalid"
+            if [[ "$renew_required" == false ]]; then
+              exit 0
+            fi
+            if [[ "$renew_required" == true ]] && \
+              SKINCOS_GLOBAL_COORDINATOR_URL="$SKINCOS_GLOBAL_COORDINATOR_URL" \
+              SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET="$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" \
+              SKINCOS_GLOBAL_COORDINATION_KEY_ID="${SKINCOS_GLOBAL_COORDINATION_KEY_ID:-}" \
+                node scripts/codex-global-coordination-workflow.mjs renew \
+                  --proof-file "$GLOBAL_PROOF_FILE" && \
             SKINCOS_GLOBAL_COORDINATOR_URL="$SKINCOS_GLOBAL_COORDINATOR_URL" \
             SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET="$SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET" \
             SKINCOS_GLOBAL_COORDINATION_KEY_ID="${SKINCOS_GLOBAL_COORDINATION_KEY_ID:-}" \
@@ -95,6 +125,7 @@ runs:
                 --source "$GLOBAL_OBSERVED_SOURCE_SHA" \
                 --candidate-source "$GLOBAL_SOURCE_SHA"; then
             exit 0
+          fi
           fi
           if (( coordination_attempt == coordination_max_attempts )); then
             echo "Global coordination revalidation failed after ${coordination_max_attempts} attempts" >&2

--- a/.github/scripts/ponto-orchestrator-lease.test.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.test.mjs
@@ -720,6 +720,16 @@ test("recovery artifact downloads isolate extraction before merging attested evi
   }
 });
 
+test("recovery rollback classification receives the attested artifact root in its own step", () => {
+  const source = workflow("ponto-progressive-release.yml");
+  const start = source.indexOf("- name: Classify whether exact rollback is required");
+  const end = source.indexOf("- name: Upload immutable ordinary-recovery reconciliation", start);
+  assert.ok(start >= 0 && end > start, "recovery rollback classification block is absent");
+  const block = source.slice(start, end);
+  assert.match(block, /PONTO_RECOVERY_ARTIFACT_ROOT: \$\{\{ runner\.temp \}\}\/ponto-ordinary-recovery\/journal/);
+  assert.match(block, /node - "\$PONTO_RECOVERY_ARTIFACT_ROOT\/watchdog-journal\.json"/);
+});
+
 test("staging Pages incumbent capture retries and requires exact terminal provenance", () => {
   const source = workflow("deploy-crm-pages.yml");
   const start = source.indexOf("- name: Capture Ponto staging Pages rollback deployment");

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -2126,6 +2126,8 @@ jobs:
           done
       - name: Classify whether exact rollback is required
         id: rollback_requirement
+        env:
+          PONTO_RECOVERY_ARTIFACT_ROOT: ${{ runner.temp }}/ponto-ordinary-recovery/journal
         run: |
           set -euo pipefail
           node - "$PONTO_RECOVERY_ARTIFACT_ROOT/watchdog-journal.json" <<'NODE'

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
@@ -8,6 +9,16 @@ const ROOT = path.resolve(import.meta.dirname, "../..");
 
 function read(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), "utf8");
+}
+
+function compositeActionBash(source) {
+  const marker = "      run: |\n";
+  const start = source.indexOf(marker);
+  assert.notEqual(start, -1, "missing composite-action Bash block");
+  return source.slice(start + marker.length)
+    .split("\n")
+    .map((line) => line.startsWith("        ") ? line.slice(8) : line)
+    .join("\n");
 }
 
 function jobBlock(workflow, jobName) {
@@ -157,6 +168,17 @@ test("the reusable check action accepts either an external proof file or an enco
   assert.match(read(".github/actions/global-coordination-release/action.yml"), /github\.event\.inputs\.target == 'production'/);
   assert.match(action, /GLOBAL_PROOF_FILE_INPUT/);
   assert.match(action, /base64 -d/);
+  assert.match(action, /GLOBAL_CHECK_RESULT/);
+  assert.match(action, /--result-file "\$GLOBAL_CHECK_RESULT"/);
+  assert.match(action, /expiresAt - Date\.now\(\) > 5 \* 60 \* 1000/);
+  assert.match(action, /if \[\[ "\$renew_required" == false \]\]; then/);
+  assert.match(action, /if \[\[ "\$renew_required" == true \]\] &&/);
+  assert.match(action, /\n {8}NODE\n {12}\)" \|\| renew_required="invalid"/);
+  const syntax = spawnSync("bash", ["-n"], {
+    input: compositeActionBash(action),
+    encoding: "utf8",
+  });
+  assert.equal(syntax.status, 0, syntax.stderr || "global coordination check Bash syntax failed");
   assert.match(action, /coordination_max_attempts=3/);
   assert.match(action, /Global coordination revalidation failed after/);
   for (const file of [


### PR DESCRIPTION
## Summary

- Checks the exact global lease immediately before the governed mutation and renews only when five minutes or less remain.
- Re-checks the renewed proof when renewal is due; any read, parse, renewal, or authorization failure still retries and fails closed.
- Restores the recovery classifier artifact-root environment so a terminal staging failure can distinguish no-mutation from exact rollback work.

## Type of change

- [x] Fix

## Operational scope

Ponto/Workforce staging governance and the shared Cloudflare coordination action only. No migration, secret, user account, grant, feature flag, or production data change is included.

## Rollback

Revert this commit before the next governed Ponto candidate. Until a new preview and staging journey both succeed, the emergency latch remains closed and Ponto remains in maintenance.

## Validation

- `npm run codex:global-coordination:test` — 199 passing tests.
- Rendered the composite action Bash block and verified it with `bash -n`.
- `git diff --check`.
- Operational preflight passed for GitHub auth, required secret/variable presence, workflow inventory, and security-exception expiry. Cloudflare/HTTP checks were intentionally not used as deployment proof for this code-only PR.

## Evidence

The failed staging run `31753396535` acquired and later released the CRM Pages lease successfully; only the immediate redundant renew returned `coordination-processing-error`. The Pages mutation journal records `mutationStarted:false`. The recovery close kept the external Ponto surface in maintenance.