### PR TITLE
fix(ponto): add maintenance-only bootstrap release

### DIFF
--- a/.github/scripts/ponto-dispatch-workflow.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.mjs
@@ -474,7 +474,7 @@ let capabilityTarget = "";
 let capabilityVerifier;
 if (leaseKey) {
   const orchestratorStage = String(process.env.STAGE || "").trim().toLowerCase();
-  if (!["staging", "pilot", "canary", "production", "rollback"].includes(orchestratorStage)) {
+  if (!["staging", "bootstrap", "pilot", "canary", "production", "rollback"].includes(orchestratorStage)) {
     throw new Error("governed child dispatch requires the exact orchestrator stage");
   }
   capabilityTarget = orchestratorStage === "staging" ? "staging" : "production";

--- a/.github/scripts/ponto-dispatch-workflow.test.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.test.mjs
@@ -51,7 +51,7 @@ test("preview dispatches never require a capability while every governed mutatio
     target: "preview",
     release_scope: "ponto",
   }), "");
-  for (const target of ["staging", "pilot", "canary", "production", "rollback"]) {
+  for (const target of ["staging", "bootstrap", "pilot", "canary", "production", "rollback"]) {
     assert.equal(governedLeaseKeyFor("deploy-timekeeping.yml", {
       target,
       release_scope: "ponto",

--- a/.github/scripts/ponto-orchestrator-lease.mjs
+++ b/.github/scripts/ponto-orchestrator-lease.mjs
@@ -15,7 +15,7 @@ const capabilityPublicKeysJson = String(
 );
 const UUIDISH_KEY = /^[a-z][a-z0-9-]{1,63}$/;
 const FULL_SHA = /^[0-9a-f]{40}$/;
-const GOVERNED_STAGES = ["staging", "pilot", "canary", "production", "rollback"];
+const GOVERNED_STAGES = ["staging", "bootstrap", "pilot", "canary", "production", "rollback"];
 const DOMAIN = "skincos/ponto/orchestrator-capability/v6";
 const CLAIM_FIELDS = [
   "schemaVersion", "domain", "repositoryId", "repository",

--- a/.github/scripts/ponto-release-evidence.mjs
+++ b/.github/scripts/ponto-release-evidence.mjs
@@ -4,8 +4,8 @@ import path from "node:path";
 import { validateRootCustody } from "./ponto-root-custody.mjs";
 import { verifyReleaseIdentity } from "./ponto-release-identity.mjs";
 
-const STAGES = ["preview", "staging", "pilot", "canary", "production", "rollback"];
-const PREDECESSOR = { staging: "preview", pilot: "staging", canary: "pilot", production: "canary" };
+const STAGES = ["preview", "staging", "bootstrap", "pilot", "canary", "production", "rollback"];
+const PREDECESSOR = { staging: "preview", bootstrap: "staging", pilot: "staging", canary: "pilot", production: "canary" };
 const ROLLBACK_PREDECESSORS = new Set(["pilot", "canary", "production"]);
 const SHA = /^[0-9a-f]{40}$/i;
 const SHA256 = /^[0-9a-f]{64}$/i;
@@ -43,21 +43,27 @@ const assertSha256 = (value, name) => assert(SHA256.test(String(value || "")), `
 
 function validateSurfaces(surfaces, stage, sourceSha, repository) {
   assert(surfaces && typeof surfaces === "object" && !Array.isArray(surfaces), "surfaces must be an object");
-  for (const unit of ["timekeeping", "coreApi", "identityWorkforce", "crmPages"]) {
+  const bootstrap = stage === "bootstrap";
+  const units = bootstrap ? ["timekeeping"] : ["timekeeping", "coreApi", "identityWorkforce", "crmPages"];
+  if (bootstrap) {
+    assert(JSON.stringify(Object.keys(surfaces).sort()) === JSON.stringify(["timekeeping"]), "bootstrap may publish only the Timekeeping surface");
+  }
+  for (const unit of units) {
     assert(surfaces[unit] && typeof surfaces[unit] === "object", `missing ${unit} surface`);
     assert(surfaces[unit].sourceSha === sourceSha, `${unit}.sourceSha differs`);
     assert(surfaces[unit].stage === stage, `${unit}.stage differs`);
     assert(/^[0-9]+$/.test(String(surfaces[unit].runId || "")), `${unit}.runId must be numeric`);
   }
-  if (!["staging", "pilot", "canary", "production", "rollback"].includes(stage)) return;
+  if (!["staging", "bootstrap", "pilot", "canary", "production", "rollback"].includes(stage)) return;
   const expectedWeights = {
     staging: { timekeeping: 100, coreApi: 100, identityWorkforce: 100 },
+    bootstrap: { timekeeping: 100 },
     pilot: { timekeeping: 0, coreApi: 0, identityWorkforce: 0 },
     canary: { timekeeping: 0, coreApi: 0, identityWorkforce: 0 },
     production: { timekeeping: 100, coreApi: 100, identityWorkforce: 100 },
     rollback: { timekeeping: 0, coreApi: 0, identityWorkforce: 0 },
   };
-  for (const unit of ["timekeeping", "coreApi", "identityWorkforce"]) {
+  for (const unit of (bootstrap ? ["timekeeping"] : ["timekeeping", "coreApi", "identityWorkforce"])) {
     const surface = surfaces[unit];
     assertUuid(surface.candidateVersionId, `${unit}.candidateVersionId`);
     assertUuid(surface.incumbentVersionId, `${unit}.incumbentVersionId`);
@@ -78,6 +84,16 @@ function validateSurfaces(surfaces, stage, sourceSha, repository) {
     requireProvenance: true,
     repository,
   });
+  if (bootstrap) {
+    const maintenance = surfaces.timekeeping.maintenance;
+    assert(maintenance && typeof maintenance === "object" && !Array.isArray(maintenance), "bootstrap requires maintenance evidence");
+    assert(maintenance.state === "maintenance", "bootstrap must leave Ponto in maintenance");
+    assert(maintenance.publicAvailable === false, "bootstrap must keep public Ponto unavailable");
+    assert(maintenance.ready === false, "bootstrap must keep Ponto unready");
+    assert(maintenance.confirmed === true, "bootstrap maintenance was not confirmed");
+    assertSha256(maintenance.healthSha256, "bootstrap maintenance healthSha256");
+    return;
+  }
   assertUuid(surfaces.crmPages.deploymentId, "crmPages.deploymentId");
   assertUuid(surfaces.crmPages.rollbackDeploymentId, "crmPages.rollbackDeploymentId");
   assert(surfaces.crmPages.candidateTag === `ponto:crmPages:${sourceSha}`, "crmPages.candidateTag does not identify source SHA");
@@ -91,7 +107,7 @@ function validateSurfaces(surfaces, stage, sourceSha, repository) {
 }
 
 function validateEdgeGuard(edgeGuard, stage, sourceSha) {
-  if (!["staging", "pilot", "canary", "production"].includes(stage)) {
+  if (!["staging", "bootstrap", "pilot", "canary", "production"].includes(stage)) {
     assert(edgeGuard === null, `${stage} must not claim a live edge guard`);
     return;
   }
@@ -290,7 +306,25 @@ function validateEvidence(evidence) {
       assert(checkpoint?.releaseSha === evidence.sourceSha, `${unit} checkpoint releaseSha differs`);
     }
   }
-  if (["staging", "pilot", "canary", "production", "rollback"].includes(evidence.stage)) {
+  if (evidence.stage === "bootstrap") {
+    const slo = evidence.slo;
+    assert(slo?.passed === true, "bootstrap maintenance confirmation did not pass");
+    assert(slo?.mode === "maintenance-bootstrap", "bootstrap SLO mode is invalid");
+    assert(Number.isInteger(slo.samples) && slo.samples === 1, "bootstrap SLO samples must equal one");
+    assert(Number.isInteger(slo.errors) && slo.errors === 0, "bootstrap SLO errors must be zero");
+    assert(Number.isFinite(slo.p95Ms) && slo.p95Ms >= 0, "bootstrap SLO p95Ms is invalid");
+    assert(Number.isInteger(slo.windowSeconds) && slo.windowSeconds > 0, "bootstrap SLO windowSeconds must be positive");
+    assertSha256(slo.digest, "bootstrap SLO digest");
+    assert(slo.digest === evidence.surfaces.timekeeping.maintenance.healthSha256, "bootstrap SLO digest differs from maintenance health");
+    assert(evidence.checkpoint?.timekeeping, "bootstrap requires a Timekeeping checkpoint");
+    assert(evidence.rollback?.executed === false, "bootstrap must not claim a full rollback");
+    assert(evidence.rollback?.mode === "timekeeping-bootstrap-maintenance", "bootstrap rollback mode is invalid");
+    assertUuid(evidence.rollback?.timekeepingVersionId, "bootstrap rollback.timekeepingVersionId");
+    assert(
+      evidence.rollback?.timekeepingVersionId === evidence.surfaces.timekeeping.incumbentVersionId,
+      "bootstrap rollback Timekeeping version differs from the incumbent",
+    );
+  } else if (["staging", "pilot", "canary", "production", "rollback"].includes(evidence.stage)) {
     const slo = evidence.slo;
     assert(slo?.passed === true, "external SLO did not pass");
     assert(Number.isInteger(slo.samples) && slo.samples > 0, "SLO samples must be positive");
@@ -399,14 +433,14 @@ if (mode === "write") {
       `artifact_sha256=${digestFile(file)}`,
       `timekeeping_candidate_version_id=${evidence.surfaces.timekeeping.candidateVersionId || ""}`,
       `timekeeping_incumbent_version_id=${evidence.surfaces.timekeeping.incumbentVersionId || ""}`,
-      `core_candidate_version_id=${evidence.surfaces.coreApi.candidateVersionId || ""}`,
-      `core_incumbent_version_id=${evidence.surfaces.coreApi.incumbentVersionId || ""}`,
-      `identity_candidate_version_id=${evidence.surfaces.identityWorkforce.candidateVersionId || ""}`,
-      `identity_incumbent_version_id=${evidence.surfaces.identityWorkforce.incumbentVersionId || ""}`,
+      `core_candidate_version_id=${evidence.surfaces.coreApi?.candidateVersionId || ""}`,
+      `core_incumbent_version_id=${evidence.surfaces.coreApi?.incumbentVersionId || ""}`,
+      `identity_candidate_version_id=${evidence.surfaces.identityWorkforce?.candidateVersionId || ""}`,
+      `identity_incumbent_version_id=${evidence.surfaces.identityWorkforce?.incumbentVersionId || ""}`,
       `identity_checkpoint_artifact=${evidence.checkpoint?.identityWorkforce?.artifactName || ""}`,
       `identity_checkpoint_sha256=${evidence.checkpoint?.identityWorkforce?.sha256 || ""}`,
-      `pages_deployment_id=${evidence.surfaces.crmPages.deploymentId || ""}`,
-      `pages_rollback_deployment_id=${evidence.surfaces.crmPages.rollbackDeploymentId || ""}`,
+      `pages_deployment_id=${evidence.surfaces.crmPages?.deploymentId || ""}`,
+      `pages_rollback_deployment_id=${evidence.surfaces.crmPages?.rollbackDeploymentId || ""}`,
       "",
     ].join("\n"));
   }

--- a/.github/scripts/ponto-release-evidence.test.mjs
+++ b/.github/scripts/ponto-release-evidence.test.mjs
@@ -23,6 +23,7 @@ const previewSurfaces = {
 };
 const stageWeights = {
   staging: { timekeeping: 100, coreApi: 100, identityWorkforce: 100 },
+  bootstrap: { timekeeping: 100, coreApi: 0, identityWorkforce: 0 },
   pilot: { timekeeping: 0, coreApi: 0, identityWorkforce: 0 },
   canary: { timekeeping: 0, coreApi: 0, identityWorkforce: 0 },
   production: { timekeeping: 100, coreApi: 100, identityWorkforce: 100 },
@@ -119,6 +120,35 @@ const stagingSloSummary = () => ({
     piiIncluded: false,
     digest,
   },
+});
+const bootstrapSurfaces = () => {
+  const { timekeeping } = liveSurfaces("bootstrap");
+  return {
+    timekeeping: {
+      ...timekeeping,
+      maintenance: {
+        state: "maintenance",
+        publicAvailable: false,
+        ready: false,
+        healthSha256: digest,
+        confirmed: true,
+      },
+    },
+  };
+};
+const bootstrapSloSummary = () => ({
+  passed: true,
+  samples: 1,
+  errors: 0,
+  p95Ms: 0,
+  windowSeconds: 1,
+  digest,
+  mode: "maintenance-bootstrap",
+});
+const bootstrapRollbackSummary = () => ({
+  executed: false,
+  mode: "timekeeping-bootstrap-maintenance",
+  timekeepingVersionId: uuid2,
 });
 const stagingBootstrapCore = () => ({
   schemaVersion: 1,
@@ -285,6 +315,54 @@ test("rejects staging evidence when the bootstrap predecessor differs from the e
   });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /Core bootstrap version differs from the staging incumbent/);
+});
+
+test("bootstrap evidence publishes only Timekeeping while public Ponto remains in maintenance", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ponto-evidence-"));
+  const { staging } = writePreviewAndStaging(dir);
+  const file = path.join(dir, "bootstrap.json");
+  const env = {
+    PONTO_RELEASE_STAGE: "bootstrap",
+    PONTO_RELEASE_SHA: sha,
+    PONTO_RELEASE_TREE: tree,
+    PONTO_PREDECESSOR_STAGE: "staging",
+    PONTO_PREDECESSOR_RUN_ID: "200",
+    PONTO_PREDECESSOR_SHA: sha,
+    PONTO_PREDECESSOR_ARTIFACT: `ponto-release-evidence-staging-${sha}`,
+    PONTO_PREDECESSOR_FILE: staging,
+    PONTO_RELEASE_SURFACES_JSON: JSON.stringify(bootstrapSurfaces()),
+    PONTO_RELEASE_EDGE_GUARD_JSON: JSON.stringify(edgeGuard("bootstrap")),
+    PONTO_RELEASE_CHECKPOINT_JSON: JSON.stringify({
+      timekeeping: { artifactName: `timekeeping-bootstrap-pre-migration-${sha}`, sha256: digest, releaseSha: sha },
+    }),
+    PONTO_RELEASE_MIGRATIONS_JSON: "[]",
+    PONTO_RELEASE_SLO_JSON: JSON.stringify(bootstrapSloSummary()),
+    PONTO_RELEASE_ROLLBACK_JSON: JSON.stringify(bootstrapRollbackSummary()),
+    GITHUB_RUN_ID: "250",
+    GITHUB_REPOSITORY: "skincos/skincos",
+  };
+  let result = run("write", file, env);
+  assert.equal(result.status, 0, result.stderr);
+  const evidence = JSON.parse(fs.readFileSync(file, "utf8"));
+  assert.deepEqual(Object.keys(evidence.surfaces), ["timekeeping"]);
+  assert.equal(evidence.surfaces.timekeeping.maintenance.publicAvailable, false);
+  result = run("verify", file, {
+    PONTO_EXPECTED_STAGE: "bootstrap",
+    PONTO_EXPECTED_SHA: sha,
+    PONTO_EXPECTED_REPOSITORY: "skincos/skincos",
+    PONTO_PREDECESSOR_FILE: staging,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  evidence.surfaces.timekeeping.maintenance.confirmed = false;
+  fs.writeFileSync(file, JSON.stringify(evidence));
+  result = run("verify", file, {
+    PONTO_EXPECTED_STAGE: "bootstrap",
+    PONTO_EXPECTED_SHA: sha,
+    PONTO_EXPECTED_REPOSITORY: "skincos/skincos",
+    PONTO_PREDECESSOR_FILE: staging,
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /bootstrap maintenance was not confirmed/);
 });
 
 test("writes and verifies schema v2 pilot evidence with a digested predecessor", () => {

--- a/.github/scripts/ponto-watchdog-context.mjs
+++ b/.github/scripts/ponto-watchdog-context.mjs
@@ -3,7 +3,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { assertPontoSourceClosureUnchanged } from "./ponto-source-closure.mjs";
 
-const TITLE = /^Ponto (preview|staging|pilot|canary|production|rollback) ([0-9a-f]{40}) orchestrator=([1-9][0-9]*)$/;
+const TITLE = /^Ponto (preview|staging|bootstrap|pilot|canary|production|rollback) ([0-9a-f]{40}) orchestrator=([1-9][0-9]*)$/;
 const FAILURE_CONCLUSIONS = new Set(["failure", "cancelled", "timed_out"]);
 const NON_TERMINAL_STATUSES = ["queued", "in_progress", "waiting", "pending", "requested"];
 

--- a/.github/scripts/ponto-watchdog-context.test.mjs
+++ b/.github/scripts/ponto-watchdog-context.test.mjs
@@ -62,6 +62,24 @@ test("watchdog accepts only an exact failed first-attempt coordinator from main"
   assert.equal(context.releaseSha, sha);
 });
 
+test("watchdog maps a failed bootstrap coordinator to the production fail-close target", async () => {
+  const bootstrapRun = {
+    ...run,
+    name: `Ponto bootstrap ${sha} orchestrator=99`,
+    display_title: `Ponto bootstrap ${sha} orchestrator=99`,
+  };
+  const context = await validateWatchdogContext(input({
+    request: async (pathname) => {
+      if (pathname.endsWith("ponto-progressive-release.yml")) return workflow;
+      if (pathname.endsWith("/jobs?per_page=100")) return jobs;
+      return bootstrapRun;
+    },
+  }));
+  assert.equal(context.stage, "bootstrap");
+  assert.equal(context.target, "production");
+  assert.equal(context.requiresClose, true);
+});
+
 test("watchdog defers a duplicate failure to an exact active coordinator", async () => {
   const peer = {
     ...run,

--- a/.github/workflows/deploy-timekeeping.yml
+++ b/.github/workflows/deploy-timekeeping.yml
@@ -9,7 +9,7 @@ on:
         required: true
         default: staging
         type: choice
-        options: [preview, staging, pilot, canary, production, rollback]
+        options: [preview, staging, bootstrap, pilot, canary, production, rollback]
       release_sha:
         description: Immutable main commit SHA
         required: true
@@ -29,7 +29,7 @@ on:
         type: choice
         options: [ponto]
       predecessor_run_id:
-        description: Required for pilot, canary, production, and rollback
+        description: Required for bootstrap, pilot, canary, production, and rollback
         required: false
         type: string
       baseline_run_id:
@@ -37,7 +37,7 @@ on:
         required: false
         type: string
       root_custody_run_id:
-        description: Required for staging and pilot; exact successful pre-mutation root-custody child run
+        description: Required for staging, bootstrap, and pilot; exact successful pre-mutation root-custody child run
         required: false
         type: string
       rollback_from_stage:
@@ -87,7 +87,7 @@ jobs:
       global_lease_required: ${{ inputs.target != 'preview' }}
       global_resource: global:ponto-workers-writer
       global_module: ponto
-      global_coordinator_url: ${{ contains(fromJSON('["pilot","canary","production","rollback"]'), inputs.target) && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+      global_coordinator_url: ${{ contains(fromJSON('["bootstrap","pilot","canary","production","rollback"]'), inputs.target) && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
       lease_key: timekeeping
       stage: ${{ inputs.orchestrator_stage || inputs.target }}
       target: ${{ inputs.target == 'staging' && 'staging' || 'production' }}
@@ -107,7 +107,7 @@ jobs:
 
   progressive:
     needs: coordination
-    if: ${{ contains(fromJSON('["pilot","canary","production","rollback"]'), inputs.target) }}
+    if: ${{ contains(fromJSON('["bootstrap","pilot","canary","production","rollback"]'), inputs.target) }}
     uses: ./.github/workflows/ponto-release-gate.yml
     with:
       stage: ${{ inputs.target }}
@@ -190,7 +190,7 @@ jobs:
         inputs.target != 'preview' &&
         (
           (inputs.target == 'staging' && needs.promotion.result == 'success') ||
-          (contains(fromJSON('["pilot","canary","production","rollback"]'), inputs.target) && needs.progressive.result == 'success')
+          (contains(fromJSON('["bootstrap","pilot","canary","production","rollback"]'), inputs.target) && needs.progressive.result == 'success')
         )
       }}
     runs-on: ubuntu-latest
@@ -248,7 +248,7 @@ jobs:
               D1_ID="$STAGING_D1_ID_RAW"; OPPOSITE_D1_ID="$PRODUCTION_D1_ID_RAW"
               MODULE_CONTROL_KV_ID="$STAGING_MODULE_CONTROL_KV_ID_RAW"; OPPOSITE_MODULE_CONTROL_KV_ID="$PRODUCTION_MODULE_CONTROL_KV_ID_RAW"
               ;;
-            pilot|canary|production|rollback)
+            bootstrap|pilot|canary|production|rollback)
               D1_ID="$PRODUCTION_D1_ID_RAW"; OPPOSITE_D1_ID="$STAGING_D1_ID_RAW"
               MODULE_CONTROL_KV_ID="$PRODUCTION_MODULE_CONTROL_KV_ID_RAW"; OPPOSITE_MODULE_CONTROL_KV_ID="$STAGING_MODULE_CONTROL_KV_ID_RAW"
               ;;
@@ -264,7 +264,7 @@ jobs:
           if [[ "$TARGET" != staging ]]; then
             [[ "$ENABLE_PRODUCTION" == true ]] || { echo 'ENABLE_PONTO_TIMEKEEPING_PRODUCTION_DEPLOY must be explicitly true'; exit 1; }
           fi
-          if [[ "$TARGET" =~ ^(staging|pilot)$ ]]; then
+          if [[ "$TARGET" =~ ^(staging|bootstrap|pilot)$ ]]; then
             [[ -n "${TIMEKEEPING_BACKUP_PASSPHRASE:-}" ]] || { echo 'TIMEKEEPING_BACKUP_PASSPHRASE is required before migrations'; exit 1; }
           fi
           {
@@ -296,13 +296,13 @@ jobs:
           export PONTO_OPPOSITE_MODULE_CONTROL_KV_ID="$OPPOSITE_MODULE_CONTROL_KV_ID"
           node .github/scripts/ponto-cloudflare-resource-identity.mjs
       - name: Fetch the exact staging root custody predecessor
-        if: ${{ inputs.target == 'pilot' }}
+        if: ${{ inputs.target == 'bootstrap' || inputs.target == 'pilot' }}
         env:
           GH_TOKEN: ${{ github.token }}
           PREDECESSOR_RUN_ID: ${{ inputs.predecessor_run_id }}
         run: |
           set -euo pipefail
-          [[ "$PREDECESSOR_RUN_ID" =~ ^[0-9]+$ ]] || { echo 'pilot requires the exact staging predecessor'; exit 1; }
+          [[ "$PREDECESSOR_RUN_ID" =~ ^[0-9]+$ ]] || { echo 'bootstrap and pilot require the exact staging predecessor'; exit 1; }
           mkdir -p "$RUNNER_TEMP/timekeeping-root-custody/staging-evidence"
           gh run download "$PREDECESSOR_RUN_ID" --repo "$GITHUB_REPOSITORY" \
             --name "ponto-release-evidence-staging-$RELEASE_SHA" \
@@ -323,7 +323,7 @@ jobs:
           NODE
           rm -rf "$RUNNER_TEMP/timekeeping-root-custody/staging-evidence"
       - name: Prove environment root separation before checkpoint or migration
-        if: ${{ inputs.target == 'staging' || inputs.target == 'pilot' }}
+        if: ${{ inputs.target == 'staging' || inputs.target == 'bootstrap' || inputs.target == 'pilot' }}
         env:
           PONTO_PROFILE_DATA_KEY: ${{ secrets.PONTO_PROFILE_DATA_KEY }}
           PONTO_IDEMPOTENCY_KEY: ${{ secrets.PONTO_IDEMPOTENCY_KEY }}
@@ -334,7 +334,7 @@ jobs:
         run: |
           set -euo pipefail
           target=staging
-          [[ "$TARGET" == pilot ]] && target=production
+          [[ "$TARGET" == bootstrap || "$TARGET" == pilot ]] && target=production
           mkdir -p "$RUNNER_TEMP/timekeeping-root-custody"
           staging_args=()
           if [[ "$target" == production ]]; then
@@ -366,7 +366,7 @@ jobs:
           fi
           ! grep -q '__CONFIGURE_.*_ID__' workforce/timekeeping/wrangler.toml || { echo 'Unresolved binding placeholder'; exit 1; }
       - name: Require selected-environment custody for both candidate root secrets
-        if: ${{ inputs.target == 'staging' || inputs.target == 'pilot' }}
+        if: ${{ inputs.target == 'staging' || inputs.target == 'bootstrap' || inputs.target == 'pilot' }}
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           TARGET_ENVIRONMENT: ${{ inputs.target == 'staging' && 'staging' || 'production' }}
@@ -433,8 +433,8 @@ jobs:
           }
           NODE
           rm -f "$list"
-      - name: Resolve incumbent version before pilot mutation
-        if: ${{ inputs.target == 'staging' || inputs.target == 'pilot' }}
+      - name: Resolve incumbent version before bootstrap or pilot mutation
+        if: ${{ inputs.target == 'staging' || inputs.target == 'bootstrap' || inputs.target == 'pilot' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -477,7 +477,7 @@ jobs:
           echo "TIMEKEEPING_INCUMBENT_VERSION_ID=$INCUMBENT_ID" >> "$GITHUB_ENV"
       - name: Capture encrypted D1 checkpoint
         id: checkpoint
-        if: ${{ inputs.target == 'staging' || inputs.target == 'pilot' }}
+        if: ${{ inputs.target == 'staging' || inputs.target == 'bootstrap' || inputs.target == 'pilot' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -505,7 +505,7 @@ jobs:
           retention-days: 90
           if-no-files-found: error
       - name: Resolve exact root custody artifact before mutation
-        if: ${{ inputs.target == 'staging' || inputs.target == 'pilot' }}
+        if: ${{ inputs.target == 'staging' || inputs.target == 'bootstrap' || inputs.target == 'pilot' }}
         env:
           GH_TOKEN: ${{ github.token }}
           ROOT_CUSTODY_RUN_ID: ${{ inputs.root_custody_run_id }}
@@ -515,7 +515,7 @@ jobs:
           [[ "$ROOT_CUSTODY_RUN_ID" =~ ^[0-9]+$ ]] || { echo 'root_custody_run_id must be numeric'; exit 1; }
           [[ "$ORCHESTRATOR_RUN_ID" =~ ^[0-9]+$ ]] || { echo 'orchestrator_run_id must be numeric'; exit 1; }
           target=staging
-          [[ "$TARGET" == pilot ]] && target=production
+          [[ "$TARGET" == bootstrap || "$TARGET" == pilot ]] && target=production
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$ROOT_CUSTODY_RUN_ID" > "$RUNNER_TEMP/timekeeping-root-custody-run.json"
           gh api "repos/$GITHUB_REPOSITORY/actions/workflows/cloudflare-workers-sync-ponto-secrets.yml" > "$RUNNER_TEMP/timekeeping-root-custody-workflow.json"
           node --input-type=module - \
@@ -648,7 +648,7 @@ jobs:
             "$artifact_list" \
             "$artifact_metadata"
       - name: Compare live root custody immediately before mutation
-        if: ${{ inputs.target == 'staging' || inputs.target == 'pilot' }}
+        if: ${{ inputs.target == 'staging' || inputs.target == 'bootstrap' || inputs.target == 'pilot' }}
         env:
           ROOT_CUSTODY_RUN_ID: ${{ inputs.root_custody_run_id }}
           ORCHESTRATOR_RUN_ID: ${{ inputs.orchestrator_run_id }}
@@ -663,7 +663,7 @@ jobs:
           [[ "$ROOT_CUSTODY_RUN_ID" =~ ^[0-9]+$ ]] || { echo 'root_custody_run_id must be numeric'; exit 1; }
           [[ "$ORCHESTRATOR_RUN_ID" =~ ^[0-9]+$ ]] || { echo 'orchestrator_run_id must be numeric'; exit 1; }
           target=staging
-          [[ "$TARGET" == pilot ]] && target=production
+          [[ "$TARGET" == bootstrap || "$TARGET" == pilot ]] && target=production
           node --input-type=module - \
             "$RUNNER_TEMP/timekeeping-root-custody/preflight-root-custody.json" \
             "$RUNNER_TEMP/timekeeping-root-custody/root-custody.json" \
@@ -749,7 +749,7 @@ jobs:
             "$RUNNER_TEMP/timekeeping-root-custody/preflight-root-custody.json" \
             "$RUNNER_TEMP/timekeeping-root-custody-provenance.json"
       - name: Apply additive Timekeeping migrations
-        if: ${{ inputs.target == 'staging' || inputs.target == 'pilot' }}
+        if: ${{ inputs.target == 'staging' || inputs.target == 'bootstrap' || inputs.target == 'pilot' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -762,7 +762,7 @@ jobs:
           ./node_modules/.bin/wrangler d1 migrations apply "$database" --remote --config wrangler.toml "${env_args[@]}"
           touch "$RUNNER_TEMP/timekeeping-migration-completed"
       - name: Upload immutable candidate version
-        if: ${{ inputs.target == 'staging' || inputs.target == 'pilot' }}
+        if: ${{ inputs.target == 'staging' || inputs.target == 'bootstrap' || inputs.target == 'pilot' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -944,7 +944,7 @@ jobs:
             env_args=(--env staging); candidate=100; incumbent=0
           elif [[ "$TARGET" == pilot || "$TARGET" == canary ]]; then
             env_args=(); candidate=0; incumbent=100
-          elif [[ "$TARGET" == production ]]; then
+          elif [[ "$TARGET" == bootstrap || "$TARGET" == production ]]; then
             env_args=(); candidate=100; incumbent=0
           else
             env_args=(); candidate=0; incumbent=100
@@ -978,12 +978,32 @@ jobs:
           echo "incumbent_percent=$incumbent" >> "$GITHUB_OUTPUT"
           rm -f "$RUNNER_TEMP/timekeeping-version-deploy.ndjson" "$RUNNER_TEMP/timekeeping-deployment.json"
       - name: Read-only Timekeeping health probe
+        id: health
         env:
           BASE_URL: ${{ inputs.target == 'staging' && 'https://api-staging.skincos.com.br' || 'https://api.skincos.com.br' }}
+          TARGET: ${{ inputs.target }}
         run: |
           set -euo pipefail
           curl --fail --silent --show-error --retry 5 --retry-delay 4 "$BASE_URL/api/ponto/health" > "$RUNNER_TEMP/timekeeping-health.json"
-          node -e "const p=require(process.argv[1]);if(typeof p.ok!=='boolean'||!p.version)process.exit(1)" "$RUNNER_TEMP/timekeeping-health.json"
+          node - "$RUNNER_TEMP/timekeeping-health.json" <<'NODE'
+          const crypto = require("crypto");
+          const fs = require("fs");
+          const payload = fs.readFileSync(process.argv[2], "utf8");
+          const health = JSON.parse(payload);
+          if (typeof health.ok !== "boolean" || !health.version) process.exit(1);
+          if (process.env.TARGET === "bootstrap") {
+            if (
+              health.ok !== false
+              || health.ready !== false
+              || health?.availability?.state !== "maintenance"
+            ) throw new Error("bootstrap must leave public Ponto fail-closed in maintenance");
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, [
+              "maintenance_confirmed=true",
+              `maintenance_health_sha256=${crypto.createHash("sha256").update(payload).digest("hex")}`,
+              "",
+            ].join("\n"));
+          }
+          NODE
       - name: Roll back this publisher after a failed mutation
         if: ${{ always() && (failure() || cancelled()) && env.TIMEKEEPING_INCUMBENT_VERSION_ID != '' }}
         env:
@@ -1042,7 +1062,7 @@ jobs:
           printf '%s\n' rolled-back > "$RUNNER_TEMP/timekeeping-compensation-disposition"
           touch "$RUNNER_TEMP/timekeeping-rollback-completed"
       - name: Write sanitized Timekeeping mutation journal
-        if: ${{ always() && contains(fromJSON('["staging","pilot","canary","production","rollback"]'), inputs.target) }}
+        if: ${{ always() && contains(fromJSON('["staging","bootstrap","pilot","canary","production","rollback"]'), inputs.target) }}
         env:
           DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
           BASELINE_RUN_ID: ${{ inputs.baseline_run_id }}
@@ -1085,7 +1105,7 @@ jobs:
           }, null, 2)}\n`, { mode: 0o600 });
           NODE
       - name: Upload Timekeeping mutation journal
-        if: ${{ always() && contains(fromJSON('["staging","pilot","canary","production","rollback"]'), inputs.target) }}
+        if: ${{ always() && contains(fromJSON('["staging","bootstrap","pilot","canary","production","rollback"]'), inputs.target) }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ponto-mutation-timekeeping-${{ inputs.target }}-${{ env.RELEASE_SHA }}
@@ -1100,6 +1120,8 @@ jobs:
           INCUMBENT_PERCENT: ${{ steps.deployment.outputs.incumbent_percent }}
           CHECKPOINT_DIGEST: ${{ steps.checkpoint.outputs.digest }}
           BASELINE_RUN_ID: ${{ inputs.baseline_run_id }}
+          MAINTENANCE_CONFIRMED: ${{ steps.health.outputs.maintenance_confirmed }}
+          MAINTENANCE_HEALTH_SHA256: ${{ steps.health.outputs.maintenance_health_sha256 }}
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/timekeeping-surface"
@@ -1111,7 +1133,7 @@ jobs:
           const rootCustodyFile = process.env.RUNNER_TEMP + "/timekeeping-root-custody/root-custody.json";
           if (!fs.existsSync(rootCustodyFile)) throw new Error("Timekeeping root custody evidence is absent");
           const rootCustody = JSON.parse(fs.readFileSync(rootCustodyFile, "utf8"));
-          const migrations = stage === "staging" || stage === "pilot"
+          const migrations = stage === "staging" || stage === "bootstrap" || stage === "pilot"
             ? fs.readdirSync("workforce/timekeeping/migrations")
               .filter(name => /^\d+.*\.sql$/.test(name))
               .sort()
@@ -1135,6 +1157,13 @@ jobs:
             incumbentPercent: Number(process.env.INCUMBENT_PERCENT),
             candidateTag: `ponto:timekeeping:${process.env.RELEASE_SHA}`,
             rootCustody,
+            maintenance: stage === "bootstrap" ? {
+              state: "maintenance",
+              publicAvailable: false,
+              ready: false,
+              healthSha256: process.env.MAINTENANCE_HEALTH_SHA256,
+              confirmed: process.env.MAINTENANCE_CONFIRMED === "true",
+            } : null,
             url: stage === "staging" ? "https://api-staging.skincos.com.br/api/ponto/health" : "https://api.skincos.com.br/api/ponto/health",
             checkpoint: process.env.CHECKPOINT_DIGEST ? {
               artifactName: `timekeeping-${stage}-pre-migration-${process.env.RELEASE_SHA}`,

--- a/.github/workflows/ponto-progressive-release.yml
+++ b/.github/workflows/ponto-progressive-release.yml
@@ -9,7 +9,7 @@ on:
         required: true
         default: preview
         type: choice
-        options: [preview, staging, pilot, canary, production, rollback]
+        options: [preview, staging, bootstrap, pilot, canary, production, rollback]
       release_sha:
         description: Exact immutable coordinator SHA at main for every surface
         required: true
@@ -123,7 +123,7 @@ jobs:
       # uses the dedicated coordinator; production remains blocked until its
       # separate endpoint and custody are provisioned.
       SKINCOS_GLOBAL_COORDINATION_REQUIRED: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
-      SKINCOS_GLOBAL_COORDINATOR_URL: ${{ contains(fromJSON('["preview","staging"]'), inputs.stage) && vars.SKINCOS_GLOBAL_COORDINATOR_URL || contains(fromJSON('["pilot","canary","production","rollback"]'), inputs.stage) && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || '' }}
+      SKINCOS_GLOBAL_COORDINATOR_URL: ${{ contains(fromJSON('["preview","staging"]'), inputs.stage) && vars.SKINCOS_GLOBAL_COORDINATOR_URL || contains(fromJSON('["bootstrap","pilot","canary","production","rollback"]'), inputs.stage) && vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL || '' }}
       SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
       SKINCOS_GLOBAL_COORDINATION_KEY_ID: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
     steps:
@@ -145,7 +145,7 @@ jobs:
           const releaseSha = String(process.env.RELEASE_SHA || "").toLowerCase();
           const coordinatorRunId = String(process.env.GITHUB_RUN_ID || "");
           if (
-            !["preview", "staging", "pilot", "canary", "production", "rollback"].includes(stage)
+            !["preview", "staging", "bootstrap", "pilot", "canary", "production", "rollback"].includes(stage)
             || !/^[0-9a-f]{40}$/.test(releaseSha)
             || !/^[1-9][0-9]*$/.test(coordinatorRunId)
           ) throw new Error("recovery intent identity is invalid");
@@ -190,6 +190,7 @@ jobs:
           case "$STAGE" in
             preview) predecessor='' ;;
             staging) predecessor=preview ;;
+            bootstrap) predecessor=staging ;;
             pilot) predecessor=staging ;;
             canary) predecessor=pilot ;;
             production) predecessor=canary ;;
@@ -307,7 +308,7 @@ jobs:
             "$RUNNER_TEMP/ponto-environment.json" \
             "$RUNNER_TEMP/ponto-environment-branch-policies.json"
       - name: Refuse a latched Ponto emergency stop before issuing capabilities
-        if: ${{ contains(fromJSON('["staging","pilot","canary","production","rollback"]'), inputs.stage) }}
+        if: ${{ contains(fromJSON('["staging","bootstrap","pilot","canary","production","rollback"]'), inputs.stage) }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -317,7 +318,7 @@ jobs:
           set -euo pipefail
           case "$STAGE" in
             staging) NAMESPACE_ID="$STAGING_NAMESPACE_ID_RAW"; OPPOSITE_NAMESPACE_ID="$PRODUCTION_NAMESPACE_ID_RAW" ;;
-            pilot|canary|production|rollback) NAMESPACE_ID="$PRODUCTION_NAMESPACE_ID_RAW"; OPPOSITE_NAMESPACE_ID="$STAGING_NAMESPACE_ID_RAW" ;;
+            bootstrap|pilot|canary|production|rollback) NAMESPACE_ID="$PRODUCTION_NAMESPACE_ID_RAW"; OPPOSITE_NAMESPACE_ID="$STAGING_NAMESPACE_ID_RAW" ;;
             *) echo 'Unsupported emergency-latch release stage'; exit 1 ;;
           esac
           for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID NAMESPACE_ID; do
@@ -400,7 +401,7 @@ jobs:
           NODE
           rm -f "$RUNNER_TEMP"/ponto-capability-*.json
       - name: Preflight selected environment secret-root custody
-        if: ${{ contains(fromJSON('["staging","pilot","canary","production","rollback"]'), inputs.stage) }}
+        if: ${{ contains(fromJSON('["staging","bootstrap","pilot","canary","production","rollback"]'), inputs.stage) }}
         env:
           # Environment secret/variable metadata requires the protected
           # read-only administration token; the automatic token is not granted
@@ -484,7 +485,7 @@ jobs:
             "$RUNNER_TEMP/ponto-root-environment-variables.json" \
             "$RUNNER_TEMP/ponto-root-repository-variables.json"
       - name: Require the single-operator no-review true-only emergency close path
-        if: ${{ contains(fromJSON('["staging","pilot","canary","production","rollback"]'), inputs.stage) }}
+        if: ${{ contains(fromJSON('["staging","bootstrap","pilot","canary","production","rollback"]'), inputs.stage) }}
         env:
           # Emergency environment secret/variable metadata requires the protected
           # read-only administration token; the automatic token is not granted
@@ -728,7 +729,7 @@ jobs:
             "$RUNNER_TEMP/ponto-pilot-runner-environment-variables.json" \
             "$RUNNER_TEMP/ponto-pilot-runner-encryption-repository-variable.json"
       - name: Attest unconditional edge blocks before any candidate mutation
-        if: ${{ contains(fromJSON('["staging","pilot","canary","production"]'), inputs.stage) }}
+        if: ${{ contains(fromJSON('["staging","bootstrap","pilot","canary","production"]'), inputs.stage) }}
         env:
           PONTO_WAF_READ_API_TOKEN: ${{ secrets.PONTO_WAF_READ_API_TOKEN }}
           CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
@@ -869,7 +870,7 @@ jobs:
           node .github/scripts/ponto-required-check-dispatch.mjs \
             "$PONTO_ARTIFACT_DIR/runs/required-check-workflows.json"
       - name: Prove selected root separation before any candidate mutation
-        if: ${{ inputs.stage == 'staging' || inputs.stage == 'pilot' }}
+        if: ${{ inputs.stage == 'staging' || inputs.stage == 'bootstrap' || inputs.stage == 'pilot' }}
         env:
           GH_TOKEN: ${{ github.token }}
           PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY: ${{ secrets.PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY }}
@@ -877,7 +878,7 @@ jobs:
         run: |
           set -euo pipefail
           target="$STAGE"
-          [[ "$target" == pilot ]] && target=production
+          [[ "$target" == bootstrap || "$target" == pilot ]] && target=production
           staging_run=''
           [[ "$target" == production ]] && staging_run="$PREDECESSOR_RUN_ID"
           node - "$RUNNER_TEMP/provision-workers.json" "$target" "$staging_run" <<'NODE'
@@ -987,7 +988,7 @@ jobs:
           echo "PONTO_BASELINE_RUN_ID=$baseline_run_id" >> "$GITHUB_ENV"
           rm -f "$RUNNER_TEMP/baseline-workflow.json" "$RUNNER_TEMP/baseline-runs.json" "$RUNNER_TEMP/reused-baseline-run.json"
       - name: Put Ponto in maintenance before staging or live mutation
-        if: ${{ contains(fromJSON('["staging","pilot","canary","production","rollback"]'), inputs.stage) }}
+        if: ${{ contains(fromJSON('["staging","bootstrap","pilot","canary","production","rollback"]'), inputs.stage) }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -1082,14 +1083,16 @@ jobs:
           const fs = require("fs");
           const inputs = { target: process.env.STAGE, release_scope: "ponto", release_sha: process.env.RELEASE_SHA, orchestrator_run_id: process.env.GITHUB_RUN_ID };
           if (process.env.STAGE === "staging") inputs.preview_run_id = process.env.PREDECESSOR_RUN_ID;
-          if (["staging", "pilot"].includes(process.env.STAGE)) {
+          if (["staging", "bootstrap", "pilot"].includes(process.env.STAGE)) {
             if (!/^[0-9]+$/.test(process.env.PONTO_ROOT_CUSTODY_RUN_ID || "")) {
-              throw new Error("staging and pilot require the exact pre-mutation root custody run");
+              throw new Error("staging, bootstrap, and pilot require the exact pre-mutation root custody run");
             }
             inputs.root_custody_run_id = process.env.PONTO_ROOT_CUSTODY_RUN_ID;
           }
-          if (["pilot", "canary", "production", "rollback"].includes(process.env.STAGE)) {
+          if (["bootstrap", "pilot", "canary", "production", "rollback"].includes(process.env.STAGE)) {
             inputs.predecessor_run_id = process.env.PREDECESSOR_RUN_ID;
+          }
+          if (["pilot", "canary", "production", "rollback"].includes(process.env.STAGE)) {
             inputs.rollback_from_stage = process.env.ROLLBACK_FROM_STAGE;
             if (process.env.STAGE === "pilot") inputs.baseline_run_id = process.env.PONTO_BASELINE_RUN_ID;
           }
@@ -1105,6 +1108,7 @@ jobs:
           fi
       - name: Publish and attest canonical Identity/Workforce surface
         id: identity
+        if: ${{ inputs.stage != 'bootstrap' }}
         env:
           GH_TOKEN: ${{ github.token }}
           PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY: ${{ secrets.PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY }}
@@ -1147,6 +1151,7 @@ jobs:
           fi
       - name: Publish and attest canonical Core API surface
         id: core
+        if: ${{ inputs.stage != 'bootstrap' }}
         env:
           GH_TOKEN: ${{ github.token }}
           PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY: ${{ secrets.PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY }}
@@ -1181,6 +1186,7 @@ jobs:
           fi
       - name: Publish and attest canonical CRM Pages surface
         id: pages
+        if: ${{ inputs.stage != 'bootstrap' }}
         env:
           GH_TOKEN: ${{ github.token }}
           PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY: ${{ secrets.PONTO_ORCHESTRATOR_CAPABILITY_PRIVATE_KEY }}
@@ -1623,13 +1629,18 @@ jobs:
           const path = require("path");
           const root = process.argv[2];
           const read = file => JSON.parse(fs.readFileSync(file, "utf8"));
-          const surfaces = {
-            timekeeping: read(path.join(root, "surfaces/timekeeping/surface.json")),
-            coreApi: read(path.join(root, "surfaces/core/surface.json")),
-            identityWorkforce: read(path.join(root, "surfaces/identity/surface.json")),
-            crmPages: read(path.join(root, "surfaces/pages/surface.json")),
-          };
-          if (process.env.STAGE === "staging" || process.env.STAGE === "pilot") {
+          const bootstrap = process.env.STAGE === "bootstrap";
+          const surfaces = bootstrap
+            ? {
+                timekeeping: read(path.join(root, "surfaces/timekeeping/surface.json")),
+              }
+            : {
+                timekeeping: read(path.join(root, "surfaces/timekeeping/surface.json")),
+                coreApi: read(path.join(root, "surfaces/core/surface.json")),
+                identityWorkforce: read(path.join(root, "surfaces/identity/surface.json")),
+                crmPages: read(path.join(root, "surfaces/pages/surface.json")),
+              };
+          if (["staging", "bootstrap", "pilot"].includes(process.env.STAGE)) {
             const preflightFile = path.join(root, "provisioning/workers/root-custody.json");
             const preflightRaw = fs.readFileSync(preflightFile);
             const preflight = JSON.parse(preflightRaw);
@@ -1668,29 +1679,53 @@ jobs:
           fs.writeFileSync(path.join(root, "surfaces.json"), JSON.stringify(surfaces));
           const checkpoints = Object.fromEntries([
             ["timekeeping", surfaces.timekeeping.checkpoint],
-            ["identityWorkforce", surfaces.identityWorkforce.checkpoint],
+            ["identityWorkforce", surfaces.identityWorkforce?.checkpoint],
           ].filter(([, value]) => value));
           fs.writeFileSync(path.join(root, "checkpoint.json"), JSON.stringify(Object.keys(checkpoints).length ? checkpoints : null));
           const migrations = [
             ...(surfaces.timekeeping.migrations || []).map(migration => ({ unit: "timekeeping", ...migration })),
-            ...(surfaces.identityWorkforce.migrations || []).map(migration => ({ unit: "identityWorkforce", ...migration })),
+            ...(surfaces.identityWorkforce?.migrations || []).map(migration => ({ unit: "identityWorkforce", ...migration })),
           ];
           fs.writeFileSync(path.join(root, "migrations.json"), JSON.stringify(migrations));
           const stagingDrill = process.env.STAGE === "staging"
             ? read(path.join(root, "staging-rollback-drill/ponto-staging-rollback-drill.json"))
             : null;
-          fs.writeFileSync(path.join(root, "rollback.json"), JSON.stringify({
-            executed: process.env.STAGE === "rollback" || stagingDrill?.passed === true,
-            mode: stagingDrill ? "staging-drill-restored-candidate" : (process.env.STAGE === "rollback" ? "live-rollback" : "not-executed"),
-            evidenceRunId: stagingDrill?.runId || "",
-            predecessorRunId: stagingDrill?.predecessor?.runId || "",
-            restoredCandidate: stagingDrill?.passed === true,
-            timekeepingVersionId: surfaces.timekeeping.incumbentVersionId,
-            coreVersionId: surfaces.coreApi.incumbentVersionId,
-            identityVersionId: surfaces.identityWorkforce.incumbentVersionId,
-            pagesDeploymentId: surfaces.crmPages.rollbackDeploymentId,
-          }));
-          if (process.env.STAGE === "staging") {
+          fs.writeFileSync(path.join(root, "rollback.json"), JSON.stringify(
+            bootstrap
+              ? {
+                  executed: false,
+                  mode: "timekeeping-bootstrap-maintenance",
+                  timekeepingVersionId: surfaces.timekeeping.incumbentVersionId,
+                }
+              : {
+                  executed: process.env.STAGE === "rollback" || stagingDrill?.passed === true,
+                  mode: stagingDrill ? "staging-drill-restored-candidate" : (process.env.STAGE === "rollback" ? "live-rollback" : "not-executed"),
+                  evidenceRunId: stagingDrill?.runId || "",
+                  predecessorRunId: stagingDrill?.predecessor?.runId || "",
+                  restoredCandidate: stagingDrill?.passed === true,
+                  timekeepingVersionId: surfaces.timekeeping.incumbentVersionId,
+                  coreVersionId: surfaces.coreApi.incumbentVersionId,
+                  identityVersionId: surfaces.identityWorkforce.incumbentVersionId,
+                  pagesDeploymentId: surfaces.crmPages.rollbackDeploymentId,
+                },
+          ));
+          if (bootstrap) {
+            const maintenance = surfaces.timekeeping.maintenance;
+            const passed = maintenance?.confirmed === true
+              && maintenance?.state === "maintenance"
+              && maintenance?.publicAvailable === false
+              && maintenance?.ready === false
+              && /^[0-9a-f]{64}$/.test(String(maintenance?.healthSha256 || ""));
+            fs.writeFileSync(path.join(root, "slo-summary.json"), JSON.stringify({
+              passed,
+              samples: 1,
+              errors: passed ? 0 : 1,
+              p95Ms: 0,
+              windowSeconds: 1,
+              digest: maintenance?.healthSha256 || "",
+              mode: "maintenance-bootstrap",
+            }));
+          } else if (process.env.STAGE === "staging") {
             const reportFile = path.join(root, "staging-slo/ponto-staging-report.json");
             const contractFile = path.join(root, "staging-slo/ponto-staging-contract.json");
             const teardownFile = path.join(root, "staging-slo/ponto-staging-teardown-report.json");

--- a/.github/workflows/ponto-release-gate.yml
+++ b/.github/workflows/ponto-release-gate.yml
@@ -107,6 +107,7 @@ jobs:
         run: |
           set -euo pipefail
           case "$STAGE" in
+            bootstrap) predecessor=staging ;;
             pilot) predecessor=staging ;;
             canary) predecessor=pilot ;;
             production) predecessor=canary ;;
@@ -114,7 +115,7 @@ jobs:
               [[ "$ROLLBACK_FROM_STAGE" =~ ^(pilot|canary|production)$ ]] || { echo 'rollback_from_stage must identify the current live stage'; exit 1; }
               predecessor="$ROLLBACK_FROM_STAGE"
               ;;
-            *) echo 'Ponto progressive gate accepts only pilot, canary, production, or rollback'; exit 1 ;;
+            *) echo 'Ponto progressive gate accepts only bootstrap, pilot, canary, production, or rollback'; exit 1 ;;
           esac
           echo "predecessor=$predecessor" >> "$GITHUB_OUTPUT"
       - name: Verify source ancestry and predecessor run provenance


### PR DESCRIPTION
## Summary
- adds the governed `bootstrap` Ponto stage to publish only Timekeeping to production at 100%
- keeps public Ponto explicitly fail-closed in `maintenance`, with health attestation
- preserves staging predecessor, production root custody, edge guard, capability lease, and watchdog fail-close
- does not run pilot credentials, identity/core/pages publishers, or cohort activation

## Validation
- `node --test .github/scripts/ponto-release-evidence.test.mjs .github/scripts/ponto-dispatch-workflow.test.mjs .github/scripts/ponto-orchestrator-lease.test.mjs .github/scripts/ponto-watchdog-context.test.mjs`
- `node --test .github/scripts/ponto-release-identity.test.mjs .github/scripts/ponto-secret-custody.test.mjs .github/scripts/ponto-watchdog-journal.test.mjs`
- `git diff --check`