### PR TITLE
fix(meta-ads): diagnose staging appsecret proof mismatch

### DIFF
--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -202,6 +202,7 @@ const STAGING_SYNTHETIC_SEED_ATTESTATION_FAILURES = Object.freeze({
   sourceUnavailable: 'meta_ads_publish_staging_seed_graph_source_unavailable',
   sourceAuthRejected: 'meta_ads_publish_staging_seed_graph_source_auth_rejected',
   pixelAccessDenied: 'meta_ads_publish_staging_seed_graph_pixel_access_denied',
+  appSecretProofMismatch: 'meta_ads_publish_staging_seed_graph_appsecret_proof_mismatch',
   pageAccessDenied: 'meta_ads_publish_staging_seed_graph_page_access_denied',
   datasetAccessDenied: 'meta_ads_publish_staging_seed_graph_dataset_access_denied',
   identityMismatch: 'meta_ads_publish_staging_seed_graph_identity_mismatch',
@@ -1272,6 +1273,7 @@ export async function attestStagingSyntheticMetaAdsTracking({ request, env, requ
       context: createStagingSyntheticSeedAttestationContext(env, requestId, input.operationKey),
       failureCodes: STAGING_SYNTHETIC_SEED_ATTESTATION_FAILURES,
       maxGraphAttempts: STAGING_SYNTHETIC_SEED_ATTEST_MAX_GRAPH_ATTEMPTS,
+      probeAppSecretProof: true,
     });
     return stagingSyntheticSeedAttestationSuccess({ requestId, operationKey: input.operationKey });
   } catch (error) {
@@ -1584,6 +1586,7 @@ function stagingSyntheticSeedFailureResponse(error, requestId) {
     'meta_ads_publish_staging_seed_graph_source_unavailable',
     'meta_ads_publish_staging_seed_graph_source_auth_rejected',
     'meta_ads_publish_staging_seed_graph_pixel_access_denied',
+    'meta_ads_publish_staging_seed_graph_appsecret_proof_mismatch',
     'meta_ads_publish_staging_seed_graph_page_access_denied',
     'meta_ads_publish_staging_seed_graph_dataset_access_denied',
     'meta_ads_publish_staging_seed_graph_identity_mismatch',
@@ -1984,18 +1987,48 @@ async function discoverStagingSyntheticSeedFacts({
   context,
   failureCodes = STAGING_SYNTHETIC_SEED_DISCOVERY_FAILURES,
   maxGraphAttempts = MAX_GRAPH_ATTEMPTS,
+  probeAppSecretProof = false,
 }) {
   const read = (path, fields, query = {}, failureCode = failureCodes.sourceUnavailable) => seedGraphRead(auth, path, fields, context, query, {
     maxAttempts: maxGraphAttempts,
     failureCode,
     authFailureCode: failureCodes.sourceAuthRejected,
   });
-  const pixel = await read(
+  const readPixel = (candidateAuth) => seedGraphRead(
+    candidateAuth,
     input.pixelId,
     'id,owner_ad_account{id}',
+    context,
     {},
-    failureCodes.pixelAccessDenied,
+    {
+      maxAttempts: maxGraphAttempts,
+      failureCode: failureCodes.pixelAccessDenied,
+      authFailureCode: failureCodes.sourceAuthRejected,
+    },
   );
+  let pixel;
+  try {
+    pixel = await readPixel(auth);
+  } catch (error) {
+    const appSecretProofMismatch = clean(failureCodes.appSecretProofMismatch);
+    if (
+      !probeAppSecretProof ||
+      !clean(auth.appSecretProof) ||
+      !appSecretProofMismatch ||
+      clean(error?.message) === 'meta_ads_publish_staging_seed_unavailable'
+    ) {
+      throw error;
+    }
+    try {
+      await readPixel({ ...auth, appSecretProof: '' });
+    } catch (fallbackError) {
+      if (clean(fallbackError?.message) === 'meta_ads_publish_staging_seed_unavailable') {
+        throw fallbackError;
+      }
+      throw error;
+    }
+    throw stagingSyntheticSeedFailure(appSecretProofMismatch, 409);
+  }
   const pixelOwner = normalizeStagingSyntheticSeedGraphId(
     asObject(pixel.owner_ad_account).id,
     'pixel_owner_account',

--- a/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
@@ -742,6 +742,97 @@ test('staging seed attestation returns a finite resource stage for permanent Gra
   }
 });
 
+test('staging seed attestation identifies a rejected appsecret proof without mutating', async () => {
+  const db = new SeedDb();
+  db.prepare = () => {
+    throw new Error('D1 must remain untouched by source attestation');
+  };
+  const graph = new FakeGraph();
+  const observedReads = [];
+  const response = await attest({
+    db,
+    graph,
+    operationKey: 'meta-ads-staging-seed:attestation-appsecret-proof-mismatch-001',
+    env: {
+      META_APP_SECRET: 'unit-test-app-secret-not-a-real-secret',
+      META_GRAPH_FETCH: async (url, init) => {
+        const target = new URL(url);
+        observedReads.push({
+          path: target.pathname.replace(/^\/v\d+\.0\//, ''),
+          method: String(init.method || 'GET').toUpperCase(),
+          hasProof: target.searchParams.has('appsecret_proof'),
+        });
+        if (target.searchParams.has('appsecret_proof')) {
+          return graphResponse({ error: { message: 'proof rejected', code: 10 } }, 403);
+        }
+        return graph.fetch(url, init);
+      },
+    },
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 409);
+  assert.equal(body.error, 'meta_ads_publish_staging_seed_graph_appsecret_proof_mismatch');
+  assert.deepEqual(observedReads, [
+    { path: PIXEL_ID, method: 'GET', hasProof: true },
+    { path: PIXEL_ID, method: 'GET', hasProof: false },
+  ]);
+  assert.equal(graph.calls.length, 1);
+  assert.equal(graph.postCalls.length, 0);
+  assert.equal(db.operations.size, 0);
+  assert.equal(db.tokens.length, 0);
+  assert.equal(db.locks.size, 0);
+  assert.equal(db.adsetLocks.size, 0);
+  const serialized = JSON.stringify(body);
+  for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID]) {
+    assert.equal(serialized.includes(value), false);
+  }
+});
+
+test('staging seed attestation keeps pixel access denied when proofless retry also fails', async () => {
+  const db = new SeedDb();
+  db.prepare = () => {
+    throw new Error('D1 must remain untouched by source attestation');
+  };
+  const graph = new FakeGraph();
+  const observedReads = [];
+  const response = await attest({
+    db,
+    graph,
+    operationKey: 'meta-ads-staging-seed:attestation-proofless-pixel-denied-001',
+    env: {
+      META_APP_SECRET: 'unit-test-app-secret-not-a-real-secret',
+      META_GRAPH_FETCH: async (url, init) => {
+        const target = new URL(url);
+        observedReads.push({
+          path: target.pathname.replace(/^\/v\d+\.0\//, ''),
+          method: String(init.method || 'GET').toUpperCase(),
+          hasProof: target.searchParams.has('appsecret_proof'),
+        });
+        return graphResponse({ error: { message: 'pixel denied', code: 10 } }, 403);
+      },
+    },
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 409);
+  assert.equal(body.error, 'meta_ads_publish_staging_seed_graph_pixel_access_denied');
+  assert.deepEqual(observedReads, [
+    { path: PIXEL_ID, method: 'GET', hasProof: true },
+    { path: PIXEL_ID, method: 'GET', hasProof: false },
+  ]);
+  assert.equal(graph.calls.length, 0);
+  assert.equal(graph.postCalls.length, 0);
+  assert.equal(db.operations.size, 0);
+  assert.equal(db.tokens.length, 0);
+  assert.equal(db.locks.size, 0);
+  assert.equal(db.adsetLocks.size, 0);
+  const serialized = JSON.stringify(body);
+  for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID]) {
+    assert.equal(serialized.includes(value), false);
+  }
+});
+
 test('staging seed attestation preserves finite non-identity source eligibility outcomes', async () => {
   const cases = [
     {


### PR DESCRIPTION
## Objective

Make the staging-only source attestation distinguish a rejected ppsecret_proof from a real Pixel-access denial before any synthetic seed, D1 write, traffic activation, or Meta mutation.

## Scope

- Adds one finite, redacted mismatch outcome only when the proof-bearing Pixel read fails and the identical proofless read succeeds.
- Keeps the existing denial outcome when both reads fail and preserves transient failures as retryable/unavailable.
- Adds regression coverage for the two-read diagnostic, zero D1/Graph POST behavior, and response redaction.

## Risk and rollback

This is a staging candidate diagnostic only. It neither broadens Worker roles nor changes seed/bootstrap mutations. Rollback is the prior Worker revision via the governed deployment workflow.

## Validation

- Focused staging synthetic-seed suite: 16/16
- Token Vault suite: 143/143
- Static governance: 18/18
- Security diff scans: no findings

No Ponto or CRM changes.