### PR TITLE
fix(ponto): coordinate bootstrap timekeeping dispatch

### DIFF
--- a/.github/scripts/ponto-dispatch-workflow.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.mjs
@@ -98,7 +98,7 @@ export function globalResourceFor(workflow, inputs) {
   const stage = String(inputs?.stage || inputs?.orchestrator_stage || "").trim().toLowerCase();
   const lifecycle = target || stage;
   const environment = target || stage;
-  if (!["preview", "staging", "pilot", "canary", "production", "rollback"].includes(lifecycle)) return "";
+  if (!["preview", "staging", "bootstrap", "pilot", "canary", "production", "rollback"].includes(lifecycle)) return "";
   if (workflow === "deploy-timekeeping.yml" && inputs.release_scope === "ponto") return normalizeResourceKey("global:ponto-workers-writer");
   if (workflow === "deploy-core-workers.yml" && inputs.release_scope === "ponto" && ["api", "inventory", "all"].includes(inputs.unit)) {
     return normalizeResourceKey("global:ponto-workers-writer");

--- a/.github/scripts/ponto-dispatch-workflow.test.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.test.mjs
@@ -165,6 +165,7 @@ test("Ponto child mutations expose the canonical global resource and conflict sc
   assert.equal(globalResourceFor("deploy-core-workers.yml", { release_scope: "ponto", unit: "inventory", target: "preview" }), "global:ponto-workers-writer");
   assert.equal(globalResourceFor("deploy-crm-pages.yml", { release_scope: "ponto", target: "preview" }), "global:crm-cloudflare-writer");
   assert.equal(globalResourceFor("deploy-timekeeping.yml", { release_scope: "ponto", target: "staging" }), "global:ponto-workers-writer");
+  assert.equal(globalResourceFor("deploy-timekeeping.yml", { release_scope: "ponto", target: "bootstrap" }), "global:ponto-workers-writer");
   assert.equal(globalResourceFor("cloudflare-pages-sync-ponto.yml", { target: "staging" }), "global:crm-cloudflare-writer");
   assert.equal(globalResourceFor("deploy-core-workers.yml", { release_scope: "ponto", unit: "api", target: "staging" }), "global:ponto-workers-writer");
   assert.equal(globalResourceFor("deploy-core-workers.yml", { release_scope: "ponto", unit: "all", target: "staging" }), "global:ponto-workers-writer");


### PR DESCRIPTION
Corrige o mapeamento de recurso de coordenação global para o estágio `bootstrap` do dispatcher Ponto.

A falha do bootstrap `31903900282` ocorreu antes de qualquer child mutation porque `deploy-timekeeping.yml` não recebia recurso de coordenação para esse estágio.

Validação:
- `node --test .github/scripts/ponto-dispatch-workflow.test.mjs` (12/12)
- `node .github/scripts/validate-deploy-topology.mjs`