### PR TITLE
governance: classify internally generated secrets

### DIFF
--- a/.codex/hooks/tests/test-skill-installer.ps1
+++ b/.codex/hooks/tests/test-skill-installer.ps1
@@ -15,6 +15,8 @@ $targetRoot = Join-Path $testRoot 'installed'
 $target = Join-Path $targetRoot 'skincos-project-orchestrator'
 $defaultTargetRoot = Join-Path $testRoot 'default-installed'
 $defaultTarget = Join-Path $defaultTargetRoot 'skincos-project-orchestrator'
+$customSkillName = 'skincos-secret-provisioning'
+$customTarget = Join-Path $defaultTargetRoot $customSkillName
 $installer = Join-Path $RepositoryRoot 'scripts\install-project-skill.ps1'
 
 try {
@@ -24,6 +26,27 @@ try {
     throw 'Installer did not resolve its default source root.'
   }
   & $installer -TargetRoot $defaultTargetRoot -Uninstall
+
+  & $installer -TargetRoot $defaultTargetRoot -SkillName $customSkillName
+  $customLink = Get-Item -LiteralPath $customTarget -Force
+  if (-not ($customLink.Attributes -band [IO.FileAttributes]::ReparsePoint)) {
+    throw 'Installer did not install the requested versioned skill.'
+  }
+  & $installer -TargetRoot $defaultTargetRoot -SkillName $customSkillName
+  & $installer -TargetRoot $defaultTargetRoot -SkillName $customSkillName -Uninstall
+  if (Test-Path -LiteralPath $customTarget) {
+    throw 'Custom skill uninstall left the junction in place.'
+  }
+
+  $invalidSkillNameRefused = $false
+  try {
+    & $installer -TargetRoot $defaultTargetRoot -SkillName '..\outside'
+  } catch {
+    $invalidSkillNameRefused = $true
+  }
+  if (-not $invalidSkillNameRefused) {
+    throw 'Installer accepted an unsafe skill name.'
+  }
 
   foreach ($source in @($sourceOne, $sourceTwo)) {
     New-Item -ItemType Directory -Path (Join-Path $source 'skills\skincos-project-orchestrator') -Force | Out-Null

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,10 @@
   flags still require applicable domain gates, real platform permission,
   rollback and evidence; a missing gate is a concrete blocker, not a reason to
   ask again for permission.
+- Before treating an absent secret as a human blocker, classify it through the
+  autonomy policy: a mission-authorized `INTERNAL GENERATED SECRET` with write
+  access to its canonical store is provisioned autonomously; an `EXTERNALLY
+  ISSUED CREDENTIAL` remains fail-closed.
 
 ## Source of Truth
 

--- a/docs/codex-autonomy.md
+++ b/docs/codex-autonomy.md
@@ -30,7 +30,7 @@ Secret values must never be committed or printed in logs. The preflight only che
 
 ## Local preflight
 
-Run before critical deploy, secret rotation, or when Codex needs full autonomy:
+Run before a production deploy, an elevated secret/credential operation, or when Codex needs full autonomy:
 
 ```bash
 npm run codex:preflight

--- a/docs/decisions/codex-autonomy-policy.md
+++ b/docs/decisions/codex-autonomy-policy.md
@@ -29,7 +29,7 @@ pergunta diferente.
 
 | Ordem | Fonte | Decide |
 | --- | --- | --- |
-| 1 | Limites não contornáveis da plataforma, lei e segurança | O que o agente não pode burlar: confiança da plataforma, credenciais inexistentes, segredo/PII exposto, ação destrutiva irreversível sobre dado real e controles externos obrigatórios. |
+| 1 | Limites não contornáveis da plataforma, lei e segurança | O que o agente não pode burlar: confiança da plataforma, emissão externa indisponível, segredo/PII exposto, ação destrutiva irreversível sobre dado real e controles externos obrigatórios. |
 | 2 | Missão explícita atual do usuário | Objetivo, superfícies, ações autorizadas, exceções humanas e critério de conclusão. |
 | 3 | Esta política | Como a autorização da missão é persistida, transportada e distinguida de gates técnicos. |
 | 4 | Políticas de domínio, runbooks e contratos de release | Elegibilidade técnica: flags, grants, migrations, rollout, testes, evidência, rollback e validação por ambiente. |
@@ -58,15 +58,45 @@ produção, smoke, rollback e cleanup.
 Autorização para segredos permite somente sua criação, rotação, referência ou
 uso por canais e armazenamentos aprovados. Valores de segredo, tokens, cookies,
 chaves privadas e PII nunca são exibidos, versionados ou incluídos em
-evidência. Autorização também não cria credenciais, bypass de MFA, permissões
-de plataforma ou acesso a dados que o agente não possui.
+evidência. Autorização não fabrica credenciais emitidas externamente, bypass de
+MFA, permissões de plataforma ou acesso a dados que o agente não possui.
 
 Risco técnico e reversibilidade definem o rigor de validação, checkpoint,
 rollout e rollback. Eles não exigem nova decisão humana quando a missão já
 autorizou a ação. Ações irreversíveis ou destrutivas sobre dados reais continuam
 fora do escopo até uma decisão humana específica.
 
-### 3.1 Validação delivery-first
+### 3.1 Classificação por emissão e contrato
+
+A classificação depende de quem define a validade do valor e do contrato que o
+aceita, não de seu nome, store atual, ausência ou presença de um gerador
+versionado.
+
+**INTERNAL GENERATED SECRET** é um bearer opaco interno, webhook secret,
+application authentication secret, signing/random secret ou outro segredo cuja
+validade seja definida inteiramente por sistemas controlados pelo SKINCOS.
+Quando a missão já autoriza a superfície e o Codex tem escrita no armazenamento
+canônico, ele deve gerar o valor automaticamente com CSPRNG de ao menos 256
+bits de entropia, salvo contrato diferente; gravá-lo diretamente no store
+canônico; nunca imprimi-lo ou registrá-lo em repositório, worktree, arquivo,
+log, artifact, PR ou conversa; validar somente existência/metadados e
+comportamento autenticado; e continuar a missão sem nova autorização humana.
+
+“Absence of a versioned generator alone is not evidence that an internal generated secret requires human intervention.”
+
+**EXTERNALLY ISSUED CREDENTIAL** é OAuth, autenticação GitHub, credencial de
+API Cloudflare/provider, Meta access token, certificado/chave privada emitida
+externamente, MFA/OTP ou outra credencial cuja emissão dependa de outra
+autoridade. O Codex nunca a fabrica: tenta primeiro o mecanismo canônico e
+autenticado de emissão, refresh ou rotação. Só a trata como blocker humano
+quando MFA/autenticação interativa, permissão realmente ausente ou decisão de
+confiança externa não puderem ser concluídos pelas ferramentas disponíveis.
+
+Compatibilidade criptográfica, migração de dados, dual-key, sobreposição e
+rollback continuam gates técnicos proporcionais ao efeito. A falta de um desses
+gates não reclassifica um segredo interno ausente como exceção humana.
+
+### 3.2 Validação delivery-first
 
 O classificador versionado em `ops/codex/risk-policy.json` usa efeito, não o
 nome da ferramenta, para escolher o gate:
@@ -89,7 +119,12 @@ domínio alterado é relevante.
 ## 4. Exceções humanas
 
 Para uma missão que adota a autorização persistente desta política, o agente só
-interrompe por uma ação humana quando houver prova de uma destas situações:
+interrompe por uma ação humana quando houver prova de uma destas situações. Para
+uma `EXTERNALLY ISSUED CREDENTIAL`, a ausência só é exceção após a tentativa
+canônica autenticada de emissão ou rotação:
+
+A ausência de um `INTERNAL GENERATED SECRET` que atende às condições da seção
+3.1 não é exceção humana.
 
 1. MFA ou reautenticação interativa que nenhuma ferramenta disponível conclui;
 2. permissão realmente ausente e não provisionável pelo Codex;
@@ -138,9 +173,11 @@ O caminho canônico para custódia GitHub -> mini-PC é o runner confiável
 usa um usuário de serviço sem login e pode chamar somente o helper root que
 escreve o arquivo privado de coordenação por stdin, atomicamente e sem emitir o
 valor. A ausência de custódia no mini-PC é, portanto, uma recuperação técnica
-executável; não é uma espera humana recorrente. Somente a criação inicial de
-uma credencial inexistente, MFA/reautenticação ou confiança de plataforma fora
-do alcance continua sendo exceção humana.
+executável; não é uma espera humana recorrente. Um `INTERNAL GENERATED SECRET`
+ausente segue a classificação desta política e é gerado quando a missão e a
+escrita no store canônico o permitem. Somente a emissão indisponível de uma
+`EXTERNALLY ISSUED CREDENTIAL`, MFA/reautenticação ou confiança de plataforma
+fora do alcance continua sendo exceção humana.
 
 Quando a sessão GitHub já autenticada e o acesso root nativo existem, o
 bootstrap do runner também é uma ação autônoma: use

--- a/docs/decisions/operational-change-policy.md
+++ b/docs/decisions/operational-change-policy.md
@@ -63,6 +63,7 @@ Antes de produção, o PR ou registro de release declara:
 - Rollback de código usa versão/deployment/release anterior comprovado.
 - Rollback de dados não apaga histórico, ledger, auditoria ou evidência. Se reversão de dado não for segura, desativar flag, bloquear escrita e recuperar de backup/checkpoint aprovado.
 - Nenhuma promoção é concluída sem prova de que o rollback identificado é executável.
+- Para rotação de secret, o rollback identifica custódia, versão ou janela de overlap previamente verificável; listagem de metadados não recompõe o valor anterior.
 
 ## 5. Feature flags e coortes
 
@@ -78,8 +79,8 @@ Antes de produção, o PR ou registro de release declara:
 | --- | --- | --- |
 | Baixo | texto, documentação, estilo sem runtime | diff check e validação estática relevante |
 | Médio | lógica isolada, componente, contrato interno | testes unitários/contrato e build/typecheck do módulo |
-| Alto | API, auth, D1/Postgres, Worker, Pages, migration, tracking, integração | domínio + integração, staging, smoke de rota/UI e rollback documentado |
-| Crítico | escrita em produção, permissões, pagamento, agenda, segredo, sessão, dado sensível | tudo de Alto, backup/checkpoint, janela para efeito externo, validação explícita e evidência pós-mudança |
+| Alto | API, auth, D1/Postgres, Worker, Pages, migration, tracking, integração, provisionamento/rotação rotineira de secret interno | testes e integração proporcionais ao domínio; staging/smoke quando a superfície exigir; rollback documentado |
+| Crítico | escrita irreversível em produção, remoção irrecuperável de acesso, pagamento/efeito financeiro, exposição de segredo/credencial ou dado sensível | tudo de Alto, backup/checkpoint, janela para efeito externo, validação explícita e evidência pós-mudança |
 
 Testes não criam booking, cobrança, campanha, mensagem ou dado real sem janela aprovada e alvo seguro.
 
@@ -94,7 +95,7 @@ Nenhuma mudança de produção ocorre enquanto faltar:
 
 1. PR mergeado ou release aprovado conforme o fluxo da superfície;
 2. todos os checks obrigatórios verdes;
-3. staging publicado e validado para risco alto/crítico;
+3. staging equivalente publicado e validado quando a política do domínio, o ambiente-alvo ou o risco concreto o exigir;
 4. migration aplicada e verificada em staging, quando existir;
 5. versão atual e rollback registrados;
 6. flag/grant não liberados mantidos desativados, salvo coorte aprovada;

--- a/docs/operations/autonomous-delivery-standard.md
+++ b/docs/operations/autonomous-delivery-standard.md
@@ -77,12 +77,15 @@ The routine path is
 `.github/workflows/provision-native-global-coordination-custody.yml`. The
 native production runner uses `SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL`; a
 staging coordinator is a separate trust plane and is never silently reused for
-production custody. The
-An already existing GitHub secret, staging, merge, release, shadow, active or
-rollback state is not a reason for a manual interruption. Human action remains
-necessary only when the authenticated GitHub session, native root/platform
-trust, or a genuinely nonexistent credential is unavailable; the normal
-registration, custody reconciliation and recovery path is otherwise
+production custody. An already existing GitHub secret, staging, merge, release,
+shadow, active or rollback state is not a reason for a manual interruption.
+Apply the autonomy policy's emission-and-contract classification before
+blocking: a mission-authorized `INTERNAL GENERATED SECRET` with write access to
+its canonical store is provisioned and verified autonomously. Human action
+remains necessary only when an `EXTERNALLY ISSUED CREDENTIAL` cannot be issued
+or rotated through its canonical authenticated mechanism because MFA,
+unavailable permission, or external platform trust cannot be completed; the
+normal registration, custody reconciliation and recovery path is otherwise
 Codex-executable and fail-closed.
 
 ## Evidence and recovery

--- a/docs/secrets-rotation.md
+++ b/docs/secrets-rotation.md
@@ -1,7 +1,7 @@
 # Secrets & Rotation Playbook
 
 ## Objetivo
-Garantir que segredos críticos (GitHub, Cloudflare, backend) tenham **escopo mínimo**, **rotação periódica** e **procedimento de emergência** documentado.
+Garantir que segredos de GitHub, Cloudflare e backend tenham **escopo mínimo**, **rotação periódica** e **procedimento de emergência** documentado; o risco decorre do efeito e da reversibilidade, não do nome do secret.
 
 ## Inventário mínimo (por área)
 

--- a/ops/runtime/github-actions-runner/README.md
+++ b/ops/runtime/github-actions-runner/README.md
@@ -106,7 +106,9 @@ apply, without extending approval to another release or arbitrary operation.
 
 The bridge removes the previous manual GitHub-to-mini-PC copy gap. If an
 authenticated GitHub session and native root/platform trust already exist,
-runner registration is executable by Codex; genuinely nonexistent secrets,
-MFA/re-authentication, or unavailable platform trust remain the only bootstrap
-boundaries. Routine rotation and reconciliation are automated through the same
-guarded workflow.
+runner registration is executable by Codex. An absent `INTERNAL GENERATED
+SECRET` follows the autonomy policy and is provisioned when the mission and
+canonical-store access permit it; MFA/re-authentication, unavailable external
+credential issuance/rotation, or unavailable platform trust remain the only
+bootstrap boundaries. Routine rotation and reconciliation are automated through
+the same guarded workflow.

--- a/scripts/install-project-skill.ps1
+++ b/scripts/install-project-skill.ps1
@@ -1,6 +1,8 @@
 [CmdletBinding()]
 param(
   [string]$SourceRoot,
+  [ValidatePattern('^(?=.{1,63}$)[a-z0-9]+(?:-[a-z0-9]+)*$')]
+  [string]$SkillName = 'skincos-project-orchestrator',
   [string]$TargetRoot = (Join-Path $env:USERPROFILE '.agents\skills'),
   [switch]$ReplaceExistingLink,
   [switch]$Uninstall
@@ -11,9 +13,8 @@ if ([string]::IsNullOrWhiteSpace($SourceRoot)) {
   $SourceRoot = Split-Path -Parent $PSScriptRoot
 }
 $projectRoot = (Resolve-Path -LiteralPath $SourceRoot).Path
-$skillName = 'skincos-project-orchestrator'
-$source = Join-Path $projectRoot "skills\$skillName"
-$target = Join-Path $TargetRoot $skillName
+$source = Join-Path $projectRoot "skills\$SkillName"
+$target = Join-Path $TargetRoot $SkillName
 
 if (-not (Test-Path -LiteralPath (Join-Path $source 'SKILL.md') -PathType Leaf)) {
   throw "Versioned skill source was not found: $source"

--- a/scripts/tests/codex-autonomy-baseline.test.mjs
+++ b/scripts/tests/codex-autonomy-baseline.test.mjs
@@ -36,6 +36,25 @@ test("exceptional paths are explicit rather than inferred from every workflow or
   assert.equal(exceptional.risk, "critical");
 });
 
+test("secret emission classification keeps internal generation autonomous and external issuance fail-closed", () => {
+  const ordinarySecret = classifyFiles(policy, ["platform/security/token-vault/secret-contract.md"]);
+  assert.equal(ordinarySecret.risk, "high");
+  const credentialExposure = classifyFiles(policy, ["ops/credential-exposure-report.md"]);
+  assert.equal(credentialExposure.risk, "critical");
+
+  const requiredSentence = "Absence of a versioned generator alone is not evidence that an internal generated secret requires human intervention.";
+  const documents = [
+    "docs/decisions/codex-autonomy-policy.md",
+    "docs/operations/autonomous-delivery-standard.md",
+    "skills/skincos-secret-provisioning/SKILL.md",
+  ].map((relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8"));
+  for (const document of documents) {
+    assert.match(document, /INTERNAL GENERATED SECRET/);
+    assert.match(document, /EXTERNALLY ISSUED CREDENTIAL/);
+  }
+  assert.ok(documents[0].includes(requiredSentence));
+});
+
 test("release input digest ignores unrelated documentation but invalidates relevant input", () => {
   const base = {
     sourceCommit: "a".repeat(40),

--- a/skills/skincos-project-orchestrator/references/authorization-boundaries.md
+++ b/skills/skincos-project-orchestrator/references/authorization-boundaries.md
@@ -17,6 +17,11 @@ while the Skill executes it.
   staging, canary, production, smoke, rollback and cleanup. Authorization for a
   secret allows secure creation, rotation, reference or use, never disclosure or
   versioning of its value.
+- Before treating an absent secret as a human interruption, classify it by
+  issuer and validity under the autonomy policy. Use
+  `skincos-secret-provisioning` for the custody workflow: a mission-authorized
+  `INTERNAL GENERATED SECRET` with canonical-store write access proceeds
+  autonomously; an `EXTERNALLY ISSUED CREDENTIAL` remains fail-closed.
 
 ## Technical eligibility is separate
 
@@ -27,10 +32,10 @@ A missing item is a concrete technical blocker; it is not a reason to request a
 second human authorization. Neither a merge nor a health endpoint proves an
 authorized production journey.
 
-Platform trust checks, unavailable credentials, MFA and non-bypassable external
-controls remain real boundaries. The agent cannot invent access, self-approve a
-trust boundary, disclose secrets/PII, or make destructive irreversible changes
-to real data.
+Platform trust checks, unavailable externally issued credentials after canonical
+issuance/rotation, MFA and non-bypassable external controls remain real
+boundaries. The agent cannot invent access, self-approve a trust boundary,
+disclose secrets/PII, or make destructive irreversible changes to real data.
 
 ## Human interruption
 

--- a/skills/skincos-secret-provisioning/SKILL.md
+++ b/skills/skincos-secret-provisioning/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: skincos-secret-provisioning
+description: Classify, generate, rotate, store, verify, and recover SKINCOS secrets without exposing their values. Use when a secret is absent, needs provisioning or rotation, or its issuer/custody is unclear.
+---
+
+# SKINCOS Secret Provisioning
+
+Use this procedure with the [autonomy policy](../../docs/decisions/codex-autonomy-policy.md)
+and the affected domain runbook. It operationalizes that policy; it never
+replaces a platform permission, trust boundary, rollback gate, or release
+contract.
+
+## 1. Discover before writing
+
+1. Inspect the accepting code and contract: issuer, systems that define
+   validity, scope, canonical secret store, runtime propagation path, and safe
+   authenticated verification endpoint.
+2. Identify the existing rotation and recovery contract before overwriting a
+   value. A metadata list does not recover a prior secret value.
+3. Keep names, scopes, timestamps, SHA/run IDs, and outcomes as evidence. Never
+   read, print, paste, version, upload, or otherwise disclose a secret value.
+
+## 2. Classify by issuer and validity
+
+- `INTERNAL GENERATED SECRET`: validity is defined entirely by SKINCOS, such as
+  an internal opaque bearer, webhook secret, application authentication secret,
+  signing secret, or random secret.
+- `EXTERNALLY ISSUED CREDENTIAL`: issuance depends on another authority, such
+  as OAuth, GitHub or provider authentication, a Cloudflare/provider API
+  credential, Meta access token, externally issued certificate/key, or MFA/OTP.
+
+Do not classify from a name, an absent store entry, or a missing versioned
+generator. Absence of a versioned generator alone is not evidence that an
+internal generated secret requires human intervention.
+
+## 3. Provision or rotate an internal secret
+
+Proceed only when the mission authorizes the surface, the canonical store is
+writable, and domain gates/rollback are technically eligible.
+
+1. Generate a CSPRNG value with at least 32 random bytes unless the accepting
+   contract specifies a different entropy or encoding requirement.
+2. Send it directly to the canonical secret store through protected stdin or an
+   in-memory secure input channel. Never put it in argv, a repository/worktree
+   file, shell trace, persistent redirect, log, artifact, PR, or conversation.
+3. Propagate it only through the established runtime path. Do not bypass a
+   workflow-owned binding with an ad-hoc copy.
+4. Verify name/timestamp metadata and an authenticated allowed/denied behavior.
+   Health alone is insufficient when the bearer is optional there.
+5. Continue the authorized mission automatically after successful verification.
+
+For rotation, establish overlap, a deployed version, or another contractually
+recoverable prior state before replacement. If no safe rollback exists, record
+that as a technical gate and repair it; do not relabel the secret as a human
+blocker or claim metadata can restore its value.
+
+## 4. Handle an external credential fail-closed
+
+Never fabricate an `EXTERNALLY ISSUED CREDENTIAL`. Use its canonical,
+authenticated issuance, refresh, or rotation mechanism first. Escalate only
+for unavailable MFA/interactive authentication, genuinely unavailable or
+unprovisionable permission, or an external trust/decision that available tools
+cannot make. Keep all other failed gates concrete and technical.

--- a/skills/skincos-secret-provisioning/agents/openai.yaml
+++ b/skills/skincos-secret-provisioning/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SKINCOS Secret Provisioning"
+  short_description: "Provision internal secrets safely"
+  default_prompt: "Use $skincos-secret-provisioning to classify and safely provision this SKINCOS secret."


### PR DESCRIPTION
## Summary

- Establishes issuer-and-contract classification for `INTERNAL GENERATED SECRET` and `EXTERNALLY ISSUED CREDENTIAL`.
- Makes mission-authorized internal secret generation autonomous when canonical-store write access and technical gates exist.
- Adds the focused `skincos-secret-provisioning` Skill and safely parameterizes the project Skill installer.
- Aligns delivery, custody, rotation, and risk wording so routine secrets are elevated rather than automatically critical.

## Root cause

The previous wording authorized secret creation while treating an initially absent credential as a generic human exception. That allowed an internal opaque bearer to be misclassified as externally issued.

## Safety

- No secret value was generated, read, written, rotated, or exposed.
- No Ponto, CRM, Meta, deployment, workflow, or runtime behavior changed in this PR.
- External credentials remain fail-closed; MFA, unavailable permission, and external trust decisions remain human boundaries.

## Validation

- `npm run codex:autonomy:test`
- `.codex/hooks/tests/test-skill-installer.ps1`
- Skill structural validation
- `git diff --check`
- Risk classification: high, with focused checks and rollback plan
- Codex Security diff scan: 0 findings

## Rollback

Revert this commit. The change contains no live secret or runtime mutation; local Skill installation occurs only after merge through the canonical junction installer.