### PR TITLE
feat(beauty-movement): reart ritmo natural

### DIFF
--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -2,7 +2,7 @@ import "@/styles/globals.css";
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { headers } from "next/headers";
-import { Oxanium, Urbanist } from "next/font/google";
+import { Bodoni_Moda, Oxanium, Urbanist } from "next/font/google";
 import Script from "next/script";
 import CookieBanner from "@/components/CookieBanner";
 import Analytics from "@/components/Analytics";
@@ -30,6 +30,17 @@ const brandTextFont = Urbanist({
   preload: false,
   variable: "--font-brand-text-loaded",
   weight: ["300", "400", "500", "600", "700", "800"],
+});
+
+// Loaded as an inert variable and consumed only by the Beauty Movement module.
+// Keeping it at the layout layer lets Next package the font without changing the
+// typography of the institutional surface.
+const beautyMovementEditorialFont = Bodoni_Moda({
+  subsets: ["latin"],
+  display: "swap",
+  preload: false,
+  variable: "--font-beauty-movement-editorial",
+  weight: ["400", "500", "600", "700"],
 });
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -124,7 +135,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         };
 
   return (
-    <html lang="pt-BR" className={`${brandUiFont.variable} ${brandTextFont.variable}`}>
+    <html lang="pt-BR" className={`${brandUiFont.variable} ${brandTextFont.variable} ${beautyMovementEditorialFont.variable}`}>
       <head>
         {buildSha ? <meta name="x-app-build" content={buildSha} /> : null}
         {buildTime ? <meta name="x-app-build-time" content={buildTime} /> : null}

--- a/website/src/components/BeautyMovementCampaign.module.css
+++ b/website/src/components/BeautyMovementCampaign.module.css
@@ -6,19 +6,19 @@
   gap: 1rem;
   padding: 3rem 1.5rem;
   text-align: center;
-  color: #303030;
-  background: #fafafa;
+  color: #17362e;
+  background: radial-gradient(circle at 72% 24%, rgba(229, 189, 49, 0.16), transparent 18rem), #f4eedf;
 }
 
 .statusPage h1 {
   max-width: 32rem;
   margin: 0;
-  font: 600 clamp(1.75rem, 5vw, 3.2rem) / 1.08 var(--font-brand-ui), sans-serif;
+  font: 500 clamp(2rem, 5vw, 3.4rem) / 0.96 var(--font-beauty-movement-editorial), "Bodoni Moda", serif;
 }
 
 .statusEyebrow {
   margin: 0;
-  color: #505050;
+  color: #5d7168;
   font: 700 0.76rem / 1.2 var(--font-brand-ui), sans-serif;
   letter-spacing: 0.13em;
   text-transform: uppercase;
@@ -32,8 +32,8 @@
 .loader {
   width: 2.5rem;
   height: 2.5rem;
-  border: 3px solid #d0d0d0;
-  border-top-color: #303030;
+  border: 2px solid #c5b58f;
+  border-top-color: #e5bd31;
   border-radius: 50%;
   animation: beautyMovementSpin 850ms linear infinite;
 }

--- a/website/src/components/BeautyMovementCardIllustration.tsx
+++ b/website/src/components/BeautyMovementCardIllustration.tsx
@@ -4,302 +4,178 @@ type BeautyMovementCardIllustrationProps = {
     cardId: string;
 };
 
-const strokeProps = {
+const lineProps = {
     fill: "none",
     stroke: "currentColor",
     strokeLinecap: "round" as const,
     strokeLinejoin: "round" as const,
-    strokeWidth: 2.4,
+    strokeWidth: 1.9,
 };
 
-const accentStrokeProps = {
+const softLineProps = {
+    ...lineProps,
+    opacity: 0.46,
+    strokeWidth: 1.15,
+};
+
+const pulseLineProps = {
     fill: "none",
     stroke: "var(--bm-yellow)",
     strokeLinecap: "round" as const,
     strokeLinejoin: "round" as const,
-    strokeWidth: 1.8,
+    strokeWidth: 1.7,
 };
 
-const accentFillProps = {
-    fill: "var(--bm-yellow)",
-};
-
-function Spark({ x, y, size = 7 }: { x: number; y: number; size?: number }) {
-    return <path d={`M ${x} ${y - size} V ${y + size} M ${x - size} ${y} H ${x + size}`} {...strokeProps} />;
+function Pulse({ x, y, r = 3 }: { x: number; y: number; r?: number }) {
+    return <circle cx={x} cy={y} r={r} fill="var(--bm-yellow)" />;
 }
 
-function AccentSpark({ x, y, size = 6 }: { x: number; y: number; size?: number }) {
-    return <path d={`M ${x} ${y - size} V ${y + size} M ${x - size} ${y} H ${x + size}`} {...accentStrokeProps} />;
+function QuietContour() {
+    return (
+        <>
+            <path d="M 34 126 C 42 87 57 51 102 34 C 119 28 132 30 140 36" {...lineProps} />
+            <path d="M 44 133 C 52 95 71 67 108 54 C 123 49 133 50 142 55" {...softLineProps} />
+            <path d="M 57 137 C 66 107 84 85 111 76 C 123 72 132 73 139 77" {...softLineProps} />
+            <path d="M 25 47 H 49 M 25 54 H 43 M 25 61 H 37" {...lineProps} />
+            <path d="M 49 126 C 73 126 84 128 99 140" {...pulseLineProps} />
+            <Pulse x={104} y={140} r={2.7} />
+        </>
+    );
 }
 
-function AccentDot({ cx, cy, r = 3 }: { cx: number; cy: number; r?: number }) {
-    return <circle cx={cx} cy={cy} r={r} {...accentFillProps} />;
+function VeinField() {
+    return (
+        <>
+            <path d="M 33 125 C 49 91 68 62 122 37" {...lineProps} />
+            <path d="M 45 116 C 66 99 79 76 87 51 M 59 127 C 82 111 101 84 111 57" {...softLineProps} />
+            <path d="M 63 103 C 74 96 84 94 96 95 M 76 80 C 88 73 100 71 114 73" {...softLineProps} />
+            <path d="M 28 136 C 61 133 101 119 137 91" {...softLineProps} />
+            <path d="M 116 38 C 125 35 133 34 140 35" {...pulseLineProps} />
+            <Pulse x={121} y={37} r={3} />
+        </>
+    );
+}
+
+function MeasuredPulse() {
+    return (
+        <>
+            <path d="M 23 66 H 52 C 63 66 66 94 80 94 C 94 94 97 66 108 66 H 139" {...lineProps} />
+            <path d="M 23 86 H 45 C 58 86 62 111 80 111 C 98 111 102 86 115 86 H 139" {...softLineProps} />
+            <path d="M 23 106 H 38 C 52 106 59 128 80 128 C 101 128 108 106 122 106 H 139" {...softLineProps} />
+            <path d="M 23 48 H 73" {...softLineProps} />
+            <path d="M 24 66 H 47" {...pulseLineProps} />
+            <Pulse x={52} y={66} r={3} />
+            <Pulse x={80} y={94} r={2.6} />
+            <Pulse x={108} y={66} r={2.2} />
+        </>
+    );
+}
+
+function RisingTrace() {
+    return (
+        <>
+            <path d="M 28 128 C 49 119 59 109 72 87 C 88 60 102 49 132 31" {...lineProps} />
+            <path d="M 28 138 C 57 130 78 110 93 85 C 105 66 118 52 137 42" {...softLineProps} />
+            <path d="M 46 104 C 60 109 70 109 82 103 M 69 77 C 83 82 96 80 107 71" {...softLineProps} />
+            <path d="M 117 40 C 124 36 132 32 141 29" {...pulseLineProps} />
+            <Pulse x={119} y={40} r={3} />
+        </>
+    );
+}
+
+function Convergence() {
+    return (
+        <>
+            <path d="M 25 38 C 48 42 63 53 80 78 C 95 100 112 116 138 123" {...lineProps} />
+            <path d="M 25 57 C 47 60 61 69 78 87 C 96 107 112 119 138 127" {...softLineProps} />
+            <path d="M 25 78 C 43 80 56 87 72 100 C 91 115 112 126 138 132" {...softLineProps} />
+            <path d="M 25 101 C 44 101 57 105 75 115 C 92 125 112 134 138 137" {...softLineProps} />
+            <path d="M 25 38 H 49" {...pulseLineProps} />
+            <Pulse x={54} y={43} r={3} />
+            <Pulse x={80} y={78} r={2.6} />
+            <Pulse x={112} y={116} r={2.2} />
+        </>
+    );
+}
+
+function QuietOrbit() {
+    return (
+        <>
+            <path d="M 47 49 C 65 30 99 28 119 45 C 139 62 137 94 118 112 C 100 129 66 132 46 114 C 27 97 28 67 47 49 Z" {...lineProps} />
+            <path d="M 56 58 C 71 43 96 42 110 55 C 124 68 123 91 109 104 C 94 117 70 118 56 105 C 42 92 42 72 56 58 Z" {...softLineProps} />
+            <path d="M 39 121 C 59 113 73 107 86 94 C 100 80 108 62 113 40" {...lineProps} />
+            <path d="M 39 121 C 48 122 57 124 66 129" {...pulseLineProps} />
+            <Pulse x={70} y={131} r={2.8} />
+        </>
+    );
+}
+
+function ReservedField() {
+    return (
+        <>
+            <path d="M 35 36 H 125 V 124 H 35 Z" {...lineProps} />
+            <path d="M 48 51 H 112 M 48 65 H 99 M 48 79 H 106 M 48 93 H 84" {...softLineProps} />
+            <path d="M 48 108 C 63 91 81 88 112 91" {...lineProps} />
+            <path d="M 48 108 C 60 105 69 106 79 113" {...pulseLineProps} />
+            <Pulse x={83} y={115} r={2.8} />
+        </>
+    );
 }
 
 function DefaultArt() {
     return (
         <>
-            <circle cx="80" cy="80" r="43" {...strokeProps} />
-            <circle cx="80" cy="80" r="8" fill="currentColor" />
-            <path d="M 80 22 V 39 M 80 121 V 138 M 22 80 H 39 M 121 80 H 138" {...strokeProps} />
+            <path d="M 31 80 H 53 C 65 80 67 58 80 58 C 93 58 95 102 108 102 H 129" {...lineProps} />
+            <path d="M 31 99 H 51 C 66 99 68 76 80 76 C 92 76 95 119 111 119 H 129" {...softLineProps} />
+            <path d="M 43 43 V 67 M 50 43 V 61 M 57 43 V 55" {...softLineProps} />
+            <Pulse x={108} y={102} r={3} />
         </>
     );
 }
 
-/** Original, monochrome editorial drawings for the card concepts. */
+/** Original campaign drawings: bar, organic trace and three changing pulses. */
 const BeautyMovementCardIllustration = memo(function BeautyMovementCardIllustration({ cardId }: BeautyMovementCardIllustrationProps) {
     let art: ReactNode;
 
     switch (cardId) {
         case "beleza-presenca":
-            art = (
-                <>
-                    <circle cx="80" cy="80" r="45" {...strokeProps} />
-                    <circle cx="80" cy="80" r="17" {...strokeProps} />
-                    <circle cx="80" cy="80" r="5" fill="currentColor" />
-                    <path d="M 80 19 C 108 34 119 52 119 80 C 119 108 105 126 80 141" {...strokeProps} />
-                    <path d="M 20 80 C 35 53 53 41 80 41" {...strokeProps} />
-                    <path d="M 80 13 C 121 25 143 51 143 80" {...accentStrokeProps} opacity="0.8" />
-                    <AccentDot cx={129} cy={42} r={2.8} />
-                    <AccentDot cx={34} cy={116} r={2.8} />
-                </>
-            );
+        case "beleza-radiancia":
+        case "beleza-harmonia":
+            art = <QuietContour />;
             break;
         case "beleza-autocuidado":
-            art = (
-                <>
-                    <path d="M 37 87 H 123 L 113 115 H 47 Z" {...strokeProps} />
-                    <path d="M 48 87 C 54 69 68 62 80 62 C 94 62 108 69 114 87" {...strokeProps} />
-                    <path d="M 80 62 C 76 48 83 35 99 29 C 104 46 98 60 80 62 Z" {...strokeProps} />
-                    <path d="M 42 125 H 118" {...strokeProps} />
-                    <Spark x={42} y={45} size={6} />
-                    <path d="M 80 62 C 82 48 90 38 99 29" {...accentStrokeProps} />
-                    <AccentDot cx={119} cy={65} r={3} />
-                    <AccentDot cx={46} cy={72} r={2.5} />
-                </>
-            );
+        case "beleza-autoria":
+        case "celebracao-renovacao":
+            art = <VeinField />;
             break;
         case "movimento-constancia":
-            art = (
-                <>
-                    <path d="M 29 112 C 45 91 48 119 64 98 C 80 76 82 103 99 81 C 111 65 119 75 130 58" {...strokeProps} />
-                    <circle cx="29" cy="112" r="5" fill="currentColor" />
-                    <circle cx="64" cy="98" r="5" fill="currentColor" />
-                    <circle cx="99" cy="81" r="5" fill="currentColor" />
-                    <circle cx="130" cy="58" r="5" fill="currentColor" />
-                    <path d="M 119 57 L 132 55 L 128 68" {...strokeProps} />
-                    <path d="M 28 122 C 57 111 82 107 111 84" {...accentStrokeProps} opacity="0.8" />
-                    <AccentDot cx={48} cy={108} r={2.5} />
-                    <AccentDot cx={113} cy={74} r={2.5} />
-                </>
-            );
+        case "movimento-ritmo":
+        case "movimento-sintonia":
+            art = <MeasuredPulse />;
             break;
         case "movimento-potencia":
-            art = (
-                <>
-                    <path d="M 80 23 L 91 61 L 132 64 L 100 87 L 111 127 L 80 104 L 49 127 L 60 87 L 28 64 L 69 61 Z" {...strokeProps} />
-                    <circle cx="80" cy="77" r="10" fill="currentColor" />
-                    <path d="M 80 23 V 12 M 28 64 L 18 59 M 132 64 L 142 59" {...strokeProps} />
-                    <path d="M 80 16 V 7 M 38 56 L 30 51 M 122 56 L 130 51" {...accentStrokeProps} />
-                    <AccentSpark x={80} y={137} size={5} />
-                </>
-            );
+        case "celebracao-impulso":
+            art = <RisingTrace />;
             break;
         case "celebracao-confianca":
-            art = (
-                <>
-                    <path d="M 80 24 L 121 40 V 76 C 121 104 103 123 80 137 C 57 123 39 104 39 76 V 40 Z" {...strokeProps} />
-                    <path d="M 80 94 C 74 88 61 80 61 70 C 61 59 75 56 80 67 C 85 56 99 59 99 70 C 99 80 86 88 80 94 Z" {...strokeProps} />
-                    <path d="M 55 39 L 80 29 L 105 39" {...strokeProps} />
-                    <path d="M 80 24 V 15 M 49 35 L 43 28 M 111 35 L 117 28" {...accentStrokeProps} />
-                    <AccentDot cx={80} cy={105} r={3} />
-                </>
-            );
-            break;
-        case "celebracao-renovacao":
-            art = (
-                <>
-                    <path d="M 50 56 C 60 35 89 27 109 43 C 123 54 126 75 118 92" {...strokeProps} />
-                    <path d="M 110 85 L 119 96 L 104 97" {...strokeProps} />
-                    <path d="M 110 104 C 100 125 71 133 51 117 C 37 106 34 85 42 68" {...strokeProps} />
-                    <path d="M 50 75 L 41 64 L 56 63" {...strokeProps} />
-                    <path d="M 80 115 C 75 99 80 87 95 78 C 98 95 92 108 80 115 Z" {...strokeProps} />
-                    <path d="M 80 115 V 75" {...strokeProps} />
-                    <path d="M 80 115 C 69 102 64 89 67 74" {...accentStrokeProps} />
-                    <AccentDot cx={42} cy={68} r={2.5} />
-                    <AccentDot cx={119} cy={96} r={2.5} />
-                </>
-            );
-            break;
-        case "beleza-radiancia":
-            art = (
-                <>
-                    <circle cx="80" cy="80" r="26" fill="currentColor" />
-                    <circle cx="80" cy="80" r="41" {...strokeProps} />
-                    {Array.from({ length: 8 }, (_, index) => {
-                        const angle = (index * Math.PI) / 4;
-                        const x1 = 80 + Math.cos(angle) * 51;
-                        const y1 = 80 + Math.sin(angle) * 51;
-                        const x2 = 80 + Math.cos(angle) * 68;
-                        const y2 = 80 + Math.sin(angle) * 68;
-                        return <path key={`${x1}-${y1}`} d={`M ${x1} ${y1} L ${x2} ${y2}`} {...strokeProps} />;
-                    })}
-                    <AccentSpark x={43} y={80} size={5} />
-                    <AccentDot cx={118} cy={43} r={3} />
-                    <AccentDot cx={43} cy={118} r={3} />
-                </>
-            );
+        case "celebracao-encontro":
+            art = <Convergence />;
             break;
         case "movimento-leveza":
-            art = (
-                <>
-                    <path d="M 31 92 C 51 52 92 35 130 48 C 111 55 99 68 91 87 C 80 112 56 119 31 112 C 43 104 45 97 31 92 Z" {...strokeProps} />
-                    <path d="M 43 103 C 68 91 89 74 112 53" {...strokeProps} />
-                    <path d="M 55 75 C 65 72 73 72 83 75 M 49 88 C 60 85 68 85 77 87" {...strokeProps} />
-                    <Spark x={119} y={106} size={6} />
-                    <path d="M 38 98 C 62 77 86 59 119 49" {...accentStrokeProps} opacity="0.8" />
-                    <AccentDot cx={42} cy={62} r={2.5} />
-                </>
-            );
-            break;
         case "celebracao-brilho":
-            art = (
-                <>
-                    <path d="M 80 19 L 88 67 L 135 80 L 88 92 L 80 141 L 72 92 L 25 80 L 72 67 Z" {...strokeProps} />
-                    <circle cx="80" cy="80" r="9" fill="currentColor" />
-                    <Spark x={42} y={42} size={5} />
-                    <Spark x={119} y={45} size={5} />
-                    <Spark x={119} y={119} size={5} />
-                    <path d="M 80 10 V 26 M 18 80 H 34 M 126 80 H 142" {...accentStrokeProps} />
-                    <AccentDot cx={40} cy={119} r={3} />
-                </>
-            );
-            break;
-        case "beleza-autoria":
-            art = (
-                <>
-                    <path d="M 32 105 C 53 77 75 62 120 48 C 111 74 91 102 62 119 C 49 126 37 119 32 105 Z" {...strokeProps} />
-                    <path d="M 48 111 L 110 58" {...strokeProps} />
-                    <path d="M 113 47 L 128 32 L 132 50 L 120 60 Z" {...strokeProps} />
-                    <path d="M 35 129 C 65 136 97 128 119 111" {...strokeProps} />
-                    <path d="M 42 118 L 108 58" {...accentStrokeProps} />
-                    <AccentDot cx={119} cy={42} r={3} />
-                </>
-            );
-            break;
-        case "movimento-ritmo":
-            art = (
-                <>
-                    <path d="M 22 67 C 37 48 52 48 67 67 C 82 86 97 86 112 67 C 123 53 132 53 140 62" {...strokeProps} />
-                    <path d="M 22 94 C 37 75 52 75 67 94 C 82 113 97 113 112 94 C 123 80 132 80 140 89" {...strokeProps} />
-                    <circle cx="44" cy="54" r="5" fill="currentColor" />
-                    <circle cx="80" cy="80" r="5" fill="currentColor" />
-                    <circle cx="116" cy="106" r="5" fill="currentColor" />
-                    <path d="M 23 55 H 41 M 77 80 H 95 M 113 105 H 137" {...accentStrokeProps} />
-                    <AccentDot cx={134} cy={48} r={3} />
-                </>
-            );
-            break;
-        case "celebracao-impulso":
-            art = (
-                <>
-                    <path d="M 24 115 C 54 108 75 91 91 64 C 101 47 113 35 134 29" {...strokeProps} />
-                    <path d="M 118 26 L 136 28 L 131 45" {...strokeProps} />
-                    <circle cx="34" cy="113" r="7" fill="currentColor" />
-                    <circle cx="63" cy="98" r="5" fill="currentColor" />
-                    <circle cx="88" cy="69" r="4" fill="currentColor" />
-                    <Spark x={123} y={93} size={6} />
-                    <path d="M 28 126 C 60 119 92 94 127 38" {...accentStrokeProps} opacity="0.78" />
-                    <AccentDot cx={107} cy={48} r={3} />
-                </>
-            );
-            break;
-        case "beleza-harmonia":
-            art = (
-                <>
-                    <circle cx="64" cy="80" r="35" {...strokeProps} />
-                    <circle cx="96" cy="80" r="35" {...strokeProps} />
-                    <path d="M 80 52 C 88 63 88 97 80 108 C 72 97 72 63 80 52 Z" fill="currentColor" opacity="0.75" />
-                    <circle cx="80" cy="80" r="5" fill="currentColor" />
-                    <path d="M 80 39 V 28 M 80 121 V 132" {...accentStrokeProps} />
-                    <AccentDot cx={45} cy={80} r={3} />
-                    <AccentDot cx={115} cy={80} r={3} />
-                </>
-            );
-            break;
-        case "movimento-sintonia":
-            art = (
-                <>
-                    <circle cx="80" cy="80" r="10" fill="currentColor" />
-                    <circle cx="80" cy="80" r="28" {...strokeProps} />
-                    <circle cx="80" cy="80" r="47" {...strokeProps} />
-                    <path d="M 31 80 H 17 M 129 80 H 143" {...strokeProps} />
-                    <circle cx="31" cy="80" r="5" fill="currentColor" />
-                    <circle cx="129" cy="80" r="5" fill="currentColor" />
-                    <path d="M 80 15 V 28 M 80 132 V 145" {...accentStrokeProps} />
-                    <AccentDot cx={41} cy={53} r={3} />
-                    <AccentDot cx={119} cy={107} r={3} />
-                </>
-            );
-            break;
-        case "celebracao-encontro":
-            art = (
-                <>
-                    <circle cx="58" cy="80" r="31" {...strokeProps} />
-                    <circle cx="102" cy="80" r="31" {...strokeProps} />
-                    <path d="M 80 48 C 67 62 67 98 80 112 C 93 98 93 62 80 48 Z" fill="currentColor" opacity="0.72" />
-                    <path d="M 47 125 C 63 136 97 136 113 125" {...strokeProps} />
-                    <Spark x={80} y={31} size={6} />
-                    <path d="M 38 80 C 52 64 65 57 80 57 C 95 57 108 64 122 80" {...accentStrokeProps} opacity="0.78" />
-                    <AccentDot cx={80} cy={132} r={3} />
-                </>
-            );
+            art = <QuietOrbit />;
             break;
         case "reward-reserved":
-            art = (
-                <>
-                    <rect x="39" y="36" width="82" height="88" rx="10" {...strokeProps} />
-                    <path d="M 54 63 H 106 M 54 82 H 94 M 54 101 H 82" {...strokeProps} />
-                    <path d="M 80 22 V 39 M 80 121 V 138" {...accentStrokeProps} />
-                    <AccentDot cx={38} cy={48} r={3} />
-                    <AccentDot cx={122} cy={112} r={3} />
-                </>
-            );
+            art = <ReservedField />;
             break;
         case "reward-procedure":
-            art = (
-                <>
-                    <circle cx="80" cy="75" r="42" {...strokeProps} />
-                    <path d="M 64 110 L 58 139 L 80 127 L 102 139 L 96 110" {...strokeProps} />
-                    <path d="M 80 46 L 87 67 L 109 68 L 92 81 L 98 103 L 80 90 L 62 103 L 68 81 L 51 68 L 73 67 Z" {...accentStrokeProps} />
-                    <AccentDot cx={39} cy={42} r={3} />
-                    <AccentDot cx={121} cy={42} r={3} />
-                </>
-            );
+            art = <Convergence />;
             break;
         case "reward-discount":
-            art = (
-                <>
-                    <path d="M 30 55 L 62 28 H 126 V 92 L 94 124 H 30 Z" {...strokeProps} />
-                    <circle cx="103" cy="52" r="6" {...accentFillProps} />
-                    <path d="M 50 100 L 104 46" {...accentStrokeProps} />
-                    <circle cx="57" cy="75" r="7" {...strokeProps} />
-                    <circle cx="94" cy="96" r="7" {...strokeProps} />
-                    <path d="M 30 55 V 124 H 94" {...accentStrokeProps} opacity="0.8" />
-                </>
-            );
+            art = <MeasuredPulse />;
             break;
         case "reward-velocity":
-            art = (
-                <>
-                    <circle cx="80" cy="80" r="48" {...strokeProps} />
-                    <path d="M 49 50 L 63 110 L 80 80 L 97 110 L 111 50" {...strokeProps} />
-                    <path d="M 22 128 C 47 143 113 143 138 128" {...accentStrokeProps} />
-                    <path d="M 31 32 C 56 16 104 16 129 32" {...accentStrokeProps} opacity="0.78" />
-                    <AccentDot cx={35} cy={128} r={3} />
-                    <AccentDot cx={125} cy={128} r={3} />
-                </>
-            );
+            art = <RisingTrace />;
             break;
         default:
             art = <DefaultArt />;

--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -1,20 +1,20 @@
 .page {
-  --bm-bg: #fafafa;
-  --bm-surface: #ffffff;
-  --bm-surface-soft: #f5f5f5;
-  --bm-ink: #303030;
-  --bm-muted: #505050;
-  --bm-line: #d0d0d0;
-  --bm-line-strong: #a8a8a8;
-  --bm-yellow: #f5b301;
-  --bm-yellow-soft: #fff2bd;
-  --bm-yellow-ink: #825900;
-  --bm-shadow: 0 10px 24px rgba(48, 48, 48, 0.08);
+  --bm-bg: #102720;
+  --bm-surface: #f4eedf;
+  --bm-surface-soft: #e8ddc8;
+  --bm-ink: #17362e;
+  --bm-muted: #5d7168;
+  --bm-line: #c5b58f;
+  --bm-line-strong: #9e865e;
+  --bm-yellow: #e5bd31;
+  --bm-yellow-soft: #f4df8d;
+  --bm-yellow-ink: #604b12;
+  --bm-shadow: 0 18px 42px rgba(5, 24, 18, 0.24);
   position: relative;
   overflow-x: hidden;
   min-height: 0;
   padding: clamp(24px, 3.5vw, 46px) 0 clamp(32px, 4vw, 56px);
-  background: var(--bm-bg);
+  background: radial-gradient(circle at 72% 16%, rgba(229, 189, 49, 0.12), transparent 23rem), var(--bm-bg);
   color: var(--bm-ink);
 }
 
@@ -813,26 +813,26 @@
 }
 
 .specialCardModalOverlay {
-  --bm-bg: #fafafa;
-  --bm-surface: #ffffff;
-  --bm-surface-soft: #f5f5f5;
-  --bm-ink: #303030;
-  --bm-muted: #505050;
-  --bm-line: #d0d0d0;
-  --bm-line-strong: #a8a8a8;
-  --bm-yellow: #f5b301;
-  --bm-yellow-soft: #fff2bd;
-  --bm-yellow-ink: #825900;
-  --bm-shadow: 0 10px 24px rgba(48, 48, 48, 0.08);
+  --bm-bg: #102720;
+  --bm-surface: #f4eedf;
+  --bm-surface-soft: #e8ddc8;
+  --bm-ink: #17362e;
+  --bm-muted: #5d7168;
+  --bm-line: #c5b58f;
+  --bm-line-strong: #9e865e;
+  --bm-yellow: #e5bd31;
+  --bm-yellow-soft: #f4df8d;
+  --bm-yellow-ink: #604b12;
+  --bm-shadow: 0 18px 42px rgba(5, 24, 18, 0.24);
   position: fixed;
   z-index: 80;
   inset: 0;
   display: grid;
   place-items: center;
   padding: clamp(16px, 4vw, 32px);
-  background: rgba(10, 10, 11, 0.64);
-  backdrop-filter: blur(10px) saturate(0.84);
-  -webkit-backdrop-filter: blur(10px) saturate(0.84);
+  background: rgba(5, 24, 18, 0.86);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
   animation: specialCardModalBackdropEnter 260ms ease-out both;
 }
 
@@ -2479,5 +2479,743 @@
     opacity: 0;
     transform: translate3d(0, 0, 0) scale(0.2);
     animation: none !important;
+  }
+}
+
+/* Ritmo Natural — a campaign-only editorial layer. The state-machine rules
+ * above deliberately remain intact; this block only changes the material,
+ * hierarchy and light of the existing experience. */
+.backgroundOrbOne,
+.backgroundOrbTwo {
+  position: absolute;
+  z-index: 0;
+  display: block;
+  pointer-events: none;
+}
+
+.backgroundOrbOne {
+  top: clamp(80px, 12vw, 180px);
+  right: min(-19vw, -180px);
+  width: clamp(300px, 43vw, 620px);
+  height: clamp(300px, 43vw, 620px);
+  border: 1px solid rgba(197, 181, 143, 0.32);
+  border-radius: 49% 51% 56% 44% / 41% 52% 48% 59%;
+  background: radial-gradient(circle at 34% 32%, rgba(244, 238, 223, 0.13), transparent 54%);
+}
+
+.backgroundOrbTwo {
+  bottom: clamp(180px, 22vw, 360px);
+  left: min(-17vw, -160px);
+  width: clamp(250px, 37vw, 510px);
+  height: clamp(250px, 37vw, 510px);
+  border: 1px solid rgba(229, 189, 49, 0.18);
+  border-radius: 56% 44% 40% 60% / 51% 43% 57% 49%;
+}
+
+.rhythmThread {
+  position: absolute;
+  z-index: 0;
+  inset: 0 0 auto;
+  width: 100%;
+  height: clamp(310px, 35vw, 420px);
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.rhythmThread svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.rhythmThreadRail,
+.rhythmThreadVein {
+  fill: none;
+  stroke: rgba(197, 181, 143, 0.72);
+  stroke-linecap: round;
+  stroke-width: 1.1;
+}
+
+.rhythmThreadRail {
+  stroke-dasharray: 4 5;
+}
+
+.rhythmThreadBeat {
+  fill: var(--bm-yellow);
+  filter: drop-shadow(0 0 7px rgba(229, 189, 49, 0.78));
+}
+
+.shell {
+  position: relative;
+  z-index: 1;
+  width: min(1180px, calc(100% - 40px));
+}
+
+.hero {
+  position: relative;
+  isolation: isolate;
+  justify-items: start;
+  max-width: 100%;
+  min-height: clamp(260px, 29vw, 390px);
+  margin: 0;
+  padding: clamp(36px, 6vw, 82px) clamp(28px, 7vw, 104px) clamp(46px, 6vw, 78px);
+  gap: clamp(18px, 2.5vw, 28px);
+  color: var(--bm-ink);
+  text-align: left;
+}
+
+.hero::before {
+  position: absolute;
+  z-index: -1;
+  inset: 0 clamp(-2px, -0.4vw, -6px) 0 0;
+  border: 1px solid rgba(158, 134, 94, 0.44);
+  border-radius: 0 0 clamp(54px, 9vw, 130px) 0;
+  background: radial-gradient(circle at 82% 34%, rgba(229, 189, 49, 0.13), transparent 20rem), var(--bm-surface);
+  box-shadow: 0 18px 42px rgba(5, 24, 18, 0.16);
+  content: "";
+}
+
+.hero::after {
+  position: absolute;
+  z-index: -1;
+  right: clamp(24px, 6vw, 94px);
+  bottom: clamp(24px, 4vw, 56px);
+  width: min(35%, 270px);
+  height: 42%;
+  border-top: 1px solid rgba(158, 134, 94, 0.52);
+  border-right: 1px solid rgba(158, 134, 94, 0.3);
+  border-radius: 100% 0 0;
+  content: "";
+  opacity: 0.8;
+}
+
+.hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.heroKicker {
+  display: inline-flex;
+  align-items: center;
+  margin: 0;
+  color: var(--bm-muted);
+  font-family: var(--font-brand-ui), sans-serif;
+  font-size: clamp(0.68rem, 0.9vw, 0.78rem);
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  line-height: 1.15;
+  text-transform: uppercase;
+}
+
+.heroKicker::before {
+  width: 26px;
+  height: 1px;
+  margin-right: 11px;
+  background: var(--bm-yellow);
+  content: "";
+}
+
+.hero h1 {
+  max-width: min(900px, 94%);
+  color: var(--bm-ink);
+  font-family: var(--font-beauty-movement-editorial), "Bodoni Moda", serif;
+  font-size: clamp(3.4rem, 7.2vw, 7.15rem);
+  font-weight: 500;
+  letter-spacing: -0.065em;
+  line-height: 0.87;
+}
+
+.heroDeckInstruction {
+  max-width: 30rem;
+  margin: 0;
+  padding-left: 16px;
+  border-left: 1px solid var(--bm-yellow);
+  color: var(--bm-muted);
+  font-family: var(--font-brand-text), sans-serif;
+  font-size: clamp(0.9rem, 1.25vw, 1.04rem);
+  font-weight: 500;
+  letter-spacing: 0.012em;
+  line-height: 1.5;
+  text-align: left;
+}
+
+.tableStage {
+  width: min(100%, 1040px);
+  margin: clamp(14px, 2vw, 22px) auto 0;
+  gap: clamp(10px, 1.6vw, 18px);
+  padding: 0 0 clamp(30px, 5vw, 70px);
+}
+
+.tableStage[data-finale-stage="hidden"] {
+  padding-bottom: clamp(92px, 10vw, 122px);
+}
+
+.tableStage::before {
+  top: 10%;
+  left: -3%;
+  width: clamp(116px, 15vw, 190px);
+  height: clamp(116px, 15vw, 190px);
+  border-color: rgba(197, 181, 143, 0.28);
+}
+
+.tableStage::after {
+  right: -1%;
+  bottom: 8%;
+  width: clamp(142px, 19vw, 250px);
+  height: clamp(142px, 19vw, 250px);
+  border-color: rgba(229, 189, 49, 0.15);
+}
+
+.progressRow {
+  justify-content: flex-start;
+  width: min(100%, 920px);
+  min-height: 52px;
+  margin: 0 auto;
+}
+
+.progressGroup {
+  width: min(100%, 700px);
+}
+
+.progress {
+  justify-content: flex-start;
+  gap: clamp(14px, 2.3vw, 34px);
+}
+
+.progressItem {
+  color: rgba(244, 238, 223, 0.52);
+}
+
+.progressItemDone {
+  color: rgba(244, 238, 223, 0.82);
+}
+
+.progressButton {
+  min-height: 38px;
+  border-bottom-color: rgba(197, 181, 143, 0.28);
+  border-radius: 0;
+  text-align: left;
+}
+
+.progressButton:hover:not(:disabled) {
+  color: var(--bm-surface);
+}
+
+.progressButton:focus-visible,
+.deckStage:focus-visible {
+  outline-color: var(--bm-yellow);
+}
+
+.progressItem strong {
+  font-family: var(--font-brand-ui), sans-serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+}
+
+.progressItemCurrent {
+  color: var(--bm-surface);
+}
+
+.progressItemCurrent .progressButton {
+  border-bottom-color: var(--bm-yellow);
+  border-radius: 0;
+  background: transparent;
+  color: var(--bm-surface);
+  box-shadow: inset 0 -1px 0 rgba(229, 189, 49, 0.24);
+}
+
+.progressItemCurrent .progressButton:hover {
+  background: transparent;
+  color: var(--bm-surface);
+}
+
+.progressTransfer {
+  border-radius: 0;
+  background: var(--bm-yellow);
+  box-shadow: 0 0 18px rgba(229, 189, 49, 0.4);
+}
+
+.autoAdvance::after {
+  background: var(--bm-yellow);
+}
+
+.tableSurface {
+  overflow: hidden;
+  border-color: rgba(197, 181, 143, 0.72);
+  border-radius: clamp(10px, 1.5vw, 18px);
+  background: radial-gradient(circle at 78% 12%, rgba(229, 189, 49, 0.13), transparent 16rem), radial-gradient(circle at 13% 86%, rgba(244, 238, 223, 0.08), transparent 20rem), var(--bm-bg);
+  box-shadow: 0 28px 58px rgba(3, 18, 13, 0.36), inset 0 1px 0 rgba(244, 238, 223, 0.08);
+}
+
+.tableSurface[data-deck-state="intro"],
+.tableSurface[data-deck-state="prompt"] {
+  border-color: rgba(197, 181, 143, 0.52);
+}
+
+.tablePrompt {
+  max-width: 41rem;
+  color: rgba(244, 238, 223, 0.78);
+  font-family: var(--font-brand-text), sans-serif;
+}
+
+.promptTitle {
+  color: var(--bm-surface);
+  font-family: var(--font-beauty-movement-editorial), "Bodoni Moda", serif;
+  font-size: clamp(1.5rem, 2.5vw, 2.25rem);
+  font-weight: 500;
+  letter-spacing: -0.045em;
+  line-height: 1.03;
+}
+
+.promptSubtitle {
+  color: rgba(244, 238, 223, 0.66);
+}
+
+.tableDeckPromptArrow {
+  color: var(--bm-yellow);
+}
+
+.deckCard {
+  border-color: rgba(197, 181, 143, 0.74);
+  border-radius: 7px;
+  background: radial-gradient(circle at 68% 22%, rgba(229, 189, 49, 0.18), transparent 4rem), #0a201a;
+  box-shadow: 0 14px 28px rgba(3, 18, 13, 0.42);
+}
+
+.deckCard::after {
+  inset: 7px;
+  border-color: rgba(197, 181, 143, 0.72);
+  border-radius: 3px;
+}
+
+.deckBrandLogo {
+  width: 42px;
+}
+
+.sectionLabel {
+  color: rgba(244, 238, 223, 0.7);
+  font-family: var(--font-brand-ui), sans-serif;
+  letter-spacing: 0.18em;
+}
+
+.cardGrid {
+  gap: clamp(12px, 2vw, 24px);
+}
+
+.cardButton {
+  overflow: visible;
+  border-radius: 7px;
+}
+
+.cardButton:hover:not(:disabled),
+.cardButton:focus-visible:not(:disabled) {
+  transform: translateY(-5px);
+}
+
+.cardFront,
+.cardBack {
+  overflow: hidden;
+  border-radius: 7px;
+}
+
+.cardFront {
+  border-color: rgba(197, 181, 143, 0.82);
+  background: radial-gradient(circle at 78% 20%, rgba(229, 189, 49, 0.12), transparent 7rem), #102a22;
+  box-shadow: 0 18px 28px rgba(3, 18, 13, 0.32), inset 0 1px 0 rgba(244, 238, 223, 0.1);
+}
+
+.cardFront::before {
+  top: 18%;
+  right: -118px;
+  width: 238px;
+  height: 238px;
+  border-color: rgba(197, 181, 143, 0.54);
+}
+
+.cardFront::after {
+  bottom: 12%;
+  left: -76px;
+  width: 170px;
+  height: 170px;
+  border-color: rgba(244, 238, 223, 0.16);
+}
+
+.cardPrompt,
+.cardActLabel {
+  font-family: var(--font-brand-ui), sans-serif;
+  font-size: 0.66rem;
+  letter-spacing: 0.18em;
+}
+
+.cardPrompt {
+  color: rgba(244, 238, 223, 0.8);
+}
+
+.cardPrompt::before {
+  width: 5px;
+  height: 5px;
+  margin-right: 8px;
+  background: var(--bm-yellow);
+  box-shadow: 0 0 9px rgba(229, 189, 49, 0.7);
+}
+
+.cardBrandMark {
+  width: 126px;
+  height: 78px;
+  border-color: rgba(197, 181, 143, 0.64);
+  border-radius: 0;
+}
+
+.cardBrandMark::before {
+  inset: 10px;
+  border-color: rgba(244, 238, 223, 0.18);
+  border-radius: 0;
+}
+
+.cardBrandMark::after {
+  top: 15px;
+  right: 16px;
+  width: 5px;
+  height: 5px;
+  background: var(--bm-yellow);
+  box-shadow: 0 0 10px rgba(229, 189, 49, 0.7);
+}
+
+.cardBrandLogo {
+  width: 72px;
+}
+
+.cardBack {
+  border: 1px solid rgba(197, 181, 143, 0.92);
+  border-top: 2px solid var(--bm-yellow);
+  background: radial-gradient(circle at 85% 14%, rgba(229, 189, 49, 0.14), transparent 8rem), var(--bm-surface);
+  box-shadow: 0 20px 32px rgba(3, 18, 13, 0.3);
+  color: var(--bm-ink);
+}
+
+.cardBack .cardIllustration,
+.finaleCardIllustration,
+.specialCardIllustration {
+  color: var(--bm-ink);
+}
+
+.cardBack strong,
+.finaleCardFace strong,
+.specialCardBack strong,
+.specialCardFront strong,
+.specialCardConfirmation h2 {
+  font-family: var(--font-beauty-movement-editorial), "Bodoni Moda", serif;
+  font-weight: 500;
+  letter-spacing: -0.045em;
+  line-height: 0.94;
+}
+
+.cardBack > span:last-child,
+.finaleCardMessage,
+.specialCardCopy {
+  color: var(--bm-muted);
+  font-family: var(--font-brand-text), sans-serif;
+}
+
+.cardSparkles > span {
+  width: 10px;
+  height: 10px;
+  border: 1px solid rgba(229, 189, 49, 0.34);
+  border-radius: 999px;
+  background: transparent;
+}
+
+.cardSparkles > span::before {
+  inset: 2px;
+  width: auto;
+  height: auto;
+  border-radius: 999px;
+  background: var(--bm-yellow);
+  box-shadow: 0 0 10px rgba(229, 189, 49, 0.72);
+  content: "";
+  transform: none;
+}
+
+.finaleCardFace {
+  border-color: rgba(197, 181, 143, 0.9);
+  border-top-color: var(--bm-yellow);
+  border-radius: 7px;
+  background: radial-gradient(circle at 84% 16%, rgba(229, 189, 49, 0.15), transparent 8rem), var(--bm-surface);
+  box-shadow: 0 22px 36px rgba(3, 18, 13, 0.34);
+}
+
+.finaleCardAct,
+.specialCardBackLabel,
+.specialCardKind {
+  color: var(--bm-yellow-ink);
+  font-family: var(--font-brand-ui), sans-serif;
+  letter-spacing: 0.18em;
+}
+
+.finaleCardIllustration svg {
+  filter: drop-shadow(0 8px 12px rgba(23, 54, 46, 0.12));
+}
+
+.specialCardStage,
+.specialCard {
+  min-height: 430px;
+}
+
+.specialCard {
+  width: min(100%, 360px);
+}
+
+.specialCardFace {
+  border-radius: 7px;
+}
+
+.specialCardBack {
+  border-color: rgba(197, 181, 143, 0.82);
+  background: radial-gradient(circle at 78% 20%, rgba(229, 189, 49, 0.16), transparent 9rem), #102a22;
+  box-shadow: 0 24px 40px rgba(3, 18, 13, 0.42);
+}
+
+.specialCardBack::before,
+.specialCardBack::after {
+  border-color: rgba(197, 181, 143, 0.36);
+  border-radius: 48% 52% 42% 58% / 55% 42% 58% 45%;
+}
+
+.specialCardBack::after {
+  border-color: rgba(229, 189, 49, 0.48);
+}
+
+.specialCardBrand {
+  width: 104px;
+  height: 72px;
+}
+
+.specialCardBackLabel {
+  color: rgba(244, 238, 223, 0.66);
+}
+
+.specialCardBack > span:not(.specialCardBrand):not(.specialCardBackLabel):not(.specialCardSeal) {
+  color: rgba(244, 238, 223, 0.72);
+  font-family: var(--font-brand-text), sans-serif;
+}
+
+.specialCardSeal {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  color: transparent;
+  font-size: 0;
+}
+
+.specialCardSeal i {
+  display: block;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--bm-yellow);
+  box-shadow: 0 0 9px rgba(229, 189, 49, 0.72);
+}
+
+.specialCardSeal i:nth-child(2) {
+  transform: translateY(-5px);
+}
+
+.specialCardFront {
+  border-color: rgba(197, 181, 143, 0.92);
+  border-top-color: var(--bm-yellow);
+  background: radial-gradient(circle at 82% 17%, rgba(229, 189, 49, 0.16), transparent 9rem), var(--bm-surface);
+  box-shadow: 0 24px 40px rgba(3, 18, 13, 0.38);
+}
+
+.specialCardModalOverlay {
+  background: rgba(5, 24, 18, 0.86);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
+.specialCardModalClose {
+  border-color: rgba(197, 181, 143, 0.58);
+  border-radius: 50%;
+  background: #102a22;
+  box-shadow: 0 10px 24px rgba(3, 18, 13, 0.38);
+  color: var(--bm-surface);
+}
+
+.specialCardModalClose:hover,
+.specialCardModalClose:focus-visible {
+  border-color: var(--bm-yellow);
+  background: var(--bm-surface);
+  color: var(--bm-ink);
+}
+
+.specialCardConfirmation {
+  border-color: rgba(197, 181, 143, 0.92);
+  border-radius: 7px;
+  background: var(--bm-surface);
+  box-shadow: 0 20px 36px rgba(3, 18, 13, 0.28);
+}
+
+.primaryButton,
+.secondaryButton {
+  border-radius: 4px;
+  font-family: var(--font-brand-ui), sans-serif;
+  font-size: 0.72rem;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.primaryButton,
+.specialCardRevealAction .primaryButton,
+.specialCardWhatsappAction {
+  border-color: var(--bm-ink);
+  background: var(--bm-ink);
+  color: var(--bm-surface);
+  box-shadow: 0 12px 22px rgba(3, 18, 13, 0.18);
+}
+
+.primaryButton:hover,
+.primaryButton:focus-visible,
+.specialCardRevealAction .primaryButton:hover,
+.specialCardRevealAction .primaryButton:focus-visible,
+.specialCardWhatsappAction:hover,
+.specialCardWhatsappAction:focus-visible {
+  border-color: var(--bm-yellow);
+  background: var(--bm-yellow);
+  color: var(--bm-ink);
+  box-shadow: 0 14px 24px rgba(3, 18, 13, 0.2);
+}
+
+.secondaryButton {
+  border-color: var(--bm-line-strong);
+  background: transparent;
+  color: var(--bm-ink);
+}
+
+.consentField {
+  border-color: rgba(197, 181, 143, 0.7);
+  border-radius: 4px;
+  background: var(--bm-surface-soft);
+  color: var(--bm-muted);
+}
+
+.consentField input {
+  accent-color: var(--bm-ink);
+}
+
+.inlineError,
+.fieldError {
+  color: #763f2e;
+}
+
+.inlineError {
+  border-color: rgba(118, 63, 46, 0.38);
+  border-radius: 4px;
+  background: #f7e7d9;
+}
+
+@keyframes deckReceivePulse {
+  0%,
+  100% {
+    box-shadow: 0 14px 28px rgba(3, 18, 13, 0.42);
+    filter: brightness(1);
+    transform: rotate(1deg) scale(1);
+  }
+
+  45% {
+    box-shadow: 0 0 0 5px rgba(229, 189, 49, 0.08), 0 0 28px rgba(229, 189, 49, 0.5);
+    filter: brightness(1.12);
+    transform: rotate(1deg) scale(1.025);
+  }
+}
+
+@media (max-width: 720px) {
+  .backgroundOrbOne {
+    top: 190px;
+    right: -190px;
+  }
+
+  .backgroundOrbTwo {
+    bottom: 280px;
+    left: -190px;
+  }
+
+  .rhythmThread {
+    height: 310px;
+    opacity: 0.74;
+  }
+
+  .shell {
+    width: min(100% - 24px, 1180px);
+  }
+
+  .hero {
+    min-height: 300px;
+    padding: 36px 26px 44px;
+  }
+
+  .hero::before {
+    border-radius: 0 0 52px 0;
+  }
+
+  .hero h1 {
+    max-width: 100%;
+    font-size: clamp(3.15rem, 15vw, 5.4rem);
+    line-height: 0.89;
+  }
+
+  .heroDeckInstruction {
+    max-width: 20rem;
+    font-size: 0.9rem;
+  }
+
+  .progressRow {
+    justify-content: center;
+  }
+
+  .progressGroup {
+    width: 100%;
+  }
+
+  .progress {
+    justify-content: center;
+    gap: clamp(10px, 3.4vw, 20px);
+  }
+
+  .progressItem strong {
+    font-size: 0.65rem;
+    letter-spacing: 0.11em;
+  }
+
+  .tableSurface {
+    border-radius: 10px;
+  }
+
+  .specialCardStage,
+  .specialCard {
+    min-height: 410px;
+  }
+
+  .cardFront,
+  .cardBack,
+  .finaleCardFace,
+  .specialCardFace {
+    border-radius: 6px;
+  }
+
+  .cardBrandMark {
+    width: 120px;
+    height: 74px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rhythmThread {
+    display: none;
+  }
+
+  .backgroundOrbOne,
+  .backgroundOrbTwo {
+    opacity: 0.45;
   }
 }

--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -1378,7 +1378,9 @@ export default function BeautyMovementExperience({
                             </div>
                         ) : null}
                         <span className={styles.specialCardSeal} aria-hidden="true">
-                            ✦
+                            <i />
+                            <i />
+                            <i />
                         </span>
                     </div>
                     <div className={`${styles.specialCardFace} ${styles.specialCardFront}`} aria-hidden={!revealed}>
@@ -1438,9 +1440,19 @@ export default function BeautyMovementExperience({
         <main className={styles.page} aria-hidden={isSpecialCardModalOpen || undefined}>
             <div className={styles.backgroundOrbOne} aria-hidden="true" />
             <div className={styles.backgroundOrbTwo} aria-hidden="true" />
+            <div className={styles.rhythmThread} aria-hidden="true">
+                <svg viewBox="0 0 1200 420" preserveAspectRatio="none" focusable="false">
+                    <path className={styles.rhythmThreadRail} d="M 0 56 H 208" />
+                    <path className={styles.rhythmThreadVein} d="M 208 56 C 306 56 310 166 412 166 C 516 166 522 86 628 86 C 742 86 728 244 844 244 C 960 244 976 156 1200 156" />
+                    <circle className={styles.rhythmThreadBeat} cx="844" cy="244" r="4" />
+                    <circle className={styles.rhythmThreadBeat} cx="876" cy="226" r="3.5" />
+                    <circle className={styles.rhythmThreadBeat} cx="908" cy="210" r="3" />
+                </svg>
+            </div>
 
             <section className={styles.shell} aria-labelledby="beauty-movement-title">
                 <header className={styles.hero}>
+                    <p className={styles.heroKicker}>3 anos. 3 cartas.</p>
                     <h1 id="beauty-movement-title">{initialState.campaign.title?.trim() || "Beleza que se move com você."}</h1>
                     <p
                         className={`${styles.heroDeckInstruction} ${waitingForInitialDeal ? "" : styles.heroDeckInstructionHidden}`.trim()}

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -233,12 +233,15 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.match(experience, /role="dialog"/);
     assert.match(experience, /aria-modal="true"/);
 
-    assert.match(styles, /--bm-bg: #fafafa/i);
-    assert.match(styles, /--bm-ink: #303030/i);
-    assert.match(styles, /--bm-muted: #505050/i);
-    assert.match(styles, /--bm-line: #d0d0d0/i);
-    assert.match(styles, /--bm-yellow: #f5b301/i);
+    assert.match(styles, /--bm-bg: #102720/i);
+    assert.match(styles, /--bm-ink: #17362e/i);
+    assert.match(styles, /--bm-muted: #5d7168/i);
+    assert.match(styles, /--bm-line: #c5b58f/i);
+    assert.match(styles, /--bm-yellow: #e5bd31/i);
     assert.doesNotMatch(styles, /Georgia|--bm-plum|--bm-coral|linear-gradient/i);
+    assert.match(styles, /\.rhythmThread \{/);
+    assert.match(styles, /\.heroKicker \{/);
+    assert.match(styles, /--font-beauty-movement-editorial/);
     assert.doesNotMatch(styles, /\.autoAdvanceNumber/);
     assert.match(styles, /@keyframes autoAdvanceProgress/);
     assert.match(styles, /@keyframes cardIllustrationDraw/);
@@ -247,7 +250,7 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.match(styles, /@keyframes cardFlipAndSettle/);
     assert.match(styles, /@keyframes cardSparkle/);
     assert.match(styles, /@keyframes deckDealPulse/);
-    assert.doesNotMatch(styles, /@keyframes deckReceivePulse/);
+    assert.match(styles, /@keyframes deckReceivePulse/);
     assert.match(styles, /@keyframes deckStageDeal/);
     assert.match(styles, /@keyframes deckStageExpand/);
     assert.match(styles, /@keyframes deckStageCollect/);
@@ -355,7 +358,7 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.match(styles, /\.specialCardStage \{[\s\S]*gap: 0;/);
     assert.match(styles, /\.specialCardStageReopen \{[\s\S]*min-height: 430px/);
     assert.doesNotMatch(styles, /\.specialCardReopenCard/);
-    assert.match(styles, /\.specialCardModalOverlay \{[\s\S]*--bm-ink: #303030[\s\S]*position: fixed[\s\S]*backdrop-filter: blur\(10px\)/);
+    assert.match(styles, /\.specialCardModalOverlay \{[\s\S]*--bm-ink: #17362e[\s\S]*position: fixed[\s\S]*backdrop-filter: none/);
     assert.match(styles, /\.specialCardModalDialog \{[\s\S]*place-items: center/);
     assert.match(styles, /\.specialCardModalClose \{[\s\S]*position: absolute/);
     assert.match(styles, /@keyframes specialCardModalBackdropEnter/);
@@ -442,7 +445,7 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.doesNotMatch(experience, /Arial, sans-serif/);
     assert.match(illustrations, /beleza-presenca/);
     assert.match(illustrations, /celebracao-encontro/);
-    assert.match(campaignStyles, /background: #fafafa/i);
+    assert.match(campaignStyles, /#f4eedf/i);
     assert.doesNotMatch(campaignStyles, /Georgia|coral|plum|linear-gradient|#fffaf2/i);
     assert.doesNotMatch(experience, /confirmationStage|confirmationIntro|contactSummary|confirmationForm/);
     assert.doesNotMatch(styles, /confirmationStage|confirmationIntro|contactSummary|confirmationForm/);


### PR DESCRIPTION
# Summary

Rearticula a experiência **Beleza em Movimento** como um único sistema editorial de ritmo natural: papel marfim, mesa verde-profunda, filetes champanhe, micro-pulsos de luz e ilustrações originais de linha. A jornada, as regras de sessão, confirmação, WhatsApp, telemetria e acessibilidade permanecem inalteradas.

## Type of change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (README, API refs, diagrams) — no contract or operational documentation changed
- [ ] Security review (CodeQL, gitleaks) — no security surface changed; existing privacy/session tests pass
- [ ] Performance impact measured

## Links
- Issue: —
- Design/ADR: visual-reference briefing supplied for this campaign
- Migration steps: none; no flags, APIs, D1 records, campaign dates or activation settings changed

## Screenshots / Evidence
- `npm test -- --test-name-pattern "continuous experience reuses the real shell"`: 134/134 passed.
- `npm run build`: passed, including `/beleza-em-movimento` and `/beleza-em-movimento/local-preview`.
- Browser journey checked from local preview: entry, three choices, automatic and manual progression, convergence, reveal, close and reopen.
- Visual QA checked at desktop and 390×844 with no horizontal overflow or console errors; `prefers-reduced-motion` keeps the manual reading state and disables auto-advance.
- Preserves the now-merged final-card geometry from #1442.