### PR TITLE
fix(ponto): allow signed onboarding in maintenance

### DIFF
--- a/workforce/timekeeping/worker.js
+++ b/workforce/timekeeping/worker.js
@@ -97,6 +97,23 @@ function timekeepingControlStatus(availability, releaseSha, workerVersionId, pee
   if (availability.rolloutStage === 'pilot' && (availability.pilotEmployeeRefs.length !== 1 || availability.pilotIdentityRefs.length !== 1 || availability.pilotIdentityLoginRefs.length !== 1 || availability.pilotNetworkContexts.length !== 1 || availability.pilotUnits.length !== 1 || availability.percentage !== 100)) return { ready: false, code: 'CANARY_CONTROL_INVALID' }
   return { ready: true, code: availability.rolloutStage.toUpperCase() }
 }
+function maintenanceInternalProvisioningStatus(availability, releaseSha, workerVersionId, identityReleaseSha, identityVersionId) {
+  if (availability?.state !== 'maintenance') return { ready: false, code: 'MODULE_MAINTENANCE' }
+  if (!FULL_RELEASE_SHA.test(releaseSha) || identityReleaseSha !== releaseSha) return { ready: false, code: 'RELEASE_AFFINITY_MISMATCH' }
+  if (!CLOUDFLARE_VERSION_ID.test(workerVersionId) || !CLOUDFLARE_VERSION_ID.test(identityVersionId)) return { ready: false, code: 'VERSION_AFFINITY_MISMATCH' }
+
+  // A latched emergency control deliberately omits mutable release metadata.
+  // When an explicit maintenance tuple exists, it remains an exact affinity
+  // requirement; otherwise the signed Identity version and local immutable SHA
+  // are the only bootstrap identity available while public traffic stays closed.
+  const configuredReleaseSha = String(availability?.releaseSha || '').trim().toLowerCase()
+  if (configuredReleaseSha && configuredReleaseSha !== releaseSha) return { ready: false, code: 'RELEASE_AFFINITY_MISMATCH' }
+  const configuredTimekeepingVersion = String(availability?.versions?.timekeeping?.candidate || '').trim()
+  const configuredIdentityVersion = String(availability?.versions?.identityWorkforce?.candidate || '').trim()
+  if (!configuredTimekeepingVersion && !configuredIdentityVersion) return { ready: true, code: 'MAINTENANCE_INTERNAL_BOOTSTRAP' }
+  if (!exactControlledVersions(availability, workerVersionId, identityVersionId, 'identityWorkforce')) return { ready: false, code: 'VERSION_AFFINITY_MISMATCH' }
+  return { ready: true, code: 'MAINTENANCE_INTERNAL_BOOTSTRAP' }
+}
 function gatewayAffinityFor(request, env, releaseSha = releaseShaFor(env)) {
   const gatewayReleaseSha = String(request.headers.get('x-skincos-gateway-release-sha') || '').trim().toLowerCase()
   const gatewayEnvironment = String(request.headers.get('x-skincos-gateway-environment') || '').trim().toLowerCase()
@@ -1002,6 +1019,7 @@ export async function handleTimekeeping(request, env) {
   const runtimeReady = runtimeBindingsReady(env)
   const scheduleReady = Boolean(env.SCHEDULE) && hasRuntimeBinding(env, 'ESCALA_ACTOR_HMAC_KEY')
   const moduleHeaders = { 'x-skincos-module-state': availability.state }
+  const maintenanceInternalProvisioning = availability.state === 'maintenance' && internalOnboarding && request.method === 'POST'
   const dependencies = {
     d1: dependencyState(Boolean(env.DB)),
     schedule: dependencyState(scheduleReady, { required: false, reason: scheduleReady ? '' : 'NOT_CONFIGURED' }),
@@ -1075,7 +1093,7 @@ export async function handleTimekeeping(request, env) {
   if (availability.state === 'canary' && internalOnboarding) {
     return json(403, { ok: false, error: 'TIMEKEEPING_CANARY_NOT_GRANTED', code: 'TIMEKEEPING_CANARY_NOT_GRANTED' }, requestId, moduleHeaders)
   }
-  if (!controlStatus.ready) {
+  if (!controlStatus.ready && !maintenanceInternalProvisioning) {
     if (availability.state === 'maintenance' || availability.state === 'disabled') {
       return moduleUnavailableResponse('timekeeping', availability, requestId, { publicOnly: true })
     }
@@ -1109,6 +1127,19 @@ export async function handleTimekeeping(request, env) {
     }
   }
   const db = env.DB
+  let maintenanceInternalServiceAuth = null
+  if (maintenanceInternalProvisioning) {
+    const bootstrapStatus = maintenanceInternalProvisioningStatus(
+      availability,
+      releaseSha,
+      workerVersionIdFor(env),
+      identityReleaseSha,
+      identityVersionId,
+    )
+    if (!bootstrapStatus.ready) return json(503, { ok: false, error: bootstrapStatus.code, code: bootstrapStatus.code }, requestId, moduleHeaders)
+    maintenanceInternalServiceAuth = await identityServiceAuthorized(request, env, bodyHash, db)
+    if (!maintenanceInternalServiceAuth.ok) return json(maintenanceInternalServiceAuth.error === 'SERVICE_REPLAY' ? 409 : 401, { ok: false, error: maintenanceInternalServiceAuth.error }, requestId, moduleHeaders)
+  }
   if (internalContractProbe && request.method === 'GET') {
     const serviceAuth = await identityServiceAuthorized(request, env, bodyHash, db, { consumeNonce: false })
     if (!serviceAuth.ok) return json(401, { ok: false, error: serviceAuth.error }, requestId, moduleHeaders)
@@ -1126,7 +1157,7 @@ export async function handleTimekeeping(request, env) {
     }, requestId, moduleHeaders)
   }
   if (path === '/api/ponto/internal/onboarding' && request.method === 'POST') {
-    const serviceAuth = await identityServiceAuthorized(request, env, bodyHash, db)
+    const serviceAuth = maintenanceInternalServiceAuth || await identityServiceAuthorized(request, env, bodyHash, db)
     if (!serviceAuth.ok) return json(serviceAuth.error === 'SERVICE_REPLAY' ? 409 : 401, { ok: false, error: serviceAuth.error }, requestId)
     try {
       const data = await syncIdentityOnboarding(db, await readJson(request), requestId)
@@ -1138,7 +1169,7 @@ export async function handleTimekeeping(request, env) {
     }
   }
   if (path === '/api/ponto/internal/onboarding/status' && request.method === 'POST') {
-    const serviceAuth = await identityServiceAuthorized(request, env, bodyHash, db)
+    const serviceAuth = maintenanceInternalServiceAuth || await identityServiceAuthorized(request, env, bodyHash, db)
     if (!serviceAuth.ok) return json(serviceAuth.error === 'SERVICE_REPLAY' ? 409 : 401, { ok: false, error: serviceAuth.error }, requestId)
     try {
       const data = await syncIdentityOnboardingStatus(db, await readJson(request), requestId)

--- a/workforce/timekeeping/worker.test.js
+++ b/workforce/timekeeping/worker.test.js
@@ -935,6 +935,161 @@ test('active permits direct Identity onboarding only with its HMAC, while canary
   assert.equal((await canary.json()).code, 'TIMEKEEPING_CANARY_NOT_GRANTED')
 })
 
+test('maintenance permits only authenticated Identity provisioning while public Ponto stays closed', async () => {
+  const onboardingId = 'maintenance-onboarding-1'
+  const employee = {
+    id: 'maintenance-employee-1',
+    canonical_employee_id: `identity:${onboardingId}`,
+    login_email: 'maintenance-bootstrap@example.invalid',
+    display_name: 'Maintenance Bootstrap',
+    job_title: 'Consultor',
+    status: 'LEAVE',
+    access_state: 'INVITED',
+    metadata_json: JSON.stringify({ identityOnboardingId: onboardingId }),
+  }
+  const seenNonces = new Set()
+  const onboardingDb = {
+    prepare(sql) {
+      return {
+        values: [],
+        bind(...values) { this.values = values; return this },
+        async run() {
+          if (sql.startsWith('INSERT INTO timekeeping_request_nonces')) {
+            if (seenNonces.has(this.values[0])) throw new Error('UNIQUE constraint failed')
+            seenNonces.add(this.values[0])
+          }
+          return { meta: { changes: 1 } }
+        },
+        async first() {
+          return sql.includes('FROM workforce_employees') ? employee : null
+        },
+      }
+    },
+  }
+  const environment = {
+    APP_VERSION: releaseSha,
+    ENVIRONMENT: 'production',
+    DB: onboardingDb,
+    // This models the real emergency latch: the public control remains closed
+    // and carries no mutable candidate tuple while the private bootstrap runs.
+    MODULE_CONTROL: controlStore(activeControl(), openEmergencyLatch({ target: 'production', latched: true })),
+    ...criticalRuntimeBindings,
+  }
+  const onboardingPayload = {
+    onboardingId,
+    fullName: employee.display_name,
+    corporateEmail: employee.login_email,
+    profile: 'CONSULTOR',
+    accountStatus: 'INVITED',
+    jobTitle: employee.job_title,
+    department: 'Comercial',
+    units: ['novo-hamburgo'],
+  }
+  const statusPayload = { onboardingId, employeeId: employee.id, accountStatus: 'INVITED' }
+  const signedIdentityRequest = async (path, payload, nonce, {
+    method = 'POST',
+    signatureOverride = '',
+    timestamp = String(Date.now()),
+    versionId = identityVersionId,
+  } = {}) => {
+    const body = method === 'GET' ? '' : JSON.stringify(payload)
+    const bodyHash = createHash('sha256').update(body).digest('hex')
+    const signature = signatureOverride || await signHmac(
+      criticalRuntimeBindings.IDENTITY_WORKFORCE_HMAC_KEY,
+      `v2.${timestamp}.${nonce}.${method}.${path}.${bodyHash}.${releaseSha}.${versionId}`,
+    )
+    return new Request(`https://timekeeping.local${path}`, {
+      method,
+      headers: {
+        ...(method === 'GET' ? {} : { 'content-type': 'application/json' }),
+        'x-skincos-service': 'identity',
+        'x-skincos-workforce-signature-version': '2',
+        'x-skincos-workforce-ts': timestamp,
+        'x-skincos-workforce-sig': signature,
+        'x-skincos-workforce-nonce': nonce,
+        'x-skincos-identity-release-sha': releaseSha,
+        'x-skincos-identity-version-id': versionId,
+        'x-request-id': `maintenance-${nonce}`,
+      },
+      body: body || undefined,
+    })
+  }
+
+  const onboarding = await worker.fetch(await signedIdentityRequest('/api/ponto/internal/onboarding', onboardingPayload, 'maintenance-onboarding'), environment)
+  assert.equal(onboarding.status, 200)
+  assert.equal((await onboarding.json()).data.employeeId, employee.id)
+
+  const status = await worker.fetch(await signedIdentityRequest('/api/ponto/internal/onboarding/status', statusPayload, 'maintenance-status'), environment)
+  assert.equal(status.status, 200)
+  assert.equal((await status.json()).data.idempotent, true)
+
+  const forged = await worker.fetch(await signedIdentityRequest('/api/ponto/internal/onboarding', onboardingPayload, 'maintenance-forged', { signatureOverride: 'forged' }), environment)
+  assert.equal(forged.status, 401)
+  assert.equal((await forged.json()).error, 'SERVICE_UNAUTHORIZED')
+
+  const replayTimestamp = String(Date.now())
+  const firstReplay = await worker.fetch(await signedIdentityRequest('/api/ponto/internal/onboarding/status', statusPayload, 'maintenance-replay', { timestamp: replayTimestamp }), environment)
+  assert.equal(firstReplay.status, 200)
+  const secondReplay = await worker.fetch(await signedIdentityRequest('/api/ponto/internal/onboarding/status', statusPayload, 'maintenance-replay', { timestamp: replayTimestamp }), environment)
+  assert.equal(secondReplay.status, 409)
+  assert.equal((await secondReplay.json()).error, 'SERVICE_REPLAY')
+
+  const wrongMethod = await worker.fetch(await signedIdentityRequest('/api/ponto/internal/onboarding', undefined, 'maintenance-get', { method: 'GET' }), environment)
+  assert.equal(wrongMethod.status, 503)
+  assert.equal((await wrongMethod.json()).error, 'MODULE_MAINTENANCE')
+
+  const contractProbe = await worker.fetch(await signedIdentityRequest('/api/ponto/internal/onboarding/contract-probe', undefined, 'maintenance-probe', { method: 'GET' }), environment)
+  assert.equal(contractProbe.status, 503)
+  assert.equal((await contractProbe.json()).error, 'MODULE_MAINTENANCE')
+
+  const consultantRaw = Buffer.from(JSON.stringify({
+    id: 'maintenance-consultor',
+    email: 'maintenance-consultor@example.invalid',
+    role: 'CONSULTOR',
+    allowedUnits: ['novo-hamburgo'],
+    releaseSha,
+  })).toString('base64url')
+  const consultantTimestamp = String(Date.now())
+  const consultantNonce = 'maintenance-consultor-read'
+  const consultantBodyHash = createHash('sha256').update('').digest('hex')
+  const consultantSignature = await signHmac(
+    criticalRuntimeBindings.PONTO_ACTOR_HMAC_KEY,
+    [consultantTimestamp, consultantRaw, 'GET', '/api/ponto/me', consultantNonce, consultantBodyHash].join('.'),
+  )
+  const publicRequest = new Request('https://timekeeping.local/api/ponto/me', {
+    headers: {
+      'x-skincos-gateway-release-sha': releaseSha,
+      'x-skincos-gateway-environment': 'production',
+      'x-skincos-gateway-version-id': gatewayVersionId,
+      'x-skincos-actor': consultantRaw,
+      'x-skincos-actor-ts': consultantTimestamp,
+      'x-skincos-actor-sig': consultantSignature,
+      'x-skincos-signature-version': '2',
+      'x-request-nonce': consultantNonce,
+    },
+  })
+  const publicResponse = await worker.fetch(publicRequest, environment)
+  assert.equal(publicResponse.status, 503)
+  assert.equal((await publicResponse.json()).error, 'MODULE_MAINTENANCE')
+
+  const explicitMaintenanceEnvironment = {
+    ...environment,
+    MODULE_CONTROL: controlStore({
+      state: 'maintenance',
+      releaseSha,
+      versions: {
+        timekeeping: { candidate: timekeepingVersionId },
+        identityWorkforce: { candidate: identityVersionId },
+      },
+    }, openEmergencyLatch({ target: 'production' })),
+  }
+  const wrongIdentityVersion = await worker.fetch(await signedIdentityRequest('/api/ponto/internal/onboarding/status', statusPayload, 'maintenance-wrong-version', {
+    versionId: '44444444-4444-4444-8444-444444444444',
+  }), explicitMaintenanceEnvironment)
+  assert.equal(wrongIdentityVersion.status, 503)
+  assert.equal((await wrongIdentityVersion.json()).code, 'VERSION_AFFINITY_MISMATCH')
+})
+
 test('Workforce never presents pending or invited onboarding as operational', () => {
   const pending = __testables.publicEmployee({ id: 'e1', canonical_employee_id: 'identity:o1', display_name: 'Synthetic', login_email: 'synthetic@example.invalid', status: 'LEAVE', access_state: 'PENDING_ACCESS' })
   const invited = __testables.publicEmployee({ id: 'e2', canonical_employee_id: 'identity:o2', display_name: 'Synthetic', login_email: 'synthetic2@example.invalid', status: 'LEAVE', access_state: 'INVITED' })


### PR DESCRIPTION
# Summary

Fixes the bootstrap deadlock that prevented the existing pilot identity from reconciling to Workforce while Ponto is fail-closed in `maintenance`.

Only the signed Identity service POST routes `/api/ponto/internal/onboarding` and `/api/ponto/internal/onboarding/status` may proceed during maintenance. They retain HMAC v2, timestamp, body hash, nonce/replay protection, identity release SHA, identity Worker version, D1, and runtime-binding checks. Public, CONSULTOR, canary, and contract-probe traffic remains closed.

## Type of change
- [x] Fix
- [x] Security

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (not needed: no public contract or operator procedure changes)
- [x] Focused security review completed with no findings
- [ ] Performance impact measured (not applicable)

## Links
- Issue: Bootstrap deadlock for the existing synthetic pilot onboarding
- Design/ADR: Existing Identity-to-Workforce HMAC v2 contract
- Migration steps: None

## Screenshots / Evidence
- `node --test workforce/timekeeping/worker.test.js`: 42 passing
- Codex Security diff scan `d2a60715-a510-4240-8969-7b1e745d6a33`: complete, no findings
- Rollback: revert this commit; Ponto module control remains `maintenance` throughout.