### PR TITLE
fix(ponto): bound staging predecessor history reads

### DIFF
--- a/.github/scripts/ponto-core-staging-precondition.mjs
+++ b/.github/scripts/ponto-core-staging-precondition.mjs
@@ -19,6 +19,10 @@ const RELEASE_WORKFLOW = '.github/workflows/ponto-progressive-release.yml';
 const DEFAULT_CATALOG = path.resolve('platform/deploy/operational-units.json');
 const EVIDENCE_DERIVED_STAGING_INCURBENT = 'evidence-derived-staging-incumbent';
 const RECENT_STAGING_RUN_LIMIT = 25;
+// The GitHub workflow-runs payload can exceed spawnSync's 1 MiB default in
+// an active repository. Keep a bounded allowance so a valid predecessor is
+// not discarded before its source-bound evidence can be verified.
+const GITHUB_HISTORY_MAX_BUFFER_BYTES = 8 * 1024 * 1024;
 
 function requireValue(condition, message) {
   if (!condition) throw new Error(message);
@@ -28,12 +32,13 @@ function jsonFile(file) {
   return JSON.parse(readFileSync(file, 'utf8'));
 }
 
-function run(command, args, options = {}) {
+export function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
     cwd: options.cwd || process.cwd(),
     env: options.env || process.env,
     encoding: 'utf8',
     stdio: options.stdio || ['ignore', 'pipe', 'pipe'],
+    maxBuffer: options.maxBuffer ?? GITHUB_HISTORY_MAX_BUFFER_BYTES,
   });
   if (result.error) throw result.error;
   if (result.status !== 0) {

--- a/.github/scripts/ponto-core-staging-precondition.test.mjs
+++ b/.github/scripts/ponto-core-staging-precondition.test.mjs
@@ -4,12 +4,22 @@ import test from 'node:test';
 
 import {
   discoverEvidenceDerivedStagingIncumbents,
+  run,
   resolveStagingCorePrecondition,
   validateEvidenceDerivedStagingIncumbent,
   validateStagingCoreIncumbentLive,
   validateStagingHistoricalBootstrapLive,
   validateStagingIncumbentCatalog,
 } from './ponto-core-staging-precondition.mjs';
+
+test('keeps a bounded buffer above the default spawn limit for GitHub run history', () => {
+  const characters = 1_100_000;
+  const output = run(process.execPath, [
+    '-e',
+    `process.stdout.write('x'.repeat(${characters}))`,
+  ]);
+  assert.equal(output.length, characters);
+});
 
 const sourceSha = '6daa6eaee7c4c49f047e97944e70ea1aa320ca61';
 const deploymentId = '2688c47a-efbb-4b97-98f7-6a1734eac354';


### PR DESCRIPTION
## Problema
O guard de predecessor Ponto consulta o histórico de execuções antes de qualquer mutação. Em um repositório ativo, a resposta ultrapassou o buffer padrão de `spawnSync`, impedindo a descoberta da evidência de staging já aprovada.

## Correção
Define um buffer máximo explícito de 8 MiB para esse leitor de histórico. O limite continua finito; depois da leitura, cada candidato ainda exige a mesma evidência imutável e atestação live.

## Validação
- `node --test .github/scripts/ponto-core-staging-precondition.test.mjs` — 11 verdes
- `npm run codex:deploy-topology:test` — verde

## Rollback
Reverter este commit restaura o limite anterior; não há mutação de dados, segredos ou configuração Cloudflare.