### PR TITLE
fix(website): resolve Beauty Movement browser feedback

### DIFF
--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -57,7 +57,7 @@
 }
 
 .heroDeckInstructionHidden {
-  visibility: hidden;
+  display: none;
 }
 
 .tableDeckPromptArrow {
@@ -108,13 +108,6 @@
 .progressRowWaiting .progressGroup {
   visibility: hidden;
   pointer-events: none;
-}
-
-.tableStageShifted {
-  /* Reuse the instruction's reserved space once the first hand begins.
-   * The category row and the complete table move as one visual group, while
-   * their normal-flow space stays intact to avoid a layout shift. */
-  transform: translateY(-38px);
 }
 
 .progressGroup {
@@ -455,6 +448,7 @@
   border-radius: 14px;
   background: rgba(255, 255, 255, 0.48);
   box-shadow: 0 18px 40px rgba(48, 48, 48, 0.06);
+  overflow: visible;
 }
 
 .tableSurface[data-deck-state="waiting"] {
@@ -971,12 +965,17 @@
   animation: specialCardEnter 820ms cubic-bezier(0.18, 0.86, 0.24, 1) both;
 }
 
+.specialCardSettled {
+  animation: none;
+}
+
 .specialCardStageReopen .specialCard {
   width: min(100%, 360px);
 }
 
 .specialCardInner {
   position: relative;
+  height: 100%;
   min-height: inherit;
   transform-style: preserve-3d;
 }
@@ -997,6 +996,7 @@
   padding: 28px;
   border-radius: 14px;
   backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
   text-align: center;
 }
 
@@ -1679,43 +1679,24 @@
 .cardBrandMark {
   position: relative;
   display: grid;
-  width: 140px;
-  height: 140px;
+  width: 76px;
+  height: 68px;
   place-items: center;
   align-self: center;
   margin: auto;
-  border: 1px solid rgba(245, 179, 1, 0.5);
-  border-radius: 999px;
   color: var(--bm-surface);
 }
 
 .cardBrandMark::before,
 .cardBrandMark::after {
-  position: absolute;
-  border: 1px solid rgba(255, 255, 255, 0.22);
-  border-radius: 999px;
-  content: "";
-  pointer-events: none;
-}
-
-.cardBrandMark::before {
-  inset: 14px;
-}
-
-.cardBrandMark::after {
-  top: 19px;
-  right: 24px;
-  width: 6px;
-  height: 6px;
-  border: 0;
-  background: var(--bm-yellow);
+  content: none;
 }
 
 .cardBrandLogo {
   position: relative;
   z-index: 1;
   display: block;
-  width: 70px;
+  width: 72px;
   height: auto;
   object-fit: contain;
 }
@@ -1843,10 +1824,10 @@
 .autoAdvance {
   display: block;
   width: 100%;
-  height: 4px;
-  margin-top: 1px;
+  height: 5px;
+  margin-top: 4px;
   border-radius: 999px;
-  background: rgba(48, 48, 48, 0.16);
+  background: rgba(244, 238, 223, 0.18);
   overflow: hidden;
   visibility: hidden;
 }
@@ -1862,6 +1843,7 @@
   border-radius: inherit;
   background: var(--bm-ink);
   content: "";
+  box-shadow: 0 0 10px rgba(229, 189, 49, 0.42);
   transform-origin: left center;
   animation: none;
 }
@@ -2556,10 +2538,10 @@
   isolation: isolate;
   justify-items: start;
   max-width: 100%;
-  min-height: clamp(260px, 29vw, 390px);
+  min-height: clamp(220px, 22vw, 292px);
   margin: 0;
-  padding: clamp(36px, 6vw, 82px) clamp(28px, 7vw, 104px) clamp(46px, 6vw, 78px);
-  gap: clamp(18px, 2.5vw, 28px);
+  padding: clamp(30px, 4vw, 50px) clamp(28px, 7vw, 104px) clamp(30px, 4vw, 48px);
+  gap: clamp(14px, 1.8vw, 20px);
   color: var(--bm-ink);
   text-align: left;
 }
@@ -2594,32 +2576,11 @@
   z-index: 1;
 }
 
-.heroKicker {
-  display: inline-flex;
-  align-items: center;
-  margin: 0;
-  color: var(--bm-muted);
-  font-family: var(--font-brand-ui), sans-serif;
-  font-size: clamp(0.68rem, 0.9vw, 0.78rem);
-  font-weight: 700;
-  letter-spacing: 0.18em;
-  line-height: 1.15;
-  text-transform: uppercase;
-}
-
-.heroKicker::before {
-  width: 26px;
-  height: 1px;
-  margin-right: 11px;
-  background: var(--bm-yellow);
-  content: "";
-}
-
 .hero h1 {
   max-width: min(900px, 94%);
   color: var(--bm-ink);
   font-family: var(--font-beauty-movement-editorial), "Bodoni Moda", serif;
-  font-size: clamp(3.4rem, 7.2vw, 7.15rem);
+  font-size: clamp(3.2rem, 6.35vw, 6rem);
   font-weight: 500;
   letter-spacing: -0.065em;
   line-height: 0.87;
@@ -2718,11 +2679,11 @@
 }
 
 .progressItemCurrent .progressButton {
-  border-bottom-color: var(--bm-yellow);
+  border-bottom-color: rgba(197, 181, 143, 0.52);
   border-radius: 0;
   background: transparent;
   color: var(--bm-surface);
-  box-shadow: inset 0 -1px 0 rgba(229, 189, 49, 0.24);
+  box-shadow: none;
 }
 
 .progressItemCurrent .progressButton:hover {
@@ -2741,7 +2702,7 @@
 }
 
 .tableSurface {
-  overflow: hidden;
+  overflow: visible;
   border-color: rgba(197, 181, 143, 0.72);
   border-radius: clamp(10px, 1.5vw, 18px);
   background: radial-gradient(circle at 78% 12%, rgba(229, 189, 49, 0.13), transparent 16rem), radial-gradient(circle at 13% 86%, rgba(244, 238, 223, 0.08), transparent 20rem), var(--bm-bg);
@@ -2861,25 +2822,8 @@
 }
 
 .cardBrandMark {
-  width: 126px;
-  height: 78px;
-  border-color: rgba(197, 181, 143, 0.64);
-  border-radius: 0;
-}
-
-.cardBrandMark::before {
-  inset: 10px;
-  border-color: rgba(244, 238, 223, 0.18);
-  border-radius: 0;
-}
-
-.cardBrandMark::after {
-  top: 15px;
-  right: 16px;
-  width: 5px;
-  height: 5px;
-  background: var(--bm-yellow);
-  box-shadow: 0 0 10px rgba(229, 189, 49, 0.7);
+  width: 76px;
+  height: 68px;
 }
 
 .cardBrandLogo {
@@ -3150,8 +3094,9 @@
   }
 
   .hero {
-    min-height: 300px;
-    padding: 36px 26px 44px;
+    min-height: 0;
+    padding: 28px 26px 32px;
+    gap: 14px;
   }
 
   .hero::before {
@@ -3204,8 +3149,8 @@
   }
 
   .cardBrandMark {
-    width: 120px;
-    height: 74px;
+    width: 76px;
+    height: 68px;
   }
 }
 

--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -621,18 +621,19 @@ export default function BeautyMovementExperience({
         scrollInterruptCleanupRef.current = null;
     }, []);
 
-    function scrollToElement(target: HTMLElement | null) {
+    function scrollToElement(target: HTMLElement | null, extraOffset = 0) {
         cancelScrollAnimation();
         if (!target) return;
 
         if (reducedMotion) {
             target.scrollIntoView({ behavior: "auto", block: "start" });
+            if (extraOffset > 0) window.scrollBy({ top: -extraOffset, behavior: "auto" });
             return;
         }
 
         const startTop = window.scrollY;
         const stickyHeader = document.querySelector("header");
-        const scrollOffset = stickyHeader instanceof HTMLElement ? stickyHeader.getBoundingClientRect().height + 4 : 32;
+        const scrollOffset = (stickyHeader instanceof HTMLElement ? stickyHeader.getBoundingClientRect().height + 4 : 32) + extraOffset;
         const targetTop = Math.max(0, startTop + target.getBoundingClientRect().top - scrollOffset);
         const distance = targetTop - startTop;
         const duration = Math.min(1040, Math.max(680, Math.abs(distance) * 0.55));
@@ -672,7 +673,12 @@ export default function BeautyMovementExperience({
 
     function scrollToTable() {
         cancelAutoAdvance();
-        scrollToElement(tableRef.current);
+        const title = document.getElementById("beauty-movement-title");
+        const titlePeek =
+            title instanceof HTMLElement
+                ? Math.min(184, Math.max(0, Math.round(title.getBoundingClientRect().height - 2)))
+                : 0;
+        scrollToElement(tableRef.current, titlePeek);
     }
 
     function clearHandTransitionTimer() {
@@ -1295,7 +1301,7 @@ export default function BeautyMovementExperience({
         );
     }
 
-    function renderSpecialCard(revealed: boolean, action: SpecialCardAction = "none") {
+    function renderSpecialCard(revealed: boolean, action: SpecialCardAction = "none", settled = false) {
         const showRevealAction = action !== "none";
         const kind: SpecialCardKind = revealed
             ? hasCourtesyClass
@@ -1342,7 +1348,7 @@ export default function BeautyMovementExperience({
 
         return (
             <article
-                className={styles.specialCard}
+                className={`${styles.specialCard} ${settled ? styles.specialCardSettled : ""}`.trim()}
                 data-special-state={revealed ? "revealed" : "locked"}
                 aria-label={revealed ? `Carta especial: ${title}` : "Carta especial reservada"}
             >
@@ -1452,7 +1458,6 @@ export default function BeautyMovementExperience({
 
             <section className={styles.shell} aria-labelledby="beauty-movement-title">
                 <header className={styles.hero}>
-                    <p className={styles.heroKicker}>3 anos. 3 cartas.</p>
                     <h1 id="beauty-movement-title">{initialState.campaign.title?.trim() || "Beleza que se move com você."}</h1>
                     <p
                         className={`${styles.heroDeckInstruction} ${waitingForInitialDeal ? "" : styles.heroDeckInstructionHidden}`.trim()}
@@ -1465,7 +1470,7 @@ export default function BeautyMovementExperience({
 
                 <section
                     ref={tableRef}
-                    className={`${styles.tableStage} ${waitingForInitialDeal ? "" : styles.tableStageShifted}`.trim()}
+                    className={styles.tableStage}
                     id="mesa-de-cartas"
                     aria-label={tableDefinition.label}
                     aria-describedby={tablePromptText ? "table-stage-prompt" : undefined}
@@ -1646,7 +1651,7 @@ export default function BeautyMovementExperience({
                                 aria-label="Carta especial da celebração"
                             >
                                 {!isLocalPreview ? renderConfirmationAction() : null}
-                                {renderSpecialCard(false, isLocalPreview ? "confirm" : "none")}
+                                {renderSpecialCard(false, isLocalPreview ? "confirm" : "none", true)}
                             </div>
                         ) : finaleStage === "result" ? (
                             <div

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -28,10 +28,8 @@ test("continuous experience reuses the real shell and keeps the special-card fin
         assert.match(route, /<Footer \/>/);
     }
 
-    assert.match(
-        experience,
-        /className=\{`\$\{styles\.tableStage\} \$\{waitingForInitialDeal \? "" : styles\.tableStageShifted\}`\.trim\(\)\}/,
-    );
+    assert.match(experience, /className=\{styles\.tableStage\}/);
+    assert.doesNotMatch(experience, /styles\.tableStageShifted/);
     assert.match(experience, /id="mesa-de-cartas"/);
     assert.match(experience, /data-hand-stage=\{handStage\}/);
     assert.match(experience, /const tableIsBusy =/);
@@ -39,6 +37,9 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.match(experience, /beauty_movement_act_view/);
     assert.match(experience, /requestAnimationFrame\(animate\)/);
     assert.match(experience, /scrollIntoView\(\{ behavior: "auto"/);
+    assert.match(experience, /function scrollToElement\(target: HTMLElement \| null, extraOffset = 0\)/);
+    assert.match(experience, /const titlePeek =/);
+    assert.match(experience, /scrollToElement\(tableRef\.current, titlePeek\)/);
     assert.match(experience, /prefers-reduced-motion/);
     assert.match(experience, /import \{ BEAUTY_MOVEMENT_MOTION, createBeautyMovementMotionGate \}/);
     assert.match(experience, /AUTO_ADVANCE_SECONDS = BEAUTY_MOVEMENT_MOTION\.autoAdvanceMs \/ 1_000/);
@@ -113,6 +114,8 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.match(experience, /styles\.progressRowWaiting/);
     assert.match(experience, /className=\{styles\.progressGroup\}/);
     assert.match(experience, /styles\.heroDeckInstructionHidden/);
+    assert.doesNotMatch(experience, /className=\{styles\.heroKicker\}/);
+    assert.doesNotMatch(experience, /<p className=\{styles\.heroKicker\}>3 anos\. 3 cartas\.<\/p>/);
     assert.match(experience, /aria-hidden=\{waitingForInitialDeal \|\| undefined\}/);
     assert.match(experience, /\$\{styles\.tablePrompt\}/);
     assert.match(experience, /key=\{introStage !== "hidden" \? "experience-intro" : tableDefinition\.id\}/);
@@ -240,7 +243,7 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.match(styles, /--bm-yellow: #e5bd31/i);
     assert.doesNotMatch(styles, /Georgia|--bm-plum|--bm-coral|linear-gradient/i);
     assert.match(styles, /\.rhythmThread \{/);
-    assert.match(styles, /\.heroKicker \{/);
+    assert.doesNotMatch(styles, /\.heroKicker/);
     assert.match(styles, /--font-beauty-movement-editorial/);
     assert.doesNotMatch(styles, /\.autoAdvanceNumber/);
     assert.match(styles, /@keyframes autoAdvanceProgress/);
@@ -322,7 +325,7 @@ test("continuous experience reuses the real shell and keeps the special-card fin
         styles.indexOf(".tableDeckPromptArrow {"),
     );
     assert.match(heroInstructionStyles, /display: block[\s\S]*font-family: var\(--font-brand-text\)/);
-    assert.match(styles, /\.heroDeckInstructionHidden \{\s*visibility: hidden;/);
+    assert.match(styles, /\.heroDeckInstructionHidden \{\s*display: none;/);
     assert.match(styles, /\.progressRow \{[\s\S]*min-height: 52px;[\s\S]*align-items: flex-start;/);
     assert.doesNotMatch(heroInstructionStyles, /cursor: pointer|:hover|:focus-visible|appearance:|background:/);
     assert.match(styles, /\.tableDeckPromptArrow \{[\s\S]*position: absolute[\s\S]*bottom: calc\(32px \+ 106px \+ 8px\)[\s\S]*font-size: 1\.35rem/);
@@ -340,7 +343,7 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.match(styles, /@keyframes deckPromptArrowFloat/);
     assert.match(styles, /\.progressRowWaiting \{[\s\S]*min-height: 52px/);
     assert.match(styles, /\.progressRowWaiting \.progressGroup \{[\s\S]*visibility: hidden[\s\S]*pointer-events: none/);
-    assert.match(styles, /\.tableStageShifted \{[\s\S]*?transform: translateY\(-38px\);/);
+    assert.doesNotMatch(styles, /\.tableStageShifted/);
     assert.doesNotMatch(styles, /\.initialDeckPrompt/);
     assert.match(styles, /\.heroDeckInstruction/);
     assert.doesNotMatch(styles, /\.tableDeckPrompt \{|\.deckPrompt \{|\.deckPromptArrow \{/);
@@ -377,7 +380,7 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.match(styles, /\.progressButton \{[\s\S]*min-height: 38px/);
     assert.match(styles, /\.progressButton \{[\s\S]*width: 100%/);
     assert.match(styles, /\.progressItemCurrent \.progressButton \{[\s\S]*grid-template-rows: 25px 5px[\s\S]*height: 38px[\s\S]*min-height: 38px[\s\S]*padding: 4px 14px 1px/);
-    assert.match(styles, /\.autoAdvance \{[\s\S]*width: 100%[\s\S]*height: 4px[\s\S]*margin-top: 1px/);
+    assert.match(styles, /\.autoAdvance \{[\s\S]*width: 100%[\s\S]*height: 5px[\s\S]*margin-top: 4px/);
     assert.match(styles, /\.autoAdvance \{[\s\S]*visibility: hidden/);
     assert.match(styles, /\.autoAdvanceVisible \{[\s\S]*visibility: visible/);
     assert.match(styles, /\.autoAdvance::after \{[\s\S]*animation: none/);
@@ -393,6 +396,9 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.match(styles, /\.progressTransfer \{[\s\S]*animation: progressHighlightTransfer var\(--bm-progress-total-ms\)/);
     assert.match(styles, /@keyframes progressHighlightTransfer[\s\S]*calc\(var\(--progress-to-left\) \+ var\(--progress-to-width\) - var\(--progress-from-left\)\)/);
     assert.match(styles, /\.autoAdvance::after \{[\s\S]*background: var\(--bm-ink\)/);
+    assert.match(styles, /\.tableSurface \{[\s\S]*overflow: visible;/);
+    assert.match(styles, /\.specialCardSettled \{\s*animation: none;/);
+    assert.match(experience, /styles\.specialCardSettled/);
     assert.match(styles, /animation: cardLiftAndSettle var\(--bm-hand-reveal-ms\)/);
     assert.match(styles, /\.tableStage\[data-hand-stage="reveal"\] \.cardButtonSelected,\s*\.tableStage\[data-hand-stage="reveal"\] \.cardButtonSelected \.cardInner/);
     assert.match(styles, /animation: deckStageDeal var\(--bm-hand-deal-ms\)/);
@@ -418,7 +424,7 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.match(experience, /BeautyMovementCardIllustration/);
     assert.match(experience, /function renderSpecialCard/);
     assert.match(experience, /type SpecialCardAction = "none" \| "confirm" \| "reopen"/);
-    assert.match(experience, /function renderSpecialCard\(revealed: boolean, action: SpecialCardAction = "none"\)/);
+    assert.match(experience, /function renderSpecialCard\(revealed: boolean, action: SpecialCardAction = "none", settled = false\)/);
     assert.match(experience, /className=\{styles\.specialCardRevealAction\}/);
     assert.match(experience, /Garantir presente e confirmar presença/);
     assert.match(experience, /if \(!operationalConsent && !isLocalPreview\) return;/);
@@ -428,7 +434,7 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.match(experience, /styles\.specialCardWhatsappAction/);
     assert.match(experience, /finaleStage === "confirmation" \?/);
     assert.match(experience, /!isLocalPreview \? renderConfirmationAction\(\) : null/);
-    assert.match(experience, /renderSpecialCard\(false, isLocalPreview \? "confirm" : "none"\)/);
+    assert.match(experience, /renderSpecialCard\(false, isLocalPreview \? "confirm" : "none", true\)/);
     assert.match(experience, /renderSpecialCard\(false, "reopen"\)/);
     assert.doesNotMatch(experience, /specialCardPrompt|Sua carta especial está pronta\./);
     assert.match(experience, /Clique aqui para revelar sua carta especial/);


### PR DESCRIPTION
# Summary

Resolves the browser feedback on the Beauty Movement local preview without changing campaign data or production behavior.

- removes the “3 anos. 3 cartas.” eyebrow from the hero, compacts the hero, and keeps the full title visible when the table receives focus;
- restores the progress row to normal flow, differentiates the active five-second advance loader, and lets deck/card motion exceed the table surface without clipping;
- simplifies the card-back brand mark so it reads as a mark instead of an unloaded asset;
- settles the locked special card after the merge handoff, preventing its entrance animation from replaying and causing a transient oversized text flash.

Root cause: the prior layout reused hidden hero space and clipped the table surface; the special-card confirmation remounted with the general entrance animation.

## Type of change
- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (README, API refs, diagrams) — not applicable; no public contract changed
- [ ] Security review (CodeQL, gitleaks) — delegated to repository CI
- [ ] Performance impact measured — no runtime dependency or asset change

## Links
- Issue: browser feedback comments 1–8
- Design/ADR: campaign visual corpus and existing Beauty Movement motion system
- Migration steps: none

## Screenshots / Evidence
- Browser QA at 1346×674: hero/title + dealt cards, reveal overflow, visible auto-advance loader, and settled special card.
- Browser QA at 390×844: initial/dealt/revealed card states with no horizontal overflow.
- Local checks: `npm run lint`, `npm run typecheck`, and `npm run test` (134 passing).
