### PR TITLE
fix(meta-ads): attest staging seed source before mutation

### DIFF
--- a/.github/workflows/deploy-token-vault.yml
+++ b/.github/workflows/deploy-token-vault.yml
@@ -1320,13 +1320,81 @@ jobs:
           echo "version_id=$TOKEN_VAULT_VERSION_ID" >> "$GITHUB_OUTPUT"
           echo "incumbent_version_id=$TOKEN_VAULT_INCUMBENT_VERSION_ID" >> "$GITHUB_OUTPUT"
 
+      - name: Attest the isolated staging Meta Ads synthetic source on the immutable candidate
+        # This candidate-only proof is Graph read-only: it has no D1 journal,
+        # lock, audit, credential sealing, or Graph mutation. The seed repeats
+        # these checks under its mutation lease immediately before it writes.
+        id: candidate_staging_synthetic_seed_attestation
+        if: inputs.operation == 'deploy' && inputs.target == 'staging'
+        env:
+          META_ADS_ACCESS_TOKEN: ${{ inputs.target == 'staging' && secrets.META_ADS_ACCESS_TOKEN || '' }}
+          META_PIXEL_ID: ${{ inputs.target == 'staging' && secrets.META_PIXEL_ID || '' }}
+          META_ADS_ACCOUNT_ID: ${{ inputs.target == 'staging' && vars.META_ADS_ACCOUNT_ID || '' }}
+          META_ADS_API_VERSION: ${{ inputs.target == 'staging' && vars.META_ADS_API_VERSION || '' }}
+          RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+
+          const preview = String(process.env.TOKEN_VAULT_CANDIDATE_PREVIEW_URL || '').replace(/\/$/, '');
+          const seedFile = String(process.env.TOKEN_VAULT_STAGING_SYNTHETIC_SEED_FILE || '');
+          const accessToken = String(process.env.META_ADS_ACCESS_TOKEN || '');
+          const pixelId = String(process.env.META_PIXEL_ID || '').trim();
+          const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
+          const apiVersion = String(process.env.META_ADS_API_VERSION || '').trim();
+          const releaseSha = String(process.env.RELEASE_SHA || '').toLowerCase();
+          const runId = String(process.env.GITHUB_RUN_ID || '');
+          const runAttempt = String(process.env.GITHUB_RUN_ATTEMPT || '');
+          if (!/^https:\/\/(?:[a-z0-9-]+\.)+workers\.dev$/.test(preview) || !seedFile) {
+            throw new Error('immutable staging synthetic-seed candidate endpoint is unavailable');
+          }
+          if (!accessToken || !/^\d{5,30}$/.test(pixelId) || !/^\d{5,30}$/.test(accountId) || !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion)) {
+            throw new Error('staging synthetic Meta source custody is unavailable or malformed');
+          }
+          if (!/^[a-f0-9]{40}$/.test(releaseSha) || !/^\d+$/.test(runId) || !/^\d+$/.test(runAttempt)) {
+            throw new Error('staging synthetic-seed operation identity is invalid');
+          }
+          const seedToken = fs.readFileSync(seedFile, 'utf8').trim();
+          if (!/^[A-Za-z0-9_-]{64,}$/.test(seedToken)) throw new Error('staging synthetic-seed bearer is unavailable');
+          const operationKey = `meta-ads-staging-seed:${releaseSha.slice(0, 12)}:${runId}:${runAttempt}`;
+          const response = await fetch(`${preview}/internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/attest`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${seedToken}`,
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify({
+              operation_key: operationKey,
+              access_token: accessToken,
+              account_id: accountId,
+              pixel_id: pixelId,
+              api_version: apiVersion,
+            }),
+            cache: 'no-store',
+            redirect: 'error',
+            signal: AbortSignal.timeout(30_000),
+          });
+          let payload = null;
+          try { payload = await response.json(); } catch {}
+          const error = /^[a-z0-9_:-]{1,120}$/i.test(String(payload?.error || '')) ? String(payload.error) : 'unknown';
+          const allowedKeys = new Set(['ok', 'attestation', 'operation_key', 'contract_version', 'requestId']);
+          const valid = response.ok && payload?.ok === true &&
+            Object.keys(payload).every((key) => allowedKeys.has(key)) &&
+            String(payload?.attestation || '') === 'match' &&
+            String(payload?.operation_key || '') === operationKey &&
+            String(payload?.contract_version || '') === 'meta-ads-tracking-v20/staging-synthetic-seed/v1' &&
+            typeof payload?.requestId === 'string';
+          if (!valid) throw new Error(`staging synthetic-seed source attestation failed: ${response.status} ${error}`);
+          NODE
+
       - name: Seal the isolated staging Meta Ads synthetic seed on the immutable candidate
         # This is deliberately before candidate config authentication and plan
         # derivation: an empty legacy authority has no prior target from which
         # to derive. The generated bearer has no role outside these two seed
         # endpoints and the Meta source inputs never enter a Worker binding.
         id: candidate_staging_synthetic_seed
-        if: inputs.operation == 'deploy' && inputs.target == 'staging'
+        if: inputs.operation == 'deploy' && inputs.target == 'staging' && steps.candidate_staging_synthetic_seed_attestation.outcome == 'success'
         env:
           META_ADS_ACCESS_TOKEN: ${{ inputs.target == 'staging' && secrets.META_ADS_ACCESS_TOKEN || '' }}
           META_PIXEL_ID: ${{ inputs.target == 'staging' && secrets.META_PIXEL_ID || '' }}

--- a/platform/deploy/operational-units.json
+++ b/platform/deploy/operational-units.json
@@ -101,14 +101,14 @@
       "workflow": ".github/workflows/deploy-token-vault.yml",
       "concurrencyPrefix": "deploy-token-vault-",
       "publishes": ["Worker:skincos-token-vault", "Worker:skincos-token-vault-staging"],
-      "resources": ["Token Vault Worker", "skincos-token-vault D1", "skincos-token-vault-staging D1", "Token Vault route and auth bindings", "Governed Meta Ads staging synthetic seed, bootstrap derivation, rollback journal and paused creative fixture"],
+      "resources": ["Token Vault Worker", "skincos-token-vault D1", "skincos-token-vault-staging D1", "Token Vault route and auth bindings", "Governed Meta Ads staging synthetic source attestation, seed, bootstrap derivation, rollback journal and paused creative fixture"],
       "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "TOKEN_VAULT_API_TOKEN", "TOKEN_VAULT_N8N_API_TOKEN", "TOKEN_VAULT_ANALYTICS_API_TOKEN", "TOKEN_VAULT_ENCRYPTION_KEY", "TOKEN_VAULT_META_ADS_CONFIG_TOKEN", "TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST", "META_ADS_ACCESS_TOKEN", "META_PIXEL_ID"],
       "migrationPaths": ["platform/security/token-vault/migrations"],
       "environments": ["preview", "staging", "production"],
       "promotion": {
         "stagingSupported": true,
         "trackingFixture": "synthetic authorized ad-set profile required before staging",
-        "trackingBootstrap": "empty staging authority uses a restricted one-shot synthetic seed; legacy authority uses restricted config bearer plus hash-bound internal derivation or protected entries override",
+        "trackingBootstrap": "empty staging authority uses a candidate-only Graph-read attestation before a restricted one-shot synthetic seed; legacy authority uses restricted config bearer plus hash-bound internal derivation or protected entries override",
         "d1Recovery": "Time Travel bookmark; manual restore only under release:token-vault"
       }
     },

--- a/platform/security/token-vault/README.md
+++ b/platform/security/token-vault/README.md
@@ -15,6 +15,7 @@ Worker interno para substituir a aba `Credencial` do Google Sheets usada pelo wo
 - `POST /internal/token-vault/v1/meta-ads-publish/config/bootstrap/derive-plan`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/bootstrap/derive`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/bootstrap/rollback`
+- `POST /internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/attest`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/rollback`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/staging-exercise`
@@ -26,9 +27,9 @@ O bearer restrito `TOKEN_VAULT_META_ADS_CONFIG_TOKEN` só pode consultar
 bootstrap governados, o rollback desse bootstrap e o exercício de staging. Ele
 não lista/altera tokens, não cria runs e não publica anúncios.
 O bearer efêmero distinto `TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN` só alcança
-os dois endpoints de seed/rollback sintéticos, exclusivamente no Worker
-staging; ele não ganha as permissões do bearer de configuração, operacional ou
-administrativo.
+os três endpoints de atestação, seed e rollback sintéticos, exclusivamente no
+Worker staging; ele não ganha as permissões do bearer de configuração,
+operacional ou administrativo.
 O endpoint de analytics exige o secret separado
 `TOKEN_VAULT_ANALYTICS_API_TOKEN` (administradores continuam podendo operar o
 endpoint para diagnóstico controlado).
@@ -136,9 +137,12 @@ retornar `reconciled_and_rolled_back`.
 
 Quando a autoridade legada de staging está vazia, o caminho canônico não
 adivinha nem importa configuração de produção. Antes de derivar o plano, o
-workflow chama `POST .../config/staging-synthetic-seed` na Preview imutável com
-um bearer aleatório exclusivo da versão candidata. Os fatos externos entram
-somente no corpo dessa chamada privada: o token Meta Ads já custodiado,
+workflow chama `POST .../config/staging-synthetic-seed/attest` na Preview
+imutável com um bearer aleatório exclusivo da versão candidata. A atestação faz
+somente leituras Graph delimitadas, não toca D1 nem cria recursos, e retorna
+apenas `match` ou um código sanitizado. Só então o workflow chama
+`POST .../config/staging-synthetic-seed`. Os fatos externos entram somente no
+corpo dessas chamadas privadas: o token Meta Ads já custodiado,
 `META_PIXEL_ID`, `META_ADS_ACCOUNT_ID` e `META_ADS_API_VERSION`. O Vault exige
 uma conta/pixel, uma Página+Instagram elegível e um dataset offline unívocos,
 cria somente recursos `PAUSED` nomeados para staging e sela duas credenciais
@@ -300,13 +304,14 @@ manualmente para publicar este serviço.
 Para o primeiro bootstrap Meta Ads de staging, o mesmo upload gera
 `TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN` com CSPRNG em um arquivo `0600` sob
 `RUNNER_TEMP`, inclui-o somente no `--secrets-file` privado da candidata e
-remove esse arquivo no encerramento do job. A chamada Preview lê o bearer por
-arquivo e entrega os fatos Meta somente em memória ao body fechado de seed; os
-valores não entram em `GITHUB_OUTPUT`, artefatos, logs, worktree ou argv. Essa
-seed é estritamente `staging`, ocorre antes da autenticação/derivação de
-configuração e possui rollback explícito antes de qualquer ativação quando o
-planejamento falha. `META_ADS_ACCESS_TOKEN` continua uma credencial externa de
-fonte: não é copiado de production nem inventado pelo fluxo.
+remove esse arquivo no encerramento do job. A atestação e a seed Preview leem o
+bearer por arquivo e entregam os fatos Meta somente em memória aos seus corpos
+fechados; os valores não entram em `GITHUB_OUTPUT`, artefatos, logs, worktree
+ou argv. A atestação é estritamente somente leitura; a seed é estritamente
+`staging`, ocorre antes da autenticação/derivação de configuração e possui
+rollback explícito antes de qualquer ativação quando o planejamento falha.
+`META_ADS_ACCESS_TOKEN` continua uma credencial externa de fonte: não é copiado
+de production nem inventado pelo fluxo.
 
 Antes da primeira promoção, disponibilize em cada GitHub Environment os
 segredos independentes exigidos pelo workflow, em especial

--- a/platform/security/token-vault/src/index.js
+++ b/platform/security/token-vault/src/index.js
@@ -16,6 +16,7 @@ const META_ADS_PUBLISH_CONFIG_BOOTSTRAP_DERIVE_PLAN_PATH = `${META_ADS_PUBLISH_C
 const META_ADS_PUBLISH_CONFIG_BOOTSTRAP_DERIVE_PATH = `${META_ADS_PUBLISH_CONFIG_BOOTSTRAP_PATH}/derive`;
 const META_ADS_PUBLISH_CONFIG_STAGING_EXERCISE_PATH = `${META_ADS_PUBLISH_CONFIG_PATH}/staging-exercise`;
 const META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH = `${META_ADS_PUBLISH_CONFIG_PATH}/staging-synthetic-seed`;
+const META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ATTEST_PATH = `${META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH}/attest`;
 const META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ROLLBACK_PATH = `${META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH}/rollback`;
 const JSON_HEADERS = {
   'content-type': 'application/json; charset=utf-8',
@@ -65,6 +66,7 @@ export async function handleRequest(request, env) {
     if (auth.role === 'meta-ads-staging-seed') {
       if (
         request.method !== 'POST' || ![
+          META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ATTEST_PATH,
           META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH,
           META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ROLLBACK_PATH,
         ].includes(pathname)
@@ -84,8 +86,9 @@ export async function handleRequest(request, env) {
 
     // Intercept these paths before the generic Meta Ads gateway. The seed is
     // not an administrative escape hatch: only its dedicated staging bearer
-    // can call either endpoint, and only with POST.
+    // can call these routes, and only with POST.
     if ([
+      META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ATTEST_PATH,
       META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH,
       META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ROLLBACK_PATH,
     ].includes(pathname)) {
@@ -648,7 +651,7 @@ function contract(requestId) {
       meta_ads_config_secret: 'TOKEN_VAULT_META_ADS_CONFIG_TOKEN',
       meta_ads_config_scope: 'health|contract|meta-ads-config-read|meta-ads-config-bootstrap|meta-ads-config-bootstrap-rollback|meta-ads-config-bootstrap-derive-plan|meta-ads-config-bootstrap-derive|meta-ads-config-staging-exercise',
       meta_ads_staging_seed_secret: 'TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN',
-      meta_ads_staging_seed_scope: 'meta-ads-config-staging-synthetic-seed|meta-ads-config-staging-synthetic-seed-rollback',
+      meta_ads_staging_seed_scope: 'meta-ads-config-staging-synthetic-seed-attest|meta-ads-config-staging-synthetic-seed|meta-ads-config-staging-synthetic-seed-rollback',
     },
     storage: {
       d1_binding: 'TOKEN_VAULT_DB',

--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -177,6 +177,7 @@ const STAGING_EXERCISE_OPERATION_KEY_PATTERN = /^staging-tracking-fixture:[A-Za-
 const STAGING_SYNTHETIC_SEED_OPERATION_KEY_PATTERN = /^meta-ads-staging-seed:[A-Za-z0-9_.:-]{8,140}$/;
 const STAGING_SYNTHETIC_SEED_MAX_REQUEST_BYTES = 16 * 1024;
 const STAGING_SYNTHETIC_SEED_CONTRACT = 'meta-ads-tracking-v20/staging-synthetic-seed/v1';
+const STAGING_SYNTHETIC_SEED_ATTEST_MAX_GRAPH_ATTEMPTS = 1;
 const STAGING_SYNTHETIC_SEED_UNIT = 'meta-ads-tracking-staging-synthetic';
 const STAGING_SYNTHETIC_SEED_SOURCE_TOKEN_TYPE = 'staging_synthetic_source';
 const STAGING_SYNTHETIC_SEED_TARGET_TOKEN_TYPE = 'staging_synthetic_target';
@@ -185,6 +186,22 @@ const STAGING_SYNTHETIC_SEED_MAX_GRAPH_OBJECTS = 5;
 const STAGING_SYNTHETIC_SEED_LANDING_GROUP = 'staging_tracking_fixture';
 const STAGING_SYNTHETIC_SEED_CREATIVE_MESSAGE = 'SKINCOS staging tracking verification';
 const STAGING_SYNTHETIC_SEED_CREATIVE_CTA = 'LEARN_MORE';
+const STAGING_SYNTHETIC_SEED_DISCOVERY_FAILURES = Object.freeze({
+  sourceUnavailable: 'meta_ads_publish_staging_seed_graph_identity_invalid',
+  identityMismatch: 'meta_ads_publish_staging_seed_graph_identity_invalid',
+  identityMalformed: 'meta_ads_publish_staging_seed_graph_identity_invalid',
+  pageAmbiguous: 'meta_ads_publish_staging_seed_graph_page_ambiguous',
+  datasetAmbiguous: 'meta_ads_publish_staging_seed_graph_dataset_ambiguous',
+  landingOrMediaUnavailable: 'meta_ads_publish_staging_seed_landing_or_media_unavailable',
+});
+const STAGING_SYNTHETIC_SEED_ATTESTATION_FAILURES = Object.freeze({
+  sourceUnavailable: 'meta_ads_publish_staging_seed_graph_source_unavailable',
+  identityMismatch: 'meta_ads_publish_staging_seed_graph_identity_mismatch',
+  identityMalformed: 'meta_ads_publish_staging_seed_graph_identity_malformed',
+  pageAmbiguous: 'meta_ads_publish_staging_seed_graph_identity_mismatch',
+  datasetAmbiguous: 'meta_ads_publish_staging_seed_graph_identity_mismatch',
+  landingOrMediaUnavailable: 'meta_ads_publish_staging_seed_graph_identity_malformed',
+});
 const STAGING_SYNTHETIC_SEED_ADSET_FIELDS = [
   'id',
   'name',
@@ -349,6 +366,10 @@ export async function handleMetaAdsPublishRequest(input) {
 
   if (request.method === 'POST' && pathname === `${PREFIX}/config/bootstrap/derive`) {
     return bootstrapMetaAdsPublishConfigFromDerivedPlan({ request, env, requestId, decryptToken, encryptToken, writeAudit });
+  }
+
+  if (request.method === 'POST' && pathname === `${PREFIX}/config/staging-synthetic-seed/attest`) {
+    return attestStagingSyntheticMetaAdsTracking({ request, env, requestId });
   }
 
   if (request.method === 'POST' && pathname === `${PREFIX}/config/staging-synthetic-seed`) {
@@ -1232,6 +1253,24 @@ export async function bootstrapMetaAdsPublishConfigFromDerivedPlan({
 // proving all external facts with bounded Graph reads. It is deliberately not
 // available to the operational/config/admin gateway roles; index.js exposes it
 // only to a release-scoped, candidate-only bearer.
+export async function attestStagingSyntheticMetaAdsTracking({ request, env, requestId }) {
+  try {
+    assertStagingSyntheticSeedAttestationEnvironment(env);
+    const input = await readStagingSyntheticSeedInput(request);
+    const auth = await buildStagingSyntheticSeedGraphAuth(input, env);
+    await discoverStagingSyntheticSeedFacts({
+      input,
+      auth,
+      context: createStagingSyntheticSeedAttestationContext(env, requestId, input.operationKey),
+      failureCodes: STAGING_SYNTHETIC_SEED_ATTESTATION_FAILURES,
+      maxGraphAttempts: STAGING_SYNTHETIC_SEED_ATTEST_MAX_GRAPH_ATTEMPTS,
+    });
+    return stagingSyntheticSeedAttestationSuccess({ requestId, operationKey: input.operationKey });
+  } catch (error) {
+    return stagingSyntheticSeedFailureResponse(normalizeStagingSyntheticSeedError(error), requestId);
+  }
+}
+
 export async function seedStagingSyntheticMetaAdsTracking({ request, env, requestId, encryptToken, writeAudit }) {
   let input;
   let operation;
@@ -1405,11 +1444,15 @@ export async function rollbackStagingSyntheticMetaAdsTracking({ request, env, re
 }
 
 function assertStagingSyntheticSeedEnvironment(env) {
-  if (clean(env?.ENVIRONMENT).toLowerCase() !== 'staging') {
-    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_disabled', 503);
-  }
+  assertStagingSyntheticSeedAttestationEnvironment(env);
   if (!env?.TOKEN_VAULT_DB || typeof env.TOKEN_VAULT_DB.prepare !== 'function' || typeof env.TOKEN_VAULT_DB.batch !== 'function') {
     throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_unavailable', 503);
+  }
+}
+
+function assertStagingSyntheticSeedAttestationEnvironment(env) {
+  if (clean(env?.ENVIRONMENT).toLowerCase() !== 'staging') {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_disabled', 503);
   }
 }
 
@@ -1530,6 +1573,9 @@ function stagingSyntheticSeedFailureResponse(error, requestId) {
     'meta_ads_publish_staging_seed_reconciliation_required',
     'meta_ads_publish_staging_seed_facebook_credentials_present',
     'meta_ads_publish_staging_seed_graph_identity_invalid',
+    'meta_ads_publish_staging_seed_graph_source_unavailable',
+    'meta_ads_publish_staging_seed_graph_identity_mismatch',
+    'meta_ads_publish_staging_seed_graph_identity_malformed',
     'meta_ads_publish_staging_seed_graph_page_ambiguous',
     'meta_ads_publish_staging_seed_graph_dataset_ambiguous',
     'meta_ads_publish_staging_seed_landing_or_media_unavailable',
@@ -1569,6 +1615,28 @@ function stagingSyntheticSeedRollbackSuccess({ requestId, operationKey, replayed
     contract_version: STAGING_SYNTHETIC_SEED_CONTRACT,
     requestId,
   });
+}
+
+function stagingSyntheticSeedAttestationSuccess({ requestId, operationKey }) {
+  return response({
+    ok: true,
+    attestation: 'match',
+    operation_key: operationKey,
+    contract_version: STAGING_SYNTHETIC_SEED_CONTRACT,
+    requestId,
+  });
+}
+
+function createStagingSyntheticSeedAttestationContext(env, requestId, operationKey) {
+  return {
+    env,
+    requestId,
+    action: 'attest_staging_synthetic_meta_ads_tracking',
+    operationKey: clean(operationKey),
+    attempts: 0,
+    rateUsage: {},
+    traceId: '',
+  };
 }
 
 function createStagingSyntheticSeedContext(env, lockOwner, requestId, action, operationKey = '') {
@@ -1898,45 +1966,74 @@ async function writeStagingSyntheticSeedAudit(writeAudit, env, requestId, status
   });
 }
 
-async function discoverStagingSyntheticSeedFacts({ input, auth, context }) {
-  const pixel = await seedGraphRead(auth, input.pixelId, 'id,owner_ad_account{id}', context);
-  const pixelOwner = normalizeStagingSyntheticSeedGraphId(asObject(pixel.owner_ad_account).id, 'pixel_owner_account');
-  if (normalizeStagingSyntheticSeedGraphId(pixel.id, 'pixel_id') !== input.pixelId || pixelOwner !== input.accountId) {
-    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_identity_invalid', 409);
+async function discoverStagingSyntheticSeedFacts({
+  input,
+  auth,
+  context,
+  failureCodes = STAGING_SYNTHETIC_SEED_DISCOVERY_FAILURES,
+  maxGraphAttempts = MAX_GRAPH_ATTEMPTS,
+}) {
+  const read = (path, fields, query = {}) => seedGraphRead(auth, path, fields, context, query, {
+    maxAttempts: maxGraphAttempts,
+    failureCode: failureCodes.sourceUnavailable,
+  });
+  const pixel = await read(input.pixelId, 'id,owner_ad_account{id}');
+  const pixelOwner = normalizeStagingSyntheticSeedGraphId(
+    asObject(pixel.owner_ad_account).id,
+    'pixel_owner_account',
+    failureCodes.identityMalformed,
+  );
+  if (
+    normalizeStagingSyntheticSeedGraphId(pixel.id, 'pixel_id', failureCodes.identityMalformed) !== input.pixelId ||
+    pixelOwner !== input.accountId
+  ) {
+    throw stagingSyntheticSeedFailure(failureCodes.identityMismatch, 409);
   }
 
-  const pages = await seedGraphRead(auth, 'me/accounts', 'id,tasks,instagram_business_account{id}', context, { limit: '100' });
+  const pages = await read('me/accounts', 'id,tasks,instagram_business_account{id}', { limit: '100' });
   if (clean(asObject(pages.paging).next)) {
-    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_page_ambiguous', 409);
+    throw stagingSyntheticSeedFailure(failureCodes.pageAmbiguous, 409);
   }
   const eligiblePages = safeArray(pages.data).map(asObject).filter((page) => {
     const tasks = new Set(safeArray(page.tasks).map((task) => clean(task).toUpperCase()));
     return tasks.has('ADVERTISE') && /^\d{5,30}$/.test(clean(asObject(page.instagram_business_account).id));
   });
   if (eligiblePages.length !== 1) {
-    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_page_ambiguous', 409);
+    throw stagingSyntheticSeedFailure(failureCodes.pageAmbiguous, 409);
   }
-  const selectedPageId = normalizeStagingSyntheticSeedGraphId(eligiblePages[0].id, 'page_id');
-  const page = await seedGraphRead(auth, selectedPageId, 'id,instagram_business_account{id},website,picture{url}', context);
-  const pageId = normalizeStagingSyntheticSeedGraphId(page.id, 'page_id');
-  const instagramUserId = normalizeStagingSyntheticSeedGraphId(asObject(page.instagram_business_account).id, 'instagram_user_id');
+  const selectedPageId = normalizeStagingSyntheticSeedGraphId(eligiblePages[0].id, 'page_id', failureCodes.identityMalformed);
+  const page = await read(selectedPageId, 'id,instagram_business_account{id},website,picture{url}');
+  const pageId = normalizeStagingSyntheticSeedGraphId(page.id, 'page_id', failureCodes.identityMalformed);
+  const instagramUserId = normalizeStagingSyntheticSeedGraphId(
+    asObject(page.instagram_business_account).id,
+    'instagram_user_id',
+    failureCodes.identityMalformed,
+  );
   if (
     pageId !== selectedPageId ||
-    instagramUserId !== normalizeStagingSyntheticSeedGraphId(asObject(eligiblePages[0].instagram_business_account).id, 'instagram_user_id')
+    instagramUserId !== normalizeStagingSyntheticSeedGraphId(
+      asObject(eligiblePages[0].instagram_business_account).id,
+      'instagram_user_id',
+      failureCodes.identityMalformed,
+    )
   ) {
-    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_identity_invalid', 409);
+    throw stagingSyntheticSeedFailure(failureCodes.identityMismatch, 409);
   }
   const landing = normalizeStagingSyntheticSeedLanding(page.website);
   const pictureUrl = normalizeStagingSyntheticSeedPicture(page.picture);
   if (!landing || !pictureUrl) {
-    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_landing_or_media_unavailable', 409);
+    throw stagingSyntheticSeedFailure(failureCodes.landingOrMediaUnavailable, 409);
   }
 
-  const datasets = await seedGraphRead(auth, `act_${input.accountId}/offline_conversion_data_sets`, 'id', context, { limit: '2' });
+  const datasets = await read(`act_${input.accountId}/offline_conversion_data_sets`, 'id', { limit: '2' });
   if (clean(asObject(datasets.paging).next) || safeArray(datasets.data).length !== 1) {
-    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_dataset_ambiguous', 409);
+    throw stagingSyntheticSeedFailure(failureCodes.datasetAmbiguous, 409);
   }
-  const datasetId = normalizeStagingSyntheticSeedGraphId(asObject(safeArray(datasets.data)[0]).id, 'offline_dataset_id');
+  const datasetId = normalizeStagingSyntheticSeedGraphId(
+    asObject(safeArray(datasets.data)[0]).id,
+    'offline_dataset_id',
+    failureCodes.identityMalformed,
+  );
   return {
     page_id: pageId,
     instagram_user_id: instagramUserId,
@@ -1947,13 +2044,17 @@ async function discoverStagingSyntheticSeedFacts({ input, auth, context }) {
   };
 }
 
-async function seedGraphRead(auth, path, fields, context, query = {}) {
+async function seedGraphRead(auth, path, fields, context, query = {}, {
+  maxAttempts = MAX_GRAPH_ATTEMPTS,
+  failureCode = 'meta_ads_publish_staging_seed_graph_identity_invalid',
+} = {}) {
   try {
     const result = await graphRequest(
       graphUrl(auth.apiVersion, path, { fields, ...query }),
       { method: 'GET' },
       auth,
       context,
+      { maxAttempts },
     );
     return asObject(result.body);
   } catch (error) {
@@ -1961,15 +2062,15 @@ async function seedGraphRead(auth, path, fields, context, query = {}) {
     if (normalized.retryable || normalized.ambiguous || Number(normalized.http_status) >= 500) {
       throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_unavailable', 503);
     }
-    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_identity_invalid', 409);
+    throw stagingSyntheticSeedFailure(failureCode, 409);
   }
 }
 
-function normalizeStagingSyntheticSeedGraphId(value, label) {
+function normalizeStagingSyntheticSeedGraphId(value, label, failureCode = 'meta_ads_publish_staging_seed_graph_identity_invalid') {
   try {
     return normalizeNumericId(value, `staging_seed_${label}`);
   } catch {
-    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_identity_invalid', 409);
+    throw stagingSyntheticSeedFailure(failureCode, 409);
   }
 }
 

--- a/platform/security/token-vault/tests/deploy-token-vault-staging-synthetic-seed-workflow.test.js
+++ b/platform/security/token-vault/tests/deploy-token-vault-staging-synthetic-seed-workflow.test.js
@@ -23,6 +23,10 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
     "      - name: Upload immutable Token Vault version",
     "      - name: Export immutable Worker and incumbent identities for the activation gate",
   );
+  const attestation = section(
+    "      - name: Attest the isolated staging Meta Ads synthetic source on the immutable candidate",
+    "      - name: Seal the isolated staging Meta Ads synthetic seed on the immutable candidate",
+  );
   const seed = section(
     "      - name: Seal the isolated staging Meta Ads synthetic seed on the immutable candidate",
     "      - name: Verify immutable Token Vault candidate config bearer before traffic",
@@ -84,8 +88,42 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
   assert.match(authorization, /\^v\(2\[5-9\]\|\[3-9\]\[0-9\]\)\\\.0\$/);
 
   assert.match(
-    seed,
+    attestation,
+    /id: candidate_staging_synthetic_seed_attestation/,
+  );
+  assert.match(
+    attestation,
     /if: inputs\.operation == 'deploy' && inputs\.target == 'staging'/,
+  );
+  for (const sourceName of [
+    "META_ADS_ACCESS_TOKEN",
+    "META_PIXEL_ID",
+    "META_ADS_ACCOUNT_ID",
+    "META_ADS_API_VERSION",
+  ]) {
+    assert.match(attestation, new RegExp(`${sourceName}: \\$\\{\\{ inputs\\.target == 'staging'`));
+  }
+  assert.match(
+    attestation,
+    /const preview = String\(process\.env\.TOKEN_VAULT_CANDIDATE_PREVIEW_URL/,
+  );
+  assert.doesNotMatch(attestation, /TOKEN_VAULT_STAGING_BASE_URL/);
+  assert.match(
+    attestation,
+    /fetch\(`\$\{preview\}\/internal\/token-vault\/v1\/meta-ads-publish\/config\/staging-synthetic-seed\/attest`/,
+  );
+  assert.match(
+    attestation,
+    /operation_key: operationKey,[\s\S]*access_token: accessToken,[\s\S]*account_id: accountId,[\s\S]*pixel_id: pixelId,[\s\S]*api_version: apiVersion/,
+  );
+  assert.match(attestation, /attestation \|\| ''\) === 'match'/);
+  assert.match(attestation, /meta-ads-tracking-v20\/staging-synthetic-seed\/v1/);
+  assert.match(attestation, /AbortSignal\.timeout\(30_000\)/);
+  assert.doesNotMatch(attestation, /GITHUB_OUTPUT|console\.log|process\.stdout\.write/);
+
+  assert.match(
+    seed,
+    /if: inputs\.operation == 'deploy' && inputs\.target == 'staging' && steps\.candidate_staging_synthetic_seed_attestation\.outcome == 'success'/,
   );
   assert.match(
     seed,
@@ -151,6 +189,9 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
   const uploadAt = workflow.indexOf(
     "      - name: Upload immutable Token Vault version",
   );
+  const attestationAt = workflow.indexOf(
+    "      - name: Attest the isolated staging Meta Ads synthetic source on the immutable candidate",
+  );
   const seedAt = workflow.indexOf(
     "      - name: Seal the isolated staging Meta Ads synthetic seed on the immutable candidate",
   );
@@ -164,7 +205,8 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
     "      - name: Activate only the selected Token Vault version in staging",
   );
   assert.ok(
-    uploadAt < seedAt &&
+    uploadAt < attestationAt &&
+      attestationAt < seedAt &&
       seedAt < configAt &&
       configAt < planAt &&
       planAt < trafficAt,
@@ -203,6 +245,7 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
   assert.match(compensationRollback, /TOKEN_VAULT_CANDIDATE_PREVIEW_URL/);
   assert.doesNotMatch(compensationRollback, /TOKEN_VAULT_STAGING_BASE_URL/);
   const sourceScopes = [
+    attestation,
     seed,
     pretrafficRollback,
     activationLeaseRollback,

--- a/platform/security/token-vault/tests/index.test.js
+++ b/platform/security/token-vault/tests/index.test.js
@@ -230,7 +230,7 @@ test('configured worker secrets must remain pairwise distinct', async () => {
   assert.equal((await response.json()).error, 'invalid_worker_secret_configuration');
 });
 
-test('Meta Ads staging seed bearer is staging-only, pairwise distinct, and exclusive to its two POST routes', async () => {
+test('Meta Ads staging seed bearer is staging-only, pairwise distinct, and exclusive to its three POST routes', async () => {
   const disabledDb = new FakeDb();
   const disabledEnvironment = env(disabledDb);
   disabledEnvironment.ENVIRONMENT = 'production';
@@ -270,6 +270,9 @@ test('Meta Ads staging seed bearer is staging-only, pairwise distinct, and exclu
     new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed', {
       headers: metaAdsStagingSeedAuthHeaders(),
     }),
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/attest', {
+      headers: metaAdsStagingSeedAuthHeaders(),
+    }),
   ]) {
     const response = await handleRequest(request, environment);
     assert.equal(response.status, 403);
@@ -277,6 +280,7 @@ test('Meta Ads staging seed bearer is staging-only, pairwise distinct, and exclu
   }
 
   for (const pathname of [
+    '/v1/meta-ads-publish/config/staging-synthetic-seed/attest',
     '/v1/meta-ads-publish/config/staging-synthetic-seed',
     '/v1/meta-ads-publish/config/staging-synthetic-seed/rollback',
   ]) {
@@ -292,17 +296,23 @@ test('Meta Ads staging seed bearer is staging-only, pairwise distinct, and exclu
     assert.notEqual((await allowedResponse.json()).error, 'meta_ads_staging_seed_credential_scope_required');
   }
 
-  for (const token of [TEST_API_TOKEN, TEST_OPERATIONAL_TOKEN, TEST_META_ADS_CONFIG_TOKEN]) {
-    const response = await handleRequest(
-      new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed', {
-        method: 'POST',
-        headers: { Authorization: `Bearer ${token}`, 'content-type': 'application/json' },
-        body: '{}',
-      }),
-      environment,
-    );
-    assert.equal(response.status, 403);
-    assert.equal((await response.json()).error, 'meta_ads_staging_seed_credential_required');
+  for (const pathname of [
+    '/v1/meta-ads-publish/config/staging-synthetic-seed/attest',
+    '/v1/meta-ads-publish/config/staging-synthetic-seed',
+    '/v1/meta-ads-publish/config/staging-synthetic-seed/rollback',
+  ]) {
+    for (const token of [TEST_API_TOKEN, TEST_OPERATIONAL_TOKEN, TEST_META_ADS_CONFIG_TOKEN]) {
+      const response = await handleRequest(
+        new Request(`https://api.skincos.com.br/internal/token-vault${pathname}`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+          body: '{}',
+        }),
+        environment,
+      );
+      assert.equal(response.status, 403);
+      assert.equal((await response.json()).error, 'meta_ads_staging_seed_credential_required');
+    }
   }
   assert.equal(db.tokens.length, 0);
 });

--- a/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  attestStagingSyntheticMetaAdsTracking,
   rollbackStagingSyntheticMetaAdsTracking,
   seedStagingSyntheticMetaAdsTracking,
 } from '../src/meta-ads-publish.js';
@@ -11,6 +12,7 @@ const PAGE_ID = '12000000000000001';
 const INSTAGRAM_ID = '17841400000000002';
 const DATASET_ID = '19944000000000001';
 const SOURCE_ACCESS_TOKEN = 'unit-test-source-access-token-not-a-real-secret';
+const MISMATCH_ACCOUNT_ID = '17841400000000009';
 
 class SeedStatement {
   constructor(db, sql) {
@@ -463,6 +465,29 @@ async function seed({ db, graph, operationKey, env = {} }) {
   });
 }
 
+function attestRequest(operationKey, overrides = {}) {
+  return new Request('https://token-vault.invalid/v1/meta-ads-publish/config/staging-synthetic-seed/attest', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      operation_key: operationKey,
+      access_token: SOURCE_ACCESS_TOKEN,
+      account_id: ACCOUNT_ID,
+      pixel_id: PIXEL_ID,
+      api_version: 'v25.0',
+      ...overrides,
+    }),
+  });
+}
+
+async function attest({ db, graph, operationKey, env = {}, requestOverrides = {} }) {
+  return attestStagingSyntheticMetaAdsTracking({
+    request: attestRequest(operationKey, requestOverrides),
+    env: environment(db, graph, env),
+    requestId: 'seed-attestation-test-request-id',
+  });
+}
+
 function rollbackRequest(operationKey, overrides = {}) {
   return new Request('https://token-vault.invalid/v1/meta-ads-publish/config/staging-synthetic-seed/rollback', {
     method: 'POST',
@@ -537,6 +562,112 @@ test('staging seed is staging-only and redacts all source inputs from a closed r
   assert.equal(JSON.stringify(body).includes(SOURCE_ACCESS_TOKEN), false);
   assert.equal(JSON.stringify(body).includes(ACCOUNT_ID), false);
   assert.equal(JSON.stringify(body).includes(PIXEL_ID), false);
+});
+
+test('staging seed attestation is staging-only and touches neither D1 nor Graph outside staging', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph();
+  const response = await attest({
+    db,
+    graph,
+    operationKey: 'meta-ads-staging-seed:attestation-production-denied-001',
+    env: { ENVIRONMENT: 'production' },
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 503);
+  assert.equal(body.error, 'meta_ads_publish_staging_seed_disabled');
+  assert.equal(graph.calls.length, 0);
+  assert.equal(graph.postCalls.length, 0);
+  assert.equal(db.operations.size, 0);
+  assert.equal(db.tokens.length, 0);
+  assert.equal(db.locks.size, 0);
+  assert.equal(JSON.stringify(body).includes(SOURCE_ACCESS_TOKEN), false);
+  assert.equal(JSON.stringify(body).includes(ACCOUNT_ID), false);
+  assert.equal(JSON.stringify(body).includes(PIXEL_ID), false);
+});
+
+test('staging seed attestation bounds Graph discovery and returns no source facts', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph();
+  const operationKey = 'meta-ads-staging-seed:attestation-match-001';
+  const response = await attest({ db, graph, operationKey });
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(body, {
+    ok: true,
+    attestation: 'match',
+    operation_key: operationKey,
+    contract_version: 'meta-ads-tracking-v20/staging-synthetic-seed/v1',
+    requestId: 'seed-attestation-test-request-id',
+  });
+  assert.equal(graph.calls.length, 4);
+  assert.ok(graph.calls.every((call) => call.method === 'GET'));
+  assert.equal(graph.postCalls.length, 0);
+  assert.equal(db.operations.size, 0);
+  assert.equal(db.tokens.length, 0);
+  assert.equal(db.locks.size, 0);
+  assert.equal(db.adsetLocks.size, 0);
+  const serialized = JSON.stringify(body);
+  for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID]) {
+    assert.equal(serialized.includes(value), false);
+  }
+});
+
+test('staging seed attestation exposes only finite mismatch, malformed, and source-unavailable outcomes', async () => {
+  const mismatchDb = new SeedDb();
+  const mismatchGraph = new FakeGraph();
+  const mismatch = await attest({
+    db: mismatchDb,
+    graph: mismatchGraph,
+    operationKey: 'meta-ads-staging-seed:attestation-mismatch-001',
+    requestOverrides: { account_id: MISMATCH_ACCOUNT_ID },
+  });
+  const mismatchBody = await mismatch.json();
+  assert.equal(mismatch.status, 409);
+  assert.equal(mismatchBody.error, 'meta_ads_publish_staging_seed_graph_identity_mismatch');
+  assert.equal(mismatchGraph.calls.length, 1);
+  assert.equal(mismatchGraph.postCalls.length, 0);
+  assert.equal(mismatchDb.operations.size, 0);
+  assert.equal(mismatchDb.tokens.length, 0);
+
+  const malformedDb = new SeedDb();
+  const malformed = await attest({
+    db: malformedDb,
+    graph: new FakeGraph(),
+    operationKey: 'meta-ads-staging-seed:attestation-malformed-001',
+    env: {
+      META_GRAPH_FETCH: async () => graphResponse({ id: PIXEL_ID, owner_ad_account: { id: 'not-a-graph-id' } }),
+    },
+  });
+  const malformedBody = await malformed.json();
+  assert.equal(malformed.status, 409);
+  assert.equal(malformedBody.error, 'meta_ads_publish_staging_seed_graph_identity_malformed');
+  assert.equal(malformedDb.operations.size, 0);
+  assert.equal(malformedDb.tokens.length, 0);
+
+  const unavailableDb = new SeedDb();
+  const unavailable = await attest({
+    db: unavailableDb,
+    graph: new FakeGraph(),
+    operationKey: 'meta-ads-staging-seed:attestation-unavailable-001',
+    env: {
+      META_GRAPH_FETCH: async () => graphResponse({ error: { message: 'denied' } }, 403),
+    },
+  });
+  const unavailableBody = await unavailable.json();
+  assert.equal(unavailable.status, 409);
+  assert.equal(unavailableBody.error, 'meta_ads_publish_staging_seed_graph_source_unavailable');
+  assert.equal(unavailableDb.operations.size, 0);
+  assert.equal(unavailableDb.tokens.length, 0);
+
+  for (const body of [mismatchBody, malformedBody, unavailableBody]) {
+    const serialized = JSON.stringify(body);
+    for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, MISMATCH_ACCOUNT_ID, PIXEL_ID]) {
+      assert.equal(serialized.includes(value), false);
+    }
+  }
 });
 
 test('staging seed creates exactly two distinct active Facebook credentials from PAUSED synthetic Graph resources', async () => {

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -78,14 +78,14 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
   const tokenVaultUnit = catalog.units.find((unit) => unit.id === "token-vault");
   assert.ok(tokenVaultUnit);
   assert.ok(!catalog.nonPublishingSurfaces.some((entry) => entry.id === "token-vault"));
-  assert.ok(tokenVaultUnit.resources.includes("Governed Meta Ads staging synthetic seed, bootstrap derivation, rollback journal and paused creative fixture"));
+  assert.ok(tokenVaultUnit.resources.includes("Governed Meta Ads staging synthetic source attestation, seed, bootstrap derivation, rollback journal and paused creative fixture"));
   assert.ok(tokenVaultUnit.secrets.includes("TOKEN_VAULT_META_ADS_CONFIG_TOKEN"));
   assert.ok(tokenVaultUnit.secrets.includes("TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST"));
   assert.ok(tokenVaultUnit.secrets.includes("META_ADS_ACCESS_TOKEN"));
   assert.ok(tokenVaultUnit.secrets.includes("META_PIXEL_ID"));
   assert.ok(!tokenVaultUnit.secrets.includes("TOKEN_VAULT_BACKUP_PASSPHRASE"));
   assert.equal(tokenVaultUnit.promotion.trackingFixture, "synthetic authorized ad-set profile required before staging");
-  assert.equal(tokenVaultUnit.promotion.trackingBootstrap, "empty staging authority uses a restricted one-shot synthetic seed; legacy authority uses restricted config bearer plus hash-bound internal derivation or protected entries override");
+  assert.equal(tokenVaultUnit.promotion.trackingBootstrap, "empty staging authority uses a candidate-only Graph-read attestation before a restricted one-shot synthetic seed; legacy authority uses restricted config bearer plus hash-bound internal derivation or protected entries override");
   assert.equal(tokenVaultUnit.promotion.d1Recovery, "Time Travel bookmark; manual restore only under release:token-vault");
 
   const workflow = read(".github/workflows/deploy-token-vault.yml");


### PR DESCRIPTION
## Summary
- add a candidate-only, staging-only source attestation before the Meta Ads synthetic seed
- preserve `META_ADS_ACCOUNT_ID` as a custody assertion; never derive or overwrite it
- bound the attestation to Graph GET discovery with no D1, lock, audit, encryption, or Meta mutation path
- gate the seed on a sanitised `match` response and expand focused regression coverage

## Validation
- `npm --prefix platform/security/token-vault test` (137/137)
- focused attestation/index/workflow tests (30/30)
- `global-concurrency-governance-static` (18/18)
- deploy topology and Cloudflare single-writer validators
- sealed Codex Security diff scan: no findings

No Ponto or CRM files changed. No secret values are included in this PR.