### PR TITLE
fix(ponto): allow bootstrap edge guard

### DIFF
--- a/.github/scripts/ponto-edge-override-guard.mjs
+++ b/.github/scripts/ponto-edge-override-guard.mjs
@@ -23,7 +23,7 @@ if (!rulesetFile || !reportFile) throw new Error("ruleset and report paths are r
 if (
   !/^[0-9a-f]{32}$/.test(zoneId)
   || !/^[0-9a-f]{40}$/.test(releaseSha)
-  || !["staging", "pilot", "canary", "production"].includes(stage)
+  || !["bootstrap", "staging", "pilot", "canary", "production"].includes(stage)
   || ![expectedRulesetId, expectedHeaderRuleId, expectedContractRuleId].every(value => /^[0-9a-f]{32}$/.test(value))
 ) {
   throw new Error("edge guard provenance is invalid");

--- a/.github/scripts/ponto-waf-security.test.mjs
+++ b/.github/scripts/ponto-waf-security.test.mjs
@@ -286,7 +286,7 @@ test("expression identity preserves literal case after whitespace normalization"
   assert.equal(reconciled.length, 2);
 });
 
-test("release edge attestation also preserves literal case", () => {
+test("release edge attestation supports bootstrap and preserves literal case", () => {
   const source = fs.readFileSync(
     path.resolve(import.meta.dirname, "ponto-edge-override-guard.mjs"),
     "utf8",
@@ -294,6 +294,10 @@ test("release edge attestation also preserves literal case", () => {
   const normalization = source.match(
     /const normalizeExpression = value =>[\s\S]*?\.replace\(\/\\s\+\/g, " "\);/,
   )?.[0] || "";
+  assert.match(
+    source,
+    /\["bootstrap", "staging", "pilot", "canary", "production"\]\.includes\(stage\)/,
+  );
   assert.match(normalization, /\.trim\(\)/);
   assert.doesNotMatch(normalization, /\.toLowerCase\(\)/);
 });


### PR DESCRIPTION
Bootstrap invokes the Ponto edge guard, but the guard rejected its own bootstrap stage before any candidate mutation. Accept the explicit bootstrap stage and cover it with the focused WAF guard test.