### PR TITLE
fix(token-vault): reject malformed config bearer before deploy

### DIFF
--- a/.github/workflows/deploy-token-vault.yml
+++ b/.github/workflows/deploy-token-vault.yml
@@ -917,6 +917,7 @@ jobs:
           for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID TOKEN_VAULT_META_ADS_CONFIG_TOKEN; do
             [[ -n "${!name:-}" ]] || { echo "Missing required environment secret: $name"; exit 1; }
           done
+          TOKEN_VAULT_META_ADS_CONFIG_TOKEN="$TOKEN_VAULT_META_ADS_CONFIG_TOKEN" node -e "const token=String(process.env.TOKEN_VAULT_META_ADS_CONFIG_TOKEN||'');if(!/^[\\x21-\\x7e]+$/.test(token))throw new Error('Token Vault Meta Ads config bearer must be printable ASCII without BOM or control characters');"
           [[ "$OPERATION" == deploy ]] || { echo 'Cross-SHA Token Vault rollback is fail-closed because it cannot prove restoration of the matching native Orb snapshot; the deployment path compensates its own transaction automatically.'; exit 1; }
           if [[ "$TARGET" == staging ]]; then
             [[ "$ENABLE_TOKEN_VAULT_DEPLOY_STAGING" == true ]] || { echo 'ENABLE_TOKEN_VAULT_DEPLOY_STAGING must be true'; exit 1; }

--- a/platform/security/token-vault/README.md
+++ b/platform/security/token-vault/README.md
@@ -220,6 +220,11 @@ candidate `--secrets-file` with private permissions and never prints it or uses
 `wrangler secret put`. Production retains its already-attested Orb/Worker
 binding; it is not copied into staging.
 
+The restricted `TOKEN_VAULT_META_ADS_CONFIG_TOKEN` must be an opaque printable
+ASCII bearer without a UTF-8 BOM or control characters. The release gate checks
+that representation before it acquires a lease, migrates D1, or changes Worker
+traffic.
+
 O Token Vault é publicado exclusivamente por
 `.github/workflows/deploy-token-vault.yml`: Preview -> Staging -> Production.
 O workflow exige o gate imutável de promoção, lease global

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -139,6 +139,11 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
   assert.match(release, /if \[\[ "\$TARGET" == staging \]\]; then[\s\S]*?TOKEN_VAULT_N8N_API_TOKEN/);
   assert.match(release, /if \(process\.env\.TARGET === 'production'\) requiredInherited\.push\('TOKEN_VAULT_N8N_API_TOKEN'\)/);
   assert.match(release, /if \(process\.env\.TARGET === 'staging'\) \{[\s\S]*?secrets\.TOKEN_VAULT_N8N_API_TOKEN/);
+  assert.match(release, /Token Vault Meta Ads config bearer must be printable ASCII without BOM or control characters/);
+  const printableAsciiBearer = /^[\x21-\x7e]+$/;
+  assert.equal(printableAsciiBearer.test('opaque-bearer_123'), true);
+  assert.equal(printableAsciiBearer.test('\uFEFFopaque-bearer_123'), false);
+  assert.equal(printableAsciiBearer.test('opaque\nbearer'), false);
   assert.match(release, /expected_config_authority_revision: expectedRevision/);
   assert.match(release, /entries: manifest\.entries/);
   assert.match(release, /bootstrap_operation_key="meta-ads-bootstrap:\$\{RELEASE_SHA:0:12\}:\$\{GITHUB_RUN_ID\}:\$\{GITHUB_RUN_ATTEMPT\}"/);


### PR DESCRIPTION
## What changed

Reject a non-printable or BOM-prefixed staging Meta Ads config bearer before the Token Vault workflow can acquire its release lease, migrate D1, upload a Worker version, or change traffic.

## Why

The prior staging attempt detected a UTF-8 BOM only while constructing the authenticated bootstrap request, after activating a candidate version. This turns that input defect into a safe pre-mutation failure.

## Validation

- static governance: 18/18
- YAML and README formatting
- isolated Bash syntax check
- Codex Security diff scan: no findings

No secrets are logged, stored in the repository, or passed via command arguments. No Ponto or CRM files are included.