### PR TITLE
fix(meta-ads): classify staging source attestation failures

### DIFF
--- a/platform/security/token-vault/README.md
+++ b/platform/security/token-vault/README.md
@@ -140,7 +140,9 @@ adivinha nem importa configuração de produção. Antes de derivar o plano, o
 workflow chama `POST .../config/staging-synthetic-seed/attest` na Preview
 imutável com um bearer aleatório exclusivo da versão candidata. A atestação faz
 somente leituras Graph delimitadas, não toca D1 nem cria recursos, e retorna
-apenas `match` ou um código sanitizado. Só então o workflow chama
+apenas `match` ou um código sanitizado que distingue rejeição da credencial de
+fonte, acesso ao Pixel, Página ou dataset, e indisponibilidade transitória. Só
+então o workflow chama
 `POST .../config/staging-synthetic-seed`. Os fatos externos entram somente no
 corpo dessas chamadas privadas: o token Meta Ads já custodiado,
 `META_PIXEL_ID`, `META_ADS_ACCOUNT_ID` e `META_ADS_API_VERSION`. O Vault exige

--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -188,6 +188,10 @@ const STAGING_SYNTHETIC_SEED_CREATIVE_MESSAGE = 'SKINCOS staging tracking verifi
 const STAGING_SYNTHETIC_SEED_CREATIVE_CTA = 'LEARN_MORE';
 const STAGING_SYNTHETIC_SEED_DISCOVERY_FAILURES = Object.freeze({
   sourceUnavailable: 'meta_ads_publish_staging_seed_graph_identity_invalid',
+  sourceAuthRejected: 'meta_ads_publish_staging_seed_graph_identity_invalid',
+  pixelAccessDenied: 'meta_ads_publish_staging_seed_graph_identity_invalid',
+  pageAccessDenied: 'meta_ads_publish_staging_seed_graph_identity_invalid',
+  datasetAccessDenied: 'meta_ads_publish_staging_seed_graph_identity_invalid',
   identityMismatch: 'meta_ads_publish_staging_seed_graph_identity_invalid',
   identityMalformed: 'meta_ads_publish_staging_seed_graph_identity_invalid',
   pageAmbiguous: 'meta_ads_publish_staging_seed_graph_page_ambiguous',
@@ -196,11 +200,15 @@ const STAGING_SYNTHETIC_SEED_DISCOVERY_FAILURES = Object.freeze({
 });
 const STAGING_SYNTHETIC_SEED_ATTESTATION_FAILURES = Object.freeze({
   sourceUnavailable: 'meta_ads_publish_staging_seed_graph_source_unavailable',
+  sourceAuthRejected: 'meta_ads_publish_staging_seed_graph_source_auth_rejected',
+  pixelAccessDenied: 'meta_ads_publish_staging_seed_graph_pixel_access_denied',
+  pageAccessDenied: 'meta_ads_publish_staging_seed_graph_page_access_denied',
+  datasetAccessDenied: 'meta_ads_publish_staging_seed_graph_dataset_access_denied',
   identityMismatch: 'meta_ads_publish_staging_seed_graph_identity_mismatch',
   identityMalformed: 'meta_ads_publish_staging_seed_graph_identity_malformed',
-  pageAmbiguous: 'meta_ads_publish_staging_seed_graph_identity_mismatch',
-  datasetAmbiguous: 'meta_ads_publish_staging_seed_graph_identity_mismatch',
-  landingOrMediaUnavailable: 'meta_ads_publish_staging_seed_graph_identity_malformed',
+  pageAmbiguous: 'meta_ads_publish_staging_seed_graph_page_ambiguous',
+  datasetAmbiguous: 'meta_ads_publish_staging_seed_graph_dataset_ambiguous',
+  landingOrMediaUnavailable: 'meta_ads_publish_staging_seed_landing_or_media_unavailable',
 });
 const STAGING_SYNTHETIC_SEED_ADSET_FIELDS = [
   'id',
@@ -1574,6 +1582,10 @@ function stagingSyntheticSeedFailureResponse(error, requestId) {
     'meta_ads_publish_staging_seed_facebook_credentials_present',
     'meta_ads_publish_staging_seed_graph_identity_invalid',
     'meta_ads_publish_staging_seed_graph_source_unavailable',
+    'meta_ads_publish_staging_seed_graph_source_auth_rejected',
+    'meta_ads_publish_staging_seed_graph_pixel_access_denied',
+    'meta_ads_publish_staging_seed_graph_page_access_denied',
+    'meta_ads_publish_staging_seed_graph_dataset_access_denied',
     'meta_ads_publish_staging_seed_graph_identity_mismatch',
     'meta_ads_publish_staging_seed_graph_identity_malformed',
     'meta_ads_publish_staging_seed_graph_page_ambiguous',
@@ -1973,11 +1985,17 @@ async function discoverStagingSyntheticSeedFacts({
   failureCodes = STAGING_SYNTHETIC_SEED_DISCOVERY_FAILURES,
   maxGraphAttempts = MAX_GRAPH_ATTEMPTS,
 }) {
-  const read = (path, fields, query = {}) => seedGraphRead(auth, path, fields, context, query, {
+  const read = (path, fields, query = {}, failureCode = failureCodes.sourceUnavailable) => seedGraphRead(auth, path, fields, context, query, {
     maxAttempts: maxGraphAttempts,
-    failureCode: failureCodes.sourceUnavailable,
+    failureCode,
+    authFailureCode: failureCodes.sourceAuthRejected,
   });
-  const pixel = await read(input.pixelId, 'id,owner_ad_account{id}');
+  const pixel = await read(
+    input.pixelId,
+    'id,owner_ad_account{id}',
+    {},
+    failureCodes.pixelAccessDenied,
+  );
   const pixelOwner = normalizeStagingSyntheticSeedGraphId(
     asObject(pixel.owner_ad_account).id,
     'pixel_owner_account',
@@ -1990,7 +2008,12 @@ async function discoverStagingSyntheticSeedFacts({
     throw stagingSyntheticSeedFailure(failureCodes.identityMismatch, 409);
   }
 
-  const pages = await read('me/accounts', 'id,tasks,instagram_business_account{id}', { limit: '100' });
+  const pages = await read(
+    'me/accounts',
+    'id,tasks,instagram_business_account{id}',
+    { limit: '100' },
+    failureCodes.pageAccessDenied,
+  );
   if (clean(asObject(pages.paging).next)) {
     throw stagingSyntheticSeedFailure(failureCodes.pageAmbiguous, 409);
   }
@@ -2002,7 +2025,12 @@ async function discoverStagingSyntheticSeedFacts({
     throw stagingSyntheticSeedFailure(failureCodes.pageAmbiguous, 409);
   }
   const selectedPageId = normalizeStagingSyntheticSeedGraphId(eligiblePages[0].id, 'page_id', failureCodes.identityMalformed);
-  const page = await read(selectedPageId, 'id,instagram_business_account{id},website,picture{url}');
+  const page = await read(
+    selectedPageId,
+    'id,instagram_business_account{id},website,picture{url}',
+    {},
+    failureCodes.pageAccessDenied,
+  );
   const pageId = normalizeStagingSyntheticSeedGraphId(page.id, 'page_id', failureCodes.identityMalformed);
   const instagramUserId = normalizeStagingSyntheticSeedGraphId(
     asObject(page.instagram_business_account).id,
@@ -2025,7 +2053,12 @@ async function discoverStagingSyntheticSeedFacts({
     throw stagingSyntheticSeedFailure(failureCodes.landingOrMediaUnavailable, 409);
   }
 
-  const datasets = await read(`act_${input.accountId}/offline_conversion_data_sets`, 'id', { limit: '2' });
+  const datasets = await read(
+    `act_${input.accountId}/offline_conversion_data_sets`,
+    'id',
+    { limit: '2' },
+    failureCodes.datasetAccessDenied,
+  );
   if (clean(asObject(datasets.paging).next) || safeArray(datasets.data).length !== 1) {
     throw stagingSyntheticSeedFailure(failureCodes.datasetAmbiguous, 409);
   }
@@ -2047,6 +2080,7 @@ async function discoverStagingSyntheticSeedFacts({
 async function seedGraphRead(auth, path, fields, context, query = {}, {
   maxAttempts = MAX_GRAPH_ATTEMPTS,
   failureCode = 'meta_ads_publish_staging_seed_graph_identity_invalid',
+  authFailureCode = failureCode,
 } = {}) {
   try {
     const result = await graphRequest(
@@ -2062,8 +2096,15 @@ async function seedGraphRead(auth, path, fields, context, query = {}, {
     if (normalized.retryable || normalized.ambiguous || Number(normalized.http_status) >= 500) {
       throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_unavailable', 503);
     }
+    if (isStagingSyntheticSeedSourceAuthFailure(normalized)) {
+      throw stagingSyntheticSeedFailure(authFailureCode, 409);
+    }
     throw stagingSyntheticSeedFailure(failureCode, 409);
   }
+}
+
+function isStagingSyntheticSeedSourceAuthFailure(normalized) {
+  return Number(normalized?.http_status) === 401 || [102, 190].includes(Number(normalized?.code || 0));
 }
 
 function normalizeStagingSyntheticSeedGraphId(value, label, failureCode = 'meta_ads_publish_staging_seed_graph_identity_invalid') {

--- a/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
@@ -297,8 +297,10 @@ class SeedDb {
 }
 
 class FakeGraph {
-  constructor({ ambiguousCreatePath = '' } = {}) {
+  constructor({ ambiguousCreatePath = '', readFailures = {}, readResponses = {} } = {}) {
     this.ambiguousCreatePath = ambiguousCreatePath;
+    this.readFailures = new Map(Object.entries(readFailures));
+    this.readResponses = new Map(Object.entries(readResponses));
     this.calls = [];
     this.postCalls = [];
     this.resources = new Map();
@@ -314,7 +316,15 @@ class FakeGraph {
       return graphResponse({ error: { message: 'invalid auth' } }, 401);
     }
 
-    if (method === 'GET') return this.read(path);
+    if (method === 'GET') {
+      const failure = this.readFailures.get(path);
+      if (failure) {
+        return graphResponse({ error: { message: 'source read denied', code: failure.code || 0 } }, failure.status ?? 403);
+      }
+      const response = this.readResponses.get(path);
+      if (response) return graphResponse(response.body, response.status ?? 200);
+      return this.read(path);
+    }
 
     this.postCalls.push(path);
     const body = JSON.parse(init.body || '{}');
@@ -615,7 +625,7 @@ test('staging seed attestation bounds Graph discovery and returns no source fact
   }
 });
 
-test('staging seed attestation exposes only finite mismatch, malformed, and source-unavailable outcomes', async () => {
+test('staging seed attestation exposes only finite mismatch, malformed, and source-auth outcomes', async () => {
   const mismatchDb = new SeedDb();
   const mismatchGraph = new FakeGraph();
   const mismatch = await attest({
@@ -647,27 +657,167 @@ test('staging seed attestation exposes only finite mismatch, malformed, and sour
   assert.equal(malformedDb.operations.size, 0);
   assert.equal(malformedDb.tokens.length, 0);
 
-  const unavailableDb = new SeedDb();
-  const unavailable = await attest({
-    db: unavailableDb,
-    graph: new FakeGraph(),
-    operationKey: 'meta-ads-staging-seed:attestation-unavailable-001',
-    env: {
-      META_GRAPH_FETCH: async () => graphResponse({ error: { message: 'denied' } }, 403),
-    },
+  const rejectedDb = new SeedDb();
+  const rejectedGraph = new FakeGraph({
+    readFailures: { [PIXEL_ID]: { status: 400, code: 190 } },
   });
-  const unavailableBody = await unavailable.json();
-  assert.equal(unavailable.status, 409);
-  assert.equal(unavailableBody.error, 'meta_ads_publish_staging_seed_graph_source_unavailable');
-  assert.equal(unavailableDb.operations.size, 0);
-  assert.equal(unavailableDb.tokens.length, 0);
+  const rejected = await attest({
+    db: rejectedDb,
+    graph: rejectedGraph,
+    operationKey: 'meta-ads-staging-seed:attestation-unavailable-001',
+  });
+  const rejectedBody = await rejected.json();
+  assert.equal(rejected.status, 409);
+  assert.equal(rejectedBody.error, 'meta_ads_publish_staging_seed_graph_source_auth_rejected');
+  assert.equal(rejectedGraph.calls.length, 1);
+  assert.equal(rejectedDb.operations.size, 0);
+  assert.equal(rejectedDb.tokens.length, 0);
 
-  for (const body of [mismatchBody, malformedBody, unavailableBody]) {
+  for (const body of [mismatchBody, malformedBody, rejectedBody]) {
     const serialized = JSON.stringify(body);
     for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, MISMATCH_ACCOUNT_ID, PIXEL_ID]) {
       assert.equal(serialized.includes(value), false);
     }
   }
+});
+
+test('staging seed attestation returns a finite resource stage for permanent Graph source failures', async () => {
+  const cases = [
+    {
+      label: 'pixel',
+      path: PIXEL_ID,
+      expectedError: 'meta_ads_publish_staging_seed_graph_pixel_access_denied',
+      expectedReads: 1,
+      status: 403,
+    },
+    {
+      label: 'page-list',
+      path: 'me/accounts',
+      expectedError: 'meta_ads_publish_staging_seed_graph_page_access_denied',
+      expectedReads: 2,
+      status: 403,
+    },
+    {
+      label: 'page-read',
+      path: PAGE_ID,
+      expectedError: 'meta_ads_publish_staging_seed_graph_page_access_denied',
+      expectedReads: 3,
+      status: 403,
+    },
+    {
+      label: 'dataset',
+      path: `act_${ACCOUNT_ID}/offline_conversion_data_sets`,
+      expectedError: 'meta_ads_publish_staging_seed_graph_dataset_access_denied',
+      expectedReads: 4,
+      // Graph can return a 2xx envelope containing an error. It remains a
+      // permanent source capability failure and must not become a success.
+      status: 200,
+    },
+  ];
+
+  for (const entry of cases) {
+    const db = new SeedDb();
+    const graph = new FakeGraph({
+      readFailures: { [entry.path]: { status: entry.status, code: 10 } },
+    });
+    const response = await attest({
+      db,
+      graph,
+      operationKey: `meta-ads-staging-seed:attestation-${entry.label}-denied-001`,
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 409, entry.label);
+    assert.equal(body.error, entry.expectedError, entry.label);
+    assert.equal(graph.calls.length, entry.expectedReads, entry.label);
+    assert.equal(graph.postCalls.length, 0, entry.label);
+    assert.equal(db.operations.size, 0, entry.label);
+    assert.equal(db.tokens.length, 0, entry.label);
+    assert.equal(db.locks.size, 0, entry.label);
+    assert.equal(db.adsetLocks.size, 0, entry.label);
+    const serialized = JSON.stringify(body);
+    for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID]) {
+      assert.equal(serialized.includes(value), false, entry.label);
+    }
+  }
+});
+
+test('staging seed attestation preserves finite non-identity source eligibility outcomes', async () => {
+  const cases = [
+    {
+      label: 'page-ambiguous',
+      path: 'me/accounts',
+      response: { body: { data: [] } },
+      expectedError: 'meta_ads_publish_staging_seed_graph_page_ambiguous',
+      expectedReads: 2,
+    },
+    {
+      label: 'dataset-ambiguous',
+      path: `act_${ACCOUNT_ID}/offline_conversion_data_sets`,
+      response: { body: { data: [] } },
+      expectedError: 'meta_ads_publish_staging_seed_graph_dataset_ambiguous',
+      expectedReads: 4,
+    },
+    {
+      label: 'landing-unavailable',
+      path: PAGE_ID,
+      response: {
+        body: {
+          id: PAGE_ID,
+          instagram_business_account: { id: INSTAGRAM_ID },
+          website: '',
+          picture: { data: { url: 'https://cdn.example.invalid/staging-fixture.jpg' } },
+        },
+      },
+      expectedError: 'meta_ads_publish_staging_seed_landing_or_media_unavailable',
+      expectedReads: 3,
+    },
+  ];
+
+  for (const entry of cases) {
+    const db = new SeedDb();
+    const graph = new FakeGraph({ readResponses: { [entry.path]: entry.response } });
+    const response = await attest({
+      db,
+      graph,
+      operationKey: `meta-ads-staging-seed:attestation-${entry.label}-001`,
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 409, entry.label);
+    assert.equal(body.error, entry.expectedError, entry.label);
+    assert.equal(graph.calls.length, entry.expectedReads, entry.label);
+    assert.equal(graph.postCalls.length, 0, entry.label);
+    assert.equal(db.operations.size, 0, entry.label);
+    assert.equal(db.tokens.length, 0, entry.label);
+    assert.equal(db.locks.size, 0, entry.label);
+    assert.equal(db.adsetLocks.size, 0, entry.label);
+    const serialized = JSON.stringify(body);
+    for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID]) {
+      assert.equal(serialized.includes(value), false, entry.label);
+    }
+  }
+});
+
+test('staging seed attestation keeps transient source failures retryable and bounded', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph({
+    readFailures: { [PIXEL_ID]: { status: 429, code: 4 } },
+  });
+  const response = await attest({
+    db,
+    graph,
+    operationKey: 'meta-ads-staging-seed:attestation-transient-unavailable-001',
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 503);
+  assert.equal(body.error, 'meta_ads_publish_staging_seed_unavailable');
+  assert.equal(graph.calls.length, 1);
+  assert.equal(graph.postCalls.length, 0);
+  assert.equal(db.operations.size, 0);
+  assert.equal(db.tokens.length, 0);
+  assert.equal(JSON.stringify(body).includes(SOURCE_ACCESS_TOKEN), false);
 });
 
 test('staging seed creates exactly two distinct active Facebook credentials from PAUSED synthetic Graph resources', async () => {


### PR DESCRIPTION
## Objetivo

Classifica de forma finita e redigida a falha da atestação pré-tráfego da seed sintética de staging, para que o rollout não trate rejeição da fonte Meta como uma causa genérica.

## Mudança

- distingue rejeição inequívoca da credencial de fonte de acesso negado a Pixel, Página e dataset;
- preserva indisponibilidade transitória como retryável e os defaults da saga mutante;
- corrige os códigos seguros para Página/dataset ambíguos e landing/mídia indisponível;
- amplia as regressões de redaction, ausência de D1/locks/audit/POST Graph e limite de leitura.

## Segurança e rollback

A atestação segue staging-only, bearer efêmero isolado e apenas GETs Graph. Não há valores de segredo, IDs ou payloads Graph no diff. O comportamento da seed mutante permanece compatível.

## Validação

- Token Vault: 140/140
- deploy topology e Cloudflare single-writer: verdes
- `git diff --check`: verde
- varredura de segurança selada sem findings (`3336b8e4-47d5-426d-90e5-a73d20ebb4e8`)

Sem alterações em Ponto ou CRM.