### PR TITLE
fix(ponto): retain attested cancelled Pages custody

### DIFF
--- a/.github/scripts/ponto-automatic-rollback.mjs
+++ b/.github/scripts/ponto-automatic-rollback.mjs
@@ -18,6 +18,7 @@ import {
 import { releaseTagFor } from "./ponto-release-identity.mjs";
 import { attestBrokerFailCloseEvidence } from "./ponto-recovery-evidence.mjs";
 import { readCloudflareKvJson } from "./ponto-kv-readback.mjs";
+import { assessPagesEnvironmentPrerequisite } from "./ponto-pages-environment-prerequisite.mjs";
 import { resolveStagingCorePrecondition } from "./ponto-core-staging-precondition.mjs";
 import {
   inspectCancelledBeforeRunnerDeployJob,
@@ -476,21 +477,20 @@ if (fs.existsSync(pagesProvisionRunFile)) {
         disposition: "no-remote-mutation",
       };
     } else {
-      const retainedSafely = run.conclusion === "success"
-        && journal.mutationCompleted === true
-        && journal.remoteAttestationCompleted === true
-        && journal.mutationSafety?.maintenanceRequired === true
-        && journal.mutationSafety?.deterministicRerun === true
-        && journal.mutationSafety?.retainedOnCodeRollback === true;
+      const prerequisite = assessPagesEnvironmentPrerequisite({
+        conclusion: String(run.conclusion || ""),
+        journal,
+      });
+      const retainedSafely = prerequisite.passed;
       environmentPrerequisites.pagesEnvironmentSecrets = {
         passed: retainedSafely,
         childRunId: String(run.runId || ""),
+        childConclusion: String(run.conclusion || ""),
         mutationStarted: true,
         mutationCompleted: journal.mutationCompleted === true,
         remoteAttestationCompleted: journal.remoteAttestationCompleted === true,
-        disposition: retainedSafely
-          ? "retained-environment-prerequisite-under-maintenance"
-          : "unresolved-secret-configuration-mutation",
+        cancelledAfterAttestedProvision: prerequisite.cancelledAfterAttestedProvision,
+        disposition: prerequisite.disposition,
       };
       if (!retainedSafely) {
         unresolved.push({

--- a/.github/scripts/ponto-pages-environment-prerequisite.mjs
+++ b/.github/scripts/ponto-pages-environment-prerequisite.mjs
@@ -1,0 +1,30 @@
+const retainedUnderMaintenance = (journal) => (
+  journal?.mutationCompleted === true
+  && journal?.remoteAttestationCompleted === true
+  && journal?.mutationSafety?.maintenanceRequired === true
+  && journal?.mutationSafety?.deterministicRerun === true
+  && journal?.mutationSafety?.retainedOnCodeRollback === true
+);
+
+/**
+ * A Pages custody child can be cancelled only after its provision job has
+ * completed and uploaded the durable remote-attestation artifact.  The
+ * watchdog owns a new recovery lease at this point, so the cancelled child
+ * cannot leave a code rollback blocked solely by its final lease-release job.
+ */
+export function assessPagesEnvironmentPrerequisite({ conclusion, journal } = {}) {
+  const attestedProvision = retainedUnderMaintenance(journal);
+  const cancelledAfterAttestedProvision = conclusion === "cancelled" && attestedProvision;
+  const passed = attestedProvision && (
+    conclusion === "success" || cancelledAfterAttestedProvision
+  );
+
+  return {
+    passed,
+    attestedProvision,
+    cancelledAfterAttestedProvision,
+    disposition: passed
+      ? "retained-environment-prerequisite-under-maintenance"
+      : "unresolved-secret-configuration-mutation",
+  };
+}

--- a/.github/scripts/ponto-pages-environment-prerequisite.test.mjs
+++ b/.github/scripts/ponto-pages-environment-prerequisite.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { assessPagesEnvironmentPrerequisite } from "./ponto-pages-environment-prerequisite.mjs";
+
+const attestedJournal = Object.freeze({
+  mutationCompleted: true,
+  remoteAttestationCompleted: true,
+  mutationSafety: {
+    maintenanceRequired: true,
+    deterministicRerun: true,
+    retainedOnCodeRollback: true,
+  },
+});
+
+test("retains an attested Pages prerequisite after its child lease cleanup is cancelled", () => {
+  const result = assessPagesEnvironmentPrerequisite({
+    conclusion: "cancelled",
+    journal: attestedJournal,
+  });
+
+  assert.deepEqual(result, {
+    passed: true,
+    attestedProvision: true,
+    cancelledAfterAttestedProvision: true,
+    disposition: "retained-environment-prerequisite-under-maintenance",
+  });
+});
+
+test("does not retain a failed, timed-out, or incompletely attested Pages provision", () => {
+  for (const conclusion of ["failure", "timed_out", "action_required"]) {
+    assert.equal(
+      assessPagesEnvironmentPrerequisite({ conclusion, journal: attestedJournal }).passed,
+      false,
+      conclusion,
+    );
+  }
+
+  assert.equal(
+    assessPagesEnvironmentPrerequisite({
+      conclusion: "cancelled",
+      journal: { ...attestedJournal, remoteAttestationCompleted: false },
+    }).passed,
+    false,
+  );
+});


### PR DESCRIPTION
## Contexto

Um workflow de custódia de Pages pode ser cancelado após o provisionamento e a atestação remota terem terminado, enquanto a liberação final do lease não chega a concluir. O rollback tratava toda conclusão `cancelled` como mutação não atestada e permanecia bloqueado apesar da evidência sanitizada completa.

## Alteração

- classifica um pré-requisito de Pages como retível apenas quando a atestação completa comprova manutenção, rerun determinístico e retenção segura;
- permite exclusivamente `cancelled` após essa atestação; `failure`, timeout e artefato incompleto continuam bloqueados;
- registra a conclusão do filho e o caso de cancelamento atestado no relatório de rollback;
- adiciona testes unitários para os caminhos permitido e recusados.

## Validação

`node --test .github/scripts/ponto-pages-environment-prerequisite.test.mjs .github/scripts/ponto-automatic-rollback-safety.test.mjs .github/scripts/ponto-reconcile-children.test.mjs .github/scripts/ponto-staging-recovery-rollback.test.mjs`