### PR TITLE
fix(ponto): accept attested active latch at edge

### DIFF
--- a/.github/scripts/ponto-recovery-materialization-workflow.test.mjs
+++ b/.github/scripts/ponto-recovery-materialization-workflow.test.mjs
@@ -48,3 +48,14 @@ test("manual emergency close materializes under the surface mutex and proves liv
   assert.match(emergencyClose, /for \(let attempt = 0; attempt < 12; attempt \+= 1\)/);
   assert.match(emergencyClose, /close:\n[\s\S]*?group: ponto-emergency-latch-\$\{\{ inputs\.target \}\}/);
 });
+
+test("manual emergency re-attestation accepts a still-visible monotonic latch without weakening direct custody", () => {
+  assert.match(
+    emergencyClose,
+    /if \(availability\.source === "emergency-latch-active"\) \{[\s\S]*?changedAt: availability\.changedAt[\s\S]*?fs\.rmSync\(process\.argv\[4\], \{ force: true \}\)/,
+  );
+  assert.match(emergencyClose, /if \[\[ -f "\$directory\/control-fallback-expectation\.json" \]\]; then/);
+  assert.match(emergencyClose, /const validAvailabilityChangedAt = Number\.isFinite\(Date\.parse\(String\(availability\?\.changedAt \|\| ""\)\)\);/);
+  assert.match(emergencyClose, /const exactControlChangedAt = availability\?\.source === "control"/);
+  assert.match(emergencyClose, /&& validAvailabilityChangedAt\s*&& exactControlChangedAt/);
+});

--- a/.github/workflows/ponto-emergency-close.yml
+++ b/.github/workflows/ponto-emergency-close.yml
@@ -112,22 +112,30 @@ jobs:
             || !["control", "emergency-latch-active"].includes(availability?.source)
             || !Number.isFinite(Date.parse(String(availability?.changedAt || "")))
           ) throw new Error("live Ponto health did not prove maintenance under the closed latch");
-          fs.writeFileSync(process.argv[3], `${JSON.stringify({
-            state: "maintenance",
-            changedAt: maintenance.latchChangedAt,
-          })}\n`, { mode: 0o600 });
-          fs.writeFileSync(process.argv[4], `${JSON.stringify({
-            state: "maintenance",
-            changedAt: availability.changedAt,
-            source: "control",
-          })}\n`, { mode: 0o600 });
+          if (availability.source === "emergency-latch-active") {
+            // A monotonic latch can already be visible at the edge before a
+            // broker-backed re-attestation transfers its ownership. The
+            // direct broker evidence remains the exact custody boundary.
+            fs.writeFileSync(process.argv[3], `${JSON.stringify({ state: "maintenance", changedAt: availability.changedAt })}\n`, { mode: 0o600 });
+            fs.rmSync(process.argv[4], { force: true });
+          } else {
+            fs.writeFileSync(process.argv[3], `${JSON.stringify({ state: "maintenance", changedAt: maintenance.latchChangedAt })}\n`, { mode: 0o600 });
+            fs.writeFileSync(process.argv[4], `${JSON.stringify({ state: "maintenance", changedAt: availability.changedAt, source: "control" })}\n`, { mode: 0o600 });
+          }
           })().catch((error) => { console.error(error); process.exitCode = 1; });
           NODE
-          PONTO_MODULE_EXPECTED_SOURCE=emergency-latch-active \
-          PONTO_MODULE_EXPECTATION_FILE="$directory/overlay-expectation.json" \
-          PONTO_MODULE_ALTERNATE_EXPECTATION_FILE="$directory/control-fallback-expectation.json" \
-          PONTO_MODULE_PROPAGATION_REPORT="$directory/final-propagation.json" \
-            node .github/scripts/ponto-module-propagation.mjs
+          if [[ -f "$directory/control-fallback-expectation.json" ]]; then
+            PONTO_MODULE_EXPECTED_SOURCE=emergency-latch-active \
+            PONTO_MODULE_EXPECTATION_FILE="$directory/overlay-expectation.json" \
+            PONTO_MODULE_ALTERNATE_EXPECTATION_FILE="$directory/control-fallback-expectation.json" \
+            PONTO_MODULE_PROPAGATION_REPORT="$directory/final-propagation.json" \
+              node .github/scripts/ponto-module-propagation.mjs
+          else
+            PONTO_MODULE_EXPECTED_SOURCE=emergency-latch-active \
+            PONTO_MODULE_EXPECTATION_FILE="$directory/overlay-expectation.json" \
+            PONTO_MODULE_PROPAGATION_REPORT="$directory/final-propagation.json" \
+              node .github/scripts/ponto-module-propagation.mjs
+          fi
           rm -f "$directory/overlay-expectation.json" "$directory/control-fallback-expectation.json"
       - name: Upload sanitized immutable emergency-close evidence
         if: always()
@@ -237,14 +245,19 @@ jobs:
             const response = await fetch(probe, { headers: { accept: "application/json", "cache-control": "no-cache" } });
             const body = await response.json().catch(() => null);
             const availability = body?.availability;
-            const expectedChangedAt = availability?.source === "emergency-latch-active"
-              ? report.emergencyLatch.changedAt
-              : report.moduleControl.changedAt;
+            const validAvailabilityChangedAt = Number.isFinite(Date.parse(String(availability?.changedAt || "")));
+            // Exact current ownership is proved by the direct materialized KV
+            // readback. An already-active latch may still expose its prior
+            // monotonic timestamp at the public edge while remaining closed.
+            const exactControlChangedAt = availability?.source === "control"
+              ? availability.changedAt === report.moduleControl.changedAt
+              : true;
             if (
               response.status === 200
               && availability?.state === "maintenance"
               && ["control", "emergency-latch-active"].includes(availability?.source)
-              && availability?.changedAt === expectedChangedAt
+              && validAvailabilityChangedAt
+              && exactControlChangedAt
             ) return;
             lastObservation = `HTTP ${response.status}, source=${String(availability?.source || "")}, changedAt=${String(availability?.changedAt || "")}`;
             if (attempt < 11) await new Promise((resolve) => setTimeout(resolve, 5_000));


### PR DESCRIPTION
Resolves the close-only re-attestation deadlock when staging already exposes a monotonic emergency latch at the edge.

- preserves fail-closed external maintenance validation;
- keeps exact ownership and new control state bound to direct materialized KV readback;
- retains strict control timestamp verification when the endpoint reports regular control.

Validation: `node --test .github/scripts/ponto-recovery-materialization-workflow.test.mjs .github/scripts/ponto-module-propagation.test.mjs` via Ubuntu-24.04 WSL.