### PR TITLE
fix(beauty-movement): prevent card copy clipping

### DIFF
--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -1122,7 +1122,7 @@
 .cardButton {
   position: relative;
   display: block;
-  min-height: clamp(280px, 25vw, 304px);
+  min-height: clamp(312px, 27vw, 324px);
   padding: 0;
   overflow: hidden;
   border: 0;
@@ -2371,7 +2371,7 @@
   }
 
   .cardButton {
-    min-height: 280px;
+    min-height: 312px;
   }
 
   .cardIllustration {
@@ -2410,7 +2410,7 @@
   }
 
   .cardButton {
-    min-height: 280px;
+    min-height: 312px;
   }
 
   .cardFront,

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -256,6 +256,8 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.match(styles, /@keyframes cardSelectedReturnToDeck/);
     assert.match(styles, /@keyframes cardFlipToDeck/);
     assert.match(styles, /@keyframes cardDealFromDeck/);
+    assert.match(styles, /\.cardButton \{[\s\S]*min-height: clamp\(312px, 27vw, 324px\)/);
+    assert.match(styles, /@media \(max-width: 720px\) \{[\s\S]*?\.cardButton \{\s*min-height: 312px;/);
     assert.match(
         styles,
         /\.tableStage\[data-hand-stage="reveal"\] \.cardButton:not\(\.cardButtonSelected\)\s*\{\s*pointer-events: none;\s*\}/,


### PR DESCRIPTION
## Summary\n- increase the card stage height reservation so long card copy stays inside the back face\n- keep the existing card motion and responsive layout intact\n- add a focused CSS regression assertion\n\n## Validation\n- 134 website tests\n- lint\n- typecheck with no emit\n- production build\n- local preview smoke on desktop and mobile\n\nNo staging or production deploy.