### PR TITLE
fix(beauty-movement): match finale card dimensions

### DIFF
--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -641,7 +641,7 @@
   gap: clamp(14px, 2.8vw, 30px);
   width: min(100%, 920px);
   margin: 2px auto 0;
-  --finale-card-height: clamp(280px, 25vw, 304px);
+  --finale-card-height: clamp(312px, 27vw, 324px);
   --finale-special-card-height: 430px;
 }
 
@@ -2311,7 +2311,7 @@
   .finaleCardGrid {
     grid-template-columns: 1fr;
     width: min(100%, 420px);
-    --finale-card-height: 280px;
+    --finale-card-height: 312px;
     --finale-special-card-height: 410px;
   }
 

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -297,7 +297,8 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.match(styles, /@keyframes finaleIllustrationPulse/);
     assert.match(styles, /@keyframes finaleIllustrationPulse[\s\S]*100%[\s\S]*opacity: 1/);
     assert.match(styles, /\.finaleCardGrid/);
-    assert.match(styles, /--finale-card-height: clamp\(280px, 25vw, 304px\)/);
+    assert.match(styles, /--finale-card-height: clamp\(312px, 27vw, 324px\)/);
+    assert.match(styles, /\.finaleCardGrid[\s\S]*--finale-card-height: 312px/);
     assert.match(styles, /\.finaleCardMessage/);
     assert.match(styles, /\.finaleSpecialCardTransform \{/);
     assert.match(styles, /\.tableStage\[data-hand-stage="finale"\] \{[\s\S]*overflow: visible;/);


### PR DESCRIPTION
## Summary
- make the reunited finale cards use the same dimensions as the selected cards
- keep the responsive mobile finale height aligned with the card shell
- add a regression assertion for both desktop and mobile finale sizing

## Validation
- `npm run test` (134/134)
- `npm run lint`
- focused Beauty Movement test
- `git diff --check`
- local preview on `http://127.0.0.1:3417/beleza-em-movimento/local-preview` returned HTTP 200
- browser journey completed through all three selections and the special-card stage; console warnings/errors: none

The local typecheck/build was attempted but timed out after the Next build was concurrently invalidated by the preview runtime; the preview was then restarted cleanly and revalidated with HTTP 200.