### PR TITLE
chore(meta-ads): attest staging source principal privately

### DIFF
--- a/.github/workflows/attest-meta-ads-source-principal.yml
+++ b/.github/workflows/attest-meta-ads-source-principal.yml
@@ -1,0 +1,89 @@
+name: Attest Meta Ads Source Principal
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: meta-ads-source-principal-attestation-staging
+  cancel-in-progress: false
+
+jobs:
+  attest:
+    if: github.ref == 'refs/heads/main'
+    name: Read the staging source principal without deployment
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    environment: staging
+    steps:
+      - name: Attest the Meta Ads source principal without exposing it
+        env:
+          META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
+          META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
+          ATTESTATION_CONTEXT: ${{ github.run_id }}:${{ github.run_attempt }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${META_ADS_ACCESS_TOKEN:-}" ]]; then
+            echo 'Meta Ads source principal attestation failed: source_credential_unavailable' >&2
+            exit 1
+          fi
+          if [[ ! "${META_ADS_API_VERSION:-}" =~ ^v(2[5-9]|[3-9][0-9])\.0$ ]]; then
+            echo 'Meta Ads source principal attestation failed: source_api_version_invalid' >&2
+            exit 1
+          fi
+
+          node --input-type=module <<'NODE'
+          import { createHash } from 'node:crypto';
+
+          const token = String(process.env.META_ADS_ACCESS_TOKEN || '');
+          const apiVersion = String(process.env.META_ADS_API_VERSION || '');
+          const context = String(process.env.ATTESTATION_CONTEXT || '');
+
+          const fail = (code) => {
+            console.error(`Meta Ads source principal attestation failed: ${code}`);
+            process.exit(1);
+          };
+
+          if (!token || !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion) || !/^\d+:\d+$/.test(context)) {
+            fail('source_contract_invalid');
+          }
+
+          let response;
+          try {
+            response = await fetch(`https://graph.facebook.com/${apiVersion}/me?fields=id`, {
+              method: 'GET',
+              headers: { Authorization: `Bearer ${token}` },
+              cache: 'no-store',
+              redirect: 'error',
+              signal: AbortSignal.timeout(12_000),
+            });
+          } catch {
+            fail('source_principal_unavailable');
+          }
+
+          if (!response || response.status !== 200) {
+            fail('source_principal_unavailable');
+          }
+
+          let payload;
+          try {
+            payload = await response.json();
+          } catch {
+            fail('source_principal_malformed');
+          }
+
+          const principalId = typeof payload?.id === 'string' ? payload.id : '';
+          if (!/^\d{5,20}$/.test(principalId) || payload?.error) {
+            fail('source_principal_malformed');
+          }
+
+          const commitment = createHash('sha256')
+            .update(`skincos-meta-source-principal/v1:${context}:${principalId}`)
+            .digest('hex');
+          process.stdout.write(
+            `source_principal_attestation=verified\nsource_principal_commitment=${commitment}\n`,
+          );
+          NODE

--- a/platform/security/token-vault/tests/meta-ads-source-principal-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-principal-attestation-workflow.test.js
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const workflow = fs.readFileSync(
+  new URL(
+    "../../../../.github/workflows/attest-meta-ads-source-principal.yml",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+test("Meta Ads source-principal attestation is manual, bounded, and non-deploying", () => {
+  assert.match(workflow, /^name: Attest Meta Ads Source Principal$/m);
+  assert.match(workflow, /^\s+workflow_dispatch:\s*$/m);
+  assert.match(workflow, /if: github\.ref == 'refs\/heads\/main'/);
+  assert.match(workflow, /environment: staging/);
+  assert.match(workflow, /timeout-minutes: 3/);
+  assert.match(workflow, /META_ADS_ACCESS_TOKEN: \$\{\{ secrets\.META_ADS_ACCESS_TOKEN \}\}/);
+  assert.match(workflow, /META_ADS_API_VERSION: \$\{\{ vars\.META_ADS_API_VERSION \}\}/);
+  assert.match(workflow, /ATTESTATION_CONTEXT: \$\{\{ github\.run_id \}\}:\$\{\{ github\.run_attempt \}\}/);
+  assert.match(workflow, /https:\/\/graph\.facebook\.com\/\$\{apiVersion\}\/me\?fields=id/);
+  assert.match(workflow, /method: 'GET'/);
+  assert.match(workflow, /Authorization: `Bearer \$\{token\}`/);
+  assert.match(workflow, /cache: 'no-store'/);
+  assert.match(workflow, /redirect: 'error'/);
+  assert.match(workflow, /AbortSignal\.timeout\(12_000\)/);
+  assert.match(workflow, /skincos-meta-source-principal\/v1:\$\{context\}:\$\{principalId\}/);
+  assert.match(workflow, /source_principal_attestation=verified/);
+  assert.match(workflow, /source_principal_commitment=\$\{commitment\}/);
+
+  assert.doesNotMatch(workflow, /access_token=/i);
+  assert.doesNotMatch(workflow, /debug_token/i);
+  assert.doesNotMatch(workflow, /upload-artifact/i);
+  assert.doesNotMatch(workflow, /wrangler/i);
+  assert.doesNotMatch(workflow, /gh secret/i);
+  assert.doesNotMatch(workflow, /secret put/i);
+  assert.doesNotMatch(workflow, /GITHUB_OUTPUT/);
+  assert.doesNotMatch(workflow, /D1|Cloudflare|Orb|n8n/);
+});


### PR DESCRIPTION
## Objetivo

Identifica de forma privada a identidade do bearer Meta atualmente usado pela atestação de staging, para conceder acesso somente ao principal correto antes de retomar o rollout v20.

## Escopo e segurança

- novo workflow manual, restrito a `main` e ao Environment `staging`;
- uma única leitura `GET /me?fields=id` no Graph, com timeout e redirects recusados;
- bearer apenas em memória/header; logs recebem somente compromisso SHA-256 vinculado ao run;
- nenhum deploy, Cloudflare, D1, Orb, artefato, secret write ou mutação Meta.

## Validação

- suíte Token Vault: 141/141;
- YAML/Prettier, topology, escritor único Cloudflare e governança GitHub verdes;
- scan de segurança `cab6150b-3d38-4eb9-a063-47dda763d593`: sem achados.

## Rollback

Remover o workflow em um commit posterior; enquanto existe, ele só pode executar a leitura delimitada manualmente.