### PR TITLE
fix(token-vault): bootstrap staging operational bearer

### DIFF
--- a/.github/workflows/deploy-token-vault.yml
+++ b/.github/workflows/deploy-token-vault.yml
@@ -901,6 +901,10 @@ jobs:
           # only for the governed v20 promotion: it is the least-privileged
           # bearer that can perform the config/exercise readbacks below.
           TOKEN_VAULT_META_ADS_CONFIG_TOKEN: ${{ secrets.TOKEN_VAULT_META_ADS_CONFIG_TOKEN }}
+          # Staging has no Orb consumer. Its operational bearer is a distinct
+          # Environment secret and is injected only into the candidate version.
+          # Production continues to inherit its established Orb-bound bearer.
+          TOKEN_VAULT_N8N_API_TOKEN: ${{ inputs.target == 'staging' && secrets.TOKEN_VAULT_N8N_API_TOKEN || '' }}
           TOKEN_VAULT_STAGING_BASE_URL: ${{ vars.TOKEN_VAULT_STAGING_BASE_URL }}
           TOKEN_VAULT_PRODUCTION_BASE_URL: ${{ vars.TOKEN_VAULT_PRODUCTION_BASE_URL }}
           ENABLE_TOKEN_VAULT_DEPLOY_STAGING: ${{ vars.ENABLE_TOKEN_VAULT_DEPLOY_STAGING }}
@@ -925,7 +929,14 @@ jobs:
           if [[ "$TARGET" == production ]]; then ENV_ARGS=(); DB=skincos-token-vault; else ENV_ARGS=(--env staging); DB=skincos-token-vault-staging; fi
           npx --yes wrangler@4.120.0 d1 list --json | DB="$DB" node -e "const fs=require('fs');const rows=JSON.parse(fs.readFileSync(0,'utf8'));if(!rows.some(row=>row.name===process.env.DB)){throw new Error('configured Token Vault D1 is absent')}"
           secrets_json="$(npx --yes wrangler@4.120.0 secret list --format json --config platform/security/token-vault/wrangler.toml "${ENV_ARGS[@]}")"
-          printf '%s' "$secrets_json" | node -e "const fs=require('fs');const rows=JSON.parse(fs.readFileSync(0,'utf8'));const names=new Set(rows.map(row=>row.name||row));for(const name of ['TOKEN_VAULT_API_TOKEN','TOKEN_VAULT_N8N_API_TOKEN','TOKEN_VAULT_ENCRYPTION_KEY'])if(!names.has(name))throw new Error('required inherited Worker secret is absent: '+name);"
+          printf '%s' "$secrets_json" | node -e "const fs=require('fs');const rows=JSON.parse(fs.readFileSync(0,'utf8'));const names=new Set(rows.map(row=>row.name||row));for(const name of ['TOKEN_VAULT_API_TOKEN','TOKEN_VAULT_ENCRYPTION_KEY'])if(!names.has(name))throw new Error('required inherited Worker secret is absent: '+name);"
+          if [[ "$TARGET" == staging ]]; then
+            [[ -n "${TOKEN_VAULT_N8N_API_TOKEN:-}" ]] || { echo 'TOKEN_VAULT_N8N_API_TOKEN must be owned by the staging Environment'; exit 1; }
+            [[ ${#TOKEN_VAULT_N8N_API_TOKEN} -ge 32 ]] || { echo 'staging operational bearer is invalid'; exit 1; }
+            [[ "$TOKEN_VAULT_N8N_API_TOKEN" != "$TOKEN_VAULT_META_ADS_CONFIG_TOKEN" ]] || { echo 'staging operational and config bearers must differ'; exit 1; }
+          else
+            printf '%s' "$secrets_json" | node -e "const fs=require('fs');const rows=JSON.parse(fs.readFileSync(0,'utf8'));const names=new Set(rows.map(row=>row.name||row));if(!names.has('TOKEN_VAULT_N8N_API_TOKEN'))throw new Error('required inherited Worker secret is absent: TOKEN_VAULT_N8N_API_TOKEN');"
+          fi
 
       - name: Validate Token Vault and Meta Ads Publish source
         timeout-minutes: 8
@@ -1132,6 +1143,10 @@ jobs:
           # The Worker treats this binding as optional, but the governed v20
           # release preflight already required the Environment-held bearer.
           TOKEN_VAULT_META_ADS_CONFIG_TOKEN: ${{ secrets.TOKEN_VAULT_META_ADS_CONFIG_TOKEN }}
+          # Environment-scoped source for the isolated staging operational
+          # bearer. It is intentionally ignored for production, where Orb and
+          # Worker must retain their already-attested shared binding.
+          TOKEN_VAULT_N8N_API_TOKEN: ${{ inputs.target == 'staging' && secrets.TOKEN_VAULT_N8N_API_TOKEN || '' }}
           TARGET: ${{ inputs.target }}
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
         run: |
@@ -1139,13 +1154,15 @@ jobs:
           if [[ "$TARGET" == production ]]; then ENV_ARGS=(); else ENV_ARGS=(--env staging); fi
           secrets_file="$RUNNER_TEMP/token-vault-${TARGET}-candidate-secrets.json"
           secret_inventory="$RUNNER_TEMP/token-vault-${TARGET}-remote-secrets.json"
-          trap 'rm -f "$secrets_file" "$secret_inventory"; unset analytics_value' EXIT
+          trap 'rm -f "$secrets_file" "$secret_inventory"; unset analytics_value n8n_value' EXIT
           npx --yes wrangler@4.120.0 secret list --format json --config platform/security/token-vault/wrangler.toml "${ENV_ARGS[@]}" > "$secret_inventory"
           analytics_required="$(node - "$secret_inventory" <<'NODE'
           const fs = require('fs');
           const rows = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
           const names = new Set(rows.map((row) => row?.name || row));
-          for (const name of ['TOKEN_VAULT_API_TOKEN', 'TOKEN_VAULT_N8N_API_TOKEN', 'TOKEN_VAULT_ENCRYPTION_KEY']) {
+          const requiredInherited = ['TOKEN_VAULT_API_TOKEN', 'TOKEN_VAULT_ENCRYPTION_KEY'];
+          if (process.env.TARGET === 'production') requiredInherited.push('TOKEN_VAULT_N8N_API_TOKEN');
+          for (const name of requiredInherited) {
             if (!names.has(name)) throw new Error(`required inherited Worker secret is absent: ${name}`);
           }
           process.stdout.write(names.has('TOKEN_VAULT_ANALYTICS_API_TOKEN') ? 'false' : 'true');
@@ -1158,7 +1175,8 @@ jobs:
               analytics_value="$(node --input-type=module -e "import { randomBytes } from 'node:crypto'; process.stdout.write(randomBytes(32).toString('base64url'));")"
             fi
           fi
-          ANALYTICS_REQUIRED="$analytics_required" ANALYTICS_VALUE="$analytics_value" META_ADS_CONFIG_VALUE="${TOKEN_VAULT_META_ADS_CONFIG_TOKEN:-}" SECRETS_FILE="$secrets_file" node --input-type=module <<'NODE'
+          n8n_value="${TOKEN_VAULT_N8N_API_TOKEN:-}"
+          ANALYTICS_REQUIRED="$analytics_required" ANALYTICS_VALUE="$analytics_value" META_ADS_CONFIG_VALUE="${TOKEN_VAULT_META_ADS_CONFIG_TOKEN:-}" N8N_VALUE="$n8n_value" TARGET="$TARGET" SECRETS_FILE="$secrets_file" node --input-type=module <<'NODE'
           import fs from 'node:fs';
 
           const secrets = {};
@@ -1169,6 +1187,12 @@ jobs:
           }
           const configToken = String(process.env.META_ADS_CONFIG_VALUE || '');
           if (configToken) secrets.TOKEN_VAULT_META_ADS_CONFIG_TOKEN = configToken;
+          if (process.env.TARGET === 'staging') {
+            const operationalToken = String(process.env.N8N_VALUE || '');
+            if (operationalToken.length < 32) throw new Error('staging operational bearer is invalid');
+            if (operationalToken === configToken) throw new Error('staging operational and config bearers must differ');
+            secrets.TOKEN_VAULT_N8N_API_TOKEN = operationalToken;
+          }
           fs.writeFileSync(process.env.SECRETS_FILE, `${JSON.stringify(secrets)}\n`, { mode: 0o600 });
           NODE
           chmod 600 "$secrets_file"

--- a/platform/security/token-vault/README.md
+++ b/platform/security/token-vault/README.md
@@ -206,7 +206,19 @@ configuração inválida fora de `staging` + `shadow` com o módulo desabilitado
 exigindo remoção/rotação explícita antes de qualquer promoção futura. A única chamada Graph do gate é
 feita depois pelo router Meta-only, com timeout de 12 s e retry seguro limitado.
 
-## Deploy
+## Governed deploy
+
+Use `.github/workflows/deploy-token-vault.yml` for every staging or production
+promotion. It creates an immutable Worker candidate, preserves inherited
+production bindings, and activates only after its environment-specific gates
+and rollback evidence pass.
+
+Staging has no Orb consumer for the Token Vault operational bearer. Its
+`TOKEN_VAULT_N8N_API_TOKEN` is therefore an independent, high-entropy protected
+GitHub Environment secret. The canonical workflow writes it only to the
+candidate `--secrets-file` with private permissions and never prints it or uses
+`wrangler secret put`. Production retains its already-attested Orb/Worker
+binding; it is not copied into staging.
 
 O Token Vault é publicado exclusivamente por
 `.github/workflows/deploy-token-vault.yml`: Preview -> Staging -> Production.
@@ -229,7 +241,8 @@ manualmente para publicar este serviço.
 
 Antes da primeira promoção, disponibilize em cada GitHub Environment os
 segredos independentes exigidos pelo workflow, em especial
-`TOKEN_VAULT_META_ADS_CONFIG_TOKEN`; disponibilize
+`TOKEN_VAULT_META_ADS_CONFIG_TOKEN` e, em staging,
+`TOKEN_VAULT_N8N_API_TOKEN`; disponibilize
 `TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST` somente com as fontes/tags autorizadas
 quando a autoridade for legada, e um perfil de tracking sintético autorizado em
 staging. A ausência de credencial, manifesto legada necessário, fixture,

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -94,6 +94,7 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
     "ENABLE_TOKEN_VAULT_DEPLOY_STAGING",
     "ENABLE_TOKEN_VAULT_PRODUCTION_DEPLOY",
     "TOKEN_VAULT_META_ADS_CONFIG_TOKEN",
+    "TOKEN_VAULT_N8N_API_TOKEN",
     "TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST",
     "Capture Token Vault D1 Time Travel recovery bookmark before migrations",
     "d1 time-travel info",
@@ -115,11 +116,12 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
   assert.doesNotMatch(workflow, /TOKEN_VAULT_BACKUP_PASSPHRASE/);
   for (const legacySecret of [
     "TOKEN_VAULT_API_TOKEN",
-    "TOKEN_VAULT_N8N_API_TOKEN",
     "TOKEN_VAULT_ENCRYPTION_KEY",
   ]) {
     assert.doesNotMatch(workflow, new RegExp(`secrets\\.${legacySecret}`));
   }
+  assert.match(workflow, /inputs\.target == 'staging' && secrets\.TOKEN_VAULT_N8N_API_TOKEN \|\| ''/);
+  assert.doesNotMatch(workflow, /TOKEN_VAULT_N8N_API_TOKEN:\s*\$\{\{\s*secrets\.TOKEN_VAULT_N8N_API_TOKEN\s*}}/);
   assert.match(workflow, /versions upload[\s\S]*?--keep-vars[\s\S]*?--strict[\s\S]*?--secrets-file/);
   assert.match(workflow, /legacy alpha backend; Time Travel recovery is unavailable and the release is ineligible/);
   assert.ok(workflow.indexOf("Capture Token Vault D1 Time Travel recovery bookmark before migrations") < workflow.indexOf("Apply additive Token Vault migrations atomically"));
@@ -133,6 +135,10 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
   assert.doesNotMatch(release, /for name [^\n]*TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST/);
   assert.match(release, /Object\.keys\(manifest\)\.length !== 1/);
   assert.match(release, /TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST is required only when legacy bootstrap is detected/);
+  assert.match(release, /TOKEN_VAULT_N8N_API_TOKEN must be owned by the staging Environment/);
+  assert.match(release, /if \[\[ "\$TARGET" == staging \]\]; then[\s\S]*?TOKEN_VAULT_N8N_API_TOKEN/);
+  assert.match(release, /if \(process\.env\.TARGET === 'production'\) requiredInherited\.push\('TOKEN_VAULT_N8N_API_TOKEN'\)/);
+  assert.match(release, /if \(process\.env\.TARGET === 'staging'\) \{[\s\S]*?secrets\.TOKEN_VAULT_N8N_API_TOKEN/);
   assert.match(release, /expected_config_authority_revision: expectedRevision/);
   assert.match(release, /entries: manifest\.entries/);
   assert.match(release, /bootstrap_operation_key="meta-ads-bootstrap:\$\{RELEASE_SHA:0:12\}:\$\{GITHUB_RUN_ID\}:\$\{GITHUB_RUN_ATTEMPT\}"/);


### PR DESCRIPTION
## What changed

Adds the governed bootstrap path for a missing staging-only `TOKEN_VAULT_N8N_API_TOKEN`.

- staging receives an independent operational bearer only from its protected GitHub Environment;
- the immutable Worker candidate receives it only through the private `--secrets-file` path;
- production continues to require and inherit its existing Orb-bound Worker secret;
- static governance coverage prevents accidental unconditional production mapping.

## Why

The staging rollout stopped before mutation because the Worker required the operational bearer but the canonical candidate upload had no bootstrap source for it. Staging has no Orb consumer, so copying the production bearer would be an incorrect trust-plane coupling.

## Validation

- Prettier YAML/Markdown check
- Bash syntax for the changed workflow blocks
- `global-concurrency-governance-static` (18/18)
- Token Vault test suite (120/120)
- Orb embedded-source synchronization
- deploy topology and Cloudflare single-writer validators

## Rollback

Revert this commit. The change does not activate or rotate any production credential; production continues to require the inherited incumbent binding.
