### PR TITLE
feat(meta-ads): bootstrap governed tracking config

### DIFF
--- a/.github/workflows/deploy-token-vault.yml
+++ b/.github/workflows/deploy-token-vault.yml
@@ -331,28 +331,154 @@ jobs:
           }
           NODE
 
-      - name: Read back production Token Vault authenticated health after activation
-        id: worker_health_readback
+      - name: Bootstrap legacy Token Vault Meta Ads configuration only when production requires it
+        id: tracking_bootstrap
         if: always() && steps.worker_activation.outcome == 'success' && steps.worker_deployment_readback.outcome == 'success'
         env:
-          TOKEN_VAULT_API_TOKEN: ${{ secrets.TOKEN_VAULT_API_TOKEN }}
-          TOKEN_VAULT_N8N_API_TOKEN: ${{ secrets.TOKEN_VAULT_N8N_API_TOKEN }}
+          # The manifest stays in the protected Environment and is read only
+          # after the activated Worker proves that its authority is legacy.
+          TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST: ${{ secrets.TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST }}
+          TOKEN_VAULT_META_ADS_CONFIG_TOKEN: ${{ secrets.TOKEN_VAULT_META_ADS_CONFIG_TOKEN }}
+          TOKEN_VAULT_PRODUCTION_BASE_URL: ${{ vars.TOKEN_VAULT_PRODUCTION_BASE_URL }}
+          RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          [[ -n "${TOKEN_VAULT_META_ADS_CONFIG_TOKEN:-}" ]] || { echo 'TOKEN_VAULT_META_ADS_CONFIG_TOKEN must be owned by the production Environment for bootstrap'; exit 1; }
+          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'bootstrap release SHA is invalid'; exit 1; }
+          [[ "$GITHUB_RUN_ID" =~ ^[0-9]+$ && "$GITHUB_RUN_ATTEMPT" =~ ^[0-9]+$ ]] || { echo 'bootstrap run identity is invalid'; exit 1; }
+          bootstrap_operation_key="meta-ads-bootstrap:${RELEASE_SHA:0:12}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+          [[ "$bootstrap_operation_key" =~ ^[A-Za-z0-9_.:-]{8,160}$ ]] || { echo 'bootstrap operation key is invalid'; exit 1; }
+          bootstrap_state="$(BOOTSTRAP_OPERATION_KEY="$bootstrap_operation_key" node --input-type=module <<'NODE'
+          const base = String(process.env.TOKEN_VAULT_PRODUCTION_BASE_URL || '').replace(/\/$/, '');
+          const token = String(process.env.TOKEN_VAULT_META_ADS_CONFIG_TOKEN || '');
+          const operationKey = String(process.env.BOOTSTRAP_OPERATION_KEY || '');
+          if (!/^https:\/\/[^/]+$/.test(base) || !token) throw new Error('Token Vault production bootstrap endpoint or credential is unavailable');
+          if (!/^[A-Za-z0-9_.:-]{8,160}$/.test(operationKey)) throw new Error('bootstrap operation identity is invalid');
+
+          const safeError = (payload) => {
+            const value = String(payload?.error || '');
+            return /^[a-z0-9_:-]{1,120}$/i.test(value) ? value : 'unknown';
+          };
+          const request = async (path, { method = 'GET', body } = {}) => {
+            const headers = { Authorization: `Bearer ${token}` };
+            if (body !== undefined) headers['content-type'] = 'application/json';
+            const response = await fetch(`${base}/internal/token-vault${path}`, {
+              method,
+              headers,
+              body: body === undefined ? undefined : JSON.stringify(body),
+              redirect: 'error',
+            });
+            let payload = null;
+            try { payload = await response.json(); } catch {}
+            return { response, payload };
+          };
+          const requireReady = ({ response, payload }, context) => {
+            if (
+              !response.ok ||
+              payload?.ok !== true ||
+              payload?.ready !== true ||
+              payload?.config_authority_mode !== 'tracking_ready' ||
+              !/^[a-f0-9]{64}$/.test(String(payload?.config_authority_revision || ''))
+            ) {
+              throw new Error(`${context} did not return a ready tracking authority`);
+            }
+          };
+
+          const initial = await request('/v1/meta-ads-publish/config');
+          if (![200, 409].includes(initial.response.status) || !initial.payload || typeof initial.payload !== 'object' || Array.isArray(initial.payload)) {
+            throw new Error(`Token Vault configuration authority readback failed: ${initial.response.status} ${safeError(initial.payload)}`);
+          }
+          const mode = String(initial.payload.config_authority_mode || '');
+          if (mode === 'tracking_ready') {
+            requireReady(initial, 'Token Vault configuration authority readback');
+            process.stdout.write('not_required\n');
+          } else if (mode === 'legacy_bootstrap') {
+            const expectedRevision = String(initial.payload.config_authority_revision || '').toLowerCase();
+            if (!/^legacy:[a-f0-9]{64}$/.test(expectedRevision)) throw new Error('legacy Token Vault authority revision is invalid');
+            const rawManifest = String(process.env.TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST || '');
+            if (!rawManifest) throw new Error('TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST is required only when legacy bootstrap is detected');
+            let manifest;
+            try { manifest = JSON.parse(rawManifest); } catch { throw new Error('TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST must be valid JSON containing only entries'); }
+            if (
+              !manifest ||
+              typeof manifest !== 'object' ||
+              Array.isArray(manifest) ||
+              Object.keys(manifest).length !== 1 ||
+              !Object.prototype.hasOwnProperty.call(manifest, 'entries') ||
+              !Array.isArray(manifest.entries) ||
+              manifest.entries.length < 2 ||
+              manifest.entries.length > 10 ||
+              new TextEncoder().encode(JSON.stringify(manifest)).length > 150 * 1024
+            ) {
+              throw new Error('TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST must contain only 2 to 10 bounded entries');
+            }
+            const bootstrap = await request('/v1/meta-ads-publish/config/bootstrap', {
+              method: 'POST',
+              body: {
+                operation_key: operationKey,
+                expected_config_authority_revision: expectedRevision,
+                entries: manifest.entries,
+              },
+            });
+            if (!bootstrap.response.ok || bootstrap.payload?.ok !== true) {
+              throw new Error(`Token Vault legacy bootstrap failed: ${bootstrap.response.status} ${safeError(bootstrap.payload)}`);
+            }
+            const bootstrapRevision = String(bootstrap.payload?.config_authority_revision || '').toLowerCase();
+            if (!/^[a-f0-9]{64}$/.test(bootstrapRevision)) throw new Error('Token Vault legacy bootstrap did not return a tracking revision');
+            const postBootstrap = await request('/v1/meta-ads-publish/config');
+            requireReady(postBootstrap, 'Token Vault post-bootstrap authority readback');
+            if (String(postBootstrap.payload?.config_authority_revision || '').toLowerCase() !== bootstrapRevision) {
+              throw new Error('Token Vault post-bootstrap authority revision changed unexpectedly');
+            }
+            process.stdout.write(`applied\t${operationKey}\t${bootstrapRevision}\n`);
+          } else {
+            throw new Error('Token Vault configuration authority mode is unsupported');
+          }
+          NODE
+          )"
+          bootstrap_status=''
+          bootstrap_recorded_operation_key=''
+          bootstrap_revision=''
+          IFS=$'\t' read -r bootstrap_status bootstrap_recorded_operation_key bootstrap_revision <<< "$bootstrap_state" || true
+          case "$bootstrap_status" in
+            not_required)
+              [[ -z "$bootstrap_recorded_operation_key" && -z "$bootstrap_revision" ]] || { echo 'Token Vault bootstrap returned an invalid no-op state'; exit 1; }
+              echo 'did_bootstrap=false' >> "$GITHUB_OUTPUT"
+              ;;
+            applied)
+              [[ "$bootstrap_recorded_operation_key" == "$bootstrap_operation_key" ]] || { echo 'Token Vault bootstrap operation key did not round-trip'; exit 1; }
+              [[ "$bootstrap_revision" =~ ^[a-f0-9]{64}$ ]] || { echo 'Token Vault bootstrap revision is invalid'; exit 1; }
+              printf '%s\n' 'did_bootstrap=true' "bootstrap_operation_key=$bootstrap_recorded_operation_key" "bootstrap_revision=$bootstrap_revision" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo 'Token Vault bootstrap returned an invalid state'; exit 1
+              ;;
+          esac
+
+      - name: Read back production Token Vault authenticated health after activation
+        id: worker_health_readback
+        if: always() && steps.worker_activation.outcome == 'success' && steps.worker_deployment_readback.outcome == 'success' && steps.tracking_bootstrap.outcome == 'success'
+        env:
+          # This release-scoped credential is intentionally narrower than the
+          # incumbent admin and Orb credentials.  It may read health/config and
+          # perform only the bounded config bootstrap; it cannot publish ads or
+          # read generic token records.
+          TOKEN_VAULT_META_ADS_CONFIG_TOKEN: ${{ secrets.TOKEN_VAULT_META_ADS_CONFIG_TOKEN }}
           TOKEN_VAULT_PRODUCTION_BASE_URL: ${{ vars.TOKEN_VAULT_PRODUCTION_BASE_URL }}
         run: |
           set -euo pipefail
+          [[ -n "${TOKEN_VAULT_META_ADS_CONFIG_TOKEN:-}" ]] || { echo 'TOKEN_VAULT_META_ADS_CONFIG_TOKEN must be owned by the production Environment for v20 readback'; exit 1; }
           BASE_URL="$TOKEN_VAULT_PRODUCTION_BASE_URL"
           anonymous_code="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' "$BASE_URL/internal/token-vault/health")"
           [[ "$anonymous_code" == 401 ]] || { echo 'Token Vault anonymous health must remain unauthorized'; exit 1; }
-          curl --fail --silent --show-error -H "Authorization: Bearer $TOKEN_VAULT_API_TOKEN" "$BASE_URL/internal/token-vault/health" \
-            | node -e "const fs=require('fs');const x=JSON.parse(fs.readFileSync(0,'utf8'));if(x.ok!==true||x.checks?.n8nApiToken!==true)throw new Error('Token Vault admin health/readback failed');"
-          curl --fail --silent --show-error -H "Authorization: Bearer $TOKEN_VAULT_N8N_API_TOKEN" "$BASE_URL/internal/token-vault/health" \
-            | node -e "const fs=require('fs');const x=JSON.parse(fs.readFileSync(0,'utf8'));if(x.ok!==true)throw new Error('Token Vault operational health/readback failed');"
-          curl --fail --silent --show-error -H "Authorization: Bearer $TOKEN_VAULT_API_TOKEN" "$BASE_URL/internal/token-vault/v1/meta-ads-publish/config" \
+          curl --fail --silent --show-error -H "Authorization: Bearer $TOKEN_VAULT_META_ADS_CONFIG_TOKEN" "$BASE_URL/internal/token-vault/health" \
+            | node -e "const fs=require('fs');const x=JSON.parse(fs.readFileSync(0,'utf8'));if(x.ok!==true||x.checks?.apiToken!==true||x.checks?.n8nApiToken!==true||x.checks?.analyticsApiToken!==true||x.checks?.encryptionKey!==true)throw new Error('Token Vault restricted health/readback failed');"
+          curl --fail --silent --show-error -H "Authorization: Bearer $TOKEN_VAULT_META_ADS_CONFIG_TOKEN" "$BASE_URL/internal/token-vault/v1/meta-ads-publish/config" \
             | node -e "const fs=require('fs');const x=JSON.parse(fs.readFileSync(0,'utf8'));const websites=(x.destinations||[]).filter(d=>d.tracking_contract?.destination_kind==='website');const valid=websites.length>0&&websites.every(d=>d.tracking_contract?.profile_configured===true&&d.tracking_contract?.url_tags_configured===true&&['required','not_required'].includes(d.tracking_contract?.website_event_requirement)&&['required','not_required'].includes(d.tracking_contract?.offline_event_dataset_requirement));if(x.ready!==true||x.capabilities?.workflow_contract_revision!=='meta_destination_contract_v20_tracking_reconciliation'||x.capabilities?.tracking?.adset_conversion_reconciliation!==true||!valid)throw new Error('production Token Vault tracking configuration readback is incomplete');"
 
       - name: Refresh candidate OIDC custody approval before final native readback
         id: candidate_final_readback_attestation
-        if: always() && steps.worker_activation.outcome == 'success' && steps.worker_deployment_readback.outcome == 'success' && steps.worker_health_readback.outcome == 'success'
+        if: always() && steps.worker_activation.outcome == 'success' && steps.worker_deployment_readback.outcome == 'success' && steps.tracking_bootstrap.outcome == 'success' && steps.worker_health_readback.outcome == 'success'
         run: |
           set -euo pipefail
           request_url="${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=skincos-meta-ads-tracking-custody%2Fv1%2Frelease%2F${RELEASE_SHA}"
@@ -405,7 +531,7 @@ jobs:
 
       - name: Read back required Website conversion and offline-dataset contracts from Graph
         id: conversion_contract_readback
-        if: always() && steps.worker_activation.outcome == 'success' && steps.worker_deployment_readback.outcome == 'success' && steps.worker_health_readback.outcome == 'success' && steps.candidate_conversion_readback_attestation.outcome == 'success'
+        if: always() && steps.worker_activation.outcome == 'success' && steps.worker_deployment_readback.outcome == 'success' && steps.tracking_bootstrap.outcome == 'success' && steps.worker_health_readback.outcome == 'success' && steps.candidate_conversion_readback_attestation.outcome == 'success'
         env:
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: |
@@ -440,7 +566,7 @@ jobs:
 
       - name: Revalidate the shared lease before cross-surface production compensation
         id: cross_surface_compensation_lease
-        if: always() && steps.native_orb_promotion.outputs.applied == 'true' && (steps.orb_pre_worker_readback.outcome != 'success' || steps.worker_activation.outcome != 'success' || steps.worker_deployment_readback.outcome != 'success' || steps.worker_health_readback.outcome != 'success' || steps.orb_live_readback.outcome != 'success' || steps.conversion_contract_readback.outcome != 'success')
+        if: always() && steps.native_orb_promotion.outputs.applied == 'true' && (steps.orb_pre_worker_readback.outcome != 'success' || steps.worker_activation.outcome != 'success' || steps.worker_deployment_readback.outcome != 'success' || steps.tracking_bootstrap.outcome != 'success' || steps.worker_health_readback.outcome != 'success' || steps.orb_live_readback.outcome != 'success' || steps.conversion_contract_readback.outcome != 'success')
         uses: ./.github/actions/global-coordination-check
         with:
           required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
@@ -453,9 +579,75 @@ jobs:
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
           key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
 
+      - name: Roll back an applied Token Vault legacy bootstrap before cross-surface compensation
+        id: tracking_bootstrap_rollback
+        if: always() && steps.cross_surface_compensation_lease.outcome == 'success'
+        env:
+          BOOTSTRAP_STEP_OUTCOME: ${{ steps.tracking_bootstrap.outcome }}
+          DID_BOOTSTRAP: ${{ steps.tracking_bootstrap.outputs.did_bootstrap }}
+          BOOTSTRAP_OPERATION_KEY: ${{ steps.tracking_bootstrap.outputs.bootstrap_operation_key }}
+          BOOTSTRAP_REVISION: ${{ steps.tracking_bootstrap.outputs.bootstrap_revision }}
+          TOKEN_VAULT_META_ADS_CONFIG_TOKEN: ${{ secrets.TOKEN_VAULT_META_ADS_CONFIG_TOKEN }}
+          TOKEN_VAULT_PRODUCTION_BASE_URL: ${{ vars.TOKEN_VAULT_PRODUCTION_BASE_URL }}
+        run: |
+          set -euo pipefail
+          case "$BOOTSTRAP_STEP_OUTCOME" in
+            skipped)
+              echo 'Token Vault bootstrap was not reached; no bootstrap rollback is required.'
+              exit 0
+              ;;
+            success)
+              ;;
+            *)
+              echo 'Token Vault bootstrap has no trusted terminal outcome; retaining the candidate Worker and native source.' >&2
+              exit 1
+              ;;
+          esac
+          case "$DID_BOOTSTRAP" in
+            false)
+              echo 'Token Vault was already tracking-ready; no bootstrap rollback is required.'
+              exit 0
+              ;;
+            true)
+              ;;
+            *)
+              echo 'Token Vault bootstrap result is indeterminate; retaining the candidate Worker and native source.' >&2
+              exit 1
+              ;;
+          esac
+          [[ -n "${TOKEN_VAULT_META_ADS_CONFIG_TOKEN:-}" ]] || { echo 'TOKEN_VAULT_META_ADS_CONFIG_TOKEN is required for bootstrap compensation'; exit 1; }
+          [[ "$BOOTSTRAP_OPERATION_KEY" =~ ^[A-Za-z0-9_.:-]{8,160}$ ]] || { echo 'Token Vault bootstrap operation key is invalid for compensation'; exit 1; }
+          [[ "$BOOTSTRAP_REVISION" =~ ^[a-f0-9]{64}$ ]] || { echo 'Token Vault bootstrap revision is invalid for compensation'; exit 1; }
+          node --input-type=module <<'NODE'
+          const base = String(process.env.TOKEN_VAULT_PRODUCTION_BASE_URL || '').replace(/\/$/, '');
+          const token = String(process.env.TOKEN_VAULT_META_ADS_CONFIG_TOKEN || '');
+          const operationKey = String(process.env.BOOTSTRAP_OPERATION_KEY || '');
+          const revision = String(process.env.BOOTSTRAP_REVISION || '');
+          if (!/^https:\/\/[^/]+$/.test(base) || !token) throw new Error('Token Vault production bootstrap rollback endpoint or credential is unavailable');
+          if (!/^[A-Za-z0-9_.:-]{8,160}$/.test(operationKey) || !/^[a-f0-9]{64}$/.test(revision)) throw new Error('Token Vault bootstrap rollback identity is invalid');
+          const response = await fetch(`${base}/internal/token-vault/v1/meta-ads-publish/config/bootstrap/rollback`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify({
+              operation_key: operationKey,
+              expected_tracking_binding_revision: revision,
+            }),
+            redirect: 'error',
+          });
+          let payload = null;
+          try { payload = await response.json(); } catch {}
+          const error = /^[a-z0-9_:-]{1,120}$/i.test(String(payload?.error || '')) ? String(payload.error) : 'unknown';
+          if (!response.ok || payload?.ok !== true || payload?.rolled_back !== true || payload?.operation_status !== 'rolled_back') {
+            throw new Error(`Token Vault bootstrap rollback failed: ${response.status} ${error}`);
+          }
+          NODE
+
       - name: Refresh candidate OIDC custody approval before cross-surface compensation
         id: candidate_compensation_attestation
-        if: always() && steps.cross_surface_compensation_lease.outcome == 'success'
+        if: always() && steps.cross_surface_compensation_lease.outcome == 'success' && steps.tracking_bootstrap_rollback.outcome == 'success'
         run: |
           set -euo pipefail
           request_url="${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=skincos-meta-ads-tracking-custody%2Fv1%2Frelease%2F${RELEASE_SHA}"
@@ -512,22 +704,19 @@ jobs:
           }
           NODE
 
-      - name: Read back the incumbent Token Vault health before restoring the Orb snapshot
+      - name: Read back the incumbent Token Vault version and public auth boundary before restoring the Orb snapshot
         id: worker_incumbent_health
         if: always() && steps.worker_compensation.outcome == 'success'
         env:
-          TOKEN_VAULT_API_TOKEN: ${{ secrets.TOKEN_VAULT_API_TOKEN }}
-          TOKEN_VAULT_N8N_API_TOKEN: ${{ secrets.TOKEN_VAULT_N8N_API_TOKEN }}
           TOKEN_VAULT_PRODUCTION_BASE_URL: ${{ vars.TOKEN_VAULT_PRODUCTION_BASE_URL }}
         run: |
           set -euo pipefail
           BASE_URL="$TOKEN_VAULT_PRODUCTION_BASE_URL"
           anonymous_code="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' "$BASE_URL/internal/token-vault/health")"
           [[ "$anonymous_code" == 401 ]] || { echo 'Token Vault anonymous health must remain unauthorized after compensation'; exit 1; }
-          curl --fail --silent --show-error -H "Authorization: Bearer $TOKEN_VAULT_API_TOKEN" "$BASE_URL/internal/token-vault/health" \
-            | node -e "const fs=require('fs');const x=JSON.parse(fs.readFileSync(0,'utf8'));if(x.ok!==true||x.checks?.n8nApiToken!==true)throw new Error('Token Vault incumbent admin health/readback failed');"
-          curl --fail --silent --show-error -H "Authorization: Bearer $TOKEN_VAULT_N8N_API_TOKEN" "$BASE_URL/internal/token-vault/health" \
-            | node -e "const fs=require('fs');const x=JSON.parse(fs.readFileSync(0,'utf8'));if(x.ok!==true)throw new Error('Token Vault incumbent operational health/readback failed');"
+          # The exact incumbent version was already proved in worker_compensation.
+          # Never reuse legacy admin/Orb bearers here: an older incumbent may not
+          # know the restricted v20 credential, and GitHub must not hold it.
 
       - name: Revalidate the shared lease before restoring the owned Orb snapshot
         id: orb_compensation_lease
@@ -708,11 +897,10 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          TOKEN_VAULT_API_TOKEN: ${{ secrets.TOKEN_VAULT_API_TOKEN }}
-          TOKEN_VAULT_N8N_API_TOKEN: ${{ secrets.TOKEN_VAULT_N8N_API_TOKEN }}
-          TOKEN_VAULT_ANALYTICS_API_TOKEN: ${{ secrets.TOKEN_VAULT_ANALYTICS_API_TOKEN }}
-          TOKEN_VAULT_ENCRYPTION_KEY: ${{ secrets.TOKEN_VAULT_ENCRYPTION_KEY }}
-          TOKEN_VAULT_BACKUP_PASSPHRASE: ${{ secrets.TOKEN_VAULT_BACKUP_PASSPHRASE }}
+          # This optional Worker binding becomes a mandatory Environment input
+          # only for the governed v20 promotion: it is the least-privileged
+          # bearer that can perform the config/exercise readbacks below.
+          TOKEN_VAULT_META_ADS_CONFIG_TOKEN: ${{ secrets.TOKEN_VAULT_META_ADS_CONFIG_TOKEN }}
           TOKEN_VAULT_STAGING_BASE_URL: ${{ vars.TOKEN_VAULT_STAGING_BASE_URL }}
           TOKEN_VAULT_PRODUCTION_BASE_URL: ${{ vars.TOKEN_VAULT_PRODUCTION_BASE_URL }}
           ENABLE_TOKEN_VAULT_DEPLOY_STAGING: ${{ vars.ENABLE_TOKEN_VAULT_DEPLOY_STAGING }}
@@ -722,7 +910,7 @@ jobs:
           CONFIRM_STAGING_TRACKING_FIXTURE: ${{ inputs.confirm_staging_tracking_fixture }}
         run: |
           set -euo pipefail
-          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID TOKEN_VAULT_API_TOKEN TOKEN_VAULT_N8N_API_TOKEN TOKEN_VAULT_ANALYTICS_API_TOKEN TOKEN_VAULT_ENCRYPTION_KEY TOKEN_VAULT_BACKUP_PASSPHRASE; do
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID TOKEN_VAULT_META_ADS_CONFIG_TOKEN; do
             [[ -n "${!name:-}" ]] || { echo "Missing required environment secret: $name"; exit 1; }
           done
           [[ "$OPERATION" == deploy ]] || { echo 'Cross-SHA Token Vault rollback is fail-closed because it cannot prove restoration of the matching native Orb snapshot; the deployment path compensates its own transaction automatically.'; exit 1; }
@@ -737,7 +925,7 @@ jobs:
           if [[ "$TARGET" == production ]]; then ENV_ARGS=(); DB=skincos-token-vault; else ENV_ARGS=(--env staging); DB=skincos-token-vault-staging; fi
           npx --yes wrangler@4.120.0 d1 list --json | DB="$DB" node -e "const fs=require('fs');const rows=JSON.parse(fs.readFileSync(0,'utf8'));if(!rows.some(row=>row.name===process.env.DB)){throw new Error('configured Token Vault D1 is absent')}"
           secrets_json="$(npx --yes wrangler@4.120.0 secret list --format json --config platform/security/token-vault/wrangler.toml "${ENV_ARGS[@]}")"
-          printf '%s' "$secrets_json" | node -e "const fs=require('fs');const rows=JSON.parse(fs.readFileSync(0,'utf8'));const names=new Set(rows.map(row=>row.name||row));for(const name of ['TOKEN_VAULT_API_TOKEN','TOKEN_VAULT_N8N_API_TOKEN','TOKEN_VAULT_ANALYTICS_API_TOKEN','TOKEN_VAULT_ENCRYPTION_KEY'])if(!names.has(name))throw new Error('required Worker secret is absent: '+name);"
+          printf '%s' "$secrets_json" | node -e "const fs=require('fs');const rows=JSON.parse(fs.readFileSync(0,'utf8'));const names=new Set(rows.map(row=>row.name||row));for(const name of ['TOKEN_VAULT_API_TOKEN','TOKEN_VAULT_N8N_API_TOKEN','TOKEN_VAULT_ENCRYPTION_KEY'])if(!names.has(name))throw new Error('required inherited Worker secret is absent: '+name);"
 
       - name: Validate Token Vault and Meta Ads Publish source
         timeout-minutes: 8
@@ -783,33 +971,75 @@ jobs:
           [[ "$incumbent" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo 'Unable to resolve the exact Token Vault Worker incumbent'; exit 1; }
           echo "TOKEN_VAULT_INCUMBENT_VERSION_ID=$incumbent" >> "$GITHUB_ENV"
 
-      - name: Capture encrypted Token Vault D1 checkpoint before migrations
+      - name: Capture Token Vault D1 Time Travel recovery bookmark before migrations
+        id: d1_time_travel_checkpoint
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          TOKEN_VAULT_BACKUP_PASSPHRASE: ${{ secrets.TOKEN_VAULT_BACKUP_PASSPHRASE }}
           TARGET: ${{ inputs.target }}
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: |
           set -euo pipefail
-          [[ -n "${TOKEN_VAULT_BACKUP_PASSPHRASE:-}" ]] || { echo 'Missing TOKEN_VAULT_BACKUP_PASSPHRASE'; exit 1; }
           if [[ "$TARGET" == production ]]; then ENV_ARGS=(); DB=skincos-token-vault; else ENV_ARGS=(--env staging); DB=skincos-token-vault-staging; fi
-          plain="$RUNNER_TEMP/token-vault-${TARGET}-pre-migration-${RELEASE_SHA}.sql"
-          encrypted="${plain}.gpg"
-          npx --yes wrangler@4.120.0 d1 export "$DB" --remote --output "$plain" --config platform/security/token-vault/wrangler.toml "${ENV_ARGS[@]}"
-          printf '%s' "$TOKEN_VAULT_BACKUP_PASSPHRASE" | gpg --batch --yes --pinentry-mode loopback --passphrase-fd 0 --symmetric --cipher-algo AES256 --output "$encrypted" "$plain"
-          rm -f "$plain"
-          sha256sum "$encrypted" | awk '{print $1}' > "$encrypted.sha256"
-          echo "CHECKPOINT=$encrypted" >> "$GITHUB_ENV"
-          echo "CHECKPOINT_DIGEST=$encrypted.sha256" >> "$GITHUB_ENV"
+          info_file="$RUNNER_TEMP/token-vault-${TARGET}-d1-info.json"
+          npx --yes wrangler@4.120.0 d1 info "$DB" --json --config platform/security/token-vault/wrangler.toml "${ENV_ARGS[@]}" > "$info_file"
+          node - "$info_file" <<'NODE'
+          const fs = require('fs');
+          const value = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          const version = String(value?.version ?? value?.result?.version ?? '').trim().toLowerCase();
+          if (version === 'alpha') {
+            throw new Error('Token Vault D1 uses the legacy alpha backend; Time Travel recovery is unavailable and the release is ineligible');
+          }
+          NODE
+          bookmark_file="$RUNNER_TEMP/token-vault-${TARGET}-d1-time-travel.json"
+          npx --yes wrangler@4.120.0 d1 time-travel info "$DB" --json --config platform/security/token-vault/wrangler.toml "${ENV_ARGS[@]}" > "$bookmark_file"
+          bookmark="$(node - "$bookmark_file" <<'NODE'
+          const fs = require('fs');
+          const value = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          const bookmark = String(value?.bookmark ?? value?.result?.bookmark ?? '').trim();
+          if (!/^[A-Za-z0-9-]{16,256}$/.test(bookmark)) throw new Error('D1 Time Travel did not return a valid recovery bookmark');
+          process.stdout.write(bookmark);
+          NODE
+          )"
+          checkpoint="$RUNNER_TEMP/token-vault-${TARGET}-pre-migration-${RELEASE_SHA}.time-travel.json"
+          TARGET="$TARGET" DB="$DB" BOOKMARK="$bookmark" CHECKPOINT="$checkpoint" node --input-type=module <<'NODE'
+          import fs from 'node:fs';
 
-      - name: Upload encrypted Token Vault D1 checkpoint
+          const envArgs = process.env.TARGET === 'production' ? [] : ['--env', 'staging'];
+          const value = {
+            schema_version: 1,
+            kind: 'cloudflare_d1_time_travel_bookmark',
+            target: process.env.TARGET,
+            database: process.env.DB,
+            backend: 'production',
+            captured_at: new Date().toISOString(),
+            bookmark: process.env.BOOKMARK,
+            recovery: {
+              action: 'manual_restore_under_release_lease',
+              command: [
+                'npx', '--yes', 'wrangler@4.120.0', 'd1', 'time-travel', 'restore', process.env.DB,
+                '--bookmark', process.env.BOOKMARK,
+                '--config', 'platform/security/token-vault/wrangler.toml',
+                ...envArgs,
+              ],
+              command_line: `npx --yes wrangler@4.120.0 d1 time-travel restore ${process.env.DB} --bookmark ${process.env.BOOKMARK} --config platform/security/token-vault/wrangler.toml${envArgs.length ? ' --env staging' : ''}`,
+              note: 'Restore overwrites the database in place. Reacquire release:token-vault, confirm the exact incumbent and stop conflicting writers before execution.',
+            },
+          };
+          fs.writeFileSync(process.env.CHECKPOINT, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+          NODE
+          digest="${checkpoint}.sha256"
+           sha256sum "$checkpoint" | awk '{print $1}' > "$digest"
+           echo "D1_TIME_TRAVEL_CHECKPOINT=$checkpoint" >> "$GITHUB_ENV"
+           echo "D1_TIME_TRAVEL_CHECKPOINT_DIGEST=$digest" >> "$GITHUB_ENV"
+
+      - name: Upload Token Vault D1 Time Travel recovery checkpoint
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: token-vault-${{ inputs.target }}-pre-migration-${{ needs.promotion.outputs.source_sha }}
+          name: token-vault-${{ inputs.target }}-pre-migration-time-travel-${{ needs.promotion.outputs.source_sha }}
           path: |
-            ${{ env.CHECKPOINT }}
-            ${{ env.CHECKPOINT_DIGEST }}
+            ${{ env.D1_TIME_TRAVEL_CHECKPOINT }}
+            ${{ env.D1_TIME_TRAVEL_CHECKPOINT_DIGEST }}
           retention-days: 30
           if-no-files-found: error
 
@@ -895,12 +1125,54 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Analytics is supplied only when the incumbent has no binding.  A
+          # generated value remains private to the candidate version; it is
+          # deliberately never printed or persisted in GitHub.
+          TOKEN_VAULT_ANALYTICS_API_TOKEN: ${{ secrets.TOKEN_VAULT_ANALYTICS_API_TOKEN }}
+          # The Worker treats this binding as optional, but the governed v20
+          # release preflight already required the Environment-held bearer.
+          TOKEN_VAULT_META_ADS_CONFIG_TOKEN: ${{ secrets.TOKEN_VAULT_META_ADS_CONFIG_TOKEN }}
           TARGET: ${{ inputs.target }}
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: |
           set -euo pipefail
           if [[ "$TARGET" == production ]]; then ENV_ARGS=(); else ENV_ARGS=(--env staging); fi
-          upload_output="$(npx --yes wrangler@4.120.0 versions upload --config platform/security/token-vault/wrangler.toml --keep-vars --message "token-vault:deploy:$RELEASE_SHA" "${ENV_ARGS[@]}")"
+          secrets_file="$RUNNER_TEMP/token-vault-${TARGET}-candidate-secrets.json"
+          secret_inventory="$RUNNER_TEMP/token-vault-${TARGET}-remote-secrets.json"
+          trap 'rm -f "$secrets_file" "$secret_inventory"; unset analytics_value' EXIT
+          npx --yes wrangler@4.120.0 secret list --format json --config platform/security/token-vault/wrangler.toml "${ENV_ARGS[@]}" > "$secret_inventory"
+          analytics_required="$(node - "$secret_inventory" <<'NODE'
+          const fs = require('fs');
+          const rows = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          const names = new Set(rows.map((row) => row?.name || row));
+          for (const name of ['TOKEN_VAULT_API_TOKEN', 'TOKEN_VAULT_N8N_API_TOKEN', 'TOKEN_VAULT_ENCRYPTION_KEY']) {
+            if (!names.has(name)) throw new Error(`required inherited Worker secret is absent: ${name}`);
+          }
+          process.stdout.write(names.has('TOKEN_VAULT_ANALYTICS_API_TOKEN') ? 'false' : 'true');
+          NODE
+          )"
+          analytics_value=''
+          if [[ "$analytics_required" == true ]]; then
+            analytics_value="${TOKEN_VAULT_ANALYTICS_API_TOKEN:-}"
+            if [[ -z "$analytics_value" ]]; then
+              analytics_value="$(node --input-type=module -e "import { randomBytes } from 'node:crypto'; process.stdout.write(randomBytes(32).toString('base64url'));")"
+            fi
+          fi
+          ANALYTICS_REQUIRED="$analytics_required" ANALYTICS_VALUE="$analytics_value" META_ADS_CONFIG_VALUE="${TOKEN_VAULT_META_ADS_CONFIG_TOKEN:-}" SECRETS_FILE="$secrets_file" node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+
+          const secrets = {};
+          if (process.env.ANALYTICS_REQUIRED === 'true') {
+            const value = String(process.env.ANALYTICS_VALUE || '');
+            if (value.length < 32) throw new Error('generated Token Vault analytics binding is invalid');
+            secrets.TOKEN_VAULT_ANALYTICS_API_TOKEN = value;
+          }
+          const configToken = String(process.env.META_ADS_CONFIG_VALUE || '');
+          if (configToken) secrets.TOKEN_VAULT_META_ADS_CONFIG_TOKEN = configToken;
+          fs.writeFileSync(process.env.SECRETS_FILE, `${JSON.stringify(secrets)}\n`, { mode: 0o600 });
+          NODE
+          chmod 600 "$secrets_file"
+          upload_output="$(npx --yes wrangler@4.120.0 versions upload --config platform/security/token-vault/wrangler.toml --keep-vars --strict --secrets-file "$secrets_file" --message "token-vault:deploy:$RELEASE_SHA" "${ENV_ARGS[@]}")"
           printf '%s\n' "$upload_output"
           VERSION_ID="$(printf '%s\n' "$upload_output" | sed -n 's/^Worker Version ID: //p' | tail -n 1)"
           [[ "$VERSION_ID" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo 'Unable to capture immutable Token Vault Worker version ID'; exit 1; }
@@ -959,170 +1231,185 @@ jobs:
           }
           NODE
 
-      - name: Read back staging Token Vault deployment and authenticated health
-        id: worker_health_readback
-        if: inputs.target == 'staging'
+      - name: Bootstrap legacy Token Vault Meta Ads configuration only when staging requires it
+        id: tracking_bootstrap
+        if: always() && inputs.target == 'staging' && steps.worker_deploy.outcome == 'success' && steps.worker_deployment_readback.outcome == 'success'
         env:
-          TOKEN_VAULT_API_TOKEN: ${{ secrets.TOKEN_VAULT_API_TOKEN }}
-          TOKEN_VAULT_N8N_API_TOKEN: ${{ secrets.TOKEN_VAULT_N8N_API_TOKEN }}
-          TOKEN_VAULT_STAGING_BASE_URL: ${{ vars.TOKEN_VAULT_STAGING_BASE_URL }}
-        run: |
-          set -euo pipefail
-          BASE_URL="$TOKEN_VAULT_STAGING_BASE_URL"
-          anonymous_code="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' "$BASE_URL/internal/token-vault/health")"
-          [[ "$anonymous_code" == 401 ]] || { echo 'Token Vault anonymous health must remain unauthorized'; exit 1; }
-          curl --fail --silent --show-error -H "Authorization: Bearer $TOKEN_VAULT_API_TOKEN" "$BASE_URL/internal/token-vault/health" \
-            | node -e "const fs=require('fs');const x=JSON.parse(fs.readFileSync(0,'utf8'));if(x.ok!==true||x.checks?.n8nApiToken!==true)throw new Error('Token Vault admin health/readback failed');"
-          curl --fail --silent --show-error -H "Authorization: Bearer $TOKEN_VAULT_N8N_API_TOKEN" "$BASE_URL/internal/token-vault/health" \
-            | node -e "const fs=require('fs');const x=JSON.parse(fs.readFileSync(0,'utf8'));if(x.ok!==true)throw new Error('Token Vault operational health/readback failed');"
-          curl --fail --silent --show-error -H "Authorization: Bearer $TOKEN_VAULT_API_TOKEN" "$BASE_URL/internal/token-vault/v1/meta-ads-publish/config" \
-            | node -e "const fs=require('fs');const x=JSON.parse(fs.readFileSync(0,'utf8'));const fixture=(x.destinations||[]).filter(d=>d.tracking_contract?.destination_kind==='website'&&d.tracking_contract?.profile_configured&&d.tracking_contract?.url_tags_configured&&d.tracking_contract?.staging_synthetic_fixture===true);if(x.ready!==true||x.capabilities?.tracking?.adset_conversion_reconciliation!==true||fixture.length!==1)throw new Error('exactly one authorized synthetic Website tracking fixture is required in staging');"
-
-      - name: Exercise reversible Meta tracking reconciliation against the isolated staging fixture
-        id: tracking_fixture
-        if: inputs.target == 'staging'
-        env:
-          TOKEN_VAULT_N8N_API_TOKEN: ${{ secrets.TOKEN_VAULT_N8N_API_TOKEN }}
+          # The manifest stays in the protected Environment and is read only
+          # after the activated Worker proves that its authority is legacy.
+          TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST: ${{ secrets.TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST }}
+          TOKEN_VAULT_META_ADS_CONFIG_TOKEN: ${{ secrets.TOKEN_VAULT_META_ADS_CONFIG_TOKEN }}
           TOKEN_VAULT_STAGING_BASE_URL: ${{ vars.TOKEN_VAULT_STAGING_BASE_URL }}
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: |
           set -euo pipefail
-          node --input-type=module <<'NODE'
+          [[ -n "${TOKEN_VAULT_META_ADS_CONFIG_TOKEN:-}" ]] || { echo 'TOKEN_VAULT_META_ADS_CONFIG_TOKEN must be owned by the staging Environment for bootstrap'; exit 1; }
+          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'bootstrap release SHA is invalid'; exit 1; }
+          [[ "$GITHUB_RUN_ID" =~ ^[0-9]+$ && "$GITHUB_RUN_ATTEMPT" =~ ^[0-9]+$ ]] || { echo 'bootstrap run identity is invalid'; exit 1; }
+          bootstrap_operation_key="meta-ads-bootstrap:${RELEASE_SHA:0:12}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+          [[ "$bootstrap_operation_key" =~ ^[A-Za-z0-9_.:-]{8,160}$ ]] || { echo 'bootstrap operation key is invalid'; exit 1; }
+          bootstrap_state="$(BOOTSTRAP_OPERATION_KEY="$bootstrap_operation_key" node --input-type=module <<'NODE'
           const base = String(process.env.TOKEN_VAULT_STAGING_BASE_URL || '').replace(/\/$/, '');
-           const token = String(process.env.TOKEN_VAULT_N8N_API_TOKEN || '');
-           const nonce = `${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT}-${process.env.RELEASE_SHA.slice(0, 12)}`;
-           let runId = '';
-           let fixture = null;
-           let snapshotId = '';
-           let rollbackConfirmed = false;
-           let completed = false;
-           const snapshotIdFromFailure = (value) => {
-             const candidate = String(value?.detail?.compensation?.snapshot_id || '');
-             return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(candidate) ? candidate : '';
-           };
+          const token = String(process.env.TOKEN_VAULT_META_ADS_CONFIG_TOKEN || '');
+          const operationKey = String(process.env.BOOTSTRAP_OPERATION_KEY || '');
+          if (!/^https:\/\/[^/]+$/.test(base) || !token) throw new Error('Token Vault staging bootstrap endpoint or credential is unavailable');
+          if (!/^[A-Za-z0-9_.:-]{8,160}$/.test(operationKey)) throw new Error('bootstrap operation identity is invalid');
+
+          const safeError = (payload) => {
+            const value = String(payload?.error || '');
+            return /^[a-z0-9_:-]{1,120}$/i.test(value) ? value : 'unknown';
+          };
           const request = async (path, { method = 'GET', body } = {}) => {
+            const headers = { Authorization: `Bearer ${token}` };
+            if (body !== undefined) headers['content-type'] = 'application/json';
             const response = await fetch(`${base}/internal/token-vault${path}`, {
               method,
-              headers: {
-                Authorization: `Bearer ${token}`,
-                ...(body ? { 'content-type': 'application/json' } : {}),
-              },
-              ...(body ? { body: JSON.stringify(body) } : {}),
+              headers,
+              body: body === undefined ? undefined : JSON.stringify(body),
+              redirect: 'error',
             });
-            let payload = {};
+            let payload = null;
             try { payload = await response.json(); } catch {}
-            if (!response.ok || payload.ok !== true) {
-              const error = new Error(`staging tracking fixture request failed: ${response.status} ${String(payload.error || 'unknown')}`);
-              // Never print the response body. The finally block may use only
-              // its validated opaque snapshot UUID to compensate a Graph POST
-              // that was accepted before a failed operation readback.
-              error.payload = payload;
-              throw error;
-             }
-             return payload;
-           };
-           const rollback = async (operationKey) => {
-             if (!runId || !fixture || !snapshotId) return;
-             const rolledBack = await request(`/v1/meta-ads-publish/runs/${encodeURIComponent(runId)}/operations`, {
-               method: 'POST',
-               body: {
-                 action: 'rollback_adset_conversion_contract',
-                 operation_key: operationKey,
-                 token_id: fixture.token_id,
-                 account_id: fixture.account_id,
-                 api_version: fixture.api_version,
-                 object_id: fixture.adset_id,
-                 snapshot_id: snapshotId,
-               },
-             });
-             const rollbackResult = rolledBack.operation?.result || {};
-             const confirmedRollback =
-               (rollbackResult.status === 'restored' && rollbackResult.graph_mutation === 'promoted_object_restored') ||
-               (['already_restored', 'not_applied'].includes(rollbackResult.status) && rollbackResult.graph_mutation === 'none');
-             if (!confirmedRollback) {
-               throw new Error('staging tracking fixture rollback was not confirmed');
-             }
-             rollbackConfirmed = true;
-           };
-           try {
-            const config = await request('/v1/meta-ads-publish/config');
-            const fixtures = (config.destinations || []).filter((destination) => {
-              const tracking = destination?.tracking_contract || {};
-              return tracking.destination_kind === 'website' && tracking.profile_configured === true &&
-                tracking.staging_synthetic_fixture === true && tracking.website_event_requirement === 'required' &&
-                tracking.offline_event_dataset_requirement === 'required';
-            });
-            if (config.capabilities?.workflow_contract_revision !== 'meta_destination_contract_v20_tracking_reconciliation' || fixtures.length !== 1) {
-              throw new Error('staging tracking fixture contract is not eligible');
+            return { response, payload };
+          };
+          const requireReady = ({ response, payload }, context) => {
+            if (
+              !response.ok ||
+              payload?.ok !== true ||
+              payload?.ready !== true ||
+              payload?.config_authority_mode !== 'tracking_ready' ||
+              !/^[a-f0-9]{64}$/.test(String(payload?.config_authority_revision || ''))
+            ) {
+              throw new Error(`${context} did not return a ready tracking authority`);
             }
-            fixture = fixtures[0];
-            const created = await request('/v1/meta-ads-publish/runs', {
+          };
+
+          const initial = await request('/v1/meta-ads-publish/config');
+          if (![200, 409].includes(initial.response.status) || !initial.payload || typeof initial.payload !== 'object' || Array.isArray(initial.payload)) {
+            throw new Error(`Token Vault configuration authority readback failed: ${initial.response.status} ${safeError(initial.payload)}`);
+          }
+          const mode = String(initial.payload.config_authority_mode || '');
+          if (mode === 'tracking_ready') {
+            requireReady(initial, 'Token Vault configuration authority readback');
+            process.stdout.write('not_required\n');
+          } else if (mode === 'legacy_bootstrap') {
+            const expectedRevision = String(initial.payload.config_authority_revision || '').toLowerCase();
+            if (!/^legacy:[a-f0-9]{64}$/.test(expectedRevision)) throw new Error('legacy Token Vault authority revision is invalid');
+            const rawManifest = String(process.env.TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST || '');
+            if (!rawManifest) throw new Error('TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST is required only when legacy bootstrap is detected');
+            let manifest;
+            try { manifest = JSON.parse(rawManifest); } catch { throw new Error('TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST must be valid JSON containing only entries'); }
+            if (
+              !manifest ||
+              typeof manifest !== 'object' ||
+              Array.isArray(manifest) ||
+              Object.keys(manifest).length !== 1 ||
+              !Object.prototype.hasOwnProperty.call(manifest, 'entries') ||
+              !Array.isArray(manifest.entries) ||
+              manifest.entries.length < 2 ||
+              manifest.entries.length > 10 ||
+              new TextEncoder().encode(JSON.stringify(manifest)).length > 150 * 1024
+            ) {
+              throw new Error('TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST must contain only 2 to 10 bounded entries');
+            }
+            const bootstrap = await request('/v1/meta-ads-publish/config/bootstrap', {
               method: 'POST',
               body: {
-                config_revision: config.config_revision,
-                tracking_binding_revision: config.tracking_binding_revision,
-                workflow_contract_revision: config.capabilities.workflow_contract_revision,
-                workflow_execution_id: `staging-tracking-fixture-${nonce}`,
-                files: [{ id: `synthetic-tracking-fixture-${nonce}`, name: 'tracking-fixture.txt', modified_time: nonce, size: '0' }],
+                operation_key: operationKey,
+                expected_config_authority_revision: expectedRevision,
+                entries: manifest.entries,
               },
             });
-            runId = String(created.run?.id || '');
-            if (!runId) throw new Error('staging tracking fixture run was not created');
-            let ensured;
-            try {
-              ensured = await request(`/v1/meta-ads-publish/runs/${encodeURIComponent(runId)}/operations`, {
-                method: 'POST',
-                body: {
-                  action: 'ensure_adset_conversion_contract',
-                  operation_key: `tracking-fixture:${nonce}`,
-                  token_id: fixture.token_id,
-                  account_id: fixture.account_id,
-                  api_version: fixture.api_version,
-                  object_id: fixture.adset_id,
-                  destination_kind: 'website',
-                  profile_ref: fixture.tracking_contract.profile_ref,
-                },
-              });
-            } catch (error) {
-              snapshotId = snapshotIdFromFailure(error?.payload);
-              throw error;
+            if (!bootstrap.response.ok || bootstrap.payload?.ok !== true) {
+              throw new Error(`Token Vault legacy bootstrap failed: ${bootstrap.response.status} ${safeError(bootstrap.payload)}`);
             }
-             const reconciliation = ensured.operation?.result || {};
-             // Store the snapshot before asserting the rest of the attestation:
-             // a successful Graph mutation with a failed readback assertion must
-             // still be compensable in this same synthetic staging run.
-             snapshotId = String(reconciliation.snapshot_id || '');
-             if (reconciliation.status !== 'reconciled' || reconciliation.website_event?.configured !== true ||
-               reconciliation.offline_event_dataset?.configured !== true || reconciliation.graph_mutation !== 'promoted_object_updated' ||
-               !snapshotId) {
-               throw new Error('staging tracking fixture did not prove Graph GET-POST-GET reconciliation');
-             }
-            await rollback(`tracking-fixture-rollback:${nonce}`);
-            completed = true;
-            process.stdout.write(`${JSON.stringify({ tracking_fixture: { reconciliation: 'reconciled', rollback: 'restored' } })}\n`);
-           } finally {
-             let cleanupFailure = '';
-             if (snapshotId && !rollbackConfirmed) {
-               try {
-                 await rollback(`tracking-fixture-cleanup:${nonce}`);
-                 process.stdout.write(`${JSON.stringify({ tracking_fixture: { cleanup_rollback: 'restored' } })}\n`);
-               } catch (error) {
-                 cleanupFailure = String(error?.message || error || 'unknown');
-               }
-             }
-             if (runId) {
-               try {
-                 await request(`/v1/meta-ads-publish/runs/${encodeURIComponent(runId)}`, {
-                   method: 'PATCH',
-                   body: {
-                     status: completed && rollbackConfirmed && !cleanupFailure ? 'completed' : 'failed',
-                     summary: { staging_tracking_fixture: true, rollback_confirmed: rollbackConfirmed },
-                   },
-                 });
-               } catch {}
-             }
-             if (cleanupFailure) throw new Error(`staging tracking fixture cleanup rollback failed: ${cleanupFailure}`);
-           }
+            const bootstrapRevision = String(bootstrap.payload?.config_authority_revision || '').toLowerCase();
+            if (!/^[a-f0-9]{64}$/.test(bootstrapRevision)) throw new Error('Token Vault legacy bootstrap did not return a tracking revision');
+            const postBootstrap = await request('/v1/meta-ads-publish/config');
+            requireReady(postBootstrap, 'Token Vault post-bootstrap authority readback');
+            if (String(postBootstrap.payload?.config_authority_revision || '').toLowerCase() !== bootstrapRevision) {
+              throw new Error('Token Vault post-bootstrap authority revision changed unexpectedly');
+            }
+            process.stdout.write(`applied\t${operationKey}\t${bootstrapRevision}\n`);
+          } else {
+            throw new Error('Token Vault configuration authority mode is unsupported');
+          }
+          NODE
+          )"
+          bootstrap_status=''
+          bootstrap_recorded_operation_key=''
+          bootstrap_revision=''
+          IFS=$'\t' read -r bootstrap_status bootstrap_recorded_operation_key bootstrap_revision <<< "$bootstrap_state" || true
+          case "$bootstrap_status" in
+            not_required)
+              [[ -z "$bootstrap_recorded_operation_key" && -z "$bootstrap_revision" ]] || { echo 'Token Vault bootstrap returned an invalid no-op state'; exit 1; }
+              echo 'did_bootstrap=false' >> "$GITHUB_OUTPUT"
+              ;;
+            applied)
+              [[ "$bootstrap_recorded_operation_key" == "$bootstrap_operation_key" ]] || { echo 'Token Vault bootstrap operation key did not round-trip'; exit 1; }
+              [[ "$bootstrap_revision" =~ ^[a-f0-9]{64}$ ]] || { echo 'Token Vault bootstrap revision is invalid'; exit 1; }
+              printf '%s\n' 'did_bootstrap=true' "bootstrap_operation_key=$bootstrap_recorded_operation_key" "bootstrap_revision=$bootstrap_revision" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo 'Token Vault bootstrap returned an invalid state'; exit 1
+              ;;
+          esac
+
+      - name: Read back staging Token Vault deployment and authenticated health
+        id: worker_health_readback
+        if: always() && inputs.target == 'staging' && steps.tracking_bootstrap.outcome == 'success'
+        env:
+          TOKEN_VAULT_META_ADS_CONFIG_TOKEN: ${{ secrets.TOKEN_VAULT_META_ADS_CONFIG_TOKEN }}
+          TOKEN_VAULT_STAGING_BASE_URL: ${{ vars.TOKEN_VAULT_STAGING_BASE_URL }}
+        run: |
+          set -euo pipefail
+          [[ -n "${TOKEN_VAULT_META_ADS_CONFIG_TOKEN:-}" ]] || { echo 'TOKEN_VAULT_META_ADS_CONFIG_TOKEN must be owned by the staging Environment for v20 readback'; exit 1; }
+          BASE_URL="$TOKEN_VAULT_STAGING_BASE_URL"
+          anonymous_code="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' "$BASE_URL/internal/token-vault/health")"
+          [[ "$anonymous_code" == 401 ]] || { echo 'Token Vault anonymous health must remain unauthorized'; exit 1; }
+          curl --fail --silent --show-error -H "Authorization: Bearer $TOKEN_VAULT_META_ADS_CONFIG_TOKEN" "$BASE_URL/internal/token-vault/health" \
+            | node -e "const fs=require('fs');const x=JSON.parse(fs.readFileSync(0,'utf8'));if(x.ok!==true||x.checks?.apiToken!==true||x.checks?.n8nApiToken!==true||x.checks?.analyticsApiToken!==true||x.checks?.encryptionKey!==true)throw new Error('Token Vault restricted health/readback failed');"
+          curl --fail --silent --show-error -H "Authorization: Bearer $TOKEN_VAULT_META_ADS_CONFIG_TOKEN" "$BASE_URL/internal/token-vault/v1/meta-ads-publish/config" \
+            | node -e "const fs=require('fs');const x=JSON.parse(fs.readFileSync(0,'utf8'));const fixture=(x.destinations||[]).filter(d=>d.tracking_contract?.destination_kind==='website'&&d.tracking_contract?.profile_configured&&d.tracking_contract?.url_tags_configured&&d.tracking_contract?.staging_synthetic_fixture===true);if(x.ready!==true||x.capabilities?.tracking?.adset_conversion_reconciliation!==true||fixture.length!==1)throw new Error('exactly one authorized synthetic Website tracking fixture is required in staging');"
+
+      - name: Exercise reversible Meta tracking reconciliation against the isolated staging fixture
+        id: tracking_fixture
+        if: always() && inputs.target == 'staging' && steps.tracking_bootstrap.outcome == 'success' && steps.worker_health_readback.outcome == 'success'
+        env:
+          TOKEN_VAULT_META_ADS_CONFIG_TOKEN: ${{ secrets.TOKEN_VAULT_META_ADS_CONFIG_TOKEN }}
+          TOKEN_VAULT_STAGING_BASE_URL: ${{ vars.TOKEN_VAULT_STAGING_BASE_URL }}
+          RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          [[ -n "${TOKEN_VAULT_META_ADS_CONFIG_TOKEN:-}" ]] || { echo 'TOKEN_VAULT_META_ADS_CONFIG_TOKEN must be owned by the staging Environment for the isolated tracking exercise'; exit 1; }
+          node --input-type=module <<'NODE'
+          const base = String(process.env.TOKEN_VAULT_STAGING_BASE_URL || '').replace(/\/$/, '');
+          const token = String(process.env.TOKEN_VAULT_META_ADS_CONFIG_TOKEN || '');
+          const nonce = `${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT}-${process.env.RELEASE_SHA.slice(0, 12)}`;
+          const response = await fetch(`${base}/internal/token-vault/v1/meta-ads-publish/config/staging-exercise`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify({ operation_key: `staging-tracking-fixture:${nonce}` }),
+          });
+          let payload = {};
+          try { payload = await response.json(); } catch {}
+          const error = /^[a-z0-9_:-]+$/i.test(String(payload?.error || '')) ? String(payload.error) : 'unknown';
+          if (!response.ok || payload.ok !== true) {
+            throw new Error(`staging tracking fixture exercise failed: ${response.status} ${error}`);
+          }
+          const exercise = payload.exercise || {};
+          if (
+            exercise.status !== 'reconciled_and_rolled_back' ||
+            exercise.reconciliation !== 'reconciled' ||
+            exercise.rollback !== 'restored' ||
+            exercise.fixture_count !== 1
+          ) {
+            throw new Error('staging tracking fixture did not prove bounded GET-POST-GET reconciliation and rollback');
+          }
+          process.stdout.write(`${JSON.stringify({ tracking_fixture: { reconciliation: exercise.reconciliation, rollback: exercise.rollback } })}\n`);
           NODE
 
       - name: Write staging Token Vault promotion evidence
@@ -1146,7 +1433,7 @@ jobs:
 
       - name: Revalidate the release lease before staging Worker compensation
         id: staging_worker_compensation_lease
-        if: always() && inputs.target == 'staging' && steps.worker_deploy.outcome != 'skipped' && (steps.worker_deploy.outcome != 'success' || steps.worker_deployment_readback.outcome != 'success' || steps.worker_health_readback.outcome != 'success' || steps.tracking_fixture.outcome != 'success' || steps.staging_evidence.outcome != 'success' || steps.staging_evidence_upload.outcome != 'success')
+        if: always() && inputs.target == 'staging' && steps.worker_deploy.outcome != 'skipped' && (steps.worker_deploy.outcome != 'success' || steps.worker_deployment_readback.outcome != 'success' || steps.tracking_bootstrap.outcome != 'success' || steps.worker_health_readback.outcome != 'success' || steps.tracking_fixture.outcome != 'success' || steps.staging_evidence.outcome != 'success' || steps.staging_evidence_upload.outcome != 'success')
         uses: ./.github/actions/global-coordination-check
         with:
           required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
@@ -1159,8 +1446,74 @@ jobs:
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
           key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
 
-      - name: Compensate the staging Worker only when this release still owns traffic
+      - name: Roll back an applied Token Vault legacy bootstrap before staging Worker compensation
+        id: tracking_bootstrap_rollback
         if: always() && steps.staging_worker_compensation_lease.outcome == 'success'
+        env:
+          BOOTSTRAP_STEP_OUTCOME: ${{ steps.tracking_bootstrap.outcome }}
+          DID_BOOTSTRAP: ${{ steps.tracking_bootstrap.outputs.did_bootstrap }}
+          BOOTSTRAP_OPERATION_KEY: ${{ steps.tracking_bootstrap.outputs.bootstrap_operation_key }}
+          BOOTSTRAP_REVISION: ${{ steps.tracking_bootstrap.outputs.bootstrap_revision }}
+          TOKEN_VAULT_META_ADS_CONFIG_TOKEN: ${{ secrets.TOKEN_VAULT_META_ADS_CONFIG_TOKEN }}
+          TOKEN_VAULT_STAGING_BASE_URL: ${{ vars.TOKEN_VAULT_STAGING_BASE_URL }}
+        run: |
+          set -euo pipefail
+          case "$BOOTSTRAP_STEP_OUTCOME" in
+            skipped)
+              echo 'Token Vault bootstrap was not reached; no bootstrap rollback is required.'
+              exit 0
+              ;;
+            success)
+              ;;
+            *)
+              echo 'Token Vault bootstrap has no trusted terminal outcome; retaining the candidate Worker.' >&2
+              exit 1
+              ;;
+          esac
+          case "$DID_BOOTSTRAP" in
+            false)
+              echo 'Token Vault was already tracking-ready; no bootstrap rollback is required.'
+              exit 0
+              ;;
+            true)
+              ;;
+            *)
+              echo 'Token Vault bootstrap result is indeterminate; retaining the candidate Worker.' >&2
+              exit 1
+              ;;
+          esac
+          [[ -n "${TOKEN_VAULT_META_ADS_CONFIG_TOKEN:-}" ]] || { echo 'TOKEN_VAULT_META_ADS_CONFIG_TOKEN is required for bootstrap compensation'; exit 1; }
+          [[ "$BOOTSTRAP_OPERATION_KEY" =~ ^[A-Za-z0-9_.:-]{8,160}$ ]] || { echo 'Token Vault bootstrap operation key is invalid for compensation'; exit 1; }
+          [[ "$BOOTSTRAP_REVISION" =~ ^[a-f0-9]{64}$ ]] || { echo 'Token Vault bootstrap revision is invalid for compensation'; exit 1; }
+          node --input-type=module <<'NODE'
+          const base = String(process.env.TOKEN_VAULT_STAGING_BASE_URL || '').replace(/\/$/, '');
+          const token = String(process.env.TOKEN_VAULT_META_ADS_CONFIG_TOKEN || '');
+          const operationKey = String(process.env.BOOTSTRAP_OPERATION_KEY || '');
+          const revision = String(process.env.BOOTSTRAP_REVISION || '');
+          if (!/^https:\/\/[^/]+$/.test(base) || !token) throw new Error('Token Vault staging bootstrap rollback endpoint or credential is unavailable');
+          if (!/^[A-Za-z0-9_.:-]{8,160}$/.test(operationKey) || !/^[a-f0-9]{64}$/.test(revision)) throw new Error('Token Vault bootstrap rollback identity is invalid');
+          const response = await fetch(`${base}/internal/token-vault/v1/meta-ads-publish/config/bootstrap/rollback`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify({
+              operation_key: operationKey,
+              expected_tracking_binding_revision: revision,
+            }),
+            redirect: 'error',
+          });
+          let payload = null;
+          try { payload = await response.json(); } catch {}
+          const error = /^[a-z0-9_:-]{1,120}$/i.test(String(payload?.error || '')) ? String(payload.error) : 'unknown';
+          if (!response.ok || payload?.ok !== true || payload?.rolled_back !== true || payload?.operation_status !== 'rolled_back') {
+            throw new Error(`Token Vault bootstrap rollback failed: ${response.status} ${error}`);
+          }
+          NODE
+
+      - name: Compensate the staging Worker only when this release still owns traffic
+        if: always() && steps.staging_worker_compensation_lease.outcome == 'success' && steps.tracking_bootstrap_rollback.outcome == 'success'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/platform/deploy/operational-units.json
+++ b/platform/deploy/operational-units.json
@@ -101,11 +101,16 @@
       "workflow": ".github/workflows/deploy-token-vault.yml",
       "concurrencyPrefix": "deploy-token-vault-",
       "publishes": ["Worker:skincos-token-vault", "Worker:skincos-token-vault-staging"],
-      "resources": ["Token Vault Worker", "skincos-token-vault D1", "skincos-token-vault-staging D1", "Token Vault route and auth bindings"],
-      "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "TOKEN_VAULT_API_TOKEN", "TOKEN_VAULT_N8N_API_TOKEN", "TOKEN_VAULT_ANALYTICS_API_TOKEN", "TOKEN_VAULT_ENCRYPTION_KEY", "TOKEN_VAULT_BACKUP_PASSPHRASE"],
+      "resources": ["Token Vault Worker", "skincos-token-vault D1", "skincos-token-vault-staging D1", "Token Vault route and auth bindings", "Governed Meta Ads tracking bootstrap, rollback journal and paused creative fixture"],
+      "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "TOKEN_VAULT_API_TOKEN", "TOKEN_VAULT_N8N_API_TOKEN", "TOKEN_VAULT_ANALYTICS_API_TOKEN", "TOKEN_VAULT_ENCRYPTION_KEY", "TOKEN_VAULT_META_ADS_CONFIG_TOKEN", "TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST"],
       "migrationPaths": ["platform/security/token-vault/migrations"],
       "environments": ["preview", "staging", "production"],
-      "promotion": {"stagingSupported": true, "trackingFixture": "synthetic authorized ad-set profile required before staging"}
+      "promotion": {
+        "stagingSupported": true,
+        "trackingFixture": "synthetic authorized ad-set profile required before staging",
+        "trackingBootstrap": "legacy authority only; restricted config bearer plus private entries manifest",
+        "d1Recovery": "Time Travel bookmark; manual restore only under release:token-vault"
+      }
     },
     {
       "id": "finance-ui",

--- a/platform/security/token-vault/README.md
+++ b/platform/security/token-vault/README.md
@@ -9,10 +9,18 @@ Worker interno para substituir a aba `Credencial` do Google Sheets usada pelo wo
 - `GET /internal/token-vault/v1/tokens?provider=threads|instagram|facebook&active=true`
 - `POST /internal/token-vault/v1/tokens`
 - `PATCH /internal/token-vault/v1/tokens/:id`
+- `GET /internal/token-vault/v1/meta-ads-publish/config`
 - `PUT /internal/token-vault/v1/meta-ads-publish/config`
+- `POST /internal/token-vault/v1/meta-ads-publish/config/bootstrap`
+- `POST /internal/token-vault/v1/meta-ads-publish/config/bootstrap/rollback`
+- `POST /internal/token-vault/v1/meta-ads-publish/config/staging-exercise`
 - `POST /internal/token-vault/v1/analytics/operations`
 
 Os endpoints administrativos exigem `Authorization: Bearer <TOKEN_VAULT_API_TOKEN>`.
+O bearer restrito `TOKEN_VAULT_META_ADS_CONFIG_TOKEN` só pode consultar
+`health`, `contract` e a configuração Meta Ads, ou chamar o bootstrap, o
+rollback desse bootstrap e o exercício de staging. Ele não lista/altera tokens,
+não cria runs e não publica anúncios.
 O endpoint de analytics exige o secret separado
 `TOKEN_VAULT_ANALYTICS_API_TOKEN` (administradores continuam podendo operar o
 endpoint para diagnóstico controlado).
@@ -24,6 +32,12 @@ endpoint para diagnóstico controlado).
 - Secret: `TOKEN_VAULT_N8N_API_TOKEN` (gateway operacional do Orb)
 - Secret: `TOKEN_VAULT_ANALYTICS_API_TOKEN` (somente analytics read-only)
 - Secret: `TOKEN_VAULT_ENCRYPTION_KEY`
+- Secret opcional do Worker: `TOKEN_VAULT_META_ADS_CONFIG_TOKEN` (papel
+  restrito de configuração Meta Ads; obrigatório no Environment quando há
+  promoção V20 governada)
+- Secret privado do GitHub Environment, não um binding do Worker:
+  `TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST` (somente as `entries` do bootstrap;
+  exigido apenas quando a autoridade ainda é legada)
 - Variável opcional: `META_GRAPH_VERSION` (default `v20.0`)
 - Variável de gate: `INFLUENCER_INTELLIGENCE_ANALYTICS_MODE` (`off` por
   padrão; `shadow` permite requests bounded; `active` exige também a flag
@@ -33,75 +47,65 @@ Os tokens são gravados em D1 como AES-GCM ciphertext. Logs, auditoria e respost
 
 ## Configuração governada do Meta Ads Publish
 
-O endpoint PUT /internal/token-vault/v1/meta-ads-publish/config é o único
-writer para metadata.meta_ads_publish. Ele exige o bearer administrativo,
-aceita somente um corpo fechado com operation_key,
-expected_tracking_binding_revision e updates; cada item de updates contém
-somente token_id e meta_ads_publish. Nenhum campo de token, access token,
-secret, ciphertext ou metadata externo é aceito.
+`PUT /internal/token-vault/v1/meta-ads-publish/config` continua sendo o writer
+administrativo para uma configuração V20 já conhecida. Ele aceita somente
+`operation_key`, `expected_tracking_binding_revision` e `updates`, preserva os
+outros campos de `metadata_json` e substitui `metadata.meta_ads_publish` em um
+batch D1 condicionado às versões lidas. `POST`/`PATCH /v1/tokens` rejeitam essa
+metadata, pois um merge raso não é seguro.
 
-O writer recebe todos os destinos que precisam mudar no mesmo lote. Ele
-preserva os outros campos de metadata_json de cada credencial e substitui
-somente metadata.meta_ads_publish com uma única operação D1 condicionada a
-todas as versões anteriores. Operação, atualizações e auditoria sanitizada são
-atômicas. POST/PATCH /v1/tokens rejeitam qualquer metadata.meta_ads_publish,
-pois o merge raso desses endpoints não é seguro para essa configuração.
-
-O operador primeiro consulta GET /v1/meta-ads-publish/config com a credencial
-administrativa e usa exatamente config_authority_revision como
-expected_tracking_binding_revision. Quando a fonte ainda é legada, esse valor
-tem o formato legacy:<hash> e é derivado da configuração atual; não existe
-valor curinga ou bypass. Após a substituição, a resposta do writer retorna
-somente hashes, status e requestId; uma repetição com o mesmo operation_key e
-o mesmo corpo é idempotente.
-
-O manifesto deve ficar em custódia privada, fora do repositório, logs e
-histórico de shell. A forma do corpo é:
+Para converter a autoridade legada, use somente o bootstrap restrito. O deploy
+consulta `GET /v1/meta-ads-publish/config`; se `config_authority_mode` for
+`legacy_bootstrap`, monta o corpo fechado abaixo com a revisão opaca devolvida
+pelo GET e as `entries` do manifesto privado. Se já for `tracking_ready`, ele
+apenas faz o readback e não solicita o manifesto.
 
     {
-      "operation_key": "...",
-      "expected_tracking_binding_revision": "...",
-      "updates": [
+      "operation_key": "meta-ads-bootstrap:<sha>:<run>:<attempt>",
+      "expected_config_authority_revision": "legacy:<hash>",
+      "entries": [
         {
-          "token_id": "...",
-          "meta_ads_publish": {
-            "destination_group": "...",
-            "api_version": "...",
-            "account_id": "...",
-            "campaign_id": "...",
-            "adset_id": "...",
-            "page_id": "...",
-            "instagram_user_id": "...",
-            "allowed_link_hosts": ["..."],
-            "landing_pages_by_creative_group": {},
-            "destination_type": "website",
-            "tracking_contract": {
-              "url_tags": "...",
-              "profile_ref": "...",
-              "production_url_tags_readback_fixture": {
-                "ad_id": "...",
-                "creative_id": "..."
-              }
-            },
-            "tracking_profiles": {}
-          }
+          "config_token_id": "...",
+          "destination_type": "website",
+          "source_config_token_id": "...",
+          "url_tags": "key1=value1&key2=value2"
+        },
+        {
+          "config_token_id": "...",
+          "destination_type": "whatsapp"
         }
       ]
     }
 
-Para destination_type="website", o contrato exige parâmetros url_tags válidos
-(pares arbitrários key=value separados por &, preservados sem double encoding),
-um perfil Website com requisitos explícitos para evento de website e dataset
-offline, e uma fixture de criativo pausado. IDs de pixel, evento e dataset não
-são aceitos no manifesto: o Gateway os lê do ad set fonte autorizado. Para
-destination_type="whatsapp", use whatsapp_destination_url HTTPS de WhatsApp e
-omita integralmente tracking_contract, tracking_profiles e campos de carousel.
+Cada Website usa uma fonte autorizada já existente (`source_config_token_id` ou
+`source_adset_id`, nunca ambos). O Vault resolve internamente credenciais e
+IDs, lê pixel/evento Website e dataset offline da fonte e cria ou reutiliza a
+fixture de criativo pausado. `url_tags` aceita pares arbitrários `key=value`
+separados por `&`, preserva UTMs quando fornecidas e não aplica double encoding.
+Click-to-WhatsApp não recebe `url_tags`, perfil Website nem configuração de
+conversão Website.
 
-Fluxo seguro: obter a revisão opaca via GET, preparar o manifesto privado,
-enviar o PUT com bearer injetado pela custódia sem imprimir o valor, repetir
-GET /v1/meta-ads-publish/config para readback e só então executar o preflight
-Meta Ads Publish. Não inclua manifestos privados, headers Authorization ou
-respostas detalhadas em Git, comentários de PR ou logs.
+No manifesto de staging, exatamente uma entry Website marca
+`staging_synthetic_fixture: true`; `fixture_source_ad_id` é opcional e serve
+somente para fixar uma cópia pausada já autorizada. A seleção nunca aceita um
+token Graph, pixel, evento ou dataset fornecido pelo chamador.
+
+O bootstrap exige que todas as credenciais Facebook já participantes sejam
+incluídas, mantém journal D1 com estado Graph cifrado e responde apenas com
+estado/revisão agregados. É idempotente por `operation_key`; não aceita tokens,
+access tokens, secrets, ciphertexts nem IDs de pixel/evento/dataset no
+manifesto. Não inclua manifestos, headers `Authorization` ou respostas
+detalhadas em Git, comentários de PR ou logs.
+
+`POST .../config/bootstrap/rollback` não é um rollback genérico: exige a mesma
+`operation_key` aplicada e a revisão V20 exata. Ele restaura primeiro o baseline
+Graph cifrado e só então a metadata legada; conflito ou readback ambíguo ficam
+em fail-closed (`reconciliation_required`).
+
+`POST .../config/staging-exercise` funciona exclusivamente no Worker staging.
+Ele seleciona uma única fixture sintética autorizada, prova a reconciliação
+GET-POST-GET do evento Website/dataset offline e restaura o snapshot antes de
+retornar `reconciled_and_rolled_back`.
 
 ## Analytics read-only
 
@@ -207,18 +211,29 @@ feita depois pelo router Meta-only, com timeout de 12 s e retry seguro limitado.
 O Token Vault é publicado exclusivamente por
 `.github/workflows/deploy-token-vault.yml`: Preview -> Staging -> Production.
 O workflow exige o gate imutável de promoção, lease global
-`release:token-vault`, checkpoint D1 cifrado, migrations aditivas, upload de
-versão imutável e readback sanitizado. Preview só emite evidência depois de
-testar o Worker e do dry-run; staging exerce a fixture reversível. Em produção,
-o workflow exige a source release nativa exata, aplica o Orb inativo com versão
-esperada, ativa só então o Worker e termina com o preflight Orb. Ele só atesta
-nomes de secrets; não cria nem imprime valores. Não execute `wrangler deploy`,
-`secret put` ou migrations remotas manualmente para publicar este serviço.
+`release:token-vault`, bookmark D1 Time Travel antes das migrations aditivas,
+upload de versão imutável e readback sanitizado. O bookmark registra somente a
+recuperação manual: restaurar D1 exige um novo lease `release:token-vault`,
+confirmação do incumbent e ausência de writers conflitantes; não há restore
+automático do banco.
+
+O upload preserva bindings incumbentes com `--keep-vars --strict`; só fornece o
+bearer restrito do Environment e, se o binding analytics ainda não existir,
+pode gerar seu valor privado para a versão candidata. Preview só emite evidência
+depois do teste e dry-run. Em staging e produção, após ativar o Worker candidato,
+o workflow faz bootstrap apenas para autoridade legada, valida o readback V20 e
+em staging executa a fixture reversível. Em produção, ele exige a source release
+nativa exata, aplica o Orb inativo com versão esperada e termina com o preflight
+Orb. Não execute `wrangler deploy`, `secret put` ou migrations remotas
+manualmente para publicar este serviço.
 
 Antes da primeira promoção, disponibilize em cada GitHub Environment os
-segredos independentes exigidos pelo workflow e um perfil de tracking sintético
-e autorizado em staging. A ausência de credencial, fixture, checkpoint ou
-evidência de staging é um bloqueio fail-closed para produção.
+segredos independentes exigidos pelo workflow, em especial
+`TOKEN_VAULT_META_ADS_CONFIG_TOKEN`; disponibilize
+`TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST` somente com as fontes/tags autorizadas
+quando a autoridade for legada, e um perfil de tracking sintético autorizado em
+staging. A ausência de credencial, manifesto legada necessário, fixture,
+bookmark ou evidência de staging é um bloqueio fail-closed para produção.
 
 ## Import inicial
 

--- a/platform/security/token-vault/migrations/0005_meta_ads_publish_bootstrap_operations.sql
+++ b/platform/security/token-vault/migrations/0005_meta_ads_publish_bootstrap_operations.sql
@@ -1,0 +1,26 @@
+-- Durable, encrypted saga state for the one-way legacy Meta Ads tracking
+-- bootstrap.  Graph resource identifiers and promoted-object snapshots only
+-- ever live in state_ciphertext; summary_json is deliberately sanitized.
+CREATE TABLE IF NOT EXISTS meta_ads_publish_bootstrap_operations (
+  id TEXT PRIMARY KEY,
+  operation_key TEXT NOT NULL UNIQUE,
+  request_hash TEXT NOT NULL,
+  expected_config_authority_revision TEXT NOT NULL,
+  resulting_tracking_binding_revision TEXT,
+  status TEXT NOT NULL CHECK(status IN (
+    'pending',
+    'fixture_created',
+    'tracking_configured',
+    'configuring',
+    'applied',
+    'rolled_back',
+    'reconciliation_required'
+  )),
+  state_ciphertext TEXT NOT NULL,
+  summary_json TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_meta_ads_publish_bootstrap_operations_updated
+  ON meta_ads_publish_bootstrap_operations(updated_at);

--- a/platform/security/token-vault/src/index.js
+++ b/platform/security/token-vault/src/index.js
@@ -9,6 +9,10 @@ import { handleAnalyticsStagingBootstrapRequest } from './analytics-staging-boot
 import { decryptToken, encryptToken } from './token-crypto.js';
 
 const TOKEN_PREFIX = '/internal/token-vault';
+const META_ADS_PUBLISH_CONFIG_PATH = '/v1/meta-ads-publish/config';
+const META_ADS_PUBLISH_CONFIG_BOOTSTRAP_PATH = `${META_ADS_PUBLISH_CONFIG_PATH}/bootstrap`;
+const META_ADS_PUBLISH_CONFIG_BOOTSTRAP_ROLLBACK_PATH = `${META_ADS_PUBLISH_CONFIG_BOOTSTRAP_PATH}/rollback`;
+const META_ADS_PUBLISH_CONFIG_STAGING_EXERCISE_PATH = `${META_ADS_PUBLISH_CONFIG_PATH}/staging-exercise`;
 const JSON_HEADERS = {
   'content-type': 'application/json; charset=utf-8',
   'cache-control': 'no-store',
@@ -51,16 +55,74 @@ export async function handleRequest(request, env) {
       return json({ ok: false, error: 'staging_bootstrap_credential_required', requestId }, { status: 403 });
     }
 
+    // This credential is deliberately isolated from the generic Meta Ads
+    // gateway. It can inspect the public contract and configuration, and its
+    // one future mutation is a dedicated bootstrap route handled by the
+    // Meta Ads module itself. Do not add it to the operational role allowlist.
+    if (auth.role === 'meta-ads-config') {
+      if (request.method === 'GET' && pathname === '/health') {
+        return health(env, requestId);
+      }
+      if (request.method === 'GET' && pathname === '/contract') {
+        return contract(requestId);
+      }
+      if (
+        (request.method === 'GET' && pathname === META_ADS_PUBLISH_CONFIG_PATH) ||
+        (request.method === 'POST' && [
+          META_ADS_PUBLISH_CONFIG_BOOTSTRAP_PATH,
+          META_ADS_PUBLISH_CONFIG_BOOTSTRAP_ROLLBACK_PATH,
+          META_ADS_PUBLISH_CONFIG_STAGING_EXERCISE_PATH,
+        ].includes(pathname))
+      ) {
+        return await handleMetaAdsPublishRequest({
+          request,
+          env,
+          requestId,
+          pathname,
+          decryptToken,
+          encryptToken,
+          writeAudit,
+        });
+      }
+      return roleRequired(requestId, 'meta_ads_config_credential_scope_required');
+    }
+
     if (request.method === 'GET' && pathname === '/health') {
       return health(env, requestId);
     }
 
-    if (request.method === 'PUT' && pathname === '/v1/meta-ads-publish/config') {
+    if (request.method === 'PUT' && pathname === META_ADS_PUBLISH_CONFIG_PATH) {
       if (auth.role !== 'admin') return adminOnly(requestId);
       return await updateMetaAdsPublishConfig({
         request,
         env,
         requestId,
+      });
+    }
+
+    // Bootstrap and staging exercise can mutate a Graph ad set and private
+    // configuration.  They are intentionally not part of the broad
+    // operational publishing gateway: only an administrator or the dedicated
+    // constrained configuration credential may invoke them.
+    if (
+      request.method === 'POST' &&
+      [
+        META_ADS_PUBLISH_CONFIG_BOOTSTRAP_PATH,
+        META_ADS_PUBLISH_CONFIG_BOOTSTRAP_ROLLBACK_PATH,
+        META_ADS_PUBLISH_CONFIG_STAGING_EXERCISE_PATH,
+      ].includes(pathname)
+    ) {
+      if (auth.role !== 'admin') {
+        return roleRequired(requestId, 'meta_ads_config_credential_required');
+      }
+      return await handleMetaAdsPublishRequest({
+        request,
+        env,
+        requestId,
+        pathname,
+        decryptToken,
+        encryptToken,
+        writeAudit,
       });
     }
 
@@ -445,14 +507,15 @@ function authorizeRequest(request, env) {
   const adminToken = safeString(env.TOKEN_VAULT_API_TOKEN);
   const operationalToken = safeString(env.TOKEN_VAULT_N8N_API_TOKEN);
   const analyticsToken = safeString(env.TOKEN_VAULT_ANALYTICS_API_TOKEN);
+  const metaAdsConfigToken = safeString(env.TOKEN_VAULT_META_ADS_CONFIG_TOKEN);
   const stagingBootstrapToken = safeString(env.TOKEN_VAULT_STAGING_ANALYTICS_BOOTSTRAP_TOKEN);
   if (stagingBootstrapToken && !stagingBootstrapEligible(env)) {
     return { ok: false, status: 500, reason: 'invalid_worker_secret_configuration' };
   }
-  if (!adminToken && !operationalToken && !analyticsToken && !stagingBootstrapToken) {
+  if (!adminToken && !operationalToken && !analyticsToken && !metaAdsConfigToken && !stagingBootstrapToken) {
     return { ok: false, status: 500, reason: 'missing_worker_secret' };
   }
-  const configuredTokens = [adminToken, operationalToken, analyticsToken, stagingBootstrapToken].filter(Boolean);
+  const configuredTokens = [adminToken, operationalToken, analyticsToken, metaAdsConfigToken, stagingBootstrapToken].filter(Boolean);
   if (new Set(configuredTokens).size !== configuredTokens.length) {
     return { ok: false, status: 500, reason: 'invalid_worker_secret_configuration' };
   }
@@ -467,6 +530,9 @@ function authorizeRequest(request, env) {
   }
   if (analyticsToken && constantTimeEqual(authHeader, `${scheme} ${analyticsToken}`.trim())) {
     return { ok: true, role: 'analytics' };
+  }
+  if (metaAdsConfigToken && constantTimeEqual(authHeader, `${scheme} ${metaAdsConfigToken}`.trim())) {
+    return { ok: true, role: 'meta-ads-config' };
   }
   if (stagingBootstrapToken && constantTimeEqual(authHeader, `${scheme} ${stagingBootstrapToken}`.trim())) {
     return { ok: true, role: 'staging-bootstrap' };
@@ -520,6 +586,8 @@ function contract(requestId) {
       analytics_secret: 'TOKEN_VAULT_ANALYTICS_API_TOKEN',
       analytics_scope: 'influencer-intelligence',
       analytics_mode: 'shadow|active',
+      meta_ads_config_secret: 'TOKEN_VAULT_META_ADS_CONFIG_TOKEN',
+      meta_ads_config_scope: 'health|contract|meta-ads-config-read|meta-ads-config-bootstrap|meta-ads-config-bootstrap-rollback|meta-ads-config-staging-exercise',
     },
     storage: {
       d1_binding: 'TOKEN_VAULT_DB',

--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -163,6 +163,21 @@ const WORKFLOW_CONTRACT_REVISION = 'meta_destination_contract_v20_tracking_recon
 const CONFIG_WRITER_LOCK_RESOURCE_KEY = 'meta_ads_publish_config_authority';
 const CONFIG_WRITER_LOCK_TTL_MS = 60 * 1000;
 const CONFIG_WRITER_MAX_REQUEST_BYTES = 150 * 1024;
+const BOOTSTRAP_LOCK_TTL_MS = 15 * 60 * 1000;
+// A bootstrap holds the same authority lease as the normal writer. Keeping
+// this batch deliberately small makes its renewable lease observable and
+// prevents a broad legacy migration from starving normal configuration work.
+const BOOTSTRAP_MAX_ENTRIES = 10;
+const BOOTSTRAP_OPERATION_KEY_PATTERN = /^[A-Za-z0-9_.:-]{8,160}$/;
+const STAGING_EXERCISE_OPERATION_KEY_PATTERN = /^staging-tracking-fixture:[A-Za-z0-9_.:-]{8,120}$/;
+const BOOTSTRAP_FIXTURE_NAME_PREFIX = 'Meta Ads URL Tags Fixture';
+const BOOTSTRAP_AD_FIELDS = [
+  'id',
+  'adset_id',
+  'status',
+  'effective_status',
+  'creative{id,name,url_tags,object_story_spec,asset_feed_spec}',
+].join(',');
 const CONFIG_WRITER_TOKEN_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,159}$/;
 const CONFIG_WRITER_OPERATION_KEY_PATTERN = /^[A-Za-z0-9_.:-]{8,160}$/;
 const CONFIG_WRITER_TOP_LEVEL_KEYS = new Set([
@@ -296,6 +311,18 @@ export async function handleMetaAdsPublishRequest(input) {
     return getConfig(env, requestId);
   }
 
+  if (request.method === 'POST' && pathname === `${PREFIX}/config/bootstrap`) {
+    return bootstrapMetaAdsPublishConfig({ request, env, requestId, decryptToken, encryptToken, writeAudit });
+  }
+
+  if (request.method === 'POST' && pathname === `${PREFIX}/config/bootstrap/rollback`) {
+    return rollbackBootstrapMetaAdsPublishConfig({ request, env, requestId, decryptToken, encryptToken, writeAudit });
+  }
+
+  if (request.method === 'POST' && pathname === `${PREFIX}/config/staging-exercise`) {
+    return exerciseStagingMetaAdsTrackingFixture({ request, env, requestId, decryptToken, encryptToken, writeAudit });
+  }
+
   if (request.method === 'POST' && pathname === `${PREFIX}/inventory`) {
     return getInventory({ request, env, requestId, decryptToken, writeAudit });
   }
@@ -342,18 +369,46 @@ export async function handleMetaAdsPublishRequest(input) {
 // credential ciphertext is never accepted, decrypted, or re-encrypted here:
 // the only mutable subtree is metadata.meta_ads_publish.
 export async function updateMetaAdsPublishConfig({ request, env, requestId }) {
-  let lockOwner = '';
-  let lockAcquired = false;
   try {
     const body = await readConfigWriterRequest(request);
     const input = await validateConfigWriterInput(body);
+    const result = await applyMetaAdsPublishConfigAtomically({ input, env, requestId });
+    return configWriterSuccessResponse({
+      replayed: result.replayed,
+      revision: result.revision,
+      requestId,
+    }, result.status);
+  } catch (error) {
+    return configWriterFailureResponse(error, requestId);
+  }
+}
+
+// Both the administrative writer and the narrowly-scoped bootstrap saga use
+// this core.  It deliberately accepts an already validated input rather than
+// an HTTP request so the bootstrap never re-enters the public handler.
+async function applyMetaAdsPublishConfigAtomically({ input, env, requestId, lockAlreadyHeld = false, assertLease = null }) {
+  let lockOwner = '';
+  let lockAcquired = false;
+  try {
     if (!env?.TOKEN_VAULT_DB || typeof env.TOKEN_VAULT_DB.batch !== 'function') {
       throw configWriterFailure('meta_ads_publish_config_authority_unavailable', 503);
     }
+    if (
+      clean(env.ENVIRONMENT).toLowerCase() !== 'staging' &&
+      safeArray(input?.updates).some((update) => hasStagingSyntheticFixture(update?.metaAdsPublish))
+    ) {
+      throw configWriterFailure('meta_ads_publish_config_invalid', 409);
+    }
 
-    lockOwner = crypto.randomUUID();
-    await acquireConfigWriterLock(env, lockOwner);
-    lockAcquired = true;
+    if (!lockAlreadyHeld) {
+      lockOwner = crypto.randomUUID();
+      await acquireConfigWriterLock(env, lockOwner);
+      lockAcquired = true;
+    } else if (typeof assertLease !== 'function') {
+      throw configWriterFailure('meta_ads_publish_config_locked', 409);
+    }
+
+    if (assertLease) await assertLease();
 
     const existingOperation = await dbFirst(
       env,
@@ -379,11 +434,11 @@ export async function updateMetaAdsPublishConfig({ request, env, requestId }) {
       ) {
         throw configWriterFailure('meta_ads_publish_config_operation_state_stale', 409);
       }
-      return configWriterSuccessResponse({
+      return {
         replayed: true,
         revision: currentAuthority.revision,
-        requestId,
-      });
+        status: 200,
+      };
     }
 
     if (currentAuthority.revision !== input.expectedTrackingBindingRevision) {
@@ -478,6 +533,7 @@ export async function updateMetaAdsPublishConfig({ request, env, requestId }) {
         'WHERE id = ? AND status = \'pending\'',
       ].join(' ')).bind(operationId),
     );
+    if (assertLease) await assertLease();
     const batchResults = await env.TOKEN_VAULT_DB.batch(batchStatements);
     if (
       batchChanges(batchResults, 1) !== plans.length ||
@@ -490,13 +546,11 @@ export async function updateMetaAdsPublishConfig({ request, env, requestId }) {
     if (!readbackAuthority.ready || readbackAuthority.revision !== candidateAuthority.revision) {
       throw configWriterFailure('meta_ads_publish_config_readback_mismatch', 409);
     }
-    return configWriterSuccessResponse({
+    return {
       replayed: false,
       revision: readbackAuthority.revision,
-      requestId,
-    }, 201);
-  } catch (error) {
-    return configWriterFailureResponse(error, requestId);
+      status: 201,
+    };
   } finally {
     if (lockAcquired) {
       await releaseConfigWriterLock(env, lockOwner);
@@ -702,6 +756,11 @@ function normalizeConfigWriterWebsiteTracking(value, targetAdsetId) {
     tracking_profiles: trackingProfiles,
     carousel: normalizeConfigWriterCarousel(value, selectedProfile),
   };
+}
+
+function hasStagingSyntheticFixture(value) {
+  return Object.values(asObject(asObject(value).tracking_profiles))
+    .some((profile) => asObject(profile).staging_synthetic_fixture === true);
 }
 
 function normalizeConfigWriterPausedFixture(value) {
@@ -924,14 +983,17 @@ function buildConfigWriterAppliedOperationUpdate(env, { plans, now, operationId 
   );
 }
 
-async function acquireConfigWriterLock(env, ownerId) {
+async function acquireConfigWriterLock(env, ownerId, {
+  resourceKey = CONFIG_WRITER_LOCK_RESOURCE_KEY,
+  ttlMs = CONFIG_WRITER_LOCK_TTL_MS,
+} = {}) {
   try {
     const now = nowIso();
-    const expiresAt = new Date(Date.now() + CONFIG_WRITER_LOCK_TTL_MS).toISOString();
+    const expiresAt = new Date(Date.now() + ttlMs).toISOString();
     await dbRun(
       env,
       'DELETE FROM meta_ads_publish_config_locks WHERE resource_key = ? AND expires_at <= ?',
-      CONFIG_WRITER_LOCK_RESOURCE_KEY,
+      resourceKey,
       now,
     );
     await dbRun(
@@ -943,7 +1005,7 @@ async function acquireConfigWriterLock(env, ownerId) {
         'expires_at = excluded.expires_at, updated_at = excluded.updated_at',
         'WHERE meta_ads_publish_config_locks.expires_at <= ?',
       ].join(' '),
-      CONFIG_WRITER_LOCK_RESOURCE_KEY,
+      resourceKey,
       ownerId,
       expiresAt,
       now,
@@ -953,7 +1015,7 @@ async function acquireConfigWriterLock(env, ownerId) {
     const lock = await dbFirst(
       env,
       'SELECT resource_key, owner_id FROM meta_ads_publish_config_locks WHERE resource_key = ?',
-      CONFIG_WRITER_LOCK_RESOURCE_KEY,
+      resourceKey,
     );
     if (!lock || clean(lock.owner_id) !== ownerId) {
       throw configWriterFailure('meta_ads_publish_config_locked', 409);
@@ -964,17 +1026,46 @@ async function acquireConfigWriterLock(env, ownerId) {
   }
 }
 
-async function releaseConfigWriterLock(env, ownerId) {
+async function releaseConfigWriterLock(env, ownerId, {
+  resourceKey = CONFIG_WRITER_LOCK_RESOURCE_KEY,
+} = {}) {
   try {
     await dbRun(
       env,
       'DELETE FROM meta_ads_publish_config_locks WHERE resource_key = ? AND owner_id = ?',
-      CONFIG_WRITER_LOCK_RESOURCE_KEY,
+      resourceKey,
       ownerId,
     );
   } catch {
     // The lock has a short expiry; a release failure cannot rewrite a committed
     // configuration and must not turn a durable result into a false failure.
+  }
+}
+
+async function renewConfigWriterLock(env, ownerId, {
+  resourceKey = CONFIG_WRITER_LOCK_RESOURCE_KEY,
+  ttlMs = CONFIG_WRITER_LOCK_TTL_MS,
+} = {}) {
+  try {
+    const now = nowIso();
+    const expiresAt = new Date(Date.now() + ttlMs).toISOString();
+    const result = await dbRun(
+      env,
+      `UPDATE meta_ads_publish_config_locks
+          SET expires_at = ?, updated_at = ?
+        WHERE resource_key = ? AND owner_id = ? AND expires_at > ?`,
+      expiresAt,
+      now,
+      resourceKey,
+      ownerId,
+      now,
+    );
+    if (statementChanges(result) !== 1) {
+      throw configWriterFailure('meta_ads_publish_config_locked', 409);
+    }
+  } catch (error) {
+    if (isConfigWriterFailure(error)) throw error;
+    throw configWriterFailure('meta_ads_publish_config_authority_unavailable', 503);
   }
 }
 
@@ -1019,6 +1110,2129 @@ function configWriterFailureResponse(error, requestId) {
         ? 503
         : 400;
   return response({ ok: false, error: code, requestId }, status);
+}
+
+// The legacy configuration predates the v20 tracking contract, so it cannot
+// create a normal creative in order to obtain the mandatory paused URL-tags
+// fixture.  This narrowly-scoped saga is the only bootstrap escape hatch. It
+// resolves every identifier and credential inside the Vault, journals all
+// Graph-side state encrypted, and commits the v20 configuration with the same
+// CAS core used by the administrative writer.
+export async function bootstrapMetaAdsPublishConfig({ request, env, requestId, decryptToken, encryptToken, writeAudit }) {
+  let input;
+  let operation;
+  let state;
+  let context;
+  let lockOwner = '';
+  let lockAcquired = false;
+  try {
+    input = await validateBootstrapInput(await readBootstrapRequest(request));
+    if (!env?.TOKEN_VAULT_DB || typeof env.TOKEN_VAULT_DB.batch !== 'function') {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_unavailable', 503);
+    }
+    if (input.entries.some((entry) => entry.stagingSyntheticFixture === true) && clean(env.ENVIRONMENT).toLowerCase() !== 'staging') {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_staging_fixture_forbidden', 409);
+    }
+
+    lockOwner = crypto.randomUUID();
+    await acquireConfigWriterLock(env, lockOwner, {
+      ttlMs: BOOTSTRAP_LOCK_TTL_MS,
+    });
+    lockAcquired = true;
+
+    const currentRows = await listMetaAdsPublishConfigRows(env);
+    assertBootstrapTargetsComplete(input.entries, currentRows);
+    const authority = await configWriterAuthorityState(currentRows);
+    operation = await loadBootstrapOperation(env, input.operationKey);
+    if (operation) {
+      if (clean(operation.request_hash) !== input.requestHash) {
+        throw bootstrapFailure('meta_ads_publish_bootstrap_operation_conflict', 409);
+      }
+      state = await decryptBootstrapState(operation, decryptToken, env);
+      if (clean(operation.status) === 'applied') {
+        if (!authority.ready || clean(operation.resulting_tracking_binding_revision) !== authority.revision) {
+          throw bootstrapFailure('meta_ads_publish_bootstrap_operation_state_stale', 409);
+        }
+        return bootstrapSuccessResponse({ input, state, revision: authority.revision, requestId, replayed: true });
+      }
+      if (['rolled_back', 'reconciliation_required'].includes(clean(operation.status))) {
+        throw bootstrapFailure('meta_ads_publish_bootstrap_reconciliation_required', 409);
+      }
+    } else {
+      if (authority.mode !== 'legacy_bootstrap' || authority.ready) {
+        throw bootstrapFailure('meta_ads_publish_bootstrap_not_legacy', 409);
+      }
+      if (authority.revision !== input.expectedConfigAuthorityRevision) {
+        throw bootstrapFailure('meta_ads_publish_bootstrap_binding_stale', 409);
+      }
+      state = {
+        schema: 'meta_ads_publish_bootstrap/v1',
+        input: {
+          operation_key: input.operationKey,
+          expected_config_authority_revision: input.expectedConfigAuthorityRevision,
+          entries: input.entries,
+        },
+        items: [],
+        config_input: null,
+        config_applied: false,
+      };
+      operation = await createBootstrapOperation({ env, input, state, encryptToken });
+    }
+
+    context = {
+      env,
+      requestId,
+      operationKey: input.operationKey,
+      ...bootstrapMutationLockIdentity(input.operationKey),
+      bootstrapMutationLockKeys: [],
+      bootstrapMutationLocksHeld: false,
+      action: 'bootstrap_meta_ads_publish_config',
+      decryptToken,
+      encryptToken,
+      attempts: 0,
+      rateUsage: {},
+      traceId: '',
+      assertBootstrapLease: async () => {
+        try {
+          await renewConfigWriterLock(env, lockOwner, { ttlMs: BOOTSTRAP_LOCK_TTL_MS });
+          await renewBootstrapMutationLocks(context);
+        } catch (error) {
+          const locked = isConfigWriterFailure(error) || clean(error?.message).startsWith('resource_locked:');
+          throw bootstrapFailure(
+            locked
+              ? 'meta_ads_publish_bootstrap_locked'
+              : 'meta_ads_publish_bootstrap_unavailable',
+            locked ? 409 : Number(error?.http_status) || 503,
+          );
+        }
+      },
+    };
+    try {
+      context.bootstrapMutationLockKeys = bootstrapMutationLockKeysForInput(input.entries, currentRows);
+      await acquireLocks(
+        env,
+        context.bootstrapMutationRunId,
+        context.bootstrapMutationOperationKey,
+        context.bootstrapMutationLockKeys,
+      );
+      context.bootstrapMutationLocksHeld = true;
+    } catch (error) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_locked', 409);
+    }
+    const result = await executeBootstrapSaga({
+      input,
+      state,
+      operation,
+      currentRows,
+      authority,
+      context,
+      requestId,
+    });
+    // The durable D1 commit is the source of truth. Audit delivery is useful
+    // but must never turn a committed v20 authority into a false failed
+    // bootstrap that a deploy may try to compensate.
+    await writeBootstrapAudit(writeAudit, env, requestId, 'ok', result.state).catch(() => undefined);
+    return bootstrapSuccessResponse({
+      input,
+      state: result.state,
+      revision: result.revision,
+      requestId,
+      replayed: result.replayed,
+    }, result.status);
+  } catch (error) {
+    const configCommitted = state && !state.config_applied
+      ? await bootstrapConfigWasCommitted(env, state).catch(() => false)
+      : Boolean(state?.config_applied);
+    if (state && configCommitted) {
+      state.config_applied = true;
+      const authority = await configWriterAuthorityState(await listMetaAdsPublishConfigRows(env)).catch(() => null);
+      if (authority?.ready) {
+        try {
+          await persistBootstrapState({
+            env,
+            operation,
+            state,
+            status: 'applied',
+            resultingRevision: authority.revision,
+            encryptToken,
+            context,
+          });
+        } catch {
+          // A Graph/D1 bootstrap is only externally compensable if its journal
+          // durably records the candidate revision and encrypted baseline.
+          // Do not report success when that evidence cannot be persisted.
+          error = bootstrapFailure('meta_ads_publish_bootstrap_reconciliation_required', 409);
+          await writeBootstrapAudit(writeAudit, env, requestId, 'failed', state).catch(() => undefined);
+          return bootstrapFailureResponse(error, requestId);
+        }
+        await writeBootstrapAudit(writeAudit, env, requestId, 'ok', state).catch(() => undefined);
+        return bootstrapSuccessResponse({
+          input: input || { operationKey: clean(operation?.operation_key) },
+          state,
+          revision: authority.revision,
+          requestId,
+          replayed: false,
+        });
+      }
+    }
+    if (operation && state && !configCommitted) {
+      const cleanupContext = context || {
+        env,
+        requestId,
+        operationKey: input?.operationKey || clean(operation.operation_key),
+        ...bootstrapMutationLockIdentity(input?.operationKey || clean(operation.operation_key)),
+        bootstrapMutationLockKeys: [],
+        bootstrapMutationLocksHeld: false,
+        action: 'bootstrap_meta_ads_publish_config_cleanup',
+        decryptToken,
+        encryptToken,
+        attempts: 0,
+        rateUsage: {},
+        traceId: '',
+        assertBootstrapLease: async () => undefined,
+      };
+      if (cleanupContext.bootstrapMutationLocksHeld === true) {
+        const compensated = await compensateBootstrapState({ state, context: cleanupContext }).catch(() => false);
+        const terminalStatus = compensated ? 'rolled_back' : 'reconciliation_required';
+        await persistBootstrapState({ env, operation, state, status: terminalStatus, encryptToken, context: cleanupContext }).catch(() => undefined);
+        if (!compensated) error = bootstrapFailure('meta_ads_publish_bootstrap_reconciliation_required', 409);
+      } else if (bootstrapStateMayHaveGraphMutation(state)) {
+        // We failed to establish the shared ad-set lease. Do not attempt a
+        // best-effort Graph cleanup that could overwrite an active v20 run.
+        await persistBootstrapState({ env, operation, state, status: 'reconciliation_required', encryptToken, context: cleanupContext }).catch(() => undefined);
+        error = bootstrapFailure('meta_ads_publish_bootstrap_reconciliation_required', 409);
+      }
+    }
+    await writeBootstrapAudit(writeAudit, env, requestId, 'failed', state).catch(() => undefined);
+    return bootstrapFailureResponse(error, requestId);
+  } finally {
+    if (context?.bootstrapMutationLocksHeld === true) {
+      await releaseOperationLocks(
+        env,
+        context.bootstrapMutationRunId,
+        context.bootstrapMutationOperationKey,
+      ).catch(() => undefined);
+    }
+    if (lockAcquired) {
+      await releaseConfigWriterLock(env, lockOwner);
+    }
+  }
+}
+
+// A deployment can cross several independently recoverable surfaces after a
+// bootstrap has committed.  This endpoint is intentionally narrower than the
+// normal configuration writer: it can only undo the exact encrypted baseline
+// captured by its own applied bootstrap operation, and only while the current
+// authority is still that operation's resulting v20 revision.
+export async function rollbackBootstrapMetaAdsPublishConfig({ request, env, requestId, decryptToken, encryptToken, writeAudit }) {
+  let input;
+  let operation;
+  let state;
+  let lockOwner = '';
+  let lockAcquired = false;
+  let context;
+  try {
+    input = validateBootstrapRollbackInput(await readBootstrapRollbackRequest(request));
+    if (!env?.TOKEN_VAULT_DB || typeof env.TOKEN_VAULT_DB.batch !== 'function') {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_unavailable', 503);
+    }
+    lockOwner = crypto.randomUUID();
+    await acquireConfigWriterLock(env, lockOwner, { ttlMs: BOOTSTRAP_LOCK_TTL_MS });
+    lockAcquired = true;
+    context = {
+      env,
+      requestId,
+      operationKey: input.operationKey,
+      ...bootstrapMutationLockIdentity(input.operationKey),
+      bootstrapMutationLockKeys: [],
+      bootstrapMutationLocksHeld: false,
+      action: 'rollback_meta_ads_publish_bootstrap',
+      decryptToken,
+      encryptToken,
+      attempts: 0,
+      rateUsage: {},
+      traceId: '',
+      assertBootstrapLease: async () => {
+        try {
+          await renewConfigWriterLock(env, lockOwner, { ttlMs: BOOTSTRAP_LOCK_TTL_MS });
+          await renewBootstrapMutationLocks(context);
+        } catch (error) {
+          const locked = isConfigWriterFailure(error) || clean(error?.message).startsWith('resource_locked:');
+          throw bootstrapFailure(
+            locked
+              ? 'meta_ads_publish_bootstrap_locked'
+              : 'meta_ads_publish_bootstrap_unavailable',
+            locked ? 409 : Number(error?.http_status) || 503,
+          );
+        }
+      },
+    };
+    operation = await loadBootstrapOperation(env, input.operationKey);
+    if (!operation) throw bootstrapFailure('meta_ads_publish_bootstrap_operation_not_found', 404);
+    if (clean(operation.resulting_tracking_binding_revision) !== input.expectedTrackingBindingRevision) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_operation_state_stale', 409);
+    }
+    state = await decryptBootstrapState(operation, decryptToken, env);
+    const currentRows = await listMetaAdsPublishConfigRows(env);
+    const currentAuthority = await configWriterAuthorityState(currentRows);
+    if (clean(operation.status) === 'rolled_back') {
+      if (currentAuthority.ready || currentAuthority.revision !== clean(state.input?.expected_config_authority_revision)) {
+        throw bootstrapFailure('meta_ads_publish_bootstrap_operation_state_stale', 409);
+      }
+      return bootstrapRollbackSuccessResponse({ state, revision: currentAuthority.revision, requestId, replayed: true });
+    }
+    if (clean(operation.status) !== 'applied' || !state.config_applied) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_reconciliation_required', 409);
+    }
+    if (!currentAuthority.ready || currentAuthority.revision !== input.expectedTrackingBindingRevision) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_operation_state_stale', 409);
+    }
+    try {
+      context.bootstrapMutationLockKeys = bootstrapMutationLockKeysForState(state, currentRows);
+      await acquireLocks(
+        env,
+        context.bootstrapMutationRunId,
+        context.bootstrapMutationOperationKey,
+        context.bootstrapMutationLockKeys,
+      );
+      context.bootstrapMutationLocksHeld = true;
+    } catch {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_locked', 409);
+    }
+
+    // Do not restore legacy metadata until Graph has been returned to the
+    // encrypted baseline.  On a failed Graph compensation we retain v20 and
+    // fail closed rather than reactivating a v18 publisher against unknown
+    // tracking state.
+    const graphCompensated = await compensateBootstrapState({ state, context });
+    if (!graphCompensated) {
+      await persistBootstrapState({
+        env,
+        operation,
+        state,
+        status: 'reconciliation_required',
+        encryptToken,
+        context,
+      });
+      throw bootstrapFailure('meta_ads_publish_bootstrap_reconciliation_required', 409);
+    }
+
+    const restored = await restoreBootstrapConfigAuthority({
+      env,
+      operation,
+      state,
+      expectedTrackingBindingRevision: input.expectedTrackingBindingRevision,
+      encryptToken,
+      context,
+    });
+    await writeBootstrapAudit(writeAudit, env, requestId, 'rolled_back', state).catch(() => undefined);
+    return bootstrapRollbackSuccessResponse({ state, revision: restored.revision, requestId, replayed: false });
+  } catch (error) {
+    await writeBootstrapAudit(writeAudit, env, requestId, 'rollback_failed', state).catch(() => undefined);
+    return bootstrapFailureResponse(error, requestId);
+  } finally {
+    if (context?.bootstrapMutationLocksHeld === true) {
+      await releaseOperationLocks(
+        env,
+        context.bootstrapMutationRunId,
+        context.bootstrapMutationOperationKey,
+      ).catch(() => undefined);
+    }
+    if (lockAcquired) await releaseConfigWriterLock(env, lockOwner);
+  }
+}
+
+async function readBootstrapRollbackRequest(request) {
+  const contentLength = Number(request.headers.get('content-length') || 0);
+  if (contentLength > 8 * 1024) throw bootstrapFailure('meta_ads_publish_bootstrap_request_too_large', 413);
+  try {
+    const body = await request.json();
+    if (!isJsonObject(body)) throw bootstrapFailure('meta_ads_publish_bootstrap_request_invalid', 400);
+    return body;
+  } catch (error) {
+    if (isBootstrapFailure(error)) throw error;
+    throw bootstrapFailure('meta_ads_publish_bootstrap_request_invalid', 400);
+  }
+}
+
+function validateBootstrapRollbackInput(body) {
+  assertBootstrapExactKeys(body, new Set(['operation_key', 'expected_tracking_binding_revision']));
+  const operationKey = clean(body.operation_key);
+  const expectedTrackingBindingRevision = clean(body.expected_tracking_binding_revision).toLowerCase();
+  if (!BOOTSTRAP_OPERATION_KEY_PATTERN.test(operationKey)) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_operation_key_invalid', 400);
+  }
+  if (!/^[a-f0-9]{64}$/.test(expectedTrackingBindingRevision)) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_expected_revision_invalid', 400);
+  }
+  return { operationKey, expectedTrackingBindingRevision };
+}
+
+async function restoreBootstrapConfigAuthority({ env, operation, state, expectedTrackingBindingRevision, encryptToken, context }) {
+  await assertBootstrapLease(context);
+  const configInput = asObject(state.config_input);
+  const updates = safeArray(configInput.updates);
+  const priorConfigs = asObject(state.previous_meta_ads_publish);
+  if (!updates.length || !Object.keys(priorConfigs).length) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_reconciliation_required', 409);
+  }
+  const currentRows = await listMetaAdsPublishConfigRows(env);
+  const plans = updates.map((update) => {
+    const tokenId = clean(update.tokenId);
+    const target = currentRows.find((row) => clean(row.id) === tokenId);
+    const expectedV20 = asObject(update.metaAdsPublish);
+    const previous = asObject(priorConfigs[tokenId]);
+    if (
+      !target || Number(target.active) !== 1 || !Object.keys(expectedV20).length || !Object.keys(previous).length
+    ) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_operation_state_stale', 409);
+    }
+    const currentMetadata = parseConfigWriterMetadata(target.metadata_json);
+    if (stableStringify(asObject(currentMetadata.meta_ads_publish)) !== stableStringify(expectedV20)) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_operation_state_stale', 409);
+    }
+    return {
+      tokenId,
+      target,
+      nextMetadataJson: JSON.stringify({ ...currentMetadata, meta_ads_publish: previous }),
+    };
+  });
+  const previousAuthorityRevision = clean(state.input?.expected_config_authority_revision);
+  if (!/^legacy:[a-f0-9]{64}$/.test(previousAuthorityRevision)) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_reconciliation_required', 409);
+  }
+  state.config_applied = false;
+  state.config_rolled_back = true;
+  const stateCiphertext = await encryptBootstrapState(state, encryptToken, env);
+  const now = nowIso();
+  await assertBootstrapLease(context);
+  const results = await env.TOKEN_VAULT_DB.batch([
+    buildBootstrapAtomicMetadataRestore(env, { plans, now }),
+    buildBootstrapRolledBackOperationUpdate(env, {
+      plans,
+      now,
+      operation,
+      expectedTrackingBindingRevision,
+      stateCiphertext,
+      summaryJson: JSON.stringify(summarizeBootstrapState(state)),
+    }),
+  ]);
+  if (batchChanges(results, 0) !== plans.length || batchChanges(results, 1) !== 1) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_operation_state_stale', 409);
+  }
+  const authority = await configWriterAuthorityState(await listMetaAdsPublishConfigRows(env));
+  if (authority.ready || authority.revision !== previousAuthorityRevision) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_reconciliation_required', 409);
+  }
+  operation.status = 'rolled_back';
+  return { revision: authority.revision };
+}
+
+function buildBootstrapAtomicMetadataRestore(env, { plans, now }) {
+  const caseClauses = plans.map(() => 'WHEN ? THEN ?').join(' ');
+  const targetPlaceholders = plans.map(() => '?').join(', ');
+  const oldConditions = plans.map(() => '(id = ? AND metadata_json = ?)').join(' OR ');
+  return env.TOKEN_VAULT_DB.prepare([
+    'UPDATE credential_tokens',
+    `SET metadata_json = CASE id ${caseClauses} ELSE metadata_json END, updated_at = ?`,
+    `WHERE id IN (${targetPlaceholders}) AND provider = 'facebook' AND active = 1`,
+    'AND (SELECT COUNT(*) FROM credential_tokens',
+    `WHERE provider = 'facebook' AND active = 1 AND (${oldConditions})) = ?`,
+  ].join(' ')).bind(
+    ...plans.flatMap((plan) => [plan.tokenId, plan.nextMetadataJson]),
+    now,
+    ...plans.map((plan) => plan.tokenId),
+    ...plans.flatMap((plan) => [plan.tokenId, plan.target.metadata_json]),
+    plans.length,
+  );
+}
+
+function buildBootstrapRolledBackOperationUpdate(env, {
+  plans,
+  now,
+  operation,
+  expectedTrackingBindingRevision,
+  stateCiphertext,
+  summaryJson,
+}) {
+  const newConditions = plans.map(() => '(id = ? AND metadata_json = ?)').join(' OR ');
+  return env.TOKEN_VAULT_DB.prepare([
+    "UPDATE meta_ads_publish_bootstrap_operations SET status = 'rolled_back', state_ciphertext = ?, summary_json = ?, updated_at = ?",
+    "WHERE id = ? AND operation_key = ? AND request_hash = ? AND status = 'applied'",
+    'AND resulting_tracking_binding_revision = ?',
+    'AND (SELECT COUNT(*) FROM credential_tokens',
+    `WHERE provider = 'facebook' AND active = 1 AND (${newConditions})) = ?`,
+  ].join(' ')).bind(
+    stateCiphertext,
+    summaryJson,
+    now,
+    clean(operation.id),
+    clean(operation.operation_key),
+    clean(operation.request_hash),
+    expectedTrackingBindingRevision,
+    ...plans.flatMap((plan) => [plan.tokenId, plan.nextMetadataJson]),
+    plans.length,
+  );
+}
+
+function bootstrapRollbackSuccessResponse({ state, revision, requestId, replayed }) {
+  const summary = summarizeBootstrapState(state);
+  return response({
+    ok: true,
+    rolled_back: true,
+    replayed: Boolean(replayed),
+    operation_status: 'rolled_back',
+    config_authority_revision: revision,
+    website_fixture_count: summary.website_fixture_count,
+    requestId,
+  });
+}
+
+// The staging deployment proves a deliberately isolated source/target pair can
+// reconcile the authorized conversion contract and restore the exact prior
+// state.  It is not a generic Meta operation: selectors stay in the private
+// configuration, the endpoint only accepts a bounded idempotency key, and it
+// is disabled outside the staging Worker.
+export async function exerciseStagingMetaAdsTrackingFixture({ request, env, requestId, decryptToken, encryptToken, writeAudit }) {
+  let input;
+  let fixture;
+  let context;
+  let snapshotId = '';
+  let runId = '';
+  let transactionOperationKey = '';
+  let transactionLockHeld = false;
+  let configLockOwner = '';
+  let configLockHeld = false;
+  let bindingRevision = '';
+  try {
+    input = await validateStagingExerciseInput(await readStagingExerciseRequest(request));
+    if (clean(env?.ENVIRONMENT).toLowerCase() !== 'staging') {
+      throw stagingExerciseFailure('staging_tracking_fixture_exercise_disabled', 503);
+    }
+    if (!env?.TOKEN_VAULT_DB || typeof env.TOKEN_VAULT_DB.prepare !== 'function') {
+      throw stagingExerciseFailure('staging_tracking_fixture_exercise_unavailable', 503);
+    }
+
+    configLockOwner = crypto.randomUUID();
+    try {
+      await acquireConfigWriterLock(env, configLockOwner, { ttlMs: BOOTSTRAP_LOCK_TTL_MS });
+      configLockHeld = true;
+    } catch (error) {
+      throw stagingExerciseFailure(
+        isConfigWriterFailure(error)
+          ? 'staging_tracking_fixture_config_locked'
+          : 'staging_tracking_fixture_exercise_unavailable',
+        Number(error?.http_status) || 503,
+      );
+    }
+
+    const rows = await listMetaAdsPublishConfigRows(env);
+    const authority = await configWriterAuthorityState(rows);
+    const binding = await deriveTrackingBindingState(rows);
+    if (!authority.ready || !binding.ready) {
+      throw stagingExerciseFailure('staging_tracking_fixture_config_not_ready', 409);
+    }
+    bindingRevision = binding.revision;
+    fixture = resolveStagingTrackingFixture(rows);
+    runId = await ensureStagingExerciseRun({ env, input, bindingRevision: binding.revision });
+    context = {
+      env,
+      runId,
+      operationKey: '',
+      action: 'staging_tracking_fixture_exercise',
+      decryptToken,
+      encryptToken,
+      attempts: 0,
+      rateUsage: {},
+      traceId: '',
+      stagingExerciseLockOperationKey: '',
+      stagingExerciseLockKeys: [],
+      assertBootstrapLease: async () => {
+        try {
+          await renewConfigWriterLock(env, configLockOwner, { ttlMs: BOOTSTRAP_LOCK_TTL_MS });
+          if (transactionLockHeld) {
+            await acquireLocks(
+              env,
+              runId,
+              transactionOperationKey,
+              context.stagingExerciseLockKeys,
+            );
+          }
+        } catch (error) {
+          const locked = isConfigWriterFailure(error) || clean(error?.message).startsWith('resource_locked:');
+          throw stagingExerciseFailure(
+            locked
+              ? 'staging_tracking_fixture_config_locked'
+              : 'staging_tracking_fixture_exercise_unavailable',
+            locked ? 409 : Number(error?.http_status) || 503,
+          );
+        }
+      },
+    };
+
+    // Keep the exact ad-set resource locked for the complete synthetic
+    // exercise. Releasing it between ensure and rollback would let a normal
+    // publication attest the temporary promoted_object and then have that
+    // state restored underneath its subsequent ad mutation.
+    transactionOperationKey = stagingExerciseOperationKey(input.operationKey, 'transaction');
+    context.stagingExerciseLockOperationKey = transactionOperationKey;
+    context.stagingExerciseLockKeys = [stagingExerciseAdsetLockKey(fixture)];
+    await acquireLocks(env, runId, transactionOperationKey, context.stagingExerciseLockKeys);
+    transactionLockHeld = true;
+
+    const creativeReadback = await readAuthorizedCreativeUrlTagsContract({
+      action: 'read_authorized_creative_url_tags_contract',
+      operation_key: stagingExerciseOperationKey(input.operationKey, 'creative-readback'),
+      token_id: fixture.tokenId,
+      account_id: fixture.accountId,
+      api_version: fixture.apiVersion,
+    }, {
+      ...context,
+      operationKey: stagingExerciseOperationKey(input.operationKey, 'creative-readback'),
+      action: 'read_authorized_creative_url_tags_contract',
+    });
+    assertStagingExerciseCreativeReadback(creativeReadback);
+
+    const ensureOperationKey = stagingExerciseOperationKey(input.operationKey, 'ensure');
+    const existingSnapshot = await loadTrackingSnapshotByOperation(env, ensureOperationKey);
+    if (existingSnapshot && clean(existingSnapshot.status) === 'restored') {
+      await completeStagingExerciseRun(env, runId, input.operationKey, true);
+      await writeStagingExerciseAudit(writeAudit, env, requestId, 'replayed');
+      return stagingExerciseSuccessResponse(requestId, true);
+    }
+    if (existingSnapshot) {
+      // A previous transport failure can leave a captured/reconciled snapshot.
+      // Restore it before refusing the replay so the next deployment attempt
+      // begins from the documented synthetic baseline rather than stale Graph
+      // state.  It never retries a potentially ambiguous Graph mutation.
+      snapshotId = clean(existingSnapshot.id);
+      const recovered = await rollbackStagingExerciseSnapshot({
+        fixture,
+        snapshotId,
+        context,
+        operationKey: stagingExerciseOperationKey(input.operationKey, 'rollback-recovery'),
+        lockOperationKey: transactionOperationKey,
+        releaseLocks: false,
+      });
+      if (!['restored', 'already_restored', 'not_applied'].includes(clean(recovered.status))) {
+        throw stagingExerciseFailure('staging_tracking_fixture_rollback_unconfirmed', 502);
+      }
+      await setRunState(env, runId, 'rolled_back', stagingExerciseRunSummary(input.operationKey, 'recovered'));
+      await writeStagingExerciseAudit(writeAudit, env, requestId, 'rolled_back');
+      return stagingExerciseFailureResponse(
+        stagingExerciseFailure('staging_tracking_fixture_retry_requires_new_operation', 409),
+        requestId,
+      );
+    }
+
+    const ensureContext = {
+      ...context,
+      operationKey: ensureOperationKey,
+      action: 'ensure_adset_conversion_contract',
+    };
+    const ensured = await ensureAdsetConversionContract(stagingExerciseEnsureBody(fixture), ensureContext);
+    snapshotId = clean(ensured?.snapshot_id);
+    if (
+      ensured?.status !== 'reconciled' ||
+      ensured?.graph_mutation !== 'promoted_object_updated' ||
+      !snapshotId ||
+      ensured?.website_event?.configured !== true ||
+      ensured?.website_event?.required !== true ||
+      ensured?.offline_event_dataset?.configured !== true ||
+      ensured?.offline_event_dataset?.required !== true
+    ) {
+      throw stagingExerciseFailure('staging_tracking_fixture_not_reconciled', 409);
+    }
+
+    const rolledBack = await rollbackStagingExerciseSnapshot({
+      fixture,
+      snapshotId,
+      context,
+      operationKey: stagingExerciseOperationKey(input.operationKey, 'rollback'),
+      lockOperationKey: transactionOperationKey,
+      releaseLocks: false,
+    });
+    if (rolledBack.status !== 'restored' || rolledBack.graph_mutation !== 'promoted_object_restored') {
+      throw stagingExerciseFailure('staging_tracking_fixture_rollback_unconfirmed', 502);
+    }
+    await assertStagingExerciseBinding(env, bindingRevision);
+    await completeStagingExerciseRun(env, runId, input.operationKey, false);
+    await writeStagingExerciseAudit(writeAudit, env, requestId, 'ok');
+    return stagingExerciseSuccessResponse(requestId, false);
+  } catch (error) {
+    const compensationSnapshotId = snapshotId || stagingExerciseCompensationSnapshotId(error);
+    let cleanupStatus = '';
+    if (fixture && context && compensationSnapshotId) {
+      try {
+        const cleanup = await rollbackStagingExerciseSnapshot({
+          fixture,
+          snapshotId: compensationSnapshotId,
+          context,
+          operationKey: stagingExerciseOperationKey(input?.operationKey || 'staging-tracking-fixture:cleanup', 'rollback-cleanup'),
+          lockOperationKey: transactionLockHeld
+            ? transactionOperationKey
+            : stagingExerciseOperationKey(input?.operationKey || 'staging-tracking-fixture:cleanup', 'rollback-cleanup'),
+          releaseLocks: !transactionLockHeld,
+        });
+        cleanupStatus = clean(cleanup.status);
+      } catch {
+        cleanupStatus = 'reconciliation_required';
+      }
+    }
+    if (runId) {
+      const terminal = ['restored', 'already_restored', 'not_applied'].includes(cleanupStatus)
+        ? 'rolled_back'
+        : 'reconciliation_required';
+      await setRunState(env, runId, terminal, stagingExerciseRunSummary(input?.operationKey || '', cleanupStatus || 'failed')).catch(() => undefined);
+    }
+    await writeStagingExerciseAudit(
+      writeAudit,
+      env,
+      requestId,
+      ['restored', 'already_restored', 'not_applied'].includes(cleanupStatus) ? 'rolled_back' : 'failed',
+    ).catch(() => undefined);
+    return stagingExerciseFailureResponse(error, requestId);
+  } finally {
+    if (transactionLockHeld && context && runId) {
+      await releaseOperationLocks(env, runId, transactionOperationKey).catch(() => undefined);
+    }
+    if (configLockHeld) await releaseConfigWriterLock(env, configLockOwner);
+  }
+}
+
+async function readStagingExerciseRequest(request) {
+  const contentLength = Number(request.headers.get('content-length') || 0);
+  if (contentLength > 8 * 1024) throw stagingExerciseFailure('staging_tracking_fixture_request_too_large', 413);
+  try {
+    const body = await request.json();
+    if (!isJsonObject(body) || Object.keys(body).length !== 1 || !Object.prototype.hasOwnProperty.call(body, 'operation_key')) {
+      throw stagingExerciseFailure('staging_tracking_fixture_request_invalid', 400);
+    }
+    return body;
+  } catch (error) {
+    if (isStagingExerciseFailure(error)) throw error;
+    throw stagingExerciseFailure('staging_tracking_fixture_request_invalid', 400);
+  }
+}
+
+function validateStagingExerciseInput(body) {
+  const operationKey = clean(body.operation_key);
+  if (!STAGING_EXERCISE_OPERATION_KEY_PATTERN.test(operationKey)) {
+    throw stagingExerciseFailure('staging_tracking_fixture_operation_key_invalid', 400);
+  }
+  return { operationKey };
+}
+
+function resolveStagingTrackingFixture(rows) {
+  const candidates = [];
+  for (const row of safeArray(rows)) {
+    const config = asObject(parseObject(row.metadata_json).meta_ads_publish);
+    if (!Object.keys(config).length) continue;
+    const contract = normalizeTrackingContract(config.tracking_contract, config.tracking_profiles, config.adset_id);
+    if (
+      normalizeDestinationKind(config.destination_type) !== 'website' ||
+      contract.destination_kind !== 'website' ||
+      contract.staging_synthetic_fixture !== true ||
+      contract.website_event_requirement !== 'required' ||
+      contract.offline_event_dataset_requirement !== 'required'
+    ) {
+      continue;
+    }
+    const profile = asObject(asObject(config.tracking_profiles)[contract.profile_ref]);
+    const sourceAdsetId = normalizeNumericId(profile.source_adset_id, 'staging_tracking_fixture_source_adset_id');
+    const targetAdsetId = normalizeNumericId(config.adset_id, 'staging_tracking_fixture_target_adset_id');
+    if (sourceAdsetId === targetAdsetId) continue;
+    candidates.push({
+      tokenId: clean(row.id),
+      accountId: normalizeNumericId(config.account_id, 'staging_tracking_fixture_account_id'),
+      apiVersion: normalizeApiVersion(config.api_version || 'v25.0'),
+      adsetId: targetAdsetId,
+      profileRef: contract.profile_ref,
+    });
+  }
+  if (candidates.length !== 1) {
+    throw stagingExerciseFailure('staging_tracking_fixture_not_unique', 409);
+  }
+  return candidates[0];
+}
+
+async function ensureStagingExerciseRun({ env, input, bindingRevision }) {
+  const fingerprint = await sha256(`staging-tracking-fixture:${input.operationKey}`);
+  const existing = await dbFirst(env,
+    `SELECT id, config_revision FROM meta_ads_publish_runs WHERE batch_fingerprint = ?`,
+    fingerprint,
+  );
+  if (existing) {
+    if (clean(existing.config_revision) !== clean(bindingRevision)) {
+      throw stagingExerciseFailure('staging_tracking_fixture_binding_stale', 409);
+    }
+    return clean(existing.id);
+  }
+  const runId = `stx_${fingerprint.slice(0, 24)}`;
+  const now = nowIso();
+  const result = await dbRun(env,
+    `INSERT INTO meta_ads_publish_runs (
+      id, batch_fingerprint, request_hash, workflow_execution_id, config_revision,
+      status, files_json, summary_json, error_json, heartbeat_at, lock_expires_at, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, 'processing', '[]', '{}', '{}', ?, ?, ?, ?)`,
+    runId,
+    fingerprint,
+    fingerprint,
+    `staging-tracking-fixture:${shortKey(input.operationKey)}`,
+    bindingRevision,
+    now,
+    new Date(Date.now() + LOCK_TTL_MS).toISOString(),
+    now,
+    now,
+  );
+  if (statementChanges(result) !== 1) {
+    throw stagingExerciseFailure('staging_tracking_fixture_run_unavailable', 503);
+  }
+  return runId;
+}
+
+function stagingExerciseOperationKey(operationKey, phase) {
+  const normalized = clean(operationKey);
+  const suffix = clean(phase).replace(/[^A-Za-z0-9_.:-]/g, '-').slice(0, 32);
+  return `${normalized}:${suffix}`.slice(0, 160);
+}
+
+function stagingExerciseAdsetLockKey(fixture) {
+  return `adset-contract:${clean(fixture.accountId)}:${clean(fixture.adsetId)}`;
+}
+
+function stagingExerciseEnsureBody(fixture) {
+  return {
+    token_id: fixture.tokenId,
+    account_id: fixture.accountId,
+    api_version: fixture.apiVersion,
+    object_id: fixture.adsetId,
+    destination_kind: 'website',
+    profile_ref: fixture.profileRef,
+    workflow_contract_revision: WORKFLOW_CONTRACT_REVISION,
+  };
+}
+
+async function assertStagingExerciseBinding(env, expectedRevision) {
+  const rows = await listMetaAdsPublishConfigRows(env);
+  const authority = await configWriterAuthorityState(rows);
+  const binding = await deriveTrackingBindingState(rows);
+  if (!authority.ready || !binding.ready || clean(binding.revision) !== clean(expectedRevision)) {
+    throw stagingExerciseFailure('staging_tracking_fixture_binding_stale', 409);
+  }
+}
+
+async function rollbackStagingExerciseSnapshot({
+  fixture,
+  snapshotId,
+  context,
+  operationKey,
+  lockOperationKey = operationKey,
+  releaseLocks = true,
+}) {
+  const normalizedSnapshotId = normalizeSnapshotId(snapshotId);
+  const normalizedLockOperationKey = clean(lockOperationKey);
+  const lockKeys = [
+    stagingExerciseAdsetLockKey(fixture),
+    `adset-contract-snapshot:${normalizedSnapshotId}`,
+  ];
+  const rollbackContext = {
+    ...context,
+    operationKey,
+    action: 'rollback_adset_conversion_contract',
+  };
+  await acquireLocks(context.env, context.runId, normalizedLockOperationKey, lockKeys);
+  if (clean(context.stagingExerciseLockOperationKey) === normalizedLockOperationKey) {
+    context.stagingExerciseLockKeys = [...new Set([
+      ...safeArray(context.stagingExerciseLockKeys),
+      ...lockKeys,
+    ])].sort();
+  }
+  try {
+    return await rollbackAdsetConversionContract({
+      token_id: fixture.tokenId,
+      account_id: fixture.accountId,
+      api_version: fixture.apiVersion,
+      object_id: fixture.adsetId,
+      snapshot_id: normalizedSnapshotId,
+    }, rollbackContext);
+  } finally {
+    if (releaseLocks) await releaseOperationLocks(context.env, context.runId, normalizedLockOperationKey);
+  }
+}
+
+function assertStagingExerciseCreativeReadback(result) {
+  if (
+    asObject(result).destination_kind !== 'website' ||
+    asObject(result).creative_url_tags?.required !== true ||
+    asObject(result).creative_url_tags?.paused_fixture_verified !== true ||
+    asObject(result).creative_url_tags?.exact_match !== true
+  ) {
+    throw stagingExerciseFailure('staging_tracking_fixture_creative_readback_mismatch', 409);
+  }
+}
+
+async function completeStagingExerciseRun(env, runId, operationKey, replayed) {
+  await setRunState(env, runId, 'completed', stagingExerciseRunSummary(operationKey, replayed ? 'replayed' : 'reconciled_and_rolled_back'));
+}
+
+function stagingExerciseRunSummary(operationKey, status) {
+  return {
+    kind: 'staging_tracking_fixture',
+    operation: shortKey(operationKey),
+    status: clean(status),
+    reconciliation: status === 'reconciled_and_rolled_back' ? 'reconciled' : '',
+    rollback: status === 'reconciled_and_rolled_back' ? 'restored' : '',
+    fixture_count: 1,
+  };
+}
+
+async function writeStagingExerciseAudit(writeAudit, env, requestId, status) {
+  if (typeof writeAudit !== 'function') return;
+  await writeAudit(env, {
+    event: 'meta_ads_publish.config.staging_tracking_fixture',
+    status,
+    requestId,
+    metadata: {
+      environment: 'staging',
+      fixture_count: 1,
+      reconciliation: status === 'ok' ? 'reconciled' : '',
+      rollback: status === 'ok' ? 'restored' : '',
+    },
+  });
+}
+
+function stagingExerciseCompensationSnapshotId(error) {
+  const normalized = normalizeFailure(error);
+  const candidate = clean(asObject(normalized.compensation).snapshot_id);
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(candidate)
+    ? candidate
+    : '';
+}
+
+function stagingExerciseSuccessResponse(requestId, replayed) {
+  return response({
+    ok: true,
+    replayed: Boolean(replayed),
+    exercise: {
+      status: 'reconciled_and_rolled_back',
+      reconciliation: 'reconciled',
+      rollback: 'restored',
+      fixture_count: 1,
+    },
+    requestId,
+  });
+}
+
+function stagingExerciseFailure(code, httpStatus = 400) {
+  return Object.assign(new Error(code), { staging_exercise_error: true, http_status: httpStatus });
+}
+
+function isStagingExerciseFailure(error) {
+  return Boolean(error && error.staging_exercise_error === true);
+}
+
+function stagingExerciseFailureResponse(error, requestId) {
+  const code = isStagingExerciseFailure(error)
+    ? clean(error.message)
+    : 'staging_tracking_fixture_exercise_failed';
+  const status = Number(error?.http_status) === 409
+    ? 409
+    : Number(error?.http_status) === 404
+      ? 404
+    : Number(error?.http_status) === 503
+      ? 503
+      : Number(error?.http_status) === 413
+        ? 413
+        : 400;
+  return response({ ok: false, error: code, requestId }, status);
+}
+
+async function executeBootstrapSaga({ input, state, operation, currentRows, authority, context, requestId }) {
+  let configInput = state.config_input;
+  if (!configInput) {
+    if (authority.mode !== 'legacy_bootstrap' || authority.revision !== input.expectedConfigAuthorityRevision) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_binding_stale', 409);
+    }
+    if (!isJsonObject(state.previous_meta_ads_publish)) {
+      state.previous_meta_ads_publish = captureBootstrapPreviousMetaAdsPublish(input.entries, currentRows);
+      await persistBootstrapState({ env: context.env, operation, state, status: 'pending', encryptToken: context.encryptToken, context });
+    }
+    const updates = await buildBootstrapUpdates({ input, state, operation, currentRows, context });
+    configInput = await validateConfigWriterInput({
+      operation_key: bootstrapConfigOperationKey(input.operationKey),
+      expected_tracking_binding_revision: input.expectedConfigAuthorityRevision,
+      updates,
+    });
+    state.config_input = configInput;
+    await persistBootstrapState({ env: context.env, operation, state, status: 'configuring', encryptToken: context.encryptToken, context });
+  }
+
+  const applied = await applyMetaAdsPublishConfigAtomically({
+    input: configInput,
+    env: context.env,
+    requestId,
+    lockAlreadyHeld: true,
+    assertLease: context.assertBootstrapLease,
+  });
+  state.config_applied = true;
+  state.resulting_tracking_binding_revision = applied.revision;
+  await persistBootstrapState({
+    env: context.env,
+    operation,
+    state,
+    status: 'applied',
+    resultingRevision: applied.revision,
+    encryptToken: context.encryptToken,
+    context,
+  });
+  return { state, revision: applied.revision, replayed: applied.replayed, status: applied.status };
+}
+
+function bootstrapMutationLockIdentity(operationKey) {
+  const normalized = clean(operationKey);
+  return {
+    bootstrapMutationRunId: `bootstrap:${normalized}`,
+    bootstrapMutationOperationKey: `bootstrap-mutation:${normalized}`,
+  };
+}
+
+function bootstrapAdsetContractLockKey(accountId, adsetId) {
+  return `adset-contract:${normalizeNumericId(accountId, 'bootstrap_lock_account_id')}:${normalizeNumericId(adsetId, 'bootstrap_lock_adset_id')}`;
+}
+
+function bootstrapMutationLockKeysForInput(entries, rows) {
+  const rowsByTokenId = new Map(safeArray(rows).map((row) => [clean(row.id), row]));
+  const keys = [];
+  for (const entry of safeArray(entries)) {
+    if (clean(entry.destinationType) !== 'website') continue;
+    const targetConfig = asObject(parseObject(rowsByTokenId.get(clean(entry.configTokenId))?.metadata_json).meta_ads_publish);
+    if (!Object.keys(targetConfig).length) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_legacy_config_invalid', 409);
+    }
+    keys.push(bootstrapAdsetContractLockKey(targetConfig.account_id, targetConfig.adset_id));
+    if (clean(entry.sourceAdsetId)) {
+      keys.push(bootstrapAdsetContractLockKey(targetConfig.account_id, entry.sourceAdsetId));
+      continue;
+    }
+    const sourceConfig = asObject(parseObject(rowsByTokenId.get(clean(entry.sourceConfigTokenId))?.metadata_json).meta_ads_publish);
+    if (!Object.keys(sourceConfig).length) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_legacy_config_invalid', 409);
+    }
+    keys.push(bootstrapAdsetContractLockKey(sourceConfig.account_id, sourceConfig.adset_id));
+  }
+  return [...new Set(keys)].sort();
+}
+
+function bootstrapMutationLockKeysForState(state, rows) {
+  const rowsByTokenId = new Map(safeArray(rows).map((row) => [clean(row.id), row]));
+  const keys = [];
+  for (const item of safeArray(state?.items)) {
+    if (clean(item.destination_type) !== 'website') continue;
+    const targetConfig = asObject(parseObject(rowsByTokenId.get(clean(item.config_token_id))?.metadata_json).meta_ads_publish);
+    if (!Object.keys(targetConfig).length) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_operation_state_stale', 409);
+    }
+    keys.push(bootstrapAdsetContractLockKey(targetConfig.account_id, targetConfig.adset_id));
+  }
+  return [...new Set(keys)].sort();
+}
+
+async function renewBootstrapMutationLocks(context) {
+  if (context?.bootstrapMutationLocksHeld !== true || !safeArray(context.bootstrapMutationLockKeys).length) return;
+  await acquireLocks(
+    context.env,
+    clean(context.bootstrapMutationRunId),
+    clean(context.bootstrapMutationOperationKey),
+    context.bootstrapMutationLockKeys,
+  );
+}
+
+function bootstrapStateMayHaveGraphMutation(state) {
+  return safeArray(state?.items).some((item) => {
+    if (clean(item.destination_type) !== 'website') return false;
+    const tracking = asObject(item.tracking);
+    const fixture = asObject(item.fixture);
+    return safeArray(tracking.keys).length > 0 ||
+      fixture.copy_pending === true ||
+      fixture.copy_ambiguous === true ||
+      Boolean(clean(fixture.ad_id));
+  });
+}
+
+function captureBootstrapPreviousMetaAdsPublish(entries, currentRows) {
+  const rowsById = new Map(safeArray(currentRows).map((row) => [clean(row.id), row]));
+  const prior = {};
+  for (const entry of safeArray(entries)) {
+    const tokenId = clean(entry.configTokenId);
+    const row = rowsById.get(tokenId);
+    const metaAdsPublish = asObject(parseObject(row?.metadata_json).meta_ads_publish);
+    if (!row || !Object.keys(metaAdsPublish).length) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_token_not_eligible', 409);
+    }
+    prior[tokenId] = metaAdsPublish;
+  }
+  return prior;
+}
+
+async function readBootstrapRequest(request) {
+  const contentLength = Number(request.headers.get('content-length') || 0);
+  if (contentLength > CONFIG_WRITER_MAX_REQUEST_BYTES) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_request_too_large', 413);
+  }
+  try {
+    const body = await request.json();
+    if (!isJsonObject(body)) throw bootstrapFailure('meta_ads_publish_bootstrap_request_invalid', 400);
+    return body;
+  } catch (error) {
+    if (isBootstrapFailure(error)) throw error;
+    throw bootstrapFailure('meta_ads_publish_bootstrap_request_invalid', 400);
+  }
+}
+
+async function validateBootstrapInput(body) {
+  assertBootstrapExactKeys(body, new Set([
+    'operation_key',
+    'expected_config_authority_revision',
+    'entries',
+  ]));
+  const operationKey = clean(body.operation_key);
+  if (!BOOTSTRAP_OPERATION_KEY_PATTERN.test(operationKey)) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_operation_key_invalid', 400);
+  }
+  const expectedConfigAuthorityRevision = clean(body.expected_config_authority_revision).toLowerCase();
+  if (!/^legacy:[a-f0-9]{64}$/.test(expectedConfigAuthorityRevision)) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_expected_revision_invalid', 400);
+  }
+  if (!Array.isArray(body.entries) || body.entries.length < 2 || body.entries.length > BOOTSTRAP_MAX_ENTRIES) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_request_invalid', 400);
+  }
+  const seen = new Set();
+  const entries = body.entries.map((value) => normalizeBootstrapEntry(value, seen))
+    .sort((left, right) => left.configTokenId.localeCompare(right.configTokenId));
+  const requestHash = await sha256(stableStringify({
+    operation_key: operationKey,
+    expected_config_authority_revision: expectedConfigAuthorityRevision,
+    entries,
+  }));
+  return { operationKey, expectedConfigAuthorityRevision, entries, requestHash };
+}
+
+function normalizeBootstrapEntry(value, seen) {
+  if (!isJsonObject(value)) throw bootstrapFailure('meta_ads_publish_bootstrap_request_invalid', 400);
+  const destinationType = normalizeDestinationKind(value.destination_type);
+  const allowed = destinationType === 'website'
+    ? new Set(['config_token_id', 'destination_type', 'source_config_token_id', 'source_adset_id', 'fixture_source_ad_id', 'url_tags', 'staging_synthetic_fixture'])
+    : new Set(['config_token_id', 'destination_type']);
+  assertBootstrapExactKeys(value, allowed);
+  const configTokenId = clean(value.config_token_id);
+  if (!CONFIG_WRITER_TOKEN_ID_PATTERN.test(configTokenId) || seen.has(configTokenId)) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_token_invalid', 400);
+  }
+  seen.add(configTokenId);
+  if (destinationType === 'whatsapp') return { configTokenId, destinationType };
+  const sourceConfigTokenId = clean(value.source_config_token_id);
+  const sourceAdsetId = clean(value.source_adset_id);
+  const hasSourceConfigToken = Boolean(sourceConfigTokenId);
+  const hasSourceAdset = Boolean(sourceAdsetId);
+  if (hasSourceConfigToken === hasSourceAdset) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_source_invalid', 400);
+  }
+  const entry = {
+    configTokenId,
+    destinationType,
+    urlTags: normalizeUrlTags(value.url_tags, { required: true }),
+  };
+  if (hasSourceConfigToken) {
+    if (!CONFIG_WRITER_TOKEN_ID_PATTERN.test(sourceConfigTokenId)) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_source_invalid', 400);
+    }
+    entry.sourceConfigTokenId = sourceConfigTokenId;
+  } else {
+    entry.sourceAdsetId = normalizeNumericId(sourceAdsetId, 'bootstrap_source_adset_id');
+  }
+  if (Object.prototype.hasOwnProperty.call(value, 'staging_synthetic_fixture')) {
+    if (typeof value.staging_synthetic_fixture !== 'boolean') {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_request_invalid', 400);
+    }
+    if (value.staging_synthetic_fixture) entry.stagingSyntheticFixture = true;
+  }
+  if (Object.prototype.hasOwnProperty.call(value, 'fixture_source_ad_id')) {
+    entry.fixtureSourceAdId = normalizeNumericId(value.fixture_source_ad_id, 'bootstrap_fixture_source_ad_id');
+  }
+  return entry;
+}
+
+function assertBootstrapExactKeys(value, allowed) {
+  if (!isJsonObject(value) || Object.keys(value).some((key) => !allowed.has(key))) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_request_invalid', 400);
+  }
+}
+
+function assertBootstrapTargetsComplete(entries, rows) {
+  // A Vault may carry unrelated active Facebook credentials.  This migration
+  // is scoped strictly to rows that already opt into meta_ads_publish; do not
+  // force a configuration write for a token that has no publishing contract.
+  const configuredIds = safeArray(rows)
+    .filter((row) => Object.keys(asObject(parseObject(row?.metadata_json).meta_ads_publish)).length > 0)
+    .map((row) => clean(row.id))
+    .sort();
+  const requestedIds = safeArray(entries).map((entry) => entry.configTokenId).sort();
+  if (configuredIds.length !== requestedIds.length || configuredIds.some((id, index) => id !== requestedIds[index])) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_targets_incomplete', 409);
+  }
+}
+
+function bootstrapConfigOperationKey(operationKey) {
+  const prefix = 'bootstrap-config:';
+  return `${prefix}${clean(operationKey).slice(0, 160 - prefix.length)}`;
+}
+
+function bootstrapFailure(code, httpStatus = 400) {
+  return Object.assign(new Error(code), { bootstrap_error: true, http_status: httpStatus });
+}
+
+function isBootstrapFailure(error) {
+  return Boolean(error && error.bootstrap_error === true);
+}
+
+function bootstrapFailureResponse(error, requestId) {
+  const code = isBootstrapFailure(error)
+    ? clean(error.message)
+    : 'meta_ads_publish_bootstrap_failed';
+  const status = Number(error?.http_status) === 409
+    ? 409
+    : Number(error?.http_status) === 503
+      ? 503
+      : Number(error?.http_status) === 413
+        ? 413
+        : 400;
+  return response({ ok: false, error: code, requestId }, status);
+}
+
+async function loadBootstrapOperation(env, operationKey) {
+  return dbFirst(env, [
+    'SELECT id, operation_key, request_hash, expected_config_authority_revision,',
+    'resulting_tracking_binding_revision, status, state_ciphertext, summary_json',
+    'FROM meta_ads_publish_bootstrap_operations WHERE operation_key = ?',
+  ].join(' '), operationKey);
+}
+
+async function createBootstrapOperation({ env, input, state, encryptToken }) {
+  const id = crypto.randomUUID();
+  const now = nowIso();
+  const stateCiphertext = await encryptBootstrapState(state, encryptToken, env);
+  const result = await dbRun(env, [
+    'INSERT INTO meta_ads_publish_bootstrap_operations (',
+    'id, operation_key, request_hash, expected_config_authority_revision, status,',
+    'state_ciphertext, summary_json, created_at, updated_at',
+    ") VALUES (?, ?, ?, ?, 'pending', ?, ?, ?, ?)",
+  ].join(' '),
+  id,
+  input.operationKey,
+  input.requestHash,
+  input.expectedConfigAuthorityRevision,
+  stateCiphertext,
+  JSON.stringify(summarizeBootstrapState(state)),
+  now,
+  now);
+  if (statementChanges(result) !== 1) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_operation_conflict', 409);
+  }
+  return {
+    id,
+    operation_key: input.operationKey,
+    request_hash: input.requestHash,
+    expected_config_authority_revision: input.expectedConfigAuthorityRevision,
+    status: 'pending',
+  };
+}
+
+async function persistBootstrapState({ env, operation, state, status, resultingRevision = '', encryptToken, context = null }) {
+  if (context?.assertBootstrapLease) await context.assertBootstrapLease();
+  const stateCiphertext = await encryptBootstrapState(state, encryptToken, env);
+  const result = await dbRun(env, [
+    'UPDATE meta_ads_publish_bootstrap_operations',
+    'SET status = ?, state_ciphertext = ?, summary_json = ?,',
+    'resulting_tracking_binding_revision = COALESCE(NULLIF(?, \'\'), resulting_tracking_binding_revision),',
+    'updated_at = ?',
+    'WHERE id = ? AND operation_key = ? AND request_hash = ?',
+  ].join(' '),
+  status,
+  stateCiphertext,
+  JSON.stringify(summarizeBootstrapState(state)),
+  clean(resultingRevision),
+  nowIso(),
+  clean(operation.id),
+  clean(operation.operation_key),
+  clean(operation.request_hash));
+  if (statementChanges(result) !== 1) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_operation_state_stale', 409);
+  }
+  operation.status = status;
+  if (resultingRevision) operation.resulting_tracking_binding_revision = resultingRevision;
+}
+
+async function assertBootstrapLease(context) {
+  if (typeof context?.assertBootstrapLease !== 'function') {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_locked', 409);
+  }
+  await context.assertBootstrapLease();
+}
+
+async function encryptBootstrapState(state, encryptToken, env) {
+  if (typeof encryptToken !== 'function') {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_unavailable', 503);
+  }
+  try {
+    return await encryptToken(JSON.stringify(state), env);
+  } catch {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_unavailable', 503);
+  }
+}
+
+async function decryptBootstrapState(operation, decryptToken, env) {
+  if (typeof decryptToken !== 'function') {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_reconciliation_required', 409);
+  }
+  try {
+    const parsed = JSON.parse(await decryptToken(clean(operation.state_ciphertext), env));
+    if (!isJsonObject(parsed) || parsed.schema !== 'meta_ads_publish_bootstrap/v1' || !Array.isArray(parsed.items)) {
+      throw new Error('invalid_bootstrap_state');
+    }
+    return parsed;
+  } catch {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_reconciliation_required', 409);
+  }
+}
+
+function summarizeBootstrapState(state) {
+  const items = safeArray(state?.items);
+  const websites = items.filter((item) => clean(item.destination_type) === 'website');
+  const whatsapp = items.filter((item) => clean(item.destination_type) === 'whatsapp');
+  return {
+    destination_count: items.length,
+    website_destination_count: websites.length,
+    whatsapp_destination_count: whatsapp.length,
+    website_fixture_count: websites.filter((item) => Boolean(clean(item?.fixture?.ad_id))).length,
+    website_event_required_count: websites.filter((item) => clean(item?.profile?.website_event_requirement) === 'required').length,
+    offline_dataset_required_count: websites.filter((item) => clean(item?.profile?.offline_event_dataset_requirement) === 'required').length,
+    website_url_tags_verified: websites.length > 0 && websites.every((item) => item?.fixture?.verified === true),
+    conversion_contract_verified: websites.every((item) => item?.tracking?.verified === true),
+  };
+}
+
+function bootstrapSuccessResponse({ input, state, revision, requestId, replayed }, status = 200) {
+  const summary = summarizeBootstrapState(state);
+  return response({
+    ok: true,
+    applied: !replayed,
+    replayed: Boolean(replayed),
+    operation_key: input.operationKey,
+    operation_status: 'applied',
+    config_authority_revision: revision,
+    config_revision: revision,
+    tracking_binding_revision: revision,
+    workflow_contract_revision: WORKFLOW_CONTRACT_REVISION,
+    website_fixture_count: summary.website_fixture_count,
+    offline_dataset_count: summary.offline_dataset_required_count,
+    website_url_tags_verified: summary.website_url_tags_verified,
+    conversion_contract_verified: summary.conversion_contract_verified,
+    requestId,
+  }, status);
+}
+
+async function bootstrapConfigWasCommitted(env, state) {
+  const configInput = asObject(state?.config_input);
+  const operationKey = clean(configInput.operationKey);
+  if (!operationKey) return false;
+  const operation = await dbFirst(env, [
+    'SELECT resulting_tracking_binding_revision, status',
+    'FROM meta_ads_publish_config_operations WHERE operation_key = ?',
+  ].join(' '), operationKey);
+  if (!operation || clean(operation.status) !== 'applied') return false;
+  const authority = await configWriterAuthorityState(await listMetaAdsPublishConfigRows(env));
+  return authority.ready && clean(operation.resulting_tracking_binding_revision) === authority.revision;
+}
+
+async function writeBootstrapAudit(writeAudit, env, requestId, status, state) {
+  if (typeof writeAudit !== 'function') return;
+  const summary = summarizeBootstrapState(state);
+  await writeAudit(env, {
+    event: 'meta_ads_publish.config.bootstrap',
+    status,
+    requestId,
+    metadata: {
+      workflow_contract_revision: WORKFLOW_CONTRACT_REVISION,
+      ...summary,
+    },
+  });
+}
+
+function statementChanges(result) {
+  return Number(result?.meta?.changes ?? result?.changes ?? 0);
+}
+
+async function buildBootstrapUpdates({ input, state, operation, currentRows, context }) {
+  const rowsById = new Map(currentRows.map((row) => [clean(row.id), row]));
+  const itemsByTokenId = new Map(safeArray(state.items).map((item) => [clean(item.config_token_id), item]));
+  const updates = [];
+  for (const entry of input.entries) {
+    const targetRow = rowsById.get(entry.configTokenId);
+    if (!targetRow) throw bootstrapFailure('meta_ads_publish_bootstrap_token_not_eligible', 409);
+    let item = itemsByTokenId.get(entry.configTokenId);
+    if (!item) {
+      item = {
+        config_token_id: entry.configTokenId,
+        destination_type: entry.destinationType,
+        source_config_token_id: entry.sourceConfigTokenId || '',
+        source_adset_id: entry.sourceAdsetId || '',
+        url_tags: entry.urlTags || '',
+        fixture_source_ad_id: entry.fixtureSourceAdId || '',
+        staging_synthetic_fixture: entry.stagingSyntheticFixture === true,
+      };
+      state.items.push(item);
+      itemsByTokenId.set(entry.configTokenId, item);
+      await persistBootstrapState({ env: context.env, operation, state, status: 'pending', encryptToken: context.encryptToken, context });
+    }
+    if (clean(item.destination_type) !== entry.destinationType ||
+      clean(item.source_config_token_id) !== clean(entry.sourceConfigTokenId) ||
+      clean(item.source_adset_id) !== clean(entry.sourceAdsetId) ||
+      String(item.url_tags || '') !== String(entry.urlTags || '') ||
+      Boolean(item.staging_synthetic_fixture) !== Boolean(entry.stagingSyntheticFixture)) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_reconciliation_required', 409);
+    }
+    const targetAuth = await resolveLegacyBootstrapGraphAuth(entry.configTokenId, context);
+    const targetAdset = await readAdsetConversionState(targetAuth, targetAuth.config.adset_id, context);
+    if (entry.destinationType === 'website') {
+      const sourceAuth = await resolveLegacyBootstrapSourceAuth(entry, targetAuth, context);
+      // The v20 runtime later reads the authorized source ad set through the
+      // destination credential. Prove that exact access path now rather than
+      // committing a profile that only the bootstrap's separate source token
+      // can inspect.
+      const sourceAdset = await readAdsetConversionState(targetAuth, sourceAuth.config.adset_id, context);
+      const profile = buildBootstrapTrackingProfile({
+        sourceAuth,
+        sourceAdset,
+        targetAuth,
+        targetAdset,
+        targetConfig: targetAuth.config,
+        stagingSyntheticFixture: entry.stagingSyntheticFixture === true,
+      });
+      item.profile = profile;
+      item.target_adset_id = targetAuth.config.adset_id;
+      item.source_adset_id = sourceAuth.config.adset_id;
+      await reconcileBootstrapTracking({ item, sourceAdset, targetAdset, sourceAuth, targetAuth, state, operation, context });
+      await createOrReuseBootstrapFixture({
+        item,
+        sourceAdsetId: sourceAuth.config.adset_id,
+        targetAuth,
+        state,
+        operation,
+        context,
+      });
+      if (item.profile?.staging_synthetic_fixture === true) {
+        await restoreBootstrapTrackingBaseline({ item, targetAuth, state, operation, context });
+      }
+      updates.push({
+        token_id: entry.configTokenId,
+        meta_ads_publish: buildBootstrapWebsiteConfig(targetAuth.config, item),
+      });
+      continue;
+    }
+
+    const whatsappDestinationUrl = await discoverBootstrapWhatsAppDestination(targetAuth, targetAdset, context, item);
+    item.whatsapp_destination_url = whatsappDestinationUrl;
+    await persistBootstrapState({ env: context.env, operation, state, status: 'pending', encryptToken: context.encryptToken, context });
+    updates.push({
+      token_id: entry.configTokenId,
+      meta_ads_publish: buildBootstrapWhatsAppConfig(targetAuth.config, whatsappDestinationUrl),
+    });
+  }
+  return updates;
+}
+
+async function resolveLegacyBootstrapGraphAuth(configTokenId, context) {
+  const tokenId = clean(configTokenId);
+  if (!CONFIG_WRITER_TOKEN_ID_PATTERN.test(tokenId)) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_token_invalid', 400);
+  }
+  const row = await dbFirst(context.env, [
+    'SELECT id, provider, active, token_ciphertext, metadata_json',
+    'FROM credential_tokens WHERE id = ?',
+  ].join(' '), tokenId);
+  if (!row || clean(row.provider) !== 'facebook' || Number(row.active) !== 1) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_token_not_eligible', 409);
+  }
+  const config = asObject(parseObject(row.metadata_json).meta_ads_publish);
+  let accountId;
+  let apiVersion;
+  let adsetId;
+  try {
+    accountId = normalizeNumericId(config.account_id, 'bootstrap_account_id');
+    apiVersion = normalizeApiVersion(config.api_version || 'v25.0');
+    adsetId = normalizeNumericId(config.adset_id, 'bootstrap_adset_id');
+  } catch {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_legacy_config_invalid', 409);
+  }
+  let accessToken;
+  try {
+    accessToken = await context.decryptToken(row.token_ciphertext, context.env);
+  } catch {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_token_unavailable', 503);
+  }
+  const appSecretProof = clean(context.env.META_APP_SECRET)
+    ? await hmacSha256(clean(context.env.META_APP_SECRET), accessToken)
+    : '';
+  return {
+    tokenId,
+    accountId,
+    apiVersion,
+    accessToken,
+    appSecretProof,
+    config: { ...config, adset_id: adsetId, account_id: accountId, api_version: apiVersion },
+  };
+}
+
+// A bootstrap manifest may either identify a separately-authorized legacy
+// source destination or point directly to a source ad set that the target
+// credential is already authorized to read.  In both cases, all Graph reads
+// use the target credential: that is the credential the v20 runtime retains.
+async function resolveLegacyBootstrapSourceAuth(entry, targetAuth, context) {
+  let sourceAdsetId = clean(entry.sourceAdsetId);
+  let sourceAccountId = targetAuth.accountId;
+  const sourceConfigTokenId = clean(entry.sourceConfigTokenId);
+  if (sourceConfigTokenId) {
+    if (!CONFIG_WRITER_TOKEN_ID_PATTERN.test(sourceConfigTokenId)) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_source_invalid', 400);
+    }
+    const row = await dbFirst(context.env, [
+      'SELECT id, provider, active, metadata_json',
+      'FROM credential_tokens WHERE id = ?',
+    ].join(' '), sourceConfigTokenId);
+    if (!row || clean(row.provider) !== 'facebook' || Number(row.active) !== 1) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_token_not_eligible', 409);
+    }
+    const config = asObject(parseObject(row.metadata_json).meta_ads_publish);
+    try {
+      sourceAdsetId = normalizeNumericId(config.adset_id, 'bootstrap_source_adset_id');
+      sourceAccountId = normalizeNumericId(config.account_id, 'bootstrap_source_account_id');
+    } catch {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_legacy_config_invalid', 409);
+    }
+  }
+  sourceAdsetId = normalizeNumericId(sourceAdsetId, 'bootstrap_source_adset_id');
+  return {
+    ...targetAuth,
+    accountId: sourceAccountId,
+    config: {
+      ...asObject(targetAuth.config),
+      adset_id: sourceAdsetId,
+      account_id: sourceAccountId,
+    },
+  };
+}
+
+function buildBootstrapTrackingProfile({ sourceAuth, sourceAdset, targetAuth, targetAdset, targetConfig, stagingSyntheticFixture = false }) {
+  const source = asObject(sourceAdset);
+  const target = asObject(targetAdset);
+  const sourceKind = normalizeDestinationKind(source.destination_type, { optional: true });
+  const targetKind = normalizeDestinationKind(target.destination_type, { optional: true });
+  if (sourceKind !== 'website' || targetKind !== 'website') {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_website_destination_required', 409);
+  }
+  assertAdsetAccountAuthorized(source, target, targetAuth.accountId);
+  const websiteRequired = websiteEventRequiredForDelivery(
+    asObject(source.campaign).objective,
+    source.optimization_goal,
+  );
+  const offlineRequired = Boolean(clean(asObject(source.promoted_object).offline_conversion_data_set_id));
+  const profile = {
+    profile_ref: bootstrapProfileRef(targetAuth.tokenId),
+    source_adset_id: sourceAuth.config.adset_id,
+    destination_kind: 'website',
+    website_event_requirement: websiteRequired ? 'required' : 'not_required',
+    offline_event_dataset_requirement: offlineRequired ? 'required' : 'not_required',
+  };
+  if (stagingSyntheticFixture) {
+    if (
+      sourceAuth.config.adset_id === targetAuth.config.adset_id ||
+      profile.website_event_requirement !== 'required' ||
+      profile.offline_event_dataset_requirement !== 'required'
+    ) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_staging_fixture_invalid', 409);
+    }
+    profile.staging_synthetic_fixture = true;
+  }
+  assertWebsiteTrackingCompatibility(source, target, profile);
+  // Retain an already verified native-carousel route rather than silently
+  // disabling an existing campaign during the legacy-to-v20 transition.
+  const carouselAdsetId = clean(targetConfig.carousel_native_adset_id);
+  if (
+    targetConfig.carousel_native_adset_verified === true &&
+    targetConfig.carousel_native_route_active === true &&
+    carouselAdsetId
+  ) {
+    profile.authorized_destination_adset_ids = [
+      normalizeNumericId(carouselAdsetId, 'bootstrap_carousel_native_adset_id'),
+    ];
+  }
+  return profile;
+}
+
+function bootstrapProfileRef(tokenId) {
+  const suffix = clean(tokenId).replace(/[^A-Za-z0-9_.:-]/g, '_').slice(0, 64);
+  return `bootstrap.${suffix}`;
+}
+
+function buildBootstrapWebsiteConfig(legacyConfig, item) {
+  const base = buildBootstrapConfigBase(legacyConfig, 'website');
+  const profile = {
+    source_adset_id: clean(item.profile?.source_adset_id),
+    destination_kind: 'website',
+    website_event_requirement: clean(item.profile?.website_event_requirement),
+    offline_event_dataset_requirement: clean(item.profile?.offline_event_dataset_requirement),
+  };
+  if (item.profile?.staging_synthetic_fixture === true) profile.staging_synthetic_fixture = true;
+  if (safeArray(item.profile?.authorized_destination_adset_ids).length) {
+    profile.authorized_destination_adset_ids = safeArray(item.profile.authorized_destination_adset_ids);
+    Object.assign(base, bootstrapCarouselConfig(legacyConfig));
+  }
+  const profileRef = clean(item.profile?.profile_ref);
+  return validateGovernedMetaAdsPublishConfig({
+    ...base,
+    tracking_contract: {
+      url_tags: String(item.url_tags || ''),
+      profile_ref: profileRef,
+      production_url_tags_readback_fixture: {
+        ad_id: clean(item.fixture?.ad_id),
+        creative_id: clean(item.fixture?.creative_id),
+      },
+    },
+    tracking_profiles: { [profileRef]: profile },
+  });
+}
+
+function buildBootstrapWhatsAppConfig(legacyConfig, whatsappDestinationUrl) {
+  return validateGovernedMetaAdsPublishConfig({
+    ...buildBootstrapConfigBase(legacyConfig, 'whatsapp'),
+    whatsapp_destination_url: whatsappDestinationUrl,
+  });
+}
+
+function buildBootstrapConfigBase(value, destinationType) {
+  const config = asObject(value);
+  const base = {
+    destination_group: clean(config.destination_group),
+    api_version: clean(config.api_version),
+    account_id: clean(config.account_id),
+    campaign_id: clean(config.campaign_id),
+    adset_id: clean(config.adset_id),
+    page_id: clean(config.page_id),
+    instagram_user_id: clean(config.instagram_user_id),
+    allowed_link_hosts: safeArray(config.allowed_link_hosts),
+    landing_pages_by_creative_group: asObject(config.landing_pages_by_creative_group),
+    freshness_window_days: config.freshness_window_days,
+    destination_type: destinationType,
+  };
+  if (Object.prototype.hasOwnProperty.call(config, 'row_number')) base.row_number = config.row_number;
+  return base;
+}
+
+function bootstrapCarouselConfig(value) {
+  const config = asObject(value);
+  return {
+    carousel_native_campaign_id: clean(config.carousel_native_campaign_id),
+    carousel_native_adset_id: clean(config.carousel_native_adset_id),
+    carousel_native_adset_verified: true,
+    carousel_native_route_active: true,
+  };
+}
+
+async function reconcileBootstrapTracking({ item, sourceAdset, targetAdset, sourceAuth, targetAuth, state, operation, context }) {
+  if (sourceAuth.accountId !== targetAuth.accountId) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_source_account_incompatible', 409);
+  }
+  const profile = asObject(item.profile);
+  const desired = projectAuthorizedTrackingPromotedObject(sourceAdset, targetAdset, profile);
+  const keys = trackingKeysForProfile(profile);
+  const previousTracking = selectTrackingKeys(asObject(targetAdset).promoted_object, keys);
+  const desiredTracking = selectTrackingKeys(desired.tracking_promoted_object, keys);
+  const stored = asObject(item.tracking);
+  if (Object.keys(stored).length) {
+    if (
+      stableStringify(safeArray(stored.keys)) !== stableStringify(keys) ||
+      stableStringify(asObject(stored.desired_tracking_promoted_object)) !== stableStringify(desiredTracking)
+    ) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_reconciliation_required', 409);
+    }
+  } else {
+    item.tracking = {
+      keys,
+      previous_tracking_promoted_object: previousTracking,
+      desired_tracking_promoted_object: desiredTracking,
+      verified: false,
+    };
+    await persistBootstrapState({ env: context.env, operation, state, status: 'pending', encryptToken: context.encryptToken, context });
+  }
+
+  const current = asObject(targetAdset).promoted_object;
+  if (!trackingKeysMatch(current, desiredTracking, keys)) {
+    const expectedPrevious = asObject(item.tracking.previous_tracking_promoted_object);
+    if (!trackingKeysMatch(current, expectedPrevious, keys)) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_tracking_concurrent_drift', 409);
+    }
+    await assertBootstrapLease(context);
+    await updateAdsetTrackingWithReconciliation(targetAuth, targetAuth.config.adset_id, desired.full_promoted_object, profile, context);
+  }
+  const readback = await readAdsetConversionState(targetAuth, targetAuth.config.adset_id, context);
+  if (!trackingKeysMatch(readback.promoted_object, desiredTracking, keys)) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_tracking_readback_mismatch', 502);
+  }
+  item.tracking.verified = true;
+  item.tracking.graph_mutation = keys.length && !trackingKeysMatch(current, desiredTracking, keys)
+    ? 'promoted_object_updated'
+    : 'none';
+  // Keep an explicit source/target proof in the encrypted state only. The
+  // public summary exposes booleans, never the pixel, event, dataset or IDs.
+  item.tracking.source = summarizeAdsetConversionTracking(sourceAdset);
+  item.tracking.target = summarizeAdsetConversionTracking(readback);
+  await persistBootstrapState({ env: context.env, operation, state, status: 'tracking_configured', encryptToken: context.encryptToken, context });
+}
+
+// A staging-only synthetic fixture must begin from a known, intentionally
+// mismatched state so the deployment can prove GET -> POST -> GET
+// reconciliation and its rollback. We create and read back the fixture while
+// the target is conforming, then restore exactly the encrypted pre-bootstrap
+// tracking fields before committing the staging profile.
+async function restoreBootstrapTrackingBaseline({ item, targetAuth, state, operation, context }) {
+  const tracking = asObject(item.tracking);
+  const keys = safeArray(tracking.keys);
+  const previous = asObject(tracking.previous_tracking_promoted_object);
+  const desired = asObject(tracking.desired_tracking_promoted_object);
+  if (!keys.length || !tracking.verified) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_staging_fixture_tracking_unverified', 409);
+  }
+  const current = await readAdsetConversionState(targetAuth, targetAuth.config.adset_id, context);
+  if (trackingKeysMatch(current.promoted_object, previous, keys)) {
+    item.tracking.staging_baseline_restored = true;
+    await persistBootstrapState({ env: context.env, operation, state, status: 'fixture_created', encryptToken: context.encryptToken, context });
+    return;
+  }
+  if (!trackingKeysMatch(current.promoted_object, desired, keys)) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_tracking_concurrent_drift', 409);
+  }
+  const restored = { ...asObject(current.promoted_object) };
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(previous, key)) restored[key] = previous[key];
+    else delete restored[key];
+  }
+  await assertBootstrapLease(context);
+  await updateAdsetPromotedObject(targetAuth, targetAuth.config.adset_id, restored, context);
+  const readback = await readAdsetConversionState(targetAuth, targetAuth.config.adset_id, context);
+  if (!trackingKeysMatch(readback.promoted_object, previous, keys)) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_staging_fixture_restore_mismatch', 502);
+  }
+  item.tracking.staging_baseline_restored = true;
+  await persistBootstrapState({ env: context.env, operation, state, status: 'fixture_created', encryptToken: context.encryptToken, context });
+}
+
+function selectTrackingKeys(value, keys) {
+  const source = asObject(value);
+  const selected = {};
+  for (const key of safeArray(keys)) {
+    if (Object.prototype.hasOwnProperty.call(source, key)) selected[key] = source[key];
+  }
+  return selected;
+}
+
+async function createOrReuseBootstrapFixture({ item, sourceAdsetId, targetAuth, state, operation, context }) {
+  const fixtureName = clean(item.fixture?.name) || await bootstrapFixtureName(context.operationKey, item.config_token_id);
+  item.fixture = { ...asObject(item.fixture), name: fixtureName };
+  await persistBootstrapState({ env: context.env, operation, state, status: 'tracking_configured', encryptToken: context.encryptToken, context });
+
+  const recordedFixture = asObject(item.fixture);
+  if (recordedFixture.copy_pending === true || recordedFixture.copy_ambiguous === true) {
+    // A process may have stopped after the single allowed POST but before a
+    // durable owned ad id was recorded. Never issue another copy or claim a
+    // clean rollback from this ambiguous state.
+    throw bootstrapFailure('meta_ads_publish_bootstrap_fixture_copy_reconciliation_required', 409);
+  }
+
+  const recordedAdId = clean(recordedFixture.ad_id);
+  if (recordedAdId) {
+    if (recordedFixture.owned_by_operation !== true) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_fixture_ownership_unconfirmed', 409);
+    }
+    try {
+      const verified = await validateBootstrapFixture(
+        targetAuth,
+        recordedAdId,
+        targetAuth.config.adset_id,
+        fixtureName,
+        item.url_tags,
+        context,
+      );
+      item.fixture = {
+        name: fixtureName,
+        source_ad_id: clean(recordedFixture.source_ad_id),
+        ad_id: verified.adId,
+        creative_id: verified.creativeId,
+        verified: true,
+        owned_by_operation: true,
+        copy_pending: false,
+      };
+      await persistBootstrapState({ env: context.env, operation, state, status: 'fixture_created', encryptToken: context.encryptToken, context });
+      return;
+    } catch (error) {
+      if (isBootstrapFailure(error)) throw error;
+      // Do not fall through to a second copy when the exact fixture recorded
+      // by this saga has changed or cannot be read. Its ownership must be
+      // reconciled explicitly before any retry.
+      throw bootstrapFailure('meta_ads_publish_bootstrap_fixture_owned_state_drift', 409);
+    }
+  }
+
+  const existing = await findBootstrapFixture(targetAuth, targetAuth.config.adset_id, fixtureName, item.url_tags, context);
+  if (existing) {
+    // A fixture with our deterministic marker but without a durable owned id
+    // may belong to a failed/foreign operation. It is never adopted or
+    // archived by this saga.
+    throw bootstrapFailure('meta_ads_publish_bootstrap_fixture_ownership_unconfirmed', 409);
+  }
+
+  // The target credential is the only credential retained by v20. It was
+  // already used to read the source ad set above; use it again here so the
+  // fixture cannot depend on a one-off bootstrap-only Facebook grant.
+  const sourceAdId = await resolveBootstrapFixtureSourceAd({
+    item,
+    auth: targetAuth,
+    expectedAdsetId: sourceAdsetId,
+    context,
+  });
+  // Persist the intent before the only mutating copy request. If the Worker
+  // dies at any later point, the next attempt refuses to duplicate an unknown
+  // paused fixture and records reconciliation as required.
+  item.fixture = {
+    ...asObject(item.fixture),
+    name: fixtureName,
+    source_ad_id: sourceAdId,
+    copy_pending: true,
+    copy_ambiguous: false,
+  };
+  await persistBootstrapState({ env: context.env, operation, state, status: 'tracking_configured', encryptToken: context.encryptToken, context });
+
+  let copiedId = '';
+  let copyIssued = false;
+  try {
+    await assertBootstrapLease(context);
+    const result = await graphRequest(
+      graphUrl(targetAuth.apiVersion, `${sourceAdId}/copies`),
+      jsonRequest('POST', {
+        adset_id: targetAuth.config.adset_id,
+        status_option: 'PAUSED',
+        creative_parameters: {
+          name: fixtureName,
+          url_tags: String(item.url_tags),
+        },
+      }),
+      targetAuth,
+      context,
+      { maxAttempts: 1 },
+    );
+    copyIssued = true;
+    copiedId = normalizeBootstrapCopiedAdId(result.body);
+  } catch (error) {
+    const normalized = normalizeFailure(error);
+    if (copyIssued || normalized.ambiguous || normalized.retryable) {
+      // The marker allows a governed recovery process to find a possible
+      // orphan, but this request does not claim ownership from a timeout.
+      // Retrying the copy could duplicate an ad; continuing could archive a
+      // human-created fixture. Preserve the encrypted intent and fail closed.
+      item.fixture = {
+        ...asObject(item.fixture),
+        copy_pending: true,
+        copy_ambiguous: true,
+      };
+      await persistBootstrapState({ env: context.env, operation, state, status: 'reconciliation_required', encryptToken: context.encryptToken, context }).catch(() => undefined);
+      throw bootstrapFailure('meta_ads_publish_bootstrap_fixture_copy_reconciliation_required', 409);
+    }
+    throw error;
+  }
+  if (!copiedId) {
+    item.fixture = {
+      ...asObject(item.fixture),
+      copy_pending: true,
+      copy_ambiguous: true,
+    };
+    await persistBootstrapState({ env: context.env, operation, state, status: 'reconciliation_required', encryptToken: context.encryptToken, context }).catch(() => undefined);
+    throw bootstrapFailure('meta_ads_publish_bootstrap_fixture_copy_reconciliation_required', 409);
+  }
+  // Persist the opaque ad ID before its Graph readback. A successful POST can
+  // still be followed by a transport/readback failure; cleanup may archive
+  // only this explicitly owned fixture after proving its marker and tags.
+  item.fixture = {
+    ...asObject(item.fixture),
+    name: fixtureName,
+    source_ad_id: sourceAdId,
+    ad_id: copiedId,
+    verified: false,
+    owned_by_operation: true,
+    copy_pending: false,
+    copy_ambiguous: false,
+  };
+  await persistBootstrapState({ env: context.env, operation, state, status: 'tracking_configured', encryptToken: context.encryptToken, context });
+  const verified = await validateBootstrapFixture(targetAuth, copiedId, targetAuth.config.adset_id, fixtureName, item.url_tags, context);
+  item.fixture = {
+    name: fixtureName,
+    source_ad_id: sourceAdId,
+    ad_id: verified.adId,
+    creative_id: verified.creativeId,
+    verified: true,
+    owned_by_operation: true,
+    copy_pending: false,
+  };
+  await persistBootstrapState({ env: context.env, operation, state, status: 'fixture_created', encryptToken: context.encryptToken, context });
+}
+
+async function bootstrapFixtureName(operationKey, configTokenId) {
+  // Never derive ownership from a shared human-readable prefix. The marker is
+  // collision-resistant across operations and token rows, but contains no raw
+  // account/ad-set ID or URL tag value.
+  const marker = await sha256(`meta-ads-bootstrap-fixture\n${clean(operationKey)}\n${clean(configTokenId)}`);
+  return `${BOOTSTRAP_FIXTURE_NAME_PREFIX} [sk:${marker.slice(0, 32)}]`.slice(0, 255);
+}
+
+async function resolveBootstrapFixtureSourceAd({ item, auth, expectedAdsetId, context }) {
+  const sourceAdsetId = normalizeNumericId(expectedAdsetId, 'bootstrap_fixture_source_adset_id');
+  const existingId = clean(item.fixture?.source_ad_id || item.fixture_source_ad_id);
+  if (existingId) {
+    const ad = await readBootstrapAd(auth, existingId, context);
+    assertBootstrapFixtureSourceAd(ad, sourceAdsetId);
+    return normalizeNumericId(ad.id, 'bootstrap_fixture_source_ad_id');
+  }
+  const candidates = (await listBootstrapAdsetAds(auth, sourceAdsetId, context))
+    .filter((entry) => isBootstrapFixtureSourceCandidate(entry, sourceAdsetId));
+  if (candidates.length !== 1) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_fixture_source_ambiguous', 409);
+  }
+  return normalizeNumericId(candidates[0].id, 'bootstrap_fixture_source_ad_id');
+}
+
+function assertBootstrapFixtureSourceAd(value, expectedAdsetId) {
+  const ad = asObject(value);
+  if (
+    normalizeNumericId(ad.adset_id, 'bootstrap_fixture_source_adset_id') !== expectedAdsetId ||
+    !isBootstrapFixtureSourceCandidate(ad, expectedAdsetId)
+  ) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_fixture_source_invalid', 409);
+  }
+}
+
+function isBootstrapFixtureSourceCandidate(value, expectedAdsetId) {
+  const ad = asObject(value);
+  const status = clean(ad.status).toUpperCase();
+  const effectiveStatus = clean(ad.effective_status).toUpperCase();
+  const creativeId = clean(asObject(ad.creative).id);
+  return clean(ad.adset_id) === clean(expectedAdsetId) &&
+    ['ACTIVE', 'PAUSED'].includes(status) &&
+    (!effectiveStatus || ['ACTIVE', 'PAUSED'].includes(effectiveStatus)) &&
+    /^\d{5,30}$/.test(creativeId);
+}
+
+async function findBootstrapFixture(auth, adsetId, fixtureName, urlTags, context) {
+  const named = (await listBootstrapAdsetAds(auth, adsetId, context)).filter((entry) => {
+    const creative = asObject(entry.creative);
+    return clean(entry.adset_id) === clean(adsetId) &&
+      clean(creative.name) === fixtureName;
+  });
+  const matches = named.filter((entry) => String(asObject(entry.creative).url_tags ?? '') === String(urlTags));
+  if (named.length !== matches.length) {
+    // The deterministic marker belongs to a fixture with different raw tags.
+    // Never overwrite its state with a new copy: it may be an interrupted
+    // prior saga whose ownership cannot be established from a list response.
+    throw bootstrapFailure('meta_ads_publish_bootstrap_fixture_marker_conflict', 409);
+  }
+  if (matches.length > 1) throw bootstrapFailure('meta_ads_publish_bootstrap_fixture_ambiguous', 409);
+  return matches[0] || null;
+}
+
+function normalizeBootstrapCopiedAdId(value) {
+  const body = asObject(value);
+  const candidate = clean(body.copied_ad_id || body.ad_id || body.id);
+  if (!candidate) return '';
+  try {
+    return normalizeNumericId(candidate, 'bootstrap_fixture_ad_id');
+  } catch {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_fixture_create_unconfirmed', 502);
+  }
+}
+
+async function validateBootstrapFixture(auth, adId, expectedAdsetId, fixtureName, urlTags, context) {
+  const ad = await readBootstrapAd(auth, adId, context);
+  if (
+    normalizeNumericId(ad.adset_id, 'bootstrap_fixture_adset_id') !== expectedAdsetId ||
+    clean(ad.status).toUpperCase() !== 'PAUSED'
+  ) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_fixture_readback_mismatch', 502);
+  }
+  const creativeId = normalizeNumericId(asObject(ad.creative).id, 'bootstrap_fixture_creative_id');
+  const creativeResult = await graphRequest(
+    graphUrl(auth.apiVersion, creativeId, { fields: CREATIVE_READ_FIELDS.join(',') }),
+    { method: 'GET' },
+    auth,
+    context,
+  );
+  const creative = asObject(creativeResult.body);
+  if (clean(creative.name) !== fixtureName || String(creative.url_tags ?? '') !== String(urlTags)) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_fixture_readback_mismatch', 502);
+  }
+  return { adId: normalizeNumericId(ad.id, 'bootstrap_fixture_ad_id'), creativeId };
+}
+
+async function readBootstrapAd(auth, adId, context) {
+  const result = await graphRequest(
+    graphUrl(auth.apiVersion, normalizeNumericId(adId, 'bootstrap_ad_id'), { fields: BOOTSTRAP_AD_FIELDS }),
+    { method: 'GET' },
+    auth,
+    context,
+  );
+  return asObject(result.body);
+}
+
+async function listBootstrapAdsetAds(auth, adsetId, context) {
+  let url = graphUrl(auth.apiVersion, `${normalizeNumericId(adsetId, 'bootstrap_adset_id')}/ads`, {
+    fields: BOOTSTRAP_AD_FIELDS,
+    limit: '100',
+  });
+  const ads = [];
+  let pages = 0;
+  while (url) {
+    pages += 1;
+    if (pages > MAX_AD_PAGES || ads.length > MAX_ADS) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_fixture_discovery_limit', 409);
+    }
+    const result = await graphRequest(url, { method: 'GET' }, auth, context);
+    ads.push(...safeArray(result.body.data).map(asObject));
+    url = validatePagingUrl(result.body?.paging?.next, auth.apiVersion);
+  }
+  return ads;
+}
+
+async function discoverBootstrapWhatsAppDestination(auth, targetAdset, context, item) {
+  const graphDestination = clean(asObject(targetAdset).destination_type).toUpperCase();
+  if (graphDestination && !isBootstrapWhatsAppGraphDestination(graphDestination)) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_whatsapp_destination_required', 409);
+  }
+  const urls = new Set();
+  for (const ad of await listBootstrapAdsetAds(auth, auth.config.adset_id, context)) {
+    const status = clean(ad.status).toUpperCase();
+    if (!['ACTIVE', 'PAUSED'].includes(status)) continue;
+    for (const rawUrl of bootstrapCreativeDestinationUrls(asObject(ad.creative))) {
+      try {
+        const normalized = normalizeConfigWriterWhatsAppUrl(rawUrl);
+        urls.add(normalized);
+      } catch {
+        // An arbitrary creative field is not evidence of a WhatsApp route.
+      }
+    }
+  }
+  if (urls.size !== 1) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_whatsapp_destination_ambiguous', 409);
+  }
+  const destination = [...urls][0];
+  if (clean(item.whatsapp_destination_url) && clean(item.whatsapp_destination_url) !== destination) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_reconciliation_required', 409);
+  }
+  return destination;
+}
+
+function isBootstrapWhatsAppGraphDestination(value) {
+  const normalized = clean(value).toUpperCase();
+  return normalized === 'WHATSAPP' || /^MESSAGING(?:_[A-Z0-9]+)*_WHATSAPP$/.test(normalized);
+}
+
+function bootstrapCreativeDestinationUrls(value) {
+  const creative = asObject(value);
+  const story = asObject(creative.object_story_spec);
+  const linkData = asObject(story.link_data);
+  const videoData = asObject(story.video_data);
+  const videoCtaValue = asObject(asObject(videoData.call_to_action).value);
+  const feed = asObject(creative.asset_feed_spec);
+  return [
+    linkData.link,
+    videoCtaValue.link,
+    ...safeArray(feed.link_urls).map((entry) => asObject(entry).website_url),
+  ].map(clean).filter(Boolean);
+}
+
+async function compensateBootstrapState({ state, context }) {
+  let safe = true;
+  const items = [...safeArray(state.items)].reverse();
+  for (const item of items) {
+    if (clean(item.destination_type) !== 'website') continue;
+    try {
+      const targetAuth = await resolveLegacyBootstrapGraphAuth(clean(item.config_token_id), context);
+      const fixture = asObject(item.fixture);
+      const tracking = asObject(item.tracking);
+      const keys = safeArray(tracking.keys);
+      if (keys.length) {
+        const current = await readAdsetConversionState(targetAuth, targetAuth.config.adset_id, context);
+        const desired = asObject(tracking.desired_tracking_promoted_object);
+        const previous = asObject(tracking.previous_tracking_promoted_object);
+        if (!trackingKeysMatch(current.promoted_object, previous, keys)) {
+          if (!trackingKeysMatch(current.promoted_object, desired, keys)) {
+            safe = false;
+            continue;
+          }
+          const restored = { ...asObject(current.promoted_object) };
+          for (const key of keys) {
+            if (Object.prototype.hasOwnProperty.call(previous, key)) restored[key] = previous[key];
+            else delete restored[key];
+          }
+          await assertBootstrapLease(context);
+          await updateAdsetPromotedObject(targetAuth, targetAuth.config.adset_id, restored, context);
+          const readback = await readAdsetConversionState(targetAuth, targetAuth.config.adset_id, context);
+          if (!trackingKeysMatch(readback.promoted_object, previous, keys)) {
+            safe = false;
+            continue;
+          }
+        }
+      }
+
+      // Do not archive the known-good paused creative before tracking has
+      // been restored. If Graph refuses the promoted_object restore, v20 stays
+      // authoritative and its required fixture remains usable for recovery.
+      if (fixture.copy_pending === true || fixture.copy_ambiguous === true) {
+        safe = false;
+        continue;
+      }
+      const fixtureAdId = clean(fixture.ad_id);
+      if (fixtureAdId && fixture.owned_by_operation === true) {
+        // Do not archive a merely discovered fixture. Even a deterministic
+        // marker is not ownership proof until this saga recorded a successful
+        // copy response; read back its exact target/name/tags before cleanup.
+        const currentFixture = await readBootstrapAd(targetAuth, fixtureAdId, context);
+        if (clean(currentFixture.status).toUpperCase() !== 'ARCHIVED') {
+          const verified = await validateBootstrapFixture(
+            targetAuth,
+            fixtureAdId,
+            targetAuth.config.adset_id,
+            clean(fixture.name),
+            String(item.url_tags || ''),
+            context,
+          );
+          await assertBootstrapLease(context);
+          await updateAdWithReconciliation(targetAuth, verified.adId, { status: 'ARCHIVED' }, context);
+          const archived = await readBootstrapAd(targetAuth, verified.adId, context);
+          if (clean(archived.status).toUpperCase() !== 'ARCHIVED') safe = false;
+        }
+      }
+    } catch {
+      safe = false;
+    }
+  }
+  return safe;
 }
 
 async function getInventory({ request, env, requestId, decryptToken, writeAudit }) {
@@ -2979,10 +5193,18 @@ async function resolveGraphAuth(body, context) {
   return { tokenId, accountId, apiVersion, accessToken, appSecretProof, config };
 }
 
-async function graphRequest(url, init, auth, context) {
+async function graphRequest(url, init, auth, context, { maxAttempts = MAX_GRAPH_ATTEMPTS } = {}) {
   let lastFailure;
   const started = Date.now();
-  for (let attempt = 1; attempt <= MAX_GRAPH_ATTEMPTS; attempt += 1) {
+  const attemptsAllowed = clampInteger(maxAttempts, MAX_GRAPH_ATTEMPTS, 1, MAX_GRAPH_ATTEMPTS);
+  for (let attempt = 1; attempt <= attemptsAllowed; attempt += 1) {
+    // Bootstrap may spend several retry windows walking a source ad set.  Its
+    // configuration lease must be renewed before every Graph request, not
+    // only before a later POST/persist, otherwise an expired saga could leave
+    // an already-mutated target without a live owner able to compensate it.
+    if (typeof context?.assertBootstrapLease === 'function') {
+      await context.assertBootstrapLease();
+    }
     context.attempts += 1;
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), GRAPH_TIMEOUT_MS);
@@ -3006,14 +5228,14 @@ async function graphRequest(url, init, auth, context) {
 
       const normalized = normalizeMetaError(body, graphResponse.status, graphResponse.headers, context.action);
       lastFailure = normalized;
-      if (!normalized.retryable || attempt === MAX_GRAPH_ATTEMPTS) throw Object.assign(new Error(normalized.message), normalized);
+      if (!normalized.retryable || attempt === attemptsAllowed) throw Object.assign(new Error(normalized.message), normalized);
       const delay = retryDelayMs(attempt, graphResponse.headers, started, normalized);
       if (delay <= 0) throw Object.assign(new Error(normalized.message), normalized);
       await (context.env.META_GRAPH_SLEEP || sleep)(delay);
     } catch (error) {
       const normalized = normalizeFailure(error);
       lastFailure = normalized;
-      if (!normalized.retryable || attempt === MAX_GRAPH_ATTEMPTS) throw Object.assign(new Error(normalized.message), normalized);
+      if (!normalized.retryable || attempt === attemptsAllowed) throw Object.assign(new Error(normalized.message), normalized);
       const delay = retryDelayMs(attempt, null, started);
       if (delay <= 0) throw Object.assign(new Error(normalized.message), normalized);
       await (context.env.META_GRAPH_SLEEP || sleep)(delay);
@@ -3454,48 +5676,83 @@ async function acquireLocks(env, runId, operationKey, resourceKeys) {
   const keys = [...new Set(safeArray(resourceKeys).map(clean).filter(Boolean))].sort();
   const now = nowIso();
   const expiresAt = new Date(Date.now() + LOCK_TTL_MS).toISOString();
-  for (const resourceKey of keys) {
-    const current = await dbFirst(env,
-      `SELECT resource_key, run_id, operation_key, expires_at FROM meta_ads_publish_locks WHERE resource_key = ?`,
-      resourceKey,
-    );
-    // A run is not a blanket lock owner. Re-entrancy is permitted only for
-    // the same idempotent operation so a same-run rollback/ensure cannot
-    // replace a stage batch's fresh ad-set attestation between its Graph GET
-    // and ad POST.
-    if (
-      current &&
-      Date.parse(current.expires_at) > Date.now() &&
-      (clean(current.run_id) !== runId || clean(current.operation_key) !== operationKey)
-    ) {
-      throw new Error(`resource_locked:${resourceKey}`);
+  const newlyAcquired = [];
+  try {
+    for (const resourceKey of keys) {
+      const current = await dbFirst(env,
+        `SELECT resource_key, run_id, operation_key, expires_at FROM meta_ads_publish_locks WHERE resource_key = ?`,
+        resourceKey,
+      );
+      const reentrant = Boolean(
+        current &&
+        Date.parse(current.expires_at) > Date.now() &&
+        clean(current.run_id) === runId &&
+        clean(current.operation_key) === operationKey,
+      );
+      // A run is not a blanket lock owner. Re-entrancy is permitted only for
+      // the same idempotent operation so a same-run rollback/ensure cannot
+      // replace a stage batch's fresh ad-set attestation between its Graph GET
+      // and ad POST.
+      if (
+        current &&
+        Date.parse(current.expires_at) > Date.now() &&
+        !reentrant
+      ) {
+        throw new Error(`resource_locked:${resourceKey}`);
+      }
+      await dbRun(env,
+        `INSERT INTO meta_ads_publish_locks (
+          resource_key, run_id, operation_key, heartbeat_at, expires_at, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(resource_key) DO UPDATE SET
+          run_id = excluded.run_id,
+          operation_key = excluded.operation_key,
+          heartbeat_at = excluded.heartbeat_at,
+          expires_at = excluded.expires_at,
+          updated_at = excluded.updated_at
+        WHERE meta_ads_publish_locks.expires_at <= ? OR
+          (meta_ads_publish_locks.run_id = ? AND meta_ads_publish_locks.operation_key = ?)`,
+        resourceKey, runId, operationKey, now, expiresAt, now, now, now, runId, operationKey,
+      );
+      const acquired = await dbFirst(env,
+        `SELECT run_id, operation_key FROM meta_ads_publish_locks WHERE resource_key = ?`,
+        resourceKey,
+      );
+      if (
+        !acquired ||
+        clean(acquired.run_id) !== runId ||
+        clean(acquired.operation_key) !== operationKey
+      ) {
+        throw new Error(`resource_locked:${resourceKey}`);
+      }
+      if (!reentrant) newlyAcquired.push(resourceKey);
     }
-    await dbRun(env,
-      `INSERT INTO meta_ads_publish_locks (
-        resource_key, run_id, operation_key, heartbeat_at, expires_at, created_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(resource_key) DO UPDATE SET
-        run_id = excluded.run_id,
-        operation_key = excluded.operation_key,
-        heartbeat_at = excluded.heartbeat_at,
-        expires_at = excluded.expires_at,
-        updated_at = excluded.updated_at
-      WHERE meta_ads_publish_locks.expires_at <= ? OR
-        (meta_ads_publish_locks.run_id = ? AND meta_ads_publish_locks.operation_key = ?)`,
-      resourceKey, runId, operationKey, now, expiresAt, now, now, now, runId, operationKey,
-    );
-    const acquired = await dbFirst(env,
-      `SELECT run_id, operation_key FROM meta_ads_publish_locks WHERE resource_key = ?`,
-      resourceKey,
-    );
-    if (
-      !acquired ||
-      clean(acquired.run_id) !== runId ||
-      clean(acquired.operation_key) !== operationKey
-    ) {
-      throw new Error(`resource_locked:${resourceKey}`);
+  } catch (error) {
+    if (newlyAcquired.length) {
+      try {
+        await releaseSpecificOperationLocks(env, runId, operationKey, newlyAcquired);
+      } catch {
+        // The caller must fail closed if D1 cannot prove that a partial lease
+        // was released. Retrying a Graph mutation in that state could race a
+        // stale owner until the bounded lease expires.
+        throw new Error('resource_lock_cleanup_failed');
+      }
     }
+    throw error;
   }
+}
+
+async function releaseSpecificOperationLocks(env, runId, operationKey, resourceKeys) {
+  const keys = [...new Set(safeArray(resourceKeys).map(clean).filter(Boolean))].sort();
+  if (!keys.length) return;
+  const placeholders = keys.map(() => '?').join(', ');
+  await dbRun(env,
+    `DELETE FROM meta_ads_publish_locks
+      WHERE run_id = ? AND operation_key = ? AND resource_key IN (${placeholders})`,
+    runId,
+    operationKey,
+    ...keys,
+  );
 }
 
 async function releaseOperationLocks(env, runId, operationKey) {

--- a/platform/security/token-vault/tests/index.test.js
+++ b/platform/security/token-vault/tests/index.test.js
@@ -6,6 +6,7 @@ const encoder = new TextEncoder();
 const TEST_API_TOKEN = ['unit', 'auth', 'token'].join('-');
 const TEST_OPERATIONAL_TOKEN = ['unit', 'operational', 'token'].join('-');
 const TEST_ANALYTICS_TOKEN = ['unit', 'analytics', 'token'].join('-');
+const TEST_META_ADS_CONFIG_TOKEN = ['unit', 'meta', 'ads', 'config', 'token'].join('-');
 const TEST_ENCRYPTION_KEY = ['unit', 'encryption', 'key', 'with', 'enough', 'length'].join('-');
 const THREADS_TOKEN = ['threads', 'fixture', 'token'].join('-');
 const FACEBOOK_TOKEN = ['facebook', 'fixture', 'token'].join('-');
@@ -85,6 +86,7 @@ function env(db) {
     TOKEN_VAULT_API_TOKEN: TEST_API_TOKEN,
     TOKEN_VAULT_N8N_API_TOKEN: TEST_OPERATIONAL_TOKEN,
     TOKEN_VAULT_ANALYTICS_API_TOKEN: TEST_ANALYTICS_TOKEN,
+    TOKEN_VAULT_META_ADS_CONFIG_TOKEN: TEST_META_ADS_CONFIG_TOKEN,
     TOKEN_VAULT_ENCRYPTION_KEY: TEST_ENCRYPTION_KEY,
     REQUIRE_AUTH: 'true',
     WORKER_AUTH_HEADER_NAME: 'Authorization',
@@ -99,6 +101,10 @@ function authHeaders() {
 
 function operationalAuthHeaders() {
   return { Authorization: `Bearer ${TEST_OPERATIONAL_TOKEN}` };
+}
+
+function metaAdsConfigAuthHeaders() {
+  return { Authorization: `Bearer ${TEST_META_ADS_CONFIG_TOKEN}` };
 }
 
 async function encryptForSeed(token, secret) {
@@ -161,6 +167,18 @@ test('health stays unhealthy when the operational Orb credential is absent', asy
   assert.equal(body.checks.n8nApiToken, false);
 });
 
+test('meta ads config credential is optional for worker health', async () => {
+  const db = new FakeDb();
+  const environment = env(db);
+  delete environment.TOKEN_VAULT_META_ADS_CONFIG_TOKEN;
+  const response = await handleRequest(
+    new Request('https://api.skincos.com.br/internal/token-vault/health', { headers: authHeaders() }),
+    environment,
+  );
+  assert.equal(response.status, 200);
+  assert.equal((await response.json()).ok, true);
+});
+
 test('analytics credential cannot reach write-capable sibling gateways', async () => {
   const db = new FakeDb();
   const socialResponse = await handleRequest(
@@ -198,13 +216,128 @@ test('invalid authentication configuration fails closed', async () => {
 test('configured worker secrets must remain pairwise distinct', async () => {
   const db = new FakeDb();
   const environment = env(db);
-  environment.TOKEN_VAULT_ANALYTICS_API_TOKEN = TEST_API_TOKEN;
+  environment.TOKEN_VAULT_META_ADS_CONFIG_TOKEN = TEST_API_TOKEN;
   const response = await handleRequest(
     new Request('https://api.skincos.com.br/internal/token-vault/health', { headers: authHeaders() }),
     environment,
   );
   assert.equal(response.status, 500);
   assert.equal((await response.json()).error, 'invalid_worker_secret_configuration');
+});
+
+test('meta ads config credential is limited to configuration reads and governed bootstrap routing', async () => {
+  const db = new FakeDb();
+  const healthResponse = await handleRequest(
+    new Request('https://api.skincos.com.br/internal/token-vault/health', { headers: metaAdsConfigAuthHeaders() }),
+    env(db),
+  );
+  assert.equal(healthResponse.status, 200);
+
+  const contractResponse = await handleRequest(
+    new Request('https://api.skincos.com.br/internal/token-vault/contract', { headers: metaAdsConfigAuthHeaders() }),
+    env(db),
+  );
+  assert.equal(contractResponse.status, 200);
+  assert.equal((await contractResponse.json()).auth.meta_ads_config_secret, 'TOKEN_VAULT_META_ADS_CONFIG_TOKEN');
+
+  const configResponse = await handleRequest(
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/config', { headers: metaAdsConfigAuthHeaders() }),
+    env(db),
+  );
+  assert.equal(configResponse.status, 409);
+  assert.equal((await configResponse.json()).config_authority_mode, 'legacy_bootstrap');
+
+  const bootstrapResponse = await handleRequest(
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/config/bootstrap', {
+      method: 'POST',
+      headers: { ...metaAdsConfigAuthHeaders(), 'content-type': 'application/json' },
+      body: '{}',
+    }),
+    env(db),
+  );
+  assert.notEqual(bootstrapResponse.status, 403);
+  assert.notEqual((await bootstrapResponse.json()).error, 'meta_ads_config_credential_scope_required');
+
+  const rollbackResponse = await handleRequest(
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/config/bootstrap/rollback', {
+      method: 'POST',
+      headers: { ...metaAdsConfigAuthHeaders(), 'content-type': 'application/json' },
+      body: '{}',
+    }),
+    env(db),
+  );
+  assert.notEqual(rollbackResponse.status, 403);
+  assert.notEqual((await rollbackResponse.json()).error, 'meta_ads_config_credential_scope_required');
+
+  const exerciseResponse = await handleRequest(
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/config/staging-exercise', {
+      method: 'POST',
+      headers: { ...metaAdsConfigAuthHeaders(), 'content-type': 'application/json' },
+      body: '{}',
+    }),
+    env(db),
+  );
+  assert.notEqual(exerciseResponse.status, 403);
+  assert.notEqual((await exerciseResponse.json()).error, 'meta_ads_config_credential_scope_required');
+});
+
+test('operational credential cannot invoke Meta Ads bootstrap or staging exercise mutations', async () => {
+  const db = new FakeDb();
+  for (const pathname of [
+    '/v1/meta-ads-publish/config/bootstrap',
+    '/v1/meta-ads-publish/config/bootstrap/rollback',
+    '/v1/meta-ads-publish/config/staging-exercise',
+  ]) {
+    const response = await handleRequest(
+      new Request(`https://api.skincos.com.br/internal/token-vault${pathname}`, {
+        method: 'POST',
+        headers: { ...operationalAuthHeaders(), 'content-type': 'application/json' },
+        body: '{}',
+      }),
+      env(db),
+    );
+    assert.equal(response.status, 403);
+    assert.equal((await response.json()).error, 'meta_ads_config_credential_required');
+  }
+});
+
+test('meta ads config credential cannot access token, analytics, social, or Meta Ads run gateways', async () => {
+  const db = new FakeDb();
+  const requests = [
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/tokens?active=true', { headers: metaAdsConfigAuthHeaders() }),
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/analytics/operations', {
+      method: 'POST',
+      headers: { ...metaAdsConfigAuthHeaders(), 'content-type': 'application/json' },
+      body: '{}',
+    }),
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/social-publish/operations', {
+      method: 'POST',
+      headers: { ...metaAdsConfigAuthHeaders(), 'content-type': 'application/json' },
+      body: '{}',
+    }),
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/runs', {
+      method: 'POST',
+      headers: { ...metaAdsConfigAuthHeaders(), 'content-type': 'application/json' },
+      body: '{}',
+    }),
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/runs/test-run/operations', {
+      method: 'POST',
+      headers: { ...metaAdsConfigAuthHeaders(), 'content-type': 'application/json' },
+      body: '{}',
+    }),
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/config', {
+      method: 'PUT',
+      headers: { ...metaAdsConfigAuthHeaders(), 'content-type': 'application/json' },
+      body: '{}',
+    }),
+  ];
+
+  for (const request of requests) {
+    const response = await handleRequest(request, env(db));
+    assert.equal(response.status, 403);
+    assert.equal((await response.json()).error, 'meta_ads_config_credential_scope_required');
+  }
+  assert.equal(db.tokens.length, 0);
 });
 
 test('routes social publication requests to the fail-closed gateway', async () => {

--- a/platform/security/token-vault/tests/meta-ads-publish-bootstrap.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-bootstrap.test.js
@@ -1,0 +1,1348 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  __test as metaAdsPublishTest,
+  bootstrapMetaAdsPublishConfig,
+  exerciseStagingMetaAdsTrackingFixture,
+  handleMetaAdsPublishRequest,
+  rollbackBootstrapMetaAdsPublishConfig,
+} from '../src/meta-ads-publish.js';
+import { handleRequest } from '../src/index.js';
+
+const RAW_URL_TAGS = 'key1=value1&payload=abc==&key2=value2%20x';
+const SOURCE_ADSET_ID = '323456790';
+const TARGET_ADSET_ID = '323456791';
+const WHATSAPP_ADSET_ID = '323456792';
+
+class BootstrapStatement {
+  constructor(db, sql) {
+    this.db = db;
+    this.sql = sql;
+    this.values = [];
+  }
+
+  bind(...values) {
+    this.values = values;
+    return this;
+  }
+
+  async first() {
+    if (this.sql.includes('FROM meta_ads_publish_runs') && this.sql.includes('batch_fingerprint = ?')) {
+      return this.db.runsByFingerprint.get(this.values[0]) || null;
+    }
+    if (this.sql.includes('FROM meta_ads_publish_adset_tracking_snapshots')) {
+      if (this.sql.includes('operation_key = ?')) return this.db.snapshotsByOperation.get(this.values[0]) || null;
+      if (this.sql.includes('id = ?')) return this.db.snapshotsById.get(this.values[0]) || null;
+    }
+    if (this.sql.includes('FROM meta_ads_publish_locks')) {
+      return this.db.operationLocks.get(this.values[0]) || null;
+    }
+    if (this.sql.includes('FROM meta_ads_publish_bootstrap_operations')) {
+      return this.db.bootstrapOperations.get(this.values[0]) || null;
+    }
+    if (this.sql.includes('FROM meta_ads_publish_config_operations')) {
+      return this.db.configOperations.get(this.values[0]) || null;
+    }
+    if (this.sql.includes('FROM meta_ads_publish_config_locks')) {
+      return this.db.locks.get(this.values[0]) || null;
+    }
+    if (this.sql.includes('FROM credential_tokens') && this.sql.includes('WHERE id = ?')) {
+      return this.db.tokens.find((row) => row.id === this.values[0]) || null;
+    }
+    throw new Error(`Unexpected first SQL: ${this.sql}`);
+  }
+
+  async all() {
+    if (this.sql.includes('FROM credential_tokens')) {
+      return {
+        results: this.db.tokens
+          .filter((row) => row.provider === 'facebook' && row.active === 1)
+          .map((row) => ({ ...row })),
+      };
+    }
+    throw new Error(`Unexpected all SQL: ${this.sql}`);
+  }
+
+  async run() {
+    if (this.sql.includes('DELETE FROM meta_ads_publish_config_locks')) {
+      const [resourceKey, ownerOrNow] = this.values;
+      const lock = this.db.locks.get(resourceKey);
+      const hasOwner = typeof ownerOrNow === 'string' && !/^\d{4}-\d{2}-\d{2}T/.test(ownerOrNow);
+      if (lock && (!hasOwner
+        ? Date.parse(lock.expires_at) <= Date.parse(ownerOrNow)
+        : lock.owner_id === ownerOrNow)) {
+        this.db.locks.delete(resourceKey);
+        return changed(1);
+      }
+      return changed(0);
+    }
+    if (this.sql.includes('INSERT INTO meta_ads_publish_config_locks')) {
+      const [resourceKey, ownerId, expiresAt] = this.values;
+      const existing = this.db.locks.get(resourceKey);
+      if (!existing || Date.parse(existing.expires_at) <= Date.now()) {
+        this.db.locks.set(resourceKey, { resource_key: resourceKey, owner_id: ownerId, expires_at: expiresAt });
+        return changed(1);
+      }
+      return changed(0);
+    }
+    if (this.sql.includes('UPDATE meta_ads_publish_config_locks')) {
+      const [expiresAt, , resourceKey, ownerId] = this.values;
+      const existing = this.db.locks.get(resourceKey);
+      if (existing && existing.owner_id === ownerId) {
+        existing.expires_at = expiresAt;
+        return changed(1);
+      }
+      return changed(0);
+    }
+    if (this.sql.includes('INSERT INTO meta_ads_publish_bootstrap_operations')) {
+      const [id, operationKey, requestHash, expectedRevision, stateCiphertext, summaryJson] = this.values;
+      if (this.db.bootstrapOperations.has(operationKey)) return changed(0);
+      this.db.bootstrapOperations.set(operationKey, {
+        id,
+        operation_key: operationKey,
+        request_hash: requestHash,
+        expected_config_authority_revision: expectedRevision,
+        resulting_tracking_binding_revision: '',
+        status: 'pending',
+        state_ciphertext: stateCiphertext,
+        summary_json: summaryJson,
+      });
+      return changed(1);
+    }
+    if (this.sql.includes('UPDATE meta_ads_publish_bootstrap_operations')) {
+      const [status, stateCiphertext, summaryJson, resultingRevision, , id, operationKey, requestHash] = this.values;
+      const operation = this.db.bootstrapOperations.get(operationKey);
+      if (!operation || operation.id !== id || operation.request_hash !== requestHash) return changed(0);
+      operation.status = status;
+      operation.state_ciphertext = stateCiphertext;
+      operation.summary_json = summaryJson;
+      if (resultingRevision) operation.resulting_tracking_binding_revision = resultingRevision;
+      return changed(1);
+    }
+    if (this.sql.includes('INSERT INTO meta_ads_publish_runs')) {
+      const [id, fingerprint, requestHash, workflowExecutionId, configRevision] = this.values;
+      if (this.db.runsByFingerprint.has(fingerprint)) return changed(0);
+      const run = {
+        id,
+        batch_fingerprint: fingerprint,
+        request_hash: requestHash,
+        workflow_execution_id: workflowExecutionId,
+        config_revision: configRevision,
+        status: 'processing',
+        summary_json: '{}',
+      };
+      this.db.runsByFingerprint.set(fingerprint, run);
+      this.db.runsById.set(id, run);
+      return changed(1);
+    }
+    if (this.sql.includes('UPDATE meta_ads_publish_runs SET status')) {
+      const [status, summaryJson, , runId] = this.values;
+      const run = this.db.runsById.get(runId);
+      if (!run) return changed(0);
+      run.status = status;
+      run.summary_json = summaryJson;
+      return changed(1);
+    }
+    if (this.sql.includes('INSERT OR IGNORE INTO meta_ads_publish_adset_tracking_snapshots')) {
+      const [
+        id, runId, operationKey, tokenId, accountId, adsetId, profileRef,
+        previousCiphertext, previousFingerprint, desiredFingerprint, desiredCiphertext, trackingKeysJson,
+      ] = this.values;
+      if (this.db.snapshotsByOperation.has(operationKey)) return changed(0);
+      const snapshot = {
+        id,
+        run_id: runId,
+        operation_key: operationKey,
+        token_id: tokenId,
+        account_id: accountId,
+        adset_id: adsetId,
+        profile_ref: profileRef,
+        previous_promoted_object_ciphertext: previousCiphertext,
+        previous_promoted_object_fingerprint: previousFingerprint,
+        desired_promoted_object_fingerprint: desiredFingerprint,
+        desired_tracking_promoted_object_ciphertext: desiredCiphertext,
+        tracking_keys_json: trackingKeysJson,
+        status: 'captured',
+      };
+      this.db.snapshotsByOperation.set(operationKey, snapshot);
+      this.db.snapshotsById.set(id, snapshot);
+      return changed(1);
+    }
+    if (this.sql.includes("UPDATE meta_ads_publish_adset_tracking_snapshots") && this.sql.includes("status = 'reconciled'")) {
+      const [, snapshotId] = this.values;
+      const snapshot = this.db.snapshotsById.get(snapshotId);
+      if (!snapshot || snapshot.status !== 'captured') return changed(0);
+      snapshot.status = 'reconciled';
+      return changed(1);
+    }
+    if (this.sql.includes("UPDATE meta_ads_publish_adset_tracking_snapshots") && this.sql.includes("status = 'restored'")) {
+      const [, , snapshotId] = this.values;
+      const snapshot = this.db.snapshotsById.get(snapshotId);
+      if (!snapshot) return changed(0);
+      snapshot.status = 'restored';
+      return changed(1);
+    }
+    if (this.sql.includes('INSERT INTO meta_ads_publish_locks')) {
+      const [resourceKey, runId, operationKey, , expiresAt] = this.values;
+      this.db.operationLocks.set(resourceKey, {
+        resource_key: resourceKey,
+        run_id: runId,
+        operation_key: operationKey,
+        expires_at: expiresAt,
+      });
+      return changed(1);
+    }
+    if (this.sql.includes('DELETE FROM meta_ads_publish_locks')) {
+      const [runId, operationKey, ...resourceKeys] = this.values;
+      for (const [resourceKey, lock] of this.db.operationLocks) {
+        if (
+          lock.run_id === runId &&
+          lock.operation_key === operationKey &&
+          (!resourceKeys.length || resourceKeys.includes(resourceKey))
+        ) {
+          this.db.operationLocks.delete(resourceKey);
+        }
+      }
+      return changed(1);
+    }
+    throw new Error(`Unexpected run SQL: ${this.sql}`);
+  }
+}
+
+class BootstrapDb {
+  constructor() {
+    this.tokens = [
+      tokenRow('facebook_a_source', 'Website source', SOURCE_ADSET_ID, 1),
+      tokenRow('facebook_b_target', 'Website target', TARGET_ADSET_ID, 2),
+      tokenRow('facebook_c_whatsapp', 'Click to WhatsApp', WHATSAPP_ADSET_ID, 3),
+      {
+        id: 'facebook_unrelated',
+        provider: 'facebook',
+        unit: 'Unrelated',
+        external_account_id: '123456789',
+        token_type: 'long_lived_access_token',
+        token_ciphertext: 'credential:facebook_unrelated',
+        expires_at: null,
+        active: 1,
+        updated_at: '2026-08-13T00:00:00.000Z',
+        metadata_json: JSON.stringify({ unrelated_metadata: { retain: true, owner: 'another-workflow' } }),
+      },
+    ];
+    this.bootstrapOperations = new Map();
+    this.configOperations = new Map();
+    this.locks = new Map();
+    this.runsByFingerprint = new Map();
+    this.runsById = new Map();
+    this.operationLocks = new Map();
+    this.snapshotsByOperation = new Map();
+    this.snapshotsById = new Map();
+  }
+
+  prepare(sql) {
+    return new BootstrapStatement(this, sql);
+  }
+
+  async batch(statements) {
+    const results = [];
+    for (const statement of statements) {
+      const { sql, values } = statement;
+      if (sql.includes('INSERT INTO meta_ads_publish_config_operations')) {
+        const [id, operationKey, targetTokenIdsJson, requestHash, expectedRevision, resultingRevision] = values;
+        if (this.configOperations.has(operationKey)) {
+          results.push(changed(0));
+          continue;
+        }
+        this.configOperations.set(operationKey, {
+          id,
+          operation_key: operationKey,
+          target_token_ids_json: targetTokenIdsJson,
+          request_hash: requestHash,
+          expected_tracking_binding_revision: expectedRevision,
+          resulting_tracking_binding_revision: resultingRevision,
+          status: 'pending',
+        });
+        results.push(changed(1));
+        continue;
+      }
+      if (sql.startsWith('UPDATE credential_tokens SET metadata_json = CASE') && !sql.includes('meta_ads_publish_config_operations')) {
+        const planCount = (sql.match(/WHEN \? THEN \?/g) || []).length;
+        const nextPairs = values.slice(0, planCount * 2);
+        const targetIds = values.slice(planCount * 2 + 1, planCount * 3 + 1);
+        const oldPairs = values.slice(planCount * 3 + 1, planCount * 5 + 1);
+        const requiredCount = values[planCount * 5 + 1];
+        const plans = Array.from({ length: planCount }, (_, index) => ({
+          id: nextPairs[index * 2],
+          nextMetadataJson: nextPairs[index * 2 + 1],
+          oldMetadataJson: oldPairs[index * 2 + 1],
+        }));
+        const eligible = targetIds.length === planCount && new Set(targetIds).size === planCount &&
+          plans.filter((plan) => {
+            const row = this.tokens.find((item) => item.id === plan.id);
+            return row && row.provider === 'facebook' && row.active === 1 && row.metadata_json === plan.oldMetadataJson;
+          }).length === requiredCount;
+        if (!eligible) {
+          results.push(changed(0));
+          continue;
+        }
+        for (const plan of plans) this.tokens.find((row) => row.id === plan.id).metadata_json = plan.nextMetadataJson;
+        results.push(changed(planCount));
+        continue;
+      }
+      if (sql.startsWith('UPDATE credential_tokens SET metadata_json = CASE')) {
+        const planCount = (sql.match(/WHEN \? THEN \?/g) || []).length;
+        const nextPairs = values.slice(0, planCount * 2);
+        const targetIds = values.slice(planCount * 2 + 1, planCount * 3 + 1);
+        const oldPairs = values.slice(planCount * 3 + 1, planCount * 5 + 1);
+        const requiredCount = values[planCount * 5 + 1];
+        const operationId = values[planCount * 5 + 2];
+        const requestHash = values[planCount * 5 + 3];
+        const operation = [...this.configOperations.values()].find((entry) => entry.id === operationId);
+        const plans = Array.from({ length: planCount }, (_, index) => ({
+          id: nextPairs[index * 2],
+          nextMetadataJson: nextPairs[index * 2 + 1],
+          oldMetadataJson: oldPairs[index * 2 + 1],
+        }));
+        const eligible = operation && operation.status === 'pending' && operation.request_hash === requestHash &&
+          targetIds.length === planCount && new Set(targetIds).size === planCount &&
+          plans.filter((plan) => {
+            const row = this.tokens.find((item) => item.id === plan.id);
+            return row && row.provider === 'facebook' && row.active === 1 && row.metadata_json === plan.oldMetadataJson;
+          }).length === requiredCount;
+        if (!eligible) {
+          results.push(changed(0));
+          continue;
+        }
+        for (const plan of plans) {
+          const row = this.tokens.find((item) => item.id === plan.id);
+          row.metadata_json = plan.nextMetadataJson;
+        }
+        results.push(changed(planCount));
+        continue;
+      }
+      if (sql.startsWith('UPDATE meta_ads_publish_config_operations SET status')) {
+        const [, operationId, ...pairsAndCount] = values;
+        const requiredCount = pairsAndCount.at(-1);
+        const pairs = pairsAndCount.slice(0, -1);
+        const operation = [...this.configOperations.values()].find((entry) => entry.id === operationId);
+        const applied = operation && operation.status === 'pending' &&
+          Array.from({ length: requiredCount }, (_, index) => {
+            const row = this.tokens.find((item) => item.id === pairs[index * 2]);
+            return row && row.metadata_json === pairs[index * 2 + 1];
+          }).every(Boolean);
+        if (applied) operation.status = 'applied';
+        results.push(changed(applied ? 1 : 0));
+        continue;
+      }
+      if (sql.startsWith("UPDATE meta_ads_publish_bootstrap_operations SET status = 'rolled_back'")) {
+        const [stateCiphertext, summaryJson, , operationId, operationKey, requestHash, expectedRevision, ...pairsAndCount] = values;
+        const requiredCount = pairsAndCount.at(-1);
+        const pairs = pairsAndCount.slice(0, -1);
+        const operation = this.bootstrapOperations.get(operationKey);
+        const restored = operation && operation.id === operationId && operation.request_hash === requestHash &&
+          operation.status === 'applied' && operation.resulting_tracking_binding_revision === expectedRevision &&
+          Array.from({ length: requiredCount }, (_, index) => {
+            const row = this.tokens.find((item) => item.id === pairs[index * 2]);
+            return row && row.metadata_json === pairs[index * 2 + 1];
+          }).every(Boolean);
+        if (restored) {
+          operation.status = 'rolled_back';
+          operation.state_ciphertext = stateCiphertext;
+          operation.summary_json = summaryJson;
+        }
+        results.push(changed(restored ? 1 : 0));
+        continue;
+      }
+      if (sql.includes('INSERT INTO credential_token_audit')) {
+        results.push(changed(1));
+        continue;
+      }
+      if (sql.includes('DELETE FROM meta_ads_publish_config_operations')) {
+        const [operationId] = values;
+        const entry = [...this.configOperations.entries()].find(([, value]) => value.id === operationId && value.status === 'pending');
+        if (entry) this.configOperations.delete(entry[0]);
+        results.push(changed(entry ? 1 : 0));
+        continue;
+      }
+      throw new Error(`Unexpected batch SQL: ${sql}`);
+    }
+    return results;
+  }
+}
+
+class BootstrapGraph {
+  constructor({
+    failTargetReadback = false,
+    failTargetTrackingRestore = false,
+    ambiguousCopyAdsetId = '',
+  } = {}) {
+    this.failTargetReadback = failTargetReadback;
+    this.failTargetTrackingRestore = failTargetTrackingRestore;
+    this.ambiguousCopyAdsetId = String(ambiguousCopyAdsetId || '');
+    this.onTargetAdsetPost = null;
+    this.onTargetAdsetRead = null;
+    this.calls = [];
+    this.nextFixture = 923456780;
+    this.targetPostCount = 0;
+    this.staleTargetReadServed = false;
+    this.adsets = new Map([
+      [SOURCE_ADSET_ID, websiteAdset({
+        pixel_id: '723456789', custom_event_type: 'SCHEDULE', offline_conversion_data_set_id: '823456789',
+      })],
+      [TARGET_ADSET_ID, websiteAdset({
+        pixel_id: '923456789', custom_conversion_id: '103456789', product_catalog_id: '113456789',
+      })],
+      [WHATSAPP_ADSET_ID, {
+        account_id: '123456789',
+        campaign: { id: '223456789', objective: 'OUTCOME_TRAFFIC' },
+        billing_event: 'IMPRESSIONS',
+        optimization_goal: 'LINK_CLICKS',
+        destination_type: 'WHATSAPP',
+        attribution_spec: [{ event_type: 'CLICK_THROUGH' }],
+        promoted_object: {},
+      }],
+    ]);
+    this.targetBefore = clone(this.adsets.get(TARGET_ADSET_ID));
+    this.ads = new Map([
+      ['723456780', ad('723456780', SOURCE_ADSET_ID, '823456780')],
+      ['723456792', {
+        ...ad('723456792', WHATSAPP_ADSET_ID, '823456792'),
+        creative: {
+          id: '823456792',
+          asset_feed_spec: {
+            link_urls: [{ website_url: 'https://api.whatsapp.com/send?phone=5551999999999' }],
+          },
+        },
+      }],
+    ]);
+    this.creatives = new Map();
+  }
+
+  async fetch(url, init = {}) {
+    const parsed = new URL(url);
+    const parts = parsed.pathname.split('/').filter(Boolean);
+    const id = parts[1];
+    const child = parts[2] || '';
+    const method = init.method || 'GET';
+    const body = init.body ? JSON.parse(init.body) : null;
+    this.calls.push({ id, child, method, body });
+
+    if (method === 'POST' && child === 'copies') {
+      const copied = this.copyFixture(body);
+      if (this.ambiguousCopyAdsetId && String(body?.adset_id) === this.ambiguousCopyAdsetId) {
+        throw new Error('simulated_copy_transport_interruption');
+      }
+      return copied;
+    }
+    if (method === 'POST' && this.adsets.has(id)) {
+      if (id === TARGET_ADSET_ID && this.failTargetTrackingRestore && this.targetPostCount > 0) {
+        return json({ error: { message: 'simulated_tracking_restore_failure', is_transient: true } }, 500);
+      }
+      this.adsets.get(id).promoted_object = clone(body.promoted_object);
+      if (id === TARGET_ADSET_ID) this.targetPostCount += 1;
+      if (id === TARGET_ADSET_ID && typeof this.onTargetAdsetPost === 'function') {
+        await this.onTargetAdsetPost({ graph: this, body: clone(body) });
+      }
+      return json({ success: true });
+    }
+    if (method === 'POST' && this.ads.has(id)) {
+      const current = this.ads.get(id);
+      current.status = body.status || current.status;
+      current.effective_status = body.status || current.effective_status;
+      return json({ success: true });
+    }
+    if (method !== 'GET') throw new Error(`Unexpected graph mutation ${method} ${parsed.pathname}`);
+
+    if (child === 'ads') {
+      return json({ data: [...this.ads.values()].filter((entry) => entry.adset_id === id).map(clone) });
+    }
+    if (this.adsets.has(id)) {
+      if (id === TARGET_ADSET_ID && typeof this.onTargetAdsetRead === 'function') {
+        await this.onTargetAdsetRead({ graph: this });
+      }
+      if (id === TARGET_ADSET_ID && this.failTargetReadback && this.targetPostCount > 0 && !this.staleTargetReadServed) {
+        this.staleTargetReadServed = true;
+        return json(this.targetBefore);
+      }
+      return json(this.adsets.get(id));
+    }
+    if (this.ads.has(id)) return json(this.ads.get(id));
+    if (this.creatives.has(id)) return json(this.creatives.get(id));
+    throw new Error(`Unexpected graph read ${parsed.pathname}`);
+  }
+
+  copyFixture(body) {
+    const adId = String(this.nextFixture++);
+    const creativeId = String(this.nextFixture++);
+    const creative = {
+      id: creativeId,
+      name: body.creative_parameters.name,
+      url_tags: body.creative_parameters.url_tags,
+    };
+    this.creatives.set(creativeId, creative);
+    this.ads.set(adId, {
+      id: adId,
+      adset_id: body.adset_id,
+      status: 'PAUSED',
+      effective_status: 'PAUSED',
+      creative: clone(creative),
+    });
+    return json({ copied_ad_id: adId });
+  }
+}
+
+function changed(count) {
+  return { meta: { changes: count } };
+}
+
+function tokenRow(id, unit, adsetId, rowNumber) {
+  return {
+    id,
+    provider: 'facebook',
+    unit,
+    external_account_id: '123456789',
+    token_type: 'long_lived_access_token',
+    token_ciphertext: `credential:${id}`,
+    expires_at: null,
+    active: 1,
+    updated_at: '2026-08-13T00:00:00.000Z',
+    metadata_json: JSON.stringify({
+      custody_owner: 'approved-private-manifest',
+      unrelated_metadata: { retain: true },
+      meta_ads_publish: legacyConfig(unit, adsetId, rowNumber),
+    }),
+  };
+}
+
+function legacyConfig(destinationGroup, adsetId, rowNumber) {
+  return {
+    row_number: rowNumber,
+    destination_group: destinationGroup,
+    api_version: 'v25.0',
+    account_id: '123456789',
+    campaign_id: '223456789',
+    adset_id: adsetId,
+    page_id: String(423456780 + rowNumber),
+    instagram_user_id: String(523456780 + rowNumber),
+    allowed_link_hosts: ['espacofacial.com'],
+    landing_pages_by_creative_group: {
+      DEFAULT: `https://espacofacial.com/agendamento?unit=${rowNumber}`,
+    },
+    legacy_marker: 'v18-source',
+  };
+}
+
+function websiteAdset(promotedObject) {
+  return {
+    account_id: '123456789',
+    campaign: { id: '223456789', objective: 'OUTCOME_SALES' },
+    billing_event: 'IMPRESSIONS',
+    optimization_goal: 'OFFSITE_CONVERSIONS',
+    destination_type: 'WEBSITE',
+    attribution_spec: [{ event_type: 'CLICK_THROUGH' }],
+    promoted_object: clone(promotedObject),
+  };
+}
+
+function ad(id, adsetId, creativeId) {
+  return {
+    id,
+    adset_id: adsetId,
+    status: 'ACTIVE',
+    effective_status: 'ACTIVE',
+    creative: { id: creativeId },
+  };
+}
+
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+async function legacyAuthorityRevision(env) {
+  const response = await handleMetaAdsPublishRequest({
+    request: new Request('https://token-vault.test/v1/meta-ads-publish/config'),
+    env,
+    requestId: 'bootstrap-authority-read',
+    pathname: '/v1/meta-ads-publish/config',
+    decryptToken: async () => { throw new Error('config read must not decrypt'); },
+    writeAudit: async () => {},
+  });
+  const body = await response.json();
+  assert.equal(response.status, 409);
+  assert.match(body.config_authority_revision, /^legacy:[a-f0-9]{64}$/);
+  return body.config_authority_revision;
+}
+
+function requestBody(expectedConfigAuthorityRevision, operationKey = 'bootstrap-test-happy-001') {
+  return {
+    operation_key: operationKey,
+    expected_config_authority_revision: expectedConfigAuthorityRevision,
+    entries: [
+      {
+        config_token_id: 'facebook_a_source',
+        destination_type: 'website',
+        source_config_token_id: 'facebook_a_source',
+        fixture_source_ad_id: '723456780',
+        url_tags: RAW_URL_TAGS,
+      },
+      {
+        config_token_id: 'facebook_b_target',
+        destination_type: 'website',
+        source_adset_id: SOURCE_ADSET_ID,
+        fixture_source_ad_id: '723456780',
+        url_tags: RAW_URL_TAGS,
+      },
+      {
+        config_token_id: 'facebook_c_whatsapp',
+        destination_type: 'whatsapp',
+      },
+    ],
+  };
+}
+
+function bootstrapRequest(body) {
+  return new Request('https://token-vault.test/v1/meta-ads-publish/config/bootstrap', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function bootstrapRollbackRequest(operationKey, expectedTrackingBindingRevision) {
+  return new Request('https://token-vault.test/v1/meta-ads-publish/config/bootstrap/rollback', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      operation_key: operationKey,
+      expected_tracking_binding_revision: expectedTrackingBindingRevision,
+    }),
+  });
+}
+
+function stagingExerciseRequest(operationKey) {
+  return new Request('https://token-vault.test/v1/meta-ads-publish/config/staging-exercise', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ operation_key: operationKey }),
+  });
+}
+
+function bootstrapContext({ db, graph, state }) {
+  const env = {
+    TOKEN_VAULT_DB: db,
+    META_GRAPH_FETCH: graph.fetch.bind(graph),
+    META_GRAPH_SLEEP: async () => {},
+    LANDING_PAGE_FETCH: async () => new Response('', { status: 200 }),
+  };
+  return {
+    env,
+    decryptToken: async (value) => state.get(value) || 'graph-access-token',
+    encryptToken: async (value) => {
+      const key = `cipher:${state.size + 1}`;
+      state.set(key, String(value));
+      return key;
+    },
+  };
+}
+
+async function applyHappyBootstrap({ db, graph, state, operationKey }) {
+  const { env, decryptToken, encryptToken } = bootstrapContext({ db, graph, state });
+  const expectedRevision = await legacyAuthorityRevision(env);
+  const body = requestBody(expectedRevision, operationKey);
+  const result = await bootstrapMetaAdsPublishConfig({
+    request: bootstrapRequest(body),
+    env,
+    requestId: `${operationKey}:apply`,
+    decryptToken,
+    encryptToken,
+    writeAudit: async () => {},
+  });
+  const payload = await result.json();
+  assert.equal(result.status, 201, JSON.stringify(payload));
+  return { env, decryptToken, encryptToken, body, payload };
+}
+
+async function recordBootstrapAdsetLockContention({ db, env, lockKey, phase, observations }) {
+  const lock = db.operationLocks.get(lockKey);
+  try {
+    await metaAdsPublishTest.acquireLocks(
+      env,
+      `competing-bootstrap-${phase}-${observations.length}`,
+      `competing-bootstrap-${phase}-${observations.length}`,
+      [lockKey],
+    );
+    observations.push({ phase, acquired: true, owner: lock?.operation_key || '', runId: lock?.run_id || '' });
+  } catch (error) {
+    observations.push({ phase, error: error.message, owner: lock?.operation_key || '', runId: lock?.run_id || '' });
+  }
+}
+
+test('multi-resource acquisition releases only locks obtained by the failed operation', async () => {
+  const db = new BootstrapDb();
+  const graph = new BootstrapGraph();
+  const state = new Map();
+  const { env } = bootstrapContext({ db, graph, state });
+  const expiresAt = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+  db.operationLocks.set('a', {
+    resource_key: 'a',
+    run_id: 'candidate',
+    operation_key: 'candidate-op',
+    expires_at: expiresAt,
+  });
+  db.operationLocks.set('z', {
+    resource_key: 'z',
+    run_id: 'incumbent',
+    operation_key: 'incumbent-op',
+    expires_at: expiresAt,
+  });
+
+  await assert.rejects(
+    () => metaAdsPublishTest.acquireLocks(env, 'candidate', 'candidate-op', ['a', 'b', 'z']),
+    { message: 'resource_locked:z' },
+  );
+
+  assert.equal(db.operationLocks.get('a')?.resource_key, 'a');
+  assert.equal(db.operationLocks.get('a')?.run_id, 'candidate');
+  assert.equal(db.operationLocks.get('a')?.operation_key, 'candidate-op');
+  assert.ok(Date.parse(db.operationLocks.get('a')?.expires_at) >= Date.parse(expiresAt));
+  assert.equal(db.operationLocks.has('b'), false);
+  assert.deepEqual(db.operationLocks.get('z'), {
+    resource_key: 'z',
+    run_id: 'incumbent',
+    operation_key: 'incumbent-op',
+    expires_at: expiresAt,
+  });
+});
+
+function assertBootstrapLockHeldThroughMutationReadback(observations, { lockKey, operationKey }) {
+  const mutationIndex = observations.findIndex((entry) => entry.phase === 'mutation');
+  const readbackIndex = observations.findIndex((entry, index) => index > mutationIndex && entry.phase === 'readback');
+  assert.ok(mutationIndex >= 0, 'expected a promoted_object mutation observation');
+  assert.ok(readbackIndex >= 0, 'expected a promoted_object readback after the mutation');
+  for (const observation of [observations[mutationIndex], observations[readbackIndex]]) {
+    assert.equal(observation.acquired, undefined);
+    assert.equal(observation.error, `resource_locked:${lockKey}`);
+    assert.equal(observation.runId, `bootstrap:${operationKey}`);
+    assert.equal(observation.owner, `bootstrap-mutation:${operationKey}`);
+  }
+}
+
+test('bootstrap moves legacy Website and Click-to-WhatsApp config to v20, preserving arbitrary raw URL tags', async () => {
+  const db = new BootstrapDb();
+  const graph = new BootstrapGraph();
+  const state = new Map();
+  const { env, decryptToken, encryptToken } = bootstrapContext({ db, graph, state });
+  const expectedRevision = await legacyAuthorityRevision(env);
+  const body = requestBody(expectedRevision);
+
+  const result = await bootstrapMetaAdsPublishConfig({
+    request: bootstrapRequest(body),
+    env,
+    requestId: 'bootstrap-happy',
+    decryptToken,
+    encryptToken,
+    writeAudit: async () => {},
+  });
+  const payload = await result.json();
+
+  assert.equal(result.status, 201, JSON.stringify(payload));
+  assert.equal(payload.ok, true);
+  assert.equal(payload.applied, true);
+  assert.equal(payload.website_fixture_count, 2);
+  assert.equal(payload.offline_dataset_count, 2);
+  assert.equal(payload.website_url_tags_verified, true);
+  assert.equal(payload.conversion_contract_verified, true);
+  assert.doesNotMatch(JSON.stringify(payload), /key1=value1|payload=abc|%2520/);
+
+  const fixtureCopies = graph.calls.filter((call) => call.method === 'POST' && call.child === 'copies');
+  assert.equal(fixtureCopies.length, 2);
+  for (const copy of fixtureCopies) {
+    assert.equal(copy.body.status_option, 'PAUSED');
+    assert.equal(copy.body.creative_parameters.url_tags, RAW_URL_TAGS);
+    assert.equal(copy.body.creative_parameters.url_tags.includes('%2520'), false);
+  }
+  assert.deepEqual(graph.adsets.get(TARGET_ADSET_ID).promoted_object, {
+    product_catalog_id: '113456789',
+    pixel_id: '723456789',
+    custom_event_type: 'SCHEDULE',
+    offline_conversion_data_set_id: '823456789',
+  });
+
+  const sourceConfig = JSON.parse(db.tokens[0].metadata_json).meta_ads_publish;
+  const targetConfig = JSON.parse(db.tokens[1].metadata_json).meta_ads_publish;
+  const whatsappConfig = JSON.parse(db.tokens[2].metadata_json).meta_ads_publish;
+  assert.equal(sourceConfig.destination_type, 'website');
+  assert.equal(targetConfig.tracking_contract.url_tags, RAW_URL_TAGS);
+  assert.equal(targetConfig.tracking_contract.url_tags.includes('%2520'), false);
+  assert.equal(targetConfig.tracking_profiles[targetConfig.tracking_contract.profile_ref].offline_event_dataset_requirement, 'required');
+  assert.equal(whatsappConfig.destination_type, 'whatsapp');
+  assert.equal(whatsappConfig.whatsapp_destination_url, 'https://api.whatsapp.com/send?phone=5551999999999');
+  assert.equal(Object.hasOwn(whatsappConfig, 'tracking_contract'), false);
+  assert.equal(JSON.parse(db.tokens[1].metadata_json).unrelated_metadata.retain, true);
+
+  const operation = db.bootstrapOperations.get(body.operation_key);
+  assert.equal(operation.status, 'applied');
+  assert.doesNotMatch(operation.summary_json, /key1=value1|723456789|823456789/);
+  assert.doesNotMatch(operation.state_ciphertext, /key1=value1|723456789|823456789/);
+
+  const replay = await bootstrapMetaAdsPublishConfig({
+    request: bootstrapRequest(body),
+    env,
+    requestId: 'bootstrap-happy-replay',
+    decryptToken,
+    encryptToken,
+    writeAudit: async () => {},
+  });
+  const replayPayload = await replay.json();
+  assert.equal(replay.status, 200);
+  assert.equal(replayPayload.replayed, true);
+  assert.equal(graph.calls.filter((call) => call.method === 'POST' && call.child === 'copies').length, 2);
+});
+
+test('bootstrap holds the shared ad-set contract lock through promoted_object mutation and Graph readback', async () => {
+  const db = new BootstrapDb();
+  const graph = new BootstrapGraph();
+  const state = new Map();
+  const { env, decryptToken, encryptToken } = bootstrapContext({ db, graph, state });
+  const operationKey = 'bootstrap-test-shared-adset-lock-001';
+  const expectedRevision = await legacyAuthorityRevision(env);
+  const lockKey = `adset-contract:123456789:${TARGET_ADSET_ID}`;
+  const observations = [];
+  let targetMutationSeen = false;
+  graph.onTargetAdsetPost = async () => {
+    targetMutationSeen = true;
+    await recordBootstrapAdsetLockContention({ db, env, lockKey, phase: 'mutation', observations });
+  };
+  graph.onTargetAdsetRead = async () => {
+    if (targetMutationSeen) {
+      await recordBootstrapAdsetLockContention({ db, env, lockKey, phase: 'readback', observations });
+    }
+  };
+
+  const result = await bootstrapMetaAdsPublishConfig({
+    request: bootstrapRequest(requestBody(expectedRevision, operationKey)),
+    env,
+    requestId: 'bootstrap-shared-adset-lock',
+    decryptToken,
+    encryptToken,
+    writeAudit: async () => {},
+  });
+  const payload = await result.json();
+
+  assert.equal(result.status, 201, JSON.stringify(payload));
+  assertBootstrapLockHeldThroughMutationReadback(observations, { lockKey, operationKey });
+  assert.equal(db.operationLocks.size, 0);
+});
+
+test('bootstrap compensates the exact promoted_object when Graph POST succeeds but its readback is stale', async () => {
+  const db = new BootstrapDb();
+  const graph = new BootstrapGraph({ failTargetReadback: true });
+  const state = new Map();
+  const { env, decryptToken, encryptToken } = bootstrapContext({ db, graph, state });
+  const expectedRevision = await legacyAuthorityRevision(env);
+  const body = requestBody(expectedRevision, 'bootstrap-test-rollback-001');
+  const targetBefore = clone(graph.targetBefore.promoted_object);
+
+  const result = await bootstrapMetaAdsPublishConfig({
+    request: bootstrapRequest(body),
+    env,
+    requestId: 'bootstrap-rollback',
+    decryptToken,
+    encryptToken,
+    writeAudit: async () => {},
+  });
+  const payload = await result.json();
+
+  assert.equal(result.status, 400);
+  assert.equal(payload.ok, false);
+  assert.equal(payload.error, 'meta_ads_publish_bootstrap_tracking_readback_mismatch');
+  const targetPosts = graph.calls.filter((call) => call.id === TARGET_ADSET_ID && call.method === 'POST');
+  assert.equal(targetPosts.length, 2);
+  assert.equal(targetPosts[0].body.promoted_object.pixel_id, '723456789');
+  assert.deepEqual(targetPosts[1].body.promoted_object, {
+    product_catalog_id: '113456789',
+    ...targetBefore,
+  });
+  assert.deepEqual(graph.adsets.get(TARGET_ADSET_ID).promoted_object, targetBefore);
+  assert.equal(db.bootstrapOperations.get(body.operation_key).status, 'rolled_back');
+});
+
+test('external bootstrap rollback restores its encrypted legacy metadata, owned fixtures, and tracking only while the exact v20 authority remains current', async () => {
+  const db = new BootstrapDb();
+  const graph = new BootstrapGraph();
+  const state = new Map();
+  const legacyByToken = new Map(db.tokens.map((row) => [
+    row.id,
+    clone(JSON.parse(row.metadata_json).meta_ads_publish || {}),
+  ]));
+  const unrelatedBefore = db.tokens.find((row) => row.id === 'facebook_unrelated').metadata_json;
+  const targetBefore = clone(graph.targetBefore.promoted_object);
+  const applied = await applyHappyBootstrap({
+    db,
+    graph,
+    state,
+    operationKey: 'bootstrap-test-external-rollback-001',
+  });
+  const ownedFixtureIds = [...graph.ads.keys()].filter((id) => !['723456780', '723456792'].includes(id));
+  assert.equal(ownedFixtureIds.length, 2);
+
+  const laterMetadata = JSON.parse(db.tokens.find((row) => row.id === 'facebook_b_target').metadata_json);
+  laterMetadata.unrelated_metadata.operator_note = 'preserve-later-non-meta-change';
+  db.tokens.find((row) => row.id === 'facebook_b_target').metadata_json = JSON.stringify(laterMetadata);
+
+  const rolledBack = await rollbackBootstrapMetaAdsPublishConfig({
+    request: bootstrapRollbackRequest(applied.body.operation_key, applied.payload.tracking_binding_revision),
+    env: applied.env,
+    requestId: 'bootstrap-external-rollback',
+    decryptToken: applied.decryptToken,
+    encryptToken: applied.encryptToken,
+    writeAudit: async () => {},
+  });
+  const rollbackPayload = await rolledBack.json();
+  assert.equal(rolledBack.status, 200, JSON.stringify(rollbackPayload));
+  assert.equal(rollbackPayload.ok, true);
+  assert.equal(rollbackPayload.rolled_back, true);
+  assert.equal(rollbackPayload.replayed, false);
+  assert.match(rollbackPayload.config_authority_revision, /^legacy:[a-f0-9]{64}$/);
+
+  for (const tokenId of ['facebook_a_source', 'facebook_b_target', 'facebook_c_whatsapp']) {
+    const row = db.tokens.find((entry) => entry.id === tokenId);
+    assert.deepEqual(JSON.parse(row.metadata_json).meta_ads_publish, legacyByToken.get(tokenId));
+  }
+  assert.equal(
+    JSON.parse(db.tokens.find((row) => row.id === 'facebook_b_target').metadata_json).unrelated_metadata.operator_note,
+    'preserve-later-non-meta-change',
+  );
+  assert.equal(db.tokens.find((row) => row.id === 'facebook_unrelated').metadata_json, unrelatedBefore);
+  assert.deepEqual(graph.adsets.get(TARGET_ADSET_ID).promoted_object, targetBefore);
+  for (const fixtureId of ownedFixtureIds) assert.equal(graph.ads.get(fixtureId).status, 'ARCHIVED');
+  assert.equal(graph.ads.get('723456780').status, 'ACTIVE');
+  assert.equal(graph.ads.get('723456792').status, 'ACTIVE');
+  assert.equal(db.bootstrapOperations.get(applied.body.operation_key).status, 'rolled_back');
+
+  const replay = await rollbackBootstrapMetaAdsPublishConfig({
+    request: bootstrapRollbackRequest(applied.body.operation_key, applied.payload.tracking_binding_revision),
+    env: applied.env,
+    requestId: 'bootstrap-external-rollback-replay',
+    decryptToken: applied.decryptToken,
+    encryptToken: applied.encryptToken,
+    writeAudit: async () => {},
+  });
+  const replayPayload = await replay.json();
+  assert.equal(replay.status, 200);
+  assert.equal(replayPayload.replayed, true);
+});
+
+test('external bootstrap rollback holds the shared ad-set contract lock through promoted_object restoration and Graph readback', async () => {
+  const db = new BootstrapDb();
+  const graph = new BootstrapGraph();
+  const state = new Map();
+  const operationKey = 'bootstrap-test-external-shared-adset-lock-001';
+  const applied = await applyHappyBootstrap({ db, graph, state, operationKey });
+  const lockKey = `adset-contract:123456789:${TARGET_ADSET_ID}`;
+  const observations = [];
+  let targetMutationSeen = false;
+  graph.onTargetAdsetPost = async () => {
+    targetMutationSeen = true;
+    await recordBootstrapAdsetLockContention({ db, env: applied.env, lockKey, phase: 'mutation', observations });
+  };
+  graph.onTargetAdsetRead = async () => {
+    if (targetMutationSeen) {
+      await recordBootstrapAdsetLockContention({ db, env: applied.env, lockKey, phase: 'readback', observations });
+    }
+  };
+
+  const result = await rollbackBootstrapMetaAdsPublishConfig({
+    request: bootstrapRollbackRequest(operationKey, applied.payload.tracking_binding_revision),
+    env: applied.env,
+    requestId: 'bootstrap-external-shared-adset-lock',
+    decryptToken: applied.decryptToken,
+    encryptToken: applied.encryptToken,
+    writeAudit: async () => {},
+  });
+  const payload = await result.json();
+
+  assert.equal(result.status, 200, JSON.stringify(payload));
+  assertBootstrapLockHeldThroughMutationReadback(observations, { lockKey, operationKey });
+  assert.equal(db.operationLocks.size, 0);
+});
+
+test('external bootstrap rollback rejects a later v20 metadata change before touching Graph state', async () => {
+  const db = new BootstrapDb();
+  const graph = new BootstrapGraph();
+  const state = new Map();
+  const applied = await applyHappyBootstrap({
+    db,
+    graph,
+    state,
+    operationKey: 'bootstrap-test-stale-rollback-001',
+  });
+  const targetMetadata = JSON.parse(db.tokens.find((row) => row.id === 'facebook_b_target').metadata_json);
+  targetMetadata.meta_ads_publish.destination_group = 'Changed after bootstrap';
+  db.tokens.find((row) => row.id === 'facebook_b_target').metadata_json = JSON.stringify(targetMetadata);
+  const callsBeforeRollback = graph.calls.length;
+
+  const rollback = await rollbackBootstrapMetaAdsPublishConfig({
+    request: bootstrapRollbackRequest(applied.body.operation_key, applied.payload.tracking_binding_revision),
+    env: applied.env,
+    requestId: 'bootstrap-stale-rollback',
+    decryptToken: applied.decryptToken,
+    encryptToken: applied.encryptToken,
+    writeAudit: async () => {},
+  });
+  const payload = await rollback.json();
+  assert.equal(rollback.status, 409);
+  assert.equal(payload.error, 'meta_ads_publish_bootstrap_operation_state_stale');
+  assert.equal(graph.calls.length, callsBeforeRollback);
+  assert.equal(db.bootstrapOperations.get(applied.body.operation_key).status, 'applied');
+  assert.equal(
+    JSON.parse(db.tokens.find((row) => row.id === 'facebook_b_target').metadata_json).meta_ads_publish.destination_group,
+    'Changed after bootstrap',
+  );
+});
+
+test('staging exercise reconciles and restores the marked Website fixture while the operational bearer is denied', async () => {
+  const db = new BootstrapDb();
+  const graph = new BootstrapGraph();
+  const state = new Map();
+  const applied = await applyHappyBootstrap({
+    db,
+    graph,
+    state,
+    operationKey: 'bootstrap-test-staging-fixture-001',
+  });
+  const targetRow = db.tokens.find((row) => row.id === 'facebook_b_target');
+  const targetMetadata = JSON.parse(targetRow.metadata_json);
+  const profileRef = targetMetadata.meta_ads_publish.tracking_contract.profile_ref;
+  targetMetadata.meta_ads_publish.tracking_profiles[profileRef].staging_synthetic_fixture = true;
+  targetRow.metadata_json = JSON.stringify(targetMetadata);
+  const targetBefore = clone(graph.targetBefore.promoted_object);
+  graph.adsets.get(TARGET_ADSET_ID).promoted_object = clone(targetBefore);
+  applied.env.ENVIRONMENT = 'staging';
+
+  const exercised = await exerciseStagingMetaAdsTrackingFixture({
+    request: stagingExerciseRequest('staging-tracking-fixture:exercise-001'),
+    env: applied.env,
+    requestId: 'staging-exercise',
+    decryptToken: applied.decryptToken,
+    encryptToken: applied.encryptToken,
+    writeAudit: async () => {},
+  });
+  const payload = await exercised.json();
+  assert.equal(exercised.status, 200, JSON.stringify(payload));
+  assert.equal(payload.ok, true);
+  assert.deepEqual(payload.exercise, {
+    status: 'reconciled_and_rolled_back',
+    reconciliation: 'reconciled',
+    rollback: 'restored',
+    fixture_count: 1,
+  });
+  assert.deepEqual(graph.adsets.get(TARGET_ADSET_ID).promoted_object, targetBefore);
+  assert.equal([...db.snapshotsById.values()].length, 1);
+  assert.equal([...db.snapshotsById.values()][0].status, 'restored');
+  assert.equal([...db.runsById.values()][0].status, 'completed');
+  assert.equal(db.operationLocks.size, 0);
+
+  const denied = await handleRequest(new Request(
+    'https://token-vault.test/internal/token-vault/v1/meta-ads-publish/config/staging-exercise',
+    {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer operational-test-token',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ operation_key: 'staging-tracking-fixture:deny-0001' }),
+    },
+  ), {
+    REQUIRE_AUTH: 'true',
+    TOKEN_VAULT_API_TOKEN: 'admin-test-token',
+    TOKEN_VAULT_N8N_API_TOKEN: 'operational-test-token',
+  });
+  const deniedPayload = await denied.json();
+  assert.equal(denied.status, 403);
+  assert.equal(deniedPayload.error, 'meta_ads_config_credential_required');
+});
+
+test('staging bootstrap uses a direct source ad set, proves the fixture exercise, and rejects that marker in production', async () => {
+  const db = new BootstrapDb();
+  const graph = new BootstrapGraph();
+  const state = new Map();
+  const { env, decryptToken, encryptToken } = bootstrapContext({ db, graph, state });
+  env.ENVIRONMENT = 'staging';
+  const expectedRevision = await legacyAuthorityRevision(env);
+  const body = requestBody(expectedRevision, 'bootstrap-test-staging-direct-source-001');
+  const targetEntry = body.entries.find((entry) => entry.config_token_id === 'facebook_b_target');
+  targetEntry.staging_synthetic_fixture = true;
+  const targetBefore = clone(graph.targetBefore.promoted_object);
+
+  const bootstrap = await bootstrapMetaAdsPublishConfig({
+    request: bootstrapRequest(body),
+    env,
+    requestId: 'bootstrap-staging-direct-source',
+    decryptToken,
+    encryptToken,
+    writeAudit: async () => {},
+  });
+  const bootstrapPayload = await bootstrap.json();
+  assert.equal(bootstrap.status, 201, JSON.stringify(bootstrapPayload));
+
+  const targetConfig = JSON.parse(db.tokens.find((row) => row.id === 'facebook_b_target').metadata_json).meta_ads_publish;
+  const profileRef = targetConfig.tracking_contract.profile_ref;
+  assert.equal(targetConfig.tracking_profiles[profileRef].source_adset_id, SOURCE_ADSET_ID);
+  assert.equal(targetConfig.tracking_profiles[profileRef].staging_synthetic_fixture, true);
+  assert.equal(targetConfig.tracking_contract.url_tags, RAW_URL_TAGS);
+  assert.deepEqual(graph.adsets.get(TARGET_ADSET_ID).promoted_object, targetBefore);
+
+  const exercise = await exerciseStagingMetaAdsTrackingFixture({
+    request: stagingExerciseRequest('staging-tracking-fixture:direct-source-001'),
+    env,
+    requestId: 'staging-direct-source-exercise',
+    decryptToken,
+    encryptToken,
+    writeAudit: async () => {},
+  });
+  const exercisePayload = await exercise.json();
+  assert.equal(exercise.status, 200, JSON.stringify(exercisePayload));
+  assert.equal(exercisePayload.exercise.rollback, 'restored');
+  assert.deepEqual(graph.adsets.get(TARGET_ADSET_ID).promoted_object, targetBefore);
+
+  const productionDb = new BootstrapDb();
+  const productionGraph = new BootstrapGraph();
+  const productionState = new Map();
+  const production = bootstrapContext({ db: productionDb, graph: productionGraph, state: productionState });
+  production.env.ENVIRONMENT = 'production';
+  const productionExpectedRevision = await legacyAuthorityRevision(production.env);
+  const productionBody = requestBody(productionExpectedRevision, 'bootstrap-test-production-marker-001');
+  productionBody.entries.find((entry) => entry.config_token_id === 'facebook_b_target').staging_synthetic_fixture = true;
+
+  const rejected = await bootstrapMetaAdsPublishConfig({
+    request: bootstrapRequest(productionBody),
+    env: production.env,
+    requestId: 'bootstrap-production-marker',
+    decryptToken: production.decryptToken,
+    encryptToken: production.encryptToken,
+    writeAudit: async () => {},
+  });
+  const rejectedPayload = await rejected.json();
+  assert.equal(rejected.status, 409);
+  assert.equal(rejectedPayload.error, 'meta_ads_publish_bootstrap_staging_fixture_forbidden');
+  assert.equal(productionDb.bootstrapOperations.size, 0);
+  assert.equal(productionGraph.calls.filter((call) => call.method === 'POST' && call.child === 'copies').length, 0);
+});
+
+test('external rollback fails closed when tracking restoration is unconfirmed, retaining v20 and the affected paused fixture', async () => {
+  const db = new BootstrapDb();
+  const graph = new BootstrapGraph();
+  const state = new Map();
+  const applied = await applyHappyBootstrap({
+    db,
+    graph,
+    state,
+    operationKey: 'bootstrap-test-external-rollback-restore-failure-001',
+  });
+  const targetRow = db.tokens.find((row) => row.id === 'facebook_b_target');
+  const v20TargetConfig = clone(JSON.parse(targetRow.metadata_json).meta_ads_publish);
+  const bootstrapState = JSON.parse(state.get(db.bootstrapOperations.get(applied.body.operation_key).state_ciphertext));
+  const targetFixtureId = bootstrapState.items.find((item) => item.config_token_id === 'facebook_b_target').fixture.ad_id;
+  graph.failTargetTrackingRestore = true;
+
+  const rollback = await rollbackBootstrapMetaAdsPublishConfig({
+    request: bootstrapRollbackRequest(applied.body.operation_key, applied.payload.tracking_binding_revision),
+    env: applied.env,
+    requestId: 'bootstrap-external-rollback-restore-failure',
+    decryptToken: applied.decryptToken,
+    encryptToken: applied.encryptToken,
+    writeAudit: async () => {},
+  });
+  const payload = await rollback.json();
+  assert.equal(rollback.status, 409);
+  assert.equal(payload.error, 'meta_ads_publish_bootstrap_reconciliation_required');
+  assert.equal(db.bootstrapOperations.get(applied.body.operation_key).status, 'reconciliation_required');
+  assert.deepEqual(JSON.parse(targetRow.metadata_json).meta_ads_publish, v20TargetConfig);
+  assert.equal(graph.ads.get(targetFixtureId).status, 'PAUSED');
+
+  const replay = await rollbackBootstrapMetaAdsPublishConfig({
+    request: bootstrapRollbackRequest(applied.body.operation_key, applied.payload.tracking_binding_revision),
+    env: applied.env,
+    requestId: 'bootstrap-external-rollback-restore-failure-replay',
+    decryptToken: applied.decryptToken,
+    encryptToken: applied.encryptToken,
+    writeAudit: async () => {},
+  });
+  const replayPayload = await replay.json();
+  assert.equal(replay.status, 409);
+  assert.equal(replayPayload.error, 'meta_ads_publish_bootstrap_reconciliation_required');
+  assert.equal(db.bootstrapOperations.get(applied.body.operation_key).status, 'reconciliation_required');
+  assert.equal(graph.ads.get(targetFixtureId).status, 'PAUSED');
+});
+
+test('an ambiguous copy after its durable pre-intent never rolls back cleanly or issues a retry copy', async () => {
+  const db = new BootstrapDb();
+  const graph = new BootstrapGraph({ ambiguousCopyAdsetId: TARGET_ADSET_ID });
+  const state = new Map();
+  const { env, decryptToken, encryptToken } = bootstrapContext({ db, graph, state });
+  const expectedRevision = await legacyAuthorityRevision(env);
+  const body = requestBody(expectedRevision, 'bootstrap-test-ambiguous-copy-preintent-001');
+
+  const interrupted = await bootstrapMetaAdsPublishConfig({
+    request: bootstrapRequest(body),
+    env,
+    requestId: 'bootstrap-ambiguous-copy-preintent',
+    decryptToken,
+    encryptToken,
+    writeAudit: async () => {},
+  });
+  const payload = await interrupted.json();
+  assert.equal(interrupted.status, 409);
+  assert.equal(payload.error, 'meta_ads_publish_bootstrap_reconciliation_required');
+  const operation = db.bootstrapOperations.get(body.operation_key);
+  assert.equal(operation.status, 'reconciliation_required');
+  const persisted = JSON.parse(state.get(operation.state_ciphertext));
+  const targetItem = persisted.items.find((item) => item.config_token_id === 'facebook_b_target');
+  assert.equal(targetItem.fixture.copy_pending, true);
+  assert.equal(targetItem.fixture.copy_ambiguous, true);
+  const targetCopies = () => graph.calls.filter((call) => (
+    call.method === 'POST' && call.child === 'copies' && call.body.adset_id === TARGET_ADSET_ID
+  ));
+  assert.equal(targetCopies().length, 1);
+  const unownedAmbiguousFixture = [...graph.ads.values()].find((entry) => entry.adset_id === TARGET_ADSET_ID);
+  assert.equal(unownedAmbiguousFixture.status, 'PAUSED');
+
+  const retry = await bootstrapMetaAdsPublishConfig({
+    request: bootstrapRequest(body),
+    env,
+    requestId: 'bootstrap-ambiguous-copy-preintent-retry',
+    decryptToken,
+    encryptToken,
+    writeAudit: async () => {},
+  });
+  const retryPayload = await retry.json();
+  assert.equal(retry.status, 409);
+  assert.equal(retryPayload.error, 'meta_ads_publish_bootstrap_reconciliation_required');
+  assert.equal(db.bootstrapOperations.get(body.operation_key).status, 'reconciliation_required');
+  assert.equal(targetCopies().length, 1);
+});
+
+test('a resumed owned fixture whose tags drifted is never replaced by a second copy', async () => {
+  const db = new BootstrapDb();
+  const graph = new BootstrapGraph();
+  const state = new Map();
+  const applied = await applyHappyBootstrap({
+    db,
+    graph,
+    state,
+    operationKey: 'bootstrap-test-owned-fixture-tag-drift-001',
+  });
+  const restored = await rollbackBootstrapMetaAdsPublishConfig({
+    request: bootstrapRollbackRequest(applied.body.operation_key, applied.payload.tracking_binding_revision),
+    env: applied.env,
+    requestId: 'bootstrap-owned-fixture-tag-drift-restore-legacy',
+    decryptToken: applied.decryptToken,
+    encryptToken: applied.encryptToken,
+    writeAudit: async () => {},
+  });
+  assert.equal(restored.status, 200);
+
+  const operation = db.bootstrapOperations.get(applied.body.operation_key);
+  const persisted = JSON.parse(state.get(operation.state_ciphertext));
+  persisted.config_input = null;
+  persisted.config_applied = false;
+  persisted.config_rolled_back = false;
+  const sourceItem = persisted.items.find((item) => item.config_token_id === 'facebook_a_source');
+  const targetItem = persisted.items.find((item) => item.config_token_id === 'facebook_b_target');
+  for (const item of [sourceItem, targetItem]) {
+    const fixture = graph.ads.get(item.fixture.ad_id);
+    fixture.status = 'PAUSED';
+    fixture.effective_status = 'PAUSED';
+  }
+  graph.ads.get(targetItem.fixture.ad_id).creative.url_tags = 'key1=externally-mutated';
+  graph.creatives.get(targetItem.fixture.creative_id).url_tags = 'key1=externally-mutated';
+  state.set(operation.state_ciphertext, JSON.stringify(persisted));
+  operation.status = 'pending';
+  operation.resulting_tracking_binding_revision = '';
+  const targetCopyCount = () => graph.calls.filter((call) => (
+    call.method === 'POST' && call.child === 'copies' && call.body.adset_id === TARGET_ADSET_ID
+  )).length;
+  const copiesBeforeResume = targetCopyCount();
+
+  const resumed = await bootstrapMetaAdsPublishConfig({
+    request: bootstrapRequest(applied.body),
+    env: applied.env,
+    requestId: 'bootstrap-owned-fixture-tag-drift-resume',
+    decryptToken: applied.decryptToken,
+    encryptToken: applied.encryptToken,
+    writeAudit: async () => {},
+  });
+  const resumedPayload = await resumed.json();
+  assert.equal(resumed.status, 409);
+  assert.equal(resumedPayload.error, 'meta_ads_publish_bootstrap_reconciliation_required');
+  assert.equal(db.bootstrapOperations.get(applied.body.operation_key).status, 'reconciliation_required');
+  assert.equal(targetCopyCount(), copiesBeforeResume);
+
+  const retry = await bootstrapMetaAdsPublishConfig({
+    request: bootstrapRequest(applied.body),
+    env: applied.env,
+    requestId: 'bootstrap-owned-fixture-tag-drift-retry',
+    decryptToken: applied.decryptToken,
+    encryptToken: applied.encryptToken,
+    writeAudit: async () => {},
+  });
+  assert.equal(retry.status, 409);
+  assert.equal(targetCopyCount(), copiesBeforeResume);
+});
+
+test('the staging exercise holds the ad-set lock through both reconciliation and rollback', async () => {
+  const db = new BootstrapDb();
+  const graph = new BootstrapGraph();
+  const state = new Map();
+  const applied = await applyHappyBootstrap({
+    db,
+    graph,
+    state,
+    operationKey: 'bootstrap-test-staging-lock-continuity-001',
+  });
+  const targetRow = db.tokens.find((row) => row.id === 'facebook_b_target');
+  const targetMetadata = JSON.parse(targetRow.metadata_json);
+  const profileRef = targetMetadata.meta_ads_publish.tracking_contract.profile_ref;
+  targetMetadata.meta_ads_publish.tracking_profiles[profileRef].staging_synthetic_fixture = true;
+  targetRow.metadata_json = JSON.stringify(targetMetadata);
+  graph.adsets.get(TARGET_ADSET_ID).promoted_object = clone(graph.targetBefore.promoted_object);
+  applied.env.ENVIRONMENT = 'staging';
+  const lockKey = `adset-contract:123456789:${TARGET_ADSET_ID}`;
+  const contentions = [];
+  graph.onTargetAdsetPost = async () => {
+    const lock = db.operationLocks.get(lockKey);
+    try {
+      await metaAdsPublishTest.acquireLocks(
+        applied.env,
+        'competing-staging-run',
+        'competing-staging-operation',
+        [lockKey],
+      );
+      contentions.push({ acquired: true, owner: lock?.operation_key || '' });
+    } catch (error) {
+      contentions.push({ error: error.message, owner: lock?.operation_key || '' });
+    }
+  };
+
+  const exercised = await exerciseStagingMetaAdsTrackingFixture({
+    request: stagingExerciseRequest('staging-tracking-fixture:lock-continuity-001'),
+    env: applied.env,
+    requestId: 'staging-lock-continuity',
+    decryptToken: applied.decryptToken,
+    encryptToken: applied.encryptToken,
+    writeAudit: async () => {},
+  });
+  const payload = await exercised.json();
+  assert.equal(exercised.status, 200, JSON.stringify(payload));
+  assert.equal(contentions.length, 2);
+  for (const contention of contentions) {
+    assert.equal(contention.acquired, undefined);
+    assert.equal(contention.error, `resource_locked:${lockKey}`);
+    assert.equal(contention.owner, 'staging-tracking-fixture:lock-continuity-001:transaction');
+  }
+  assert.equal(db.operationLocks.size, 0);
+});

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -75,8 +75,16 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
   ]);
 
   const catalog = JSON.parse(read("platform/deploy/operational-units.json"));
-  assert.ok(catalog.units.some((unit) => unit.id === "token-vault"));
+  const tokenVaultUnit = catalog.units.find((unit) => unit.id === "token-vault");
+  assert.ok(tokenVaultUnit);
   assert.ok(!catalog.nonPublishingSurfaces.some((entry) => entry.id === "token-vault"));
+  assert.ok(tokenVaultUnit.resources.includes("Governed Meta Ads tracking bootstrap, rollback journal and paused creative fixture"));
+  assert.ok(tokenVaultUnit.secrets.includes("TOKEN_VAULT_META_ADS_CONFIG_TOKEN"));
+  assert.ok(tokenVaultUnit.secrets.includes("TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST"));
+  assert.ok(!tokenVaultUnit.secrets.includes("TOKEN_VAULT_BACKUP_PASSPHRASE"));
+  assert.equal(tokenVaultUnit.promotion.trackingFixture, "synthetic authorized ad-set profile required before staging");
+  assert.equal(tokenVaultUnit.promotion.trackingBootstrap, "legacy authority only; restricted config bearer plus private entries manifest");
+  assert.equal(tokenVaultUnit.promotion.d1Recovery, "Time Travel bookmark; manual restore only under release:token-vault");
 
   const workflow = read(".github/workflows/deploy-token-vault.yml");
   for (const marker of [
@@ -85,19 +93,36 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
     "confirm_staging_tracking_fixture",
     "ENABLE_TOKEN_VAULT_DEPLOY_STAGING",
     "ENABLE_TOKEN_VAULT_PRODUCTION_DEPLOY",
-    "TOKEN_VAULT_N8N_API_TOKEN",
-    "Capture encrypted Token Vault D1 checkpoint before migrations",
+    "TOKEN_VAULT_META_ADS_CONFIG_TOKEN",
+    "TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST",
+    "Capture Token Vault D1 Time Travel recovery bookmark before migrations",
+    "d1 time-travel info",
+    "d1 time-travel restore",
+    "manual_restore_under_release_lease",
     "Apply additive Token Vault migrations atomically",
     "versions upload",
+    "--secrets-file",
+    "--strict",
     "versions deploy",
     "promotion-evidence-token-vault",
+    "/v1/meta-ads-publish/config/bootstrap/rollback",
   ]) assert.match(workflow, new RegExp(marker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   assert.match(workflow, /uses: \.\/\.github\/actions\/global-coordination-acquire/);
   assert.match(workflow, /uses: \.\/\.github\/actions\/global-coordination-check/);
   assert.match(workflow, /uses: \.\/\.github\/actions\/global-coordination-release/);
   assert.doesNotMatch(workflow, /\bsecret\s+put\b/);
   assert.doesNotMatch(workflow, /secrets:\s*inherit/);
-  assert.ok(workflow.indexOf("Capture encrypted Token Vault D1 checkpoint before migrations") < workflow.indexOf("Apply additive Token Vault migrations atomically"));
+  assert.doesNotMatch(workflow, /TOKEN_VAULT_BACKUP_PASSPHRASE/);
+  for (const legacySecret of [
+    "TOKEN_VAULT_API_TOKEN",
+    "TOKEN_VAULT_N8N_API_TOKEN",
+    "TOKEN_VAULT_ENCRYPTION_KEY",
+  ]) {
+    assert.doesNotMatch(workflow, new RegExp(`secrets\\.${legacySecret}`));
+  }
+  assert.match(workflow, /versions upload[\s\S]*?--keep-vars[\s\S]*?--strict[\s\S]*?--secrets-file/);
+  assert.match(workflow, /legacy alpha backend; Time Travel recovery is unavailable and the release is ineligible/);
+  assert.ok(workflow.indexOf("Capture Token Vault D1 Time Travel recovery bookmark before migrations") < workflow.indexOf("Apply additive Token Vault migrations atomically"));
   assert.ok(workflow.indexOf("Check Token Vault release lease before version upload") < workflow.indexOf("Upload immutable Token Vault version"));
   const release = jobBlock(workflow, "release");
   const orbContract = jobBlock(workflow, "orb_contract");
@@ -105,7 +130,30 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
   assert.match(release, /Cross-SHA Token Vault rollback is fail-closed/);
   assert.match(release, /Export immutable Worker and incumbent identities for the activation gate/);
   assert.match(release, /Activate only the selected Token Vault version in staging[\s\S]*?if: inputs\.target == 'staging'/);
+  assert.doesNotMatch(release, /for name [^\n]*TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST/);
+  assert.match(release, /Object\.keys\(manifest\)\.length !== 1/);
+  assert.match(release, /TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST is required only when legacy bootstrap is detected/);
+  assert.match(release, /expected_config_authority_revision: expectedRevision/);
+  assert.match(release, /entries: manifest\.entries/);
+  assert.match(release, /bootstrap_operation_key="meta-ads-bootstrap:\$\{RELEASE_SHA:0:12\}:\$\{GITHUB_RUN_ID\}:\$\{GITHUB_RUN_ATTEMPT\}"/);
+  assert.match(release, /did_bootstrap=true/);
+  assert.match(release, /bootstrap_operation_key=\$bootstrap_recorded_operation_key/);
+  assert.match(release, /bootstrap_revision=\$bootstrap_revision/);
+  assert.match(release, /mode === 'tracking_ready'/);
+  assert.match(release, /mode === 'legacy_bootstrap'/);
+  assert.match(release, /\/v1\/meta-ads-publish\/config\/bootstrap/);
+  assert.match(release, /\/v1\/meta-ads-publish\/config\/bootstrap\/rollback/);
+  assert.match(release, /payload\?\.rolled_back !== true/);
+  assert.match(release, /payload\?\.operation_status !== 'rolled_back'/);
+  assert.equal((workflow.match(/const postBootstrap = await request\('\/v1\/meta-ads-publish\/config'\);/g) || []).length, 2);
+  assert.equal((workflow.match(/process\.stdout\.write\(`applied\\t\$\{operationKey\}\\t\$\{bootstrapRevision\}\\n`\);/g) || []).length, 2);
+  assert.equal((workflow.match(/id: tracking_bootstrap_rollback/g) || []).length, 2);
+  assert.equal((workflow.match(/\/v1\/meta-ads-publish\/config\/bootstrap\/rollback/g) || []).length, 2);
+  assert.doesNotMatch(release, /process\.stdout\.write\([^\n]*manifest/i);
   assert.ok(release.indexOf("Upload immutable Token Vault version") < release.indexOf("Activate only the selected Token Vault version in staging"));
+  assert.ok(release.indexOf("Read back the exact active Token Vault Worker version in staging") < release.indexOf("Bootstrap legacy Token Vault Meta Ads configuration only when staging requires it"));
+  assert.ok(release.indexOf("Bootstrap legacy Token Vault Meta Ads configuration only when staging requires it") < release.indexOf("Read back staging Token Vault deployment and authenticated health"));
+  assert.ok(release.indexOf("Roll back an applied Token Vault legacy bootstrap before staging Worker compensation") < release.indexOf("Compensate the staging Worker only when this release still owns traffic"));
   assert.match(orbContract, /needs: \[promotion, release\]/);
   assert.match(orbContract, /RELEASE_SHA: \$\{\{ needs\.promotion\.outputs\.source_sha \}\}/);
   assert.match(orbContract, /id-token: write/);
@@ -127,11 +175,15 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
   assert.ok(orbContract.indexOf("Promote and apply the version-checked inactive Meta Ads tracking workflow atomically") < orbContract.indexOf("Read back the promoted native Orb source and live workflow before Worker activation"));
   assert.ok(orbContract.indexOf("Refresh candidate OIDC custody approval before pre-Worker native readback") < orbContract.indexOf("Read back the promoted native Orb source and live workflow before Worker activation"));
   assert.ok(orbContract.indexOf("Read back the promoted native Orb source and live workflow before Worker activation") < orbContract.indexOf("Activate the exact immutable Token Vault Worker after native Orb readback"));
+  assert.ok(orbContract.indexOf("Read back the exact active Token Vault Worker version after the native Orb apply") < orbContract.indexOf("Bootstrap legacy Token Vault Meta Ads configuration only when production requires it"));
+  assert.ok(orbContract.indexOf("Bootstrap legacy Token Vault Meta Ads configuration only when production requires it") < orbContract.indexOf("Read back production Token Vault authenticated health after activation"));
+  assert.ok(orbContract.indexOf("Roll back an applied Token Vault legacy bootstrap before cross-surface compensation") < orbContract.indexOf("Refresh candidate OIDC custody approval before cross-surface compensation"));
+  assert.ok(orbContract.indexOf("Roll back an applied Token Vault legacy bootstrap before cross-surface compensation") < orbContract.indexOf("Compensate the production Worker first only when this release still owns traffic"));
   assert.ok(orbContract.indexOf("Activate the exact immutable Token Vault Worker after native Orb readback") < orbContract.indexOf("Revalidate final native Orb source and live workflow after Worker activation"));
   assert.ok(orbContract.indexOf("Revalidate final native Orb source and live workflow after Worker activation") < orbContract.indexOf("Refresh candidate OIDC custody approval before Graph conversion readback"));
   assert.ok(orbContract.indexOf("Refresh candidate OIDC custody approval before Graph conversion readback") < orbContract.indexOf("Read back required Website conversion and offline-dataset contracts from Graph"));
-  assert.ok(orbContract.indexOf("Compensate the production Worker first only when this release still owns traffic") < orbContract.indexOf("Read back the incumbent Token Vault health before restoring the Orb snapshot"));
-  assert.ok(orbContract.indexOf("Read back the incumbent Token Vault health before restoring the Orb snapshot") < orbContract.indexOf("Revalidate the shared lease before restoring the owned Orb snapshot"));
+  assert.ok(orbContract.indexOf("Compensate the production Worker first only when this release still owns traffic") < orbContract.indexOf("Read back the incumbent Token Vault version and public auth boundary before restoring the Orb snapshot"));
+  assert.ok(orbContract.indexOf("Read back the incumbent Token Vault version and public auth boundary before restoring the Orb snapshot") < orbContract.indexOf("Revalidate the shared lease before restoring the owned Orb snapshot"));
   assert.ok(orbContract.indexOf("Revalidate the shared lease before restoring the owned Orb snapshot") < orbContract.indexOf("Refresh candidate OIDC custody approval before restoring the owned Orb snapshot"));
   assert.ok(orbContract.indexOf("Refresh candidate OIDC custody approval before restoring the owned Orb snapshot") < orbContract.indexOf("Restore the pre-apply Orb snapshot only after the Worker incumbent readback"));
   assert.ok(orbContract.indexOf("Restore the pre-apply Orb snapshot only after the Worker incumbent readback") < orbContract.indexOf("Restore the prior immutable native source after the Worker and Orb rollback"));
@@ -163,12 +215,17 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
   assert.match(workflow, /pausedFixtureVerifiedCreativeUrlTagFixtures/);
   assert.match(workflow, /exactMatchCreativeUrlTagFixtures/);
   assert.match(workflow, /production Token Vault tracking configuration readback is incomplete/);
+  assert.match(workflow, /\/v1\/meta-ads-publish\/config\/bootstrap/);
+  assert.match(workflow, /config_authority_mode/);
+  assert.match(workflow, /legacy_bootstrap/);
+  assert.match(workflow, /tracking_ready/);
+  assert.equal((workflow.match(/steps\.tracking_bootstrap\.outcome != 'success'/g) || []).length, 2);
   assert.match(workflow, /Exercise reversible Meta tracking reconciliation against the isolated staging fixture/);
-  assert.match(workflow, /snapshotIdFromFailure/);
-  assert.match(workflow, /detail\?\.compensation\?\.snapshot_id/);
-  assert.match(workflow, /rollbackResult\.status === 'restored'/);
-  assert.match(workflow, /\['already_restored', 'not_applied'\]/);
-  assert.match(workflow, /tracking-fixture-cleanup/);
+  assert.match(workflow, /\/v1\/meta-ads-publish\/config\/staging-exercise/);
+  assert.match(workflow, /reconciled_and_rolled_back/);
+  assert.match(workflow, /fixture_count !== 1/);
+  assert.match(workflow, /operation_key: `staging-tracking-fixture:\$\{nonce\}`/);
+  assert.doesNotMatch(workflow, /\/v1\/meta-ads-publish\/runs/);
   assert.match(workflow, /Revalidate the release lease before staging Worker compensation/);
   assert.match(workflow, /Validate immutable Token Vault preview source/);
   assert.match(workflow, /if: \$\{\{ inputs\.target != 'preview' \}\}/);


### PR DESCRIPTION
## Resumo

Entrega o bootstrap governado do contrato Meta Ads v20 e fecha a lacuna entre validação local e configuração persistida na Meta.

- preserva `url_tags` brutos, incluindo parâmetros arbitrários e valores com `=`; não exige UTMs;
- separa Website de Click-to-WhatsApp;
- reconcilia Pixel/evento e dataset offline no ad set, com GET/POST/GET, readback e rollback fail-closed;
- adiciona bootstrap restrito para migrar a autoridade v18 sem IDs ou tokens hardcoded, com fixture Website pausada e journal cifrado;
- adiciona exercício staging e ponte de deploy versionada com compensação;
- corrige limpeza atômica de locks parciais e regressões de concorrência.

## Validação

- Token Vault: 120/120 testes; bootstrap: 13/13;
- source/snapshot Orb sincronizados;
- governança, topologia e single-writer verdes;
- revisão de segurança pós-rebase: 0 achados reportáveis.

## Rollout

O deploy online continua bloqueado corretamente até existirem o bearer/config manifest protegidos, URLs/flags de staging e o predecessor de preview do SHA integrado. Nenhuma mutação Meta ou Cloudflare foi feita nesta PR.