### PR TITLE
fix(codex): attest website local preview identity

### DIFF
--- a/scripts/materialize-website-local-preview-source.sh
+++ b/scripts/materialize-website-local-preview-source.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Materialize a website worktree into a private WSL cache without ever building
+# or installing dependencies in the source worktree.  This is intentionally a
+# small, explicit contract rather than a general-purpose copy command.
+#
+# Required environment:
+#   PREVIEW_MATERIALIZE_SOURCE_ROOT       Existing checkout containing website/
+#   PREVIEW_MATERIALIZE_DESTINATION_ROOT  Private output root; website/ is made here
+#   PREVIEW_MATERIALIZE_ALLOWED_ROOT      Existing private root containing destination
+#   PREVIEW_MATERIALIZE_DEPENDENCY_ROOT   Private dependency cache root; website/node_modules lives here
+#
+# Optional environment:
+#   PREVIEW_MATERIALIZE_DEPENDENCY_STATE_FILE
+#     Private state file. Defaults to <dependency-root>/website/.preview-dependencies.state.
+
+require_environment() {
+  local name="$1"
+  local value="${!name:-}"
+
+  if [[ -z "$value" ]]; then
+    echo "${name} is required." >&2
+    exit 2
+  fi
+  if [[ "$value" != /* ]]; then
+    echo "${name} must be an absolute WSL path." >&2
+    exit 2
+  fi
+}
+
+canonical_existing_directory() {
+  local path="$1"
+  if [[ ! -d "$path" ]]; then
+    echo "Directory does not exist: $path" >&2
+    exit 2
+  fi
+  realpath -e -- "$path"
+}
+
+canonical_planned_path() {
+  realpath -m -- "$1"
+}
+
+require_descendant_of() {
+  local candidate="$1"
+  local root="$2"
+  local label="$3"
+
+  if [[ "$candidate" != "$root"/* ]]; then
+    echo "${label} must be a descendant of PREVIEW_MATERIALIZE_ALLOWED_ROOT." >&2
+    exit 2
+  fi
+}
+
+require_environment PREVIEW_MATERIALIZE_SOURCE_ROOT
+require_environment PREVIEW_MATERIALIZE_DESTINATION_ROOT
+require_environment PREVIEW_MATERIALIZE_ALLOWED_ROOT
+require_environment PREVIEW_MATERIALIZE_DEPENDENCY_ROOT
+
+if ! command -v rsync >/dev/null 2>&1; then
+  echo "rsync is required to materialize the local website preview." >&2
+  exit 1
+fi
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is required to prepare the local website preview dependencies." >&2
+  exit 1
+fi
+
+ALLOWED_ROOT="$(canonical_existing_directory "$PREVIEW_MATERIALIZE_ALLOWED_ROOT")"
+SOURCE_ROOT="$(canonical_existing_directory "$PREVIEW_MATERIALIZE_SOURCE_ROOT")"
+SOURCE_WEBSITE="$(canonical_existing_directory "$SOURCE_ROOT/website")"
+DESTINATION_ROOT="$(canonical_planned_path "$PREVIEW_MATERIALIZE_DESTINATION_ROOT")"
+DEPENDENCY_ROOT="$(canonical_planned_path "$PREVIEW_MATERIALIZE_DEPENDENCY_ROOT")"
+DESTINATION_WEBSITE="$(canonical_planned_path "$DESTINATION_ROOT/website")"
+DEPENDENCY_WEBSITE="$(canonical_planned_path "$DEPENDENCY_ROOT/website")"
+DEPENDENCY_STATE_FILE="$(canonical_planned_path "${PREVIEW_MATERIALIZE_DEPENDENCY_STATE_FILE:-$DEPENDENCY_WEBSITE/.preview-dependencies.state}")"
+
+require_descendant_of "$DESTINATION_ROOT" "$ALLOWED_ROOT" "PREVIEW_MATERIALIZE_DESTINATION_ROOT"
+require_descendant_of "$DEPENDENCY_ROOT" "$ALLOWED_ROOT" "PREVIEW_MATERIALIZE_DEPENDENCY_ROOT"
+require_descendant_of "$DEPENDENCY_STATE_FILE" "$ALLOWED_ROOT" "PREVIEW_MATERIALIZE_DEPENDENCY_STATE_FILE"
+
+if [[ "$DESTINATION_ROOT" == "$DEPENDENCY_ROOT" || "$DESTINATION_ROOT" == "$DEPENDENCY_ROOT"/* || "$DEPENDENCY_ROOT" == "$DESTINATION_ROOT"/* ]]; then
+  echo "The materialized source root and dependency root must be distinct private directories." >&2
+  exit 2
+fi
+if [[ "$DESTINATION_ROOT" == "$SOURCE_ROOT" || "$DESTINATION_ROOT" == "$SOURCE_ROOT"/* || "$SOURCE_ROOT" == "$DESTINATION_ROOT"/* ]]; then
+  echo "The materialized destination must not overlap the source checkout." >&2
+  exit 2
+fi
+if [[ "$DEPENDENCY_ROOT" == "$SOURCE_ROOT" || "$DEPENDENCY_ROOT" == "$SOURCE_ROOT"/* || "$SOURCE_ROOT" == "$DEPENDENCY_ROOT"/* ]]; then
+  echo "The dependency cache must not overlap the source checkout." >&2
+  exit 2
+fi
+if [[ "$DEPENDENCY_STATE_FILE" == "$SOURCE_ROOT" || "$DEPENDENCY_STATE_FILE" == "$SOURCE_ROOT"/* ]]; then
+  echo "The dependency state file must not overlap the source checkout." >&2
+  exit 2
+fi
+
+SOURCE_PACKAGE_JSON="$SOURCE_WEBSITE/package.json"
+SOURCE_LOCK_FILE="$SOURCE_WEBSITE/package-lock.json"
+if [[ ! -f "$SOURCE_PACKAGE_JSON" || ! -f "$SOURCE_LOCK_FILE" ]]; then
+  echo "The website source must contain package.json and package-lock.json for npm ci." >&2
+  exit 1
+fi
+
+DEPENDENCY_FINGERPRINT="$({
+  for manifest_name in package.json package-lock.json npm-shrinkwrap.json .npmrc; do
+    source_manifest="$SOURCE_WEBSITE/$manifest_name"
+    if [[ -f "$source_manifest" ]]; then
+      printf '%s\0present\0' "$manifest_name"
+      sha256sum "$source_manifest" | awk '{print $1}'
+    else
+      printf '%s\0missing\0' "$manifest_name"
+    fi
+  done
+} | sha256sum | awk '{print $1}')"
+DEPENDENCY_FINGERPRINT="sha256:$DEPENDENCY_FINGERPRINT"
+
+mkdir -p "$DESTINATION_WEBSITE" "$DEPENDENCY_WEBSITE" "$(dirname "$DEPENDENCY_STATE_FILE")"
+
+# `--delete-excluded` is deliberate: stale generated outputs and test/document
+# trees must not survive a source refresh.  Dependencies are attached below,
+# after the materialized tree is complete.
+rsync -a --delete --delete-excluded \
+  --exclude '/node_modules/' \
+  --exclude '/.next/' \
+  --exclude '/.next-codex-preview/' \
+  --exclude '/.open-next/' \
+  --exclude '/.wrangler/' \
+  --exclude '/docs/' \
+  --exclude '/logs/' \
+  --exclude '/reports/' \
+  --exclude '/tests/' \
+  --exclude '/tmp/' \
+  --exclude '/.git/' \
+  "$SOURCE_WEBSITE/" "$DESTINATION_WEBSITE/"
+
+# npm ci runs only inside the private dependency cache.  Mirror the manifests
+# needed by npm there first; .npmrc remains private if the source uses one.
+for manifest_name in package.json package-lock.json .npmrc; do
+  source_manifest="$SOURCE_WEBSITE/$manifest_name"
+  dependency_manifest="$DEPENDENCY_WEBSITE/$manifest_name"
+  if [[ -f "$source_manifest" ]]; then
+    rsync -a "$source_manifest" "$dependency_manifest"
+  else
+    rm -f "$dependency_manifest"
+  fi
+done
+
+previous_dependency_fingerprint=""
+if [[ -f "$DEPENDENCY_STATE_FILE" ]]; then
+  previous_dependency_fingerprint="$(awk -F= '$1 == "dependencyFingerprint" { print $2; exit }' "$DEPENDENCY_STATE_FILE" 2>/dev/null || true)"
+fi
+
+if [[ -L "$DEPENDENCY_WEBSITE/node_modules" ]]; then
+  # Never let npm ci follow a pre-existing link.  The dependency root is
+  # private and validated above, so removing the link cannot touch its target.
+  rm -f "$DEPENDENCY_WEBSITE/node_modules"
+fi
+
+if [[ ! -d "$DEPENDENCY_WEBSITE/node_modules" || "$previous_dependency_fingerprint" != "$DEPENDENCY_FINGERPRINT" ]]; then
+  npm --prefix "$DEPENDENCY_WEBSITE" ci
+  state_temporary="$DEPENDENCY_STATE_FILE.tmp.$$"
+  (
+    umask 077
+    printf 'version=1\ndependencyFingerprint=%s\n' "$DEPENDENCY_FINGERPRINT" > "$state_temporary"
+  )
+  mv -f "$state_temporary" "$DEPENDENCY_STATE_FILE"
+fi
+
+DESTINATION_NODE_MODULES="$DESTINATION_WEBSITE/node_modules"
+if [[ -e "$DESTINATION_NODE_MODULES" || -L "$DESTINATION_NODE_MODULES" ]]; then
+  rm -rf "$DESTINATION_NODE_MODULES"
+fi
+ln -s "$DEPENDENCY_WEBSITE/node_modules" "$DESTINATION_NODE_MODULES"
+
+printf '[website-local-preview] materialized source=%s destination=%s lock=%s dependencies=%s\n' \
+  "$SOURCE_ROOT" "$DESTINATION_ROOT" "$DEPENDENCY_FINGERPRINT" "$DEPENDENCY_WEBSITE/node_modules"

--- a/scripts/run-local-website.sh
+++ b/scripts/run-local-website.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+SCRIPT_SOURCE="${BASH_SOURCE[0]:-$0}"
+ROOT_DIR="$(cd "$(dirname "$SCRIPT_SOURCE")/.." && pwd)"
+SCRIPT_PATH="$(cd "$(dirname "$SCRIPT_SOURCE")" && pwd)/$(basename "$SCRIPT_SOURCE")"
 WEBSITE_SOURCE_ROOT="${WEBSITE_SOURCE_ROOT:-$ROOT_DIR}"
 WEBSITE_DIR="$WEBSITE_SOURCE_ROOT/website"
 WEBSITE_HOST="${WEBSITE_HOST:-0.0.0.0}"
@@ -21,6 +22,42 @@ WEBSITE_DETACH="${WEBSITE_DETACH:-0}"
 WEBSITE_SUPERVISOR_MODE="${WEBSITE_SUPERVISOR_MODE:-0}"
 WEBSITE_START_TIMEOUT="${WEBSITE_START_TIMEOUT:-90}"
 WEBSITE_SKIP_WORKERD_CHECK="${WEBSITE_SKIP_WORKERD_CHECK:-0}"
+# The generic website launcher deliberately remains usable without an identity
+# contract.  The Codex local-preview action opts into the stricter branch below
+# by supplying both values.  Keeping that distinction here prevents a generic
+# `website:local` caller from being coupled to the private preview protocol.
+WEBSITE_INSTANCE_FINGERPRINT="${WEBSITE_INSTANCE_FINGERPRINT:-}"
+WEBSITE_INSTANCE_ID="${WEBSITE_INSTANCE_ID:-}"
+WEBSITE_INSTANCE_EXPECTED_FINGERPRINT="${WEBSITE_INSTANCE_EXPECTED_FINGERPRINT:-$WEBSITE_INSTANCE_FINGERPRINT}"
+WEBSITE_INSTANCE_EXPECTED_ID="${WEBSITE_INSTANCE_EXPECTED_ID:-$WEBSITE_INSTANCE_ID}"
+WEBSITE_INSTANCE_FINGERPRINT_HEADER="${WEBSITE_INSTANCE_FINGERPRINT_HEADER:-X-Skincos-Preview-Fingerprint}"
+WEBSITE_INSTANCE_ID_HEADER="${WEBSITE_INSTANCE_ID_HEADER:-X-Skincos-Preview-Instance}"
+WEBSITE_LOCAL_PREVIEW_DIST_DIR="${WEBSITE_LOCAL_PREVIEW_DIST_DIR:-${SKINCOS_LOCAL_PREVIEW_DIST_DIR:-}}"
+SKINCOS_LOCAL_PREVIEW_DIST_DIR="${SKINCOS_LOCAL_PREVIEW_DIST_DIR:-$WEBSITE_LOCAL_PREVIEW_DIST_DIR}"
+SKINCOS_LOCAL_PREVIEW_FINGERPRINT="${SKINCOS_LOCAL_PREVIEW_FINGERPRINT:-$WEBSITE_INSTANCE_FINGERPRINT}"
+SKINCOS_LOCAL_PREVIEW_INSTANCE="${SKINCOS_LOCAL_PREVIEW_INSTANCE:-$WEBSITE_INSTANCE_ID}"
+WEBSITE_INSTANCE_STATE_FILE="${WEBSITE_INSTANCE_STATE_FILE:-$WEBSITE_STATE_DIR/instance.json}"
+WEBSITE_SUPERVISOR_TOKEN_FILE="${WEBSITE_SUPERVISOR_TOKEN_FILE:-$WEBSITE_STATE_DIR/.website-local-supervisor.token}"
+WEBSITE_SUPERVISOR_TOKEN="${WEBSITE_SUPERVISOR_TOKEN:-}"
+WEBSITE_ALLOW_PORT_FALLBACK="${WEBSITE_ALLOW_PORT_FALLBACK:-0}"
+
+if [[ -n "$WEBSITE_INSTANCE_FINGERPRINT$WEBSITE_INSTANCE_ID$WEBSITE_INSTANCE_EXPECTED_FINGERPRINT$WEBSITE_INSTANCE_EXPECTED_ID" ]]; then
+  if [[ -z "$WEBSITE_INSTANCE_FINGERPRINT" || -z "$WEBSITE_INSTANCE_ID" || -z "$WEBSITE_INSTANCE_EXPECTED_FINGERPRINT" || -z "$WEBSITE_INSTANCE_EXPECTED_ID" ]]; then
+    echo "WEBSITE_INSTANCE_FINGERPRINT and WEBSITE_INSTANCE_ID must be provided together for an attested preview." >&2
+    exit 1
+  fi
+  if [[ "${SKINCOS_LOCAL_PREVIEW:-}" != "true" ]]; then
+    echo "An attested preview requires SKINCOS_LOCAL_PREVIEW=true." >&2
+    exit 1
+  fi
+  if [[ "$WEBSITE_INSTANCE_EXPECTED_FINGERPRINT" != "$WEBSITE_INSTANCE_FINGERPRINT" || "$WEBSITE_INSTANCE_EXPECTED_ID" != "$WEBSITE_INSTANCE_ID" || "$SKINCOS_LOCAL_PREVIEW_FINGERPRINT" != "$WEBSITE_INSTANCE_FINGERPRINT" || "$SKINCOS_LOCAL_PREVIEW_INSTANCE" != "$WEBSITE_INSTANCE_ID" ]]; then
+    echo "The SKINCOS local-preview headers must represent the requested website instance." >&2
+    exit 1
+  fi
+  WEBSITE_INSTANCE_CONTRACT_ACTIVE=1
+else
+  WEBSITE_INSTANCE_CONTRACT_ACTIVE=0
+fi
 
 if [[ -n "${OPEN_BROWSER+x}" ]]; then
   OPEN_BROWSER_EXPLICIT=1
@@ -119,54 +156,256 @@ terminate_pid() {
   kill -KILL "$target_pid" >/dev/null 2>&1 || true
 }
 
+is_numeric_pid() {
+  [[ "${1:-}" =~ ^[0-9]+$ ]]
+}
+
+pid_start_ticks() {
+  local pid="$1"
+  local stat_line
+  local stat_fields
+
+  is_numeric_pid "$pid" || return 1
+  [[ -r "/proc/$pid/stat" ]] || return 1
+  stat_line="$(<"/proc/$pid/stat")"
+  # The command name is enclosed in parentheses and can contain spaces, so
+  # parse only the fields after its final closing parenthesis.  starttime is
+  # field 22 overall, i.e. offset 19 after the state field.
+  stat_fields="${stat_line##*) }"
+  local -a fields=()
+  read -r -a fields <<<"$stat_fields"
+  [[ "${fields[19]:-}" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "${fields[19]}"
+}
+
+pid_parent_pid() {
+  local pid="$1"
+  local stat_line
+  local stat_fields
+
+  is_numeric_pid "$pid" || return 1
+  [[ -r "/proc/$pid/stat" ]] || return 1
+  stat_line="$(<"/proc/$pid/stat")"
+  stat_fields="${stat_line##*) }"
+  local -a fields=()
+  read -r -a fields <<<"$stat_fields"
+  [[ "${fields[1]:-}" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "${fields[1]}"
+}
+
+pid_command_line() {
+  local pid="$1"
+
+  is_numeric_pid "$pid" || return 1
+  [[ -r "/proc/$pid/cmdline" ]] || return 1
+  tr '\0' ' ' < "/proc/$pid/cmdline"
+}
+
+pid_is_descendant_of() {
+  local candidate_pid="$1"
+  local ancestor_pid="$2"
+  local parent_pid
+  local remaining=128
+
+  is_numeric_pid "$candidate_pid" || return 1
+  is_numeric_pid "$ancestor_pid" || return 1
+
+  while (( remaining > 0 )); do
+    [[ "$candidate_pid" == "$ancestor_pid" ]] && return 0
+    [[ "$candidate_pid" == "1" ]] && return 1
+    parent_pid="$(pid_parent_pid "$candidate_pid" 2>/dev/null || true)"
+    [[ -n "$parent_pid" && "$parent_pid" != "$candidate_pid" ]] || return 1
+    candidate_pid="$parent_pid"
+    remaining=$((remaining - 1))
+  done
+
+  return 1
+}
+
+is_owned_website_supervisor() {
+  local pid="$1"
+  local expected_start_ticks="${2:-}"
+  local actual_start_ticks
+  local command_line
+  local cwd
+
+  is_numeric_pid "$pid" || return 1
+  kill -0 "$pid" >/dev/null 2>&1 || return 1
+  actual_start_ticks="$(pid_start_ticks "$pid" 2>/dev/null || true)"
+  [[ -n "$actual_start_ticks" ]] || return 1
+  if [[ -n "$expected_start_ticks" && "$actual_start_ticks" != "$expected_start_ticks" ]]; then
+    return 1
+  fi
+
+  command_line="$(pid_command_line "$pid" 2>/dev/null || true)"
+  cwd="$(readlink -f "/proc/$pid/cwd" 2>/dev/null || true)"
+  [[ "$cwd" == "$WEBSITE_SOURCE_ROOT" ]] || return 1
+  [[ "$command_line" == *"$SCRIPT_PATH"* || "$command_line" == *"scripts/run-local-website.sh"* ]] || return 1
+}
+
+is_next_website_listener() {
+  local pid="$1"
+  local command_line
+  local cwd
+
+  is_numeric_pid "$pid" || return 1
+  kill -0 "$pid" >/dev/null 2>&1 || return 1
+  command_line="$(pid_command_line "$pid" 2>/dev/null || true)"
+  cwd="$(readlink -f "/proc/$pid/cwd" 2>/dev/null || true)"
+  [[ "$cwd" == "$WEBSITE_DIR" || "$cwd" == "$WEBSITE_SOURCE_ROOT" ]] || return 1
+
+  # Next's listener is named `next-server` in current releases, while older
+  # versions expose `next dev` or the bin path.  All forms are deliberate.
+  [[ "$command_line" == *"next-server"* || "$command_line" == *"next dev"* || "$command_line" == *"npm run dev"* || "$command_line" == *"/next/dist/bin/next"* ]]
+}
+
+is_owned_website_listener() {
+  local listener_pid="$1"
+  local supervisor_pid="$2"
+  local supervisor_start_ticks="${3:-}"
+
+  is_next_website_listener "$listener_pid" || return 1
+  is_owned_website_supervisor "$supervisor_pid" "$supervisor_start_ticks" || return 1
+  pid_is_descendant_of "$listener_pid" "$supervisor_pid"
+}
+
 port_listener_pids() {
   local port="$1"
+  local lsof_pids=""
+  local ss_pids=""
 
   if command -v lsof >/dev/null 2>&1; then
-    lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true
-    return 0
+    lsof_pids="$(lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)"
   fi
 
   if command -v ss >/dev/null 2>&1; then
-    ss -ltnp "( sport = :$port )" 2>/dev/null |
+    ss_pids="$(ss -ltnp "( sport = :$port )" 2>/dev/null |
       sed -n 's/.*pid=\([0-9][0-9]*\).*/\1/p' |
-      sort -u
+      sort -u || true)"
   fi
+
+  # `lsof` under WSL can return no listeners even when `ss` can see the
+  # Next process.  Combine both observations instead of treating an empty
+  # lsof result as authoritative.
+  printf '%s\n%s\n' "$lsof_pids" "$ss_pids" | sed '/^$/d' | sort -u
 }
 
 is_port_free() {
   local port="$1"
-  [[ -z "$(port_listener_pids "$port")" ]]
+  [[ -z "$(port_listener_pids "$port")" ]] || return 1
+
+  # A Windows-owned relay can be reachable from WSL without exposing a PID to
+  # either lsof or ss.  Treat a successful TCP handshake as occupied so an
+  # unknown listener can never be mistaken for a free Action port.
+  if command -v timeout >/dev/null 2>&1 &&
+    timeout 1 bash -c "exec 3<>/dev/tcp/127.0.0.1/${port}" >/dev/null 2>&1; then
+    return 1
+  fi
+  return 0
 }
 
-is_owned_website_listener() {
-  local pid="$1"
-  local args
-  local cwd
+write_supervisor_attestation() {
+  local supervisor_pid="$1"
+  local supervisor_start_ticks="$2"
+  local token="$3"
+  local state_dir
+  local temporary_file
 
-  args="$(ps -p "$pid" -o args= 2>/dev/null || true)"
-  cwd="$(readlink -f "/proc/$pid/cwd" 2>/dev/null || true)"
+  [[ -n "$token" ]] || return 1
+  state_dir="$(dirname "$WEBSITE_SUPERVISOR_TOKEN_FILE")"
+  mkdir -p "$state_dir"
+  temporary_file="$WEBSITE_SUPERVISOR_TOKEN_FILE.tmp.$$"
+  (umask 077; printf '%s\t%s\t%s\n' "$token" "$supervisor_pid" "$supervisor_start_ticks" > "$temporary_file")
+  mv -f "$temporary_file" "$WEBSITE_SUPERVISOR_TOKEN_FILE"
+}
 
-  [[ -n "$args" ]] || return 1
-  [[ "$args" == *"next dev"* || "$args" == *"npm run dev"* || "$args" == *"/next/dist/bin/next"* ]] || return 1
-  [[ "$cwd" == "$WEBSITE_DIR" || "$cwd" == "$WEBSITE_SOURCE_ROOT" ]] || return 1
+read_supervisor_attestation() {
+  local expected_token="${1:-}"
+  local token
+  local supervisor_pid
+  local supervisor_start_ticks
+
+  [[ -f "$WEBSITE_SUPERVISOR_TOKEN_FILE" ]] || return 1
+  IFS=$'\t' read -r token supervisor_pid supervisor_start_ticks < "$WEBSITE_SUPERVISOR_TOKEN_FILE" || return 1
+  [[ -n "$token" && -n "$supervisor_pid" && -n "$supervisor_start_ticks" ]] || return 1
+  if [[ -n "$expected_token" && "$token" != "$expected_token" ]]; then
+    return 1
+  fi
+  is_numeric_pid "$supervisor_pid" || return 1
+  [[ "$supervisor_start_ticks" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\t%s\t%s\n' "$token" "$supervisor_pid" "$supervisor_start_ticks"
+}
+
+remove_supervisor_attestation_if_current() {
+  local expected_token="${1:-}"
+  local token
+  local _supervisor_pid
+  local _supervisor_start_ticks
+
+  [[ -f "$WEBSITE_SUPERVISOR_TOKEN_FILE" ]] || return 0
+  if ! IFS=$'\t' read -r token _supervisor_pid _supervisor_start_ticks < "$WEBSITE_SUPERVISOR_TOKEN_FILE"; then
+    return 0
+  fi
+  if [[ -z "$expected_token" || "$token" == "$expected_token" ]]; then
+    rm -f "$WEBSITE_SUPERVISOR_TOKEN_FILE"
+  fi
+}
+
+resolve_owned_supervisor() {
+  local candidate_pid=""
+  local token=""
+  local attested_pid=""
+  local attested_start_ticks=""
+  local current_start_ticks=""
+  local -a candidates=()
+
+  if [[ -f "$PID_FILE" ]]; then
+    candidate_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
+    is_numeric_pid "$candidate_pid" && candidates+=("$candidate_pid")
+  fi
+
+  if IFS=$'\t' read -r token attested_pid attested_start_ticks < <(read_supervisor_attestation 2>/dev/null || true); then
+    if is_numeric_pid "$attested_pid"; then
+      candidates+=("$attested_pid")
+    fi
+  fi
+
+  for candidate_pid in "${candidates[@]:-}"; do
+    [[ -n "$candidate_pid" ]] || continue
+    current_start_ticks=""
+    if [[ "$candidate_pid" == "$attested_pid" ]]; then
+      current_start_ticks="$attested_start_ticks"
+    elif [[ "$WEBSITE_INSTANCE_CONTRACT_ACTIVE" == "1" ]]; then
+      # A strict preview never authorizes a PID that lacks a recorded start
+      # tick; a reused PID could otherwise target an unrelated WSL process.
+      continue
+    fi
+
+    if is_owned_website_supervisor "$candidate_pid" "$current_start_ticks"; then
+      printf '%s\t%s\n' "$candidate_pid" "$(pid_start_ticks "$candidate_pid")"
+      return 0
+    fi
+  done
+
+  return 1
 }
 
 stop_owned_port_listener() {
   local port="$1"
-  local found_existing=1
+  local supervisor_pid="$2"
+  local supervisor_start_ticks="${3:-}"
   local listening_pid
 
   while IFS= read -r listening_pid; do
     [[ -n "$listening_pid" ]] || continue
-    if is_owned_website_listener "$listening_pid"; then
-      found_existing=0
-      echo "Processo do website local preso na porta $port detectado (PID $listening_pid). Finalizando..."
-      terminate_pid "$listening_pid"
+    if is_owned_website_listener "$listening_pid" "$supervisor_pid" "$supervisor_start_ticks"; then
+      echo "Processo do website local preso na porta $port detectado (PID $listening_pid, supervisor $supervisor_pid). Finalizando..."
+      terminate_pid "$supervisor_pid"
+      return 0
     fi
   done < <(port_listener_pids "$port")
 
-  return "$found_existing"
+  return 1
 }
 
 resolve_website_port() {
@@ -179,7 +418,7 @@ resolve_website_port() {
     return 0
   fi
 
-  if [[ "$WEBSITE_PORT_EXPLICIT" == "1" ]]; then
+  if [[ "$WEBSITE_PORT_EXPLICIT" == "1" && "$WEBSITE_ALLOW_PORT_FALLBACK" != "1" ]]; then
     echo "Porta $port já está em uso. Defina WEBSITE_PORT para outra porta ou finalize o processo atual." >&2
     exit 1
   fi
@@ -199,25 +438,35 @@ resolve_website_port() {
 
 stop_existing_site() {
   local found_existing=0
-  local existing_pid
+  local owned_supervisor=""
+  local owned_supervisor_pid=""
+  local owned_supervisor_start_ticks=""
   local tracked_port
 
-  if [ -f "$PID_FILE" ]; then
-    existing_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
-    if [ -n "$existing_pid" ] && kill -0 "$existing_pid" >/dev/null 2>&1; then
-      found_existing=1
-      echo "Instância anterior detectada (PID $existing_pid). Finalizando..."
-      terminate_pid "$existing_pid"
-    fi
-    rm -f "$PID_FILE"
+  if owned_supervisor="$(resolve_owned_supervisor 2>/dev/null || true)"; then
+    IFS=$'\t' read -r owned_supervisor_pid owned_supervisor_start_ticks <<<"$owned_supervisor"
+  fi
+
+  if [[ -n "$owned_supervisor_pid" ]]; then
+    found_existing=1
+    echo "Instância anterior comprovada (PID $owned_supervisor_pid). Finalizando..."
+    terminate_pid "$owned_supervisor_pid"
   fi
 
   if [ -f "$PORT_FILE" ]; then
     tracked_port="$(cat "$PORT_FILE" 2>/dev/null || true)"
-    if [[ -n "$tracked_port" ]] && stop_owned_port_listener "$tracked_port"; then
+    if [[ -n "$tracked_port" && -n "$owned_supervisor_pid" ]] && stop_owned_port_listener "$tracked_port" "$owned_supervisor_pid" "$owned_supervisor_start_ticks"; then
       found_existing=1
     fi
-    rm -f "$PORT_FILE"
+  fi
+
+  # Stale PID/port files are not ownership proof.  Remove the pointers, but
+  # leave an unverified listener alone; resolve_website_port will lease another
+  # safe port instead of taking over or killing it.
+  rm -f "$PID_FILE" "$PORT_FILE"
+  if [[ "$found_existing" -eq 1 && "$WEBSITE_INSTANCE_CONTRACT_ACTIVE" == "1" ]]; then
+    remove_supervisor_attestation_if_current
+    rm -f "$WEBSITE_INSTANCE_STATE_FILE"
   fi
 
   if [ "$found_existing" -eq 1 ]; then
@@ -236,6 +485,110 @@ wait_for_site() {
     sleep 1
     retries=$((retries - 1))
   done
+  return 1
+}
+
+response_matches_instance_identity() {
+  local url="$1"
+  local headers_file
+  local status=0
+
+  [[ "$WEBSITE_INSTANCE_CONTRACT_ACTIVE" == "1" ]] || return 0
+  headers_file="$(mktemp "${TMPDIR:-/tmp}/skincos-preview-headers.XXXXXX")"
+  if ! curl -fsS -D "$headers_file" -o /dev/null --max-time 3 "$url" >/dev/null 2>&1; then
+    status=1
+  elif ! awk \
+    -v fingerprint_header="$WEBSITE_INSTANCE_FINGERPRINT_HEADER" \
+    -v fingerprint="$WEBSITE_INSTANCE_EXPECTED_FINGERPRINT" \
+    -v instance_header="$WEBSITE_INSTANCE_ID_HEADER" \
+    -v instance_id="$WEBSITE_INSTANCE_EXPECTED_ID" '
+      BEGIN {
+        fingerprint_header = tolower(fingerprint_header)
+        instance_header = tolower(instance_header)
+      }
+      {
+        sub(/\r$/, "")
+        separator = index($0, ":")
+        if (separator > 0) {
+          name = tolower(substr($0, 1, separator - 1))
+          value = substr($0, separator + 1)
+          sub(/^[[:space:]]+/, "", value)
+          sub(/[[:space:]]+$/, "", value)
+          if (name == fingerprint_header) {
+            fingerprint_count += 1
+            if (value == fingerprint) fingerprint_match += 1
+          }
+          if (name == instance_header) {
+            instance_count += 1
+            if (value == instance_id) instance_match += 1
+          }
+        }
+      }
+      END { exit !(fingerprint_count == 1 && fingerprint_match == 1 && instance_count == 1 && instance_match == 1) }
+    ' "$headers_file"; then
+    status=1
+  fi
+  rm -f "$headers_file"
+  return "$status"
+}
+
+wait_for_fresh_supervisor() {
+  local expected_token="$1"
+  local retries="${2:-$WEBSITE_START_TIMEOUT}"
+  local attestation
+  local _token
+  local supervisor_pid
+  local supervisor_start_ticks
+
+  while [ "$retries" -gt 0 ]; do
+    attestation="$(read_supervisor_attestation "$expected_token" 2>/dev/null || true)"
+    if [[ -n "$attestation" ]]; then
+      IFS=$'\t' read -r _token supervisor_pid supervisor_start_ticks <<<"$attestation"
+      if is_owned_website_supervisor "$supervisor_pid" "$supervisor_start_ticks"; then
+        printf '%s\t%s\n' "$supervisor_pid" "$supervisor_start_ticks"
+        return 0
+      fi
+    fi
+    sleep 1
+    retries=$((retries - 1))
+  done
+
+  return 1
+}
+
+wait_for_attested_site_or_supervisor() {
+  local url="$1"
+  local supervisor_pid="$2"
+  local supervisor_start_ticks="$3"
+  local retries="${4:-$WEBSITE_START_TIMEOUT}"
+  local listener_pid
+  local listener_owned
+
+  while [ "$retries" -gt 0 ]; do
+    if ! is_owned_website_supervisor "$supervisor_pid" "$supervisor_start_ticks"; then
+      return 2
+    fi
+
+    listener_owned=0
+    while IFS= read -r listener_pid; do
+      [[ -n "$listener_pid" ]] || continue
+      if is_owned_website_listener "$listener_pid" "$supervisor_pid" "$supervisor_start_ticks"; then
+        listener_owned=1
+        break
+      fi
+    done < <(port_listener_pids "$WEBSITE_PORT")
+
+    if [[ "$listener_owned" == "1" ]] && response_matches_instance_identity "$url"; then
+      # Recheck the owned process after the response so a listener replacement
+      # between the port probe and curl cannot be mistaken for this instance.
+      if is_owned_website_supervisor "$supervisor_pid" "$supervisor_start_ticks" && is_owned_website_listener "$listener_pid" "$supervisor_pid" "$supervisor_start_ticks"; then
+        return 0
+      fi
+    fi
+    sleep 1
+    retries=$((retries - 1))
+  done
+
   return 1
 }
 
@@ -258,6 +611,52 @@ wait_for_site_or_supervisor() {
   return 1
 }
 
+write_instance_state() {
+  local supervisor_pid="$1"
+  local supervisor_start_ticks="$2"
+  local state_directory
+  local temporary_file
+
+  [[ "$WEBSITE_INSTANCE_CONTRACT_ACTIVE" == "1" ]] || return 0
+  state_directory="$(dirname "$WEBSITE_INSTANCE_STATE_FILE")"
+  mkdir -p "$state_directory"
+  temporary_file="$WEBSITE_INSTANCE_STATE_FILE.tmp.$$"
+
+  WEBSITE_INSTANCE_STATE_FILE="$WEBSITE_INSTANCE_STATE_FILE" \
+    WEBSITE_INSTANCE_STATE_TEMPORARY_FILE="$temporary_file" \
+    WEBSITE_INSTANCE_STATE_SUPERVISOR_PID="$supervisor_pid" \
+    WEBSITE_INSTANCE_STATE_SUPERVISOR_START_TICKS="$supervisor_start_ticks" \
+    WEBSITE_INSTANCE_STATE_SOURCE_ROOT="$WEBSITE_SOURCE_ROOT" \
+    WEBSITE_INSTANCE_STATE_WEBSITE_DIR="$WEBSITE_DIR" \
+    WEBSITE_INSTANCE_STATE_ROUTE="$WEBSITE_ROUTE" \
+    WEBSITE_INSTANCE_STATE_HOST="$WEBSITE_HOST" \
+    WEBSITE_INSTANCE_STATE_PORT="$WEBSITE_PORT" \
+    WEBSITE_INSTANCE_STATE_FINGERPRINT="$WEBSITE_INSTANCE_EXPECTED_FINGERPRINT" \
+    WEBSITE_INSTANCE_STATE_INSTANCE_ID="$WEBSITE_INSTANCE_EXPECTED_ID" \
+    WEBSITE_INSTANCE_STATE_DIST_DIR="$WEBSITE_LOCAL_PREVIEW_DIST_DIR" \
+    node -e '
+      const fs = require("node:fs")
+      const output = process.env.WEBSITE_INSTANCE_STATE_FILE
+      const temporary = process.env.WEBSITE_INSTANCE_STATE_TEMPORARY_FILE
+      const state = {
+        version: 1,
+        supervisorPid: Number(process.env.WEBSITE_INSTANCE_STATE_SUPERVISOR_PID),
+        supervisorStartTicks: process.env.WEBSITE_INSTANCE_STATE_SUPERVISOR_START_TICKS,
+        sourceRoot: process.env.WEBSITE_INSTANCE_STATE_SOURCE_ROOT,
+        websiteDir: process.env.WEBSITE_INSTANCE_STATE_WEBSITE_DIR,
+        route: process.env.WEBSITE_INSTANCE_STATE_ROUTE,
+        host: process.env.WEBSITE_INSTANCE_STATE_HOST,
+        port: Number(process.env.WEBSITE_INSTANCE_STATE_PORT),
+        fingerprint: process.env.WEBSITE_INSTANCE_STATE_FINGERPRINT,
+        instanceId: process.env.WEBSITE_INSTANCE_STATE_INSTANCE_ID,
+        distDir: process.env.WEBSITE_INSTANCE_STATE_DIST_DIR || null,
+        startedAt: new Date().toISOString(),
+      }
+      fs.writeFileSync(temporary, `${JSON.stringify(state)}\n`, { encoding: "utf8", mode: 0o600 })
+      fs.renameSync(temporary, output)
+    '
+}
+
 open_browser() {
   if command -v open >/dev/null 2>&1; then
     open "$DEFAULT_URL"
@@ -268,6 +667,17 @@ open_browser() {
 
 run_website_supervisor() {
   local server_pid
+  local supervisor_start_ticks
+
+  if [[ "$WEBSITE_INSTANCE_CONTRACT_ACTIVE" == "1" ]]; then
+    supervisor_start_ticks="$(pid_start_ticks "$$" 2>/dev/null || true)"
+    if [[ -z "$WEBSITE_SUPERVISOR_TOKEN" ]]; then
+      WEBSITE_SUPERVISOR_TOKEN="$(date '+%s').$$.$RANDOM"
+    fi
+    if [[ -n "$supervisor_start_ticks" ]]; then
+      write_supervisor_attestation "$$" "$supervisor_start_ticks" "$WEBSITE_SUPERVISOR_TOKEN"
+    fi
+  fi
 
   if [[ "$WEBSITE_SUPERVISOR_MODE" == "1" ]]; then
     nohup npm --prefix "$WEBSITE_DIR" run dev -- --hostname "$WEBSITE_HOST" --port "$WEBSITE_PORT" >>"$LOG_FILE" 2>&1 < /dev/null &
@@ -289,6 +699,9 @@ run_website_supervisor() {
       if [ "$tracked_pid" = "$$" ]; then
         rm -f "$PID_FILE"
         rm -f "$PORT_FILE"
+        if [[ "$WEBSITE_INSTANCE_CONTRACT_ACTIVE" == "1" ]]; then
+          remove_supervisor_attestation_if_current "$WEBSITE_SUPERVISOR_TOKEN"
+        fi
       fi
     fi
   }
@@ -298,6 +711,9 @@ run_website_supervisor() {
 }
 
 start_detached_supervisor() {
+  if [[ "$WEBSITE_INSTANCE_CONTRACT_ACTIVE" == "1" && -z "$WEBSITE_SUPERVISOR_TOKEN" ]]; then
+    WEBSITE_SUPERVISOR_TOKEN="$(date '+%s').$$.$RANDOM"
+  fi
   nohup setsid env \
     OPEN_BROWSER=0 \
     WEBSITE_SUPERVISOR_MODE=1 \
@@ -310,6 +726,24 @@ start_detached_supervisor() {
     WEBSITE_LOG_FILE="$LOG_FILE" \
     WEBSITE_PORT_FILE="$PORT_FILE" \
     WEBSITE_ROUTE="$WEBSITE_ROUTE" \
+    WEBSITE_INSTANCE_FINGERPRINT="$WEBSITE_INSTANCE_FINGERPRINT" \
+    WEBSITE_INSTANCE_ID="$WEBSITE_INSTANCE_ID" \
+    WEBSITE_INSTANCE_EXPECTED_FINGERPRINT="$WEBSITE_INSTANCE_EXPECTED_FINGERPRINT" \
+    WEBSITE_INSTANCE_EXPECTED_ID="$WEBSITE_INSTANCE_EXPECTED_ID" \
+    WEBSITE_INSTANCE_FINGERPRINT_HEADER="$WEBSITE_INSTANCE_FINGERPRINT_HEADER" \
+    WEBSITE_INSTANCE_ID_HEADER="$WEBSITE_INSTANCE_ID_HEADER" \
+    WEBSITE_INSTANCE_STATE_FILE="$WEBSITE_INSTANCE_STATE_FILE" \
+    WEBSITE_SUPERVISOR_TOKEN_FILE="$WEBSITE_SUPERVISOR_TOKEN_FILE" \
+    WEBSITE_SUPERVISOR_TOKEN="$WEBSITE_SUPERVISOR_TOKEN" \
+    WEBSITE_ALLOW_PORT_FALLBACK="$WEBSITE_ALLOW_PORT_FALLBACK" \
+    WEBSITE_LOCAL_PREVIEW_DIST_DIR="$WEBSITE_LOCAL_PREVIEW_DIST_DIR" \
+    SKINCOS_LOCAL_PREVIEW_DIST_DIR="$SKINCOS_LOCAL_PREVIEW_DIST_DIR" \
+    SKINCOS_LOCAL_PREVIEW="${SKINCOS_LOCAL_PREVIEW:-}" \
+    SKINCOS_LOCAL_PREVIEW_FINGERPRINT="$SKINCOS_LOCAL_PREVIEW_FINGERPRINT" \
+    SKINCOS_LOCAL_PREVIEW_INSTANCE="$SKINCOS_LOCAL_PREVIEW_INSTANCE" \
+    NEXT_TELEMETRY_DISABLED="${NEXT_TELEMETRY_DISABLED:-}" \
+    NEXT_PUBLIC_BUILD_SHA="${NEXT_PUBLIC_BUILD_SHA:-}" \
+    NEXT_PUBLIC_BUILD_TIME="${NEXT_PUBLIC_BUILD_TIME:-}" \
     TMPDIR="${TMPDIR:-}" \
     TMP="${TMP:-}" \
     TEMP="${TEMP:-}" \
@@ -338,6 +772,13 @@ ensure_website_dependencies() {
     npm --prefix "$WEBSITE_DIR" install --no-save workerd
   fi
 }
+
+# Shell fixtures source the reusable process and readiness helpers without
+# launching npm.  This branch is intentionally opt-in and has no effect on
+# normal callers.
+if [[ "${RUN_LOCAL_WEBSITE_LIBRARY:-0}" == "1" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
 
 if ! command -v npm >/dev/null 2>&1; then
   echo "npm não encontrado no PATH."
@@ -400,9 +841,26 @@ printf '\n[%s] Starting website local on %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$
 
 if [[ "$WEBSITE_DETACH" == "1" ]]; then
   startup_status=0
+  supervisor_attestation=""
+  supervisor_pid=""
+  supervisor_start_ticks=""
+  rm -f "$WEBSITE_SUPERVISOR_TOKEN_FILE"
   start_detached_supervisor
-  wait_for_site_or_supervisor "$DEFAULT_URL" "${DETACHED_SUPERVISOR_PID:-}" || startup_status=$?
+  if [[ "$WEBSITE_INSTANCE_CONTRACT_ACTIVE" == "1" ]]; then
+    supervisor_attestation="$(wait_for_fresh_supervisor "$WEBSITE_SUPERVISOR_TOKEN" || true)"
+    if [[ -z "$supervisor_attestation" ]]; then
+      startup_status=2
+    else
+      IFS=$'\t' read -r supervisor_pid supervisor_start_ticks <<<"$supervisor_attestation"
+      wait_for_attested_site_or_supervisor "$DEFAULT_URL" "$supervisor_pid" "$supervisor_start_ticks" || startup_status=$?
+    fi
+  else
+    wait_for_site_or_supervisor "$DEFAULT_URL" "${DETACHED_SUPERVISOR_PID:-}" || startup_status=$?
+  fi
   if [[ "$startup_status" -eq 0 ]]; then
+    if [[ "$WEBSITE_INSTANCE_CONTRACT_ACTIVE" == "1" ]]; then
+      write_instance_state "$supervisor_pid" "$supervisor_start_ticks"
+    fi
     echo "Website local pronto em $DEFAULT_URL"
     exit 0
   fi

--- a/scripts/start-beauty-movement-local-preview.ps1
+++ b/scripts/start-beauty-movement-local-preview.ps1
@@ -1,215 +1,487 @@
 [CmdletBinding()]
 param(
     [switch]$Stop,
-    [switch]$NoBrowser
+    [switch]$NoBrowser,
+    [ValidateRange(1024, 65535)][int]$Port = 3417,
+    [string]$StateRoot
 )
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 $LASTEXITCODE = 0
 
-# This launcher intentionally resolves the checkout from its own location. It
-# therefore follows the worktree that contains the Action instead of a shared
-# campaign checkout or the former private environment.
-$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
-$projectRoot = Split-Path -Parent $scriptRoot
-$wslInvoker = Join-Path $scriptRoot 'invoke-skincos-wsl.ps1'
-$websiteRoot = Join-Path $projectRoot 'website'
-
+$previewProtocol = 'beauty-movement-local-preview-v2'
+$buildContract = 'next-dev-isolated-v1'
+$moduleName = 'website'
 $route = '/beleza-em-movimento/local-preview'
-$port = 3417
-$url = "http://127.0.0.1:$port$route"
+$fingerprintHeader = 'X-Skincos-Preview-Fingerprint'
+$instanceHeader = 'X-Skincos-Preview-Instance'
 
-if (-not (Test-Path -LiteralPath $wslInvoker -PathType Leaf)) {
-    throw "The typed WSL gateway is unavailable: $wslInvoker"
-}
-if (-not (Test-Path -LiteralPath $websiteRoot -PathType Container)) {
-    throw "The website directory is unavailable in this checkout: $websiteRoot"
-}
-if ([string]::IsNullOrWhiteSpace([string]$env:LOCALAPPDATA)) {
-    throw 'LOCALAPPDATA is required for the private local-preview state.'
-}
-
-$stateRoot = Join-Path $env:LOCALAPPDATA 'Codex\skincos\beauty-movement-local-preview'
-$manifestPath = Join-Path $stateRoot 'current.json'
-$pidPath = Join-Path $stateRoot 'server.pid'
-$portPath = Join-Path $stateRoot 'server.port'
-$logPath = Join-Path $stateRoot 'server.log'
-
-function Convert-WindowsPathToWsl {
-    param([Parameter(Mandatory = $true)][string]$Path)
-
-    if ($Path -match '^(?<drive>[A-Za-z]):[\\/](?<rest>.*)$') {
-        return "/mnt/$($Matches.drive.ToLowerInvariant())/$($Matches.rest -replace '\\', '/')"
-    }
-
-    throw "Cannot convert the checkout path to WSL: $Path"
-}
+# Resolve only the worktree that owns this Action; never search for a different
+# Beauty Movement checkout by branch, timestamp, or fixed path.
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$projectRoot = (Resolve-Path -LiteralPath (Split-Path -Parent $scriptRoot)).Path
+$wslInvoker = Join-Path $scriptRoot 'invoke-skincos-wsl.ps1'
+$materializer = Join-Path $scriptRoot 'materialize-website-local-preview-source.sh'
+$websiteRoot = Join-Path $projectRoot $moduleName
+$previewPage = Join-Path $websiteRoot 'src\app\beleza-em-movimento\local-preview\page.tsx'
 
 function Get-Sha256 {
     param([Parameter(Mandatory = $true)][string]$Value)
-
     $hasher = [Security.Cryptography.SHA256]::Create()
     try {
         $bytes = [Text.Encoding]::UTF8.GetBytes($Value)
         return (($hasher.ComputeHash($bytes) | ForEach-Object { $_.ToString('x2') }) -join '')
     }
-    finally {
-        $hasher.Dispose()
+    finally { $hasher.Dispose() }
+}
+
+function Convert-WindowsPathToWsl {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    if ($Path -match '^(?<drive>[A-Za-z]):[\\/](?<rest>.*)$') {
+        return "/mnt/$($Matches.drive.ToLowerInvariant())/$($Matches.rest -replace '\\', '/')"
+    }
+    throw "Cannot convert the checkout path to WSL: $Path"
+}
+
+function Test-ExactPath {
+    param([AllowNull()][string]$Left, [AllowNull()][string]$Right)
+    if ([string]::IsNullOrWhiteSpace($Left) -or [string]::IsNullOrWhiteSpace($Right)) { return $false }
+    $normalizedLeft = $Left.TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)
+    $normalizedRight = $Right.TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)
+    return $normalizedLeft.Equals($normalizedRight, [StringComparison]::OrdinalIgnoreCase)
+}
+
+function Assert-ActionSourceRoot {
+    if (-not (Test-Path -LiteralPath $wslInvoker -PathType Leaf)) {
+        throw "The typed WSL gateway is unavailable: $wslInvoker"
+    }
+    if (-not (Test-Path -LiteralPath $materializer -PathType Leaf)) {
+        throw "The private preview materializer is unavailable: $materializer"
+    }
+    if (-not (Test-Path -LiteralPath $websiteRoot -PathType Container) -or -not (Test-Path -LiteralPath $previewPage -PathType Leaf)) {
+        throw "This Codex Action must be opened from a worktree containing $moduleName and the Beauty Movement local-preview route. Resolved worktree: $projectRoot"
+    }
+    $gitTopOutput = @(& git -C $projectRoot rev-parse --show-toplevel 2>$null)
+    $gitTopExitCode = $LASTEXITCODE
+    $gitTop = ([string]($gitTopOutput | Select-Object -First 1)).Trim()
+    if ($gitTopExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($gitTop)) {
+        throw "The Action worktree is not a Git checkout: $projectRoot"
+    }
+    $resolvedGitTop = (Resolve-Path -LiteralPath $gitTop).Path
+    if (-not (Test-ExactPath -Left $resolvedGitTop -Right $projectRoot)) {
+        throw "The Action script is not rooted at its Git checkout. Script worktree: $projectRoot; Git worktree: $resolvedGitTop"
     }
 }
 
-function Get-SourceIdentity {
-    $commitOutput = @(& git -C $projectRoot rev-parse --verify 'HEAD^{commit}' 2>$null)
-    $commitExitCode = $LASTEXITCODE
-    $commit = ([string]($commitOutput | Select-Object -First 1)).Trim().ToLowerInvariant()
-    if ($commitExitCode -ne 0 -or $commit -notmatch '^[0-9a-f]{40}$') {
-        throw "Could not resolve the checkout commit from $projectRoot."
+function Invoke-PreviewWsl {
+    param(
+        [Parameter(Mandatory = $true)][ValidateSet('Executable', 'BashScript')][string]$Mode,
+        [Parameter(Mandatory = $true)][string]$Target,
+        [string[]]$Arguments = @(),
+        [string[]]$EnvironmentVariables = @()
+    )
+    $parameters = @{
+        ProjectRoot = $projectRoot
+        Argument = $Arguments
+        EnvVar = $EnvironmentVariables
+        SkipBootstrapCheck = $true
     }
-
-    $trackedDiffOutput = @(& git -C $projectRoot diff --binary HEAD -- website 2>$null)
-    $trackedDiffExitCode = $LASTEXITCODE
-    $trackedDiff = $trackedDiffOutput -join "`n"
-    if ($trackedDiffExitCode -ne 0) {
-        throw "Could not inspect website changes in $projectRoot."
+    if ($Mode -eq 'Executable') {
+        $parameters.Executable = $Target
     }
-
-    $statusOutput = @(& git -C $projectRoot status --short --untracked-files=all -- website 2>$null)
-    $statusExitCode = $LASTEXITCODE
-    $status = $statusOutput -join "`n"
-    if ($statusExitCode -ne 0) {
-        throw "Could not inspect website status in $projectRoot."
+    else {
+        $parameters.ScriptPath = $Target
     }
-
-    $untrackedPaths = @(& git -C $projectRoot ls-files --others --exclude-standard -- 'website/*' 2>$null)
-    $untrackedExitCode = $LASTEXITCODE
-    if ($untrackedExitCode -ne 0) {
-        throw "Could not inspect untracked website files in $projectRoot."
+    $output = & $wslInvoker @parameters
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        $detail = (@($output) -join [Environment]::NewLine).Trim()
+        if ([string]::IsNullOrWhiteSpace($detail)) { $detail = 'no diagnostic output' }
+        throw "The Beauty Movement local preview command failed ($Target, exit $exitCode): $detail"
     }
+    return @($output)
+}
 
-    $untrackedDigests = foreach ($relativePath in $untrackedPaths) {
-        $candidate = Join-Path $projectRoot ([string]$relativePath)
-        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
-            $hash = (Get-FileHash -LiteralPath $candidate -Algorithm SHA256).Hash.ToLowerInvariant()
-            "${relativePath}:$hash"
+function Invoke-PreviewStateTool {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+    $output = Invoke-PreviewWsl -Mode Executable -Target 'node' -Arguments (@('scripts/website-local-preview-state.mjs') + $Arguments)
+    $json = (@($output) -join [Environment]::NewLine).Trim()
+    if ([string]::IsNullOrWhiteSpace($json)) { throw 'The preview identity helper returned no JSON.' }
+    try { $document = $json | ConvertFrom-Json -ErrorAction Stop }
+    catch { throw "The preview identity helper returned invalid JSON: $json" }
+    if ($document.ok -ne $true) { throw "The preview identity helper rejected the request: $json" }
+    return $document
+}
+
+function Get-PreviewIdentity {
+    param([Parameter(Mandatory = $true)][string]$SourceRootWsl)
+    $identity = Invoke-PreviewStateTool -Arguments @(
+        'identity', '--source-root', $SourceRootWsl, '--route', $route,
+        '--protocol', $previewProtocol, '--build-contract', $buildContract, '--json'
+    )
+    if ([int]$identity.version -ne 2 -or
+        [string]$identity.module -ne $moduleName -or
+        [string]$identity.route -ne $route -or
+        [string]$identity.protocol -ne $previewProtocol -or
+        [string]$identity.buildContract -ne $buildContract -or
+        [string]$identity.instanceFingerprint -notmatch '^sha256:[0-9a-f]{64}$' -or
+        [string]$identity.inputFingerprint -notmatch '^sha256:[0-9a-f]{64}$' -or
+        [string]$identity.contractFingerprint -notmatch '^sha256:[0-9a-f]{64}$' -or
+        [string]$identity.cacheKey -notmatch '^[0-9a-f]{64}$') {
+        throw 'The preview identity helper returned an invalid v2 identity.'
+    }
+    return $identity
+}
+
+function Get-DependencyFingerprint {
+    param([Parameter(Mandatory = $true)][string]$WebsitePath)
+    $names = @('package.json', 'package-lock.json', 'npm-shrinkwrap.json', '.npmrc')
+    $descriptor = New-Object Text.StringBuilder
+    [void]$descriptor.Append("skincos:website-local-preview-dependencies:v1`0")
+    foreach ($name in $names) {
+        $path = Join-Path $WebsitePath $name
+        [void]$descriptor.Append($name).Append("`0")
+        if (Test-Path -LiteralPath $path -PathType Leaf) {
+            $fileHash = (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash.ToLowerInvariant()
+            [void]$descriptor.Append($fileHash)
         }
+        else { [void]$descriptor.Append('missing') }
+        [void]$descriptor.Append("`n")
     }
+    return "sha256:$(Get-Sha256 -Value $descriptor.ToString())"
+}
 
-    $payload = @(
-        "commit=$commit"
-        "status=$status"
-        "diff=$trackedDiff"
-        "untracked=$($untrackedDigests -join "`n")"
-    ) -join "`n"
-    $digest = Get-Sha256 -Value $payload
+function Get-MaterializedSourcePath {
+    param([Parameter(Mandatory = $true)][object]$Identity)
+    return (Join-Path (Join-Path $stateRoot 'source') ([string]$Identity.cacheKey))
+}
 
-    [ordered]@{
-        commit = $commit
-        digest = $digest
-        fingerprint = "local:${commit}:$digest"
+function Get-MaterializedDependencyPath {
+    param([Parameter(Mandatory = $true)][string]$DependencyFingerprint)
+    $key = (Get-Sha256 -Value $DependencyFingerprint).Substring(0, 40)
+    return (Join-Path (Join-Path $stateRoot 'dependencies') $key)
+}
+
+function Materialize-PreviewSource {
+    param([Parameter(Mandatory = $true)][object]$Identity, [Parameter(Mandatory = $true)][string]$ActionSourceRootWsl)
+    $destination = Get-MaterializedSourcePath -Identity $Identity
+    $dependencyFingerprint = Get-DependencyFingerprint -WebsitePath $websiteRoot
+    $dependencyRoot = Get-MaterializedDependencyPath -DependencyFingerprint $dependencyFingerprint
+    $dependencyStatePath = Join-Path $dependencyRoot 'website\.preview-dependencies.state'
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $destination), $dependencyRoot | Out-Null
+    $destinationWsl = Convert-WindowsPathToWsl -Path $destination
+    $dependencyRootWsl = Convert-WindowsPathToWsl -Path $dependencyRoot
+    $dependencyStateWsl = Convert-WindowsPathToWsl -Path $dependencyStatePath
+    $output = Invoke-PreviewWsl -Mode BashScript -Target './scripts/materialize-website-local-preview-source.sh' -EnvironmentVariables @(
+        "PREVIEW_MATERIALIZE_SOURCE_ROOT=$ActionSourceRootWsl", "PREVIEW_MATERIALIZE_DESTINATION_ROOT=$destinationWsl",
+        "PREVIEW_MATERIALIZE_ALLOWED_ROOT=$stateRootWsl", "PREVIEW_MATERIALIZE_DEPENDENCY_ROOT=$dependencyRootWsl",
+        "PREVIEW_MATERIALIZE_DEPENDENCY_STATE_FILE=$dependencyStateWsl"
+    )
+    foreach ($line in @($output)) { if ($null -ne $line) { Write-Host ([string]$line) } }
+    return [pscustomobject]@{
+        sourceRoot = $destination
+        sourceRootWsl = $destinationWsl
+        dependencyRoot = $dependencyRoot
+        dependencyFingerprint = $dependencyFingerprint
     }
+}
+
+function Read-JsonFile {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return $null }
+    try { return (Get-Content -LiteralPath $Path -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop) }
+    catch { return $null }
+}
+
+function Write-AtomicJson {
+    param([Parameter(Mandatory = $true)][string]$Path, [Parameter(Mandatory = $true)][object]$Value)
+    $directory = Split-Path -Parent $Path
+    New-Item -ItemType Directory -Force -Path $directory | Out-Null
+    $temporaryPath = Join-Path $directory (".$([IO.Path]::GetFileName($Path)).$([Guid]::NewGuid().ToString('N')).tmp")
+    try {
+        $Value | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $temporaryPath -Encoding utf8 -NoNewline
+        Move-Item -LiteralPath $temporaryPath -Destination $Path -Force
+    }
+    finally { Remove-Item -LiteralPath $temporaryPath -Force -ErrorAction SilentlyContinue }
+}
+
+function Get-HeaderValue {
+    param([Parameter(Mandatory = $true)][object]$Response, [Parameter(Mandatory = $true)][string]$Name)
+    $value = $Response.Headers[$Name]
+    if ($value -is [Array]) { return ([string]($value | Select-Object -First 1)).Trim() }
+    return ([string]$value).Trim()
 }
 
 function Test-PreviewReady {
+    param(
+        [Parameter(Mandatory = $true)][string]$Url,
+        [Parameter(Mandatory = $true)][string]$Fingerprint,
+        [Parameter(Mandatory = $true)][string]$InstanceId
+    )
     try {
-        $response = Invoke-WebRequest -Uri $url -UseBasicParsing -TimeoutSec 3
-        return $response.StatusCode -eq 200 -and
+        $response = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 5
+        $valid = $response.StatusCode -eq 200 -and
+            (Get-HeaderValue -Response $response -Name $fingerprintHeader) -ceq $Fingerprint -and
+            (Get-HeaderValue -Response $response -Name $instanceHeader) -ceq $InstanceId -and
             $response.Content -match 'Beleza que se move com você' -and
             $response.Content -match 'Novo Hamburgo'
+        return [pscustomobject]@{ Ready = $valid; Response = $response }
     }
-    catch {
-        return $false
-    }
+    catch { return [pscustomobject]@{ Ready = $false; Response = $null } }
 }
 
-function Invoke-WebsiteLauncher {
+function Get-VerifiedRunnerState {
     param(
-        [Parameter(Mandatory = $true)][string[]]$EnvironmentVariables,
-        [string[]]$Arguments = @()
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][object]$Identity,
+        [Parameter(Mandatory = $true)][string]$SourceRootWsl,
+        [Parameter(Mandatory = $true)][string]$InstanceId,
+        [Parameter(Mandatory = $true)][int]$ExpectedPort,
+        [Parameter(Mandatory = $true)][string]$ExpectedDistDir
     )
-
-    $output = & $wslInvoker `
-        -ProjectRoot $projectRoot `
-        -ScriptPath './scripts/run-local-website.sh' `
-        -Argument $Arguments `
-        -EnvVar $EnvironmentVariables `
-        -SkipBootstrapCheck
-
-    $exitCode = $LASTEXITCODE
-    foreach ($line in @($output)) {
-        if ($null -ne $line) {
-            Write-Host ([string]$line)
-        }
-    }
-    if ($exitCode -ne 0) {
-        throw "The website local preview command failed with exit code $exitCode."
-    }
+    $state = Read-JsonFile -Path $Path
+    if ($null -eq $state -or
+        [int]$state.version -ne 1 -or
+        [string]$state.sourceRoot -ne $SourceRootWsl -or
+        [string]$state.websiteDir -ne "$SourceRootWsl/$moduleName" -or
+        [string]$state.route -ne $route -or
+        [string]$state.host -ne '127.0.0.1' -or
+        [int]$state.port -ne $ExpectedPort -or
+        [string]$state.fingerprint -ne [string]$Identity.instanceFingerprint -or
+        [string]$state.instanceId -ne $InstanceId -or
+        [string]$state.distDir -ne $ExpectedDistDir -or
+        [int]$state.supervisorPid -le 0 -or
+        [string]$state.supervisorStartTicks -notmatch '^[0-9]+$') { return $null }
+    return $state
 }
 
-New-Item -ItemType Directory -Force -Path $stateRoot | Out-Null
-$sourceIdentity = Get-SourceIdentity
+function Test-VerifiedSupervisor {
+    param([Parameter(Mandatory = $true)][object]$RunnerState, [Parameter(Mandatory = $true)][string]$SourceRootWsl)
+    try {
+        $probe = Invoke-PreviewStateTool -Arguments @(
+            'process', '--pid', ([string]$RunnerState.supervisorPid), '--source-root', $SourceRootWsl,
+            '--expected-start-ticks', ([string]$RunnerState.supervisorStartTicks),
+            '--script-marker', 'scripts/run-local-website.sh', '--json'
+        )
+        return $probe.valid -eq $true
+    }
+    catch { return $false }
+}
+
+function Test-ReusablePreview {
+    param(
+        [AllowNull()][object]$Manifest,
+        [Parameter(Mandatory = $true)][object]$Identity,
+        [Parameter(Mandatory = $true)][string]$ActionSourceRootWsl,
+        [Parameter(Mandatory = $true)][string]$MaterializedSourceRootWsl,
+        [Parameter(Mandatory = $true)][string]$RunnerStatePath
+    )
+    if ($null -eq $Manifest) { return [pscustomobject]@{ Reusable = $false; Reason = 'manifest_missing_or_invalid' } }
+    if ([int]$Manifest.version -ne 2 -or [string]$Manifest.state -ne 'ready' -or
+        [string]$Manifest.projectRoot -ne $projectRoot -or [string]$Manifest.sourceRootWsl -ne $ActionSourceRootWsl -or
+        [string]$Manifest.materializedSourceRootWsl -ne $MaterializedSourceRootWsl -or
+        [string]$Manifest.module -ne $moduleName -or [string]$Manifest.route -ne $route -or
+        [string]$Manifest.protocol -ne $previewProtocol -or [string]$Manifest.buildContract -ne $buildContract -or
+        [string]$Manifest.instanceFingerprint -ne [string]$Identity.instanceFingerprint -or
+        [string]$Manifest.inputFingerprint -ne [string]$Identity.inputFingerprint -or
+        [string]$Manifest.contractFingerprint -ne [string]$Identity.contractFingerprint -or
+        [string]$Manifest.cacheKey -notmatch '^[0-9a-f]{64}$' -or
+        [string]$Manifest.distDir -notmatch '^\.next-codex-preview/[0-9a-f]{64}-[0-9a-f]{12}$' -or
+        [string]$Manifest.instanceId -notmatch '^[0-9a-f]{32}$' -or
+        [int]$Manifest.port -lt 1024 -or [int]$Manifest.port -gt 65535 -or
+        [int]$Manifest.supervisorPid -le 0 -or [string]$Manifest.supervisorStartTicks -notmatch '^[0-9]+$') {
+        return [pscustomobject]@{ Reusable = $false; Reason = 'manifest_contract_mismatch' }
+    }
+    $expectedUrl = "http://127.0.0.1:$([int]$Manifest.port)$route"
+    if ([string]$Manifest.url -ne $expectedUrl) { return [pscustomobject]@{ Reusable = $false; Reason = 'manifest_url_mismatch' } }
+    $runnerState = Get-VerifiedRunnerState -Path $RunnerStatePath -Identity $Identity -SourceRootWsl $MaterializedSourceRootWsl `
+        -InstanceId ([string]$Manifest.instanceId) -ExpectedPort ([int]$Manifest.port) -ExpectedDistDir ([string]$Manifest.distDir)
+    if ($null -eq $runnerState -or [int]$runnerState.supervisorPid -ne [int]$Manifest.supervisorPid -or
+        [string]$runnerState.supervisorStartTicks -ne [string]$Manifest.supervisorStartTicks) {
+        return [pscustomobject]@{ Reusable = $false; Reason = 'runner_state_mismatch' }
+    }
+    if (-not (Test-VerifiedSupervisor -RunnerState $runnerState -SourceRootWsl $MaterializedSourceRootWsl)) {
+        return [pscustomobject]@{ Reusable = $false; Reason = 'supervisor_not_proven' }
+    }
+    $ready = Test-PreviewReady -Url $expectedUrl -Fingerprint ([string]$Identity.instanceFingerprint) -InstanceId ([string]$Manifest.instanceId)
+    if (-not $ready.Ready) { return [pscustomobject]@{ Reusable = $false; Reason = 'served_attestation_mismatch' } }
+    return [pscustomobject]@{ Reusable = $true; Reason = 'verified'; Url = $expectedUrl; RunnerState = $runnerState }
+}
+
+function Get-OwnedPreviewSupervisor {
+    param(
+        [AllowNull()][object]$Manifest,
+        [Parameter(Mandatory = $true)][string]$ActionSourceRootWsl,
+        [Parameter(Mandatory = $true)][string]$RunnerStatePath
+    )
+    if ($null -eq $Manifest -or [int]$Manifest.version -ne 2 -or [string]$Manifest.projectRoot -ne $projectRoot -or
+        [string]$Manifest.sourceRootWsl -ne $ActionSourceRootWsl -or [string]$Manifest.materializedSourceRootWsl -notlike "$stateRootWsl/source/*" -or
+        [int]$Manifest.port -lt 1024 -or [int]$Manifest.port -gt 65535 -or [int]$Manifest.supervisorPid -le 0 -or
+        [string]$Manifest.supervisorStartTicks -notmatch '^[0-9]+$' -or [string]$Manifest.instanceId -notmatch '^[0-9a-f]{32}$') {
+        return $null
+    }
+    $runnerState = Read-JsonFile -Path $RunnerStatePath
+    if ($null -eq $runnerState -or [int]$runnerState.version -ne 1 -or
+        [string]$runnerState.sourceRoot -ne [string]$Manifest.materializedSourceRootWsl -or
+        [string]$runnerState.websiteDir -ne "$($Manifest.materializedSourceRootWsl)/$moduleName" -or
+        [string]$runnerState.route -ne $route -or [string]$runnerState.host -ne '127.0.0.1' -or
+        [int]$runnerState.port -ne [int]$Manifest.port -or [string]$runnerState.instanceId -ne [string]$Manifest.instanceId -or
+        [int]$runnerState.supervisorPid -ne [int]$Manifest.supervisorPid -or
+        [string]$runnerState.supervisorStartTicks -ne [string]$Manifest.supervisorStartTicks) {
+        return $null
+    }
+    if (-not (Test-VerifiedSupervisor -RunnerState $runnerState -SourceRootWsl ([string]$Manifest.materializedSourceRootWsl))) { return $null }
+    return $runnerState
+}
+
+function Get-SelectedPort {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { throw "The preview runner did not publish a selected port: $Path" }
+    $raw = (Get-Content -LiteralPath $Path -Raw -ErrorAction Stop).Trim()
+    $selected = 0
+    if (-not [int]::TryParse($raw, [ref]$selected) -or $selected -lt 1024 -or $selected -gt 65535) {
+        throw "The preview runner published an invalid port: $raw"
+    }
+    return $selected
+}
+
+function Invoke-WebsiteRunner {
+    param([Parameter(Mandatory = $true)][string[]]$EnvironmentVariables, [string[]]$Arguments = @())
+    $output = Invoke-PreviewWsl -Mode BashScript -Target './scripts/run-local-website.sh' -Arguments $Arguments -EnvironmentVariables $EnvironmentVariables
+    foreach ($line in @($output)) { if ($null -ne $line) { Write-Host ([string]$line) } }
+}
+
+function Get-BaseRunnerEnvironment {
+    param([Parameter(Mandatory = $true)][string]$RunnerSourceRootWsl)
+    return @(
+        "WEBSITE_SOURCE_ROOT=$RunnerSourceRootWsl", 'WEBSITE_HOST=127.0.0.1', "WEBSITE_PORT=$Port", "WEBSITE_ROUTE=$route",
+        "WEBSITE_STATE_DIR=$stateRootWsl", "WEBSITE_PID_FILE=$pidPathWsl", "WEBSITE_PORT_FILE=$portPathWsl",
+        "WEBSITE_LOG_FILE=$logPathWsl", "WEBSITE_INSTANCE_STATE_FILE=$runnerStatePathWsl",
+        "WEBSITE_SUPERVISOR_TOKEN_FILE=$supervisorTokenPathWsl", 'WEBSITE_DETACH=1', 'WEBSITE_ALLOW_PORT_FALLBACK=1',
+        'OPEN_BROWSER=0', 'SKINCOS_LOCAL_PREVIEW=true', 'NEXT_TELEMETRY_DISABLED=1'
+    )
+}
+
+Assert-ActionSourceRoot
+if ([string]::IsNullOrWhiteSpace([string]$env:LOCALAPPDATA)) { throw 'LOCALAPPDATA is required for the private local-preview state.' }
+
+$worktreeKey = (Get-Sha256 -Value $projectRoot).Substring(0, 20)
+if ([string]::IsNullOrWhiteSpace($StateRoot)) {
+    $stateRoot = Join-Path $env:LOCALAPPDATA "Codex\skincos\beauty-movement-local-preview\v2\$worktreeKey"
+}
+else { $stateRoot = [IO.Path]::GetFullPath($StateRoot) }
+
+$manifestPath = Join-Path $stateRoot 'current.json'
+$pidPath = Join-Path $stateRoot 'server.pid'
+$portPath = Join-Path $stateRoot 'server.port'
+$logPath = Join-Path $stateRoot 'server.log'
+$runnerStatePath = Join-Path $stateRoot 'instance.json'
+$supervisorTokenPath = Join-Path $stateRoot 'supervisor.token'
 $sourceRootWsl = Convert-WindowsPathToWsl -Path $projectRoot
 $stateRootWsl = Convert-WindowsPathToWsl -Path $stateRoot
 $pidPathWsl = Convert-WindowsPathToWsl -Path $pidPath
 $portPathWsl = Convert-WindowsPathToWsl -Path $portPath
 $logPathWsl = Convert-WindowsPathToWsl -Path $logPath
+$runnerStatePathWsl = Convert-WindowsPathToWsl -Path $runnerStatePath
+$supervisorTokenPathWsl = Convert-WindowsPathToWsl -Path $supervisorTokenPath
 
-$environmentVariables = @(
-    "WEBSITE_SOURCE_ROOT=$sourceRootWsl",
-    'WEBSITE_HOST=127.0.0.1',
-    "WEBSITE_PORT=$port",
-    "WEBSITE_ROUTE=$route",
-    "WEBSITE_STATE_DIR=$stateRootWsl",
-    "WEBSITE_PID_FILE=$pidPathWsl",
-    "WEBSITE_PORT_FILE=$portPathWsl",
-    "WEBSITE_LOG_FILE=$logPathWsl",
-    'WEBSITE_DETACH=1',
-    'OPEN_BROWSER=0',
-    'SKINCOS_LOCAL_PREVIEW=true',
-    'NEXT_TELEMETRY_DISABLED=1'
-)
+New-Item -ItemType Directory -Force -Path $stateRoot | Out-Null
+$mutex = New-Object Threading.Mutex($false, "Local\SkincosBeautyMovementPreviewV2_$worktreeKey")
+$lockTaken = $false
+try {
+    try { $lockTaken = $mutex.WaitOne([TimeSpan]::FromSeconds(120)) }
+    catch [Threading.AbandonedMutexException] { $lockTaken = $true }
+    if (-not $lockTaken) { throw 'Another invocation of this Beauty Movement Action is still reconciling the local preview.' }
 
-if ($Stop) {
-    Invoke-WebsiteLauncher -EnvironmentVariables $environmentVariables -Arguments @('--stop')
-    Remove-Item -LiteralPath $manifestPath -Force -ErrorAction SilentlyContinue
-    Write-Output 'Cartas da Beleza – Prévia Local encerrada.'
-    exit 0
-}
+    $actionSourceRootWsl = $sourceRootWsl
+    $identity = Get-PreviewIdentity -SourceRootWsl $actionSourceRootWsl
+    $candidateMaterializedSource = Get-MaterializedSourcePath -Identity $identity
+    $candidateMaterializedSourceWsl = Convert-WindowsPathToWsl -Path $candidateMaterializedSource
+    $current = Read-JsonFile -Path $manifestPath
 
-if (Test-Path -LiteralPath $manifestPath -PathType Leaf) {
-    try {
-        $current = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
-        if ([string]$current.sourceFingerprint -eq [string]$sourceIdentity.fingerprint -and (Test-PreviewReady)) {
-            Write-Output "Cartas da Beleza – Prévia Local já está pronta: $url"
-            if (-not $NoBrowser) {
-                Start-Process $url | Out-Null
-            }
-            exit 0
+    if ($Stop) {
+        $owned = Get-OwnedPreviewSupervisor -Manifest $current -ActionSourceRootWsl $actionSourceRootWsl -RunnerStatePath $runnerStatePath
+        $stopSourceRootWsl = if ($null -ne $owned) { [string]$current.materializedSourceRootWsl } else { $candidateMaterializedSourceWsl }
+        Invoke-WebsiteRunner -EnvironmentVariables (Get-BaseRunnerEnvironment -RunnerSourceRootWsl $stopSourceRootWsl) -Arguments @('--stop')
+        Remove-Item -LiteralPath $manifestPath, $runnerStatePath, $supervisorTokenPath -Force -ErrorAction SilentlyContinue
+        Write-Output "Cartas da Beleza – Prévia Local encerrada. worktree=$projectRoot"
+        return
+    }
+
+    $reuse = Test-ReusablePreview -Manifest $current -Identity $identity -ActionSourceRootWsl $actionSourceRootWsl `
+        -MaterializedSourceRootWsl $candidateMaterializedSourceWsl -RunnerStatePath $runnerStatePath
+    if ($reuse.Reusable) {
+        Write-Output "Cartas da Beleza – Prévia Local reutilizada. worktree=$projectRoot module=$moduleName fingerprint=$($identity.instanceFingerprint) instance=$($current.instanceId) url=$($reuse.Url)"
+        if (-not $NoBrowser) { Start-Process $reuse.Url | Out-Null }
+        return
+    }
+
+    # A stale process is stopped only when the v2 manifest, runner state and
+    # /proc proof all agree that it belongs to this Action.  Anything less is
+    # deliberately left alone; the runner will allocate a fresh local port.
+    $owned = Get-OwnedPreviewSupervisor -Manifest $current -ActionSourceRootWsl $actionSourceRootWsl -RunnerStatePath $runnerStatePath
+    if ($null -ne $owned) {
+        Invoke-WebsiteRunner -EnvironmentVariables (Get-BaseRunnerEnvironment -RunnerSourceRootWsl ([string]$current.materializedSourceRootWsl)) -Arguments @('--stop')
+    }
+
+    $materialized = $null
+    for ($attempt = 1; $attempt -le 3; $attempt++) {
+        $sourceAtCopyStart = $identity
+        $materialized = Materialize-PreviewSource -Identity $sourceAtCopyStart -ActionSourceRootWsl $actionSourceRootWsl
+        $sourceAfterCopy = Get-PreviewIdentity -SourceRootWsl $actionSourceRootWsl
+        if ([string]$sourceAtCopyStart.instanceFingerprint -eq [string]$sourceAfterCopy.instanceFingerprint -and
+            [string]$sourceAtCopyStart.inputFingerprint -eq [string]$sourceAfterCopy.inputFingerprint -and
+            [string]$sourceAtCopyStart.contractFingerprint -eq [string]$sourceAfterCopy.contractFingerprint) {
+            $identity = $sourceAfterCopy
+            break
         }
+        $identity = $sourceAfterCopy
+        $materialized = $null
     }
-    catch {
-        # A stale or damaged manifest is replaced only after the route is healthy.
+    if ($null -eq $materialized) {
+        throw 'The website inputs changed while the private preview source was being materialized. Please run the Action again after the local edits settle.'
     }
+
+    $baseEnvironment = Get-BaseRunnerEnvironment -RunnerSourceRootWsl ([string]$materialized.sourceRootWsl)
+    $instanceId = [Guid]::NewGuid().ToString('N')
+    $distDir = ".next-codex-preview/$($identity.cacheKey)-$($instanceId.Substring(0, 12))"
+    $launchEnvironment = @($baseEnvironment + @(
+        "WEBSITE_INSTANCE_FINGERPRINT=$($identity.instanceFingerprint)", "WEBSITE_INSTANCE_ID=$instanceId",
+        "WEBSITE_INSTANCE_EXPECTED_FINGERPRINT=$($identity.instanceFingerprint)", "WEBSITE_INSTANCE_EXPECTED_ID=$instanceId",
+        "WEBSITE_INSTANCE_FINGERPRINT_HEADER=$fingerprintHeader", "WEBSITE_INSTANCE_ID_HEADER=$instanceHeader",
+        "WEBSITE_LOCAL_PREVIEW_DIST_DIR=$distDir", "SKINCOS_LOCAL_PREVIEW_FINGERPRINT=$($identity.instanceFingerprint)",
+        "SKINCOS_LOCAL_PREVIEW_INSTANCE=$instanceId", "SKINCOS_LOCAL_PREVIEW_DIST_DIR=$distDir",
+        "NEXT_PUBLIC_BUILD_SHA=$($identity.sourceCommit)"
+    ))
+
+    Remove-Item -LiteralPath $runnerStatePath -Force -ErrorAction SilentlyContinue
+    Invoke-WebsiteRunner -EnvironmentVariables $launchEnvironment -Arguments @($route)
+    $selectedPort = Get-SelectedPort -Path $portPath
+    $url = "http://127.0.0.1:$selectedPort$route"
+    $ready = Test-PreviewReady -Url $url -Fingerprint ([string]$identity.instanceFingerprint) -InstanceId $instanceId
+    if (-not $ready.Ready) { throw "The Beauty Movement local preview did not attest the requested instance at $url. See $logPath." }
+    $runnerState = Get-VerifiedRunnerState -Path $runnerStatePath -Identity $identity -SourceRootWsl ([string]$materialized.sourceRootWsl) `
+        -InstanceId $instanceId -ExpectedPort $selectedPort -ExpectedDistDir $distDir
+    if ($null -eq $runnerState -or -not (Test-VerifiedSupervisor -RunnerState $runnerState -SourceRootWsl ([string]$materialized.sourceRootWsl))) {
+        throw "The preview response was reachable but its WSL supervisor could not be proven. The URL will not be published. See $logPath."
+    }
+
+    $manifest = [ordered]@{
+        version = 2; state = 'ready'; protocol = $previewProtocol; buildContract = $buildContract; module = $moduleName
+        projectRoot = $projectRoot; sourceRootWsl = $actionSourceRootWsl; materializedSourceRootWsl = $materialized.sourceRootWsl; sourceCommit = $identity.sourceCommit
+        inputFingerprint = $identity.inputFingerprint; contractFingerprint = $identity.contractFingerprint
+        sourceFingerprint = $identity.instanceFingerprint; instanceFingerprint = $identity.instanceFingerprint; cacheKey = $identity.cacheKey
+        distDir = $distDir; route = $route; port = $selectedPort; url = $url; instanceId = $instanceId
+        supervisorPid = [int]$runnerState.supervisorPid; supervisorStartTicks = [string]$runnerState.supervisorStartTicks
+        runnerStatePath = $runnerStatePath; startedAt = (Get-Date).ToUniversalTime().ToString('o')
+        attestation = [ordered]@{ fingerprintHeader = $fingerprintHeader; fingerprint = $identity.instanceFingerprint; instanceHeader = $instanceHeader; instanceId = $instanceId }
+    }
+    Write-AtomicJson -Path $manifestPath -Value $manifest
+    Write-Output "Cartas da Beleza – Prévia Local reconstruída. reason=$($reuse.Reason) worktree=$projectRoot module=$moduleName fingerprint=$($identity.instanceFingerprint) instance=$instanceId url=$url"
+    if (-not $NoBrowser) { Start-Process $url | Out-Null }
 }
-
-Invoke-WebsiteLauncher -EnvironmentVariables $environmentVariables -Arguments @($route)
-if (-not (Test-PreviewReady)) {
-    throw "The Beauty Movement local preview did not become healthy at $url. See $logPath."
-}
-
-[ordered]@{
-    version = 1
-    state = 'ready'
-    sourceCommit = $sourceIdentity.commit
-    sourceFingerprint = $sourceIdentity.fingerprint
-    projectRoot = $projectRoot
-    route = $route
-    url = $url
-    port = $port
-    startedAt = (Get-Date).ToUniversalTime().ToString('o')
-} | ConvertTo-Json | Set-Content -LiteralPath $manifestPath -Encoding utf8
-
-Write-Output "Cartas da Beleza – Prévia Local pronta: $url"
-if (-not $NoBrowser) {
-    Start-Process $url | Out-Null
+finally {
+    if ($lockTaken) { $mutex.ReleaseMutex() | Out-Null }
+    $mutex.Dispose()
 }

--- a/scripts/tests/beauty-movement-local-preview-action.test.mjs
+++ b/scripts/tests/beauty-movement-local-preview-action.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+const environment = readFileSync(path.join(repositoryRoot, '.codex', 'environments', 'environment.toml'), 'utf8')
+const launcher = readFileSync(path.join(repositoryRoot, 'scripts', 'start-beauty-movement-local-preview.ps1'), 'utf8')
+
+test('Beauty Movement Action stays relative to the opened worktree', () => {
+  const actionBlocks = environment.match(/\[\[actions\]\][\s\S]*?(?=\n\[\[actions\]\]|$)/g) ?? []
+  const beautyActions = actionBlocks.filter((block) => block.includes('name = "Cartas da Beleza – Prévia Local"'))
+
+  assert.equal(beautyActions.length, 1)
+  assert.match(beautyActions[0], /-File \.\/scripts\/start-beauty-movement-local-preview\.ps1/)
+  assert.doesNotMatch(beautyActions[0], /CodexRuntime|beauty-movement-canonical/i)
+})
+
+test('launcher v2 fails closed unless manifest, WSL process, and served headers agree', () => {
+  assert.match(launcher, /Assert-ActionSourceRoot/)
+  assert.match(launcher, /This Codex Action must be opened from a worktree containing/)
+  assert.match(launcher, /\$previewProtocol = 'beauty-movement-local-preview-v2'/)
+  assert.match(launcher, /Get-PreviewIdentity/)
+  assert.match(launcher, /inputFingerprint/)
+  assert.match(launcher, /contractFingerprint/)
+  assert.match(launcher, /instanceFingerprint/)
+  assert.match(launcher, /Get-VerifiedRunnerState/)
+  assert.match(launcher, /Test-VerifiedSupervisor/)
+  assert.match(launcher, /Materialize-PreviewSource/)
+  assert.match(launcher, /materializedSourceRootWsl/)
+  assert.match(launcher, /Get-OwnedPreviewSupervisor/)
+  assert.match(launcher, /X-Skincos-Preview-Fingerprint/)
+  assert.match(launcher, /X-Skincos-Preview-Instance/)
+  assert.match(launcher, /WEBSITE_ALLOW_PORT_FALLBACK=1/)
+  assert.match(launcher, /Write-AtomicJson/)
+  assert.doesNotMatch(launcher, /beauty-movement-canonical/)
+  assert.doesNotMatch(launcher, /C:\\CodexRuntime/)
+})

--- a/scripts/tests/materialize-website-local-preview-source.test.mjs
+++ b/scripts/tests/materialize-website-local-preview-source.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+const materializer = path.join(repositoryRoot, 'scripts', 'materialize-website-local-preview-source.sh')
+
+async function writeFile(target, content) {
+  await fs.mkdir(path.dirname(target), { recursive: true })
+  await fs.writeFile(target, content)
+}
+
+test('private materialization copies runtime inputs, excludes artifacts, and reuses only private dependencies', async (t) => {
+  if (process.platform !== 'linux') {
+    t.skip('the materializer intentionally runs inside WSL/Linux')
+    return
+  }
+
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'website-preview-materialize-'))
+  t.after(() => fs.rm(root, { recursive: true, force: true }))
+  const source = path.join(root, 'source')
+  const privateState = path.join(root, 'state')
+  const destination = path.join(privateState, 'source', 'identity')
+  const dependencies = path.join(privateState, 'dependencies', 'lock')
+  const fakeBin = path.join(root, 'bin')
+  const npmLog = path.join(root, 'npm.log')
+  const sourcePage = path.join(source, 'website', 'src', 'app', 'page.tsx')
+  const sourceLock = path.join(source, 'website', 'package-lock.json')
+
+  await writeFile(path.join(source, 'website', 'package.json'), JSON.stringify({
+    name: 'preview-fixture', version: '1.0.0', scripts: { dev: 'next dev' },
+  }))
+  await writeFile(sourceLock, JSON.stringify({ name: 'preview-fixture', lockfileVersion: 3, packages: { '': { name: 'preview-fixture' } } }))
+  await writeFile(sourcePage, 'export default function Page() { return <main>first</main> }\n')
+  await writeFile(path.join(source, 'website', '.env.local'), 'PRIVATE_VALUE=not-exposed\n')
+  await writeFile(path.join(source, 'website', 'docs', 'ignored.md'), 'ignored\n')
+  await writeFile(path.join(source, 'website', '.next', 'stale.js'), 'generated\n')
+  await writeFile(path.join(source, 'website', 'node_modules', 'old', 'index.js'), 'old\n')
+  await fs.mkdir(privateState, { recursive: true })
+  await writeFile(path.join(fakeBin, 'npm'), `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "${npmLog}"
+mkdir -p "$2/node_modules/fixture"
+printf 'prepared\\n' > "$2/node_modules/fixture/index.js"
+`)
+  await fs.chmod(path.join(fakeBin, 'npm'), 0o755)
+
+  const run = () => spawnSync('bash', [materializer], {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      PREVIEW_MATERIALIZE_SOURCE_ROOT: source,
+      PREVIEW_MATERIALIZE_DESTINATION_ROOT: destination,
+      PREVIEW_MATERIALIZE_ALLOWED_ROOT: privateState,
+      PREVIEW_MATERIALIZE_DEPENDENCY_ROOT: dependencies,
+      PREVIEW_MATERIALIZE_DEPENDENCY_STATE_FILE: path.join(dependencies, 'website', '.preview-dependencies.state'),
+    },
+  })
+
+  const first = run()
+  assert.equal(first.status, 0, first.stderr)
+  assert.match(first.stdout, /materialized source=/)
+  assert.equal(await fs.readFile(path.join(destination, 'website', 'src', 'app', 'page.tsx'), 'utf8'),
+    'export default function Page() { return <main>first</main> }\n')
+  assert.equal(await fs.readFile(path.join(destination, 'website', '.env.local'), 'utf8'), 'PRIVATE_VALUE=not-exposed\n')
+  await assert.rejects(fs.access(path.join(destination, 'website', 'docs', 'ignored.md')))
+  await assert.rejects(fs.access(path.join(destination, 'website', '.next', 'stale.js')))
+  assert.equal((await fs.lstat(path.join(destination, 'website', 'node_modules'))).isSymbolicLink(), true)
+  assert.equal(await fs.realpath(path.join(destination, 'website', 'node_modules')),
+    await fs.realpath(path.join(dependencies, 'website', 'node_modules')))
+  assert.equal((await fs.readFile(npmLog, 'utf8')).trim().split('\n').length, 1)
+  assert.match(await fs.readFile(path.join(dependencies, 'website', '.preview-dependencies.state'), 'utf8'), /dependencyFingerprint=sha256:/)
+
+  await writeFile(sourcePage, 'export default function Page() { return <main>second</main> }\n')
+  const second = run()
+  assert.equal(second.status, 0, second.stderr)
+  assert.equal(await fs.readFile(path.join(destination, 'website', 'src', 'app', 'page.tsx'), 'utf8'),
+    'export default function Page() { return <main>second</main> }\n')
+  assert.equal((await fs.readFile(npmLog, 'utf8')).trim().split('\n').length, 1,
+    'a source-only change must not reinstall dependencies')
+
+  await fs.appendFile(sourceLock, '\n')
+  const third = run()
+  assert.equal(third.status, 0, third.stderr)
+  assert.equal((await fs.readFile(npmLog, 'utf8')).trim().split('\n').length, 2,
+    'a dependency-input change must rebuild the private dependency cache')
+  assert.equal(await fs.readFile(sourcePage, 'utf8'), 'export default function Page() { return <main>second</main> }\n',
+    'materialization must not rewrite the source checkout')
+})

--- a/scripts/tests/run-local-website.test.mjs
+++ b/scripts/tests/run-local-website.test.mjs
@@ -1,0 +1,225 @@
+import assert from 'node:assert/strict'
+import { spawn, spawnSync } from 'node:child_process'
+import { once } from 'node:events'
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+const runner = path.join(repositoryRoot, 'scripts', 'run-local-website.sh')
+const runnerSource = readFileSync(runner, 'utf8')
+
+const runFixture = ({ body, env = {}, cwd = repositoryRoot }) => {
+  const result = spawnSync(
+    'bash',
+    ['-c', `set -euo pipefail\nsource "$RUNNER"\n${body}`],
+    {
+      cwd,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        RUNNER: runner,
+        RUN_LOCAL_WEBSITE_LIBRARY: '1',
+        WEBSITE_SOURCE_ROOT: repositoryRoot,
+        WEBSITE_HOST: '127.0.0.1',
+        WEBSITE_PORT: '3417',
+        WEBSITE_ROUTE: '/fixture',
+        WEBSITE_STATE_DIR: cwd,
+        ...env,
+      },
+    },
+  )
+
+  if (result.error) throw result.error
+  assert.equal(result.status, 0, result.stderr || result.stdout)
+  return result.stdout.trim()
+}
+
+const writeExecutable = (filePath, body) => {
+  writeFileSync(filePath, body, { encoding: 'utf8', mode: 0o700 })
+  chmodSync(filePath, 0o700)
+}
+
+test('falls through from an empty lsof result to ss and preserves the next-server PID', () => {
+  const fixture = mkdtempSync(path.join(tmpdir(), 'skincos-website-runner-'))
+  try {
+    writeExecutable(path.join(fixture, 'lsof'), '#!/usr/bin/env bash\nexit 1\n')
+    writeExecutable(
+      path.join(fixture, 'ss'),
+      '#!/usr/bin/env bash\ncase "$*" in\n  *:3417*) printf \'LISTEN 0 511 127.0.0.1:3417 0.0.0.0:* users:(("next-server (v15)",pid=4242,fd=22))\\n\' ;;\nesac\n',
+    )
+
+    const output = runFixture({
+      cwd: fixture,
+      env: { PATH: `${fixture}:${process.env.PATH}` },
+      body: 'port_listener_pids 3417',
+    })
+    assert.equal(output, '4242')
+    assert.equal(
+      runFixture({
+        cwd: fixture,
+        env: {
+          PATH: `${fixture}:${process.env.PATH}`,
+          WEBSITE_PORT: '3417',
+          WEBSITE_ALLOW_PORT_FALLBACK: '1',
+        },
+        body: 'resolve_website_port "$WEBSITE_PORT"; printf "$WEBSITE_PORT"',
+      }),
+      '3418',
+    )
+  } finally {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+})
+
+test('strict readiness rejects generic 200 responses and accepts only exact instance headers', () => {
+  const fixture = mkdtempSync(path.join(tmpdir(), 'skincos-website-runner-'))
+  try {
+    writeExecutable(
+      path.join(fixture, 'curl'),
+      `#!/usr/bin/env bash
+headers=''
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -D) headers="$2"; shift 2 ;;
+    -o|--max-time) shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf 'HTTP/1.1 200 OK\\r\\nX-Skincos-Preview-Fingerprint: fixture-fingerprint\\r\\nX-Skincos-Preview-Instance: %s\\r\\n' "$FIXTURE_HEADER_INSTANCE" > "$headers"
+if [[ -n "$FIXTURE_SECOND_INSTANCE" ]]; then
+  printf 'X-Skincos-Preview-Instance: %s\\r\\n' "$FIXTURE_SECOND_INSTANCE" >> "$headers"
+fi
+printf 'X-App-Build: unknown\\r\\n\\r\\n' >> "$headers"
+`,
+    )
+
+    const commonEnvironment = {
+      PATH: `${fixture}:${process.env.PATH}`,
+      SKINCOS_LOCAL_PREVIEW: 'true',
+      WEBSITE_INSTANCE_FINGERPRINT: 'fixture-fingerprint',
+      WEBSITE_INSTANCE_ID: 'fixture-instance',
+      FIXTURE_HEADER_INSTANCE: 'fixture-instance',
+    }
+    assert.equal(
+      runFixture({ env: commonEnvironment, cwd: fixture, body: 'response_matches_instance_identity http://127.0.0.1:3417/fixture && printf accepted' }),
+      'accepted',
+    )
+    assert.equal(
+      runFixture({
+        env: { ...commonEnvironment, FIXTURE_HEADER_INSTANCE: 'different-instance' },
+        cwd: fixture,
+        body: 'if response_matches_instance_identity http://127.0.0.1:3417/fixture; then exit 31; fi; printf rejected',
+      }),
+      'rejected',
+    )
+    assert.equal(
+      runFixture({
+        env: { ...commonEnvironment, FIXTURE_SECOND_INSTANCE: 'fixture-instance' },
+        cwd: fixture,
+        body: 'if response_matches_instance_identity http://127.0.0.1:3417/fixture; then exit 32; fi; printf duplicate-rejected',
+      }),
+      'duplicate-rejected',
+    )
+  } finally {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+})
+
+test('writes the attested instance state atomically only after the strict contract is active', () => {
+  const fixture = mkdtempSync(path.join(tmpdir(), 'skincos-website-runner-'))
+  const instanceState = path.join(fixture, 'instance.json')
+  try {
+    runFixture({
+      cwd: fixture,
+      env: {
+        SKINCOS_LOCAL_PREVIEW: 'true',
+        WEBSITE_INSTANCE_FINGERPRINT: 'fixture-fingerprint',
+        WEBSITE_INSTANCE_ID: 'fixture-instance',
+        WEBSITE_INSTANCE_STATE_FILE: instanceState,
+        WEBSITE_LOCAL_PREVIEW_DIST_DIR: '.next-codex-preview/fixture',
+      },
+      body: 'write_instance_state 123 456',
+    })
+    const state = JSON.parse(readFileSync(instanceState, 'utf8'))
+    assert.deepEqual(
+      {
+        version: state.version,
+        supervisorPid: state.supervisorPid,
+        supervisorStartTicks: state.supervisorStartTicks,
+        sourceRoot: state.sourceRoot,
+        route: state.route,
+        port: state.port,
+        fingerprint: state.fingerprint,
+        instanceId: state.instanceId,
+        distDir: state.distDir,
+      },
+      {
+        version: 1,
+        supervisorPid: 123,
+        supervisorStartTicks: '456',
+        sourceRoot: repositoryRoot,
+        route: '/fixture',
+        port: 3417,
+        fingerprint: 'fixture-fingerprint',
+        instanceId: 'fixture-instance',
+        distDir: '.next-codex-preview/fixture',
+      },
+    )
+  } finally {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+})
+
+test('accepts a supervisor only when /proc start ticks, cwd, and launcher command all match', async () => {
+  const child = spawn('bash', ['-c', `source "${runner}"; sleep 30 & wait`], {
+    cwd: repositoryRoot,
+    env: {
+      ...process.env,
+      RUN_LOCAL_WEBSITE_LIBRARY: '1',
+      WEBSITE_SOURCE_ROOT: repositoryRoot,
+      WEBSITE_STATE_DIR: repositoryRoot,
+    },
+    stdio: 'ignore',
+  })
+  try {
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    assert.ok(child.pid)
+    const ticks = runFixture({
+      env: { TARGET_PID: String(child.pid) },
+      body: 'ticks="$(pid_start_ticks "$TARGET_PID")"; is_owned_website_supervisor "$TARGET_PID" "$ticks"; printf "$ticks"',
+    })
+    assert.match(ticks, /^\d+$/)
+    assert.equal(
+      runFixture({
+        env: { TARGET_PID: String(child.pid) },
+        body: 'ticks="$(pid_start_ticks "$TARGET_PID")"; if is_owned_website_supervisor "$TARGET_PID" "$((ticks + 1))"; then exit 31; fi; printf rejected',
+      }),
+      'rejected',
+    )
+  } finally {
+    if (child.exitCode === null) {
+      child.kill('SIGTERM')
+      await once(child, 'close')
+    }
+  }
+})
+
+test('keeps generic callers compatible while relaying the strict preview contract to the detached supervisor', () => {
+  assert.equal(
+    runFixture({ body: '[[ "$WEBSITE_INSTANCE_CONTRACT_ACTIVE" == "0" ]] && response_matches_instance_identity http://127.0.0.1:3417/fixture && printf generic' }),
+    'generic',
+  )
+  assert.match(runnerSource, /WEBSITE_INSTANCE_CONTRACT_ACTIVE=0/)
+  assert.match(runnerSource, /WEBSITE_INSTANCE_FINGERPRINT="\$WEBSITE_INSTANCE_FINGERPRINT"/)
+  assert.match(runnerSource, /WEBSITE_INSTANCE_ID="\$WEBSITE_INSTANCE_ID"/)
+  assert.match(runnerSource, /SKINCOS_LOCAL_PREVIEW="\$\{SKINCOS_LOCAL_PREVIEW:-\}"/)
+  assert.match(runnerSource, /WEBSITE_LOCAL_PREVIEW_DIST_DIR="\$WEBSITE_LOCAL_PREVIEW_DIST_DIR"/)
+  assert.match(runnerSource, /SKINCOS_LOCAL_PREVIEW_FINGERPRINT="\$SKINCOS_LOCAL_PREVIEW_FINGERPRINT"/)
+  assert.match(runnerSource, /SKINCOS_LOCAL_PREVIEW_INSTANCE="\$SKINCOS_LOCAL_PREVIEW_INSTANCE"/)
+  assert.match(runnerSource, /next-server/)
+  assert.match(runnerSource, /pid_start_ticks/)
+  assert.match(runnerSource, /wait_for_attested_site_or_supervisor/)
+})

--- a/scripts/tests/website-local-preview-next-contract.test.mjs
+++ b/scripts/tests/website-local-preview-next-contract.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const websiteRoot = path.join(repositoryRoot, "website");
+const configPath = path.join(websiteRoot, "next.config.mjs");
+const configSource = readFileSync(configPath, "utf8");
+// Keep the test independent from an installed website dependency tree. The
+// production config is evaluated unchanged apart from OpenNext setup and the
+// CSP import, neither of which affects the local-preview contract.
+const testableConfigSource = configSource
+  .replace(
+    'import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";',
+    "const initOpenNextCloudflareForDev = () => {};",
+  )
+  .replace(
+    'import { contentSecurityPolicy } from "./contentSecurityPolicy.mjs";',
+    'const contentSecurityPolicy = "default-src \'self\'";',
+  )
+  .replace(
+    "const appRoot = path.dirname(fileURLToPath(import.meta.url));",
+    'const appRoot = "/skincos/website";',
+  );
+const configModuleUrl = `data:text/javascript;base64,${Buffer.from(testableConfigSource).toString("base64")}`;
+
+function loadConfig(environment = {}) {
+  const env = { ...process.env };
+  for (const name of [
+    "SKINCOS_LOCAL_PREVIEW",
+    "SKINCOS_LOCAL_PREVIEW_DIST_DIR",
+    "SKINCOS_LOCAL_PREVIEW_FINGERPRINT",
+    "SKINCOS_LOCAL_PREVIEW_INSTANCE",
+  ]) {
+    delete env[name];
+  }
+  Object.assign(env, environment);
+
+  const program = `
+    const { default: config } = await import(${JSON.stringify(configModuleUrl)});
+    const rules = await config.headers();
+    const headers = rules.flatMap((rule) => rule.headers);
+    console.log("__SKINCOS_LOCAL_PREVIEW_CONTRACT__" + JSON.stringify({ distDir: config.distDir ?? null, headers }));
+  `;
+  const result = spawnSync(process.execPath, ["--input-type=module", "--eval", program], {
+    cwd: websiteRoot,
+    encoding: "utf8",
+    env,
+  });
+
+  const marker = result.stdout
+    .split(/\r?\n/)
+    .find((line) => line.startsWith("__SKINCOS_LOCAL_PREVIEW_CONTRACT__"));
+  return { result, contract: marker ? JSON.parse(marker.slice("__SKINCOS_LOCAL_PREVIEW_CONTRACT__".length)) : null };
+}
+
+function headerValue(contract, name) {
+  return contract.headers.find((header) => header.key === name)?.value;
+}
+
+test("normal Next configuration keeps the standard output directory and has no local-preview attestation", () => {
+  const { result, contract } = loadConfig();
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(contract.distDir, null);
+  assert.equal(headerValue(contract, "X-Skincos-Preview-Fingerprint"), undefined);
+  assert.equal(headerValue(contract, "X-Skincos-Preview-Instance"), undefined);
+});
+
+test("local preview configuration isolates output and sends the exact attested identity", () => {
+  const { result, contract } = loadConfig({
+    SKINCOS_LOCAL_PREVIEW: "true",
+    SKINCOS_LOCAL_PREVIEW_DIST_DIR: ".next-codex-preview/preview-identity-v2",
+    SKINCOS_LOCAL_PREVIEW_FINGERPRINT: "v2:ab12cd34",
+    SKINCOS_LOCAL_PREVIEW_INSTANCE: "instance-20260816-001",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(contract.distDir, ".next-codex-preview/preview-identity-v2");
+  assert.equal(headerValue(contract, "X-Skincos-Preview-Fingerprint"), "v2:ab12cd34");
+  assert.equal(headerValue(contract, "X-Skincos-Preview-Instance"), "instance-20260816-001");
+});
+
+test("local preview refuses unsafe identity inputs instead of falling back to .next", () => {
+  const { result } = loadConfig({
+    SKINCOS_LOCAL_PREVIEW: "true",
+    SKINCOS_LOCAL_PREVIEW_DIST_DIR: ".next-codex-preview/../shared",
+    SKINCOS_LOCAL_PREVIEW_FINGERPRINT: "v2:ab12cd34",
+    SKINCOS_LOCAL_PREVIEW_INSTANCE: "instance-20260816-001",
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /SKINCOS_LOCAL_PREVIEW_DIST_DIR must be \.next-codex-preview/);
+});
+
+test("the isolated local-preview build output is ignored", () => {
+  const gitignore = readFileSync(path.join(websiteRoot, ".gitignore"), "utf8");
+  assert.match(gitignore, /^\.next-codex-preview\/$/m);
+});

--- a/scripts/tests/website-local-preview-state.test.mjs
+++ b/scripts/tests/website-local-preview-state.test.mjs
@@ -1,0 +1,309 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+import {
+  calculateWebsitePreviewIdentity,
+  DEFAULT_BUILD_CONTRACT,
+  DEFAULT_PREVIEW_PROTOCOL,
+  DEFAULT_PREVIEW_ROUTE,
+  fingerprintWebsitePreviewInputs,
+  inspectWebsitePreviewSupervisor,
+  PREVIEW_IDENTITY_VERSION,
+} from '../website-local-preview-state.mjs'
+
+const helperPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'website-local-preview-state.mjs')
+
+const fixtureFiles = {
+  'website/src/app/page.tsx': 'export default function Page() { return <main>initial</main> }\n',
+  'website/src/styles/site.css': 'body { color: #123; }\n',
+  'website/public/brand.svg': '<svg viewBox="0 0 1 1"/>\n',
+  'website/next.config.mjs': 'export default {}\n',
+  'website/open-next.config.ts': 'export default {}\n',
+  'website/contentSecurityPolicy.mjs': 'export default {}\n',
+  'website/package.json': '{"name":"fixture","scripts":{"dev":"next dev"}}\n',
+  'website/package-lock.json': '{"lockfileVersion":3,"packages":{}}\n',
+  'website/tsconfig.json': '{"compilerOptions":{}}\n',
+  'website/next-env.d.ts': '/// <reference types="next" />\n',
+  'scripts/start-beauty-movement-local-preview.ps1': 'param()\n',
+  'scripts/materialize-website-local-preview-source.sh': '#!/usr/bin/env bash\n',
+  'scripts/run-local-website.sh': '#!/usr/bin/env bash\n',
+  'scripts/website-local-preview-state.mjs': '// fixture contract\n',
+  '.codex/environments/environment.toml': '[[actions]]\nname = "fixture"\n',
+}
+
+async function tempDirectory(prefix) {
+  return fs.mkdtemp(path.join(os.tmpdir(), prefix))
+}
+
+async function writeFixture(root, entries = Object.entries(fixtureFiles)) {
+  for (const [relativePath, content] of entries) {
+    const target = path.join(root, relativePath)
+    await fs.mkdir(path.dirname(target), { recursive: true })
+    await fs.writeFile(target, content)
+  }
+}
+
+async function createFixture(t, prefix = 'website-preview-identity-') {
+  const root = await tempDirectory(prefix)
+  t.after(() => fs.rm(root, { recursive: true, force: true }))
+  await writeFixture(root)
+  return root
+}
+
+test('fingerprints deterministic runtime inputs independent of mtime', async (t) => {
+  const root = await createFixture(t, 'website-preview-deterministic-')
+  const first = await fingerprintWebsitePreviewInputs(root, { includeEntries: true })
+  const oldTime = new Date('2001-01-01T00:00:00.000Z')
+  await fs.utimes(path.join(root, 'website', 'src', 'app', 'page.tsx'), oldTime, oldTime)
+  const second = await fingerprintWebsitePreviewInputs(root, { includeEntries: true })
+
+  assert.equal(second.fingerprint, first.fingerprint)
+  assert.deepEqual(second.entries.map((entry) => entry.path), first.entries.map((entry) => entry.path))
+  assert.ok(first.entries.some((entry) => entry.path === 'src/app/page.tsx'))
+  assert.ok(first.entries.some((entry) => entry.path === 'public/brand.svg'))
+  assert.ok(first.entries.some((entry) => entry.path === 'next.config.mjs'))
+  assert.ok(first.entries.some((entry) => entry.path === 'package-lock.json'))
+})
+
+test('relevant tracked-like and untracked website changes invalidate the input fingerprint', async (t) => {
+  const root = await createFixture(t, 'website-preview-inputs-')
+  let previous = await fingerprintWebsitePreviewInputs(root)
+
+  for (const relativePath of [
+    'website/src/app/page.tsx',
+    'website/public/brand.svg',
+    'website/next.config.mjs',
+    'website/open-next.config.ts',
+    'website/contentSecurityPolicy.mjs',
+    'website/package.json',
+    'website/package-lock.json',
+    'website/tsconfig.json',
+  ]) {
+    await fs.appendFile(path.join(root, relativePath), `// changed ${relativePath}\n`)
+    const current = await fingerprintWebsitePreviewInputs(root)
+    assert.notEqual(current.fingerprint, previous.fingerprint, `${relativePath} did not invalidate the preview`)
+    previous = current
+  }
+
+  const untrackedPath = path.join(root, 'website', 'src', 'app', 'uncommitted-preview-sentinel.ts')
+  await fs.writeFile(untrackedPath, 'export const sentinel = "uncommitted"\n')
+  const untracked = await fingerprintWebsitePreviewInputs(root)
+  assert.notEqual(untracked.fingerprint, previous.fingerprint, 'an untracked relevant file did not invalidate the preview')
+  await fs.appendFile(untrackedPath, '// modified without a commit\n')
+  assert.notEqual((await fingerprintWebsitePreviewInputs(root)).fingerprint, untracked.fingerprint,
+    'editing an existing untracked file did not invalidate the preview')
+})
+
+test('local environment files are fingerprinted without exposing their contents or individual digests', async (t) => {
+  const root = await createFixture(t, 'website-preview-local-env-')
+  const envPath = path.join(root, 'website', '.env.local')
+  const devVarsPath = path.join(root, 'website', '.dev.vars.local')
+  const firstSecret = 'FIRST_LOCAL_SECRET_DO_NOT_PRINT'
+  const secondSecret = 'SECOND_LOCAL_SECRET_DO_NOT_PRINT'
+  await fs.writeFile(envPath, `PREVIEW_SECRET=${firstSecret}\n`)
+  await fs.writeFile(devVarsPath, 'BINDING=one\n')
+  const first = await fingerprintWebsitePreviewInputs(root, { includeEntries: true })
+  const firstEntry = first.entries.find((entry) => entry.path === '.env.local')
+  assert.deepEqual(firstEntry, {
+    path: '.env.local',
+    type: 'file',
+    size: `PREVIEW_SECRET=${firstSecret}\n`.length,
+    sensitive: true,
+  })
+  assert.ok(first.entries.find((entry) => entry.path === '.dev.vars.local')?.sensitive)
+  assert.equal(JSON.stringify(first).includes(firstSecret), false)
+  assert.equal(JSON.stringify(first).includes('digest'), false)
+
+  await fs.writeFile(envPath, `PREVIEW_SECRET=${secondSecret}\n`)
+  const second = await fingerprintWebsitePreviewInputs(root)
+  assert.notEqual(second.fingerprint, first.fingerprint)
+  await fs.appendFile(devVarsPath, 'BINDING=two\n')
+  assert.notEqual((await fingerprintWebsitePreviewInputs(root)).fingerprint, second.fingerprint)
+})
+
+test('generated artifacts and non-runtime areas do not invalidate the preview fingerprint', async (t) => {
+  const root = await createFixture(t, 'website-preview-excluded-')
+  const baseline = await fingerprintWebsitePreviewInputs(root, { includeEntries: true })
+  const excluded = {
+    'website/.next/server/app/page.js': 'old generated output\n',
+    'website/.next-codex-preview/old/server/app/page.js': 'old isolated output\n',
+    'website/node_modules/next/index.js': 'dependency output\n',
+    'website/docs/reference.md': '# documentation\n',
+    'website/src/docs/reference.ts': 'not route runtime input\n',
+    'website/src/.next/server/app/page.js': 'nested generated output\n',
+    'website/tests/local-preview.test.ts': 'test only\n',
+    'website/reports/quality.json': '{}\n',
+    'website/tmp/runtime.log': 'temporary runtime data\n',
+    'website/logs/preview.log': 'runtime log\n',
+  }
+  await writeFixture(root, Object.entries(excluded))
+  const current = await fingerprintWebsitePreviewInputs(root, { includeEntries: true })
+
+  assert.equal(current.fingerprint, baseline.fingerprint)
+  for (const relativePath of Object.keys(excluded)) {
+    const websitePath = relativePath.replace(/^website\//, '')
+    assert.equal(current.entries.some((entry) => entry.path === websitePath), false, `${websitePath} was included`)
+  }
+})
+
+test('instance identity binds canonical worktree, route, protocol and build contract while HEAD stays diagnostic', async (t) => {
+  const root = await createFixture(t, 'website-preview-instance-')
+  const first = await calculateWebsitePreviewIdentity(root, {
+    sourceCommit: 'a'.repeat(40),
+  })
+  const differentHead = await calculateWebsitePreviewIdentity(root, {
+    sourceCommit: 'b'.repeat(40),
+  })
+  const differentRoute = await calculateWebsitePreviewIdentity(root, {
+    route: '/beleza-em-movimento/other-preview',
+    sourceCommit: 'a'.repeat(40),
+  })
+  const differentProtocol = await calculateWebsitePreviewIdentity(root, {
+    protocol: 'beauty-movement-local-preview-v3',
+    sourceCommit: 'a'.repeat(40),
+  })
+  const differentContract = await calculateWebsitePreviewIdentity(root, {
+    buildContract: 'next-dev-isolated-v2',
+    sourceCommit: 'a'.repeat(40),
+  })
+
+  assert.equal(first.version, PREVIEW_IDENTITY_VERSION)
+  assert.equal(first.route, DEFAULT_PREVIEW_ROUTE)
+  assert.equal(first.protocol, DEFAULT_PREVIEW_PROTOCOL)
+  assert.equal(first.buildContract, DEFAULT_BUILD_CONTRACT)
+  assert.match(first.inputFingerprint, /^sha256:[a-f0-9]{64}$/)
+  assert.match(first.contractFingerprint, /^sha256:[a-f0-9]{64}$/)
+  assert.match(first.instanceFingerprint, /^sha256:[a-f0-9]{64}$/)
+  assert.equal(first.cacheKey, first.instanceFingerprint.slice('sha256:'.length))
+  assert.equal(first.inputFingerprint, differentHead.inputFingerprint)
+  assert.equal(first.contractFingerprint, differentHead.contractFingerprint)
+  assert.equal(first.instanceFingerprint, differentHead.instanceFingerprint)
+  assert.equal(first.sourceCommit, 'a'.repeat(40))
+  assert.equal(differentHead.sourceCommit, 'b'.repeat(40))
+  assert.notEqual(first.instanceFingerprint, differentRoute.instanceFingerprint)
+  assert.notEqual(first.instanceFingerprint, differentProtocol.instanceFingerprint)
+  assert.notEqual(first.instanceFingerprint, differentContract.instanceFingerprint)
+  assert.ok(first.sourceRoot.endsWith(path.basename(root)))
+})
+
+test('Action contract changes invalidate the instance without falsely treating Git HEAD as an input', async (t) => {
+  const root = await createFixture(t, 'website-preview-contract-')
+  const first = await calculateWebsitePreviewIdentity(root, { sourceCommit: 'c'.repeat(40) })
+  await fs.appendFile(path.join(root, 'scripts', 'run-local-website.sh'), '# changed runner\n')
+  const afterRunner = await calculateWebsitePreviewIdentity(root, { sourceCommit: 'c'.repeat(40) })
+  await fs.appendFile(path.join(root, 'scripts', 'materialize-website-local-preview-source.sh'), '# changed materializer\n')
+  const afterMaterializer = await calculateWebsitePreviewIdentity(root, { sourceCommit: 'c'.repeat(40) })
+  await fs.appendFile(path.join(root, '.codex', 'environments', 'environment.toml'), '# changed Action config\n')
+  const afterConfig = await calculateWebsitePreviewIdentity(root, { sourceCommit: 'd'.repeat(40) })
+
+  assert.equal(first.inputFingerprint, afterRunner.inputFingerprint)
+  assert.notEqual(first.contractFingerprint, afterRunner.contractFingerprint)
+  assert.notEqual(first.instanceFingerprint, afterRunner.instanceFingerprint)
+  assert.equal(afterRunner.inputFingerprint, afterMaterializer.inputFingerprint)
+  assert.notEqual(afterRunner.contractFingerprint, afterMaterializer.contractFingerprint)
+  assert.notEqual(afterRunner.instanceFingerprint, afterMaterializer.instanceFingerprint)
+  assert.equal(afterMaterializer.inputFingerprint, afterConfig.inputFingerprint)
+  assert.notEqual(afterMaterializer.contractFingerprint, afterConfig.contractFingerprint)
+  assert.notEqual(afterMaterializer.instanceFingerprint, afterConfig.instanceFingerprint)
+})
+
+test('CLI emits one JSON object suitable for the PowerShell launcher without local secret contents', async (t) => {
+  const root = await createFixture(t, 'website-preview-cli-')
+  const secret = 'CLI_LOCAL_SECRET_DO_NOT_PRINT'
+  await fs.writeFile(path.join(root, 'website', '.env.local'), `TOKEN=${secret}\n`)
+  const result = spawnSync(process.execPath, [
+    helperPath,
+    'identity',
+    '--source-root',
+    root,
+    '--route',
+    DEFAULT_PREVIEW_ROUTE,
+    '--protocol',
+    DEFAULT_PREVIEW_PROTOCOL,
+    '--build-contract',
+    DEFAULT_BUILD_CONTRACT,
+    '--json',
+  ], { encoding: 'utf8' })
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.equal(result.stdout.trim().split('\n').length, 1)
+  const output = JSON.parse(result.stdout)
+  assert.equal(output.ok, true)
+  assert.equal(output.module, 'website')
+  assert.equal(output.route, DEFAULT_PREVIEW_ROUTE)
+  assert.equal(output.protocol, DEFAULT_PREVIEW_PROTOCOL)
+  assert.match(output.instanceFingerprint, /^sha256:[a-f0-9]{64}$/)
+  assert.equal(result.stdout.includes(secret), false)
+  assert.equal(result.stdout.includes('inputEntries'), false)
+})
+
+test('WSL supervisor probe proves PID start ticks, cwd and script marker fail-closed', async (t) => {
+  if (process.platform !== 'linux') {
+    t.skip('process proof is intentionally available only inside WSL/Linux')
+    return
+  }
+  const sourceRoot = process.cwd()
+  const verified = await inspectWebsitePreviewSupervisor(process.pid, {
+    sourceRoot,
+    scriptMarker: 'website-local-preview-state.test.mjs',
+  })
+  assert.equal(verified.alive, true)
+  assert.equal(verified.valid, true)
+  assert.match(verified.startTicks, /^[0-9]+$/)
+  assert.equal(verified.cwdMatches, true)
+  assert.equal(verified.commandMarkerMatches, true)
+  assert.match(verified.commandLineFingerprint, /^sha256:[a-f0-9]{64}$/)
+  assert.equal(Object.hasOwn(verified, 'commandLine'), false)
+
+  const wrongTicks = await inspectWebsitePreviewSupervisor(process.pid, {
+    sourceRoot,
+    scriptMarker: 'website-local-preview-state.test.mjs',
+    expectedStartTicks: `${Number(verified.startTicks) + 1}`,
+  })
+  assert.equal(wrongTicks.valid, false)
+  assert.equal(wrongTicks.reason, 'start_ticks_mismatch')
+
+  const wrongRoot = await createFixture(t, 'website-preview-wrong-root-')
+  const wrongCwd = await inspectWebsitePreviewSupervisor(process.pid, {
+    sourceRoot: wrongRoot,
+    scriptMarker: 'website-local-preview-state.test.mjs',
+  })
+  assert.equal(wrongCwd.valid, false)
+  assert.equal(wrongCwd.reason, 'cwd_mismatch')
+
+  const wrongMarker = await inspectWebsitePreviewSupervisor(process.pid, {
+    sourceRoot,
+    scriptMarker: 'not-a-supervisor-marker',
+  })
+  assert.equal(wrongMarker.valid, false)
+  assert.equal(wrongMarker.reason, 'script_marker_mismatch')
+
+  const missing = await inspectWebsitePreviewSupervisor(2_000_000_000, {
+    sourceRoot,
+    scriptMarker: 'website-local-preview-state.test.mjs',
+  })
+  assert.equal(missing.valid, false)
+  assert.equal(missing.reason, 'process_missing')
+
+  const cli = spawnSync(process.execPath, [
+    helperPath,
+    'process',
+    '--pid',
+    String(process.pid),
+    '--source-root',
+    sourceRoot,
+    '--script-marker',
+    'website-local-preview-state.test.mjs',
+    '--json',
+  ], { encoding: 'utf8' })
+  assert.equal(cli.status, 0, cli.stderr)
+  const cliOutput = JSON.parse(cli.stdout)
+  assert.equal(cliOutput.ok, true)
+  assert.equal(cliOutput.valid, true)
+  assert.equal(Object.hasOwn(cliOutput, 'commandLine'), false)
+})

--- a/scripts/website-local-preview-state.mjs
+++ b/scripts/website-local-preview-state.mjs
@@ -1,0 +1,644 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { createReadStream } from 'node:fs'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+export const PREVIEW_IDENTITY_VERSION = 2
+export const WEBSITE_MODULE = 'website'
+export const DEFAULT_PREVIEW_ROUTE = '/beleza-em-movimento/local-preview'
+export const DEFAULT_PREVIEW_PROTOCOL = 'beauty-movement-local-preview-v2'
+export const DEFAULT_BUILD_CONTRACT = 'next-dev-isolated-v1'
+
+const HASH_ALGORITHM = 'sha256'
+const HASH_PREFIX = `${HASH_ALGORITHM}:`
+const DEFAULT_SOURCE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const EXCLUDED_DIRECTORY_NAMES = new Set([
+  '.next',
+  '.next-codex-preview',
+  '.open-next',
+  '.wrangler',
+  'docs',
+  'logs',
+  'node_modules',
+  'reports',
+  'tests',
+  'tmp',
+])
+const DEFAULT_CONTRACT_PATHS = Object.freeze([
+  '.codex/environments/environment.toml',
+  'scripts/start-beauty-movement-local-preview.ps1',
+  'scripts/materialize-website-local-preview-source.sh',
+  'scripts/run-local-website.sh',
+  'scripts/website-local-preview-state.mjs',
+])
+const ROOT_RUNTIME_FILE_NAMES = new Set([
+  '.npmrc',
+  'next-env.d.ts',
+  'npm-shrinkwrap.json',
+  'package-lock.json',
+  'package.json',
+  'pnpm-lock.yaml',
+  'yarn.lock',
+])
+const ROOT_RUNTIME_FILE_PATTERNS = [
+  /^contentsecuritypolicy\.[a-z0-9]+$/,
+  /^instrumentation\.[a-z0-9]+$/,
+  /^middleware\.[a-z0-9]+$/,
+  /^next\.config\.[a-z0-9]+$/,
+  /^open-next\.config\.[a-z0-9]+$/,
+  /^postcss\.config\.[a-z0-9]+$/,
+  /^proxy\.[a-z0-9]+$/,
+  /^tailwind\.config\.[a-z0-9]+$/,
+  /^tsconfig(?:\.[a-z0-9_-]+)?\.json$/,
+  /^wrangler(?:-[a-z0-9_-]+)?\.(?:json|toml)$/,
+  /^[a-z0-9_.-]+\.d\.ts$/,
+]
+
+export class PreviewIdentityError extends Error {
+  constructor(code, message, details = undefined) {
+    super(message)
+    this.name = 'PreviewIdentityError'
+    this.code = code
+    this.details = details
+  }
+}
+
+function compareNames(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
+function normalizePath(value) {
+  return value.split(path.sep).join('/')
+}
+
+function isWithin(parent, candidate) {
+  const relative = path.relative(parent, candidate)
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+}
+
+function hashText(value) {
+  return createHash(HASH_ALGORITHM).update(value).digest('hex')
+}
+
+async function hashFile(filePath) {
+  const hash = createHash(HASH_ALGORITHM)
+  let size = 0
+  await new Promise((resolve, reject) => {
+    const stream = createReadStream(filePath)
+    stream.on('data', (chunk) => {
+      size += chunk.length
+      hash.update(chunk)
+    })
+    stream.on('error', reject)
+    stream.on('end', resolve)
+  })
+  return { digest: hash.digest('hex'), size }
+}
+
+function fingerprintEntries(entries, namespace) {
+  const hash = createHash(HASH_ALGORITHM)
+  hash.update(`skincos:${namespace}:v${PREVIEW_IDENTITY_VERSION}\0`)
+  for (const entry of entries) {
+    const encodedPath = Buffer.from(entry.path, 'utf8')
+    hash.update(`${encodedPath.length}:`)
+    hash.update(encodedPath)
+    hash.update(`\0${entry.type}\0${entry.size}\0${entry.digest}\0${entry.sensitive ? 'sensitive' : 'regular'}\n`)
+  }
+  return `${HASH_PREFIX}${hash.digest('hex')}`
+}
+
+function fingerprintDescriptor(descriptor) {
+  const hash = createHash(HASH_ALGORITHM)
+  hash.update(`skincos:website-local-preview-instance:v${PREVIEW_IDENTITY_VERSION}\0`)
+  for (const [key, value] of Object.entries(descriptor)) {
+    const encodedKey = Buffer.from(key, 'utf8')
+    const encodedValue = Buffer.from(String(value), 'utf8')
+    hash.update(`${encodedKey.length}:`)
+    hash.update(encodedKey)
+    hash.update(`\0${encodedValue.length}:`)
+    hash.update(encodedValue)
+    hash.update('\n')
+  }
+  return `${HASH_PREFIX}${hash.digest('hex')}`
+}
+
+function validateIdentityText(value, name) {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 256 || /[\0\r\n]/.test(value)) {
+    throw new PreviewIdentityError('INVALID_IDENTITY_VALUE', `${name} must be a non-empty one-line value`)
+  }
+  return value
+}
+
+function normalizeRoute(route) {
+  const normalized = validateIdentityText(route, 'route')
+  if (!normalized.startsWith('/')) {
+    throw new PreviewIdentityError('INVALID_ROUTE', 'route must start with /')
+  }
+  return normalized
+}
+
+function isSensitiveRootFile(name) {
+  const lower = name.toLowerCase()
+  return lower.startsWith('.env') || lower === '.dev.vars' || lower.startsWith('.dev.vars.')
+}
+
+function isRuntimeRootFile(name) {
+  const lower = name.toLowerCase()
+  return isSensitiveRootFile(lower) ||
+    ROOT_RUNTIME_FILE_NAMES.has(lower) ||
+    ROOT_RUNTIME_FILE_PATTERNS.some((pattern) => pattern.test(lower))
+}
+
+function pathHasExcludedDirectory(relativePath) {
+  return normalizePath(relativePath)
+    .split('/')
+    .some((segment) => EXCLUDED_DIRECTORY_NAMES.has(segment.toLowerCase()))
+}
+
+function normalizeContractPath(value) {
+  const normalized = validateIdentityText(value, 'contract path').replace(/\\/g, '/')
+  if (normalized.startsWith('/') || /^[a-z]:/i.test(normalized) || normalized.split('/').includes('..')) {
+    throw new PreviewIdentityError('INVALID_CONTRACT_PATH', `contract path must stay below the source root: ${value}`)
+  }
+  return normalized.replace(/^\.\//, '')
+}
+
+async function pathKind(filePath) {
+  try {
+    const stat = await fs.lstat(filePath)
+    if (stat.isSymbolicLink()) return 'symlink'
+    if (stat.isFile()) return 'file'
+    if (stat.isDirectory()) return 'directory'
+    return 'other'
+  } catch (error) {
+    if (error?.code === 'ENOENT') return 'missing'
+    throw error
+  }
+}
+
+async function resolveFileEntry(absolutePath, relativePath, { sensitive = false, allowedRoot }) {
+  const kind = await pathKind(absolutePath)
+  if (kind === 'missing') return null
+  if (kind === 'directory' || kind === 'other') {
+    throw new PreviewIdentityError('UNSUPPORTED_INPUT', `Preview input is not a regular file: ${absolutePath}`)
+  }
+  if (kind === 'symlink') {
+    const target = await fs.realpath(absolutePath)
+    if (!isWithin(allowedRoot, target)) {
+      throw new PreviewIdentityError('UNSAFE_SYMLINK', `Preview input symlink resolves outside website: ${absolutePath}`)
+    }
+    const targetStat = await fs.stat(absolutePath)
+    if (!targetStat.isFile()) {
+      throw new PreviewIdentityError('UNSUPPORTED_SYMLINK', `Preview input symlink must target a file: ${absolutePath}`)
+    }
+    const hashed = await hashFile(absolutePath)
+    return { path: relativePath, ...hashed, type: 'symlink-file', sensitive }
+  }
+  const hashed = await hashFile(absolutePath)
+  return { path: relativePath, ...hashed, type: 'file', sensitive }
+}
+
+async function collectDirectoryEntries(directory, prefix, websiteRoot) {
+  let children
+  try {
+    children = await fs.readdir(directory, { withFileTypes: true })
+  } catch (error) {
+    if (error?.code === 'ENOENT') return []
+    throw error
+  }
+  children.sort((left, right) => compareNames(left.name, right.name))
+  const entries = []
+  for (const child of children) {
+    const relativePath = path.join(prefix, child.name)
+    if (pathHasExcludedDirectory(relativePath)) continue
+    const absolutePath = path.join(directory, child.name)
+    if (child.isDirectory()) {
+      entries.push(...await collectDirectoryEntries(absolutePath, relativePath, websiteRoot))
+      continue
+    }
+    if (child.isSymbolicLink()) {
+      const target = await fs.realpath(absolutePath)
+      const targetStat = await fs.stat(absolutePath)
+      if (targetStat.isDirectory()) {
+        throw new PreviewIdentityError('UNSUPPORTED_SYMLINK', `Preview input symlink must not target a directory: ${absolutePath}`)
+      }
+      if (!isWithin(websiteRoot, target)) {
+        throw new PreviewIdentityError('UNSAFE_SYMLINK', `Preview input symlink resolves outside website: ${absolutePath}`)
+      }
+    }
+    const entry = await resolveFileEntry(absolutePath, normalizePath(relativePath), { allowedRoot: websiteRoot })
+    if (entry) entries.push(entry)
+  }
+  return entries
+}
+
+function sanitizeEntries(entries) {
+  return entries.map(({ path: entryPath, type, size, sensitive }) => ({
+    path: entryPath,
+    type,
+    size,
+    ...(sensitive ? { sensitive: true } : {}),
+  }))
+}
+
+async function resolvePreviewSource(sourceRoot) {
+  const requestedRoot = path.resolve(sourceRoot)
+  let canonicalRoot
+  try {
+    canonicalRoot = await fs.realpath(requestedRoot)
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      throw new PreviewIdentityError('SOURCE_ROOT_MISSING', `Preview source root does not exist: ${requestedRoot}`)
+    }
+    throw error
+  }
+  const sourceStat = await fs.stat(canonicalRoot)
+  if (!sourceStat.isDirectory()) {
+    throw new PreviewIdentityError('SOURCE_ROOT_INVALID', `Preview source root is not a directory: ${canonicalRoot}`)
+  }
+  const websiteRoot = path.join(canonicalRoot, WEBSITE_MODULE)
+  try {
+    if (!(await fs.stat(websiteRoot)).isDirectory()) {
+      throw new PreviewIdentityError('WEBSITE_MISSING', `Preview source root does not contain website/: ${canonicalRoot}`)
+    }
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      throw new PreviewIdentityError('WEBSITE_MISSING', `Preview source root does not contain website/: ${canonicalRoot}`)
+    }
+    throw error
+  }
+  return {
+    sourceRoot: normalizePath(canonicalRoot),
+    sourceRootNative: canonicalRoot,
+    websiteRoot: normalizePath(websiteRoot),
+    websiteRootNative: websiteRoot,
+  }
+}
+
+async function fingerprintResolvedWebsiteInputs(source) {
+  const entries = []
+  let rootEntries
+  try {
+    rootEntries = await fs.readdir(source.websiteRootNative, { withFileTypes: true })
+  } catch (error) {
+    throw new PreviewIdentityError('WEBSITE_READ_FAILED', `Could not read website inputs: ${source.websiteRoot}`, error?.code)
+  }
+  rootEntries.sort((left, right) => compareNames(left.name, right.name))
+  for (const entry of rootEntries) {
+    const absolutePath = path.join(source.websiteRootNative, entry.name)
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DIRECTORY_NAMES.has(entry.name.toLowerCase())) continue
+      entries.push(...await collectDirectoryEntries(absolutePath, entry.name, source.websiteRootNative))
+      continue
+    }
+    if (!isRuntimeRootFile(entry.name)) continue
+    const fileEntry = await resolveFileEntry(absolutePath, entry.name, {
+      sensitive: isSensitiveRootFile(entry.name),
+      allowedRoot: source.websiteRootNative,
+    })
+    if (fileEntry) entries.push(fileEntry)
+  }
+  entries.sort((left, right) => compareNames(left.path, right.path))
+  return {
+    fingerprint: fingerprintEntries(entries, 'website-preview-inputs'),
+    fileCount: entries.length,
+    totalBytes: entries.reduce((total, entry) => total + entry.size, 0),
+    sensitiveFileCount: entries.filter((entry) => entry.sensitive).length,
+    entries,
+  }
+}
+
+async function fingerprintPreviewContract(source, contractPaths) {
+  const entries = []
+  const uniquePaths = [...new Set(contractPaths.map(normalizeContractPath))].sort(compareNames)
+  for (const contractPath of uniquePaths) {
+    const nativeRelative = contractPath.split('/').join(path.sep)
+    const absolutePath = path.resolve(source.sourceRootNative, nativeRelative)
+    if (!isWithin(source.sourceRootNative, absolutePath)) {
+      throw new PreviewIdentityError('INVALID_CONTRACT_PATH', `contract path escapes source root: ${contractPath}`)
+    }
+    const entry = await resolveFileEntry(absolutePath, `repo/${contractPath}`, {
+      allowedRoot: source.sourceRootNative,
+    })
+    if (entry) {
+      entries.push(entry)
+      continue
+    }
+    entries.push({
+      path: `repo/${contractPath}`,
+      digest: hashText(`missing:${contractPath}`),
+      size: 0,
+      type: 'missing',
+      sensitive: false,
+    })
+  }
+  return {
+    fingerprint: fingerprintEntries(entries, 'website-preview-contract'),
+    fileCount: entries.length,
+    totalBytes: entries.reduce((total, entry) => total + entry.size, 0),
+    entries,
+  }
+}
+
+function getGitHead(sourceRoot) {
+  const result = spawnSync('git', ['-C', sourceRoot, 'rev-parse', '--verify', 'HEAD^{commit}'], {
+    encoding: 'utf8',
+    windowsHide: true,
+  })
+  if (result.status !== 0) return null
+  const commit = String(result.stdout || '').trim().toLowerCase()
+  return /^[0-9a-f]{40}$/.test(commit) ? commit : null
+}
+
+function normalizePid(value) {
+  const text = String(value)
+  if (!/^[1-9][0-9]*$/.test(text)) {
+    throw new PreviewIdentityError('INVALID_PID', 'pid must be a positive integer')
+  }
+  const pid = Number(text)
+  if (!Number.isSafeInteger(pid)) {
+    throw new PreviewIdentityError('INVALID_PID', 'pid is outside the safe integer range')
+  }
+  return pid
+}
+
+function normalizeStartTicks(value) {
+  if (value === undefined || value === null || value === '') return null
+  const text = String(value)
+  if (!/^[0-9]+$/.test(text)) {
+    throw new PreviewIdentityError('INVALID_START_TICKS', 'expected start ticks must be decimal digits')
+  }
+  return text
+}
+
+async function readProcFile(pid, name) {
+  try {
+    return await fs.readFile(`/proc/${pid}/${name}`)
+  } catch (error) {
+    if (['EACCES', 'ENOENT', 'ESRCH'].includes(error?.code)) return null
+    throw error
+  }
+}
+
+function parseProcStartTicks(stat) {
+  const text = String(stat || '')
+  const commandEnd = text.lastIndexOf(')')
+  if (commandEnd < 0) return null
+  const fields = text.slice(commandEnd + 2).trim().split(/\s+/)
+  const startTicks = fields[19]
+  return /^[0-9]+$/.test(startTicks || '') ? startTicks : null
+}
+
+/**
+ * Proves that a manifest PID still names the exact WSL supervisor that was
+ * started for this worktree.  A missing/reused/unreadable PID is not an error
+ * condition for callers: it is an explicitly unprovable, fail-closed result.
+ * The command line itself is intentionally not returned because it can carry
+ * unrelated sensitive arguments; callers receive a marker check and digest.
+ */
+export async function inspectWebsitePreviewSupervisor(pid, {
+  sourceRoot = DEFAULT_SOURCE_ROOT,
+  expectedStartTicks = null,
+  scriptMarker = 'scripts/run-local-website.sh',
+} = {}) {
+  const normalizedPid = normalizePid(pid)
+  const normalizedExpectedStartTicks = normalizeStartTicks(expectedStartTicks)
+  const normalizedMarker = validateIdentityText(scriptMarker, 'script marker')
+  const source = await resolvePreviewSource(sourceRoot)
+  const base = {
+    pid: normalizedPid,
+    sourceRoot: source.sourceRoot,
+    expectedStartTicks: normalizedExpectedStartTicks,
+    scriptMarker: normalizedMarker,
+    alive: false,
+    startTicks: null,
+    cwd: null,
+    cwdMatches: false,
+    commandMarkerMatches: false,
+    commandLineFingerprint: null,
+    valid: false,
+    reason: null,
+  }
+  if (process.platform !== 'linux') {
+    return { ...base, reason: 'linux_procfs_unavailable' }
+  }
+
+  const stat = await readProcFile(normalizedPid, 'stat')
+  if (!stat) return { ...base, reason: 'process_missing' }
+  const startTicks = parseProcStartTicks(stat.toString('utf8'))
+  if (!startTicks) return { ...base, reason: 'start_ticks_unavailable' }
+
+  let cwd
+  try {
+    cwd = normalizePath(await fs.realpath(`/proc/${normalizedPid}/cwd`))
+  } catch (error) {
+    if (['EACCES', 'ENOENT', 'ESRCH'].includes(error?.code)) {
+      return { ...base, alive: true, startTicks, reason: 'cwd_unavailable' }
+    }
+    throw error
+  }
+  const commandLine = await readProcFile(normalizedPid, 'cmdline')
+  if (!commandLine) {
+    return {
+      ...base,
+      alive: true,
+      startTicks,
+      cwd,
+      cwdMatches: cwd === source.sourceRoot,
+      reason: 'cmdline_unavailable',
+    }
+  }
+  const commandText = commandLine.toString('utf8').replace(/\0/g, ' ').trim()
+  const cwdMatches = cwd === source.sourceRoot
+  const commandMarkerMatches = commandText.includes(normalizedMarker)
+  const startTicksMatch = normalizedExpectedStartTicks === null || startTicks === normalizedExpectedStartTicks
+  const valid = startTicksMatch && cwdMatches && commandMarkerMatches
+  return {
+    ...base,
+    alive: true,
+    startTicks,
+    cwd,
+    cwdMatches,
+    commandMarkerMatches,
+    commandLineFingerprint: `${HASH_PREFIX}${hashText(commandLine)}`,
+    valid,
+    reason: valid
+      ? 'verified'
+      : !startTicksMatch
+        ? 'start_ticks_mismatch'
+        : !cwdMatches
+          ? 'cwd_mismatch'
+          : 'script_marker_mismatch',
+  }
+}
+
+export async function fingerprintWebsitePreviewInputs(sourceRoot = DEFAULT_SOURCE_ROOT, { includeEntries = false } = {}) {
+  const source = await resolvePreviewSource(sourceRoot)
+  const result = await fingerprintResolvedWebsiteInputs(source)
+  return {
+    fingerprint: result.fingerprint,
+    fileCount: result.fileCount,
+    totalBytes: result.totalBytes,
+    sensitiveFileCount: result.sensitiveFileCount,
+    ...(includeEntries ? { entries: sanitizeEntries(result.entries) } : {}),
+  }
+}
+
+export async function calculateWebsitePreviewIdentity(sourceRoot = DEFAULT_SOURCE_ROOT, {
+  route = DEFAULT_PREVIEW_ROUTE,
+  protocol = DEFAULT_PREVIEW_PROTOCOL,
+  buildContract = DEFAULT_BUILD_CONTRACT,
+  contractPaths = DEFAULT_CONTRACT_PATHS,
+  includeEntries = false,
+  sourceCommit = undefined,
+} = {}) {
+  const normalizedRoute = normalizeRoute(route)
+  const normalizedProtocol = validateIdentityText(protocol, 'protocol')
+  const normalizedBuildContract = validateIdentityText(buildContract, 'build contract')
+  if (!Array.isArray(contractPaths)) {
+    throw new PreviewIdentityError('INVALID_CONTRACT_PATHS', 'contractPaths must be an array')
+  }
+  const source = await resolvePreviewSource(sourceRoot)
+  const [inputs, contract] = await Promise.all([
+    fingerprintResolvedWebsiteInputs(source),
+    fingerprintPreviewContract(source, contractPaths),
+  ])
+  const diagnosticCommit = sourceCommit === undefined ? getGitHead(source.sourceRootNative) : sourceCommit
+  if (diagnosticCommit !== null && diagnosticCommit !== undefined &&
+    (typeof diagnosticCommit !== 'string' || !/^[0-9a-f]{40}$/i.test(diagnosticCommit))) {
+    throw new PreviewIdentityError('INVALID_SOURCE_COMMIT', 'sourceCommit must be a Git SHA or null')
+  }
+  const instanceFingerprint = fingerprintDescriptor({
+    sourceRoot: source.sourceRoot,
+    module: WEBSITE_MODULE,
+    route: normalizedRoute,
+    protocol: normalizedProtocol,
+    buildContract: normalizedBuildContract,
+    inputFingerprint: inputs.fingerprint,
+    contractFingerprint: contract.fingerprint,
+  })
+  return {
+    version: PREVIEW_IDENTITY_VERSION,
+    algorithm: HASH_ALGORITHM,
+    module: WEBSITE_MODULE,
+    sourceRoot: source.sourceRoot,
+    websiteRoot: source.websiteRoot,
+    route: normalizedRoute,
+    protocol: normalizedProtocol,
+    buildContract: normalizedBuildContract,
+    sourceCommit: diagnosticCommit ? diagnosticCommit.toLowerCase() : null,
+    inputFingerprint: inputs.fingerprint,
+    contractFingerprint: contract.fingerprint,
+    instanceFingerprint,
+    cacheKey: instanceFingerprint.slice(HASH_PREFIX.length),
+    inputFileCount: inputs.fileCount,
+    contractFileCount: contract.fileCount,
+    totalBytes: inputs.totalBytes + contract.totalBytes,
+    sensitiveFileCount: inputs.sensitiveFileCount,
+    ...(includeEntries ? {
+      inputEntries: sanitizeEntries(inputs.entries),
+      contractEntries: sanitizeEntries(contract.entries),
+    } : {}),
+  }
+}
+
+function parseArgs(argv) {
+  const options = { json: false, entries: false, contractFiles: [] }
+  const positional = []
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index]
+    if (value === '--json') {
+      options.json = true
+    } else if (value === '--entries') {
+      options.entries = true
+    } else if (value === '--contract-file') {
+      const next = argv[index + 1]
+      if (next === undefined || next.startsWith('--')) {
+        throw new PreviewIdentityError('USAGE', 'Missing value for --contract-file')
+      }
+      options.contractFiles.push(next)
+      index += 1
+    } else if (value.startsWith('--')) {
+      const key = value.slice(2)
+      const next = argv[index + 1]
+      if (next === undefined || next.startsWith('--')) {
+        throw new PreviewIdentityError('USAGE', `Missing value for ${value}`)
+      }
+      options[key] = next
+      index += 1
+    } else {
+      positional.push(value)
+    }
+  }
+  return { command: positional[0], options }
+}
+
+function printUsage() {
+  process.stdout.write(`Usage:\n  website-local-preview-state.mjs identity [--source-root PATH] [--route ROUTE] [--protocol VALUE] [--build-contract VALUE] [--contract-file PATH]... [--entries] [--json]\n  website-local-preview-state.mjs inputs [--source-root PATH] [--entries] [--json]\n  website-local-preview-state.mjs process --pid PID [--source-root PATH] [--expected-start-ticks TICKS] [--script-marker TEXT] [--json]\n`)
+}
+
+function printResult(result, { json = false } = {}) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify({ ok: true, ...result })}\n`)
+    return
+  }
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`)
+}
+
+async function runCli(argv) {
+  const { command, options } = parseArgs(argv)
+  if (!command || command === 'help') {
+    printUsage()
+    return
+  }
+  const sourceRoot = options['source-root'] || DEFAULT_SOURCE_ROOT
+  if (command === 'inputs') {
+    const result = await fingerprintWebsitePreviewInputs(sourceRoot, { includeEntries: options.entries })
+    printResult(result, options)
+    return
+  }
+  if (command === 'identity') {
+    const result = await calculateWebsitePreviewIdentity(sourceRoot, {
+      route: options.route || DEFAULT_PREVIEW_ROUTE,
+      protocol: options.protocol || DEFAULT_PREVIEW_PROTOCOL,
+      buildContract: options['build-contract'] || DEFAULT_BUILD_CONTRACT,
+      contractPaths: [...DEFAULT_CONTRACT_PATHS, ...options.contractFiles],
+      includeEntries: options.entries,
+    })
+    printResult(result, options)
+    return
+  }
+  if (command === 'process') {
+    if (!options.pid) throw new PreviewIdentityError('USAGE', 'Missing required option --pid')
+    const result = await inspectWebsitePreviewSupervisor(options.pid, {
+      sourceRoot,
+      expectedStartTicks: options['expected-start-ticks'] || null,
+      scriptMarker: options['script-marker'] || 'scripts/run-local-website.sh',
+    })
+    printResult(result, options)
+    return
+  }
+  throw new PreviewIdentityError('USAGE', `Unknown command: ${command}`)
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : null
+if (invokedPath === import.meta.url) {
+  runCli(process.argv.slice(2)).catch((error) => {
+    const payload = {
+      ok: false,
+      error: {
+        code: error?.code || 'UNEXPECTED',
+        message: error?.message || String(error),
+        details: error?.details,
+      },
+    }
+    if (process.argv.includes('--json')) process.stderr.write(`${JSON.stringify(payload)}\n`)
+    else process.stderr.write(`[website-local-preview-state] ${payload.error.code}: ${payload.error.message}\n`)
+    process.exitCode = error?.code === 'USAGE' ? 2 : 1
+  })
+}

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 
 # Next.js
 .next/
+.next-codex-preview/
 out/
 
 # OpenNext build output

--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -7,12 +7,50 @@ import { contentSecurityPolicy } from "./contentSecurityPolicy.mjs";
 const buildSha = process.env.NEXT_PUBLIC_BUILD_SHA || "";
 const buildTime = process.env.NEXT_PUBLIC_BUILD_TIME || "";
 const appRoot = path.dirname(fileURLToPath(import.meta.url));
+const localPreviewEnabled = process.env.SKINCOS_LOCAL_PREVIEW === "true";
+const localPreviewTokenPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/;
+const localPreviewDistDirPattern = /^\.next-codex-preview\/[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+function requireLocalPreviewToken(name, value) {
+  if (typeof value === "string" && localPreviewTokenPattern.test(value)) {
+    return value;
+  }
+
+  throw new Error(
+    `[skincos-local-preview] ${name} must be a controlled header-safe token when SKINCOS_LOCAL_PREVIEW=true.`,
+  );
+}
+
+function requireLocalPreviewDistDir(value) {
+  if (typeof value === "string" && localPreviewDistDirPattern.test(value)) {
+    return value;
+  }
+
+  throw new Error(
+    "[skincos-local-preview] SKINCOS_LOCAL_PREVIEW_DIST_DIR must be .next-codex-preview/<safe-identity-key> when SKINCOS_LOCAL_PREVIEW=true.",
+  );
+}
+
+const localPreview = localPreviewEnabled
+  ? {
+      fingerprint: requireLocalPreviewToken(
+        "SKINCOS_LOCAL_PREVIEW_FINGERPRINT",
+        process.env.SKINCOS_LOCAL_PREVIEW_FINGERPRINT,
+      ),
+      instance: requireLocalPreviewToken(
+        "SKINCOS_LOCAL_PREVIEW_INSTANCE",
+        process.env.SKINCOS_LOCAL_PREVIEW_INSTANCE,
+      ),
+      distDir: requireLocalPreviewDistDir(process.env.SKINCOS_LOCAL_PREVIEW_DIST_DIR),
+    }
+  : null;
 
 initOpenNextCloudflareForDev();
 
 const nextConfig = {
   outputFileTracingRoot: appRoot,
   poweredByHeader: false,
+  ...(localPreview ? { distDir: localPreview.distDir } : {}),
   images: {
     // Keep explicit local image patterns so cache-busted local assets remain valid in Next 16.
     localPatterns: [
@@ -54,6 +92,18 @@ const nextConfig = {
           // Helps validate which deployment is currently served (useful when debugging caching / stale deploys).
           { key: "X-App-Build", value: buildSha || "unknown" },
           { key: "X-App-Build-Time", value: buildTime || "" },
+          ...(localPreview
+            ? [
+                {
+                  key: "X-Skincos-Preview-Fingerprint",
+                  value: localPreview.fingerprint,
+                },
+                {
+                  key: "X-Skincos-Preview-Instance",
+                  value: localPreview.instance,
+                },
+              ]
+            : []),
           { key: "X-Content-Type-Options", value: "nosniff" },
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
           { key: "X-Frame-Options", value: "SAMEORIGIN" },


### PR DESCRIPTION
## Objetivo
Fazer com que a Action `Cartas da Beleza – Prévia Local` só reutilize uma instância que prove ter sido produzida pelo estado relevante atual do `website` no worktree aberto.

## Superfície e risco
- Superfície: configuração local do Codex App, launcher PowerShell, runner WSL e `next dev` local.
- Risco: médio e local; não publica código, não modifica produção, dados, flags ou credenciais.
- Flags/coortes e migrations: não aplicáveis.

## Causa raiz
Duas Actions com o mesmo rótulo podiam apontar para worktrees diferentes e ambas aceitavam uma resposta `200` com texto genérico como prova de frescor. O launcher v1 também não atestava processo, saída de build ou a resposta efetivamente servida; `.next` era compartilhado.

## Mudança
- Troca a identidade por fingerprint v2 do worktree, rota, protocolo, contrato e entradas relevantes do `website`, incluindo edições locais, untracked e ambientes locais sem expor conteúdos.
- Materializa fonte, dependências e `distDir` em estado privado por identidade; o Next não altera o checkout nem reutiliza `.next` comum.
- Reuso exige manifesto v2, supervisor WSL com PID/start-ticks/cwd/comando comprovados e os dois cabeçalhos exatos da resposta.
- Processo ou manifesto não comprovado é stale. Processo comprovadamente pertencente à Action pode ser encerrado; ocupante desconhecido preserva-se e a Action usa porta local alternativa.
- Remove somente a Action duplicada da configuração compartilhada sem módulo e faz o dispatcher externo legado falhar fechado.

## Validação
- 20 testes focados: seleção de entradas, `.env.local`, untracked, exclusões, manifesto/processo, `lsof`/`ss`, cabeçalhos, saída Next isolada e materialização privada.
- Execuções reais: reuso sem mudança; alteração não commitada com marcador servido; commit relevante com marcador servido; manifesto/PID corrompidos; fallback seguro quando 3417 estava ocupada.
- Navegador nativo: rota e título corretos, conteúdo renderizado, interação do baralho e console sem erros.

## Rollback
Reverter o commit desta PR restaura o launcher anterior. A retirada do dispatcher legado possui checkpoint privado do operador; nenhum processo existente foi encerrado pela migração. O gatilho de rollback é qualquer falha em iniciar uma prévia atestada a partir do worktree correto.