### PR TITLE
fix(ponto): bind recovery leases to controller SHA

### DIFF
--- a/.github/scripts/ponto-staging-core-provenance-recovery.test.mjs
+++ b/.github/scripts/ponto-staging-core-provenance-recovery.test.mjs
@@ -36,3 +36,11 @@ test("Core provenance recovery is staging-only, exact, and fail-closed", () => {
   assert.match(workflow, /name: Upload immutable Core provenance recovery evidence[\s\S]*?if: always\(\)/);
   assert.doesNotMatch(workflow, /target:\s*production/);
 });
+
+test("Core provenance recovery leases the current trusted controller SHA", () => {
+  assert.equal(
+    (workflow.match(/source_sha: \$\{\{ github\.sha \}\}/g) || []).length,
+    3,
+  );
+  assert.doesNotMatch(workflow, /source_sha:\s*\$\{\{ inputs\.release_sha \}\}/);
+});

--- a/.github/scripts/ponto-staging-recovery-rollback.test.mjs
+++ b/.github/scripts/ponto-staging-recovery-rollback.test.mjs
@@ -63,3 +63,11 @@ test("staging recovery rollback is exact, serialized, and environment protected"
   assert.match(workflow, /name: Upload immutable staging recovery evidence[\s\S]*?if: always\(\)/);
   assert.doesNotMatch(workflow, /target:\s*production/);
 });
+
+test("staging recovery rollback leases the current trusted controller SHA", () => {
+  assert.equal(
+    (workflow.match(/source_sha: \$\{\{ github\.sha \}\}/g) || []).length,
+    3,
+  );
+  assert.doesNotMatch(workflow, /source_sha:\s*\$\{\{ inputs\.release_sha \}\}/);
+});

--- a/.github/workflows/ponto-staging-core-provenance-recovery.yml
+++ b/.github/workflows/ponto-staging-core-provenance-recovery.yml
@@ -240,7 +240,7 @@ jobs:
           key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
           resource: global:ponto-workers-writer
           module: ponto
-          source_sha: ${{ inputs.release_sha }}
+          source_sha: ${{ github.sha }}
           proof_file: ${{ runner.temp }}/skincos-global-coordination-core-recovery.json
 
       - name: Download the exact close and historical Core custody
@@ -279,7 +279,7 @@ jobs:
           proof_file: ${{ runner.temp }}/skincos-global-coordination-core-recovery.json
           resource: global:ponto-workers-writer
           module: ponto
-          source_sha: ${{ inputs.release_sha }}
+          source_sha: ${{ github.sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
@@ -412,7 +412,7 @@ jobs:
           proof_file: ${{ runner.temp }}/skincos-global-coordination-core-recovery.json
           resource: global:ponto-workers-writer
           module: ponto
-          source_sha: ${{ inputs.release_sha }}
+          source_sha: ${{ github.sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}

--- a/.github/workflows/ponto-staging-recovery-rollback.yml
+++ b/.github/workflows/ponto-staging-recovery-rollback.yml
@@ -307,7 +307,7 @@ jobs:
           key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
           resource: release:ponto
           module: ponto
-          source_sha: ${{ inputs.release_sha }}
+          source_sha: ${{ github.sha }}
           proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-staging-rollback.json
 
       - name: Validate current source and exact failed-run provenance
@@ -495,7 +495,7 @@ jobs:
           proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-staging-rollback.json
           resource: release:ponto
           module: ponto
-          source_sha: ${{ inputs.release_sha }}
+          source_sha: ${{ github.sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
@@ -633,7 +633,7 @@ jobs:
           proof_file: ${{ runner.temp }}/skincos-global-coordination-ponto-staging-rollback.json
           resource: release:ponto
           module: ponto
-          source_sha: ${{ inputs.release_sha }}
+          source_sha: ${{ github.sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}


### PR DESCRIPTION
## Summary
- bind recovery custody to the current trusted controller SHA
- keep failed-release SHA restricted to immutable historical evidence
- cover both Core provenance and staging worker recovery workflows

## Validation
- node --test .github/scripts/ponto-staging-core-provenance-recovery.test.mjs .github/scripts/ponto-staging-recovery-rollback.test.mjs
- node --test .github/scripts/ponto-automatic-rollback-safety.test.mjs
- node --test scripts/tests/global-concurrency-governance-static.test.mjs
- node .github/scripts/validate-deploy-topology.mjs
- node .github/scripts/validate-progressive-release.mjs