### PR TITLE
fix(meta-ads): derive governed bootstrap plan

### DIFF
--- a/.github/workflows/deploy-token-vault.yml
+++ b/.github/workflows/deploy-token-vault.yml
@@ -121,6 +121,25 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Validate sealed Token Vault bootstrap plan before native mutation
+        env:
+          BOOTSTRAP_STRATEGY: ${{ needs.release.outputs.bootstrap_strategy }}
+          BOOTSTRAP_PLAN_REVISION: ${{ needs.release.outputs.bootstrap_plan_revision }}
+          BOOTSTRAP_MANIFEST_SHA256: ${{ needs.release.outputs.bootstrap_manifest_sha256 }}
+        run: |
+          set -euo pipefail
+          case "$BOOTSTRAP_STRATEGY" in
+            not_required)
+              [[ "$BOOTSTRAP_PLAN_REVISION" =~ ^[a-f0-9]{64}$ && -z "$BOOTSTRAP_MANIFEST_SHA256" ]] || { echo 'Token Vault ready bootstrap plan identity is invalid'; exit 1; }
+              ;;
+            derive|manifest)
+              [[ "$BOOTSTRAP_PLAN_REVISION" =~ ^legacy:[a-f0-9]{64}$ && "$BOOTSTRAP_MANIFEST_SHA256" =~ ^[a-f0-9]{64}$ ]] || { echo 'Token Vault legacy bootstrap plan identity is invalid'; exit 1; }
+              ;;
+            *)
+              echo 'Token Vault bootstrap strategy is invalid'; exit 1
+              ;;
+          esac
+
       - name: Attest the already staged immutable candidate through GitHub OIDC
         id: candidate_initial_attestation
         run: |
@@ -370,9 +389,13 @@ jobs:
         id: tracking_bootstrap
         if: always() && steps.worker_activation.outcome == 'success' && steps.worker_deployment_readback.outcome == 'success' && steps.production_route_auth_convergence.outcome == 'success'
         env:
-          # The manifest stays in the protected Environment and is read only
-          # after the activated Worker proves that its authority is legacy.
-          TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST: ${{ secrets.TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST }}
+          # A protected manifest remains an optional explicit override. The
+          # default legacy path rederives its bounded plan privately inside the
+          # Vault from the candidate-bound digest sealed before traffic.
+          BOOTSTRAP_STRATEGY: ${{ needs.release.outputs.bootstrap_strategy }}
+          BOOTSTRAP_PLAN_REVISION: ${{ needs.release.outputs.bootstrap_plan_revision }}
+          BOOTSTRAP_MANIFEST_SHA256: ${{ needs.release.outputs.bootstrap_manifest_sha256 }}
+          TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST: ${{ needs.release.outputs.bootstrap_strategy == 'manifest' && secrets.TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST || '' }}
           TOKEN_VAULT_META_ADS_CONFIG_TOKEN: ${{ secrets.TOKEN_VAULT_META_ADS_CONFIG_TOKEN }}
           TOKEN_VAULT_PRODUCTION_BASE_URL: ${{ vars.TOKEN_VAULT_PRODUCTION_BASE_URL }}
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
@@ -384,11 +407,21 @@ jobs:
           bootstrap_operation_key="meta-ads-bootstrap:${RELEASE_SHA:0:12}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
           [[ "$bootstrap_operation_key" =~ ^[A-Za-z0-9_.:-]{8,160}$ ]] || { echo 'bootstrap operation key is invalid'; exit 1; }
           bootstrap_state="$(BOOTSTRAP_OPERATION_KEY="$bootstrap_operation_key" node --input-type=module <<'NODE'
+          import { createHash } from 'node:crypto';
+
           const base = String(process.env.TOKEN_VAULT_PRODUCTION_BASE_URL || '').replace(/\/$/, '');
           const token = String(process.env.TOKEN_VAULT_META_ADS_CONFIG_TOKEN || '');
           const operationKey = String(process.env.BOOTSTRAP_OPERATION_KEY || '');
+          const strategy = String(process.env.BOOTSTRAP_STRATEGY || '');
+          const planRevision = String(process.env.BOOTSTRAP_PLAN_REVISION || '').toLowerCase();
+          const planDigest = String(process.env.BOOTSTRAP_MANIFEST_SHA256 || '').toLowerCase();
+          const rawManifest = String(process.env.TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST || '');
           if (!/^https:\/\/[^/]+$/.test(base) || !token) throw new Error('Token Vault production bootstrap endpoint or credential is unavailable');
           if (!/^[A-Za-z0-9_.:-]{8,160}$/.test(operationKey)) throw new Error('bootstrap operation identity is invalid');
+          if (!['not_required', 'manifest', 'derive'].includes(strategy)) throw new Error('Token Vault candidate bootstrap strategy is unavailable');
+          if (!/^(?:legacy:)?[a-f0-9]{64}$/.test(planRevision)) throw new Error('Token Vault candidate bootstrap plan revision is invalid');
+          if ((strategy === 'derive' || strategy === 'manifest') && !/^[a-f0-9]{64}$/.test(planDigest)) throw new Error('Token Vault candidate bootstrap plan digest is invalid');
+          if (strategy !== 'manifest' && rawManifest) throw new Error('Token Vault derived or ready bootstrap strategy must not receive a protected manifest');
 
           const safeError = (payload) => {
             const value = String(payload?.error || '');
@@ -402,6 +435,7 @@ jobs:
               headers,
               body: body === undefined ? undefined : JSON.stringify(body),
               redirect: 'error',
+              signal: AbortSignal.timeout(20_000),
             });
             let payload = null;
             try { payload = await response.json(); } catch {}
@@ -426,37 +460,43 @@ jobs:
           const mode = String(initial.payload.config_authority_mode || '');
           if (mode === 'tracking_ready') {
             requireReady(initial, 'Token Vault configuration authority readback');
+            if (strategy !== 'not_required' || planRevision !== String(initial.payload?.config_authority_revision || '').toLowerCase() || planDigest || rawManifest) {
+              throw new Error('Token Vault configuration authority changed after candidate planning');
+            }
             process.stdout.write('not_required\n');
           } else if (mode === 'legacy_bootstrap') {
             const expectedRevision = String(initial.payload.config_authority_revision || '').toLowerCase();
             if (!/^legacy:[a-f0-9]{64}$/.test(expectedRevision)) throw new Error('legacy Token Vault authority revision is invalid');
-            const rawManifest = String(process.env.TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST || '');
-            if (!rawManifest) throw new Error('TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST is required only when legacy bootstrap is detected');
-            let manifest;
-            try { manifest = JSON.parse(rawManifest); } catch { throw new Error('TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST must be valid JSON containing only entries'); }
-            if (
-              !manifest ||
-              typeof manifest !== 'object' ||
-              Array.isArray(manifest) ||
-              Object.keys(manifest).length !== 1 ||
-              !Object.prototype.hasOwnProperty.call(manifest, 'entries') ||
-              !Array.isArray(manifest.entries) ||
-              manifest.entries.length < 2 ||
-              manifest.entries.length > 10 ||
-              new TextEncoder().encode(JSON.stringify(manifest)).length > 150 * 1024
-            ) {
-              throw new Error('TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST must contain only 2 to 10 bounded entries');
+            if (planRevision !== expectedRevision || !['manifest', 'derive'].includes(strategy)) throw new Error('Token Vault legacy authority changed after candidate planning');
+            let bootstrap;
+            if (strategy === 'manifest') {
+              const actualHex = createHash('sha256').update(rawManifest).digest('hex');
+              if (!rawManifest || actualHex !== planDigest) throw new Error('Token Vault protected bootstrap manifest changed after candidate planning');
+              let manifest;
+              try { manifest = JSON.parse(rawManifest); } catch { throw new Error('TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST must be valid JSON containing only entries'); }
+              if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest) || Object.keys(manifest).length !== 1 || !Object.prototype.hasOwnProperty.call(manifest, 'entries') || !Array.isArray(manifest.entries) || manifest.entries.length < 2 || manifest.entries.length > 10 || new TextEncoder().encode(JSON.stringify(manifest)).length > 150 * 1024) {
+                throw new Error('TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST must contain only 2 to 10 bounded entries');
+              }
+              bootstrap = await request('/v1/meta-ads-publish/config/bootstrap', {
+                method: 'POST',
+                body: {
+                  operation_key: operationKey,
+                  expected_config_authority_revision: expectedRevision,
+                  entries: manifest.entries,
+                },
+              });
+            } else {
+              bootstrap = await request('/v1/meta-ads-publish/config/bootstrap/derive', {
+                method: 'POST',
+                body: {
+                  operation_key: operationKey,
+                  expected_config_authority_revision: expectedRevision,
+                  expected_manifest_sha256: planDigest,
+                },
+              });
             }
-            const bootstrap = await request('/v1/meta-ads-publish/config/bootstrap', {
-              method: 'POST',
-              body: {
-                operation_key: operationKey,
-                expected_config_authority_revision: expectedRevision,
-                entries: manifest.entries,
-              },
-            });
             if (!bootstrap.response.ok || bootstrap.payload?.ok !== true) {
-              throw new Error(`Token Vault legacy bootstrap failed: ${bootstrap.response.status} ${safeError(bootstrap.payload)}`);
+              throw new Error(`Token Vault ${strategy} bootstrap failed: ${bootstrap.response.status} ${safeError(bootstrap.payload)}`);
             }
             const bootstrapRevision = String(bootstrap.payload?.config_authority_revision || '').toLowerCase();
             if (!/^[a-f0-9]{64}$/.test(bootstrapRevision)) throw new Error('Token Vault legacy bootstrap did not return a tracking revision');
@@ -912,6 +952,9 @@ jobs:
     outputs:
       token_vault_version_id: ${{ steps.selected_worker_version.outputs.version_id }}
       token_vault_incumbent_version_id: ${{ steps.selected_worker_version.outputs.incumbent_version_id }}
+      bootstrap_strategy: ${{ steps.candidate_bootstrap_plan.outputs.bootstrap_strategy }}
+      bootstrap_plan_revision: ${{ steps.candidate_bootstrap_plan.outputs.bootstrap_plan_revision }}
+      bootstrap_manifest_sha256: ${{ steps.candidate_bootstrap_plan.outputs.bootstrap_manifest_sha256 }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.target }}
     steps:
@@ -1269,11 +1312,17 @@ jobs:
           if (!/^https:\/\/(?:[a-z0-9-]+\.)+workers\.dev$/.test(base) || !token) {
             throw new Error('Token Vault immutable candidate preview endpoint or credential is unavailable');
           }
-          function authenticatedAuthorityMode(response, payload) {
-            if (!payload || typeof payload !== 'object') return '';
-            if (response.status === 200 && payload.ready === true && payload.config_authority_mode === 'tracking_ready') return 'tracking_ready';
-            if (response.status === 409 && payload.ready === false && payload.config_authority_mode === 'legacy_bootstrap') return 'legacy_bootstrap';
-            return '';
+          function authenticatedAuthority(response, payload) {
+            if (!payload || typeof payload !== 'object') return null;
+            const mode = String(payload.config_authority_mode || '');
+            const revision = String(payload.config_authority_revision || '').toLowerCase();
+            if (response.status === 200 && payload.ready === true && mode === 'tracking_ready' && /^[a-f0-9]{64}$/.test(revision)) {
+              return { mode, revision };
+            }
+            if (response.status === 409 && payload.ready === false && mode === 'legacy_bootstrap' && /^legacy:[a-f0-9]{64}$/.test(revision)) {
+              return { mode, revision };
+            }
+            return null;
           }
           const deadline = Date.now() + 90_000;
           while (Date.now() < deadline) {
@@ -1284,10 +1333,10 @@ jobs:
                 redirect: 'error',
                 signal: AbortSignal.timeout(10_000),
               });
-              const mode = authenticatedAuthorityMode(response, await response.json());
-              if (mode) {
+              const authority = authenticatedAuthority(response, await response.json());
+              if (authority) {
                 const fs = await import('node:fs');
-                fs.appendFileSync(process.env.GITHUB_OUTPUT, `config_authority_mode=${mode}\n`);
+                fs.appendFileSync(process.env.GITHUB_OUTPUT, `config_authority_mode=${authority.mode}\nconfig_authority_revision=${authority.revision}\n`);
                 process.exit(0);
               }
             } catch {}
@@ -1296,20 +1345,31 @@ jobs:
           throw new Error('Token Vault immutable candidate config bearer did not authenticate before traffic');
           NODE
 
-      - name: Verify protected legacy Token Vault bootstrap manifest before traffic
-        id: candidate_bootstrap_manifest
+      - name: Seal a private or internally-derived legacy Token Vault bootstrap plan before traffic
+        id: candidate_bootstrap_plan
         if: inputs.operation == 'deploy' && steps.candidate_config_bearer.outcome == 'success'
         env:
           CANDIDATE_CONFIG_AUTHORITY_MODE: ${{ steps.candidate_config_bearer.outputs.config_authority_mode }}
+          CANDIDATE_CONFIG_AUTHORITY_REVISION: ${{ steps.candidate_config_bearer.outputs.config_authority_revision }}
+          TOKEN_VAULT_META_ADS_CONFIG_TOKEN: ${{ secrets.TOKEN_VAULT_META_ADS_CONFIG_TOKEN }}
           # The protected manifest is injected only for a candidate that has
           # already authenticated as legacy_bootstrap. A tracking-ready
-          # candidate deliberately receives no manifest.
+          # candidate deliberately receives no manifest; an absent legacy
+          # manifest falls back to the Worker-internal, Graph-read-only plan.
           TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST: ${{ steps.candidate_config_bearer.outputs.config_authority_mode == 'legacy_bootstrap' && secrets.TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST || '' }}
+          TARGET: ${{ inputs.target }}
         run: |
           set -euo pipefail
           node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+          import { createHash } from 'node:crypto';
+
           const mode = String(process.env.CANDIDATE_CONFIG_AUTHORITY_MODE || '');
+          const authorityRevision = String(process.env.CANDIDATE_CONFIG_AUTHORITY_REVISION || '').toLowerCase();
+          const preview = String(process.env.TOKEN_VAULT_CANDIDATE_PREVIEW_URL || '').replace(/\/$/, '');
+          const configToken = String(process.env.TOKEN_VAULT_META_ADS_CONFIG_TOKEN || '');
           const rawManifest = String(process.env.TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST || '');
+          const target = String(process.env.TARGET || '');
           const maxBytes = 150 * 1024;
           const tokenIdPattern = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,159}$/;
           const urlTagKeyPattern = /^[A-Za-z0-9][A-Za-z0-9._~-]{0,127}$/;
@@ -1334,12 +1394,53 @@ jobs:
             });
           };
 
+          const writeOutput = (strategy, manifestSha256 = '') => {
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, [
+              `bootstrap_strategy=${strategy}`,
+              `bootstrap_plan_revision=${authorityRevision}`,
+              `bootstrap_manifest_sha256=${manifestSha256}`,
+              '',
+            ].join('\n'));
+          };
+          const validateSummary = (summary) => {
+            if (!isJsonObject(summary) || !Object.keys(summary).every((key) => new Set(['destination_count', 'website_destination_count', 'whatsapp_destination_count', 'staging_fixture_count']).has(key))) return false;
+            const values = ['destination_count', 'website_destination_count', 'whatsapp_destination_count', 'staging_fixture_count'].map((key) => summary[key]);
+            if (!values.every((value) => Number.isInteger(value) && value >= 0)) return false;
+            if (summary.destination_count < 2 || summary.destination_count > 10 || summary.website_destination_count < 1 || summary.destination_count !== summary.website_destination_count + summary.whatsapp_destination_count) return false;
+            return target === 'staging' ? summary.staging_fixture_count === 1 : summary.staging_fixture_count === 0;
+          };
+
           if (mode === 'tracking_ready') {
             if (rawManifest) throw new Error('Token Vault tracking-ready candidate must not receive a bootstrap manifest');
+            if (!/^[a-f0-9]{64}$/.test(authorityRevision)) throw new Error('Token Vault candidate tracking authority revision is invalid');
+            writeOutput('not_required');
             process.exit(0);
           }
           if (mode !== 'legacy_bootstrap') throw new Error('Token Vault candidate authority mode is unavailable for manifest validation');
-          if (!rawManifest) throw new Error('TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST is required for a legacy Token Vault candidate before traffic');
+          if (!/^legacy:[a-f0-9]{64}$/.test(authorityRevision)) throw new Error('Token Vault candidate legacy authority revision is invalid');
+          if (!rawManifest) {
+            if (!/^https:\/\/(?:[a-z0-9-]+\.)+workers\.dev$/.test(preview) || !configToken) throw new Error('Token Vault immutable candidate derivation endpoint or credential is unavailable');
+            const response = await fetch(`${preview}/internal/token-vault/v1/meta-ads-publish/config/bootstrap/derive-plan`, {
+              method: 'POST',
+              headers: {
+                Authorization: `Bearer ${configToken}`,
+                'content-type': 'application/json',
+              },
+              body: JSON.stringify({ expected_config_authority_revision: authorityRevision }),
+              cache: 'no-store',
+              redirect: 'error',
+              signal: AbortSignal.timeout(20_000),
+            });
+            let payload = null;
+            try { payload = await response.json(); } catch {}
+            const digest = String(payload?.manifest_sha256 || '').toLowerCase();
+            if (!response.ok || payload?.ok !== true || String(payload?.config_authority_revision || '').toLowerCase() !== authorityRevision || !/^[a-f0-9]{64}$/.test(digest) || !validateSummary(payload?.summary)) {
+              const error = /^[a-z0-9_:-]{1,120}$/i.test(String(payload?.error || '')) ? String(payload.error) : 'unknown';
+              throw new Error(`Token Vault internal bootstrap derivation failed: ${response.status} ${error}`);
+            }
+            writeOutput('derive', digest);
+            process.exit(0);
+          }
           if (new TextEncoder().encode(rawManifest).length > maxBytes) throw new Error('Token Vault bootstrap manifest exceeds the bounded request size');
 
           let manifest;
@@ -1374,7 +1475,32 @@ jobs:
               throw new Error('Token Vault bootstrap manifest has an unsafe Website entry');
             }
           }
+          writeOutput('manifest', createHash('sha256').update(rawManifest).digest('hex'));
           NODE
+
+      - name: Validate sealed Token Vault bootstrap plan before staging traffic
+        # No D1 or traffic mutation can start unless the candidate emitted a
+        # complete opaque plan identity. The plan contents never leave the
+        # Worker; only strategy, authority revision and digest travel here.
+        id: validate_staging_bootstrap_plan
+        if: inputs.target == 'staging' && steps.candidate_bootstrap_plan.outcome == 'success'
+        env:
+          BOOTSTRAP_STRATEGY: ${{ steps.candidate_bootstrap_plan.outputs.bootstrap_strategy }}
+          BOOTSTRAP_PLAN_REVISION: ${{ steps.candidate_bootstrap_plan.outputs.bootstrap_plan_revision }}
+          BOOTSTRAP_MANIFEST_SHA256: ${{ steps.candidate_bootstrap_plan.outputs.bootstrap_manifest_sha256 }}
+        run: |
+          set -euo pipefail
+          case "$BOOTSTRAP_STRATEGY" in
+            not_required)
+              [[ "$BOOTSTRAP_PLAN_REVISION" =~ ^[a-f0-9]{64}$ && -z "$BOOTSTRAP_MANIFEST_SHA256" ]] || { echo 'Token Vault ready bootstrap plan identity is invalid'; exit 1; }
+              ;;
+            derive|manifest)
+              [[ "$BOOTSTRAP_PLAN_REVISION" =~ ^legacy:[a-f0-9]{64}$ && "$BOOTSTRAP_MANIFEST_SHA256" =~ ^[a-f0-9]{64}$ ]] || { echo 'Token Vault legacy bootstrap plan identity is invalid'; exit 1; }
+              ;;
+            *)
+              echo 'Token Vault bootstrap strategy is invalid'; exit 1
+              ;;
+          esac
 
       - name: Check Token Vault release lease before staging version deployment
         if: inputs.target == 'staging'
@@ -1459,9 +1585,13 @@ jobs:
         id: tracking_bootstrap
         if: always() && inputs.target == 'staging' && steps.worker_deploy.outcome == 'success' && steps.worker_deployment_readback.outcome == 'success' && steps.staging_route_auth_convergence.outcome == 'success'
         env:
-          # The manifest stays in the protected Environment and is read only
-          # after the activated Worker proves that its authority is legacy.
-          TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST: ${{ secrets.TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST }}
+          # A protected manifest remains an optional explicit override. The
+          # default legacy path rederives its bounded plan privately inside the
+          # Vault from the candidate-bound digest sealed before traffic.
+          BOOTSTRAP_STRATEGY: ${{ steps.candidate_bootstrap_plan.outputs.bootstrap_strategy }}
+          BOOTSTRAP_PLAN_REVISION: ${{ steps.candidate_bootstrap_plan.outputs.bootstrap_plan_revision }}
+          BOOTSTRAP_MANIFEST_SHA256: ${{ steps.candidate_bootstrap_plan.outputs.bootstrap_manifest_sha256 }}
+          TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST: ${{ steps.candidate_bootstrap_plan.outputs.bootstrap_strategy == 'manifest' && secrets.TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST || '' }}
           TOKEN_VAULT_META_ADS_CONFIG_TOKEN: ${{ secrets.TOKEN_VAULT_META_ADS_CONFIG_TOKEN }}
           TOKEN_VAULT_STAGING_BASE_URL: ${{ vars.TOKEN_VAULT_STAGING_BASE_URL }}
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
@@ -1473,11 +1603,21 @@ jobs:
           bootstrap_operation_key="meta-ads-bootstrap:${RELEASE_SHA:0:12}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
           [[ "$bootstrap_operation_key" =~ ^[A-Za-z0-9_.:-]{8,160}$ ]] || { echo 'bootstrap operation key is invalid'; exit 1; }
           bootstrap_state="$(BOOTSTRAP_OPERATION_KEY="$bootstrap_operation_key" node --input-type=module <<'NODE'
+          import { createHash } from 'node:crypto';
+
           const base = String(process.env.TOKEN_VAULT_STAGING_BASE_URL || '').replace(/\/$/, '');
           const token = String(process.env.TOKEN_VAULT_META_ADS_CONFIG_TOKEN || '');
           const operationKey = String(process.env.BOOTSTRAP_OPERATION_KEY || '');
+          const strategy = String(process.env.BOOTSTRAP_STRATEGY || '');
+          const planRevision = String(process.env.BOOTSTRAP_PLAN_REVISION || '').toLowerCase();
+          const planDigest = String(process.env.BOOTSTRAP_MANIFEST_SHA256 || '').toLowerCase();
+          const rawManifest = String(process.env.TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST || '');
           if (!/^https:\/\/[^/]+$/.test(base) || !token) throw new Error('Token Vault staging bootstrap endpoint or credential is unavailable');
           if (!/^[A-Za-z0-9_.:-]{8,160}$/.test(operationKey)) throw new Error('bootstrap operation identity is invalid');
+          if (!['not_required', 'manifest', 'derive'].includes(strategy)) throw new Error('Token Vault candidate bootstrap strategy is unavailable');
+          if (!/^(?:legacy:)?[a-f0-9]{64}$/.test(planRevision)) throw new Error('Token Vault candidate bootstrap plan revision is invalid');
+          if ((strategy === 'derive' || strategy === 'manifest') && !/^[a-f0-9]{64}$/.test(planDigest)) throw new Error('Token Vault candidate bootstrap plan digest is invalid');
+          if (strategy !== 'manifest' && rawManifest) throw new Error('Token Vault derived or ready bootstrap strategy must not receive a protected manifest');
 
           const safeError = (payload) => {
             const value = String(payload?.error || '');
@@ -1491,6 +1631,7 @@ jobs:
               headers,
               body: body === undefined ? undefined : JSON.stringify(body),
               redirect: 'error',
+              signal: AbortSignal.timeout(20_000),
             });
             let payload = null;
             try { payload = await response.json(); } catch {}
@@ -1515,37 +1656,43 @@ jobs:
           const mode = String(initial.payload.config_authority_mode || '');
           if (mode === 'tracking_ready') {
             requireReady(initial, 'Token Vault configuration authority readback');
+            if (strategy !== 'not_required' || planRevision !== String(initial.payload?.config_authority_revision || '').toLowerCase() || planDigest || rawManifest) {
+              throw new Error('Token Vault configuration authority changed after candidate planning');
+            }
             process.stdout.write('not_required\n');
           } else if (mode === 'legacy_bootstrap') {
             const expectedRevision = String(initial.payload.config_authority_revision || '').toLowerCase();
             if (!/^legacy:[a-f0-9]{64}$/.test(expectedRevision)) throw new Error('legacy Token Vault authority revision is invalid');
-            const rawManifest = String(process.env.TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST || '');
-            if (!rawManifest) throw new Error('TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST is required only when legacy bootstrap is detected');
-            let manifest;
-            try { manifest = JSON.parse(rawManifest); } catch { throw new Error('TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST must be valid JSON containing only entries'); }
-            if (
-              !manifest ||
-              typeof manifest !== 'object' ||
-              Array.isArray(manifest) ||
-              Object.keys(manifest).length !== 1 ||
-              !Object.prototype.hasOwnProperty.call(manifest, 'entries') ||
-              !Array.isArray(manifest.entries) ||
-              manifest.entries.length < 2 ||
-              manifest.entries.length > 10 ||
-              new TextEncoder().encode(JSON.stringify(manifest)).length > 150 * 1024
-            ) {
-              throw new Error('TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST must contain only 2 to 10 bounded entries');
+            if (planRevision !== expectedRevision || !['manifest', 'derive'].includes(strategy)) throw new Error('Token Vault legacy authority changed after candidate planning');
+            let bootstrap;
+            if (strategy === 'manifest') {
+              const actualHex = createHash('sha256').update(rawManifest).digest('hex');
+              if (!rawManifest || actualHex !== planDigest) throw new Error('Token Vault protected bootstrap manifest changed after candidate planning');
+              let manifest;
+              try { manifest = JSON.parse(rawManifest); } catch { throw new Error('TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST must be valid JSON containing only entries'); }
+              if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest) || Object.keys(manifest).length !== 1 || !Object.prototype.hasOwnProperty.call(manifest, 'entries') || !Array.isArray(manifest.entries) || manifest.entries.length < 2 || manifest.entries.length > 10 || new TextEncoder().encode(JSON.stringify(manifest)).length > 150 * 1024) {
+                throw new Error('TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST must contain only 2 to 10 bounded entries');
+              }
+              bootstrap = await request('/v1/meta-ads-publish/config/bootstrap', {
+                method: 'POST',
+                body: {
+                  operation_key: operationKey,
+                  expected_config_authority_revision: expectedRevision,
+                  entries: manifest.entries,
+                },
+              });
+            } else {
+              bootstrap = await request('/v1/meta-ads-publish/config/bootstrap/derive', {
+                method: 'POST',
+                body: {
+                  operation_key: operationKey,
+                  expected_config_authority_revision: expectedRevision,
+                  expected_manifest_sha256: planDigest,
+                },
+              });
             }
-            const bootstrap = await request('/v1/meta-ads-publish/config/bootstrap', {
-              method: 'POST',
-              body: {
-                operation_key: operationKey,
-                expected_config_authority_revision: expectedRevision,
-                entries: manifest.entries,
-              },
-            });
             if (!bootstrap.response.ok || bootstrap.payload?.ok !== true) {
-              throw new Error(`Token Vault legacy bootstrap failed: ${bootstrap.response.status} ${safeError(bootstrap.payload)}`);
+              throw new Error(`Token Vault ${strategy} bootstrap failed: ${bootstrap.response.status} ${safeError(bootstrap.payload)}`);
             }
             const bootstrapRevision = String(bootstrap.payload?.config_authority_revision || '').toLowerCase();
             if (!/^[a-f0-9]{64}$/.test(bootstrapRevision)) throw new Error('Token Vault legacy bootstrap did not return a tracking revision');

--- a/platform/deploy/operational-units.json
+++ b/platform/deploy/operational-units.json
@@ -101,14 +101,14 @@
       "workflow": ".github/workflows/deploy-token-vault.yml",
       "concurrencyPrefix": "deploy-token-vault-",
       "publishes": ["Worker:skincos-token-vault", "Worker:skincos-token-vault-staging"],
-      "resources": ["Token Vault Worker", "skincos-token-vault D1", "skincos-token-vault-staging D1", "Token Vault route and auth bindings", "Governed Meta Ads tracking bootstrap, rollback journal and paused creative fixture"],
+      "resources": ["Token Vault Worker", "skincos-token-vault D1", "skincos-token-vault-staging D1", "Token Vault route and auth bindings", "Governed Meta Ads tracking bootstrap derivation, rollback journal and paused creative fixture"],
       "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "TOKEN_VAULT_API_TOKEN", "TOKEN_VAULT_N8N_API_TOKEN", "TOKEN_VAULT_ANALYTICS_API_TOKEN", "TOKEN_VAULT_ENCRYPTION_KEY", "TOKEN_VAULT_META_ADS_CONFIG_TOKEN", "TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST"],
       "migrationPaths": ["platform/security/token-vault/migrations"],
       "environments": ["preview", "staging", "production"],
       "promotion": {
         "stagingSupported": true,
         "trackingFixture": "synthetic authorized ad-set profile required before staging",
-        "trackingBootstrap": "legacy authority only; restricted config bearer plus private entries manifest",
+        "trackingBootstrap": "legacy authority only; restricted config bearer plus hash-bound internal derivation or protected entries override",
         "d1Recovery": "Time Travel bookmark; manual restore only under release:token-vault"
       }
     },

--- a/platform/security/token-vault/README.md
+++ b/platform/security/token-vault/README.md
@@ -12,15 +12,17 @@ Worker interno para substituir a aba `Credencial` do Google Sheets usada pelo wo
 - `GET /internal/token-vault/v1/meta-ads-publish/config`
 - `PUT /internal/token-vault/v1/meta-ads-publish/config`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/bootstrap`
+- `POST /internal/token-vault/v1/meta-ads-publish/config/bootstrap/derive-plan`
+- `POST /internal/token-vault/v1/meta-ads-publish/config/bootstrap/derive`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/bootstrap/rollback`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/staging-exercise`
 - `POST /internal/token-vault/v1/analytics/operations`
 
 Os endpoints administrativos exigem `Authorization: Bearer <TOKEN_VAULT_API_TOKEN>`.
 O bearer restrito `TOKEN_VAULT_META_ADS_CONFIG_TOKEN` só pode consultar
-`health`, `contract` e a configuração Meta Ads, ou chamar o bootstrap, o
-rollback desse bootstrap e o exercício de staging. Ele não lista/altera tokens,
-não cria runs e não publica anúncios.
+`health`, `contract` e a configuração Meta Ads, ou chamar o planejamento e
+bootstrap governados, o rollback desse bootstrap e o exercício de staging. Ele
+não lista/altera tokens, não cria runs e não publica anúncios.
 O endpoint de analytics exige o secret separado
 `TOKEN_VAULT_ANALYTICS_API_TOKEN` (administradores continuam podendo operar o
 endpoint para diagnóstico controlado).
@@ -35,9 +37,9 @@ endpoint para diagnóstico controlado).
 - Secret opcional do Worker: `TOKEN_VAULT_META_ADS_CONFIG_TOKEN` (papel
   restrito de configuração Meta Ads; obrigatório no Environment quando há
   promoção V20 governada)
-- Secret privado do GitHub Environment, não um binding do Worker:
-  `TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST` (somente as `entries` do bootstrap;
-  exigido apenas quando a autoridade ainda é legada)
+- Secret privado opcional do GitHub Environment, não um binding do Worker:
+  `TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST` (override explícito das `entries`
+  do bootstrap legado; nunca é recebido quando o plano interno é derivável)
 - Variável opcional: `META_GRAPH_VERSION` (default `v20.0`)
 - Variável de gate: `INFLUENCER_INTELLIGENCE_ANALYTICS_MODE` (`off` por
   padrão; `shadow` permite requests bounded; `active` exige também a flag
@@ -55,10 +57,23 @@ batch D1 condicionado às versões lidas. `POST`/`PATCH /v1/tokens` rejeitam ess
 metadata, pois um merge raso não é seguro.
 
 Para converter a autoridade legada, use somente o bootstrap restrito. O deploy
-autentica primeiro a URL Preview imutável candidata; se
-`config_authority_mode` for `legacy_bootstrap`, valida o envelope privado do
-manifesto antes de qualquer ativação de tráfego e só então monta o corpo fechado
-abaixo com a revisão opaca devolvida pelo GET e as `entries` do manifesto. Se já
+autentica primeiro a URL Preview imutável candidata. Se
+`config_authority_mode` for `legacy_bootstrap`, ele prefere
+`POST .../bootstrap/derive-plan`: o Vault faz apenas Graph GETs sobre os
+destinos já configurados, aceita fonte e tags somente quando há seletor privado
+explícito ou peer distinto na mesma linhagem única/compatível (nunca adota a
+creative do próprio target como fonte), e devolve exclusivamente a revisão
+opaca, hash do plano completo e contagens agregadas. O hash cobre os fatos
+Graph que influenciam perfil e reconciliação. Após o candidato receber tráfego,
+`POST .../bootstrap/derive` refaz essa leitura e só invoca a saga journalizada
+se o hash e a revisão ainda coincidirem. IDs, tags e entries nunca atravessam o
+Worker.
+
+`TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST` continua como override protegido para
+uma fonte já autorizada que não seja derivável; nesse caso o deploy valida e
+hash-vincula seu envelope antes do tráfego. Se a derivação for ambígua,
+incompatível, indisponível ou mudar entre as duas fases, o rollout falha fechado
+sem ativar tráfego novo ou escolher uma campanha por inventário de conta. Se já
 for `tracking_ready`, ele apenas faz o readback e não solicita nem recebe o
 manifesto.
 
@@ -254,11 +269,12 @@ manualmente para publicar este serviço.
 Antes da primeira promoção, disponibilize em cada GitHub Environment os
 segredos independentes exigidos pelo workflow, em especial
 `TOKEN_VAULT_META_ADS_CONFIG_TOKEN` e, em staging,
-`TOKEN_VAULT_N8N_API_TOKEN`; disponibilize
-`TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST` somente com as fontes/tags autorizadas
-quando a autoridade for legada, e um perfil de tracking sintético autorizado em
-staging. A ausência de credencial, manifesto legada necessário, fixture,
-bookmark ou evidência de staging é um bloqueio fail-closed para produção.
+`TOKEN_VAULT_N8N_API_TOKEN`. Para uma autoridade legada, o Vault primeiro tenta
+derivar internamente um plano único e hash-vinculado; disponibilize
+`TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST` somente como override protegido quando
+essa prova não for derivável. A ausência de credencial, uma derivação/override
+factualmente inválida, fixture, bookmark ou evidência de staging é um bloqueio
+fail-closed para produção.
 
 ## Import inicial
 

--- a/platform/security/token-vault/src/index.js
+++ b/platform/security/token-vault/src/index.js
@@ -12,6 +12,8 @@ const TOKEN_PREFIX = '/internal/token-vault';
 const META_ADS_PUBLISH_CONFIG_PATH = '/v1/meta-ads-publish/config';
 const META_ADS_PUBLISH_CONFIG_BOOTSTRAP_PATH = `${META_ADS_PUBLISH_CONFIG_PATH}/bootstrap`;
 const META_ADS_PUBLISH_CONFIG_BOOTSTRAP_ROLLBACK_PATH = `${META_ADS_PUBLISH_CONFIG_BOOTSTRAP_PATH}/rollback`;
+const META_ADS_PUBLISH_CONFIG_BOOTSTRAP_DERIVE_PLAN_PATH = `${META_ADS_PUBLISH_CONFIG_BOOTSTRAP_PATH}/derive-plan`;
+const META_ADS_PUBLISH_CONFIG_BOOTSTRAP_DERIVE_PATH = `${META_ADS_PUBLISH_CONFIG_BOOTSTRAP_PATH}/derive`;
 const META_ADS_PUBLISH_CONFIG_STAGING_EXERCISE_PATH = `${META_ADS_PUBLISH_CONFIG_PATH}/staging-exercise`;
 const JSON_HEADERS = {
   'content-type': 'application/json; charset=utf-8',
@@ -71,6 +73,8 @@ export async function handleRequest(request, env) {
         (request.method === 'POST' && [
           META_ADS_PUBLISH_CONFIG_BOOTSTRAP_PATH,
           META_ADS_PUBLISH_CONFIG_BOOTSTRAP_ROLLBACK_PATH,
+          META_ADS_PUBLISH_CONFIG_BOOTSTRAP_DERIVE_PLAN_PATH,
+          META_ADS_PUBLISH_CONFIG_BOOTSTRAP_DERIVE_PATH,
           META_ADS_PUBLISH_CONFIG_STAGING_EXERCISE_PATH,
         ].includes(pathname))
       ) {
@@ -109,6 +113,8 @@ export async function handleRequest(request, env) {
       [
         META_ADS_PUBLISH_CONFIG_BOOTSTRAP_PATH,
         META_ADS_PUBLISH_CONFIG_BOOTSTRAP_ROLLBACK_PATH,
+        META_ADS_PUBLISH_CONFIG_BOOTSTRAP_DERIVE_PLAN_PATH,
+        META_ADS_PUBLISH_CONFIG_BOOTSTRAP_DERIVE_PATH,
         META_ADS_PUBLISH_CONFIG_STAGING_EXERCISE_PATH,
       ].includes(pathname)
     ) {
@@ -587,7 +593,7 @@ function contract(requestId) {
       analytics_scope: 'influencer-intelligence',
       analytics_mode: 'shadow|active',
       meta_ads_config_secret: 'TOKEN_VAULT_META_ADS_CONFIG_TOKEN',
-      meta_ads_config_scope: 'health|contract|meta-ads-config-read|meta-ads-config-bootstrap|meta-ads-config-bootstrap-rollback|meta-ads-config-staging-exercise',
+      meta_ads_config_scope: 'health|contract|meta-ads-config-read|meta-ads-config-bootstrap|meta-ads-config-bootstrap-rollback|meta-ads-config-bootstrap-derive-plan|meta-ads-config-bootstrap-derive|meta-ads-config-staging-exercise',
     },
     storage: {
       d1_binding: 'TOKEN_VAULT_DB',

--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -57,6 +57,8 @@ const ADSET_CONVERSION_CONTRACT_FIELDS = [
   'attribution_spec',
   'promoted_object',
 ].join(',');
+// The autonomous legacy bootstrap may inspect candidate source ad sets, but it
+// must not use the broad inventory endpoint or persist raw account inventory.
 const TRACKING_PROMOTED_OBJECT_KEYS = Object.freeze([
   'pixel_id',
   'custom_event_type',
@@ -313,6 +315,14 @@ export async function handleMetaAdsPublishRequest(input) {
 
   if (request.method === 'POST' && pathname === `${PREFIX}/config/bootstrap`) {
     return bootstrapMetaAdsPublishConfig({ request, env, requestId, decryptToken, encryptToken, writeAudit });
+  }
+
+  if (request.method === 'POST' && pathname === `${PREFIX}/config/bootstrap/derive-plan`) {
+    return deriveMetaAdsPublishBootstrapPlan({ request, env, requestId, decryptToken });
+  }
+
+  if (request.method === 'POST' && pathname === `${PREFIX}/config/bootstrap/derive`) {
+    return bootstrapMetaAdsPublishConfigFromDerivedPlan({ request, env, requestId, decryptToken, encryptToken, writeAudit });
   }
 
   if (request.method === 'POST' && pathname === `${PREFIX}/config/bootstrap/rollback`) {
@@ -1112,6 +1122,685 @@ function configWriterFailureResponse(error, requestId) {
   return response({ ok: false, error: code, requestId }, status);
 }
 
+// A legacy v18 destination has enough private authority to identify its target,
+// but not enough governed v20 metadata to name an authorized source or raw URL
+// tag fragment. The derive endpoints keep those values inside the Vault: they
+// use only bounded Graph GETs, return a digest/count summary, and then bind the
+// normal encrypted bootstrap saga to the exact plan that was observed on the
+// immutable Worker candidate.
+export async function deriveMetaAdsPublishBootstrapPlan({ request, env, requestId, decryptToken }) {
+  try {
+    const input = validateBootstrapDerivePlanInput(await readBootstrapDeriveRequest(request));
+    const plan = await deriveBootstrapManifestPlan({
+      env,
+      requestId,
+      decryptToken,
+      expectedConfigAuthorityRevision: input.expectedConfigAuthorityRevision,
+    });
+    return bootstrapDerivePlanResponse(plan, requestId);
+  } catch (error) {
+    return bootstrapFailureResponse(normalizeBootstrapDeriveFailure(error), requestId);
+  }
+}
+
+export async function bootstrapMetaAdsPublishConfigFromDerivedPlan({
+  request,
+  env,
+  requestId,
+  decryptToken,
+  encryptToken,
+  writeAudit,
+}) {
+  try {
+    const input = validateBootstrapDeriveApplyInput(await readBootstrapDeriveRequest(request));
+    const replay = await replayDerivedBootstrapIfApplied({
+      env,
+      requestId,
+      decryptToken,
+      input,
+    });
+    if (replay) return replay;
+    const plan = await deriveBootstrapManifestPlan({
+      env,
+      requestId,
+      decryptToken,
+      expectedConfigAuthorityRevision: input.expectedConfigAuthorityRevision,
+    });
+    if (plan.manifestSha256 !== input.expectedManifestSha256) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_derive_plan_stale', 409);
+    }
+    const bootstrapRequest = new Request('https://token-vault.invalid/internal/token-vault/v1/meta-ads-publish/config/bootstrap', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        operation_key: input.operationKey,
+        expected_config_authority_revision: input.expectedConfigAuthorityRevision,
+        derived_plan_sha256: input.expectedManifestSha256,
+        entries: plan.entries,
+      }),
+    });
+    return bootstrapMetaAdsPublishConfig({
+      request: bootstrapRequest,
+      env,
+      requestId,
+      decryptToken,
+      encryptToken,
+      writeAudit,
+    });
+  } catch (error) {
+    return bootstrapFailureResponse(normalizeBootstrapDeriveFailure(error), requestId);
+  }
+}
+
+function normalizeBootstrapDeriveFailure(error) {
+  if (isBootstrapFailure(error)) return error;
+  return bootstrapFailure('meta_ads_publish_bootstrap_derive_unavailable', 503);
+}
+
+async function replayDerivedBootstrapIfApplied({ env, requestId, decryptToken, input }) {
+  if (!env?.TOKEN_VAULT_DB || typeof env.TOKEN_VAULT_DB.prepare !== 'function') {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_unavailable', 503);
+  }
+  const operation = await loadBootstrapOperation(env, input.operationKey);
+  if (!operation || clean(operation.status) !== 'applied') return null;
+  if (clean(operation.expected_config_authority_revision) !== input.expectedConfigAuthorityRevision) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_operation_conflict', 409);
+  }
+  const state = await decryptBootstrapState(operation, decryptToken, env);
+  const stateInput = asObject(state.input);
+  if (
+    clean(stateInput.operation_key) !== input.operationKey ||
+    clean(stateInput.expected_config_authority_revision) !== input.expectedConfigAuthorityRevision ||
+    !Array.isArray(stateInput.entries)
+  ) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_reconciliation_required', 409);
+  }
+  if (clean(stateInput.derived_plan_sha256) !== input.expectedManifestSha256) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_operation_conflict', 409);
+  }
+  const authority = await configWriterAuthorityState(await listMetaAdsPublishConfigRows(env));
+  if (!authority.ready || clean(operation.resulting_tracking_binding_revision) !== authority.revision) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_operation_state_stale', 409);
+  }
+  return bootstrapSuccessResponse({
+    input: { operationKey: input.operationKey },
+    state,
+    revision: authority.revision,
+    requestId,
+    replayed: true,
+  });
+}
+
+async function readBootstrapDeriveRequest(request) {
+  const contentLength = Number(request.headers.get('content-length') || 0);
+  if (contentLength > 8 * 1024) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_derive_request_too_large', 413);
+  }
+  try {
+    const body = await request.json();
+    if (!isJsonObject(body)) throw bootstrapFailure('meta_ads_publish_bootstrap_derive_request_invalid', 400);
+    return body;
+  } catch (error) {
+    if (isBootstrapFailure(error)) throw error;
+    throw bootstrapFailure('meta_ads_publish_bootstrap_derive_request_invalid', 400);
+  }
+}
+
+function validateBootstrapDerivePlanInput(body) {
+  assertBootstrapExactKeys(body, new Set(['expected_config_authority_revision']));
+  return {
+    expectedConfigAuthorityRevision: normalizeBootstrapDeriveRevision(body.expected_config_authority_revision),
+  };
+}
+
+function validateBootstrapDeriveApplyInput(body) {
+  assertBootstrapExactKeys(body, new Set([
+    'operation_key',
+    'expected_config_authority_revision',
+    'expected_manifest_sha256',
+  ]));
+  const operationKey = clean(body.operation_key);
+  if (!BOOTSTRAP_OPERATION_KEY_PATTERN.test(operationKey)) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_operation_key_invalid', 400);
+  }
+  const expectedManifestSha256 = clean(body.expected_manifest_sha256).toLowerCase();
+  if (!/^[a-f0-9]{64}$/.test(expectedManifestSha256)) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_derive_digest_invalid', 400);
+  }
+  return {
+    operationKey,
+    expectedConfigAuthorityRevision: normalizeBootstrapDeriveRevision(body.expected_config_authority_revision),
+    expectedManifestSha256,
+  };
+}
+
+function normalizeBootstrapDeriveRevision(value) {
+  const revision = clean(value).toLowerCase();
+  if (!/^legacy:[a-f0-9]{64}$/.test(revision)) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_expected_revision_invalid', 400);
+  }
+  return revision;
+}
+
+async function deriveBootstrapManifestPlan({ env, requestId, decryptToken, expectedConfigAuthorityRevision }) {
+  if (!env?.TOKEN_VAULT_DB || typeof env.TOKEN_VAULT_DB.prepare !== 'function') {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_unavailable', 503);
+  }
+  if (typeof decryptToken !== 'function') {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_token_unavailable', 503);
+  }
+  const currentRows = await listMetaAdsPublishConfigRows(env);
+  const authority = await configWriterAuthorityState(currentRows);
+  if (authority.ready || authority.mode !== 'legacy_bootstrap') {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_not_legacy', 409);
+  }
+  if (authority.revision !== expectedConfigAuthorityRevision) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_binding_stale', 409);
+  }
+  const context = {
+    env,
+    requestId,
+    action: 'derive_meta_ads_publish_bootstrap_plan',
+    decryptToken,
+    attempts: 0,
+    rateUsage: {},
+    traceId: '',
+  };
+  const plan = await deriveBootstrapManifestEntries({
+    rows: currentRows,
+    context,
+    staging: clean(env.ENVIRONMENT).toLowerCase() === 'staging',
+  });
+  // The digest is an execution seal, not merely a manifest hash. It covers
+  // every Graph fact that can affect the persisted profile or the tracking
+  // promoted-object mutation, and it is rederived before the saga can write.
+  const manifestSha256 = await sha256(stableStringify({
+    entries: plan.entries,
+    graph_contract: plan.graphContract,
+  }));
+  return {
+    authority,
+    entries: plan.entries,
+    manifestSha256,
+    summary: summarizeBootstrapDeriveEntries(plan.entries),
+  };
+}
+
+async function deriveBootstrapManifestEntries({ rows, context, staging }) {
+  const configuredRows = safeArray(rows)
+    .filter((row) => Object.keys(asObject(parseObject(row?.metadata_json).meta_ads_publish)).length > 0)
+    .sort((left, right) => clean(left.id).localeCompare(clean(right.id)));
+  if (configuredRows.length < 2 || configuredRows.length > BOOTSTRAP_MAX_ENTRIES) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_derive_targets_invalid', 409);
+  }
+
+  const records = [];
+  const stagingCandidates = [];
+  for (const targetRow of configuredRows) {
+    const targetAuth = await resolveLegacyBootstrapGraphAuth(clean(targetRow.id), context);
+    const targetAdset = await readAdsetConversionState(targetAuth, targetAuth.config.adset_id, context);
+    const graphDestination = safeTrackingEnum(targetAdset.destination_type);
+    if (graphDestination === 'WEBSITE') {
+      const standardRecord = await deriveWebsiteBootstrapEntry({
+        targetRow,
+        targetAuth,
+        targetAdset,
+        configuredRows,
+        context,
+        staging: false,
+      });
+      records.push(standardRecord);
+      if (staging) {
+        const stagingRecord = await tryDeriveStagingWebsiteBootstrapEntry({
+          targetRow,
+          targetAuth,
+          targetAdset,
+          configuredRows,
+          context,
+        });
+        stagingCandidates.push({ standardRecord, stagingRecord });
+      }
+      continue;
+    }
+    if (isBootstrapWhatsAppGraphDestination(graphDestination)) {
+      const whatsappDestinationUrl = await discoverBootstrapWhatsAppDestination(targetAuth, targetAdset, context, {});
+      records.push({
+        entry: {
+          config_token_id: targetAuth.tokenId,
+          destination_type: 'whatsapp',
+        },
+        graphFact: deriveWhatsAppBootstrapGraphFact({
+          targetAuth,
+          targetAdset,
+          whatsappDestinationUrl,
+        }),
+      });
+      continue;
+    }
+    throw bootstrapFailure('meta_ads_publish_bootstrap_derive_destination_invalid', 409);
+  }
+
+  const websites = records.filter((record) => record.entry.destination_type === 'website');
+  if (!websites.length) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_derive_website_destination_required', 409);
+  }
+  if (staging) {
+    const eligible = stagingCandidates.filter((candidate) => candidate.stagingRecord);
+    if (eligible.length !== 1) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_derive_staging_fixture_ambiguous', 409);
+    }
+    const selected = eligible[0];
+    const index = records.indexOf(selected.standardRecord);
+    if (index < 0) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_derive_staging_fixture_ambiguous', 409);
+    }
+    records[index] = selected.stagingRecord;
+  }
+  const ordered = records.sort((left, right) => clean(left.entry.config_token_id).localeCompare(clean(right.entry.config_token_id)));
+  return {
+    entries: ordered.map((record) => record.entry),
+    graphContract: ordered.map((record) => record.graphFact),
+  };
+}
+
+async function tryDeriveStagingWebsiteBootstrapEntry(input) {
+  try {
+    return await deriveWebsiteBootstrapEntry({ ...input, staging: true });
+  } catch (error) {
+    return derivedBootstrapCandidateOrNull(error);
+  }
+}
+
+async function deriveWebsiteBootstrapEntry({
+  targetRow,
+  targetAuth,
+  targetAdset,
+  configuredRows,
+  context,
+  staging,
+}) {
+  const targetConfig = asObject(targetAuth.config);
+  // A target-declared tag fragment is an authority fact, not a candidate
+  // preference. Validate it before examining any potential source so a bad
+  // target value can never make another source look acceptable by fallback.
+  const targetCanonicalUrlTags = resolveDerivedCanonicalUrlTags([targetConfig]);
+  const source = await deriveWebsiteBootstrapSource({
+    targetRow,
+    targetAuth,
+    targetAdset,
+    targetConfig,
+    configuredRows,
+    context,
+    staging,
+    targetCanonicalUrlTags,
+  });
+  const entry = {
+    config_token_id: targetAuth.tokenId,
+    destination_type: 'website',
+  };
+  if (source.selector.sourceConfigTokenId) {
+    entry.source_config_token_id = source.selector.sourceConfigTokenId;
+  } else {
+    entry.source_adset_id = source.sourceAuth.config.adset_id;
+  }
+  entry.fixture_source_ad_id = source.fixture.adId;
+  entry.url_tags = source.fixture.urlTags;
+  if (source.profile.staging_synthetic_fixture === true) {
+    entry.staging_synthetic_fixture = true;
+  }
+  return {
+    entry,
+    graphFact: deriveWebsiteBootstrapGraphFact({
+      targetAuth,
+      targetAdset,
+      source,
+      entry,
+    }),
+  };
+}
+
+async function deriveWebsiteBootstrapSource({
+  targetRow,
+  targetAuth,
+  targetAdset,
+  targetConfig,
+  configuredRows,
+  context,
+  staging,
+  targetCanonicalUrlTags,
+}) {
+  const canonical = deriveCanonicalBootstrapSourceSelector(targetConfig);
+  if (canonical) {
+    const resolved = await tryResolveDerivedBootstrapSource({
+      selector: canonical,
+      targetAuth,
+      targetAdset,
+      targetConfig,
+      context,
+      staging,
+    });
+    const finalized = resolved && await tryFinalizeDerivedBootstrapSource({ resolved, targetCanonicalUrlTags, context });
+    if (!finalized) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_derive_canonical_source_invalid', 409);
+    }
+    return finalized;
+  }
+
+  const pipeline = derivePipelineBootstrapSourceSelectors({
+    targetRow,
+    targetAuth,
+    targetConfig,
+    configuredRows,
+  });
+  const pipelineSource = await selectSingleDerivedBootstrapSource({
+    selectors: pipeline,
+    targetAuth,
+    targetAdset,
+    targetConfig,
+    context,
+    staging,
+    targetCanonicalUrlTags,
+  });
+  if (pipeline.length) {
+    if (pipelineSource) return pipelineSource;
+    if (staging) throw bootstrapFailure('meta_ads_publish_bootstrap_derive_source_unavailable', 409);
+  }
+
+  // The target's live creatives are delivery state, not source authority.
+  // A legacy destination may promote only an explicit private selector or a
+  // distinct peer already enrolled in the same bounded publishing lineage.
+  // In particular, never turn a single target ad into a production source.
+  throw bootstrapFailure('meta_ads_publish_bootstrap_derive_source_unavailable', 409);
+}
+
+function deriveCanonicalBootstrapSourceSelector(config) {
+  const sourceConfigTokenId = clean(config.source_config_token_id);
+  const sourceAdsetId = clean(config.source_adset_id);
+  if (!sourceConfigTokenId && !sourceAdsetId) return null;
+  if (Boolean(sourceConfigTokenId) === Boolean(sourceAdsetId)) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_derive_canonical_source_invalid', 409);
+  }
+  const fixtureSourceAdId = clean(config.fixture_source_ad_id);
+  if (sourceConfigTokenId) {
+    if (!CONFIG_WRITER_TOKEN_ID_PATTERN.test(sourceConfigTokenId)) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_derive_canonical_source_invalid', 409);
+    }
+    return { sourceConfigTokenId, fixtureSourceAdId, provenance: 'canonical_config' };
+  }
+  try {
+    return {
+      sourceAdsetId: normalizeNumericId(sourceAdsetId, 'bootstrap_derive_source_adset_id'),
+      fixtureSourceAdId,
+      provenance: 'canonical_config',
+    };
+  } catch {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_derive_canonical_source_invalid', 409);
+  }
+}
+
+function derivePipelineBootstrapSourceSelectors({ targetRow, targetAuth, targetConfig, configuredRows }) {
+  let targetCampaignId = '';
+  try {
+    targetCampaignId = normalizeNumericId(targetConfig.campaign_id, 'bootstrap_derive_target_campaign_id');
+  } catch {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_derive_target_invalid', 409);
+  }
+  const selectors = [];
+  for (const row of configuredRows) {
+    if (clean(row.id) === clean(targetRow.id)) continue;
+    const config = asObject(parseObject(row.metadata_json).meta_ads_publish);
+    try {
+      if (
+        normalizeNumericId(config.account_id, 'bootstrap_derive_source_account_id') !== targetAuth.accountId ||
+        normalizeNumericId(config.campaign_id, 'bootstrap_derive_source_campaign_id') !== targetCampaignId
+      ) {
+        continue;
+      }
+      selectors.push({
+        sourceAdsetId: normalizeNumericId(config.adset_id, 'bootstrap_derive_source_adset_id'),
+        provenance: 'pipeline_source',
+      });
+    } catch {
+      // A malformed or unrelated legacy destination is never evidence for a
+      // source selector. The bounded Graph compatibility test below still
+      // decides whether every remaining candidate is authorized.
+    }
+  }
+  return uniqueDerivedBootstrapSelectors(selectors);
+}
+
+function uniqueDerivedBootstrapSelectors(selectors) {
+  const byAdset = new Map();
+  for (const selector of safeArray(selectors)) {
+    const key = clean(selector?.sourceAdsetId);
+    if (!key || byAdset.has(key)) continue;
+    byAdset.set(key, selector);
+  }
+  return [...byAdset.values()].sort((left, right) => clean(left.sourceAdsetId).localeCompare(clean(right.sourceAdsetId)));
+}
+
+async function selectSingleDerivedBootstrapSource({
+  selectors,
+  targetAuth,
+  targetAdset,
+  targetConfig,
+  context,
+  staging,
+  targetCanonicalUrlTags,
+}) {
+  const resolved = [];
+  for (const selector of uniqueDerivedBootstrapSelectors(selectors)) {
+    const candidate = await tryResolveDerivedBootstrapSource({
+      selector,
+      targetAuth,
+      targetAdset,
+      targetConfig,
+      context,
+      staging,
+    });
+    if (candidate) resolved.push(candidate);
+  }
+  if (resolved.length > 1) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_derive_source_ambiguous', 409);
+  }
+  if (!resolved[0]) return null;
+  return tryFinalizeDerivedBootstrapSource({ resolved: resolved[0], targetCanonicalUrlTags, context });
+}
+
+async function tryResolveDerivedBootstrapSource({
+  selector,
+  targetAuth,
+  targetAdset,
+  targetConfig,
+  context,
+  staging,
+}) {
+  try {
+    const sourceAuth = await resolveLegacyBootstrapSourceAuth({
+      sourceConfigTokenId: clean(selector.sourceConfigTokenId),
+      sourceAdsetId: clean(selector.sourceAdsetId),
+    }, targetAuth, context);
+    const sourceAdset = await readAdsetConversionState(targetAuth, sourceAuth.config.adset_id, context);
+    const profile = buildBootstrapTrackingProfile({
+      sourceAuth,
+      sourceAdset,
+      targetAuth,
+      targetAdset,
+      targetConfig,
+      stagingSyntheticFixture: staging,
+    });
+    return { selector, sourceAuth, sourceAdset, profile };
+  } catch (error) {
+    return derivedBootstrapCandidateOrNull(error);
+  }
+}
+
+async function tryFinalizeDerivedBootstrapSource({ resolved, targetCanonicalUrlTags, context }) {
+  try {
+    const sourceCanonicalUrlTags = resolveDerivedCanonicalUrlTags([resolved.sourceAuth.config]);
+    if (targetCanonicalUrlTags && sourceCanonicalUrlTags && targetCanonicalUrlTags !== sourceCanonicalUrlTags) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_derive_source_url_tags_incompatible', 409);
+    }
+    const canonicalUrlTags = targetCanonicalUrlTags || sourceCanonicalUrlTags;
+    const fixture = await deriveBootstrapFixtureSource({
+      source: resolved,
+      canonicalUrlTags,
+      context,
+    });
+    return { ...resolved, fixture };
+  } catch (error) {
+    return derivedBootstrapCandidateOrNull(error);
+  }
+}
+
+function derivedBootstrapCandidateOrNull(error) {
+  if (isBootstrapFailure(error)) {
+    if (Number(error?.http_status) === 409) return null;
+    throw error;
+  }
+  const normalized = normalizeFailure(error);
+  if (Number(normalized.http_status) === 409 && normalized.classification === 'permanent') {
+    return null;
+  }
+  throw bootstrapFailure('meta_ads_publish_bootstrap_derive_unavailable', 503);
+}
+
+function resolveDerivedCanonicalUrlTags(configs) {
+  const values = new Set();
+  for (const configValue of safeArray(configs)) {
+    const config = asObject(configValue);
+    const tracking = asObject(config.tracking_contract);
+    for (const value of [config.url_tags, tracking.url_tags]) {
+      if (String(value ?? '') === '') continue;
+      try {
+        values.add(normalizeUrlTags(value, { required: true }));
+      } catch {
+        throw bootstrapFailure('meta_ads_publish_bootstrap_derive_canonical_url_tags_invalid', 409);
+      }
+    }
+  }
+  if (values.size > 1) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_derive_canonical_url_tags_ambiguous', 409);
+  }
+  return values.size === 1 ? [...values][0] : '';
+}
+
+async function deriveBootstrapFixtureSource({ source, canonicalUrlTags, context }) {
+  const sourceAdsetId = source.sourceAuth.config.adset_id;
+  let ad;
+  const requestedId = clean(source.selector.fixtureSourceAdId);
+  if (requestedId) {
+    try {
+      ad = await readBootstrapAd(source.sourceAuth, requestedId, context);
+      assertBootstrapFixtureSourceAd(ad, sourceAdsetId);
+    } catch (error) {
+      const candidate = derivedBootstrapCandidateOrNull(error);
+      if (candidate === null) throw bootstrapFailure('meta_ads_publish_bootstrap_derive_fixture_source_invalid', 409);
+      throw bootstrapFailure('meta_ads_publish_bootstrap_derive_unavailable', 503);
+    }
+  } else {
+    const candidates = (await listBootstrapAdsetAds(source.sourceAuth, sourceAdsetId, context))
+      .filter((entry) => isBootstrapFixtureSourceCandidate(entry, sourceAdsetId));
+    if (candidates.length !== 1) {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_derive_fixture_source_ambiguous', 409);
+    }
+    ad = candidates[0];
+  }
+  let urlTags = canonicalUrlTags;
+  if (!urlTags) {
+    try {
+      urlTags = normalizeUrlTags(asObject(ad.creative).url_tags, { required: true });
+    } catch {
+      throw bootstrapFailure('meta_ads_publish_bootstrap_derive_url_tags_unavailable', 409);
+    }
+  }
+  return {
+    adId: normalizeNumericId(ad.id, 'bootstrap_derive_fixture_source_ad_id'),
+    urlTags,
+  };
+}
+
+function deriveWebsiteBootstrapGraphFact({ targetAuth, targetAdset, source, entry }) {
+  const profile = asObject(source.profile);
+  const projected = projectAuthorizedTrackingPromotedObject(
+    source.sourceAdset,
+    targetAdset,
+    profile,
+  );
+  return {
+    config_token_id: targetAuth.tokenId,
+    destination_type: 'website',
+    source_adset_id: clean(source.sourceAuth.config.adset_id),
+    fixture_source_ad_id: clean(source.fixture.adId),
+    url_tags: clean(entry.url_tags),
+    profile: {
+      source_adset_id: clean(profile.source_adset_id),
+      destination_kind: clean(profile.destination_kind),
+      website_event_requirement: clean(profile.website_event_requirement),
+      offline_event_dataset_requirement: clean(profile.offline_event_dataset_requirement),
+      staging_synthetic_fixture: profile.staging_synthetic_fixture === true,
+      authorized_destination_adset_ids: safeArray(profile.authorized_destination_adset_ids),
+    },
+    source_adset: deriveAdsetGraphContractFact(source.sourceAdset),
+    target_adset: deriveAdsetGraphContractFact(targetAdset),
+    desired_tracking_promoted_object: asObject(projected.tracking_promoted_object),
+  };
+}
+
+function deriveWhatsAppBootstrapGraphFact({ targetAuth, targetAdset, whatsappDestinationUrl }) {
+  return {
+    config_token_id: targetAuth.tokenId,
+    destination_type: 'whatsapp',
+    target_adset: deriveAdsetGraphContractFact(targetAdset),
+    whatsapp_destination_url: clean(whatsappDestinationUrl),
+  };
+}
+
+function deriveAdsetGraphContractFact(value) {
+  const adset = asObject(value);
+  try {
+    const promotedObject = asObject(adset.promoted_object);
+    const trackingPromotedObject = {};
+    for (const key of TRACKING_PROMOTED_OBJECT_KEYS) {
+      if (Object.prototype.hasOwnProperty.call(promotedObject, key)) {
+        trackingPromotedObject[key] = clean(promotedObject[key]);
+      }
+    }
+    return {
+      account_id: normalizeNumericId(adset.account_id, 'bootstrap_derive_adset_account_id'),
+      campaign_objective: safeTrackingEnum(asObject(adset.campaign).objective),
+      optimization_goal: safeTrackingEnum(adset.optimization_goal),
+      destination_type: safeTrackingEnum(adset.destination_type),
+      billing_event: safeTrackingEnum(adset.billing_event),
+      attribution_spec: safeArray(adset.attribution_spec),
+      tracking_promoted_object: trackingPromotedObject,
+    };
+  } catch {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_derive_graph_contract_invalid', 409);
+  }
+}
+
+function summarizeBootstrapDeriveEntries(entries) {
+  const websites = safeArray(entries).filter((entry) => clean(entry.destination_type) === 'website');
+  const whatsapp = safeArray(entries).filter((entry) => clean(entry.destination_type) === 'whatsapp');
+  return {
+    destination_count: websites.length + whatsapp.length,
+    website_destination_count: websites.length,
+    whatsapp_destination_count: whatsapp.length,
+    staging_fixture_count: websites.filter((entry) => entry.staging_synthetic_fixture === true).length,
+  };
+}
+
+function bootstrapDerivePlanResponse(plan, requestId) {
+  return response({
+    ok: true,
+    config_authority_revision: plan.authority.revision,
+    manifest_sha256: plan.manifestSha256,
+    summary: plan.summary,
+    requestId,
+  });
+}
+
 // The legacy configuration predates the v20 tracking contract, so it cannot
 // create a normal creative in order to obtain the mandatory paused URL-tags
 // fixture.  This narrowly-scoped saga is the only bootstrap escape hatch. It
@@ -1170,6 +1859,7 @@ export async function bootstrapMetaAdsPublishConfig({ request, env, requestId, d
         input: {
           operation_key: input.operationKey,
           expected_config_authority_revision: input.expectedConfigAuthorityRevision,
+          ...(input.derivedPlanSha256 ? { derived_plan_sha256: input.derivedPlanSha256 } : {}),
           entries: input.entries,
         },
         items: [],
@@ -2194,6 +2884,7 @@ async function validateBootstrapInput(body) {
   assertBootstrapExactKeys(body, new Set([
     'operation_key',
     'expected_config_authority_revision',
+    'derived_plan_sha256',
     'entries',
   ]));
   const operationKey = clean(body.operation_key);
@@ -2210,12 +2901,23 @@ async function validateBootstrapInput(body) {
   const seen = new Set();
   const entries = body.entries.map((value) => normalizeBootstrapEntry(value, seen))
     .sort((left, right) => left.configTokenId.localeCompare(right.configTokenId));
+  const derivedPlanSha256 = clean(body.derived_plan_sha256).toLowerCase();
+  if (derivedPlanSha256 && !/^[a-f0-9]{64}$/.test(derivedPlanSha256)) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_derive_digest_invalid', 400);
+  }
   const requestHash = await sha256(stableStringify({
     operation_key: operationKey,
     expected_config_authority_revision: expectedConfigAuthorityRevision,
+    derived_plan_sha256: derivedPlanSha256,
     entries,
   }));
-  return { operationKey, expectedConfigAuthorityRevision, entries, requestHash };
+  return {
+    operationKey,
+    expectedConfigAuthorityRevision,
+    derivedPlanSha256,
+    entries,
+    requestHash,
+  };
 }
 
 function normalizeBootstrapEntry(value, seen) {

--- a/platform/security/token-vault/tests/index.test.js
+++ b/platform/security/token-vault/tests/index.test.js
@@ -258,6 +258,22 @@ test('meta ads config credential is limited to configuration reads and governed 
   assert.notEqual(bootstrapResponse.status, 403);
   assert.notEqual((await bootstrapResponse.json()).error, 'meta_ads_config_credential_scope_required');
 
+  for (const pathname of [
+    '/v1/meta-ads-publish/config/bootstrap/derive-plan',
+    '/v1/meta-ads-publish/config/bootstrap/derive',
+  ]) {
+    const deriveResponse = await handleRequest(
+      new Request(`https://api.skincos.com.br/internal/token-vault${pathname}`, {
+        method: 'POST',
+        headers: { ...metaAdsConfigAuthHeaders(), 'content-type': 'application/json' },
+        body: '{}',
+      }),
+      env(db),
+    );
+    assert.notEqual(deriveResponse.status, 403);
+    assert.notEqual((await deriveResponse.json()).error, 'meta_ads_config_credential_scope_required');
+  }
+
   const rollbackResponse = await handleRequest(
     new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/config/bootstrap/rollback', {
       method: 'POST',
@@ -286,6 +302,8 @@ test('operational credential cannot invoke Meta Ads bootstrap or staging exercis
   for (const pathname of [
     '/v1/meta-ads-publish/config/bootstrap',
     '/v1/meta-ads-publish/config/bootstrap/rollback',
+    '/v1/meta-ads-publish/config/bootstrap/derive-plan',
+    '/v1/meta-ads-publish/config/bootstrap/derive',
     '/v1/meta-ads-publish/config/staging-exercise',
   ]) {
     const response = await handleRequest(

--- a/platform/security/token-vault/tests/meta-ads-publish-bootstrap.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-bootstrap.test.js
@@ -3,6 +3,8 @@ import test from 'node:test';
 import {
   __test as metaAdsPublishTest,
   bootstrapMetaAdsPublishConfig,
+  bootstrapMetaAdsPublishConfigFromDerivedPlan,
+  deriveMetaAdsPublishBootstrapPlan,
   exerciseStagingMetaAdsTrackingFixture,
   handleMetaAdsPublishRequest,
   rollbackBootstrapMetaAdsPublishConfig,
@@ -403,7 +405,7 @@ class BootstrapGraph {
     ]);
     this.targetBefore = clone(this.adsets.get(TARGET_ADSET_ID));
     this.ads = new Map([
-      ['723456780', ad('723456780', SOURCE_ADSET_ID, '823456780')],
+      ['723456780', ad('723456780', SOURCE_ADSET_ID, '823456780', RAW_URL_TAGS)],
       ['723456792', {
         ...ad('723456792', WHATSAPP_ADSET_ID, '823456792'),
         creative: {
@@ -452,6 +454,11 @@ class BootstrapGraph {
     }
     if (method !== 'GET') throw new Error(`Unexpected graph mutation ${method} ${parsed.pathname}`);
 
+    if (child === 'adsets' && id === 'act_123456789') {
+      return json({
+        data: [...this.adsets.entries()].map(([adsetId, value]) => ({ id: adsetId, ...clone(value) })),
+      });
+    }
     if (child === 'ads') {
       return json({ data: [...this.ads.values()].filter((entry) => entry.adset_id === id).map(clone) });
     }
@@ -543,14 +550,21 @@ function websiteAdset(promotedObject) {
   };
 }
 
-function ad(id, adsetId, creativeId) {
+function ad(id, adsetId, creativeId, urlTags = '') {
   return {
     id,
     adset_id: adsetId,
     status: 'ACTIVE',
     effective_status: 'ACTIVE',
-    creative: { id: creativeId },
+    creative: { id: creativeId, ...(urlTags ? { url_tags: urlTags } : {}) },
   };
+}
+
+function enableDerivedStagingLineage(graph) {
+  // Each legacy Website destination must have a distinct, already-enrolled
+  // peer source. The source row itself is never implicitly adopted from its
+  // own delivery creative.
+  graph.ads.set('723456791', ad('723456791', TARGET_ADSET_ID, '823456791', RAW_URL_TAGS));
 }
 
 function json(body, status = 200) {
@@ -611,6 +625,26 @@ function bootstrapRequest(body) {
   });
 }
 
+function bootstrapDerivePlanRequest(expectedConfigAuthorityRevision) {
+  return new Request('https://token-vault.test/v1/meta-ads-publish/config/bootstrap/derive-plan', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ expected_config_authority_revision: expectedConfigAuthorityRevision }),
+  });
+}
+
+function bootstrapDeriveRequest({ operationKey, expectedConfigAuthorityRevision, expectedManifestSha256 }) {
+  return new Request('https://token-vault.test/v1/meta-ads-publish/config/bootstrap/derive', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      operation_key: operationKey,
+      expected_config_authority_revision: expectedConfigAuthorityRevision,
+      expected_manifest_sha256: expectedManifestSha256,
+    }),
+  });
+}
+
 function bootstrapRollbackRequest(operationKey, expectedTrackingBindingRevision) {
   return new Request('https://token-vault.test/v1/meta-ads-publish/config/bootstrap/rollback', {
     method: 'POST',
@@ -664,6 +698,273 @@ async function applyHappyBootstrap({ db, graph, state, operationKey }) {
   assert.equal(result.status, 201, JSON.stringify(payload));
   return { env, decryptToken, encryptToken, body, payload };
 }
+
+test('autonomous bootstrap derivation keeps the manifest private and applies only its hash-bound plan', async () => {
+  const db = new BootstrapDb();
+  const graph = new BootstrapGraph();
+  enableDerivedStagingLineage(graph);
+  const state = new Map();
+  const { env, decryptToken, encryptToken } = bootstrapContext({ db, graph, state });
+  env.ENVIRONMENT = 'staging';
+  const expectedRevision = await legacyAuthorityRevision(env);
+
+  const plan = await deriveMetaAdsPublishBootstrapPlan({
+    request: bootstrapDerivePlanRequest(expectedRevision),
+    env,
+    requestId: 'bootstrap-derive-plan-private',
+    decryptToken,
+  });
+  const planPayload = await plan.json();
+  assert.equal(plan.status, 200, JSON.stringify(planPayload));
+  assert.equal(planPayload.ok, true);
+  assert.equal(planPayload.config_authority_revision, expectedRevision);
+  assert.match(planPayload.manifest_sha256, /^[a-f0-9]{64}$/);
+  assert.deepEqual(planPayload.summary, {
+    destination_count: 3,
+    website_destination_count: 2,
+    whatsapp_destination_count: 1,
+    staging_fixture_count: 1,
+  });
+  const serializedPlan = JSON.stringify(planPayload);
+  assert.equal(serializedPlan.includes(RAW_URL_TAGS), false);
+  assert.equal(serializedPlan.includes(SOURCE_ADSET_ID), false);
+  assert.equal(graph.calls.some((call) => call.method !== 'GET'), false);
+
+  const applied = await bootstrapMetaAdsPublishConfigFromDerivedPlan({
+    request: bootstrapDeriveRequest({
+      operationKey: 'bootstrap-derive-apply-private-001',
+      expectedConfigAuthorityRevision: expectedRevision,
+      expectedManifestSha256: planPayload.manifest_sha256,
+    }),
+    env,
+    requestId: 'bootstrap-derive-apply-private',
+    decryptToken,
+    encryptToken,
+    writeAudit: async () => {},
+  });
+  const appliedPayload = await applied.json();
+  assert.equal(applied.status, 201, JSON.stringify(appliedPayload));
+  assert.equal(appliedPayload.ok, true);
+  assert.equal(appliedPayload.website_fixture_count, 2);
+  const targetConfig = JSON.parse(db.tokens.find((row) => row.id === 'facebook_b_target').metadata_json).meta_ads_publish;
+  assert.equal(targetConfig.tracking_contract.url_tags, RAW_URL_TAGS);
+  assert.equal(targetConfig.tracking_profiles[targetConfig.tracking_contract.profile_ref].staging_synthetic_fixture, true);
+  assert.deepEqual(graph.adsets.get(TARGET_ADSET_ID).promoted_object, graph.targetBefore.promoted_object);
+
+  const callsBeforeReplay = graph.calls.length;
+  const replay = await bootstrapMetaAdsPublishConfigFromDerivedPlan({
+    request: bootstrapDeriveRequest({
+      operationKey: 'bootstrap-derive-apply-private-001',
+      expectedConfigAuthorityRevision: expectedRevision,
+      expectedManifestSha256: planPayload.manifest_sha256,
+    }),
+    env,
+    requestId: 'bootstrap-derive-apply-private-replay',
+    decryptToken,
+    encryptToken,
+    writeAudit: async () => {},
+  });
+  const replayPayload = await replay.json();
+  assert.equal(replay.status, 200, JSON.stringify(replayPayload));
+  assert.equal(replayPayload.ok, true);
+  assert.equal(replayPayload.replayed, true);
+  assert.equal(graph.calls.length, callsBeforeReplay);
+});
+
+test('autonomous bootstrap derivation rejects digest, authority and source ambiguity before any Graph mutation', async () => {
+  const db = new BootstrapDb();
+  const graph = new BootstrapGraph();
+  enableDerivedStagingLineage(graph);
+  const state = new Map();
+  const { env, decryptToken, encryptToken } = bootstrapContext({ db, graph, state });
+  env.ENVIRONMENT = 'staging';
+  const expectedRevision = await legacyAuthorityRevision(env);
+  const plan = await deriveMetaAdsPublishBootstrapPlan({
+    request: bootstrapDerivePlanRequest(expectedRevision),
+    env,
+    requestId: 'bootstrap-derive-plan-stale',
+    decryptToken,
+  });
+  const planPayload = await plan.json();
+  assert.equal(plan.status, 200, JSON.stringify(planPayload));
+
+  const callsBeforeWrongDigest = graph.calls.length;
+  const wrongDigest = await bootstrapMetaAdsPublishConfigFromDerivedPlan({
+    request: bootstrapDeriveRequest({
+      operationKey: 'bootstrap-derive-wrong-digest-001',
+      expectedConfigAuthorityRevision: expectedRevision,
+      expectedManifestSha256: '0'.repeat(64),
+    }),
+    env,
+    requestId: 'bootstrap-derive-wrong-digest',
+    decryptToken,
+    encryptToken,
+    writeAudit: async () => {},
+  });
+  const wrongDigestPayload = await wrongDigest.json();
+  assert.equal(wrongDigest.status, 409);
+  assert.equal(wrongDigestPayload.error, 'meta_ads_publish_bootstrap_derive_plan_stale');
+  assert.equal(graph.calls.slice(callsBeforeWrongDigest).some((call) => call.method !== 'GET'), false);
+
+  const contractDb = new BootstrapDb();
+  const contractGraph = new BootstrapGraph();
+  enableDerivedStagingLineage(contractGraph);
+  const contractState = new Map();
+  const contract = bootstrapContext({ db: contractDb, graph: contractGraph, state: contractState });
+  contract.env.ENVIRONMENT = 'staging';
+  const contractRevision = await legacyAuthorityRevision(contract.env);
+  const contractPlan = await deriveMetaAdsPublishBootstrapPlan({
+    request: bootstrapDerivePlanRequest(contractRevision),
+    env: contract.env,
+    requestId: 'bootstrap-derive-plan-contract-drift',
+    decryptToken: contract.decryptToken,
+  });
+  const contractPlanPayload = await contractPlan.json();
+  assert.equal(contractPlan.status, 200, JSON.stringify(contractPlanPayload));
+  contractGraph.adsets.get(SOURCE_ADSET_ID).promoted_object.offline_conversion_data_set_id = '823456788';
+  const callsBeforeContractDrift = contractGraph.calls.length;
+  const contractDrift = await bootstrapMetaAdsPublishConfigFromDerivedPlan({
+    request: bootstrapDeriveRequest({
+      operationKey: 'bootstrap-derive-contract-drift-001',
+      expectedConfigAuthorityRevision: contractRevision,
+      expectedManifestSha256: contractPlanPayload.manifest_sha256,
+    }),
+    env: contract.env,
+    requestId: 'bootstrap-derive-contract-drift',
+    decryptToken: contract.decryptToken,
+    encryptToken: contract.encryptToken,
+    writeAudit: async () => {},
+  });
+  const contractDriftPayload = await contractDrift.json();
+  assert.equal(contractDrift.status, 409);
+  assert.equal(contractDriftPayload.error, 'meta_ads_publish_bootstrap_derive_plan_stale');
+  assert.equal(contractGraph.calls.slice(callsBeforeContractDrift).some((call) => call.method !== 'GET'), false);
+
+  graph.ads.get('723456780').creative.url_tags = 'source=changed&value=1';
+  const callsBeforeApply = graph.calls.length;
+  const stale = await bootstrapMetaAdsPublishConfigFromDerivedPlan({
+    request: bootstrapDeriveRequest({
+      operationKey: 'bootstrap-derive-stale-apply-001',
+      expectedConfigAuthorityRevision: expectedRevision,
+      expectedManifestSha256: planPayload.manifest_sha256,
+    }),
+    env,
+    requestId: 'bootstrap-derive-stale-apply',
+    decryptToken,
+    encryptToken,
+    writeAudit: async () => {},
+  });
+  const stalePayload = await stale.json();
+  assert.equal(stale.status, 409);
+  assert.equal(stalePayload.error, 'meta_ads_publish_bootstrap_derive_plan_stale');
+  assert.equal(graph.calls.slice(callsBeforeApply).some((call) => call.method !== 'GET'), false);
+
+  const revisionDb = new BootstrapDb();
+  const revisionGraph = new BootstrapGraph();
+  enableDerivedStagingLineage(revisionGraph);
+  const revisionState = new Map();
+  const revision = bootstrapContext({ db: revisionDb, graph: revisionGraph, state: revisionState });
+  revision.env.ENVIRONMENT = 'staging';
+  const revisionBefore = await legacyAuthorityRevision(revision.env);
+  const revisionPlan = await deriveMetaAdsPublishBootstrapPlan({
+    request: bootstrapDerivePlanRequest(revisionBefore),
+    env: revision.env,
+    requestId: 'bootstrap-derive-plan-authority-drift',
+    decryptToken: revision.decryptToken,
+  });
+  const revisionPlanPayload = await revisionPlan.json();
+  assert.equal(revisionPlan.status, 200, JSON.stringify(revisionPlanPayload));
+  const changedMetadata = JSON.parse(revisionDb.tokens[0].metadata_json);
+  changedMetadata.meta_ads_publish.legacy_marker = 'v18-source-revised';
+  revisionDb.tokens[0].metadata_json = JSON.stringify(changedMetadata);
+  const callsBeforeAuthorityDrift = revisionGraph.calls.length;
+  const authorityDrift = await bootstrapMetaAdsPublishConfigFromDerivedPlan({
+    request: bootstrapDeriveRequest({
+      operationKey: 'bootstrap-derive-authority-drift-001',
+      expectedConfigAuthorityRevision: revisionBefore,
+      expectedManifestSha256: revisionPlanPayload.manifest_sha256,
+    }),
+    env: revision.env,
+    requestId: 'bootstrap-derive-authority-drift',
+    decryptToken: revision.decryptToken,
+    encryptToken: revision.encryptToken,
+    writeAudit: async () => {},
+  });
+  const authorityDriftPayload = await authorityDrift.json();
+  assert.equal(authorityDrift.status, 409);
+  assert.equal(authorityDriftPayload.error, 'meta_ads_publish_bootstrap_binding_stale');
+  assert.equal(revisionGraph.calls.slice(callsBeforeAuthorityDrift).some((call) => call.method !== 'GET'), false);
+
+  const ambiguousDb = new BootstrapDb();
+  const ambiguousGraph = new BootstrapGraph();
+  const ambiguousState = new Map();
+  const ambiguous = bootstrapContext({ db: ambiguousDb, graph: ambiguousGraph, state: ambiguousState });
+  ambiguous.env.ENVIRONMENT = 'staging';
+  const peerAdsetId = '323456793';
+  ambiguousDb.tokens.push(tokenRow('facebook_d_peer', 'Website peer source', peerAdsetId, 4));
+  ambiguousGraph.adsets.set(peerAdsetId, clone(ambiguousGraph.adsets.get(SOURCE_ADSET_ID)));
+  ambiguousGraph.ads.set('723456781', ad('723456781', peerAdsetId, '823456781', 'source=other&value=2'));
+  const ambiguousRevision = await legacyAuthorityRevision(ambiguous.env);
+  const rejected = await deriveMetaAdsPublishBootstrapPlan({
+    request: bootstrapDerivePlanRequest(ambiguousRevision),
+    env: ambiguous.env,
+    requestId: 'bootstrap-derive-plan-ambiguous',
+    decryptToken: ambiguous.decryptToken,
+  });
+  const rejectedPayload = await rejected.json();
+  assert.equal(rejected.status, 409);
+  assert.equal(rejectedPayload.error, 'meta_ads_publish_bootstrap_derive_source_ambiguous');
+  assert.equal(ambiguousGraph.calls.some((call) => call.method !== 'GET'), false);
+});
+
+test('autonomous bootstrap derivation fails closed instead of falling back after a source Graph authorization failure', async () => {
+  const db = new BootstrapDb();
+  const graph = new BootstrapGraph();
+  const state = new Map();
+  const { env, decryptToken } = bootstrapContext({ db, graph, state });
+  env.ENVIRONMENT = 'staging';
+  const unreadableAdsetId = '323456793';
+  db.tokens.push(tokenRow('facebook_d_unreadable', 'Website unreadable peer', unreadableAdsetId, 4));
+  const graphFetch = graph.fetch.bind(graph);
+  env.META_GRAPH_FETCH = async (url, init) => {
+    const parsed = new URL(url);
+    if (parsed.pathname.endsWith(`/${unreadableAdsetId}`)) {
+      return json({ error: { message: 'permission denied' } }, 403);
+    }
+    return graphFetch(url, init);
+  };
+  const expectedRevision = await legacyAuthorityRevision(env);
+  const result = await deriveMetaAdsPublishBootstrapPlan({
+    request: bootstrapDerivePlanRequest(expectedRevision),
+    env,
+    requestId: 'bootstrap-derive-source-auth-failure',
+    decryptToken,
+  });
+  const payload = await result.json();
+  assert.equal(result.status, 503);
+  assert.equal(payload.error, 'meta_ads_publish_bootstrap_derive_unavailable');
+  assert.equal(JSON.stringify(payload).includes(unreadableAdsetId), false);
+  assert.equal(graph.calls.some((call) => call.method !== 'GET'), false);
+});
+
+test('autonomous bootstrap derivation never promotes a target creative into its own production source', async () => {
+  const db = new BootstrapDb();
+  const graph = new BootstrapGraph();
+  const state = new Map();
+  const { env, decryptToken } = bootstrapContext({ db, graph, state });
+  env.ENVIRONMENT = 'production';
+  const expectedRevision = await legacyAuthorityRevision(env);
+  const result = await deriveMetaAdsPublishBootstrapPlan({
+    request: bootstrapDerivePlanRequest(expectedRevision),
+    env,
+    requestId: 'bootstrap-derive-no-self-source',
+    decryptToken,
+  });
+  const payload = await result.json();
+  assert.equal(result.status, 409);
+  assert.equal(payload.error, 'meta_ads_publish_bootstrap_derive_source_unavailable');
+  assert.equal(graph.calls.some((call) => call.method !== 'GET'), false);
+});
 
 async function recordBootstrapAdsetLockContention({ db, env, lockKey, phase, observations }) {
   const lock = db.operationLocks.get(lockKey);

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -78,12 +78,12 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
   const tokenVaultUnit = catalog.units.find((unit) => unit.id === "token-vault");
   assert.ok(tokenVaultUnit);
   assert.ok(!catalog.nonPublishingSurfaces.some((entry) => entry.id === "token-vault"));
-  assert.ok(tokenVaultUnit.resources.includes("Governed Meta Ads tracking bootstrap, rollback journal and paused creative fixture"));
+  assert.ok(tokenVaultUnit.resources.includes("Governed Meta Ads tracking bootstrap derivation, rollback journal and paused creative fixture"));
   assert.ok(tokenVaultUnit.secrets.includes("TOKEN_VAULT_META_ADS_CONFIG_TOKEN"));
   assert.ok(tokenVaultUnit.secrets.includes("TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST"));
   assert.ok(!tokenVaultUnit.secrets.includes("TOKEN_VAULT_BACKUP_PASSPHRASE"));
   assert.equal(tokenVaultUnit.promotion.trackingFixture, "synthetic authorized ad-set profile required before staging");
-  assert.equal(tokenVaultUnit.promotion.trackingBootstrap, "legacy authority only; restricted config bearer plus private entries manifest");
+  assert.equal(tokenVaultUnit.promotion.trackingBootstrap, "legacy authority only; restricted config bearer plus hash-bound internal derivation or protected entries override");
   assert.equal(tokenVaultUnit.promotion.d1Recovery, "Time Travel bookmark; manual restore only under release:token-vault");
 
   const workflow = read(".github/workflows/deploy-token-vault.yml");
@@ -106,6 +106,8 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
     "--strict",
     "versions deploy",
     "promotion-evidence-token-vault",
+    "/v1/meta-ads-publish/config/bootstrap/derive-plan",
+    "/v1/meta-ads-publish/config/bootstrap/derive",
     "/v1/meta-ads-publish/config/bootstrap/rollback",
   ]) assert.match(workflow, new RegExp(marker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   assert.match(workflow, /uses: \.\/\.github\/actions\/global-coordination-acquire/);
@@ -134,7 +136,6 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
   assert.match(release, /Activate only the selected Token Vault version in staging[\s\S]*?if: inputs\.target == 'staging'/);
   assert.doesNotMatch(release, /for name [^\n]*TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST/);
   assert.match(release, /Object\.keys\(manifest\)\.length !== 1/);
-  assert.match(release, /TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST is required only when legacy bootstrap is detected/);
   assert.match(release, /TOKEN_VAULT_N8N_API_TOKEN must be owned by the staging Environment/);
   assert.match(release, /if \[\[ "\$TARGET" == staging \]\]; then[\s\S]*?TOKEN_VAULT_N8N_API_TOKEN/);
   assert.match(release, /if \(process\.env\.TARGET === 'production'\) requiredInherited\.push\('TOKEN_VAULT_N8N_API_TOKEN'\)/);
@@ -152,21 +153,31 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
   assert.match(release, /grep -F -x "\$expected_preview_url"/);
   assert.match(release, /Verify immutable Token Vault candidate config bearer before traffic/);
   assert.match(release, /Token Vault immutable candidate config bearer did not authenticate before traffic/);
-  assert.match(release, /config_authority_mode=\$\{mode\}/);
-  assert.match(release, /Verify protected legacy Token Vault bootstrap manifest before traffic/);
+  assert.match(release, /config_authority_mode=\$\{authority\.mode\}/);
+  assert.match(release, /config_authority_revision=\$\{authority\.revision\}/);
+  assert.match(release, /Seal a private or internally-derived legacy Token Vault bootstrap plan before traffic/);
   assert.match(release, /CANDIDATE_CONFIG_AUTHORITY_MODE: \$\{\{ steps\.candidate_config_bearer\.outputs\.config_authority_mode \}\}/);
+  assert.match(release, /CANDIDATE_CONFIG_AUTHORITY_REVISION: \$\{\{ steps\.candidate_config_bearer\.outputs\.config_authority_revision \}\}/);
   assert.match(release, /outputs\.config_authority_mode == 'legacy_bootstrap' && secrets\.TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST \|\| ''/);
   assert.match(release, /Token Vault tracking-ready candidate must not receive a bootstrap manifest/);
   assert.match(release, /Token Vault bootstrap manifest has an unsafe entry envelope/);
   assert.match(release, /Token Vault bootstrap manifest has an unsafe Website entry/);
   assert.match(release, /forbiddenUrlTagKeyPattern/);
-  assert.match(release, /config_authority_mode === 'tracking_ready'/);
-  assert.match(release, /config_authority_mode === 'legacy_bootstrap'/);
+  assert.match(release, /mode === 'tracking_ready'/);
+  assert.match(release, /mode === 'legacy_bootstrap'/);
   assert.match(release, /signal: AbortSignal\.timeout\(10_000\)/);
+  assert.match(release, /signal: AbortSignal\.timeout\(20_000\)/);
+  assert.match(release, /TOKEN_VAULT_CANDIDATE_PREVIEW_URL=\$CANDIDATE_PREVIEW_URL/);
+  assert.match(release, /process\.env\.TOKEN_VAULT_CANDIDATE_PREVIEW_URL/);
+  assert.match(release, /\/v1\/meta-ads-publish\/config\/bootstrap\/derive-plan/);
+  assert.match(release, /bootstrap_strategy=\$\{strategy\}/);
+  assert.match(release, /bootstrap_plan_revision=\$\{authorityRevision\}/);
+  assert.match(release, /bootstrap_manifest_sha256=\$\{manifestSha256\}/);
   assert.ok(release.indexOf("Verify immutable Token Vault candidate config bearer before traffic") < release.indexOf("Activate only the selected Token Vault version in staging"));
-  assert.ok(release.indexOf("Verify immutable Token Vault candidate config bearer before traffic") < release.indexOf("Verify protected legacy Token Vault bootstrap manifest before traffic"));
-  assert.ok(release.indexOf("Verify protected legacy Token Vault bootstrap manifest before traffic") < release.indexOf("Activate only the selected Token Vault version in staging"));
-  assert.ok(release.indexOf("Verify protected legacy Token Vault bootstrap manifest before traffic") < release.indexOf("Check Token Vault release lease before staging version deployment"));
+  assert.ok(release.indexOf("Verify immutable Token Vault candidate config bearer before traffic") < release.indexOf("Seal a private or internally-derived legacy Token Vault bootstrap plan before traffic"));
+  assert.ok(release.indexOf("Seal a private or internally-derived legacy Token Vault bootstrap plan before traffic") < release.indexOf("Validate sealed Token Vault bootstrap plan before staging traffic"));
+  assert.ok(release.indexOf("Validate sealed Token Vault bootstrap plan before staging traffic") < release.indexOf("Activate only the selected Token Vault version in staging"));
+  assert.ok(release.indexOf("Validate sealed Token Vault bootstrap plan before staging traffic") < release.indexOf("Check Token Vault release lease before staging version deployment"));
   assert.match(release, /Wait for staging Token Vault route to accept the candidate config bearer/);
   assert.match(release, /Token Vault staging route did not accept the candidate config bearer before bootstrap/);
   assert.ok(release.indexOf("Read back the exact active Token Vault Worker version in staging") < release.indexOf("Wait for staging Token Vault route to accept the candidate config bearer"));
@@ -180,6 +191,12 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
   assert.match(orbContract, /steps\.production_route_auth_convergence\.outcome != 'success'/);
   assert.match(release, /expected_config_authority_revision: expectedRevision/);
   assert.match(release, /entries: manifest\.entries/);
+  assert.equal((workflow.match(/import \{ createHash \} from 'node:crypto';/g) || []).length, 3);
+  assert.match(release, /expected_manifest_sha256: planDigest/);
+  assert.match(release, /\/v1\/meta-ads-publish\/config\/bootstrap\/derive/);
+  assert.match(release, /BOOTSTRAP_STRATEGY: \$\{\{ steps\.candidate_bootstrap_plan\.outputs\.bootstrap_strategy \}\}/);
+  assert.match(release, /BOOTSTRAP_PLAN_REVISION: \$\{\{ steps\.candidate_bootstrap_plan\.outputs\.bootstrap_plan_revision \}\}/);
+  assert.match(release, /BOOTSTRAP_MANIFEST_SHA256: \$\{\{ steps\.candidate_bootstrap_plan\.outputs\.bootstrap_manifest_sha256 \}\}/);
   assert.match(release, /bootstrap_operation_key="meta-ads-bootstrap:\$\{RELEASE_SHA:0:12\}:\$\{GITHUB_RUN_ID\}:\$\{GITHUB_RUN_ATTEMPT\}"/);
   assert.match(release, /did_bootstrap=true/);
   assert.match(release, /bootstrap_operation_key=\$bootstrap_recorded_operation_key/);
@@ -195,12 +212,18 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
   assert.equal((workflow.match(/id: tracking_bootstrap_rollback/g) || []).length, 2);
   assert.equal((workflow.match(/\/v1\/meta-ads-publish\/config\/bootstrap\/rollback/g) || []).length, 2);
   assert.doesNotMatch(release, /process\.stdout\.write\([^\n]*manifest/i);
+  assert.doesNotMatch(release, /GITHUB_OUTPUT[^\n]*(?:entries|summary|TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST)/i);
   assert.ok(release.indexOf("Upload immutable Token Vault version") < release.indexOf("Activate only the selected Token Vault version in staging"));
   assert.ok(release.indexOf("Read back the exact active Token Vault Worker version in staging") < release.indexOf("Bootstrap legacy Token Vault Meta Ads configuration only when staging requires it"));
   assert.ok(release.indexOf("Bootstrap legacy Token Vault Meta Ads configuration only when staging requires it") < release.indexOf("Read back staging Token Vault deployment and authenticated health"));
   assert.ok(release.indexOf("Roll back an applied Token Vault legacy bootstrap before staging Worker compensation") < release.indexOf("Compensate the staging Worker only when this release still owns traffic"));
   assert.match(orbContract, /needs: \[promotion, release\]/);
   assert.match(orbContract, /RELEASE_SHA: \$\{\{ needs\.promotion\.outputs\.source_sha \}\}/);
+  assert.match(orbContract, /BOOTSTRAP_STRATEGY: \$\{\{ needs\.release\.outputs\.bootstrap_strategy \}\}/);
+  assert.match(orbContract, /BOOTSTRAP_PLAN_REVISION: \$\{\{ needs\.release\.outputs\.bootstrap_plan_revision \}\}/);
+  assert.match(orbContract, /BOOTSTRAP_MANIFEST_SHA256: \$\{\{ needs\.release\.outputs\.bootstrap_manifest_sha256 \}\}/);
+  assert.match(orbContract, /Validate sealed Token Vault bootstrap plan before native mutation/);
+  assert.ok(orbContract.indexOf("Validate sealed Token Vault bootstrap plan before native mutation") < orbContract.indexOf("Attest the already staged immutable candidate through GitHub OIDC"));
   assert.match(orbContract, /id-token: write/);
   assert.match(orbContract, /Attest the already staged immutable candidate through GitHub OIDC/);
   assert.match(orbContract, /Capture the complete incumbent inactive Orb checkpoint before compound transition/);


### PR DESCRIPTION
## What changed

Adds a restricted, Graph-read-only derivation path for legacy Meta Ads Tracking configuration. The Worker seals a complete private bootstrap plan and the workflow applies only its matching digest; a protected manifest remains an override for genuinely non-derivable facts.

## Why

The prior governed rollout correctly stopped before traffic when legacy authority had no Environment manifest. This closes the bootstrap gap without inferring URL tags or source ownership from the target creative, and without exposing entries, tags, IDs, or credentials.

## Safety and rollback

The plan rejects ambiguity, source authorization failures, drift, stale revisions, and target-self sourcing before Graph mutation. Replays are hash-bound and idempotent. Existing journaled bootstrap rollback and Worker/native compensation remain the recovery path.

## Validation

- Token Vault tests: 124/124
- Global concurrency governance: 18/18
- Deploy topology and Cloudflare single-writer checks
- YAML/README formatting and diff checks