### PR TITLE
fix(ponto): pin staging health to candidate core

### DIFF
--- a/crm/console/functions/api/ponto/[[path]].ts
+++ b/crm/console/functions/api/ponto/[[path]].ts
@@ -1022,6 +1022,7 @@ export async function onRequest(context: any): Promise<Response> {
   const basePath = targetUrl.pathname.replace(/\/$/, '')
   targetUrl.pathname = `${basePath}/api/ponto${rest.startsWith('/') ? '' : '/'}${rest}`
   targetUrl.search = url.search
+  const useCanonicalGateway = rest === '/health' || rest === '/health/' || rest === '/readiness' || rest === '/readiness/'
 
   // Cookies and browser Authorization never cross this boundary. Device tokens are
   // accepted only on explicit device routes; CRM users receive signed actor claims.
@@ -1031,6 +1032,21 @@ export async function onRequest(context: any): Promise<Response> {
   if (configuration.localDirectTimekeeping) {
     headers.set('x-skincos-gateway-release-sha', configuration.releaseSha)
     headers.set('x-skincos-gateway-environment', 'local')
+  }
+  if (
+    useCanonicalGateway
+    && configuration.rolloutStage === 'staging'
+    && CLOUDFLARE_VERSION_ID_RE.test(configuration.coreVersionId)
+  ) {
+    const control = await readPontoControl(env)
+    if (!exactLiveControl(control, configuration)) {
+      return json(
+        503,
+        { ok: false, error: 'PONTO_RELEASE_CONTROL_NOT_AUTHORIZED' },
+        releaseHeaders,
+      )
+    }
+    headers.set('cloudflare-workers-version-overrides', `skincos-ponto-core-staging="${configuration.coreVersionId}"`)
   }
   const method = (request.method || 'GET').toUpperCase()
   let body: ArrayBuffer | undefined
@@ -1109,7 +1125,6 @@ export async function onRequest(context: any): Promise<Response> {
   // from the canonical gateway, rather than a possibly stale Pages service
   // binding, so a maintenance/degraded response cannot be reintroduced as a
   // legacy ready=true result through the CRM alias.
-  const useCanonicalGateway = rest === '/health' || rest === '/health/' || rest === '/readiness' || rest === '/readiness/'
   let upstream: Response
   try {
     upstream = configuration.localDirectTimekeeping || useCanonicalGateway

--- a/crm/console/tests/pontoProxy.test.ts
+++ b/crm/console/tests/pontoProxy.test.ts
@@ -711,6 +711,65 @@ describe('Ponto CRM proxy', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
+  it('pins public staging health to the exact controlled Core candidate', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true, ready: true })))
+    vi.stubGlobal('fetch', fetchMock)
+    const stagingControl = (syntheticOnly: boolean) => ({
+      state: 'active',
+      schemaVersion: 2,
+      rolloutStage: 'staging',
+      releaseSha: RELEASE_SHA,
+      syntheticOnly,
+      versions: {
+        coreApi: { candidate: CORE_VERSION_ID },
+        identityWorkforce: { candidate: IDENTITY_VERSION_ID },
+      },
+    })
+    const allowed = context('/api/ponto/health?probe=candidate')
+    Object.assign(allowed.env, {
+      SKINCOS_DEPLOYMENT_ENV: 'staging',
+      PONTO_API_TARGET: 'https://api-staging.skincos.com.br',
+      PONTO_ROLLOUT_STAGE: 'staging',
+      PONTO_CORE_VERSION_ID: CORE_VERSION_ID,
+      PONTO_IDENTITY_VERSION_ID: IDENTITY_VERSION_ID,
+      MODULE_CONTROL: {
+        get: async (key: string) => key === 'module-control:timekeeping:emergency-latch'
+          ? { ...OPEN_EMERGENCY_LATCH, target: 'staging' }
+          : stagingControl(true),
+      },
+    })
+
+    expect((await onRequest(allowed)).status).toBe(200)
+    const upstream = fetchMock.mock.calls[0][0] as Request
+    expect(upstream.url).toBe('https://api-staging.skincos.com.br/api/ponto/health?probe=candidate')
+    expect(upstream.headers.get('cloudflare-workers-version-overrides'))
+      .toBe(`skincos-ponto-core-staging="${CORE_VERSION_ID}"`)
+    expect(upstream.headers.get('x-skincos-actor')).toBeNull()
+    expect(getInsumosUser).not.toHaveBeenCalled()
+
+    const drifted = context('/api/ponto/health')
+    Object.assign(drifted.env, {
+      SKINCOS_DEPLOYMENT_ENV: 'staging',
+      PONTO_API_TARGET: 'https://api-staging.skincos.com.br',
+      PONTO_ROLLOUT_STAGE: 'staging',
+      PONTO_CORE_VERSION_ID: CORE_VERSION_ID,
+      PONTO_IDENTITY_VERSION_ID: IDENTITY_VERSION_ID,
+      MODULE_CONTROL: {
+        get: async (key: string) => key === 'module-control:timekeeping:emergency-latch'
+          ? { ...OPEN_EMERGENCY_LATCH, target: 'staging' }
+          : stagingControl(false),
+      },
+    })
+
+    const driftedResponse = await onRequest(drifted)
+    expect(driftedResponse.status).toBe(503)
+    await expect(driftedResponse.json()).resolves.toMatchObject({
+      ok: false,
+      error: 'PONTO_RELEASE_CONTROL_NOT_AUTHORIZED',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('proves candidate Identity auth, grants, session read and teardown only through the internal binding', async () => {
     const login = 'pilot@example.test'
     const password = 'synthetic-password-123'

--- a/crm/console/tests/pontoProxy.test.ts
+++ b/crm/console/tests/pontoProxy.test.ts
@@ -714,6 +714,7 @@ describe('Ponto CRM proxy', () => {
   it('pins public staging health to the exact controlled Core candidate', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true, ready: true })))
     vi.stubGlobal('fetch', fetchMock)
+    const initialGetInsumosCalls = (getInsumosUser as Mock).mock.calls.length
     const stagingControl = (syntheticOnly: boolean) => ({
       state: 'active',
       schemaVersion: 2,
@@ -745,7 +746,7 @@ describe('Ponto CRM proxy', () => {
     expect(upstream.headers.get('cloudflare-workers-version-overrides'))
       .toBe(`skincos-ponto-core-staging="${CORE_VERSION_ID}"`)
     expect(upstream.headers.get('x-skincos-actor')).toBeNull()
-    expect(getInsumosUser).not.toHaveBeenCalled()
+    expect(getInsumosUser).toHaveBeenCalledTimes(initialGetInsumosCalls)
 
     const drifted = context('/api/ponto/health')
     Object.assign(drifted.env, {


### PR DESCRIPTION
## Contexto\n\nA jornada de staging verificava a rota pública autenticada de Ponto e não convergia na afinidade da versão Core. O probe protegido passava porque já usava o pin de versão no service binding, enquanto /api/ponto/health ia ao gateway canônico sem esse pin.\n\n## Mudança\n\n- aplica o override da versão Core candidata à saúde/readiness pública somente em staging e somente sob controle sintético exato;\n- retorna 503 fail-closed antes do upstream quando esse controle diverge;\n- adiciona teste focal do pin e da recusa por deriva.\n\n## Validação\n\n- git diff --check\n- o runtime Vitest não estava materializado no worktree WSL; os checks hospedados desta PR executam a suíte canônica.