### PR TITLE
feat(meta-ads): seed empty staging tracking authority

### DIFF
--- a/.github/workflows/deploy-token-vault.yml
+++ b/.github/workflows/deploy-token-vault.yml
@@ -1254,8 +1254,21 @@ jobs:
               analytics_value="$(node --input-type=module -e "import { randomBytes } from 'node:crypto'; process.stdout.write(randomBytes(32).toString('base64url'));")"
             fi
           fi
+          # The staging synthetic-seed bearer is an internally generated,
+          # candidate-only capability. It never becomes a GitHub secret or
+          # crosses a step boundary as a value: only this private runner-temp
+          # file path is exported for the bounded seed and rollback calls.
+          seed_secret_file=''
+          if [[ "$TARGET" == staging ]]; then
+            seed_secret_file="$RUNNER_TEMP/token-vault-staging-synthetic-seed-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            umask 077
+            node --input-type=module -e "import { randomBytes } from 'node:crypto'; process.stdout.write(randomBytes(48).toString('base64url'));" > "$seed_secret_file"
+            [[ "$(wc -c < "$seed_secret_file")" -ge 64 ]] || { echo 'generated staging synthetic-seed bearer is invalid'; exit 1; }
+            chmod 600 "$seed_secret_file"
+            echo "TOKEN_VAULT_STAGING_SYNTHETIC_SEED_FILE=$seed_secret_file" >> "$GITHUB_ENV"
+          fi
           n8n_value="${TOKEN_VAULT_N8N_API_TOKEN:-}"
-          ANALYTICS_REQUIRED="$analytics_required" ANALYTICS_VALUE="$analytics_value" META_ADS_CONFIG_VALUE="${TOKEN_VAULT_META_ADS_CONFIG_TOKEN:-}" N8N_VALUE="$n8n_value" TARGET="$TARGET" SECRETS_FILE="$secrets_file" node --input-type=module <<'NODE'
+          ANALYTICS_REQUIRED="$analytics_required" ANALYTICS_VALUE="$analytics_value" META_ADS_CONFIG_VALUE="${TOKEN_VAULT_META_ADS_CONFIG_TOKEN:-}" N8N_VALUE="$n8n_value" STAGING_SYNTHETIC_SEED_FILE="$seed_secret_file" TARGET="$TARGET" SECRETS_FILE="$secrets_file" node --input-type=module <<'NODE'
           import fs from 'node:fs';
 
           const secrets = {};
@@ -1271,6 +1284,12 @@ jobs:
             if (operationalToken.length < 32) throw new Error('staging operational bearer is invalid');
             if (operationalToken === configToken) throw new Error('staging operational and config bearers must differ');
             secrets.TOKEN_VAULT_N8N_API_TOKEN = operationalToken;
+            const seedFile = String(process.env.STAGING_SYNTHETIC_SEED_FILE || '');
+            if (!seedFile) throw new Error('staging synthetic-seed bearer file is unavailable');
+            const seedToken = fs.readFileSync(seedFile, 'utf8').trim();
+            if (!/^[A-Za-z0-9_-]{64,}$/.test(seedToken)) throw new Error('staging synthetic-seed bearer is invalid');
+            if (seedToken === configToken || seedToken === operationalToken) throw new Error('staging synthetic-seed bearer must be distinct');
+            secrets.TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN = seedToken;
           }
           fs.writeFileSync(process.env.SECRETS_FILE, `${JSON.stringify(secrets)}\n`, { mode: 0o600 });
           NODE
@@ -1298,6 +1317,82 @@ jobs:
           [[ "${TOKEN_VAULT_INCUMBENT_VERSION_ID:-}" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo 'Token Vault incumbent version was not captured'; exit 1; }
           echo "version_id=$TOKEN_VAULT_VERSION_ID" >> "$GITHUB_OUTPUT"
           echo "incumbent_version_id=$TOKEN_VAULT_INCUMBENT_VERSION_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Seal the isolated staging Meta Ads synthetic seed on the immutable candidate
+        # This is deliberately before candidate config authentication and plan
+        # derivation: an empty legacy authority has no prior target from which
+        # to derive. The generated bearer has no role outside these two seed
+        # endpoints and the Meta source inputs never enter a Worker binding.
+        id: candidate_staging_synthetic_seed
+        if: inputs.operation == 'deploy' && inputs.target == 'staging'
+        env:
+          META_ADS_ACCESS_TOKEN: ${{ inputs.target == 'staging' && secrets.META_ADS_ACCESS_TOKEN || '' }}
+          META_PIXEL_ID: ${{ inputs.target == 'staging' && secrets.META_PIXEL_ID || '' }}
+          META_ADS_ACCOUNT_ID: ${{ inputs.target == 'staging' && vars.META_ADS_ACCOUNT_ID || '' }}
+          META_ADS_API_VERSION: ${{ inputs.target == 'staging' && vars.META_ADS_API_VERSION || '' }}
+          RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+
+          const preview = String(process.env.TOKEN_VAULT_CANDIDATE_PREVIEW_URL || '').replace(/\/$/, '');
+          const seedFile = String(process.env.TOKEN_VAULT_STAGING_SYNTHETIC_SEED_FILE || '');
+          const accessToken = String(process.env.META_ADS_ACCESS_TOKEN || '');
+          const pixelId = String(process.env.META_PIXEL_ID || '').trim();
+          const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
+          const apiVersion = String(process.env.META_ADS_API_VERSION || '').trim();
+          const releaseSha = String(process.env.RELEASE_SHA || '').toLowerCase();
+          const runId = String(process.env.GITHUB_RUN_ID || '');
+          const runAttempt = String(process.env.GITHUB_RUN_ATTEMPT || '');
+          if (!/^https:\/\/(?:[a-z0-9-]+\.)+workers\.dev$/.test(preview) || !seedFile) {
+            throw new Error('immutable staging synthetic-seed candidate endpoint is unavailable');
+          }
+          if (!accessToken || !/^\d{5,30}$/.test(pixelId) || !/^\d{5,30}$/.test(accountId) || !/^v\d+\.\d+$/.test(apiVersion)) {
+            throw new Error('staging synthetic Meta source custody is unavailable or malformed');
+          }
+          if (!/^[a-f0-9]{40}$/.test(releaseSha) || !/^\d+$/.test(runId) || !/^\d+$/.test(runAttempt)) {
+            throw new Error('staging synthetic-seed operation identity is invalid');
+          }
+          const seedToken = fs.readFileSync(seedFile, 'utf8').trim();
+          if (!/^[A-Za-z0-9_-]{64,}$/.test(seedToken)) throw new Error('staging synthetic-seed bearer is unavailable');
+          const operationKey = `meta-ads-staging-seed:${releaseSha.slice(0, 12)}:${runId}:${runAttempt}`;
+          // Persist only the opaque operation identity before making the
+          // network call. An interrupted request can then be reconciled by the
+          // explicit rollback step without ever emitting source credentials.
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `seed_attempted=true\nseed_operation_key=${operationKey}\n`);
+          const response = await fetch(`${preview}/internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${seedToken}`,
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify({
+              operation_key: operationKey,
+              access_token: accessToken,
+              account_id: accountId,
+              pixel_id: pixelId,
+              api_version: apiVersion,
+            }),
+            cache: 'no-store',
+            redirect: 'error',
+            signal: AbortSignal.timeout(30_000),
+          });
+          let payload = null;
+          try { payload = await response.json(); } catch {}
+          const error = /^[a-z0-9_:-]{1,120}$/i.test(String(payload?.error || '')) ? String(payload.error) : 'unknown';
+          const seed = String(payload?.seed || '');
+          const valid = response.ok && payload?.ok === true &&
+            (seed === 'sealed' || seed === 'not_required') &&
+            String(payload?.operation_status || '') === seed &&
+            typeof payload?.replayed === 'boolean' &&
+            String(payload?.operation_key || '') === operationKey &&
+            String(payload?.contract_version || '') === 'meta-ads-tracking-v20/staging-synthetic-seed/v1';
+          if (!valid) throw new Error(`staging synthetic-seed failed: ${response.status} ${error}`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, seed === 'sealed'
+            ? `did_seed=true\nseed_status=${seed}\n`
+            : `did_seed=false\nseed_status=${seed}\n`);
+          NODE
 
       - name: Verify immutable Token Vault candidate config bearer before traffic
         id: candidate_config_bearer
@@ -1502,7 +1597,57 @@ jobs:
               ;;
           esac
 
+      - name: Roll back the isolated staging synthetic seed before traffic when candidate planning fails
+        id: pretraffic_staging_synthetic_seed_rollback
+        if: always() && inputs.target == 'staging' && steps.candidate_staging_synthetic_seed.outputs.seed_attempted == 'true' && (steps.candidate_staging_synthetic_seed.outcome != 'success' || steps.candidate_config_bearer.outcome != 'success' || steps.candidate_bootstrap_plan.outcome != 'success' || steps.validate_staging_bootstrap_plan.outcome != 'success')
+        env:
+          META_ADS_ACCESS_TOKEN: ${{ inputs.target == 'staging' && secrets.META_ADS_ACCESS_TOKEN || '' }}
+          META_ADS_ACCOUNT_ID: ${{ inputs.target == 'staging' && vars.META_ADS_ACCOUNT_ID || '' }}
+          META_ADS_API_VERSION: ${{ inputs.target == 'staging' && vars.META_ADS_API_VERSION || '' }}
+          SEED_OPERATION_KEY: ${{ steps.candidate_staging_synthetic_seed.outputs.seed_operation_key }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+
+          const preview = String(process.env.TOKEN_VAULT_CANDIDATE_PREVIEW_URL || '').replace(/\/$/, '');
+          const seedFile = String(process.env.TOKEN_VAULT_STAGING_SYNTHETIC_SEED_FILE || '');
+          const accessToken = String(process.env.META_ADS_ACCESS_TOKEN || '');
+          const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
+          const apiVersion = String(process.env.META_ADS_API_VERSION || '').trim();
+          const operationKey = String(process.env.SEED_OPERATION_KEY || '');
+          if (!/^https:\/\/(?:[a-z0-9-]+\.)+workers\.dev$/.test(preview) || !seedFile || !accessToken || !/^\d{5,30}$/.test(accountId) || !/^v\d+\.\d+$/.test(apiVersion) || !/^meta-ads-staging-seed:[A-Za-z0-9_.:-]{8,140}$/.test(operationKey)) {
+            throw new Error('staging synthetic-seed rollback custody or identity is invalid');
+          }
+          const seedToken = fs.readFileSync(seedFile, 'utf8').trim();
+          if (!/^[A-Za-z0-9_-]{64,}$/.test(seedToken)) throw new Error('staging synthetic-seed rollback bearer is unavailable');
+          const response = await fetch(`${preview}/internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/rollback`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${seedToken}`,
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify({
+              operation_key: operationKey,
+              access_token: accessToken,
+              account_id: accountId,
+              api_version: apiVersion,
+            }),
+            cache: 'no-store',
+            redirect: 'error',
+            signal: AbortSignal.timeout(30_000),
+          });
+          let payload = null;
+          try { payload = await response.json(); } catch {}
+          const error = /^[a-z0-9_:-]{1,120}$/i.test(String(payload?.error || '')) ? String(payload.error) : 'unknown';
+          const absent = response.status === 409 && payload?.ok === false && payload?.error === 'meta_ads_publish_staging_seed_operation_not_found';
+          if (!absent && (!response.ok || payload?.ok !== true || payload?.rolled_back !== true || String(payload?.operation_status || '') !== 'rolled_back' || typeof payload?.replayed !== 'boolean' || String(payload?.operation_key || '') !== operationKey || String(payload?.contract_version || '') !== 'meta-ads-tracking-v20/staging-synthetic-seed/v1')) {
+            throw new Error(`staging synthetic-seed pre-traffic rollback failed: ${response.status} ${error}`);
+          }
+          NODE
+
       - name: Check Token Vault release lease before staging version deployment
+        id: staging_worker_activation_lease
         if: inputs.target == 'staging'
         uses: ./.github/actions/global-coordination-check
         with:
@@ -1515,6 +1660,55 @@ jobs:
           coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
           key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+
+      - name: Roll back the isolated staging synthetic seed when the activation lease rejects it
+        id: activation_lease_staging_synthetic_seed_rollback
+        if: always() && inputs.target == 'staging' && steps.candidate_staging_synthetic_seed.outputs.seed_attempted == 'true' && steps.candidate_staging_synthetic_seed.outcome == 'success' && steps.candidate_config_bearer.outcome == 'success' && steps.candidate_bootstrap_plan.outcome == 'success' && steps.validate_staging_bootstrap_plan.outcome == 'success' && steps.staging_worker_activation_lease.outcome != 'success'
+        env:
+          META_ADS_ACCESS_TOKEN: ${{ inputs.target == 'staging' && secrets.META_ADS_ACCESS_TOKEN || '' }}
+          META_ADS_ACCOUNT_ID: ${{ inputs.target == 'staging' && vars.META_ADS_ACCOUNT_ID || '' }}
+          META_ADS_API_VERSION: ${{ inputs.target == 'staging' && vars.META_ADS_API_VERSION || '' }}
+          SEED_OPERATION_KEY: ${{ steps.candidate_staging_synthetic_seed.outputs.seed_operation_key }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+
+          const preview = String(process.env.TOKEN_VAULT_CANDIDATE_PREVIEW_URL || '').replace(/\/$/, '');
+          const seedFile = String(process.env.TOKEN_VAULT_STAGING_SYNTHETIC_SEED_FILE || '');
+          const accessToken = String(process.env.META_ADS_ACCESS_TOKEN || '');
+          const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
+          const apiVersion = String(process.env.META_ADS_API_VERSION || '').trim();
+          const operationKey = String(process.env.SEED_OPERATION_KEY || '');
+          if (!/^https:\/\/(?:[a-z0-9-]+\.)+workers\.dev$/.test(preview) || !seedFile || !accessToken || !/^\d{5,30}$/.test(accountId) || !/^v\d+\.\d+$/.test(apiVersion) || !/^meta-ads-staging-seed:[A-Za-z0-9_.:-]{8,140}$/.test(operationKey)) {
+            throw new Error('staging synthetic-seed rollback custody or identity is invalid');
+          }
+          const seedToken = fs.readFileSync(seedFile, 'utf8').trim();
+          if (!/^[A-Za-z0-9_-]{64,}$/.test(seedToken)) throw new Error('staging synthetic-seed rollback bearer is unavailable');
+          const response = await fetch(`${preview}/internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/rollback`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${seedToken}`,
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify({
+              operation_key: operationKey,
+              access_token: accessToken,
+              account_id: accountId,
+              api_version: apiVersion,
+            }),
+            cache: 'no-store',
+            redirect: 'error',
+            signal: AbortSignal.timeout(30_000),
+          });
+          let payload = null;
+          try { payload = await response.json(); } catch {}
+          const error = /^[a-z0-9_:-]{1,120}$/i.test(String(payload?.error || '')) ? String(payload.error) : 'unknown';
+          const absent = response.status === 409 && payload?.ok === false && payload?.error === 'meta_ads_publish_staging_seed_operation_not_found';
+          if (!absent && (!response.ok || payload?.ok !== true || payload?.rolled_back !== true || String(payload?.operation_status || '') !== 'rolled_back' || typeof payload?.replayed !== 'boolean' || String(payload?.operation_key || '') !== operationKey || String(payload?.contract_version || '') !== 'meta-ads-tracking-v20/staging-synthetic-seed/v1')) {
+            throw new Error(`staging synthetic-seed activation-lease rollback failed: ${response.status} ${error}`);
+          }
+          NODE
 
       - name: Activate only the selected Token Vault version in staging
         id: worker_deploy
@@ -1883,8 +2077,56 @@ jobs:
           }
           NODE
 
+      - name: Roll back the isolated staging synthetic seed before Worker compensation
+        id: staging_synthetic_seed_rollback
+        if: always() && steps.staging_worker_compensation_lease.outcome == 'success' && steps.tracking_bootstrap_rollback.outcome == 'success' && steps.candidate_staging_synthetic_seed.outputs.did_seed == 'true'
+        env:
+          META_ADS_ACCESS_TOKEN: ${{ inputs.target == 'staging' && secrets.META_ADS_ACCESS_TOKEN || '' }}
+          META_ADS_ACCOUNT_ID: ${{ inputs.target == 'staging' && vars.META_ADS_ACCOUNT_ID || '' }}
+          META_ADS_API_VERSION: ${{ inputs.target == 'staging' && vars.META_ADS_API_VERSION || '' }}
+          SEED_OPERATION_KEY: ${{ steps.candidate_staging_synthetic_seed.outputs.seed_operation_key }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+
+          const preview = String(process.env.TOKEN_VAULT_CANDIDATE_PREVIEW_URL || '').replace(/\/$/, '');
+          const seedFile = String(process.env.TOKEN_VAULT_STAGING_SYNTHETIC_SEED_FILE || '');
+          const accessToken = String(process.env.META_ADS_ACCESS_TOKEN || '');
+          const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
+          const apiVersion = String(process.env.META_ADS_API_VERSION || '').trim();
+          const operationKey = String(process.env.SEED_OPERATION_KEY || '');
+          if (!/^https:\/\/(?:[a-z0-9-]+\.)+workers\.dev$/.test(preview) || !seedFile || !accessToken || !/^\d{5,30}$/.test(accountId) || !/^v\d+\.\d+$/.test(apiVersion) || !/^meta-ads-staging-seed:[A-Za-z0-9_.:-]{8,140}$/.test(operationKey)) {
+            throw new Error('staging synthetic-seed rollback custody or identity is invalid');
+          }
+          const seedToken = fs.readFileSync(seedFile, 'utf8').trim();
+          if (!/^[A-Za-z0-9_-]{64,}$/.test(seedToken)) throw new Error('staging synthetic-seed rollback bearer is unavailable');
+          const response = await fetch(`${preview}/internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/rollback`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${seedToken}`,
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify({
+              operation_key: operationKey,
+              access_token: accessToken,
+              account_id: accountId,
+              api_version: apiVersion,
+            }),
+            cache: 'no-store',
+            redirect: 'error',
+            signal: AbortSignal.timeout(30_000),
+          });
+          let payload = null;
+          try { payload = await response.json(); } catch {}
+          const error = /^[a-z0-9_:-]{1,120}$/i.test(String(payload?.error || '')) ? String(payload.error) : 'unknown';
+          if (!response.ok || payload?.ok !== true || payload?.rolled_back !== true || String(payload?.operation_status || '') !== 'rolled_back' || typeof payload?.replayed !== 'boolean' || String(payload?.operation_key || '') !== operationKey || String(payload?.contract_version || '') !== 'meta-ads-tracking-v20/staging-synthetic-seed/v1') {
+            throw new Error(`staging synthetic-seed rollback failed: ${response.status} ${error}`);
+          }
+          NODE
+
       - name: Compensate the staging Worker only when this release still owns traffic
-        if: always() && steps.staging_worker_compensation_lease.outcome == 'success' && steps.tracking_bootstrap_rollback.outcome == 'success'
+        if: always() && steps.staging_worker_compensation_lease.outcome == 'success' && steps.tracking_bootstrap_rollback.outcome == 'success' && (steps.candidate_staging_synthetic_seed.outputs.did_seed != 'true' || steps.staging_synthetic_seed_rollback.outcome == 'success')
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -1920,6 +2162,20 @@ jobs:
             throw new Error('staging Token Vault compensation did not restore the exact incumbent Worker version');
           }
           NODE
+
+      - name: Remove the ephemeral staging synthetic-seed bearer
+        if: always() && inputs.target == 'staging'
+        run: |
+          set -euo pipefail
+          seed_file="${TOKEN_VAULT_STAGING_SYNTHETIC_SEED_FILE:-}"
+          if [[ -z "$seed_file" ]]; then
+            exit 0
+          fi
+          case "$seed_file" in
+            "$RUNNER_TEMP"/token-vault-staging-synthetic-seed-*) ;;
+            *) echo 'staging synthetic-seed bearer path is outside private runner temp'; exit 1 ;;
+          esac
+          rm -f -- "$seed_file"
 
       - name: Release Token Vault release lease
         if: always()

--- a/platform/deploy/operational-units.json
+++ b/platform/deploy/operational-units.json
@@ -101,14 +101,14 @@
       "workflow": ".github/workflows/deploy-token-vault.yml",
       "concurrencyPrefix": "deploy-token-vault-",
       "publishes": ["Worker:skincos-token-vault", "Worker:skincos-token-vault-staging"],
-      "resources": ["Token Vault Worker", "skincos-token-vault D1", "skincos-token-vault-staging D1", "Token Vault route and auth bindings", "Governed Meta Ads tracking bootstrap derivation, rollback journal and paused creative fixture"],
-      "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "TOKEN_VAULT_API_TOKEN", "TOKEN_VAULT_N8N_API_TOKEN", "TOKEN_VAULT_ANALYTICS_API_TOKEN", "TOKEN_VAULT_ENCRYPTION_KEY", "TOKEN_VAULT_META_ADS_CONFIG_TOKEN", "TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST"],
+      "resources": ["Token Vault Worker", "skincos-token-vault D1", "skincos-token-vault-staging D1", "Token Vault route and auth bindings", "Governed Meta Ads staging synthetic seed, bootstrap derivation, rollback journal and paused creative fixture"],
+      "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "TOKEN_VAULT_API_TOKEN", "TOKEN_VAULT_N8N_API_TOKEN", "TOKEN_VAULT_ANALYTICS_API_TOKEN", "TOKEN_VAULT_ENCRYPTION_KEY", "TOKEN_VAULT_META_ADS_CONFIG_TOKEN", "TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST", "META_ADS_ACCESS_TOKEN", "META_PIXEL_ID"],
       "migrationPaths": ["platform/security/token-vault/migrations"],
       "environments": ["preview", "staging", "production"],
       "promotion": {
         "stagingSupported": true,
         "trackingFixture": "synthetic authorized ad-set profile required before staging",
-        "trackingBootstrap": "legacy authority only; restricted config bearer plus hash-bound internal derivation or protected entries override",
+        "trackingBootstrap": "empty staging authority uses a restricted one-shot synthetic seed; legacy authority uses restricted config bearer plus hash-bound internal derivation or protected entries override",
         "d1Recovery": "Time Travel bookmark; manual restore only under release:token-vault"
       }
     },

--- a/platform/security/token-vault/README.md
+++ b/platform/security/token-vault/README.md
@@ -15,6 +15,8 @@ Worker interno para substituir a aba `Credencial` do Google Sheets usada pelo wo
 - `POST /internal/token-vault/v1/meta-ads-publish/config/bootstrap/derive-plan`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/bootstrap/derive`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/bootstrap/rollback`
+- `POST /internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed`
+- `POST /internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/rollback`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/staging-exercise`
 - `POST /internal/token-vault/v1/analytics/operations`
 
@@ -23,6 +25,10 @@ O bearer restrito `TOKEN_VAULT_META_ADS_CONFIG_TOKEN` só pode consultar
 `health`, `contract` e a configuração Meta Ads, ou chamar o planejamento e
 bootstrap governados, o rollback desse bootstrap e o exercício de staging. Ele
 não lista/altera tokens, não cria runs e não publica anúncios.
+O bearer efêmero distinto `TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN` só alcança
+os dois endpoints de seed/rollback sintéticos, exclusivamente no Worker
+staging; ele não ganha as permissões do bearer de configuração, operacional ou
+administrativo.
 O endpoint de analytics exige o secret separado
 `TOKEN_VAULT_ANALYTICS_API_TOKEN` (administradores continuam podendo operar o
 endpoint para diagnóstico controlado).
@@ -37,6 +43,10 @@ endpoint para diagnóstico controlado).
 - Secret opcional do Worker: `TOKEN_VAULT_META_ADS_CONFIG_TOKEN` (papel
   restrito de configuração Meta Ads; obrigatório no Environment quando há
   promoção V20 governada)
+- Secret efêmero opcional do Worker: `TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN`
+  (capacidade exclusiva dos endpoints de seed/rollback sintéticos; o workflow
+  gera-o em `RUNNER_TEMP` somente para a versão candidata de staging, e nunca
+  o persiste como secret do GitHub)
 - Secret privado opcional do GitHub Environment, não um binding do Worker:
   `TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST` (override explícito das `entries`
   do bootstrap legado; nunca é recebido quando o plano interno é derivável)
@@ -123,6 +133,27 @@ em fail-closed (`reconciliation_required`).
 Ele seleciona uma única fixture sintética autorizada, prova a reconciliação
 GET-POST-GET do evento Website/dataset offline e restaura o snapshot antes de
 retornar `reconciled_and_rolled_back`.
+
+Quando a autoridade legada de staging está vazia, o caminho canônico não
+adivinha nem importa configuração de produção. Antes de derivar o plano, o
+workflow chama `POST .../config/staging-synthetic-seed` na Preview imutável com
+um bearer aleatório exclusivo da versão candidata. Os fatos externos entram
+somente no corpo dessa chamada privada: o token Meta Ads já custodiado,
+`META_PIXEL_ID`, `META_ADS_ACCOUNT_ID` e `META_ADS_API_VERSION`. O Vault exige
+uma conta/pixel, uma Página+Instagram elegível e um dataset offline unívocos,
+cria somente recursos `PAUSED` nomeados para staging e sela duas credenciais
+internas cifradas. Não seleciona campanhas, conjuntos ou anúncios comerciais,
+nem torna o token Meta um binding do Worker.
+
+O endpoint responde apenas `sealed` ou `not_required` e uma identidade opaca
+de operação. Se qualquer passo subsequente falhar antes do tráfego, ou se a
+compensação de staging for acionada, `POST .../staging-synthetic-seed/rollback`
+usa a mesma capacidade efêmera para arquivar exclusivamente os objetos de
+entrega marcados e desativar as credenciais seladas. Um `AdCreative` já
+desanexado não possui estado de arquivamento documentado: ele fica inerte,
+identificado somente no journal cifrado, sem ad ativo, conjunto ativo ou
+credencial ativa. Estados ambíguos falham fechados; o workflow nunca repete uma
+criação Graph incerta nem usa `wrangler secret put`.
 
 ## Analytics read-only
 
@@ -265,6 +296,17 @@ em staging executa a fixture reversível. Em produção, ele exige a source rele
 nativa exata, aplica o Orb inativo com versão esperada e termina com o preflight
 Orb. Não execute `wrangler deploy`, `secret put` ou migrations remotas
 manualmente para publicar este serviço.
+
+Para o primeiro bootstrap Meta Ads de staging, o mesmo upload gera
+`TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN` com CSPRNG em um arquivo `0600` sob
+`RUNNER_TEMP`, inclui-o somente no `--secrets-file` privado da candidata e
+remove esse arquivo no encerramento do job. A chamada Preview lê o bearer por
+arquivo e entrega os fatos Meta somente em memória ao body fechado de seed; os
+valores não entram em `GITHUB_OUTPUT`, artefatos, logs, worktree ou argv. Essa
+seed é estritamente `staging`, ocorre antes da autenticação/derivação de
+configuração e possui rollback explícito antes de qualquer ativação quando o
+planejamento falha. `META_ADS_ACCESS_TOKEN` continua uma credencial externa de
+fonte: não é copiado de production nem inventado pelo fluxo.
 
 Antes da primeira promoção, disponibilize em cada GitHub Environment os
 segredos independentes exigidos pelo workflow, em especial

--- a/platform/security/token-vault/migrations/0006_meta_ads_publish_staging_synthetic_seed.sql
+++ b/platform/security/token-vault/migrations/0006_meta_ads_publish_staging_synthetic_seed.sql
@@ -1,0 +1,23 @@
+-- A one-time, staging-only Meta Ads tracking seed has a separate durable
+-- journal. Raw Graph IDs, the temporary source token and created-object
+-- ownership stay encrypted in state_ciphertext; summary_json is aggregate-only.
+CREATE TABLE IF NOT EXISTS meta_ads_publish_staging_seed_operations (
+  id TEXT PRIMARY KEY,
+  operation_key TEXT NOT NULL UNIQUE,
+  request_hash TEXT NOT NULL,
+  status TEXT NOT NULL CHECK(status IN (
+    'pending',
+    'creating',
+    'sealed',
+    'rolling_back',
+    'rolled_back',
+    'reconciliation_required'
+  )),
+  state_ciphertext TEXT NOT NULL,
+  summary_json TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_meta_ads_publish_staging_seed_operations_updated
+  ON meta_ads_publish_staging_seed_operations(updated_at);

--- a/platform/security/token-vault/src/index.js
+++ b/platform/security/token-vault/src/index.js
@@ -15,6 +15,8 @@ const META_ADS_PUBLISH_CONFIG_BOOTSTRAP_ROLLBACK_PATH = `${META_ADS_PUBLISH_CONF
 const META_ADS_PUBLISH_CONFIG_BOOTSTRAP_DERIVE_PLAN_PATH = `${META_ADS_PUBLISH_CONFIG_BOOTSTRAP_PATH}/derive-plan`;
 const META_ADS_PUBLISH_CONFIG_BOOTSTRAP_DERIVE_PATH = `${META_ADS_PUBLISH_CONFIG_BOOTSTRAP_PATH}/derive`;
 const META_ADS_PUBLISH_CONFIG_STAGING_EXERCISE_PATH = `${META_ADS_PUBLISH_CONFIG_PATH}/staging-exercise`;
+const META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH = `${META_ADS_PUBLISH_CONFIG_PATH}/staging-synthetic-seed`;
+const META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ROLLBACK_PATH = `${META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH}/rollback`;
 const JSON_HEADERS = {
   'content-type': 'application/json; charset=utf-8',
   'cache-control': 'no-store',
@@ -55,6 +57,39 @@ export async function handleRequest(request, env) {
 
     if (request.method === 'POST' && pathname === '/v1/analytics/staging-bootstrap') {
       return json({ ok: false, error: 'staging_bootstrap_credential_required', requestId }, { status: 403 });
+    }
+
+    // This one-shot credential is even narrower than the Meta Ads config
+    // credential: it can only construct or compensate the isolated staging
+    // synthetic lineage. Keep it outside every general publishing role.
+    if (auth.role === 'meta-ads-staging-seed') {
+      if (
+        request.method !== 'POST' || ![
+          META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH,
+          META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ROLLBACK_PATH,
+        ].includes(pathname)
+      ) {
+        return roleRequired(requestId, 'meta_ads_staging_seed_credential_scope_required');
+      }
+      return await handleMetaAdsPublishRequest({
+        request,
+        env,
+        requestId,
+        pathname,
+        decryptToken,
+        encryptToken,
+        writeAudit,
+      });
+    }
+
+    // Intercept these paths before the generic Meta Ads gateway. The seed is
+    // not an administrative escape hatch: only its dedicated staging bearer
+    // can call either endpoint, and only with POST.
+    if ([
+      META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH,
+      META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ROLLBACK_PATH,
+    ].includes(pathname)) {
+      return roleRequired(requestId, 'meta_ads_staging_seed_credential_required');
     }
 
     // This credential is deliberately isolated from the generic Meta Ads
@@ -247,6 +282,10 @@ function stagingBootstrapEligible(env) {
   return safeString(env.ENVIRONMENT).toLowerCase() === 'staging'
     && analyticsMode(env) === 'shadow'
     && safeString(env.INFLUENCER_INTELLIGENCE_ENABLED).toLowerCase() === 'false';
+}
+
+function stagingMetaAdsSeedEligible(env) {
+  return safeString(env.ENVIRONMENT).toLowerCase() === 'staging';
 }
 
 async function listTokens(url, env, requestId) {
@@ -515,13 +554,24 @@ function authorizeRequest(request, env) {
   const analyticsToken = safeString(env.TOKEN_VAULT_ANALYTICS_API_TOKEN);
   const metaAdsConfigToken = safeString(env.TOKEN_VAULT_META_ADS_CONFIG_TOKEN);
   const stagingBootstrapToken = safeString(env.TOKEN_VAULT_STAGING_ANALYTICS_BOOTSTRAP_TOKEN);
+  const stagingMetaAdsSeedToken = safeString(env.TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN);
   if (stagingBootstrapToken && !stagingBootstrapEligible(env)) {
     return { ok: false, status: 500, reason: 'invalid_worker_secret_configuration' };
   }
-  if (!adminToken && !operationalToken && !analyticsToken && !metaAdsConfigToken && !stagingBootstrapToken) {
+  if (stagingMetaAdsSeedToken && !stagingMetaAdsSeedEligible(env)) {
+    return { ok: false, status: 500, reason: 'invalid_worker_secret_configuration' };
+  }
+  if (!adminToken && !operationalToken && !analyticsToken && !metaAdsConfigToken && !stagingBootstrapToken && !stagingMetaAdsSeedToken) {
     return { ok: false, status: 500, reason: 'missing_worker_secret' };
   }
-  const configuredTokens = [adminToken, operationalToken, analyticsToken, metaAdsConfigToken, stagingBootstrapToken].filter(Boolean);
+  const configuredTokens = [
+    adminToken,
+    operationalToken,
+    analyticsToken,
+    metaAdsConfigToken,
+    stagingBootstrapToken,
+    stagingMetaAdsSeedToken,
+  ].filter(Boolean);
   if (new Set(configuredTokens).size !== configuredTokens.length) {
     return { ok: false, status: 500, reason: 'invalid_worker_secret_configuration' };
   }
@@ -542,6 +592,9 @@ function authorizeRequest(request, env) {
   }
   if (stagingBootstrapToken && constantTimeEqual(authHeader, `${scheme} ${stagingBootstrapToken}`.trim())) {
     return { ok: true, role: 'staging-bootstrap' };
+  }
+  if (stagingMetaAdsSeedToken && constantTimeEqual(authHeader, `${scheme} ${stagingMetaAdsSeedToken}`.trim())) {
+    return { ok: true, role: 'meta-ads-staging-seed' };
   }
   if (operationalToken && constantTimeEqual(authHeader, `${scheme} ${operationalToken}`.trim())) {
     return { ok: true, role: 'operational' };
@@ -594,6 +647,8 @@ function contract(requestId) {
       analytics_mode: 'shadow|active',
       meta_ads_config_secret: 'TOKEN_VAULT_META_ADS_CONFIG_TOKEN',
       meta_ads_config_scope: 'health|contract|meta-ads-config-read|meta-ads-config-bootstrap|meta-ads-config-bootstrap-rollback|meta-ads-config-bootstrap-derive-plan|meta-ads-config-bootstrap-derive|meta-ads-config-staging-exercise',
+      meta_ads_staging_seed_secret: 'TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN',
+      meta_ads_staging_seed_scope: 'meta-ads-config-staging-synthetic-seed|meta-ads-config-staging-synthetic-seed-rollback',
     },
     storage: {
       d1_binding: 'TOKEN_VAULT_DB',

--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -1,3 +1,5 @@
+import { readBoundedText } from './bounded-body.js';
+
 const PREFIX = '/v1/meta-ads-publish';
 const GRAPH_ORIGIN = 'https://graph.facebook.com';
 const GRAPH_VIDEO_ORIGIN = 'https://graph-video.facebook.com';
@@ -172,6 +174,30 @@ const BOOTSTRAP_LOCK_TTL_MS = 15 * 60 * 1000;
 const BOOTSTRAP_MAX_ENTRIES = 10;
 const BOOTSTRAP_OPERATION_KEY_PATTERN = /^[A-Za-z0-9_.:-]{8,160}$/;
 const STAGING_EXERCISE_OPERATION_KEY_PATTERN = /^staging-tracking-fixture:[A-Za-z0-9_.:-]{8,120}$/;
+const STAGING_SYNTHETIC_SEED_OPERATION_KEY_PATTERN = /^meta-ads-staging-seed:[A-Za-z0-9_.:-]{8,140}$/;
+const STAGING_SYNTHETIC_SEED_MAX_REQUEST_BYTES = 16 * 1024;
+const STAGING_SYNTHETIC_SEED_CONTRACT = 'meta-ads-tracking-v20/staging-synthetic-seed/v1';
+const STAGING_SYNTHETIC_SEED_UNIT = 'meta-ads-tracking-staging-synthetic';
+const STAGING_SYNTHETIC_SEED_SOURCE_TOKEN_TYPE = 'staging_synthetic_source';
+const STAGING_SYNTHETIC_SEED_TARGET_TOKEN_TYPE = 'staging_synthetic_target';
+const STAGING_SYNTHETIC_SEED_LOCK_TTL_MS = 15 * 60 * 1000;
+const STAGING_SYNTHETIC_SEED_MAX_GRAPH_OBJECTS = 5;
+const STAGING_SYNTHETIC_SEED_LANDING_GROUP = 'staging_tracking_fixture';
+const STAGING_SYNTHETIC_SEED_CREATIVE_MESSAGE = 'SKINCOS staging tracking verification';
+const STAGING_SYNTHETIC_SEED_CREATIVE_CTA = 'LEARN_MORE';
+const STAGING_SYNTHETIC_SEED_ADSET_FIELDS = [
+  'id',
+  'name',
+  'account_id',
+  'campaign{id,objective}',
+  'campaign_id',
+  'status',
+  'billing_event',
+  'optimization_goal',
+  'destination_type',
+  'attribution_spec',
+  'promoted_object',
+].join(',');
 const BOOTSTRAP_FIXTURE_NAME_PREFIX = 'Meta Ads URL Tags Fixture';
 const BOOTSTRAP_AD_FIELDS = [
   'id',
@@ -323,6 +349,14 @@ export async function handleMetaAdsPublishRequest(input) {
 
   if (request.method === 'POST' && pathname === `${PREFIX}/config/bootstrap/derive`) {
     return bootstrapMetaAdsPublishConfigFromDerivedPlan({ request, env, requestId, decryptToken, encryptToken, writeAudit });
+  }
+
+  if (request.method === 'POST' && pathname === `${PREFIX}/config/staging-synthetic-seed`) {
+    return seedStagingSyntheticMetaAdsTracking({ request, env, requestId, encryptToken, writeAudit });
+  }
+
+  if (request.method === 'POST' && pathname === `${PREFIX}/config/staging-synthetic-seed/rollback`) {
+    return rollbackStagingSyntheticMetaAdsTracking({ request, env, requestId, decryptToken, encryptToken, writeAudit });
   }
 
   if (request.method === 'POST' && pathname === `${PREFIX}/config/bootstrap/rollback`) {
@@ -1190,6 +1224,1371 @@ export async function bootstrapMetaAdsPublishConfigFromDerivedPlan({
   } catch (error) {
     return bootstrapFailureResponse(normalizeBootstrapDeriveFailure(error), requestId);
   }
+}
+
+// A staging D1 starts empty by design. The normal legacy bootstrap is not a
+// credential importer, so it cannot migrate an empty authority set. This
+// narrow, one-shot seed creates only a paused synthetic Website lineage after
+// proving all external facts with bounded Graph reads. It is deliberately not
+// available to the operational/config/admin gateway roles; index.js exposes it
+// only to a release-scoped, candidate-only bearer.
+export async function seedStagingSyntheticMetaAdsTracking({ request, env, requestId, encryptToken, writeAudit }) {
+  let input;
+  let operation;
+  let state;
+  let context;
+  let lockOwner = '';
+  try {
+    assertStagingSyntheticSeedEnvironment(env);
+    input = await readStagingSyntheticSeedInput(request);
+    if (typeof encryptToken !== 'function') {
+      throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_unavailable', 503);
+    }
+    lockOwner = `staging-seed:${input.operationKey}:${crypto.randomUUID()}`;
+    await acquireConfigWriterLock(env, lockOwner, { ttlMs: STAGING_SYNTHETIC_SEED_LOCK_TTL_MS });
+    context = createStagingSyntheticSeedContext(env, lockOwner, requestId, 'seed_staging_synthetic_meta_ads_tracking', input.operationKey);
+
+    operation = await loadStagingSyntheticSeedOperation(env, input.operationKey);
+    if (operation) {
+      return await replayStagingSyntheticSeed({ operation, input, env, requestId, decryptToken: null });
+    }
+
+    const currentRows = await listMetaAdsPublishConfigRows(env);
+    const configuredCount = currentRows.filter((row) => Object.keys(asObject(parseObject(row?.metadata_json).meta_ads_publish)).length > 0).length;
+    if (configuredCount > 0) {
+      return stagingSyntheticSeedSuccess({ requestId, operationKey: input.operationKey, status: 'not_required', replayed: false });
+    }
+    const outstanding = await loadOutstandingStagingSyntheticSeedOperation(env);
+    if (outstanding && clean(outstanding.operation_key) !== input.operationKey) {
+      throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+    }
+    const facebookCount = await countFacebookCredentials(env);
+    if (facebookCount !== 0) {
+      throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_facebook_credentials_present', 409);
+    }
+
+    state = await createInitialStagingSyntheticSeedState(input);
+    operation = await createStagingSyntheticSeedOperation({ env, input, state, encryptToken });
+
+    const auth = await buildStagingSyntheticSeedGraphAuth(input, env);
+    const facts = await discoverStagingSyntheticSeedFacts({ input, auth, context });
+    state.facts = facts;
+    state.phase = 'graph_validated';
+    await persistStagingSyntheticSeedState({ env, operation, state, status: 'creating', encryptToken, context });
+
+    await createStagingSyntheticSeedResources({ input, auth, facts, operation, state, encryptToken, context });
+    await sealStagingSyntheticSeedCredentials({ input, env, operation, state, encryptToken, requestId, context });
+    // The durable seal is authoritative. An audit delivery outage must not
+    // make a successful one-shot seed appear failed to the deploy workflow.
+    await writeStagingSyntheticSeedAudit(writeAudit, env, requestId, 'ok', { phase: 'sealed' }).catch(() => undefined);
+    return stagingSyntheticSeedSuccess({ requestId, operationKey: input.operationKey, status: 'sealed', replayed: false });
+  } catch (error) {
+    const normalized = normalizeStagingSyntheticSeedError(error);
+    if (operation && state && !state.credentials_sealed && !state.reconciliation_required) {
+      try {
+        // A failed shared ad-set lease means another governed data-plane
+        // operation may own one of the newly created targets. Do not attempt a
+        // best-effort cleanup under only the config lock.
+        if (context?.stagingSyntheticSeedMutationLocksRequired === true && context.stagingSyntheticSeedMutationLocksHeld !== true) {
+          throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+        }
+        const rollbackInput = input || {};
+        const auth = rollbackInput.accessToken ? await buildStagingSyntheticSeedGraphAuth(rollbackInput, env) : null;
+        const rollback = await compensateStagingSyntheticSeed({
+          env,
+          operation,
+          state,
+          auth,
+          encryptToken,
+          context: context || createStagingSyntheticSeedContext(env, lockOwner, requestId, 'rollback_staging_synthetic_meta_ads_tracking', clean(input?.operationKey)),
+          deactivateCredentials: false,
+        });
+        if (!rollback.ok) {
+          normalized.code = 'meta_ads_publish_staging_seed_reconciliation_required';
+          normalized.status = 409;
+        }
+      } catch {
+        normalized.code = 'meta_ads_publish_staging_seed_reconciliation_required';
+        normalized.status = 409;
+      }
+    }
+    try {
+      await writeStagingSyntheticSeedAudit(writeAudit, env, requestId, normalized.code, {
+        phase: clean(state?.phase) || 'not_started',
+      });
+    } catch {
+      // An audit outage must never turn a sanitized error into a raw exception.
+    }
+    return stagingSyntheticSeedFailureResponse(normalized, requestId);
+  } finally {
+    if (context?.stagingSyntheticSeedMutationLocksHeld === true) {
+      await releaseOperationLocks(
+        env,
+        context.stagingSyntheticSeedMutationRunId,
+        context.stagingSyntheticSeedMutationOperationKey,
+      ).catch(() => undefined);
+    }
+    if (lockOwner) await releaseConfigWriterLock(env, lockOwner);
+  }
+}
+
+export async function rollbackStagingSyntheticMetaAdsTracking({ request, env, requestId, decryptToken, encryptToken, writeAudit }) {
+  let input;
+  let operation;
+  let state;
+  let context;
+  let lockOwner = '';
+  try {
+    assertStagingSyntheticSeedEnvironment(env);
+    input = await readStagingSyntheticSeedRollbackInput(request);
+    if (typeof decryptToken !== 'function' || typeof encryptToken !== 'function') {
+      throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_unavailable', 503);
+    }
+    lockOwner = `staging-seed-rollback:${input.operationKey}:${crypto.randomUUID()}`;
+    await acquireConfigWriterLock(env, lockOwner, { ttlMs: STAGING_SYNTHETIC_SEED_LOCK_TTL_MS });
+    context = createStagingSyntheticSeedContext(env, lockOwner, requestId, 'rollback_staging_synthetic_meta_ads_tracking', input.operationKey);
+    operation = await loadStagingSyntheticSeedOperation(env, input.operationKey);
+    if (!operation) throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_operation_not_found', 409);
+    state = await decryptStagingSyntheticSeedState(operation, decryptToken, env);
+    assertStagingSyntheticSeedStateMatchesInput(state, input);
+    if (clean(operation.status) === 'rolled_back') {
+      return stagingSyntheticSeedRollbackSuccess({ requestId, operationKey: input.operationKey, replayed: true });
+    }
+    if (state.reconciliation_required === true) {
+      throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+    }
+    if (stagingSyntheticSeedStateHasNoGraphMutation(state)) {
+      state.phase = 'rolled_back';
+      await persistStagingSyntheticSeedState({ env, operation, state, status: 'rolled_back', encryptToken, context });
+      await writeStagingSyntheticSeedAudit(writeAudit, env, requestId, 'rolled_back', { phase: 'rolled_back' }).catch(() => undefined);
+      return stagingSyntheticSeedRollbackSuccess({ requestId, operationKey: input.operationKey, replayed: false });
+    }
+    if (!['creating', 'sealed'].includes(clean(operation.status)) || stagingSyntheticSeedStateHasAmbiguousMutation(state)) {
+      throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+    }
+    if (clean(operation.status) === 'sealed') {
+      await assertStagingSyntheticSeedRollbackAuthority(env, state);
+    }
+    await acquireStagingSyntheticSeedMutationLocks(context, state);
+    const auth = await buildStagingSyntheticSeedGraphAuth(input, env);
+    const rollback = await compensateStagingSyntheticSeed({
+      env,
+      operation,
+      state,
+      auth,
+      encryptToken,
+      decryptToken,
+      context,
+      deactivateCredentials: true,
+    });
+    if (!rollback.ok) throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+    await writeStagingSyntheticSeedAudit(writeAudit, env, requestId, 'rolled_back', { phase: 'rolled_back' }).catch(() => undefined);
+    return stagingSyntheticSeedRollbackSuccess({ requestId, operationKey: input.operationKey, replayed: false });
+  } catch (error) {
+    const normalized = normalizeStagingSyntheticSeedError(error);
+    try {
+      await writeStagingSyntheticSeedAudit(writeAudit, env, requestId, normalized.code, { phase: clean(state?.phase) || 'rollback' });
+    } catch {
+      // Keep the endpoint fail-closed without exposing persistence internals.
+    }
+    return stagingSyntheticSeedFailureResponse(normalized, requestId);
+  } finally {
+    if (context?.stagingSyntheticSeedMutationLocksHeld === true) {
+      await releaseOperationLocks(
+        env,
+        context.stagingSyntheticSeedMutationRunId,
+        context.stagingSyntheticSeedMutationOperationKey,
+      ).catch(() => undefined);
+    }
+    if (lockOwner) await releaseConfigWriterLock(env, lockOwner);
+  }
+}
+
+function assertStagingSyntheticSeedEnvironment(env) {
+  if (clean(env?.ENVIRONMENT).toLowerCase() !== 'staging') {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_disabled', 503);
+  }
+  if (!env?.TOKEN_VAULT_DB || typeof env.TOKEN_VAULT_DB.prepare !== 'function' || typeof env.TOKEN_VAULT_DB.batch !== 'function') {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_unavailable', 503);
+  }
+}
+
+async function readStagingSyntheticSeedInput(request) {
+  const body = await readStagingSyntheticSeedBody(request, new Set([
+    'operation_key', 'access_token', 'account_id', 'pixel_id', 'api_version',
+  ]));
+  const operationKey = clean(body.operation_key);
+  if (!STAGING_SYNTHETIC_SEED_OPERATION_KEY_PATTERN.test(operationKey)) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_operation_key_invalid', 400);
+  }
+  const accessToken = normalizeStagingSyntheticSeedAccessToken(body.access_token);
+  return {
+    operationKey,
+    accessToken,
+    accountId: normalizeStagingSyntheticSeedNumericId(body.account_id, 'account_id'),
+    pixelId: normalizeStagingSyntheticSeedNumericId(body.pixel_id, 'pixel_id'),
+    apiVersion: normalizeStagingSyntheticSeedApiVersion(body.api_version),
+  };
+}
+
+async function readStagingSyntheticSeedRollbackInput(request) {
+  const body = await readStagingSyntheticSeedBody(request, new Set([
+    'operation_key', 'access_token', 'account_id', 'api_version',
+  ]));
+  const operationKey = clean(body.operation_key);
+  if (!STAGING_SYNTHETIC_SEED_OPERATION_KEY_PATTERN.test(operationKey)) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_operation_key_invalid', 400);
+  }
+  return {
+    operationKey,
+    accessToken: normalizeStagingSyntheticSeedAccessToken(body.access_token),
+    accountId: normalizeStagingSyntheticSeedNumericId(body.account_id, 'account_id'),
+    apiVersion: normalizeStagingSyntheticSeedApiVersion(body.api_version),
+  };
+}
+
+async function readStagingSyntheticSeedBody(request, allowed) {
+  const contentLength = Number(request.headers.get('content-length') || 0);
+  if (Number.isInteger(contentLength) && contentLength > STAGING_SYNTHETIC_SEED_MAX_REQUEST_BYTES) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_request_too_large', 413);
+  }
+  let body;
+  try {
+    const text = request.body
+      ? await readBoundedText(request.body, STAGING_SYNTHETIC_SEED_MAX_REQUEST_BYTES, () => stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_request_too_large', 413))
+      : await request.text();
+    body = JSON.parse(text);
+  } catch (error) {
+    if (isStagingSyntheticSeedFailure(error)) throw error;
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_request_invalid', 400);
+  }
+  if (!isJsonObject(body) || Object.keys(body).some((key) => !allowed.has(key))) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_request_invalid', 400);
+  }
+  return body;
+}
+
+function normalizeStagingSyntheticSeedAccessToken(value) {
+  if (typeof value !== 'string') throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_request_invalid', 400);
+  const token = value.trim();
+  if (token.length < 20 || token.length > 4096 || /[\s\u0000-\u001f\u007f]/.test(token)) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_request_invalid', 400);
+  }
+  return token;
+}
+
+function normalizeStagingSyntheticSeedNumericId(value, label) {
+  try {
+    return normalizeNumericId(value, `staging_seed_${label}`);
+  } catch {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_request_invalid', 400);
+  }
+}
+
+function normalizeStagingSyntheticSeedApiVersion(value) {
+  try {
+    return normalizeApiVersion(clean(value) || 'v25.0');
+  } catch {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_request_invalid', 400);
+  }
+}
+
+function stagingSyntheticSeedFailure(code, httpStatus = 400) {
+  return Object.assign(new Error(code), {
+    staging_synthetic_seed_error: true,
+    http_status: httpStatus,
+  });
+}
+
+function isStagingSyntheticSeedFailure(error) {
+  return Boolean(error && error.staging_synthetic_seed_error === true);
+}
+
+function normalizeStagingSyntheticSeedError(error) {
+  if (isStagingSyntheticSeedFailure(error)) {
+    return { code: clean(error.message), status: Number(error.http_status) || 400 };
+  }
+  const normalized = normalizeFailure(error);
+  return {
+    code: normalized.retryable || normalized.ambiguous
+      ? 'meta_ads_publish_staging_seed_unavailable'
+      : 'meta_ads_publish_staging_seed_failed',
+    status: normalized.retryable || normalized.ambiguous ? 503 : 409,
+  };
+}
+
+function stagingSyntheticSeedFailureResponse(error, requestId) {
+  const code = clean(error?.code);
+  const allowed = new Set([
+    'meta_ads_publish_staging_seed_disabled',
+    'meta_ads_publish_staging_seed_unavailable',
+    'meta_ads_publish_staging_seed_request_too_large',
+    'meta_ads_publish_staging_seed_request_invalid',
+    'meta_ads_publish_staging_seed_operation_key_invalid',
+    'meta_ads_publish_staging_seed_operation_not_found',
+    'meta_ads_publish_staging_seed_operation_conflict',
+    'meta_ads_publish_staging_seed_reconciliation_required',
+    'meta_ads_publish_staging_seed_facebook_credentials_present',
+    'meta_ads_publish_staging_seed_graph_identity_invalid',
+    'meta_ads_publish_staging_seed_graph_page_ambiguous',
+    'meta_ads_publish_staging_seed_graph_dataset_ambiguous',
+    'meta_ads_publish_staging_seed_landing_or_media_unavailable',
+    'meta_ads_publish_staging_seed_graph_contract_invalid',
+    'meta_ads_publish_staging_seed_failed',
+  ]);
+  const safeCode = allowed.has(code) ? code : 'meta_ads_publish_staging_seed_unavailable';
+  const status = Number(error?.status) === 413
+    ? 413
+    : Number(error?.status) === 503
+      ? 503
+      : Number(error?.status) === 409
+        ? 409
+        : 400;
+  return response({ ok: false, error: safeCode, requestId }, status);
+}
+
+function stagingSyntheticSeedSuccess({ requestId, operationKey, status, replayed }) {
+  return response({
+    ok: true,
+    seed: status,
+    operation_status: status,
+    replayed: Boolean(replayed),
+    operation_key: operationKey,
+    contract_version: STAGING_SYNTHETIC_SEED_CONTRACT,
+    requestId,
+  }, status === 'sealed' && !replayed ? 201 : 200);
+}
+
+function stagingSyntheticSeedRollbackSuccess({ requestId, operationKey, replayed }) {
+  return response({
+    ok: true,
+    rolled_back: true,
+    operation_status: 'rolled_back',
+    replayed: Boolean(replayed),
+    operation_key: operationKey,
+    contract_version: STAGING_SYNTHETIC_SEED_CONTRACT,
+    requestId,
+  });
+}
+
+function createStagingSyntheticSeedContext(env, lockOwner, requestId, action, operationKey = '') {
+  const context = {
+    env,
+    requestId,
+    action,
+    operationKey: clean(operationKey),
+    ...stagingSyntheticSeedMutationLockIdentity(operationKey),
+    stagingSyntheticSeedMutationLockKeys: [],
+    stagingSyntheticSeedMutationLocksHeld: false,
+    stagingSyntheticSeedMutationLocksRequired: false,
+    attempts: 0,
+    rateUsage: {},
+    traceId: '',
+    assertBootstrapLease: async () => {
+      try {
+        await renewConfigWriterLock(env, lockOwner, { ttlMs: STAGING_SYNTHETIC_SEED_LOCK_TTL_MS });
+        await renewStagingSyntheticSeedMutationLocks(context);
+      } catch (error) {
+        const locked = isConfigWriterFailure(error) || clean(error?.message).startsWith('resource_locked:');
+        throw stagingSyntheticSeedFailure(
+          locked
+            ? 'meta_ads_publish_staging_seed_reconciliation_required'
+            : 'meta_ads_publish_staging_seed_unavailable',
+          locked ? 409 : 503,
+        );
+      }
+    },
+  };
+  return context;
+}
+
+function stagingSyntheticSeedMutationLockIdentity(operationKey) {
+  const normalized = clean(operationKey);
+  return {
+    stagingSyntheticSeedMutationRunId: `staging-seed:${normalized}`,
+    stagingSyntheticSeedMutationOperationKey: `staging-seed-mutation:${normalized}`,
+  };
+}
+
+function stagingSyntheticSeedMutationLockKeys(state) {
+  const accountId = normalizeStagingSyntheticSeedGraphId(asObject(state?.input).account_id, 'lock_account_id');
+  const resources = asObject(state?.resources);
+  const adsetIds = [
+    clean(asObject(resources.source_adset).id),
+    clean(asObject(resources.target_adset).id),
+  ].filter(Boolean);
+  return [...new Set(adsetIds.map((adsetId) => bootstrapAdsetContractLockKey(accountId, adsetId)))].sort();
+}
+
+async function acquireStagingSyntheticSeedMutationLocks(context, state) {
+  const keys = stagingSyntheticSeedMutationLockKeys(state);
+  if (!keys.length) return;
+  context.stagingSyntheticSeedMutationLocksRequired = true;
+  context.stagingSyntheticSeedMutationLockKeys = keys;
+  await acquireLocks(
+    context.env,
+    context.stagingSyntheticSeedMutationRunId,
+    context.stagingSyntheticSeedMutationOperationKey,
+    keys,
+  );
+  context.stagingSyntheticSeedMutationLocksHeld = true;
+}
+
+async function renewStagingSyntheticSeedMutationLocks(context) {
+  if (context?.stagingSyntheticSeedMutationLocksHeld !== true || !safeArray(context.stagingSyntheticSeedMutationLockKeys).length) return;
+  await acquireLocks(
+    context.env,
+    context.stagingSyntheticSeedMutationRunId,
+    context.stagingSyntheticSeedMutationOperationKey,
+    context.stagingSyntheticSeedMutationLockKeys,
+  );
+}
+
+async function buildStagingSyntheticSeedGraphAuth(input, env) {
+  const appSecretProof = clean(env.META_APP_SECRET)
+    ? await hmacSha256(clean(env.META_APP_SECRET), input.accessToken)
+    : '';
+  return {
+    tokenId: '',
+    accountId: input.accountId,
+    apiVersion: input.apiVersion,
+    accessToken: input.accessToken,
+    appSecretProof,
+    config: {},
+  };
+}
+
+async function createInitialStagingSyntheticSeedState(input) {
+  const marker = await sha256(`meta-ads-staging-synthetic-seed\n${input.operationKey}`);
+  const sourceTokenId = `staging.meta-ads.source.${marker.slice(0, 32)}`;
+  const targetTokenId = `staging.meta-ads.target.${marker.slice(0, 32)}`;
+  return {
+    contract: STAGING_SYNTHETIC_SEED_CONTRACT,
+    phase: 'pending',
+    reconciliation_required: false,
+    input: {
+      operation_key: input.operationKey,
+      account_id: input.accountId,
+      pixel_id: input.pixelId,
+      api_version: input.apiVersion,
+    },
+    marker,
+    url_tags: `skincos_staging_v20=${marker.slice(0, 32)}`,
+    credential_ids: { source: sourceTokenId, target: targetTokenId },
+    credentials_sealed: false,
+    facts: {},
+    resources: {},
+  };
+}
+
+async function countFacebookCredentials(env) {
+  try {
+    const row = await dbFirst(env, 'SELECT COUNT(*) AS count FROM credential_tokens WHERE provider = ? AND active = 1', 'facebook');
+    return Number(row?.count || 0);
+  } catch {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_unavailable', 503);
+  }
+}
+
+async function loadStagingSyntheticSeedOperation(env, operationKey) {
+  try {
+    return await dbFirst(env, [
+      'SELECT id, operation_key, request_hash, status, state_ciphertext, summary_json',
+      'FROM meta_ads_publish_staging_seed_operations WHERE operation_key = ?',
+    ].join(' '), operationKey);
+  } catch {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_unavailable', 503);
+  }
+}
+
+async function loadOutstandingStagingSyntheticSeedOperation(env) {
+  try {
+    return await dbFirst(env, [
+      'SELECT id, operation_key, status FROM meta_ads_publish_staging_seed_operations',
+      "WHERE status IN ('pending', 'creating', 'rolling_back', 'reconciliation_required')",
+      'ORDER BY updated_at DESC LIMIT 1',
+    ].join(' '));
+  } catch {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_unavailable', 503);
+  }
+}
+
+async function createStagingSyntheticSeedOperation({ env, input, state, encryptToken }) {
+  const requestHash = await stagingSyntheticSeedRequestHash(input);
+  const stateCiphertext = await encryptStagingSyntheticSeedState(state, encryptToken, env);
+  const now = nowIso();
+  try {
+    await dbRun(env, [
+      'INSERT INTO meta_ads_publish_staging_seed_operations',
+      '(id, operation_key, request_hash, status, state_ciphertext, summary_json, created_at, updated_at)',
+      'VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+    ].join(' '),
+    crypto.randomUUID(), input.operationKey, requestHash, 'pending', stateCiphertext,
+    JSON.stringify(summarizeStagingSyntheticSeedState(state)), now, now);
+  } catch {
+    const existing = await loadStagingSyntheticSeedOperation(env, input.operationKey);
+    if (existing) return existing;
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_unavailable', 503);
+  }
+  const operation = await loadStagingSyntheticSeedOperation(env, input.operationKey);
+  if (!operation) throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_unavailable', 503);
+  return operation;
+}
+
+async function stagingSyntheticSeedRequestHash(input) {
+  return sha256(stableStringify({
+    operation_key: input.operationKey,
+    account_id: input.accountId,
+    pixel_id: input.pixelId || '',
+    api_version: input.apiVersion,
+  }));
+}
+
+async function encryptStagingSyntheticSeedState(state, encryptToken, env) {
+  try {
+    return await encryptToken(JSON.stringify(state), env);
+  } catch {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_unavailable', 503);
+  }
+}
+
+async function decryptStagingSyntheticSeedState(operation, decryptToken, env) {
+  try {
+    const parsed = JSON.parse(await decryptToken(operation.state_ciphertext, env));
+    if (!isJsonObject(parsed) || clean(parsed.contract) !== STAGING_SYNTHETIC_SEED_CONTRACT) {
+      throw new Error('invalid_seed_state');
+    }
+    return parsed;
+  } catch {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+}
+
+async function persistStagingSyntheticSeedState({ env, operation, state, status, encryptToken, context }) {
+  if (context?.assertBootstrapLease) await context.assertBootstrapLease();
+  if (typeof encryptToken !== 'function') {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_unavailable', 503);
+  }
+  const stateCiphertext = await encryptStagingSyntheticSeedState(state, encryptToken, env);
+  try {
+    const result = await dbRun(env, [
+      'UPDATE meta_ads_publish_staging_seed_operations',
+      'SET status = ?, state_ciphertext = ?, summary_json = ?, updated_at = ?',
+      'WHERE id = ? AND operation_key = ?',
+    ].join(' '),
+    status, stateCiphertext, JSON.stringify(summarizeStagingSyntheticSeedState(state)), nowIso(), operation.id, operation.operation_key);
+    if (statementChanges(result) !== 1) {
+      throw new Error('seed_state_missing');
+    }
+    operation.status = status;
+    operation.state_ciphertext = stateCiphertext;
+  } catch {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_unavailable', 503);
+  }
+}
+
+function summarizeStagingSyntheticSeedState(state) {
+  const resources = asObject(state?.resources);
+  return {
+    contract: STAGING_SYNTHETIC_SEED_CONTRACT,
+    phase: clean(state?.phase) || 'unknown',
+    reconciliation_required: state?.reconciliation_required === true,
+    graph_facts_verified: Boolean(clean(asObject(state?.facts).page_id) && clean(asObject(state?.facts).dataset_id)),
+    campaign_created: Boolean(clean(asObject(resources.campaign).id)),
+    adset_count: ['source_adset', 'target_adset'].filter((key) => clean(asObject(resources[key]).id)).length,
+    creative_created: Boolean(clean(asObject(resources.source_creative).id)),
+    detached_creative_retained: state?.detached_creative_retained === true,
+    ad_created: Boolean(clean(asObject(resources.source_ad).id)),
+    credentials_sealed: state?.credentials_sealed === true,
+  };
+}
+
+async function replayStagingSyntheticSeed({ operation, input, env, requestId, decryptToken }) {
+  const requestHash = await stagingSyntheticSeedRequestHash(input);
+  if (clean(operation.request_hash) !== requestHash) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_operation_conflict', 409);
+  }
+  const status = clean(operation.status);
+  if (status === 'sealed') {
+    // A sealed operation never needs the inbound source token to prove its
+    // replay. The caller still supplied it because this route intentionally
+    // has one closed request shape.
+    return stagingSyntheticSeedSuccess({ requestId, operationKey: input.operationKey, status: 'sealed', replayed: true });
+  }
+  if (status === 'rolled_back') {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_operation_conflict', 409);
+  }
+  // Do not attempt to decrypt or heal a partial operation in the seed path.
+  // A caller must use the explicit rollback surface under a new governed run.
+  void env;
+  void decryptToken;
+  throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+}
+
+function assertStagingSyntheticSeedStateMatchesInput(state, input) {
+  const saved = asObject(state?.input);
+  if (
+    clean(saved.operation_key) !== input.operationKey ||
+    clean(saved.account_id) !== input.accountId ||
+    clean(saved.api_version) !== input.apiVersion
+  ) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_operation_conflict', 409);
+  }
+}
+
+function stagingSyntheticSeedStateHasNoGraphMutation(state) {
+  const resources = asObject(state?.resources);
+  return (
+    state?.credentials_sealed !== true &&
+    state?.credentials_sealing_started !== true &&
+    Object.values(resources).every((resource) => {
+      const value = asObject(resource);
+      return !value.pending && !clean(value.id);
+    })
+  );
+}
+
+function stagingSyntheticSeedStateHasAmbiguousMutation(state) {
+  return state?.credentials_sealing_started === true ||
+    Object.values(asObject(state?.resources)).some((resource) => asObject(resource).pending === true);
+}
+
+async function assertStagingSyntheticSeedRollbackAuthority(env, state) {
+  const expected = asObject(state?.seeded_authority);
+  const expectedRevision = clean(expected.revision);
+  const credentials = asObject(state?.credential_ids);
+  const sourceId = clean(credentials.source);
+  const targetId = clean(credentials.target);
+  const expectedSource = asObject(expected.source_meta_ads_publish);
+  const expectedTarget = asObject(expected.target_meta_ads_publish);
+  if (!expectedRevision || !sourceId || !targetId || sourceId === targetId || !Object.keys(expectedSource).length || !Object.keys(expectedTarget).length) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+  const currentRows = await listMetaAdsPublishConfigRows(env);
+  const authority = await configWriterAuthorityState(currentRows);
+  const rowsById = new Map(currentRows.map((row) => [clean(row.id), row]));
+  const source = asObject(parseObject(rowsById.get(sourceId)?.metadata_json).meta_ads_publish);
+  const target = asObject(parseObject(rowsById.get(targetId)?.metadata_json).meta_ads_publish);
+  if (
+    authority.ready ||
+    authority.mode !== 'legacy_bootstrap' ||
+    clean(authority.revision) !== expectedRevision ||
+    stableStringify(source) !== stableStringify(expectedSource) ||
+    stableStringify(target) !== stableStringify(expectedTarget)
+  ) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+}
+
+async function writeStagingSyntheticSeedAudit(writeAudit, env, requestId, status, metadata = {}) {
+  if (typeof writeAudit !== 'function') return;
+  await writeAudit(env, {
+    tokenId: null,
+    event: 'meta_ads_publish.staging_synthetic_seed',
+    provider: 'facebook',
+    unit: STAGING_SYNTHETIC_SEED_UNIT,
+    tokenType: 'staging_synthetic',
+    status: clean(status).slice(0, 120) || 'unknown',
+    requestId,
+    metadata: {
+      contract: STAGING_SYNTHETIC_SEED_CONTRACT,
+      environment: 'staging',
+      ...metadata,
+    },
+  });
+}
+
+async function discoverStagingSyntheticSeedFacts({ input, auth, context }) {
+  const pixel = await seedGraphRead(auth, input.pixelId, 'id,owner_ad_account{id}', context);
+  const pixelOwner = normalizeStagingSyntheticSeedGraphId(asObject(pixel.owner_ad_account).id, 'pixel_owner_account');
+  if (normalizeStagingSyntheticSeedGraphId(pixel.id, 'pixel_id') !== input.pixelId || pixelOwner !== input.accountId) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_identity_invalid', 409);
+  }
+
+  const pages = await seedGraphRead(auth, 'me/accounts', 'id,tasks,instagram_business_account{id}', context, { limit: '100' });
+  if (clean(asObject(pages.paging).next)) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_page_ambiguous', 409);
+  }
+  const eligiblePages = safeArray(pages.data).map(asObject).filter((page) => {
+    const tasks = new Set(safeArray(page.tasks).map((task) => clean(task).toUpperCase()));
+    return tasks.has('ADVERTISE') && /^\d{5,30}$/.test(clean(asObject(page.instagram_business_account).id));
+  });
+  if (eligiblePages.length !== 1) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_page_ambiguous', 409);
+  }
+  const selectedPageId = normalizeStagingSyntheticSeedGraphId(eligiblePages[0].id, 'page_id');
+  const page = await seedGraphRead(auth, selectedPageId, 'id,instagram_business_account{id},website,picture{url}', context);
+  const pageId = normalizeStagingSyntheticSeedGraphId(page.id, 'page_id');
+  const instagramUserId = normalizeStagingSyntheticSeedGraphId(asObject(page.instagram_business_account).id, 'instagram_user_id');
+  if (
+    pageId !== selectedPageId ||
+    instagramUserId !== normalizeStagingSyntheticSeedGraphId(asObject(eligiblePages[0].instagram_business_account).id, 'instagram_user_id')
+  ) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_identity_invalid', 409);
+  }
+  const landing = normalizeStagingSyntheticSeedLanding(page.website);
+  const pictureUrl = normalizeStagingSyntheticSeedPicture(page.picture);
+  if (!landing || !pictureUrl) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_landing_or_media_unavailable', 409);
+  }
+
+  const datasets = await seedGraphRead(auth, `act_${input.accountId}/offline_conversion_data_sets`, 'id', context, { limit: '2' });
+  if (clean(asObject(datasets.paging).next) || safeArray(datasets.data).length !== 1) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_dataset_ambiguous', 409);
+  }
+  const datasetId = normalizeStagingSyntheticSeedGraphId(asObject(safeArray(datasets.data)[0]).id, 'offline_dataset_id');
+  return {
+    page_id: pageId,
+    instagram_user_id: instagramUserId,
+    landing_url: landing.url,
+    landing_host: landing.host,
+    page_picture_url: pictureUrl,
+    dataset_id: datasetId,
+  };
+}
+
+async function seedGraphRead(auth, path, fields, context, query = {}) {
+  try {
+    const result = await graphRequest(
+      graphUrl(auth.apiVersion, path, { fields, ...query }),
+      { method: 'GET' },
+      auth,
+      context,
+    );
+    return asObject(result.body);
+  } catch (error) {
+    const normalized = normalizeFailure(error);
+    if (normalized.retryable || normalized.ambiguous || Number(normalized.http_status) >= 500) {
+      throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_unavailable', 503);
+    }
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_identity_invalid', 409);
+  }
+}
+
+function normalizeStagingSyntheticSeedGraphId(value, label) {
+  try {
+    return normalizeNumericId(value, `staging_seed_${label}`);
+  } catch {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_identity_invalid', 409);
+  }
+}
+
+function normalizeStagingSyntheticSeedLanding(value) {
+  try {
+    const url = new URL(clean(value));
+    if (
+      url.protocol !== 'https:' ||
+      !url.hostname ||
+      url.username ||
+      url.password ||
+      url.hash ||
+      url.search ||
+      /(?:facebook|instagram|whatsapp)\.com$/i.test(url.hostname)
+    ) {
+      return null;
+    }
+    return { url: url.toString(), host: url.hostname.toLowerCase() };
+  } catch {
+    return null;
+  }
+}
+
+function normalizeStagingSyntheticSeedPicture(value) {
+  const picture = asObject(value);
+  const candidate = clean(picture.url || asObject(picture.data).url);
+  try {
+    const url = new URL(candidate);
+    if (url.protocol !== 'https:' || !url.hostname || url.username || url.password) return '';
+    return url.toString();
+  } catch {
+    return '';
+  }
+}
+
+async function createStagingSyntheticSeedResources({ input, auth, facts, operation, state, encryptToken, context }) {
+  state.phase = 'creating_resources';
+  await persistStagingSyntheticSeedState({ env: context.env, operation, state, status: 'creating', encryptToken, context });
+  const marker = stagingSyntheticSeedMarker(state);
+
+  const campaign = await createStagingSyntheticSeedGraphResource({
+    key: 'campaign',
+    name: `${marker} Campaign`,
+    operation,
+    state,
+    encryptToken,
+    context,
+    create: () => seedGraphCreate(auth, `act_${input.accountId}/campaigns`, {
+      name: `${marker} Campaign`,
+      objective: 'OUTCOME_LEADS',
+      buying_type: 'AUCTION',
+      special_ad_categories: [],
+      is_adset_budget_sharing_enabled: false,
+      status: 'PAUSED',
+    }, context),
+    read: (id) => readStagingSyntheticSeedCampaign(auth, id, `${marker} Campaign`, context),
+  });
+
+  const commonAdset = {
+    campaign_id: campaign.id,
+    billing_event: 'IMPRESSIONS',
+    optimization_goal: 'OFFSITE_CONVERSIONS',
+    destination_type: 'WEBSITE',
+    daily_budget: '1000',
+    attribution_spec: [
+      { event_type: 'CLICK_THROUGH', window_days: 7 },
+      { event_type: 'VIEW_THROUGH', window_days: 1 },
+    ],
+    targeting: { geo_locations: { countries: ['BR'] } },
+    status: 'PAUSED',
+  };
+  const sourceAdset = await createStagingSyntheticSeedGraphResource({
+    key: 'source_adset',
+    name: `${marker} Source Ad Set`,
+    operation,
+    state,
+    encryptToken,
+    context,
+    create: () => seedGraphCreate(auth, `act_${input.accountId}/adsets`, {
+      ...commonAdset,
+      name: `${marker} Source Ad Set`,
+      promoted_object: {
+        pixel_id: input.pixelId,
+        custom_event_type: 'LEAD',
+        offline_conversion_data_set_id: facts.dataset_id,
+      },
+    }, context),
+    read: (id) => readStagingSyntheticSeedAdset(auth, id, campaign.id, `${marker} Source Ad Set`, context),
+  });
+  const targetAdset = await createStagingSyntheticSeedGraphResource({
+    key: 'target_adset',
+    name: `${marker} Target Ad Set`,
+    operation,
+    state,
+    encryptToken,
+    context,
+    create: () => seedGraphCreate(auth, `act_${input.accountId}/adsets`, {
+      ...commonAdset,
+      name: `${marker} Target Ad Set`,
+    }, context),
+    read: (id) => readStagingSyntheticSeedAdset(auth, id, campaign.id, `${marker} Target Ad Set`, context),
+  });
+  // From here on the synthetic ad sets are durable and can be referenced by a
+  // concurrent data-plane request. Hold the same resource locks used by normal
+  // ensure/stage/rollback operations until this seed has either sealed or
+  // compensated them.
+  await acquireStagingSyntheticSeedMutationLocks(context, state);
+  assertStagingSyntheticSeedAdsetContract({ input, source: sourceAdset.value, target: targetAdset.value });
+
+  const creative = await createStagingSyntheticSeedGraphResource({
+    key: 'source_creative',
+    name: `${marker} Source Creative`,
+    operation,
+    state,
+    encryptToken,
+    context,
+    create: () => seedGraphCreate(auth, `act_${input.accountId}/adcreatives`, {
+      name: `${marker} Source Creative`,
+      object_story_spec: {
+        page_id: facts.page_id,
+        instagram_actor_id: facts.instagram_user_id,
+        link_data: {
+          link: facts.landing_url,
+          picture: facts.page_picture_url,
+          message: STAGING_SYNTHETIC_SEED_CREATIVE_MESSAGE,
+          call_to_action: {
+            type: STAGING_SYNTHETIC_SEED_CREATIVE_CTA,
+            value: { link: facts.landing_url },
+          },
+        },
+      },
+      url_tags: state.url_tags,
+    }, context),
+    read: (id) => readStagingSyntheticSeedCreative(auth, id, `${marker} Source Creative`, state.url_tags, context),
+  });
+  const ad = await createStagingSyntheticSeedGraphResource({
+    key: 'source_ad',
+    name: `${marker} Source Ad`,
+    operation,
+    state,
+    encryptToken,
+    context,
+    create: () => seedGraphCreate(auth, `act_${input.accountId}/ads`, {
+      name: `${marker} Source Ad`,
+      adset_id: sourceAdset.id,
+      creative: { creative_id: creative.id },
+      status: 'PAUSED',
+    }, context),
+    read: (id) => readStagingSyntheticSeedAd(auth, id, sourceAdset.id, creative.id, `${marker} Source Ad`, context),
+  });
+
+  state.phase = 'resources_verified';
+  await persistStagingSyntheticSeedState({ env: context.env, operation, state, status: 'creating', encryptToken, context });
+  return { campaign, sourceAdset, targetAdset, creative, ad };
+}
+
+function stagingSyntheticSeedMarker(state) {
+  return `[SKINCOS-STAGING-V20:${clean(state?.marker).slice(0, 24)}]`;
+}
+
+async function createStagingSyntheticSeedGraphResource({ key, name, operation, state, encryptToken, context, create, read }) {
+  const existing = asObject(asObject(state.resources)[key]);
+  if (clean(existing.id)) {
+    const value = await read(clean(existing.id));
+    return { id: clean(existing.id), value };
+  }
+  state.resources[key] = { name, pending: true, owned_by_operation: false };
+  await persistStagingSyntheticSeedState({ env: context.env, operation, state, status: 'creating', encryptToken, context });
+  let created;
+  try {
+    created = await create();
+  } catch (error) {
+    const normalized = normalizeFailure(error);
+    if (normalized.ambiguous || normalized.retryable) {
+      state.reconciliation_required = true;
+      state.phase = 'reconciliation_required';
+      await persistStagingSyntheticSeedState({ env: context.env, operation, state, status: 'reconciliation_required', encryptToken, context }).catch(() => undefined);
+      throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+    }
+    state.resources[key].pending = false;
+    await persistStagingSyntheticSeedState({ env: context.env, operation, state, status: 'creating', encryptToken, context });
+    throw error;
+  }
+  const id = normalizeStagingSyntheticSeedCreatedId(created, key);
+  state.resources[key] = { id, name, pending: false, owned_by_operation: true };
+  // Persist the durable acknowledgement before the first readback. A process
+  // loss after Meta accepted the POST must become reconciliation, never a
+  // duplicate create or an unowned cleanup.
+  await persistStagingSyntheticSeedState({ env: context.env, operation, state, status: 'creating', encryptToken, context });
+  const value = await read(id);
+  return { id, value };
+}
+
+async function seedGraphCreate(auth, path, body, context) {
+  try {
+    const result = await graphRequest(
+      graphUrl(auth.apiVersion, path),
+      seedJsonRequest('POST', body),
+      auth,
+      context,
+      { maxAttempts: 1 },
+    );
+    return asObject(result.body);
+  } catch (error) {
+    throw error;
+  }
+}
+
+function seedJsonRequest(method, body) {
+  // jsonRequest intentionally removes empty arrays. Meta requires an explicit
+  // empty special_ad_categories list for a campaign, so this one narrow helper
+  // preserves the closed synthetic payload exactly.
+  return {
+    method,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(sanitizeGraphValue(body)),
+  };
+}
+
+function normalizeStagingSyntheticSeedCreatedId(value, key) {
+  try {
+    return normalizeNumericId(asObject(value).id, `staging_seed_${key}_id`);
+  } catch {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+}
+
+async function readStagingSyntheticSeedCampaign(auth, campaignId, expectedName, context) {
+  const result = await graphRequest(
+    graphUrl(auth.apiVersion, campaignId, { fields: CAMPAIGN_READ_FIELDS }),
+    { method: 'GET' }, auth, context,
+  );
+  const campaign = asObject(result.body);
+  if (
+    normalizeStagingSyntheticSeedGraphId(campaign.id, 'campaign_id') !== campaignId ||
+    clean(campaign.name) !== expectedName ||
+    clean(campaign.status).toUpperCase() !== 'PAUSED' ||
+    clean(campaign.objective).toUpperCase() !== 'OUTCOME_LEADS'
+  ) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_contract_invalid', 409);
+  }
+  return campaign;
+}
+
+async function readStagingSyntheticSeedAdset(auth, adsetId, campaignId, expectedName, context) {
+  const result = await graphRequest(
+    graphUrl(auth.apiVersion, adsetId, { fields: STAGING_SYNTHETIC_SEED_ADSET_FIELDS }),
+    { method: 'GET' }, auth, context,
+  );
+  const adset = asObject(result.body);
+  if (
+    normalizeStagingSyntheticSeedGraphId(adset.account_id, 'adset_account_id') !== auth.accountId ||
+    normalizeStagingSyntheticSeedGraphId(adset.campaign_id || asObject(adset.campaign).id, 'adset_campaign_id') !== campaignId ||
+    clean(adset.name) !== expectedName ||
+    clean(adset.status).toUpperCase() !== 'PAUSED' ||
+    safeTrackingEnum(adset.destination_type) !== 'WEBSITE'
+  ) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_contract_invalid', 409);
+  }
+  return adset;
+}
+
+function assertStagingSyntheticSeedAdsetContract({ input, source, target }) {
+  try {
+    const sourcePromoted = asObject(source.promoted_object);
+    if (
+      normalizeNumericId(sourcePromoted.pixel_id, 'staging_seed_source_pixel_id') !== input.pixelId ||
+      !safeTrackingEnum(sourcePromoted.custom_event_type) ||
+      !normalizeNumericId(sourcePromoted.offline_conversion_data_set_id, 'staging_seed_source_dataset_id')
+    ) {
+      throw new Error('source_tracking_missing');
+    }
+    assertWebsiteTrackingCompatibility(source, target, {
+      website_event_requirement: 'required',
+      offline_event_dataset_requirement: 'required',
+    });
+  } catch {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_contract_invalid', 409);
+  }
+}
+
+async function readStagingSyntheticSeedCreative(auth, creativeId, expectedName, expectedUrlTags, context) {
+  const result = await graphRequest(
+    graphUrl(auth.apiVersion, creativeId, { fields: 'id,name,url_tags' }),
+    { method: 'GET' }, auth, context,
+  );
+  const creative = asObject(result.body);
+  try {
+    if (
+      normalizeNumericId(creative.id, 'staging_seed_creative_id') !== creativeId ||
+      clean(creative.name) !== expectedName ||
+      normalizeUrlTags(creative.url_tags, { required: true }) !== expectedUrlTags
+    ) {
+      throw new Error('creative_mismatch');
+    }
+  } catch {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_contract_invalid', 409);
+  }
+  return creative;
+}
+
+async function readStagingSyntheticSeedAd(auth, adId, expectedAdsetId, expectedCreativeId, expectedName, context) {
+  const result = await graphRequest(
+    graphUrl(auth.apiVersion, adId, { fields: AD_STATE_FIELDS }),
+    { method: 'GET' }, auth, context,
+  );
+  const ad = asObject(result.body);
+  try {
+    if (
+      normalizeNumericId(ad.id, 'staging_seed_ad_id') !== adId ||
+      normalizeNumericId(ad.adset_id, 'staging_seed_ad_adset_id') !== expectedAdsetId ||
+      normalizeNumericId(asObject(ad.creative).id, 'staging_seed_ad_creative_id') !== expectedCreativeId ||
+      clean(ad.name) !== expectedName ||
+      clean(ad.status).toUpperCase() !== 'PAUSED' ||
+      !['PAUSED', 'PENDING_REVIEW', 'WITH_ISSUES'].includes(clean(ad.effective_status).toUpperCase())
+    ) {
+      throw new Error('ad_mismatch');
+    }
+  } catch {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_contract_invalid', 409);
+  }
+  return ad;
+}
+
+async function sealStagingSyntheticSeedCredentials({ input, env, operation, state, encryptToken, requestId, context }) {
+  const resources = asObject(state.resources);
+  const facts = asObject(state.facts);
+  const required = [
+    clean(asObject(resources.campaign).id),
+    clean(asObject(resources.source_adset).id),
+    clean(asObject(resources.target_adset).id),
+    clean(asObject(resources.source_creative).id),
+    clean(asObject(resources.source_ad).id),
+    clean(facts.page_id),
+    clean(facts.instagram_user_id),
+    clean(facts.dataset_id),
+  ];
+  if (required.some((value) => !/^\d{5,30}$/.test(value))) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+  await context.assertBootstrapLease();
+  let sourceCiphertext;
+  let targetCiphertext;
+  try {
+    sourceCiphertext = await encryptToken(input.accessToken, env);
+    targetCiphertext = await encryptToken(input.accessToken, env);
+  } catch {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_unavailable', 503);
+  }
+  const metadata = buildStagingSyntheticSeedCredentialMetadata({ input, state });
+  const sourceMetadataJson = JSON.stringify(metadata.source);
+  const targetMetadataJson = JSON.stringify(metadata.target);
+  const seededAuthority = await configWriterAuthorityState([
+    {
+      id: state.credential_ids.source,
+      external_account_id: input.accountId,
+      metadata_json: sourceMetadataJson,
+    },
+    {
+      id: state.credential_ids.target,
+      external_account_id: input.accountId,
+      metadata_json: targetMetadataJson,
+    },
+  ]);
+  if (seededAuthority.ready || seededAuthority.mode !== 'legacy_bootstrap' || !clean(seededAuthority.revision)) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+  state.credentials_sealing_started = true;
+  state.credentials = {
+    source: { id: state.credential_ids.source, token_type: STAGING_SYNTHETIC_SEED_SOURCE_TOKEN_TYPE },
+    target: { id: state.credential_ids.target, token_type: STAGING_SYNTHETIC_SEED_TARGET_TOKEN_TYPE },
+  };
+  state.seeded_authority = {
+    revision: seededAuthority.revision,
+    source_meta_ads_publish: asObject(metadata.source.meta_ads_publish),
+    target_meta_ads_publish: asObject(metadata.target.meta_ads_publish),
+  };
+  await persistStagingSyntheticSeedState({ env, operation, state, status: 'creating', encryptToken, context });
+  const nextState = {
+    ...state,
+    phase: 'sealed',
+    credentials_sealed: true,
+    credentials_sealing_started: false,
+  };
+  const stateCiphertext = await encryptStagingSyntheticSeedState(nextState, encryptToken, env);
+  const now = nowIso();
+  const statements = [
+    env.TOKEN_VAULT_DB.prepare([
+      'INSERT INTO credential_tokens (id, provider, unit, external_account_id, token_type, token_ciphertext, active, metadata_json, created_at, updated_at)',
+      'SELECT ?, ?, ?, ?, ?, ?, 1, ?, ?, ?',
+      "WHERE NOT EXISTS (SELECT 1 FROM credential_tokens WHERE provider = 'facebook' AND active = 1 AND id NOT IN (?, ?))",
+    ].join(' ')).bind(
+      state.credential_ids.source, 'facebook', STAGING_SYNTHETIC_SEED_UNIT, input.accountId,
+      STAGING_SYNTHETIC_SEED_SOURCE_TOKEN_TYPE, sourceCiphertext, sourceMetadataJson, now, now,
+      state.credential_ids.source, state.credential_ids.target,
+    ),
+    env.TOKEN_VAULT_DB.prepare([
+      'INSERT INTO credential_tokens (id, provider, unit, external_account_id, token_type, token_ciphertext, active, metadata_json, created_at, updated_at)',
+      'SELECT ?, ?, ?, ?, ?, ?, 1, ?, ?, ?',
+      "WHERE NOT EXISTS (SELECT 1 FROM credential_tokens WHERE provider = 'facebook' AND active = 1 AND id NOT IN (?, ?))",
+    ].join(' ')).bind(
+      state.credential_ids.target, 'facebook', STAGING_SYNTHETIC_SEED_UNIT, input.accountId,
+      STAGING_SYNTHETIC_SEED_TARGET_TOKEN_TYPE, targetCiphertext, targetMetadataJson, now, now,
+      state.credential_ids.source, state.credential_ids.target,
+    ),
+    env.TOKEN_VAULT_DB.prepare([
+      'UPDATE meta_ads_publish_staging_seed_operations',
+      "SET status = 'sealed', state_ciphertext = ?, summary_json = ?, updated_at = ?",
+      "WHERE id = ? AND operation_key = ? AND status = 'creating'",
+      'AND (SELECT COUNT(*) FROM credential_tokens',
+      "WHERE provider = 'facebook' AND active = 1 AND id IN (?, ?)) = 2",
+      'AND NOT EXISTS (SELECT 1 FROM credential_tokens',
+      "WHERE provider = 'facebook' AND active = 1 AND id NOT IN (?, ?))",
+    ].join(' ')).bind(
+      stateCiphertext, JSON.stringify(summarizeStagingSyntheticSeedState(nextState)), now, operation.id, operation.operation_key,
+      state.credential_ids.source, state.credential_ids.target, state.credential_ids.source, state.credential_ids.target,
+    ),
+  ];
+  let results;
+  try {
+    results = await env.TOKEN_VAULT_DB.batch(statements);
+  } catch {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_unavailable', 503);
+  }
+  if (safeArray(results).some((result) => statementChanges(result) !== 1)) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+  Object.assign(state, nextState);
+  operation.status = 'sealed';
+  void requestId;
+}
+
+function buildStagingSyntheticSeedCredentialMetadata({ input, state }) {
+  const facts = asObject(state.facts);
+  const resources = asObject(state.resources);
+  const common = {
+    destination_group: STAGING_SYNTHETIC_SEED_UNIT,
+    api_version: input.apiVersion,
+    account_id: input.accountId,
+    campaign_id: clean(asObject(resources.campaign).id),
+    page_id: clean(facts.page_id),
+    instagram_user_id: clean(facts.instagram_user_id),
+    allowed_link_hosts: [clean(facts.landing_host)],
+    landing_pages_by_creative_group: { [STAGING_SYNTHETIC_SEED_LANDING_GROUP]: clean(facts.landing_url) },
+    freshness_window_days: 7,
+    destination_type: 'website',
+    fixture_source_ad_id: clean(asObject(resources.source_ad).id),
+    url_tags: normalizeUrlTags(state.url_tags, { required: true }),
+  };
+  return {
+    source: {
+      meta_ads_publish: {
+        ...common,
+        adset_id: clean(asObject(resources.source_adset).id),
+        source_adset_id: clean(asObject(resources.source_adset).id),
+      },
+    },
+    target: {
+      meta_ads_publish: {
+        ...common,
+        adset_id: clean(asObject(resources.target_adset).id),
+        source_config_token_id: clean(state.credential_ids.source),
+      },
+    },
+  };
+}
+
+async function compensateStagingSyntheticSeed({ env, operation, state, auth, encryptToken, context, deactivateCredentials }) {
+  if (state.reconciliation_required === true) return { ok: false };
+  const resources = asObject(state.resources);
+  if (Object.values(resources).some((value) => asObject(value).pending === true)) {
+    state.reconciliation_required = true;
+    state.phase = 'reconciliation_required';
+    if (typeof encryptToken === 'function') {
+      await persistStagingSyntheticSeedState({ env, operation, state, status: 'reconciliation_required', encryptToken, context }).catch(() => undefined);
+    }
+    return { ok: false };
+  }
+  try {
+    if (context?.stagingSyntheticSeedMutationLocksHeld !== true) {
+      await acquireStagingSyntheticSeedMutationLocks(context, state);
+    }
+    if (auth) {
+      await archiveStagingSyntheticSeedAd(auth, asObject(resources.source_ad), asObject(resources.source_adset), context);
+      await archiveStagingSyntheticSeedAdset(auth, asObject(resources.target_adset), asObject(resources.campaign), context);
+      await archiveStagingSyntheticSeedAdset(auth, asObject(resources.source_adset), asObject(resources.campaign), context);
+      await archiveStagingSyntheticSeedCampaign(auth, asObject(resources.campaign), context);
+    }
+    // An AdCreative has no documented archive state, but once every owned ad
+    // has been read back as ARCHIVED it is detached from delivery. Retain that
+    // inert creative under the encrypted operation journal rather than let an
+    // otherwise complete rollback strand the candidate Worker forever.
+    state.detached_creative_retained = Boolean(clean(asObject(resources.source_creative).id));
+    if (deactivateCredentials || state.credentials_sealing_started === true) {
+      await deactivateStagingSyntheticSeedCredentials({ env, operation, state, encryptToken, context });
+    } else {
+      state.phase = 'rolled_back';
+      await persistStagingSyntheticSeedState({ env, operation, state, status: 'rolled_back', encryptToken, context });
+    }
+    return { ok: true };
+  } catch {
+    state.reconciliation_required = true;
+    state.phase = 'reconciliation_required';
+    if (typeof encryptToken === 'function') {
+      await persistStagingSyntheticSeedState({ env, operation, state, status: 'reconciliation_required', encryptToken, context }).catch(() => undefined);
+    }
+    return { ok: false };
+  }
+}
+
+async function archiveStagingSyntheticSeedAd(auth, resource, adset, context) {
+  const id = clean(resource.id);
+  if (!id) return;
+  const currentResult = await graphRequest(
+    graphUrl(auth.apiVersion, id, { fields: AD_STATE_FIELDS }),
+    { method: 'GET' }, auth, context,
+  );
+  const current = asObject(currentResult.body);
+  if (clean(current.status).toUpperCase() === 'ARCHIVED') return;
+  if (clean(current.name) !== clean(resource.name) || clean(current.adset_id) !== clean(adset.id)) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+  await graphRequest(graphUrl(auth.apiVersion, id), seedJsonRequest('POST', { status: 'ARCHIVED' }), auth, context, { maxAttempts: 1 });
+  const readbackResult = await graphRequest(
+    graphUrl(auth.apiVersion, id, { fields: AD_STATE_FIELDS }),
+    { method: 'GET' }, auth, context,
+  );
+  const readback = asObject(readbackResult.body);
+  if (clean(readback.status).toUpperCase() !== 'ARCHIVED') {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+}
+
+async function archiveStagingSyntheticSeedAdset(auth, resource, campaign, context) {
+  const id = clean(resource.id);
+  if (!id) return;
+  const currentResult = await graphRequest(
+    graphUrl(auth.apiVersion, id, { fields: STAGING_SYNTHETIC_SEED_ADSET_FIELDS }),
+    { method: 'GET' }, auth, context,
+  );
+  const current = asObject(currentResult.body);
+  if (clean(current.status).toUpperCase() === 'ARCHIVED') return;
+  if (
+    clean(current.campaign_id || asObject(current.campaign).id) !== clean(campaign.id) ||
+    clean(current.name) !== clean(resource.name)
+  ) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+  await graphRequest(graphUrl(auth.apiVersion, id), seedJsonRequest('POST', { status: 'ARCHIVED' }), auth, context, { maxAttempts: 1 });
+  const readbackResult = await graphRequest(
+    graphUrl(auth.apiVersion, id, { fields: STAGING_SYNTHETIC_SEED_ADSET_FIELDS }),
+    { method: 'GET' }, auth, context,
+  );
+  const readback = asObject(readbackResult.body);
+  if (clean(readback.status).toUpperCase() !== 'ARCHIVED') {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+}
+
+async function archiveStagingSyntheticSeedCampaign(auth, resource, context) {
+  const id = clean(resource.id);
+  if (!id) return;
+  const current = await graphRequest(graphUrl(auth.apiVersion, id, { fields: CAMPAIGN_READ_FIELDS }), { method: 'GET' }, auth, context);
+  if (clean(asObject(current.body).status).toUpperCase() === 'ARCHIVED') return;
+  if (clean(asObject(current.body).name) !== clean(resource.name)) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+  await graphRequest(graphUrl(auth.apiVersion, id), seedJsonRequest('POST', { status: 'ARCHIVED' }), auth, context, { maxAttempts: 1 });
+  const readback = await graphRequest(graphUrl(auth.apiVersion, id, { fields: CAMPAIGN_READ_FIELDS }), { method: 'GET' }, auth, context);
+  if (clean(asObject(readback.body).status).toUpperCase() !== 'ARCHIVED') {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+}
+
+async function deactivateStagingSyntheticSeedCredentials({ env, operation, state, encryptToken, context }) {
+  const credentials = asObject(state.credentials);
+  const sourceId = clean(asObject(credentials.source).id || asObject(state.credential_ids).source);
+  const targetId = clean(asObject(credentials.target).id || asObject(state.credential_ids).target);
+  if (!sourceId || !targetId || sourceId === targetId) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+  const present = await dbFirst(env, [
+    'SELECT COUNT(*) AS count FROM credential_tokens',
+    "WHERE provider = 'facebook' AND unit = ? AND active = 1 AND id IN (?, ?)",
+  ].join(' '), STAGING_SYNTHETIC_SEED_UNIT, sourceId, targetId);
+  const presentCount = Number(present?.count || 0);
+  if (presentCount !== 0 && presentCount !== 2) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+  state.phase = 'rolling_back';
+  await persistStagingSyntheticSeedState({ env, operation, state, status: 'rolling_back', encryptToken, context });
+  const nextState = { ...state, phase: 'rolled_back', credentials_sealed: false };
+  const stateCiphertext = await encryptStagingSyntheticSeedState(nextState, encryptToken, env);
+  const now = nowIso();
+  const statements = [
+    ...(presentCount === 2 ? [
+      env.TOKEN_VAULT_DB.prepare([
+        'UPDATE credential_tokens SET active = 0, updated_at = ?',
+        'WHERE id = ? AND provider = ? AND unit = ? AND token_type = ? AND active = 1',
+      ].join(' ')).bind(now, sourceId, 'facebook', STAGING_SYNTHETIC_SEED_UNIT, STAGING_SYNTHETIC_SEED_SOURCE_TOKEN_TYPE),
+      env.TOKEN_VAULT_DB.prepare([
+        'UPDATE credential_tokens SET active = 0, updated_at = ?',
+        'WHERE id = ? AND provider = ? AND unit = ? AND token_type = ? AND active = 1',
+      ].join(' ')).bind(now, targetId, 'facebook', STAGING_SYNTHETIC_SEED_UNIT, STAGING_SYNTHETIC_SEED_TARGET_TOKEN_TYPE),
+    ] : []),
+    env.TOKEN_VAULT_DB.prepare([
+      'UPDATE meta_ads_publish_staging_seed_operations',
+      "SET status = 'rolled_back', state_ciphertext = ?, summary_json = ?, updated_at = ?",
+      "WHERE id = ? AND operation_key = ? AND status = 'rolling_back'",
+    ].join(' ')).bind(
+      stateCiphertext, JSON.stringify(summarizeStagingSyntheticSeedState(nextState)), now, operation.id, operation.operation_key,
+    ),
+  ];
+  const results = await env.TOKEN_VAULT_DB.batch(statements);
+  if (safeArray(results).some((result) => statementChanges(result) !== 1)) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+  Object.assign(state, nextState);
+  operation.status = 'rolled_back';
 }
 
 function normalizeBootstrapDeriveFailure(error) {

--- a/platform/security/token-vault/tests/deploy-token-vault-staging-synthetic-seed-workflow.test.js
+++ b/platform/security/token-vault/tests/deploy-token-vault-staging-synthetic-seed-workflow.test.js
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const workflow = fs.readFileSync(
+  new URL(
+    "../../../../.github/workflows/deploy-token-vault.yml",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+function section(start, end) {
+  const from = workflow.indexOf(start);
+  assert.notEqual(from, -1, `missing workflow section: ${start}`);
+  const to = end ? workflow.indexOf(end, from + start.length) : workflow.length;
+  assert.notEqual(to, -1, `missing workflow boundary: ${end}`);
+  return workflow.slice(from, to);
+}
+
+test("staging synthetic seed is candidate-scoped, ordered before derivation, and fails closed", () => {
+  const upload = section(
+    "      - name: Upload immutable Token Vault version",
+    "      - name: Export immutable Worker and incumbent identities for the activation gate",
+  );
+  const seed = section(
+    "      - name: Seal the isolated staging Meta Ads synthetic seed on the immutable candidate",
+    "      - name: Verify immutable Token Vault candidate config bearer before traffic",
+  );
+  const pretrafficRollback = section(
+    "      - name: Roll back the isolated staging synthetic seed before traffic when candidate planning fails",
+    "      - name: Check Token Vault release lease before staging version deployment",
+  );
+  const activationLeaseRollback = section(
+    "      - name: Roll back the isolated staging synthetic seed when the activation lease rejects it",
+    "      - name: Activate only the selected Token Vault version in staging",
+  );
+  const routeConvergence = section(
+    "      - name: Wait for staging Token Vault route to accept the candidate config bearer",
+    "      - name: Bootstrap legacy Token Vault Meta Ads configuration only when staging requires it",
+  );
+  const candidatePlan = section(
+    "      - name: Seal a private or internally-derived legacy Token Vault bootstrap plan before traffic",
+    "      - name: Validate sealed Token Vault bootstrap plan before staging traffic",
+  );
+  const bootstrap = section(
+    "      - name: Bootstrap legacy Token Vault Meta Ads configuration only when staging requires it",
+    "      - name: Read back staging Token Vault deployment and authenticated health",
+  );
+  const compensationRollback = section(
+    "      - name: Roll back the isolated staging synthetic seed before Worker compensation",
+    "      - name: Compensate the staging Worker only when this release still owns traffic",
+  );
+  const cleanup = section(
+    "      - name: Remove the ephemeral staging synthetic-seed bearer",
+    "      - name: Release Token Vault release lease",
+  );
+
+  assert.match(upload, /randomBytes\(48\)\.toString\('base64url'\)/);
+  assert.match(
+    upload,
+    /\$RUNNER_TEMP\/token-vault-staging-synthetic-seed-\$\{GITHUB_RUN_ID\}-\$\{GITHUB_RUN_ATTEMPT\}/,
+  );
+  assert.match(upload, /chmod 600 "\$seed_secret_file"/);
+  assert.match(upload, /TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN = seedToken/);
+  assert.doesNotMatch(
+    upload,
+    /META_ADS_ACCESS_TOKEN|META_PIXEL_ID|META_ADS_ACCOUNT_ID|META_ADS_API_VERSION/,
+  );
+  assert.doesNotMatch(workflow, /\bwrangler\s+secret\s+put\b/i);
+
+  assert.match(
+    seed,
+    /if: inputs\.operation == 'deploy' && inputs\.target == 'staging'/,
+  );
+  assert.match(
+    seed,
+    /META_ADS_ACCESS_TOKEN: \$\{\{ inputs\.target == 'staging'/,
+  );
+  assert.match(seed, /META_PIXEL_ID: \$\{\{ inputs\.target == 'staging'/);
+  assert.match(seed, /META_ADS_ACCOUNT_ID: \$\{\{ inputs\.target == 'staging'/);
+  assert.match(
+    seed,
+    /META_ADS_API_VERSION: \$\{\{ inputs\.target == 'staging'/,
+  );
+  assert.match(seed, /staging-synthetic-seed`, \{/);
+  assert.match(
+    seed,
+    /const preview = String\(process\.env\.TOKEN_VAULT_CANDIDATE_PREVIEW_URL/,
+  );
+  assert.doesNotMatch(seed, /TOKEN_VAULT_STAGING_BASE_URL/);
+  assert.match(
+    seed,
+    /operation_key: operationKey,[\s\S]*access_token: accessToken,[\s\S]*account_id: accountId,[\s\S]*pixel_id: pixelId,[\s\S]*api_version: apiVersion/,
+  );
+  assert.match(seed, /meta-ads-tracking-v20\/staging-synthetic-seed\/v1/);
+  assert.match(
+    seed,
+    /seed_attempted=true\\nseed_operation_key=\$\{operationKey\}/,
+  );
+  assert.match(
+    seed,
+    /appendFileSync\(process\.env\.GITHUB_OUTPUT, `seed_attempted=true\\nseed_operation_key=\$\{operationKey\}\\n`\);/,
+  );
+  assert.match(
+    seed,
+    /appendFileSync\(process\.env\.GITHUB_OUTPUT, seed === 'sealed'[\s\S]*`did_seed=true\\nseed_status=\$\{seed\}\\n`[\s\S]*`did_seed=false\\nseed_status=\$\{seed\}\\n`\);/,
+  );
+  assert.equal(
+    [...seed.matchAll(/process\.env\.GITHUB_OUTPUT/g)].length,
+    2,
+    "only opaque seed state may reach workflow outputs",
+  );
+  assert.doesNotMatch(seed, /console\.log|process\.stdout\.write/);
+
+  assert.match(
+    routeConvergence,
+    /const base = String\(process\.env\.TOKEN_VAULT_STAGING_BASE_URL/,
+  );
+  assert.doesNotMatch(routeConvergence, /TOKEN_VAULT_CANDIDATE_PREVIEW_URL/);
+  assert.match(
+    candidatePlan,
+    /const preview = String\(process\.env\.TOKEN_VAULT_CANDIDATE_PREVIEW_URL/,
+  );
+  assert.match(
+    candidatePlan,
+    /fetch\(`\$\{preview\}\/internal\/token-vault\/v1\/meta-ads-publish\/config\/bootstrap\/derive-plan`/,
+  );
+  assert.doesNotMatch(candidatePlan, /TOKEN_VAULT_STAGING_BASE_URL/);
+  assert.match(
+    bootstrap,
+    /const base = String\(process\.env\.TOKEN_VAULT_STAGING_BASE_URL/,
+  );
+  assert.doesNotMatch(bootstrap, /TOKEN_VAULT_CANDIDATE_PREVIEW_URL/);
+
+  const uploadAt = workflow.indexOf(
+    "      - name: Upload immutable Token Vault version",
+  );
+  const seedAt = workflow.indexOf(
+    "      - name: Seal the isolated staging Meta Ads synthetic seed on the immutable candidate",
+  );
+  const configAt = workflow.indexOf(
+    "      - name: Verify immutable Token Vault candidate config bearer before traffic",
+  );
+  const planAt = workflow.indexOf(
+    "      - name: Seal a private or internally-derived legacy Token Vault bootstrap plan before traffic",
+  );
+  const trafficAt = workflow.indexOf(
+    "      - name: Activate only the selected Token Vault version in staging",
+  );
+  assert.ok(
+    uploadAt < seedAt &&
+      seedAt < configAt &&
+      configAt < planAt &&
+      planAt < trafficAt,
+  );
+
+  assert.match(
+    activationLeaseRollback,
+    /steps\.staging_worker_activation_lease\.outcome != 'success'/,
+  );
+  for (const rollback of [
+    pretrafficRollback,
+    activationLeaseRollback,
+    compensationRollback,
+  ]) {
+    assert.match(
+      rollback,
+      /const preview = String\(process\.env\.TOKEN_VAULT_CANDIDATE_PREVIEW_URL/,
+    );
+    assert.match(
+      rollback,
+      /fetch\(`\$\{preview\}\/internal\/token-vault\/v1\/meta-ads-publish\/config\/staging-synthetic-seed\/rollback`/,
+    );
+    assert.doesNotMatch(rollback, /TOKEN_VAULT_STAGING_BASE_URL/);
+    assert.match(rollback, /staging-synthetic-seed\/rollback/);
+    assert.match(
+      rollback,
+      /operation_key: operationKey,[\s\S]*access_token: accessToken,[\s\S]*account_id: accountId,[\s\S]*api_version: apiVersion/,
+    );
+    assert.match(rollback, /payload\?\.rolled_back !== true/);
+    assert.match(rollback, /meta-ads-tracking-v20\/staging-synthetic-seed\/v1/);
+  }
+  for (const rollback of [pretrafficRollback, activationLeaseRollback]) {
+    assert.match(rollback, /meta_ads_publish_staging_seed_operation_not_found/);
+  }
+  assert.match(compensationRollback, /TOKEN_VAULT_CANDIDATE_PREVIEW_URL/);
+  assert.doesNotMatch(compensationRollback, /TOKEN_VAULT_STAGING_BASE_URL/);
+  const sourceScopes = [
+    seed,
+    pretrafficRollback,
+    activationLeaseRollback,
+    compensationRollback,
+  ];
+  for (const sourceName of [
+    "META_ADS_ACCESS_TOKEN",
+    "META_PIXEL_ID",
+    "META_ADS_ACCOUNT_ID",
+    "META_ADS_API_VERSION",
+  ]) {
+    const total = [...workflow.matchAll(new RegExp(sourceName, "g"))].length;
+    const scoped = sourceScopes.reduce(
+      (count, scope) =>
+        count + [...scope.matchAll(new RegExp(sourceName, "g"))].length,
+      0,
+    );
+    assert.equal(
+      total,
+      scoped,
+      `${sourceName} must only reach bounded staging seed calls`,
+    );
+  }
+  assert.match(
+    cleanup,
+    /\$RUNNER_TEMP"\/token-vault-staging-synthetic-seed-\*/,
+  );
+  assert.match(cleanup, /rm -f -- "\$seed_file"/);
+});

--- a/platform/security/token-vault/tests/index.test.js
+++ b/platform/security/token-vault/tests/index.test.js
@@ -7,6 +7,7 @@ const TEST_API_TOKEN = ['unit', 'auth', 'token'].join('-');
 const TEST_OPERATIONAL_TOKEN = ['unit', 'operational', 'token'].join('-');
 const TEST_ANALYTICS_TOKEN = ['unit', 'analytics', 'token'].join('-');
 const TEST_META_ADS_CONFIG_TOKEN = ['unit', 'meta', 'ads', 'config', 'token'].join('-');
+const TEST_META_ADS_STAGING_SEED_TOKEN = ['unit', 'meta', 'ads', 'staging', 'seed', 'token'].join('-');
 const TEST_ENCRYPTION_KEY = ['unit', 'encryption', 'key', 'with', 'enough', 'length'].join('-');
 const THREADS_TOKEN = ['threads', 'fixture', 'token'].join('-');
 const FACEBOOK_TOKEN = ['facebook', 'fixture', 'token'].join('-');
@@ -105,6 +106,10 @@ function operationalAuthHeaders() {
 
 function metaAdsConfigAuthHeaders() {
   return { Authorization: `Bearer ${TEST_META_ADS_CONFIG_TOKEN}` };
+}
+
+function metaAdsStagingSeedAuthHeaders() {
+  return { Authorization: `Bearer ${TEST_META_ADS_STAGING_SEED_TOKEN}` };
 }
 
 async function encryptForSeed(token, secret) {
@@ -223,6 +228,83 @@ test('configured worker secrets must remain pairwise distinct', async () => {
   );
   assert.equal(response.status, 500);
   assert.equal((await response.json()).error, 'invalid_worker_secret_configuration');
+});
+
+test('Meta Ads staging seed bearer is staging-only, pairwise distinct, and exclusive to its two POST routes', async () => {
+  const disabledDb = new FakeDb();
+  const disabledEnvironment = env(disabledDb);
+  disabledEnvironment.ENVIRONMENT = 'production';
+  disabledEnvironment.TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN = TEST_META_ADS_STAGING_SEED_TOKEN;
+  const disabledResponse = await handleRequest(
+    new Request('https://api.skincos.com.br/internal/token-vault/health', { headers: authHeaders() }),
+    disabledEnvironment,
+  );
+  assert.equal(disabledResponse.status, 500);
+  assert.equal((await disabledResponse.json()).error, 'invalid_worker_secret_configuration');
+
+  const duplicateDb = new FakeDb();
+  const duplicateEnvironment = env(duplicateDb);
+  duplicateEnvironment.ENVIRONMENT = 'staging';
+  duplicateEnvironment.TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN = TEST_API_TOKEN;
+  const duplicateResponse = await handleRequest(
+    new Request('https://api.skincos.com.br/internal/token-vault/health', { headers: authHeaders() }),
+    duplicateEnvironment,
+  );
+  assert.equal(duplicateResponse.status, 500);
+  assert.equal((await duplicateResponse.json()).error, 'invalid_worker_secret_configuration');
+
+  const db = new FakeDb();
+  const environment = env(db);
+  environment.ENVIRONMENT = 'staging';
+  environment.TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN = TEST_META_ADS_STAGING_SEED_TOKEN;
+
+  for (const request of [
+    new Request('https://api.skincos.com.br/internal/token-vault/health', { headers: metaAdsStagingSeedAuthHeaders() }),
+    new Request('https://api.skincos.com.br/internal/token-vault/contract', { headers: metaAdsStagingSeedAuthHeaders() }),
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/config', { headers: metaAdsStagingSeedAuthHeaders() }),
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/runs', {
+      method: 'POST',
+      headers: { ...metaAdsStagingSeedAuthHeaders(), 'content-type': 'application/json' },
+      body: '{}',
+    }),
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed', {
+      headers: metaAdsStagingSeedAuthHeaders(),
+    }),
+  ]) {
+    const response = await handleRequest(request, environment);
+    assert.equal(response.status, 403);
+    assert.equal((await response.json()).error, 'meta_ads_staging_seed_credential_scope_required');
+  }
+
+  for (const pathname of [
+    '/v1/meta-ads-publish/config/staging-synthetic-seed',
+    '/v1/meta-ads-publish/config/staging-synthetic-seed/rollback',
+  ]) {
+    const allowedResponse = await handleRequest(
+      new Request(`https://api.skincos.com.br/internal/token-vault${pathname}`, {
+        method: 'POST',
+        headers: { ...metaAdsStagingSeedAuthHeaders(), 'content-type': 'application/json' },
+        body: '{}',
+      }),
+      environment,
+    );
+    assert.notEqual(allowedResponse.status, 403);
+    assert.notEqual((await allowedResponse.json()).error, 'meta_ads_staging_seed_credential_scope_required');
+  }
+
+  for (const token of [TEST_API_TOKEN, TEST_OPERATIONAL_TOKEN, TEST_META_ADS_CONFIG_TOKEN]) {
+    const response = await handleRequest(
+      new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        body: '{}',
+      }),
+      environment,
+    );
+    assert.equal(response.status, 403);
+    assert.equal((await response.json()).error, 'meta_ads_staging_seed_credential_required');
+  }
+  assert.equal(db.tokens.length, 0);
 });
 
 test('meta ads config credential is limited to configuration reads and governed bootstrap routing', async () => {

--- a/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
@@ -1,0 +1,770 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  rollbackStagingSyntheticMetaAdsTracking,
+  seedStagingSyntheticMetaAdsTracking,
+} from '../src/meta-ads-publish.js';
+
+const ACCOUNT_ID = '17841400000000001';
+const PIXEL_ID = '99444000000000001';
+const PAGE_ID = '12000000000000001';
+const INSTAGRAM_ID = '17841400000000002';
+const DATASET_ID = '19944000000000001';
+const SOURCE_ACCESS_TOKEN = 'unit-test-source-access-token-not-a-real-secret';
+
+class SeedStatement {
+  constructor(db, sql) {
+    this.db = db;
+    this.sql = sql;
+    this.values = [];
+  }
+
+  bind(...values) {
+    this.values = values;
+    return this;
+  }
+
+  first() {
+    return this.db.first(this.sql, this.values);
+  }
+
+  all() {
+    return this.db.all(this.sql, this.values);
+  }
+
+  run() {
+    return this.db.run(this.sql, this.values);
+  }
+}
+
+class SeedDb {
+  constructor() {
+    this.locks = new Map();
+    this.adsetLocks = new Map();
+    this.blockAdsetLocks = false;
+    this.adsetLockReads = [];
+    this.operations = new Map();
+    this.tokens = [];
+  }
+
+  prepare(sql) {
+    return new SeedStatement(this, sql);
+  }
+
+  async first(sql, values) {
+    const normalized = compactSql(sql);
+    if (normalized.startsWith('select resource_key, owner_id from meta_ads_publish_config_locks')) {
+      const lock = this.locks.get(values[0]);
+      return lock ? { resource_key: values[0], owner_id: lock.owner_id } : null;
+    }
+    if (normalized.includes('from meta_ads_publish_locks where resource_key = ?')) {
+      const resourceKey = values[0];
+      this.adsetLockReads.push(resourceKey);
+      const lock = this.blockAdsetLocks
+        ? {
+          resource_key: resourceKey,
+          run_id: 'independent-stage-run',
+          operation_key: 'independent-stage-operation',
+          expires_at: new Date(Date.now() + 60_000).toISOString(),
+        }
+        : this.adsetLocks.get(resourceKey);
+      return lock ? { ...lock } : null;
+    }
+    if (
+      normalized.startsWith('select count(*) as count from credential_tokens') &&
+      normalized.includes('unit = ?') &&
+      normalized.includes('id in')
+    ) {
+      const [unit, ...ids] = values;
+      return {
+        count: this.tokens.filter((token) => (
+          token.provider === 'facebook' &&
+          token.unit === unit &&
+          token.active === 1 &&
+          ids.includes(token.id)
+        )).length,
+      };
+    }
+    if (normalized.startsWith('select count(*) as count from credential_tokens where provider = ?')) {
+      return { count: this.tokens.filter((token) => token.provider === values[0] && token.active === 1).length };
+    }
+    if (normalized.startsWith('select id, operation_key, status from meta_ads_publish_staging_seed_operations where status in')) {
+      return [...this.operations.values()].find((operation) => [
+        'pending', 'creating', 'rolling_back', 'reconciliation_required',
+      ].includes(operation.status)) || null;
+    }
+    if (normalized.includes('from meta_ads_publish_staging_seed_operations where operation_key = ?')) {
+      return this.operations.get(values[0]) || null;
+    }
+    throw new Error(`Unexpected D1 first: ${normalized}`);
+  }
+
+  async all(sql) {
+    const normalized = compactSql(sql);
+    if (normalized.includes('from credential_tokens') && normalized.includes("where provider = 'facebook' and active = 1")) {
+      return {
+        results: this.tokens
+          .filter((token) => token.provider === 'facebook' && token.active === 1)
+          .sort((left, right) => `${left.unit}:${left.external_account_id}`.localeCompare(`${right.unit}:${right.external_account_id}`))
+          .map((token) => ({
+            id: token.id,
+            unit: token.unit,
+            external_account_id: token.external_account_id,
+            token_type: token.token_type,
+            expires_at: null,
+            active: token.active,
+            metadata_json: token.metadata_json,
+            updated_at: token.updated_at,
+          })),
+      };
+    }
+    throw new Error(`Unexpected D1 all: ${normalized}`);
+  }
+
+  async run(sql, values) {
+    const normalized = compactSql(sql);
+    if (normalized.startsWith('delete from meta_ads_publish_config_locks where resource_key = ? and expires_at <= ?')) {
+      return changes(0);
+    }
+    if (normalized.startsWith('insert into meta_ads_publish_config_locks')) {
+      const [resourceKey, ownerId, expiresAt] = values;
+      const current = this.locks.get(resourceKey);
+      if (!current || current.expires_at <= new Date().toISOString()) {
+        this.locks.set(resourceKey, { owner_id: ownerId, expires_at: expiresAt });
+        return changes(1);
+      }
+      return changes(0);
+    }
+    if (normalized.startsWith('update meta_ads_publish_config_locks set expires_at = ?, updated_at = ?')) {
+      const [, , resourceKey, ownerId] = values;
+      const current = this.locks.get(resourceKey);
+      if (!current || current.owner_id !== ownerId) return changes(0);
+      current.expires_at = values[0];
+      return changes(1);
+    }
+    if (normalized.startsWith('delete from meta_ads_publish_config_locks where resource_key = ? and owner_id = ?')) {
+      const [resourceKey, ownerId] = values;
+      if (this.locks.get(resourceKey)?.owner_id !== ownerId) return changes(0);
+      this.locks.delete(resourceKey);
+      return changes(1);
+    }
+    if (normalized.startsWith('insert into meta_ads_publish_locks')) {
+      const [resourceKey, runId, operationKey, , expiresAt] = values;
+      const current = this.adsetLocks.get(resourceKey);
+      if (
+        current &&
+        new Date(current.expires_at).getTime() > Date.now() &&
+        (current.run_id !== runId || current.operation_key !== operationKey)
+      ) {
+        return changes(0);
+      }
+      this.adsetLocks.set(resourceKey, {
+        resource_key: resourceKey,
+        run_id: runId,
+        operation_key: operationKey,
+        expires_at: expiresAt,
+      });
+      return changes(1);
+    }
+    if (normalized.startsWith('delete from meta_ads_publish_locks where run_id = ? and operation_key = ?')) {
+      const [runId, operationKey] = values;
+      for (const [resourceKey, lock] of this.adsetLocks) {
+        if (lock.run_id === runId && lock.operation_key === operationKey) this.adsetLocks.delete(resourceKey);
+      }
+      return changes(1);
+    }
+    if (normalized.startsWith('update credential_tokens set active = 0')) {
+      const [, id, provider, unit, tokenType] = values;
+      const token = this.tokens.find((entry) => (
+        entry.id === id &&
+        entry.provider === provider &&
+        entry.unit === unit &&
+        entry.token_type === tokenType &&
+        entry.active === 1
+      ));
+      if (!token) return changes(0);
+      token.active = 0;
+      token.updated_at = values[0];
+      return changes(1);
+    }
+    if (normalized.startsWith('insert into meta_ads_publish_staging_seed_operations')) {
+      const [id, operationKey, requestHash, status, stateCiphertext, summaryJson, createdAt, updatedAt] = values;
+      if (this.operations.has(operationKey)) throw new Error('UNIQUE constraint failed');
+      this.operations.set(operationKey, {
+        id,
+        operation_key: operationKey,
+        request_hash: requestHash,
+        status,
+        state_ciphertext: stateCiphertext,
+        summary_json: summaryJson,
+        created_at: createdAt,
+        updated_at: updatedAt,
+      });
+      return changes(1);
+    }
+    if (normalized.startsWith('update meta_ads_publish_staging_seed_operations set status = ?, state_ciphertext = ?')) {
+      const [status, stateCiphertext, summaryJson, updatedAt, id, operationKey] = values;
+      const operation = this.operations.get(operationKey);
+      if (!operation || operation.id !== id) return changes(0);
+      Object.assign(operation, {
+        status,
+        state_ciphertext: stateCiphertext,
+        summary_json: summaryJson,
+        updated_at: updatedAt,
+      });
+      return changes(1);
+    }
+    throw new Error(`Unexpected D1 run: ${normalized}`);
+  }
+
+  async batch(statements) {
+    const stagedTokens = [];
+    const stagedDeactivations = [];
+    let operationUpdate = null;
+
+    for (const statement of statements) {
+      const normalized = compactSql(statement.sql);
+      if (normalized.startsWith('insert into credential_tokens')) {
+        const [id, provider, unit, externalAccountId, tokenType, tokenCiphertext, metadataJson, createdAt, updatedAt] = statement.values;
+        stagedTokens.push({
+          id,
+          provider,
+          unit,
+          external_account_id: externalAccountId,
+          token_type: tokenType,
+          token_ciphertext: tokenCiphertext,
+          metadata_json: metadataJson,
+          active: 1,
+          created_at: createdAt,
+          updated_at: updatedAt,
+        });
+        continue;
+      }
+      if (normalized.startsWith('update credential_tokens set active = 0')) {
+        const [, id, provider, unit, tokenType] = statement.values;
+        stagedDeactivations.push({ id, provider, unit, tokenType, updatedAt: statement.values[0] });
+        continue;
+      }
+      if (normalized.startsWith('update meta_ads_publish_staging_seed_operations set status =')) {
+        const [stateCiphertext, summaryJson, updatedAt, operationId, operationKey] = statement.values;
+        operationUpdate = {
+          status: normalized.includes("set status = 'sealed'") ? 'sealed' : 'rolled_back',
+          stateCiphertext,
+          summaryJson,
+          updatedAt,
+          operationId,
+          operationKey,
+        };
+        continue;
+      }
+      throw new Error(`Unexpected D1 batch statement: ${normalized}`);
+    }
+
+    if (!operationUpdate) throw new Error('seed batch missing operation update');
+    const operation = this.operations.get(operationUpdate.operationKey);
+    if (!operation || operation.id !== operationUpdate.operationId) {
+      throw new Error('seed operation missing');
+    }
+    if (stagedTokens.some((token) => this.tokens.some((existing) => existing.id === token.id))) {
+      throw new Error('UNIQUE constraint failed');
+    }
+    for (const deactivation of stagedDeactivations) {
+      const token = this.tokens.find((entry) => (
+        entry.id === deactivation.id &&
+        entry.provider === deactivation.provider &&
+        entry.unit === deactivation.unit &&
+        entry.token_type === deactivation.tokenType &&
+        entry.active === 1
+      ));
+      if (!token) throw new Error('seed credential missing for deactivate');
+    }
+    this.tokens.push(...stagedTokens);
+    for (const deactivation of stagedDeactivations) {
+      const token = this.tokens.find((entry) => entry.id === deactivation.id);
+      token.active = 0;
+      token.updated_at = deactivation.updatedAt;
+    }
+    Object.assign(operation, {
+      status: operationUpdate.status,
+      state_ciphertext: operationUpdate.stateCiphertext,
+      summary_json: operationUpdate.summaryJson,
+      updated_at: operationUpdate.updatedAt,
+    });
+    return statements.map(() => changes(1));
+  }
+}
+
+class FakeGraph {
+  constructor({ ambiguousCreatePath = '' } = {}) {
+    this.ambiguousCreatePath = ambiguousCreatePath;
+    this.calls = [];
+    this.postCalls = [];
+    this.resources = new Map();
+    this.nextId = 23800000000000001n;
+  }
+
+  async fetch(url, init = {}) {
+    const target = new URL(url);
+    const path = target.pathname.replace(/^\/v\d+\.0\//, '');
+    const method = String(init.method || 'GET').toUpperCase();
+    this.calls.push({ path, method });
+    if (init.headers?.get?.('Authorization') !== `Bearer ${SOURCE_ACCESS_TOKEN}`) {
+      return graphResponse({ error: { message: 'invalid auth' } }, 401);
+    }
+
+    if (method === 'GET') return this.read(path);
+
+    this.postCalls.push(path);
+    const body = JSON.parse(init.body || '{}');
+    if (this.resources.has(path) && body.status === 'ARCHIVED') {
+      const resource = this.resources.get(path);
+      resource.body = { ...resource.body, status: 'ARCHIVED' };
+      return graphResponse({ success: true });
+    }
+    if (path === this.ambiguousCreatePath) {
+      return graphResponse({ error: { message: 'transient unit failure', is_transient: true } }, 503);
+    }
+    return this.create(path, body);
+  }
+
+  read(path) {
+    if (path === PIXEL_ID) {
+      return graphResponse({ id: PIXEL_ID, owner_ad_account: { id: ACCOUNT_ID } });
+    }
+    if (path === 'me/accounts') {
+      return graphResponse({ data: [{ id: PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } }] });
+    }
+    if (path === PAGE_ID) {
+      return graphResponse({
+        id: PAGE_ID,
+        instagram_business_account: { id: INSTAGRAM_ID },
+        website: 'https://staging.example.invalid/tracking-fixture',
+        picture: { data: { url: 'https://cdn.example.invalid/staging-fixture.jpg' } },
+      });
+    }
+    if (path === `act_${ACCOUNT_ID}/offline_conversion_data_sets`) {
+      return graphResponse({ data: [{ id: DATASET_ID }] });
+    }
+    const resource = this.resources.get(path);
+    if (!resource) return graphResponse({ error: { message: 'not found' } }, 404);
+    if (resource.kind === 'campaign') {
+      return graphResponse({
+        id: resource.id,
+        name: resource.body.name,
+        objective: resource.body.objective,
+        buying_type: resource.body.buying_type,
+        special_ad_categories: resource.body.special_ad_categories,
+        is_adset_budget_sharing_enabled: resource.body.is_adset_budget_sharing_enabled,
+        status: resource.body.status,
+      });
+    }
+    if (resource.kind === 'adset') {
+      return graphResponse({
+        id: resource.id,
+        name: resource.body.name,
+        account_id: ACCOUNT_ID,
+        campaign_id: resource.body.campaign_id,
+        campaign: { id: resource.body.campaign_id, objective: 'OUTCOME_LEADS' },
+        status: resource.body.status,
+        billing_event: resource.body.billing_event,
+        optimization_goal: resource.body.optimization_goal,
+        destination_type: resource.body.destination_type,
+        attribution_spec: resource.body.attribution_spec,
+        promoted_object: resource.body.promoted_object,
+      });
+    }
+    if (resource.kind === 'creative') {
+      return graphResponse({ id: resource.id, name: resource.body.name, url_tags: resource.body.url_tags });
+    }
+    if (resource.kind === 'ad') {
+      return graphResponse({
+        id: resource.id,
+        name: resource.body.name,
+        adset_id: resource.body.adset_id,
+        creative: { id: resource.body.creative.creative_id },
+        status: resource.body.status,
+        effective_status: 'PAUSED',
+      });
+    }
+    throw new Error(`Unsupported fake resource type ${resource.kind}`);
+  }
+
+  create(path, body) {
+    const kinds = new Map([
+      [`act_${ACCOUNT_ID}/campaigns`, 'campaign'],
+      [`act_${ACCOUNT_ID}/adsets`, 'adset'],
+      [`act_${ACCOUNT_ID}/adcreatives`, 'creative'],
+      [`act_${ACCOUNT_ID}/ads`, 'ad'],
+    ]);
+    const kind = kinds.get(path);
+    if (!kind) return graphResponse({ error: { message: 'unsupported mutation' } }, 400);
+    const id = String(this.nextId++);
+    this.resources.set(id, { id, kind, body });
+    return graphResponse({ id });
+  }
+}
+
+function compactSql(sql) {
+  return String(sql).replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+function changes(count) {
+  return { success: true, meta: { changes: count } };
+}
+
+function graphResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function environment(db, graph, overrides = {}) {
+  return {
+    ENVIRONMENT: 'staging',
+    TOKEN_VAULT_DB: db,
+    META_GRAPH_FETCH: graph.fetch.bind(graph),
+    META_GRAPH_SLEEP: async () => {},
+    ...overrides,
+  };
+}
+
+function request(operationKey, overrides = {}) {
+  return new Request('https://token-vault.invalid/v1/meta-ads-publish/config/staging-synthetic-seed', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      operation_key: operationKey,
+      access_token: SOURCE_ACCESS_TOKEN,
+      account_id: ACCOUNT_ID,
+      pixel_id: PIXEL_ID,
+      api_version: 'v25.0',
+      ...overrides,
+    }),
+  });
+}
+
+async function encrypt(value) {
+  return `enc:${Buffer.from(value).toString('base64')}`;
+}
+
+async function decrypt(value) {
+  if (!String(value).startsWith('enc:')) throw new Error('ciphertext unavailable');
+  return Buffer.from(String(value).slice(4), 'base64').toString();
+}
+
+async function seed({ db, graph, operationKey, env = {} }) {
+  return seedStagingSyntheticMetaAdsTracking({
+    request: request(operationKey),
+    env: environment(db, graph, env),
+    requestId: 'seed-test-request-id',
+    encryptToken: encrypt,
+    writeAudit: async () => {},
+  });
+}
+
+function rollbackRequest(operationKey, overrides = {}) {
+  return new Request('https://token-vault.invalid/v1/meta-ads-publish/config/staging-synthetic-seed/rollback', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      operation_key: operationKey,
+      access_token: SOURCE_ACCESS_TOKEN,
+      account_id: ACCOUNT_ID,
+      api_version: 'v25.0',
+      ...overrides,
+    }),
+  });
+}
+
+async function rollback({ db, graph, operationKey, env = {} }) {
+  return rollbackStagingSyntheticMetaAdsTracking({
+    request: rollbackRequest(operationKey),
+    env: environment(db, graph, env),
+    requestId: 'seed-rollback-test-request-id',
+    decryptToken: decrypt,
+    encryptToken: encrypt,
+    writeAudit: async () => {},
+  });
+}
+
+async function pendingSeedState(operationKey) {
+  return {
+    contract: 'meta-ads-tracking-v20/staging-synthetic-seed/v1',
+    phase: 'pending',
+    reconciliation_required: false,
+    input: {
+      operation_key: operationKey,
+      account_id: ACCOUNT_ID,
+      pixel_id: PIXEL_ID,
+      api_version: 'v25.0',
+    },
+    marker: 'a'.repeat(64),
+    url_tags: 'skincos_staging_v20=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    credential_ids: {
+      source: 'staging.meta-ads.source.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      target: 'staging.meta-ads.target.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    },
+    credentials_sealed: false,
+    facts: {},
+    resources: {},
+  };
+}
+
+function operationSnapshot(db, operationKey) {
+  const operation = db.operations.get(operationKey);
+  return {
+    operation: operation ? { ...operation } : null,
+    tokens: db.tokens.map((token) => ({ ...token })),
+  };
+}
+
+test('staging seed is staging-only and redacts all source inputs from a closed response', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph();
+  const response = await seed({
+    db,
+    graph,
+    operationKey: 'meta-ads-staging-seed:production-denied-001',
+    env: { ENVIRONMENT: 'production' },
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 503);
+  assert.equal(body.error, 'meta_ads_publish_staging_seed_disabled');
+  assert.equal(graph.calls.length, 0);
+  assert.equal(db.tokens.length, 0);
+  assert.equal(JSON.stringify(body).includes(SOURCE_ACCESS_TOKEN), false);
+  assert.equal(JSON.stringify(body).includes(ACCOUNT_ID), false);
+  assert.equal(JSON.stringify(body).includes(PIXEL_ID), false);
+});
+
+test('staging seed creates exactly two distinct active Facebook credentials from PAUSED synthetic Graph resources', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph();
+  const operationKey = 'meta-ads-staging-seed:happy-path-001';
+  const response = await seed({ db, graph, operationKey });
+  const body = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.deepEqual(body, {
+    ok: true,
+    seed: 'sealed',
+    operation_status: 'sealed',
+    replayed: false,
+    operation_key: operationKey,
+    contract_version: 'meta-ads-tracking-v20/staging-synthetic-seed/v1',
+    requestId: 'seed-test-request-id',
+  });
+  assert.equal(JSON.stringify(body).includes(SOURCE_ACCESS_TOKEN), false);
+  assert.equal(JSON.stringify(body).includes(ACCOUNT_ID), false);
+  assert.equal(JSON.stringify(body).includes(PIXEL_ID), false);
+
+  assert.equal(db.tokens.length, 2);
+  assert.equal(new Set(db.tokens.map((token) => token.id)).size, 2);
+  assert.deepEqual(new Set(db.tokens.map((token) => token.provider)), new Set(['facebook']));
+  assert.deepEqual(new Set(db.tokens.map((token) => token.active)), new Set([1]));
+  assert.deepEqual(
+    new Set(db.tokens.map((token) => token.token_type)),
+    new Set(['staging_synthetic_source', 'staging_synthetic_target']),
+  );
+  assert.ok(db.tokens.every((token) => token.token_ciphertext.includes(SOURCE_ACCESS_TOKEN) === false));
+
+  const metadata = db.tokens.map((token) => JSON.parse(token.metadata_json).meta_ads_publish);
+  assert.equal(metadata.filter((entry) => entry.source_config_token_id).length, 1);
+  assert.equal(metadata.filter((entry) => entry.source_adset_id).length, 1);
+  assert.ok(metadata.every((entry) => entry.destination_type === 'website'));
+  assert.ok(metadata.every((entry) => entry.url_tags.startsWith('skincos_staging_v20=')));
+
+  assert.deepEqual(graph.postCalls, [
+    `act_${ACCOUNT_ID}/campaigns`,
+    `act_${ACCOUNT_ID}/adsets`,
+    `act_${ACCOUNT_ID}/adsets`,
+    `act_${ACCOUNT_ID}/adcreatives`,
+    `act_${ACCOUNT_ID}/ads`,
+  ]);
+  const deliveryResources = [...graph.resources.values()].filter((resource) => resource.kind !== 'creative');
+  assert.equal(deliveryResources.length, 4);
+  assert.ok(deliveryResources.every((resource) => resource.body.status === 'PAUSED'));
+  assert.equal(db.operations.get(operationKey).status, 'sealed');
+  assert.equal(JSON.stringify({ operations: [...db.operations.values()], tokens: db.tokens }).includes(SOURCE_ACCESS_TOKEN), false);
+});
+
+test('a matching sealed operation replays idempotently without another Graph mutation', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph();
+  const operationKey = 'meta-ads-staging-seed:replay-001';
+  const first = await seed({ db, graph, operationKey });
+  assert.equal(first.status, 201);
+  const postCount = graph.postCalls.length;
+
+  const replay = await seed({ db, graph, operationKey });
+  const body = await replay.json();
+  assert.equal(replay.status, 200);
+  assert.equal(body.seed, 'sealed');
+  assert.equal(body.replayed, true);
+  assert.equal(graph.postCalls.length, postCount);
+  assert.equal(db.tokens.length, 2);
+});
+
+test('an ambiguous synthetic POST is never retried and leaves the operation fail-closed for reconciliation', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph({ ambiguousCreatePath: `act_${ACCOUNT_ID}/campaigns` });
+  const operationKey = 'meta-ads-staging-seed:ambiguous-post-001';
+  const response = await seed({ db, graph, operationKey });
+  const body = await response.json();
+
+  assert.equal(response.status, 409);
+  assert.equal(body.error, 'meta_ads_publish_staging_seed_reconciliation_required');
+  assert.deepEqual(graph.postCalls, [`act_${ACCOUNT_ID}/campaigns`]);
+  assert.equal(db.tokens.length, 0);
+  assert.equal(db.operations.get(operationKey).status, 'reconciliation_required');
+  assert.equal(JSON.stringify(body).includes(SOURCE_ACCESS_TOKEN), false);
+  assert.equal(JSON.stringify(body).includes(ACCOUNT_ID), false);
+});
+
+test('rollback rejects a drifted seeded authority before it mutates Graph delivery or D1 credentials', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph();
+  const operationKey = 'meta-ads-staging-seed:rollback-authority-stale-001';
+  const created = await seed({ db, graph, operationKey });
+  assert.equal(created.status, 201);
+
+  const source = db.tokens.find((token) => token.token_type === 'staging_synthetic_source');
+  const sourceMetadata = JSON.parse(source.metadata_json);
+  sourceMetadata.meta_ads_publish.url_tags = 'skincos_staging_v20=authority_drifted';
+  source.metadata_json = JSON.stringify(sourceMetadata);
+
+  const before = operationSnapshot(db, operationKey);
+  const graphCallsBefore = graph.calls.length;
+  const graphPostsBefore = graph.postCalls.length;
+  const response = await rollback({ db, graph, operationKey });
+  const body = await response.json();
+
+  assert.equal(response.status, 409);
+  assert.equal(body.ok, false);
+  assert.equal(graph.calls.length, graphCallsBefore);
+  assert.equal(graph.postCalls.length, graphPostsBefore);
+  assert.deepEqual(operationSnapshot(db, operationKey), before);
+  assert.equal(db.tokens.every((token) => token.active === 1), true);
+  assert.equal(JSON.stringify(body).includes(SOURCE_ACCESS_TOKEN), false);
+});
+
+test('normal rollback archives every delivery object, deactivates both credentials, and leaves the detached creative inert', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph();
+  const operationKey = 'meta-ads-staging-seed:rollback-happy-001';
+  const created = await seed({ db, graph, operationKey });
+  assert.equal(created.status, 201);
+  const mutationCountBeforeRollback = graph.postCalls.length;
+
+  const response = await rollback({ db, graph, operationKey });
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(body, {
+    ok: true,
+    rolled_back: true,
+    operation_status: 'rolled_back',
+    replayed: false,
+    operation_key: operationKey,
+    contract_version: 'meta-ads-tracking-v20/staging-synthetic-seed/v1',
+    requestId: 'seed-rollback-test-request-id',
+  });
+  assert.equal(db.operations.get(operationKey).status, 'rolled_back');
+  assert.equal(db.tokens.length, 2);
+  assert.equal(db.tokens.every((token) => token.active === 0), true);
+
+  const delivery = [...graph.resources.values()].filter((resource) => resource.kind !== 'creative');
+  assert.equal(delivery.length, 4);
+  assert.equal(delivery.every((resource) => resource.body.status === 'ARCHIVED'), true);
+  const creative = [...graph.resources.values()].find((resource) => resource.kind === 'creative');
+  assert.ok(creative);
+  assert.equal(creative.body.status, undefined);
+  assert.equal(
+    [...graph.resources.values()].filter((resource) => resource.kind === 'ad').every((resource) => resource.body.status === 'ARCHIVED'),
+    true,
+  );
+  assert.equal(graph.postCalls.length, mutationCountBeforeRollback + 4);
+});
+
+test('an explicitly requested rollback can close a pending seed before any Graph object or credential exists', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph();
+  const operationKey = 'meta-ads-staging-seed:pending-rollback-001';
+  const state = await pendingSeedState(operationKey);
+  db.operations.set(operationKey, {
+    id: 'seed-pending-operation-id',
+    operation_key: operationKey,
+    request_hash: 'opaque-test-request-hash',
+    status: 'pending',
+    state_ciphertext: await encrypt(JSON.stringify(state)),
+    summary_json: JSON.stringify({ phase: 'pending' }),
+    created_at: '2026-08-15T00:00:00.000Z',
+    updated_at: '2026-08-15T00:00:00.000Z',
+  });
+
+  const response = await rollback({ db, graph, operationKey });
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.ok, true);
+  assert.equal(body.rolled_back, true);
+  assert.equal(body.replayed, false);
+  assert.equal(db.operations.get(operationKey).status, 'rolled_back');
+  assert.equal(db.tokens.length, 0);
+  assert.equal(graph.calls.length, 0);
+  assert.equal(graph.postCalls.length, 0);
+});
+
+test('shared adset-contract leases stop a new seed before credential seal and a sealed rollback before delivery mutation', async () => {
+  const contendedSeedDb = new SeedDb();
+  contendedSeedDb.blockAdsetLocks = true;
+  const contendedSeedGraph = new FakeGraph();
+  const contendedSeedKey = 'meta-ads-staging-seed:adset-lock-seed-001';
+  const seedResponse = await seed({ db: contendedSeedDb, graph: contendedSeedGraph, operationKey: contendedSeedKey });
+  const seedBody = await seedResponse.json();
+
+  assert.equal(seedResponse.status, 409);
+  assert.equal(seedBody.ok, false);
+  assert.equal(contendedSeedDb.tokens.length, 0);
+  assert.notEqual(contendedSeedDb.operations.get(contendedSeedKey)?.status, 'sealed');
+  assert.equal(
+    [...contendedSeedGraph.resources.values()]
+      .filter((resource) => resource.kind === 'creative' || resource.kind === 'ad').length,
+    0,
+  );
+  assert.equal(
+    [...contendedSeedGraph.resources.values()]
+      .filter((resource) => resource.kind !== 'creative')
+      .every((resource) => resource.body.status === 'PAUSED'),
+    true,
+  );
+  assert.equal(
+    contendedSeedDb.adsetLockReads.some((resourceKey) => resourceKey.startsWith(`adset-contract:${ACCOUNT_ID}:`)),
+    true,
+  );
+
+  const db = new SeedDb();
+  const graph = new FakeGraph();
+  const operationKey = 'meta-ads-staging-seed:adset-lock-rollback-001';
+  const created = await seed({ db, graph, operationKey });
+  assert.equal(created.status, 201);
+  db.blockAdsetLocks = true;
+  const before = operationSnapshot(db, operationKey);
+  const graphCallsBefore = graph.calls.length;
+  const graphPostsBefore = graph.postCalls.length;
+
+  const response = await rollback({ db, graph, operationKey });
+  const body = await response.json();
+
+  assert.ok(response.status >= 400);
+  assert.equal(body.ok, false);
+  assert.deepEqual(operationSnapshot(db, operationKey), before);
+  assert.equal(graph.calls.length, graphCallsBefore);
+  assert.equal(graph.postCalls.length, graphPostsBefore);
+  assert.equal(
+    db.adsetLockReads.some((resourceKey) => resourceKey.startsWith(`adset-contract:${ACCOUNT_ID}:`)),
+    true,
+  );
+});

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -78,12 +78,14 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
   const tokenVaultUnit = catalog.units.find((unit) => unit.id === "token-vault");
   assert.ok(tokenVaultUnit);
   assert.ok(!catalog.nonPublishingSurfaces.some((entry) => entry.id === "token-vault"));
-  assert.ok(tokenVaultUnit.resources.includes("Governed Meta Ads tracking bootstrap derivation, rollback journal and paused creative fixture"));
+  assert.ok(tokenVaultUnit.resources.includes("Governed Meta Ads staging synthetic seed, bootstrap derivation, rollback journal and paused creative fixture"));
   assert.ok(tokenVaultUnit.secrets.includes("TOKEN_VAULT_META_ADS_CONFIG_TOKEN"));
   assert.ok(tokenVaultUnit.secrets.includes("TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST"));
+  assert.ok(tokenVaultUnit.secrets.includes("META_ADS_ACCESS_TOKEN"));
+  assert.ok(tokenVaultUnit.secrets.includes("META_PIXEL_ID"));
   assert.ok(!tokenVaultUnit.secrets.includes("TOKEN_VAULT_BACKUP_PASSPHRASE"));
   assert.equal(tokenVaultUnit.promotion.trackingFixture, "synthetic authorized ad-set profile required before staging");
-  assert.equal(tokenVaultUnit.promotion.trackingBootstrap, "legacy authority only; restricted config bearer plus hash-bound internal derivation or protected entries override");
+  assert.equal(tokenVaultUnit.promotion.trackingBootstrap, "empty staging authority uses a restricted one-shot synthetic seed; legacy authority uses restricted config bearer plus hash-bound internal derivation or protected entries override");
   assert.equal(tokenVaultUnit.promotion.d1Recovery, "Time Travel bookmark; manual restore only under release:token-vault");
 
   const workflow = read(".github/workflows/deploy-token-vault.yml");


### PR DESCRIPTION
## What changed

- Adds a staging-only, one-shot Meta Ads synthetic seed for an empty Token Vault authority.
- Seals two encrypted Facebook credentials only after bounded Graph identity checks and creates only marked, paused delivery resources.
- Adds durable journal state, authority CAS, shared ad-set leases, and fail-closed compensation.
- Wires the immutable candidate preview seed/rollback flow into the governed Token Vault deploy workflow and documents the custody boundary.

## Why

The previous staging rollout correctly stopped because its D1 authority had no configured Facebook targets, so a legacy bootstrap plan could not be derived. This makes that first governed staging bootstrap recoverable without borrowing production configuration or exposing credentials.

## Validation

- `npm --prefix platform/security/token-vault test` — 134/134
- Focused staging seed/workflow tests — 9/9
- Global concurrency governance static checks — 19/19
- Deploy topology, Cloudflare single-writer, dependency-closure, and Orb source sync checks
- Sealed security diff scan — 0 P0/P1 findings

## Safety

The seed bearer is CSPRNG-generated per candidate and exists only in the private candidate secrets file. Source Meta material is sent only in-memory to the immutable preview endpoint; no secret values, Ponto, or CRM changes are included.