### PR TITLE
fix(ponto): attest immutable Core recovery child

### DIFF
--- a/.github/scripts/ponto-automatic-rollback-safety.test.mjs
+++ b/.github/scripts/ponto-automatic-rollback-safety.test.mjs
@@ -91,6 +91,18 @@ test("recovery accepts only children from the exact immutable Ponto release tag"
   assert.doesNotMatch(source, /run\.headBranch !== "main"/);
 });
 
+test("Core provenance recovery accepts only its exact immutable child release tag", () => {
+  const recovery = fs.readFileSync(
+    new URL("../workflows/ponto-staging-core-provenance-recovery.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    recovery,
+    /const expectedChildReleaseTag = `skincos\/release\/ponto\/\$\{process\.env\.RELEASE_SHA\}`;/,
+  );
+  assert.match(recovery, /run\.headBranch !== expectedChildReleaseTag/);
+});
+
 test("a cancelled staging Core child is untouched only with runner and live-incumbent proof", () => {
   assert.match(source, /const preMutationJobNames = Object\.freeze\(\{\s*coreApi: "deploy",/s);
   assert.match(source, /actions\/runs\/\$\{encodeURIComponent\(childRunId\)\}\/jobs\?filter=latest&per_page=100/);

--- a/.github/workflows/ponto-staging-core-provenance-recovery.yml
+++ b/.github/workflows/ponto-staging-core-provenance-recovery.yml
@@ -108,6 +108,7 @@ jobs:
           const run = JSON.parse(fs.readFileSync(runPath, "utf8"));
           const surface = JSON.parse(fs.readFileSync(surfacePath, "utf8"));
           const uuid = (value) => /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(String(value || ""));
+          const expectedChildReleaseTag = `skincos/release/ponto/${process.env.RELEASE_SHA}`;
           if (
             run.schemaVersion !== 1
             || run.workflow !== "deploy-core-workers.yml"
@@ -115,7 +116,7 @@ jobs:
             || run.status !== "completed"
             || run.conclusion !== "success"
             || run.event !== "workflow_dispatch"
-            || run.headBranch !== "main"
+            || run.headBranch !== expectedChildReleaseTag
             || run.headSha !== process.env.RELEASE_SHA
             || run.repository !== process.env.GITHUB_REPOSITORY
             || run.runId !== surface.runId


### PR DESCRIPTION
## Summary
- accept only the exact immutable Ponto release tag for the recovered Core child run
- retain exact SHA, workflow, repository, and custody checks
- cover the recovery workflow guard with the existing rollback safety suite

## Validation
- node --test .github/scripts/ponto-automatic-rollback-safety.test.mjs
- node --test .github/scripts/ponto-rollback-ownership.test.mjs
- node .github/scripts/validate-deploy-topology.mjs
- node .github/scripts/validate-progressive-release.mjs