### PR TITLE
fix(ponto): align staged health and recovery custody

### DIFF
--- a/.github/workflows/ponto-release-watchdog.yml
+++ b/.github/workflows/ponto-release-watchdog.yml
@@ -178,6 +178,10 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 1
       - name: Acquire global Ponto recovery lease for fail-close materialization
+        # The watchdog runs from GitHub's trusted default-branch source. Its
+        # lease fences only recovery mutations under an already-closed latch;
+        # the failed coordinator SHA remains bound to the rollback evidence,
+        # not to this current recovery implementation.
         uses: ./.github/actions/global-coordination-acquire
         with:
           required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
@@ -187,7 +191,7 @@ jobs:
           key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
           resource: release:ponto
           module: ponto
-          source_sha: ${{ needs.context.outputs.release_sha }}
+          source_sha: ${{ github.sha }}
           proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-watchdog-close.json
           wait_timeout_seconds: '960'
           retry_interval_seconds: '10'
@@ -198,7 +202,7 @@ jobs:
           proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-watchdog-close.json
           resource: release:ponto
           module: ponto
-          source_sha: ${{ needs.context.outputs.release_sha }}
+          source_sha: ${{ github.sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ contains(fromJSON('["pilot","canary","production"]'), needs.context.outputs.target) && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
@@ -319,6 +323,10 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 1
       - name: Acquire global Ponto recovery lease for watchdog rollback
+        # The rollback procedure is executed from the trusted default branch;
+        # its lease must not be invalidated by unrelated main advancement after
+        # the failed candidate was selected. Exact rollback targets still come
+        # exclusively from the failed coordinator's immutable evidence.
         uses: ./.github/actions/global-coordination-acquire
         with:
           required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
@@ -328,7 +336,7 @@ jobs:
           key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
           resource: release:ponto
           module: ponto
-          source_sha: ${{ needs.context.outputs.release_sha }}
+          source_sha: ${{ github.sha }}
           proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-watchdog-rollback.json
       - name: Revalidate protected target environment before watchdog rollback
         env:
@@ -375,7 +383,7 @@ jobs:
           proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-watchdog-rollback.json
           resource: release:ponto
           module: ponto
-          source_sha: ${{ needs.context.outputs.release_sha }}
+          source_sha: ${{ github.sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ contains(fromJSON('["pilot","canary","production"]'), needs.context.outputs.target) && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
@@ -472,7 +480,7 @@ jobs:
           proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-watchdog-rollback.json
           resource: release:ponto
           module: ponto
-          source_sha: ${{ needs.context.outputs.release_sha }}
+          source_sha: ${{ github.sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ contains(fromJSON('["pilot","canary","production"]'), needs.context.outputs.target) && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}

--- a/.github/workflows/timekeeping-staging-journey.yml
+++ b/.github/workflows/timekeeping-staging-journey.yml
@@ -601,7 +601,8 @@ jobs:
             "corrections", "pin_failures", "pin_credentials", "request_nonces", "departments", "policies",
           ].reduce((total, key) => total + numeric(timekeeping[key]), 0);
           const coreAuditPreserved = numeric(core.audit_count) >= 2 && numeric(core.teardown_audit) >= 1;
-          const timekeepingAuditPreserved = numeric(timekeeping.audit_count) >= 1;
+          const expectedTimekeepingAuditMinimum = numeric(timekeeping.expected_audit_minimum);
+          const timekeepingAuditPreserved = numeric(timekeeping.audit_count) >= expectedTimekeepingAuditMinimum;
           if (coreResidualCount !== 0 || timekeepingResidualCount !== 0 || !coreAuditPreserved || !timekeepingAuditPreserved) {
             throw new Error("synthetic teardown did not prove zero operational residue and preserved audit");
           }
@@ -613,6 +614,7 @@ jobs:
             timekeepingResidualCount,
             coreAuditPreserved,
             timekeepingAuditPreserved,
+            expectedTimekeepingAuditMinimum,
             credentialsIncluded: false,
             piiIncluded: false,
           }, null, 2)}\n`, { mode: 0o600 });

--- a/crm/console/functions/api/ponto/[[path]].ts
+++ b/crm/console/functions/api/ponto/[[path]].ts
@@ -937,7 +937,8 @@ export async function onRequest(context: any): Promise<Response> {
     return authorizedReleaseReadinessProbe(env, configuration, request, requestId)
   }
 
-  const isPublicRoute = ['/health', '/health/', '/readiness', '/readiness/', '/_proxy-status', '/_proxy-status/'].includes(rest)
+  const isOperationalProbe = rest === '/health' || rest === '/health/' || rest === '/readiness' || rest === '/readiness/'
+  const isPublicRoute = isOperationalProbe || rest === '/_proxy-status' || rest === '/_proxy-status/'
   const isDeviceRoute = rest === '/device' || rest.startsWith('/device/')
   const isAdminRoute = rest === '/admin' || rest.startsWith('/admin/')
   const requiresActor = !isPublicRoute && !isDeviceRoute
@@ -1098,6 +1099,29 @@ export async function onRequest(context: any): Promise<Response> {
     }
   }
 
+  // Public health normally goes through the externally routed gateway, which
+  // prevents an arbitrary or stale Pages binding from masking a degraded
+  // public contract. During an exact, live staged release, though, that public
+  // gateway can still be an incumbent while authenticated Ponto traffic is
+  // deliberately pinned to the candidate Core. In that narrow state, make the
+  // observability request follow the same server-owned candidate binding and
+  // version override. The control record is checked server-side; a browser can
+  // neither select a version nor cause this routing change.
+  let useReleaseBoundCoreForOperationalProbe = false
+  if (
+    isOperationalProbe
+    && !configuration.localDirectTimekeeping
+    && CLOUDFLARE_VERSION_ID_RE.test(configuration.coreVersionId)
+    && ['staging', 'pilot', 'canary'].includes(configuration.rolloutStage)
+  ) {
+    const control = await readPontoControl(env)
+    useReleaseBoundCoreForOperationalProbe = exactLiveControl(control, configuration)
+    if (useReleaseBoundCoreForOperationalProbe) {
+      const coreService = configuration.environment === 'staging' ? 'skincos-ponto-core-staging' : 'skincos-ponto-core'
+      headers.set('cloudflare-workers-version-overrides', `${coreService}="${configuration.coreVersionId}"`)
+    }
+  }
+
   const upstreamRequest = new Request(targetUrl.toString(), {
     method,
     headers,
@@ -1105,11 +1129,10 @@ export async function onRequest(context: any): Promise<Response> {
     redirect: 'manual',
   })
 
-  // Health and readiness are public observability contracts. They must be read
-  // from the canonical gateway, rather than a possibly stale Pages service
-  // binding, so a maintenance/degraded response cannot be reintroduced as a
-  // legacy ready=true result through the CRM alias.
-  const useCanonicalGateway = rest === '/health' || rest === '/health/' || rest === '/readiness' || rest === '/readiness/'
+  // Outside the exact candidate state above, health and readiness remain on
+  // the canonical external gateway. This preserves the public fail-closed
+  // contract rather than trusting a stale Pages binding.
+  const useCanonicalGateway = isOperationalProbe && !useReleaseBoundCoreForOperationalProbe
   let upstream: Response
   try {
     upstream = configuration.localDirectTimekeeping || useCanonicalGateway

--- a/crm/console/tests/pontoProxy.test.ts
+++ b/crm/console/tests/pontoProxy.test.ts
@@ -19,6 +19,10 @@ const OPEN_EMERGENCY_LATCH = {
   changedAt: '2026-07-30T00:00:00.000Z',
   changedBy: 'ponto-emergency-latch-reset',
 }
+const OPEN_STAGING_EMERGENCY_LATCH = {
+  ...OPEN_EMERGENCY_LATCH,
+  target: 'staging',
+}
 
 async function reserveProbeForTest(env: any, used: Set<string>, request: Request): Promise<Response> {
   const nonce = String(request.headers.get('x-request-nonce') || '')
@@ -235,6 +239,91 @@ describe('Ponto CRM proxy', () => {
     expect((fetchMock.mock.calls[0][0] as Request).url).toBe('https://api.skincos.com.br/api/ponto/readiness?probe=maintenance')
     expect(coreFetch).not.toHaveBeenCalled()
     expect(response.headers.get('x-skincos-gateway-release-sha')).toBe('gateway-release')
+  })
+
+  it('uses the exact release-bound Core for public staging health and readiness only while its control is active', async () => {
+    const externalGateway = vi.fn().mockRejectedValue(new Error('active staging candidate must not fall back to the external gateway'))
+    vi.stubGlobal('fetch', externalGateway)
+
+    for (const path of ['/api/ponto/health?probe=candidate', '/api/ponto/readiness?probe=candidate']) {
+      const ctx = context(path)
+      Object.assign(ctx.env, {
+        SKINCOS_DEPLOYMENT_ENV: 'staging',
+        PONTO_API_TARGET: 'https://api-staging.skincos.com.br',
+        PONTO_ROLLOUT_STAGE: 'staging',
+        PONTO_CORE_VERSION_ID: CORE_VERSION_ID,
+        PONTO_IDENTITY_VERSION_ID: IDENTITY_VERSION_ID,
+      })
+      ctx.env.MODULE_CONTROL = {
+        get: async (key: string) => {
+          if (key === 'module-control:timekeeping:emergency-latch') return OPEN_STAGING_EMERGENCY_LATCH
+          if (key !== 'module-control:timekeeping') return null
+          return {
+            state: 'active',
+            schemaVersion: 2,
+            rolloutStage: 'staging',
+            releaseSha: RELEASE_SHA,
+            syntheticOnly: true,
+            versions: {
+              coreApi: { candidate: CORE_VERSION_ID },
+              identityWorkforce: { candidate: IDENTITY_VERSION_ID },
+            },
+          }
+        },
+      }
+      const coreFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true, ready: true }), {
+        headers: {
+          'content-type': 'application/json',
+          'x-skincos-gateway-release-sha': RELEASE_SHA,
+          'x-skincos-gateway-environment': 'staging',
+          'x-skincos-gateway-version-id': CORE_VERSION_ID,
+        },
+      }))
+      ctx.env.PONTO_CORE = { fetch: coreFetch }
+
+      const response = await onRequest(ctx)
+
+      expect(response.status).toBe(200)
+      expect(coreFetch).toHaveBeenCalledOnce()
+      const upstream = coreFetch.mock.calls[0][0] as Request
+      expect(upstream.url).toBe(`https://api-staging.skincos.com.br${path}`)
+      expect(upstream.headers.get('cloudflare-workers-version-overrides'))
+        .toBe(`skincos-ponto-core-staging="${CORE_VERSION_ID}"`)
+      expect(response.headers.get('x-skincos-gateway-release-sha')).toBe(RELEASE_SHA)
+    }
+
+    expect(externalGateway).not.toHaveBeenCalled()
+    expect(getInsumosUser).not.toHaveBeenCalled()
+  })
+
+  it('keeps staging health on the canonical gateway when the candidate control is not exact', async () => {
+    const externalGateway = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: false, ready: false }), {
+      status: 503,
+      headers: { 'content-type': 'application/json', 'x-skincos-gateway-release-sha': 'incumbent-gateway' },
+    }))
+    vi.stubGlobal('fetch', externalGateway)
+    const ctx = context('/api/ponto/health?probe=inactive')
+    Object.assign(ctx.env, {
+      SKINCOS_DEPLOYMENT_ENV: 'staging',
+      PONTO_API_TARGET: 'https://api-staging.skincos.com.br',
+      PONTO_ROLLOUT_STAGE: 'staging',
+      PONTO_CORE_VERSION_ID: CORE_VERSION_ID,
+      PONTO_IDENTITY_VERSION_ID: IDENTITY_VERSION_ID,
+      PONTO_CORE: { fetch: vi.fn().mockRejectedValue(new Error('inactive staged control must not use candidate Core')) },
+      MODULE_CONTROL: {
+        get: async (key: string) => key === 'module-control:timekeeping:emergency-latch'
+          ? OPEN_STAGING_EMERGENCY_LATCH
+          : { state: 'maintenance' },
+      },
+    })
+
+    const response = await onRequest(ctx)
+
+    expect(response.status).toBe(503)
+    expect((externalGateway.mock.calls[0][0] as Request).url)
+      .toBe('https://api-staging.skincos.com.br/api/ponto/health?probe=inactive')
+    expect(ctx.env.PONTO_CORE.fetch).not.toHaveBeenCalled()
+    expect(response.headers.get('x-skincos-gateway-release-sha')).toBe('incumbent-gateway')
   })
 
   it('signs canonical protected routes and strips browser cookies and authorization', async () => {

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -261,6 +261,16 @@ test("legacy recovery and WAF mutators are fail-closed through the same authorit
   assert.ok(stagingRecovery.indexOf("Check global Ponto recovery lease immediately before staging rollback") < stagingRecovery.indexOf("node .github/scripts/ponto-automatic-rollback.mjs"));
 });
 
+test("Ponto watchdog recovery leases use the trusted watchdog source, not the failed candidate", () => {
+  const watchdog = read(".github/workflows/ponto-release-watchdog.yml");
+  for (const jobName of ["fail-close", "rollback"]) {
+    const block = jobBlock(watchdog, jobName);
+    assert.match(block, /source_sha: \$\{\{ github\.sha \}\}/);
+    assert.doesNotMatch(block, /source_sha: \$\{\{ needs\.context\.outputs\.release_sha \}\}/);
+    assert.doesNotMatch(block, /observed_source_sha:/);
+  }
+});
+
 test("the reusable check action accepts either an external proof file or an encoded proof", () => {
   const action = read(".github/actions/global-coordination-check/action.yml");
   assert.match(action, /proof_b64:[\s\S]*?required: false/);

--- a/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs
+++ b/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs
@@ -159,6 +159,11 @@ if (action === 'provision') {
   const requestIdList = requestIds.length ? requestIds.map(sql).join(',') : "''";
   const eventIds = Array.from(new Set(fixture.teardownEventIds || []));
   const eventIdList = eventIds.length ? eventIds.map(sql).join(',') : "''";
+  // A journey can fail safely before it makes a Ponto mutation (for example,
+  // while proving release affinity). In that case there is no Timekeeping
+  // audit event to preserve. Once a request reached Ponto, retain the prior
+  // minimum-one-audit proof without requiring a one-to-one count for retries.
+  const expectedAuditMinimum = requestIds.length ? 1 : 0;
   const separateAttestation = Boolean(coreAttestationSqlPath && timekeepingAttestationSqlPath);
   const coreAttestation = `SELECT
       (SELECT COUNT(*) FROM crm_users WHERE username IN (${sql(fixture.username)},${sql(fixture.adminUsername)})) AS users,
@@ -214,7 +219,8 @@ if (action === 'provision') {
       (SELECT COUNT(*) FROM timekeeping_request_nonces WHERE request_id IN (${requestIdList})) AS request_nonces,
       (SELECT COUNT(*) FROM workforce_departments WHERE normalized_name=${sql(fixture.onboardingDepartment.toLowerCase())}) AS departments,
       (SELECT COUNT(*) FROM timekeeping_unit_presence_policies WHERE unit_id=${sql(fixture.unitId)} AND updated_by=${sql(`${prefix}:presence-policy`)}) AS policies,
-      (SELECT COUNT(*) FROM timekeeping_audit_events WHERE request_id IN (${requestIdList})) AS audit_count;`]),
+      (SELECT COUNT(*) FROM timekeeping_audit_events WHERE request_id IN (${requestIdList})) AS audit_count,
+      ${expectedAuditMinimum} AS expected_audit_minimum;`]),
   ];
   const timekeepingAttestation = `SELECT
       (SELECT COUNT(*) FROM workforce_employees WHERE id=${sql(fixture.employeeId)} OR canonical_employee_id=${sql(`identity:${fixture.onboardingId}`)}) AS employees,
@@ -229,7 +235,8 @@ if (action === 'provision') {
       (SELECT COUNT(*) FROM timekeeping_request_nonces WHERE request_id IN (${requestIdList})) AS request_nonces,
       (SELECT COUNT(*) FROM workforce_departments WHERE normalized_name=${sql(fixture.onboardingDepartment.toLowerCase())}) AS departments,
       (SELECT COUNT(*) FROM timekeeping_unit_presence_policies WHERE unit_id=${sql(fixture.unitId)} AND updated_by=${sql(`${prefix}:presence-policy`)}) AS policies,
-      (SELECT COUNT(*) FROM timekeeping_audit_events WHERE request_id IN (${requestIdList})) AS audit_count;`;
+      (SELECT COUNT(*) FROM timekeeping_audit_events WHERE request_id IN (${requestIdList})) AS audit_count,
+      ${expectedAuditMinimum} AS expected_audit_minimum;`;
   writeFileSync(coreSqlPath, `${coreStatements.join('\n')}\n`, { mode: 0o600 });
   writeFileSync(timekeepingSqlPath, `${timekeepingStatements.join('\n')}\n`, { mode: 0o600 });
   if (separateAttestation) {

--- a/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.test.mjs
+++ b/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.test.mjs
@@ -152,6 +152,7 @@ test('staging fixture SQL is run-scoped, secret-free, and teardown preserves aud
       assert.equal(coreResiduals.teardown_audit, 1);
       assert.equal(timekeepingResiduals.employees, 0);
       assert.equal(timekeepingResiduals.audit_count, 0);
+      assert.equal(timekeepingResiduals.expected_audit_minimum, 1);
       assert.equal(database.prepare('SELECT COUNT(*) AS count FROM crm_users WHERE username IN (?, ?)').get(
         fixture.username,
         fixture.adminUsername,
@@ -187,6 +188,27 @@ test('staging fixture SQL is run-scoped, secret-free, and teardown preserves aud
       database.close();
       timekeepingDatabase.close();
     }
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('teardown permits a safely aborted journey before it reaches a Ponto mutation', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'skincos-ponto-fixture-abort-'));
+  const paths = {
+    fixture: join(directory, 'fixture.json'),
+    core: join(directory, 'core.sql'),
+    timekeeping: join(directory, 'timekeeping.sql'),
+    coreAttestation: join(directory, 'core-attestation.sql'),
+    timekeepingAttestation: join(directory, 'timekeeping-attestation.sql'),
+  };
+
+  try {
+    generate('provision', paths);
+    generate('teardown', paths, '', true);
+    const attestation = readFileSync(paths.timekeepingAttestation, 'utf8');
+    assert.match(attestation, /0 AS expected_audit_minimum/);
+    assert.match(attestation, /timekeeping_audit_events WHERE request_id IN \(''\)/);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }


### PR DESCRIPTION
# Summary

Corrige os dois bloqueios encontrados no staging do Ponto:

- Durante um candidato de staging exatamente ativo, `/api/ponto/health` e `/api/ponto/readiness` passam pelo mesmo Core/version override server-side usado pela jornada autenticada. Fora desse estado estrito, continuam no gateway externo canônico e fail-closed.
- O teardown sintético só exige auditoria do Timekeeping quando a jornada já registrou uma mutação do Ponto; uma falha segura de afinidade antes disso continua exigindo resíduo zero, sem inventar uma auditoria impossível.
- O watchdog de recuperação passa a adquirir/revalidar o lease usando o SHA confiável do próprio workflow no default branch. O SHA do candidato falho permanece limitado à evidência e aos alvos imutáveis de rollback.

A causa observada foi a divergência entre o gateway público de staging ainda no incumbent e o Core candidato já pinado para a jornada. A alteração não abre rota de seleção pelo navegador nem libera produção.

## Type of change

- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [ ] Security
- [ ] Breaking change

## Operational scope and rollback

- Superfícies: CRM Pages proxy, jornada sintética de staging e watchdog de release Ponto.
- Flag/coorte: nenhuma flag ou grant é ativado por esta PR; produção permanece fail-closed.
- Migration: não aplicável.
- Rollback: reverter este commit e manter/restaurar a maintenance latch pelo broker governado. A promoção subsequente continua exigindo versões imutáveis e rollback comprovado.
- Próximo ambiente autorizado: novo preview e staging governado, somente depois dos checks terminais.

## Checklist

- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (README, API refs, diagrams)
- [ ] Security review (CodeQL, gitleaks)
- [ ] Performance impact measured

## Validation

- `crm/console`: `pontoProxy.test.ts` — 35 passed
- Fixtures/jornada + governança estática — 21 passed
- `npm run codex:global-coordination:test` — 201 passed
- `.github/scripts/ponto-*.test.mjs` — 353 passed
- CRM typecheck, política de release e sintaxe Bash dos blocos de workflow — passed
- `git diff --check` — passed

## Evidence

- Falha de staging analisada: workflow 31756835802; a jornada encontrou afinidade do gateway incumbent enquanto o candidato Core estava ativo.
- Watchdog fail-closed analisado: workflow 31758136066; nenhuma mutação de produção foi executada.
