### PR TITLE
fix(ponto): await emergency close propagation

### DIFF
--- a/.github/scripts/ponto-recovery-materialization-workflow.test.mjs
+++ b/.github/scripts/ponto-recovery-materialization-workflow.test.mjs
@@ -49,12 +49,14 @@ test("manual emergency close materializes under the surface mutex and proves liv
   assert.match(emergencyClose, /close:\n[\s\S]*?group: ponto-emergency-latch-\$\{\{ inputs\.target \}\}/);
 });
 
-test("manual emergency re-attestation accepts a still-visible monotonic latch without weakening direct custody", () => {
-  assert.match(
-    emergencyClose,
-    /if \(availability\.source === "emergency-latch-active"\) \{[\s\S]*?changedAt: availability\.changedAt[\s\S]*?fs\.rmSync\(process\.argv\[4\], \{ force: true \}\)/,
-  );
+test("manual emergency re-attestation gives bounded propagation the broker-attested timestamps", () => {
+  assert.match(emergencyClose, /maintenance\?\.schemaVersion !== 1[\s\S]*?maintenance\?\.passed !== true/);
+  assert.match(emergencyClose, /changedAt: maintenance\.latchChangedAt/);
+  assert.match(emergencyClose, /changedAt: maintenance\.controlChangedAt, source: "control"/);
   assert.match(emergencyClose, /if \[\[ -f "\$directory\/control-fallback-expectation\.json" \]\]; then/);
+  assert.match(emergencyClose, /ponto-module-propagation\.mjs/);
+  assert.doesNotMatch(emergencyClose, /emergency_close_probe/);
+  assert.doesNotMatch(emergencyClose, /live Ponto health did not prove maintenance under the closed latch/);
   assert.match(emergencyClose, /const validAvailabilityChangedAt = Number\.isFinite\(Date\.parse\(String\(availability\?\.changedAt \|\| ""\)\)\);/);
   assert.match(emergencyClose, /const exactControlChangedAt = availability\?\.source === "control"/);
   assert.match(emergencyClose, /&& validAvailabilityChangedAt\s*&& exactControlChangedAt/);

--- a/.github/workflows/ponto-emergency-close.yml
+++ b/.github/workflows/ponto-emergency-close.yml
@@ -97,32 +97,21 @@ jobs:
           node - "$directory/maintenance.json" \
             "$directory/overlay-expectation.json" \
             "$directory/control-fallback-expectation.json" <<'NODE'
-          (async () => {
           const fs = require("fs");
           const maintenance = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
-          const headers = { accept: "application/json", "cache-control": "no-cache" };
-          const probe = new URL(process.env.PONTO_MODULE_HEALTH_URL);
-          probe.searchParams.set("emergency_close_probe", process.env.GITHUB_RUN_ID);
-          const response = await fetch(probe, { headers });
-          const body = await response.json().catch(() => null);
-          const availability = body?.availability;
           if (
-            response.status !== 200
-            || availability?.state !== "maintenance"
-            || !["control", "emergency-latch-active"].includes(availability?.source)
-            || !Number.isFinite(Date.parse(String(availability?.changedAt || "")))
-          ) throw new Error("live Ponto health did not prove maintenance under the closed latch");
-          if (availability.source === "emergency-latch-active") {
-            // A monotonic latch can already be visible at the edge before a
-            // broker-backed re-attestation transfers its ownership. The
-            // direct broker evidence remains the exact custody boundary.
-            fs.writeFileSync(process.argv[3], `${JSON.stringify({ state: "maintenance", changedAt: availability.changedAt })}\n`, { mode: 0o600 });
-            fs.rmSync(process.argv[4], { force: true });
-          } else {
-            fs.writeFileSync(process.argv[3], `${JSON.stringify({ state: "maintenance", changedAt: maintenance.latchChangedAt })}\n`, { mode: 0o600 });
-            fs.writeFileSync(process.argv[4], `${JSON.stringify({ state: "maintenance", changedAt: availability.changedAt, source: "control" })}\n`, { mode: 0o600 });
-          }
-          })().catch((error) => { console.error(error); process.exitCode = 1; });
+            maintenance?.schemaVersion !== 1
+            || maintenance?.state !== "maintenance"
+            || maintenance?.latched !== true
+            || maintenance?.passed !== true
+            || !Number.isFinite(Date.parse(String(maintenance?.latchChangedAt || "")))
+            || !Number.isFinite(Date.parse(String(maintenance?.controlChangedAt || "")))
+          ) throw new Error("broker maintenance evidence is invalid");
+          // The broker attests both exact timestamps. Let the bounded
+          // propagation checker own all edge reads: an immediate probe can
+          // still observe the predecessor while the close is propagating.
+          fs.writeFileSync(process.argv[3], `${JSON.stringify({ state: "maintenance", changedAt: maintenance.latchChangedAt })}\n`, { mode: 0o600 });
+          fs.writeFileSync(process.argv[4], `${JSON.stringify({ state: "maintenance", changedAt: maintenance.controlChangedAt, source: "control" })}\n`, { mode: 0o600 });
           NODE
           if [[ -f "$directory/control-fallback-expectation.json" ]]; then
             PONTO_MODULE_EXPECTED_SOURCE=emergency-latch-active \


### PR DESCRIPTION
## Objetivo
Eliminar a corrida de propagação que fazia o fechamento manual de emergência falhar antes do verificador canônico de propagação iniciar.

## Escopo e risco
Apenas `.github/workflows/ponto-emergency-close.yml` e seu teste estático focal. A alteração mantém Ponto fail-closed: o workflow continua exigindo a atestação do broker e duas observações externas consecutivas de `maintenance`.

## Validação
- `node --test .github/scripts/ponto-recovery-materialization-workflow.test.mjs .github/scripts/ponto-module-propagation.test.mjs`
- `git diff --check`

## Rollback
Reverter este commit restaura a leitura imediata anterior. Não há migration, alteração de dados ou publicação de Ponto nesta PR.