### PR TITLE
fix(api): preserve Ponto readiness contract

### DIFF
--- a/api/src/gateway.js
+++ b/api/src/gateway.js
@@ -5,6 +5,7 @@ import { createSignedDomainContext } from '../../shared/service-adapters/signed-
 
 const gatewayError = (status, error) => new Response(JSON.stringify({ ok: false, error }), { status, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' } });
 const isOperationalProbe = (request) => request.method === 'GET' && ['/health', '/readiness'].includes(new URL(request.url).pathname);
+const isPontoReadinessProbe = (request) => request.method === 'GET' && new URL(request.url).pathname === '/api/ponto/readiness';
 const FINANCE_PROBE_TIMEOUT_MS = 3_000;
 const FINANCE_READ_TIMEOUT_MS = 3_000;
 const FINANCE_WRITE_TIMEOUT_MS = 5_000;
@@ -148,6 +149,12 @@ export { createGatewayHandler } from './router.js';
 
 export const handleGatewayRequest = createApiGateway({
     inventoryHandler: (request, env) => fetchBoundService(request, env, 'INVENTORY', { timeoutMs: inventoryServiceTimeout(request) }),
-    timekeepingHandler: (request, env) => fetchBoundService(request, env, 'TIMEKEEPING', { timeoutMs: 800 }),
+    timekeepingHandler: (request, env) => fetchBoundService(request, env, 'TIMEKEEPING', {
+        timeoutMs: 800,
+        // A failed Ponto readiness probe is often the authoritative
+        // maintenance contract. Preserve that body and its release identity
+        // instead of replacing it with the generic dependency fallback.
+        passThroughErrorStatuses: isPontoReadinessProbe(request) ? [503] : [],
+    }),
     financeDomainHandler: forwardFinanceToService,
 });

--- a/api/test/gateway.test.mjs
+++ b/api/test/gateway.test.mjs
@@ -348,6 +348,52 @@ test('a timing-out optional Workforce binding degrades only workforce and opens 
     assert.equal(health.status, 200);
 });
 
+test('canonical public Ponto readiness preserves the authoritative maintenance contract', async () => {
+    resetBoundServiceResilienceForTest();
+    const releaseSha = 'a'.repeat(40);
+    const timekeepingVersionId = '33333333-3333-4333-8333-333333333333';
+    let forwarded = null;
+    const response = await handleGatewayRequest(new Request('https://api-staging.skincos.com.br/api/ponto/readiness'), {
+        APP_VERSION: 'b'.repeat(40),
+        ENVIRONMENT: 'staging',
+        TIMEKEEPING: {
+            fetch: async (request) => {
+                forwarded = request;
+                return new Response(JSON.stringify({
+                    service: 'workforce-timekeeping',
+                    ok: false,
+                    ready: false,
+                    code: 'MODULE_MAINTENANCE',
+                    availability: { state: 'maintenance', source: 'control' },
+                    versionMetadata: { releaseSha },
+                }), {
+                    status: 503,
+                    headers: {
+                        'content-type': 'application/json; charset=utf-8',
+                        'x-skincos-timekeeping-release-sha': releaseSha,
+                        'x-skincos-timekeeping-version-id': timekeepingVersionId,
+                        'x-skincos-timekeeping-environment': 'staging',
+                    },
+                });
+            },
+        },
+    }, {});
+
+    assert.equal(response.status, 503);
+    assert.equal(new URL(forwarded.url).pathname, '/api/ponto/readiness');
+    assert.equal(response.headers.get('x-skincos-dependency-status'), 'live');
+    assert.equal(response.headers.get('x-skincos-timekeeping-release-sha'), releaseSha);
+    assert.equal(response.headers.get('x-skincos-timekeeping-version-id'), timekeepingVersionId);
+    assert.equal(response.headers.get('x-skincos-timekeeping-environment'), 'staging');
+    const body = await response.json();
+    assert.equal(body.service, 'workforce-timekeeping');
+    assert.equal(body.ready, false);
+    assert.equal(body.code, 'MODULE_MAINTENANCE');
+    assert.equal(body.availability.state, 'maintenance');
+    assert.equal(body.versionMetadata.releaseSha, releaseSha);
+    resetBoundServiceResilienceForTest();
+});
+
 test('workforce owns the canonical public Ponto mount', async () => {
     const response = await gateway(new Request('https://api.skincos.com.br/api/ponto/health', { headers: { 'x-request-id': 'ponto-1' } }), {}, {});
     assert.equal(response.status, 200);


### PR DESCRIPTION
## Problema
O gateway público convertia o 503 autoritativo de manutencao do Timekeeping em uma resposta genérica de dependência. Isso removia `ready`, identidade de release e o contrato operacional de `/api/ponto/readiness`.

## Correção
Preserva exclusivamente o status 503 do probe GET `/api/ponto/readiness`, incluindo corpo e headers emitidos pelo Timekeeping. Outros erros e rotas continuam no tratamento fail-closed existente.

## Validação
- `npm run api:test` — 33 testes verdes
- `npm run codex:deploy-topology:test` — verde

## Rollback
Reverter este commit restaura o tratamento anterior do gateway; sem dados, schema, segredos ou flags envolvidos.