### PR TITLE
fix(ponto): verify top-level version upload output

### DIFF
--- a/.github/scripts/ponto-wrangler-output.mjs
+++ b/.github/scripts/ponto-wrangler-output.mjs
@@ -16,11 +16,18 @@ const actualName = String(record.worker_name || record.project_name || record.na
 if (actualName !== expectedName) throw new Error(`Wrangler output target differs: ${actualName || "missing"}`);
 const expectedEnvironment = String(process.env.PONTO_EXPECTED_WRANGLER_ENV || "").trim();
 const actualEnvironment = String(record.wrangler_environment || record.environment || "");
-// Wrangler's version-deploy NDJSON record identifies the exact Worker and
-// deployment, but does not currently repeat the --env value. Keep strict
-// environment validation for records that expose it and for version-upload;
-// the exact Worker name remains mandatory for version-deploy.
-const missingEnvironmentAllowed = expectedType === "version-deploy" && !actualEnvironment;
+// Wrangler's top-level production version-upload and version-deploy NDJSON
+// records identify the exact Worker and version/deployment, but do not always
+// repeat the --env value. Keep strict environment validation for every named
+// environment, especially staging; the exact Worker name remains mandatory.
+const missingEnvironmentAllowed = !actualEnvironment && (
+  expectedType === "version-deploy"
+  || (
+    expectedType === "version-upload"
+    && expectedEnvironment === "production"
+    && expectedName === "skincos-timekeeping"
+  )
+);
 if (expectedEnvironment && actualEnvironment !== expectedEnvironment && !missingEnvironmentAllowed) {
   throw new Error(`Wrangler output environment differs: ${actualEnvironment || "missing"}`);
 }

--- a/.github/scripts/ponto-wrangler-output.test.mjs
+++ b/.github/scripts/ponto-wrangler-output.test.mjs
@@ -8,7 +8,7 @@ import test from "node:test";
 const script = path.resolve(import.meta.dirname, "ponto-wrangler-output.mjs");
 const uuid = "11111111-1111-4111-8111-111111111111";
 
-test("extracts only a structured version upload for the exact Worker", () => {
+test("accepts a top-level production version upload without a repeated Wrangler environment", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wrangler-output-"));
   const file = path.join(dir, "output.ndjson");
   fs.writeFileSync(file, [
@@ -16,8 +16,25 @@ test("extracts only a structured version upload for the exact Worker", () => {
     JSON.stringify({ type: "version-upload", version: 1, worker_name: "skincos-timekeeping", version_id: uuid }),
     "",
   ].join("\n"));
-  const result = spawnSync(process.execPath, [script, file, "version-upload", "skincos-timekeeping"], { encoding: "utf8" });
+  const result = spawnSync(process.execPath, [script, file, "version-upload", "skincos-timekeeping"], {
+    encoding: "utf8",
+    env: { ...process.env, PONTO_EXPECTED_WRANGLER_ENV: "production" },
+  });
   assert.equal(result.status, 0, result.stderr);
+});
+
+test("rejects a staging version upload without its Wrangler environment", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wrangler-output-"));
+  const file = path.join(dir, "output.ndjson");
+  fs.writeFileSync(file, [
+    JSON.stringify({ type: "version-upload", version: 1, worker_name: "skincos-timekeeping-staging", version_id: uuid }),
+    "",
+  ].join("\n"));
+  const result = spawnSync(process.execPath, [script, file, "version-upload", "skincos-timekeeping-staging"], {
+    encoding: "utf8",
+    env: { ...process.env, PONTO_EXPECTED_WRANGLER_ENV: "staging" },
+  });
+  assert.notEqual(result.status, 0);
 });
 
 test("accepts version deploy output without a repeated Wrangler environment", () => {


### PR DESCRIPTION
## Summary
- accept Wrangler NDJSON that omits the environment only for the exact top-level production Timekeeping version upload
- retain strict environment validation for staging and explicit environment records

## Validation
- `node --test .github/scripts/ponto-wrangler-output.test.mjs`

## Rollback
- Revert this isolated parser change; staging and production remain fail-closed until the governed Ponto promotion succeeds.