### PR TITLE
fix(meta-ads): validate staging Graph API contract early

### DIFF
--- a/.github/workflows/deploy-token-vault.yml
+++ b/.github/workflows/deploy-token-vault.yml
@@ -987,6 +987,7 @@ jobs:
           TOKEN_VAULT_PRODUCTION_BASE_URL: ${{ vars.TOKEN_VAULT_PRODUCTION_BASE_URL }}
           ENABLE_TOKEN_VAULT_DEPLOY_STAGING: ${{ vars.ENABLE_TOKEN_VAULT_DEPLOY_STAGING }}
           ENABLE_TOKEN_VAULT_PRODUCTION_DEPLOY: ${{ vars.ENABLE_TOKEN_VAULT_PRODUCTION_DEPLOY }}
+          META_ADS_API_VERSION: ${{ inputs.target == 'staging' && vars.META_ADS_API_VERSION || '' }}
           TARGET: ${{ inputs.target }}
           OPERATION: ${{ inputs.operation }}
           CONFIRM_STAGING_TRACKING_FIXTURE: ${{ inputs.confirm_staging_tracking_fixture }}
@@ -1001,6 +1002,7 @@ jobs:
             [[ "$ENABLE_TOKEN_VAULT_DEPLOY_STAGING" == true ]] || { echo 'ENABLE_TOKEN_VAULT_DEPLOY_STAGING must be true'; exit 1; }
             [[ "$CONFIRM_STAGING_TRACKING_FIXTURE" == true ]] || { echo 'An isolated synthetic tracking fixture must be confirmed for staging'; exit 1; }
             [[ "$TOKEN_VAULT_STAGING_BASE_URL" =~ ^https://[^/]+$ ]] || { echo 'TOKEN_VAULT_STAGING_BASE_URL must be an HTTPS origin'; exit 1; }
+            [[ "$META_ADS_API_VERSION" =~ ^v(2[5-9]|[3-9][0-9])\.0$ ]] || { echo 'META_ADS_API_VERSION must be v25.0 or a newer supported Graph API version for the governed staging seed'; exit 1; }
           else
             [[ "$ENABLE_TOKEN_VAULT_PRODUCTION_DEPLOY" == true ]] || { echo 'ENABLE_TOKEN_VAULT_PRODUCTION_DEPLOY must be true'; exit 1; }
             [[ "$TOKEN_VAULT_PRODUCTION_BASE_URL" =~ ^https://[^/]+$ ]] || { echo 'TOKEN_VAULT_PRODUCTION_BASE_URL must be an HTTPS origin'; exit 1; }
@@ -1348,7 +1350,7 @@ jobs:
           if (!/^https:\/\/(?:[a-z0-9-]+\.)+workers\.dev$/.test(preview) || !seedFile) {
             throw new Error('immutable staging synthetic-seed candidate endpoint is unavailable');
           }
-          if (!accessToken || !/^\d{5,30}$/.test(pixelId) || !/^\d{5,30}$/.test(accountId) || !/^v\d+\.\d+$/.test(apiVersion)) {
+          if (!accessToken || !/^\d{5,30}$/.test(pixelId) || !/^\d{5,30}$/.test(accountId) || !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion)) {
             throw new Error('staging synthetic Meta source custody is unavailable or malformed');
           }
           if (!/^[a-f0-9]{40}$/.test(releaseSha) || !/^\d+$/.test(runId) || !/^\d+$/.test(runAttempt)) {
@@ -1616,7 +1618,7 @@ jobs:
           const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
           const apiVersion = String(process.env.META_ADS_API_VERSION || '').trim();
           const operationKey = String(process.env.SEED_OPERATION_KEY || '');
-          if (!/^https:\/\/(?:[a-z0-9-]+\.)+workers\.dev$/.test(preview) || !seedFile || !accessToken || !/^\d{5,30}$/.test(accountId) || !/^v\d+\.\d+$/.test(apiVersion) || !/^meta-ads-staging-seed:[A-Za-z0-9_.:-]{8,140}$/.test(operationKey)) {
+          if (!/^https:\/\/(?:[a-z0-9-]+\.)+workers\.dev$/.test(preview) || !seedFile || !accessToken || !/^\d{5,30}$/.test(accountId) || !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion) || !/^meta-ads-staging-seed:[A-Za-z0-9_.:-]{8,140}$/.test(operationKey)) {
             throw new Error('staging synthetic-seed rollback custody or identity is invalid');
           }
           const seedToken = fs.readFileSync(seedFile, 'utf8').trim();
@@ -1680,7 +1682,7 @@ jobs:
           const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
           const apiVersion = String(process.env.META_ADS_API_VERSION || '').trim();
           const operationKey = String(process.env.SEED_OPERATION_KEY || '');
-          if (!/^https:\/\/(?:[a-z0-9-]+\.)+workers\.dev$/.test(preview) || !seedFile || !accessToken || !/^\d{5,30}$/.test(accountId) || !/^v\d+\.\d+$/.test(apiVersion) || !/^meta-ads-staging-seed:[A-Za-z0-9_.:-]{8,140}$/.test(operationKey)) {
+          if (!/^https:\/\/(?:[a-z0-9-]+\.)+workers\.dev$/.test(preview) || !seedFile || !accessToken || !/^\d{5,30}$/.test(accountId) || !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion) || !/^meta-ads-staging-seed:[A-Za-z0-9_.:-]{8,140}$/.test(operationKey)) {
             throw new Error('staging synthetic-seed rollback custody or identity is invalid');
           }
           const seedToken = fs.readFileSync(seedFile, 'utf8').trim();
@@ -2096,7 +2098,7 @@ jobs:
           const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
           const apiVersion = String(process.env.META_ADS_API_VERSION || '').trim();
           const operationKey = String(process.env.SEED_OPERATION_KEY || '');
-          if (!/^https:\/\/(?:[a-z0-9-]+\.)+workers\.dev$/.test(preview) || !seedFile || !accessToken || !/^\d{5,30}$/.test(accountId) || !/^v\d+\.\d+$/.test(apiVersion) || !/^meta-ads-staging-seed:[A-Za-z0-9_.:-]{8,140}$/.test(operationKey)) {
+          if (!/^https:\/\/(?:[a-z0-9-]+\.)+workers\.dev$/.test(preview) || !seedFile || !accessToken || !/^\d{5,30}$/.test(accountId) || !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion) || !/^meta-ads-staging-seed:[A-Za-z0-9_.:-]{8,140}$/.test(operationKey)) {
             throw new Error('staging synthetic-seed rollback custody or identity is invalid');
           }
           const seedToken = fs.readFileSync(seedFile, 'utf8').trim();

--- a/platform/security/token-vault/tests/deploy-token-vault-staging-synthetic-seed-workflow.test.js
+++ b/platform/security/token-vault/tests/deploy-token-vault-staging-synthetic-seed-workflow.test.js
@@ -55,6 +55,10 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
     "      - name: Remove the ephemeral staging synthetic-seed bearer",
     "      - name: Release Token Vault release lease",
   );
+  const authorization = section(
+    "      - name: Attest Token Vault deployment authorization and remote resources before mutation",
+    "      - name: Validate Token Vault and Meta Ads Publish source",
+  );
 
   assert.match(upload, /randomBytes\(48\)\.toString\('base64url'\)/);
   assert.match(
@@ -68,6 +72,16 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
     /META_ADS_ACCESS_TOKEN|META_PIXEL_ID|META_ADS_ACCOUNT_ID|META_ADS_API_VERSION/,
   );
   assert.doesNotMatch(workflow, /\bwrangler\s+secret\s+put\b/i);
+
+  assert.match(
+    authorization,
+    /META_ADS_API_VERSION: \$\{\{ inputs\.target == 'staging' && vars\.META_ADS_API_VERSION \|\| '' \}\}/,
+  );
+  assert.match(
+    authorization,
+    /META_ADS_API_VERSION must be v25\.0 or a newer supported Graph API version for the governed staging seed/,
+  );
+  assert.match(authorization, /\^v\(2\[5-9\]\|\[3-9\]\[0-9\]\)\\\.0\$/);
 
   assert.match(
     seed,
@@ -94,6 +108,7 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
     /operation_key: operationKey,[\s\S]*access_token: accessToken,[\s\S]*account_id: accountId,[\s\S]*pixel_id: pixelId,[\s\S]*api_version: apiVersion/,
   );
   assert.match(seed, /meta-ads-tracking-v20\/staging-synthetic-seed\/v1/);
+  assert.match(seed, /\^v\(\?:2\[5-9\]\|\[3-9\]\[0-9\]\)\\\.0\$/);
   assert.match(
     seed,
     /seed_attempted=true\\nseed_operation_key=\$\{operationKey\}/,
@@ -180,6 +195,7 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
     );
     assert.match(rollback, /payload\?\.rolled_back !== true/);
     assert.match(rollback, /meta-ads-tracking-v20\/staging-synthetic-seed\/v1/);
+    assert.match(rollback, /\^v\(\?:2\[5-9\]\|\[3-9\]\[0-9\]\)\\\.0\$/);
   }
   for (const rollback of [pretrafficRollback, activationLeaseRollback]) {
     assert.match(rollback, /meta_ads_publish_staging_seed_operation_not_found/);
@@ -199,7 +215,11 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
     "META_ADS_API_VERSION",
   ]) {
     const total = [...workflow.matchAll(new RegExp(sourceName, "g"))].length;
-    const scoped = sourceScopes.reduce(
+    const allowedScopes =
+      sourceName === "META_ADS_API_VERSION"
+        ? [...sourceScopes, authorization]
+        : sourceScopes;
+    const scoped = allowedScopes.reduce(
       (count, scope) =>
         count + [...scope.matchAll(new RegExp(sourceName, "g"))].length,
       0,


### PR DESCRIPTION
## Root cause\nThe governed staging seed accepted META_ADS_API_VERSION=v24.0, while the deployed v20 Worker accepts v25.0 or newer. The request therefore failed before Graph or traffic activation.\n\n## Change\n- Fail closed before D1 checkpoint, migrations, upload, or traffic when staging does not supply v25.0+.\n- Apply the same contract to the candidate seed and all seed rollback paths.\n- Cover the workflow contract with the focused regression.\n\n## Validation\n- 
ode --test platform/security/token-vault/tests/deploy-token-vault-staging-synthetic-seed-workflow.test.js scripts/tests/global-concurrency-governance-static.test.mjs (19/19)\n- Prettier check for workflow and focused test\n- git diff --check\n\nThe staging Environment variable was corrected to 25.0 separately; no secret values were accessed or emitted.