### PR TITLE
fix(beauty-movement): keep active progress and auto-advance

### DIFF
--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -2679,16 +2679,16 @@
 }
 
 .progressItemCurrent .progressButton {
-  border-bottom-color: rgba(197, 181, 143, 0.52);
-  border-radius: 0;
-  background: transparent;
-  color: var(--bm-surface);
-  box-shadow: none;
+  border-bottom-color: var(--bm-yellow);
+  border-radius: 8px;
+  background: var(--bm-yellow);
+  color: var(--bm-ink);
+  box-shadow: 0 8px 18px rgba(229, 189, 49, 0.18);
 }
 
 .progressItemCurrent .progressButton:hover {
-  background: transparent;
-  color: var(--bm-surface);
+  background: var(--bm-yellow);
+  color: var(--bm-ink);
 }
 
 .progressTransfer {
@@ -2698,7 +2698,7 @@
 }
 
 .autoAdvance::after {
-  background: var(--bm-yellow);
+  background: var(--bm-ink);
 }
 
 .tableSurface {

--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -319,6 +319,8 @@ export default function BeautyMovementExperience({
     const mountedRef = useRef(true);
     const revealTransitionTokenRef = useRef<number | null>(null);
     const autoAdvanceGateRef = useRef(createBeautyMovementMotionGate());
+    const autoAdvanceScheduledRef = useRef(false);
+    const autoAdvancePendingRef = useRef(false);
     const handTransitionGateRef = useRef(createBeautyMovementMotionGate());
     const introTransitionGateRef = useRef(createBeautyMovementMotionGate());
     const progressMotionKeyRef = useRef(0);
@@ -601,6 +603,8 @@ export default function BeautyMovementExperience({
 
     const cancelAutoAdvance = useCallback(() => {
         autoAdvanceGateRef.current.invalidate();
+        autoAdvanceScheduledRef.current = false;
+        autoAdvancePendingRef.current = false;
         if (autoAdvanceTimerRef.current !== null) {
             window.clearTimeout(autoAdvanceTimerRef.current);
             autoAdvanceTimerRef.current = null;
@@ -926,28 +930,51 @@ export default function BeautyMovementExperience({
 
     function startAutoAdvance(index: number, delayMs = BEAUTY_MOVEMENT_MOTION.autoAdvanceMs) {
         const token = autoAdvanceGateRef.current.start();
+        autoAdvanceScheduledRef.current = true;
+        autoAdvancePendingRef.current = false;
+        // The countdown belongs to the choice, not to the end of the flip.
+        // Render it before the RAF/timer so a fast or throttled frame cannot
+        // leave the category without feedback.
+        setAutoAdvanceActive(true);
         autoAdvanceFrameRef.current = window.requestAnimationFrame(() => {
             autoAdvanceFrameRef.current = null;
             if (
                 !mountedRef.current ||
                 reducedMotionRef.current ||
                 !autoAdvanceGateRef.current.isCurrent(token) ||
-                handStageRef.current !== "held" ||
+                (handStageRef.current !== "reveal" && handStageRef.current !== "held") ||
                 displayedActIndexRef.current !== index ||
                 finaleStageRef.current !== "hidden"
-            ) return;
+            ) {
+                autoAdvanceScheduledRef.current = false;
+                setAutoAdvanceActive(false);
+                return;
+            }
 
-            setAutoAdvanceActive(true);
             autoAdvanceTimerRef.current = window.setTimeout(() => {
                 autoAdvanceTimerRef.current = null;
                 if (
                     !mountedRef.current ||
                     !autoAdvanceGateRef.current.isCurrent(token) ||
-                    handStageRef.current !== "held" ||
+                    (handStageRef.current !== "reveal" && handStageRef.current !== "held") ||
                     displayedActIndexRef.current !== index ||
                     finaleStageRef.current !== "hidden"
-                ) return;
+                ) {
+                    autoAdvanceScheduledRef.current = false;
+                    autoAdvancePendingRef.current = false;
+                    setAutoAdvanceActive(false);
+                    return;
+                }
 
+                if (handStageRef.current === "reveal") {
+                    // The fallback reveal timer will settle the card. Keep the
+                    // completed countdown latched so settleReveal can advance
+                    // immediately instead of silently dropping the hand.
+                    autoAdvancePendingRef.current = true;
+                    return;
+                }
+
+                autoAdvanceScheduledRef.current = false;
                 setAutoAdvanceActive(false);
                 moveToNextHand(index);
             }, delayMs);
@@ -1065,7 +1092,12 @@ export default function BeautyMovementExperience({
         clearHandTransitionTimer();
         revealTransitionTokenRef.current = null;
         setCurrentHandStage("held");
-        scheduleNextHand(actIndex);
+        if (autoAdvancePendingRef.current) {
+            autoAdvancePendingRef.current = false;
+            autoAdvanceScheduledRef.current = false;
+            setAutoAdvanceActive(false);
+            moveToNextHand(actIndex);
+        }
     }
 
     function handleSelectedCardAnimationEnd(event: ReactAnimationEvent<HTMLButtonElement>, actIndex: number) {
@@ -1111,6 +1143,7 @@ export default function BeautyMovementExperience({
             const handToken = beginHandTransition();
             revealTransitionTokenRef.current = handToken;
             setCurrentHandStage("reveal");
+            scheduleNextHand(actIndex);
             scheduleHandTransition(handToken, BEAUTY_MOVEMENT_MOTION.handRevealFallbackMs, () => {
                 settleReveal(actIndex, handToken);
             });

--- a/website/tests/beautyMovementProgress.test.ts
+++ b/website/tests/beautyMovementProgress.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const sourceUrl = (relativePath: string) => new URL(`../${relativePath}`, import.meta.url);
+
+test("the active category keeps its yellow state and the countdown is armed with the choice", async () => {
+    const [experience, styles] = await Promise.all([
+        readFile(sourceUrl("src/components/BeautyMovementExperience.tsx"), "utf8"),
+        readFile(sourceUrl("src/components/BeautyMovementExperience.module.css"), "utf8"),
+    ]);
+
+    const start = experience.slice(
+        experience.indexOf("function startAutoAdvance"),
+        experience.indexOf("function scheduleNextHand"),
+    );
+    const reveal = experience.slice(
+        experience.indexOf("async function handleReveal"),
+        experience.indexOf("async function handleConfirm"),
+    );
+    const settle = experience.slice(
+        experience.indexOf("function settleReveal"),
+        experience.indexOf("function handleSelectedCardAnimationEnd"),
+    );
+
+    assert.match(experience, /const autoAdvanceScheduledRef = useRef\(false\)/);
+    assert.match(experience, /const autoAdvancePendingRef = useRef\(false\)/);
+    assert.ok(start.indexOf("setAutoAdvanceActive(true)") < start.indexOf("window.requestAnimationFrame"));
+    assert.match(start, /handStageRef\.current !== "reveal" && handStageRef\.current !== "held"/);
+    assert.match(start, /autoAdvancePendingRef\.current = true/);
+    assert.match(reveal, /setCurrentHandStage\("reveal"\);\s*scheduleNextHand\(actIndex\)/);
+    assert.doesNotMatch(settle, /scheduleNextHand\(actIndex\)/);
+    assert.match(experience, /const isAutoAdvanceVisible = isCurrent && !progressMotion && autoAdvanceActive/);
+
+    const rhythmLayer = styles.slice(styles.indexOf("/* Ritmo Natural"));
+    assert.match(
+        rhythmLayer,
+        /\.progressItemCurrent \.progressButton \{[\s\S]*background: var\(--bm-yellow\);[\s\S]*color: var\(--bm-ink\);/,
+    );
+    assert.match(rhythmLayer, /\.progressItemCurrent \.progressButton:hover \{[\s\S]*background: var\(--bm-yellow\);/);
+    assert.match(rhythmLayer, /\.autoAdvance::after \{[\s\S]*background: var\(--bm-ink\);/);
+});


### PR DESCRIPTION
## What changed
- keep the active Beauty / Movimento / Celebração progress control visibly highlighted in yellow, with readable ink contrast
- arm the five-second auto-advance countdown as soon as a card choice is accepted, before the flip settles
- keep the countdown latched through a delayed reveal and advance immediately when the reveal settles, instead of silently dropping the hand
- add a focused regression test for the active-state styling and reveal-to-auto-advance contract

## Root cause
The final rhythm CSS layer overrode the active progress control with a transparent background and surface-colored text, so the selected category lost its yellow relevance. The timer was only scheduled after the reveal settled and only became visible inside a later animation frame; when the reveal callback/animation timing was delayed or cancelled, the progress feedback could disappear and the five-second transition was never armed.

## Validation
- focused motion/continuous/progress tests: 5 passed
- TypeScript noEmit: passed
- ESLint for `BeautyMovementExperience.tsx`: passed
- native in-app browser on the dedicated preview: active category rendered yellow, countdown status was visible during reveal, `Movimento` became active automatically, and console errors/warnings were empty