### PR TITLE
ops: materialize protected Ponto pilot cohort

### DIFF
--- a/.github/governance/cloudflare-single-writer-policy.json
+++ b/.github/governance/cloudflare-single-writer-policy.json
@@ -20,6 +20,15 @@
         "--local",
         "--dry-run"
       ]
+    },
+    {
+      "workflow": ".github/workflows/materialize-native-pilot-cohort-custody.yml",
+      "reason": "Reads the pinned production identity through the D1 query endpoint to derive a GitHub environment secret; it has no Cloudflare mutation authority.",
+      "requiredMarkers": [
+        "/d1/database/${databaseId}/query",
+        "SELECT",
+        "PILOT_COHORT_IDENTITY_INVALID"
+      ]
     }
   ],
   "coordinationGroups": [

--- a/.github/workflows/materialize-native-pilot-cohort-custody.yml
+++ b/.github/workflows/materialize-native-pilot-cohort-custody.yml
@@ -98,10 +98,9 @@ jobs:
           source_sha: ${{ inputs.release_sha }}
           proof_file: ${{ runner.temp }}/pilot-cohort-custody/global-coordination-release-ponto.json
 
-      - name: Derive and write the single allowed cohort directly to production custody
+      - name: Derive and validate the single allowed cohort inside production custody
         if: ${{ steps.acquire.outcome == 'success' }}
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           PONTO_RELEASE_SHA: ${{ inputs.release_sha }}
           PONTO_PILOT_LOGIN: ${{ secrets.PONTO_PILOT_LOGIN }}
           PONTO_IDEMPOTENCY_KEY: ${{ secrets.PONTO_IDEMPOTENCY_KEY }}
@@ -112,8 +111,7 @@ jobs:
           set -euo pipefail
           umask 077
           cohort_file="$RUNNER_TEMP/pilot-cohort.json"
-          secret_metadata="$RUNNER_TEMP/pilot-cohort-secret-write-metadata.json"
-          trap 'rm -f "$cohort_file" "$secret_metadata"' EXIT
+          trap 'rm -f "$cohort_file"' ERR
           node scripts/runtime/materialize-pilot-cohort.mjs > "$cohort_file"
           [[ -s "$cohort_file" ]] || { echo 'Pilot cohort materialization did not produce a protected value.' >&2; exit 78; }
           node - "$cohort_file" <<'NODE'
@@ -134,8 +132,34 @@ jobs:
             throw new Error("pilot cohort unit is invalid");
           }
           NODE
+
+      - name: Revalidate the composite Ponto release lease before custody mutation
+        id: revalidate
+        if: ${{ steps.acquire.outcome == 'success' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: true
+          proof_file: ${{ runner.temp }}/pilot-cohort-custody/global-coordination-release-ponto.json
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+
+      - name: Write the validated cohort only after revalidated production custody
+        if: ${{ steps.revalidate.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          set -euo pipefail
+          umask 077
+          cohort_file="$RUNNER_TEMP/pilot-cohort.json"
+          secret_metadata="$RUNNER_TEMP/pilot-cohort-secret-write-metadata.json"
+          trap 'rm -f "$cohort_file" "$secret_metadata"' EXIT
+          [[ -s "$cohort_file" ]] || { echo 'Pilot cohort materialization did not produce a protected value.' >&2; exit 78; }
           gh secret set PONTO_PILOT_COHORT_JSON --repo "$GITHUB_REPOSITORY" --env production < "$cohort_file"
-          rm -f "$cohort_file"
           gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/environments/production/secrets?per_page=100" > "$secret_metadata"
           node - "$secret_metadata" <<'NODE'
           const fs = require("fs");
@@ -146,6 +170,12 @@ jobs:
           if (!names.has("PONTO_PILOT_COHORT_JSON")) throw new Error("pilot cohort secret write did not become observable");
           NODE
           echo 'pilot_cohort_custody=written identity_count=1 values_emitted=false'
+
+      - name: Remove the protected cohort buffer
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          rm -f "$RUNNER_TEMP/pilot-cohort.json" "$RUNNER_TEMP/pilot-cohort-secret-write-metadata.json"
 
       - name: Release the composite Ponto release lease
         if: ${{ always() && steps.acquire.outcome == 'success' }}

--- a/.github/workflows/materialize-native-pilot-cohort-custody.yml
+++ b/.github/workflows/materialize-native-pilot-cohort-custody.yml
@@ -1,0 +1,143 @@
+name: Materialize native pilot cohort custody
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Immutable Ponto source SHA whose dependency closure remains current
+        required: true
+        type: string
+
+concurrency:
+  group: native-pilot-cohort-custody-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  materialize:
+    name: Materialize one production pilot cohort
+    if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && github.repository == 'jubenitogarcia/skincos' }}
+    runs-on: [self-hosted, Linux, X64, skincos-native-custody]
+    environment: production
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify the exact main source and compatible immutable Ponto closure
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          set -euo pipefail
+          [[ -n "$GH_TOKEN" ]] || { echo 'GitHub custody authority is unavailable.' >&2; exit 78; }
+          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'Ponto release SHA is invalid.' >&2; exit 78; }
+          main_sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')"
+          [[ "$GITHUB_REF" == 'refs/heads/main' && "$main_sha" == "$GITHUB_SHA" ]] || {
+            echo 'Pilot cohort custody requires the exact current main SHA.' >&2
+            exit 78
+          }
+          git cat-file -e "$RELEASE_SHA^{commit}"
+          git merge-base --is-ancestor "$RELEASE_SHA" "$GITHUB_SHA"
+          PONTO_RELEASE_SHA="$RELEASE_SHA" PONTO_OBSERVED_SHA="$GITHUB_SHA" node --input-type=module <<'NODE'
+          import { assertPontoSourceClosureUnchanged } from "./.github/scripts/ponto-source-closure.mjs";
+          assertPontoSourceClosureUnchanged(process.env.PONTO_RELEASE_SHA, process.env.PONTO_OBSERVED_SHA);
+          NODE
+
+      - name: Confirm secret custody metadata before the one-time write
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          set -euo pipefail
+          secret_metadata="$RUNNER_TEMP/pilot-cohort-secret-metadata.json"
+          trap 'rm -f "$secret_metadata"' EXIT
+          gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/environments/production/secrets?per_page=100" > "$secret_metadata"
+          node - "$secret_metadata" <<'NODE'
+          const fs = require("fs");
+          const pages = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const names = new Set((Array.isArray(pages) ? pages : [pages])
+            .flatMap(page => Array.isArray(page?.secrets) ? page.secrets : [])
+            .map(item => item.name));
+          for (const name of ["PONTO_PILOT_LOGIN", "PONTO_PILOT_PASSWORD", "PONTO_IDEMPOTENCY_KEY"]) {
+            if (!names.has(name)) throw new Error("required production secret metadata is absent");
+          }
+          if (names.has("PONTO_PILOT_COHORT_JSON")) throw new Error("pilot cohort secret is already present; refusing a concurrent replacement");
+          NODE
+
+      - name: Acquire the composite Ponto release lease
+        id: acquire
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: true
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          resource: release:ponto
+          module: ponto
+          source_sha: ${{ inputs.release_sha }}
+          proof_file: ${{ runner.temp }}/pilot-cohort-custody/global-coordination-release-ponto.json
+
+      - name: Derive and write the single allowed cohort directly to production custody
+        if: ${{ steps.acquire.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          PONTO_RELEASE_SHA: ${{ inputs.release_sha }}
+          PONTO_PILOT_LOGIN: ${{ secrets.PONTO_PILOT_LOGIN }}
+          PONTO_IDEMPOTENCY_KEY: ${{ secrets.PONTO_IDEMPOTENCY_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          PONTO_TIMEKEEPING_D1_PRODUCTION_ID: ${{ vars.PONTO_TIMEKEEPING_D1_PRODUCTION_ID }}
+        run: |
+          set -euo pipefail
+          umask 077
+          cohort_file="$RUNNER_TEMP/pilot-cohort.json"
+          secret_metadata="$RUNNER_TEMP/pilot-cohort-secret-write-metadata.json"
+          trap 'rm -f "$cohort_file" "$secret_metadata"' EXIT
+          node scripts/runtime/materialize-pilot-cohort.mjs > "$cohort_file"
+          [[ -s "$cohort_file" ]] || { echo 'Pilot cohort materialization did not produce a protected value.' >&2; exit 78; }
+          node - "$cohort_file" <<'NODE'
+          const fs = require("fs");
+          const cohort = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const expected = ["pilotEmployeeRefs", "pilotIdentityLoginRefs", "pilotIdentityRefs", "pilotNetworkContexts", "pilotUnits"];
+          const opaque = /^v1:[A-Za-z0-9_-]{43}$/;
+          if (JSON.stringify(Object.keys(cohort).sort()) !== JSON.stringify([...expected].sort())) {
+            throw new Error("pilot cohort fields differ");
+          }
+          for (const key of expected) {
+            if (!Array.isArray(cohort[key]) || cohort[key].length !== 1) throw new Error("pilot cohort cardinality differs");
+          }
+          for (const key of expected.filter(key => key !== "pilotUnits")) {
+            if (!opaque.test(cohort[key][0])) throw new Error("pilot cohort opaque reference is invalid");
+          }
+          if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$/.test(cohort.pilotUnits[0])) {
+            throw new Error("pilot cohort unit is invalid");
+          }
+          NODE
+          gh secret set PONTO_PILOT_COHORT_JSON --repo "$GITHUB_REPOSITORY" --env production < "$cohort_file"
+          rm -f "$cohort_file"
+          gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/environments/production/secrets?per_page=100" > "$secret_metadata"
+          node - "$secret_metadata" <<'NODE'
+          const fs = require("fs");
+          const pages = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const names = new Set((Array.isArray(pages) ? pages : [pages])
+            .flatMap(page => Array.isArray(page?.secrets) ? page.secrets : [])
+            .map(item => item.name));
+          if (!names.has("PONTO_PILOT_COHORT_JSON")) throw new Error("pilot cohort secret write did not become observable");
+          NODE
+          echo 'pilot_cohort_custody=written identity_count=1 values_emitted=false'
+
+      - name: Release the composite Ponto release lease
+        if: ${{ always() && steps.acquire.outcome == 'success' }}
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: true
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          proof_file: ${{ runner.temp }}/pilot-cohort-custody/global-coordination-release-ponto.json

--- a/.github/workflows/materialize-native-pilot-cohort-custody.yml
+++ b/.github/workflows/materialize-native-pilot-cohort-custody.yml
@@ -49,6 +49,21 @@ jobs:
           assertPontoSourceClosureUnchanged(process.env.PONTO_RELEASE_SHA, process.env.PONTO_OBSERVED_SHA);
           NODE
 
+      - name: Resolve the fixed production Identity D1 binding from source
+        run: |
+          set -euo pipefail
+          identity_d1_id="$(node --input-type=module <<'NODE'
+          import fs from "node:fs";
+          const source = fs.readFileSync("inventory/wrangler.toml", "utf8");
+          const production = source.split(/^\[env\.staging\]/m, 1)[0];
+          const match = production.match(/\[\[d1_databases\]\]\s+binding\s*=\s*"DB"\s+database_name\s*=\s*"skincos-db"\s+database_id\s*=\s*"([0-9a-f-]{36})"/i);
+          if (!match) throw new Error("production Identity D1 binding is unavailable");
+          process.stdout.write(match[1].toLowerCase());
+          NODE
+          )"
+          [[ "$identity_d1_id" =~ ^[0-9a-f-]{36}$ ]] || { echo 'production Identity D1 binding is invalid.' >&2; exit 78; }
+          echo "PONTO_IDENTITY_D1_PRODUCTION_ID=$identity_d1_id" >> "$GITHUB_ENV"
+
       - name: Confirm secret custody metadata before the one-time write
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/scripts/runtime/materialize-pilot-cohort.mjs
+++ b/scripts/runtime/materialize-pilot-cohort.mjs
@@ -22,6 +22,10 @@ const required = (env, name) => {
 
 const normalize = (value) => String(value || "").trim();
 const normalizedLogin = (value) => normalize(value).toLowerCase();
+const normalizedPilotRole = (value) => {
+  const role = normalize(value).toUpperCase();
+  return role === "EMPLOYEE" ? "CONSULTOR" : role;
+};
 
 const parseUnits = (value) => {
   try {
@@ -82,7 +86,7 @@ export async function observedEgressAddress({ fetchImpl = fetch } = {}) {
 function assertIdentity(row, pilotLogin) {
   const username = normalize(row.username).toLowerCase();
   const login = normalizedLogin(row.identity_login);
-  const identityRole = normalize(row.identity_role).toUpperCase();
+  const identityRole = normalizedPilotRole(row.identity_role);
   const onboardingId = normalize(row.onboarding_id);
   const workforceEmployeeId = normalize(row.workforce_employee_id);
   const linkUsername = normalize(row.link_username).toLowerCase();

--- a/scripts/runtime/materialize-pilot-cohort.mjs
+++ b/scripts/runtime/materialize-pilot-cohort.mjs
@@ -82,8 +82,45 @@ export async function observedEgressAddress({ fetchImpl = fetch } = {}) {
 function assertIdentity(row, pilotLogin) {
   const username = normalize(row.username).toLowerCase();
   const login = normalizedLogin(row.identity_login);
+  const identityRole = normalize(row.identity_role).toUpperCase();
   const onboardingId = normalize(row.onboarding_id);
   const workforceEmployeeId = normalize(row.workforce_employee_id);
+  const linkUsername = normalize(row.link_username).toLowerCase();
+  const linkOnboardingId = normalize(row.link_onboarding_id);
+  const linkWorkforceEmployeeId = normalize(row.link_workforce_employee_id);
+  const linkReviewStatus = normalize(row.link_review_status).toUpperCase();
+  const identityUnits = parseUnits(row.identity_units_json);
+  const onboardingUnits = parseUnits(row.onboarding_units_json);
+
+  if (
+    username !== PILOT_USERNAME
+    || !EMAIL.test(login)
+    || login !== normalizedLogin(pilotLogin)
+    || Number(row.identity_active) !== 1
+    || identityRole !== "CONSULTOR"
+    || !UUID.test(onboardingId)
+    || normalize(row.account_status).toUpperCase() !== "ACTIVE"
+    || normalize(row.provisioning_state).toUpperCase() !== "COMPLETED"
+    || normalize(row.last_error_code)
+    || !UUID.test(workforceEmployeeId)
+    || linkUsername !== username
+    || linkOnboardingId !== onboardingId
+    || linkWorkforceEmployeeId !== workforceEmployeeId
+    || linkReviewStatus !== "CONFIRMED"
+  ) throw failure("PILOT_COHORT_IDENTITY_INVALID");
+
+  return {
+    actorId: username,
+    username,
+    login,
+    onboardingId,
+    workforceEmployeeId,
+    identityUnits,
+    onboardingUnits,
+  };
+}
+
+function assertWorkforce(row, identity) {
   const employeeId = normalize(row.employee_id);
   const canonicalEmployeeId = normalize(row.canonical_employee_id);
   const workforceLogin = normalizedLogin(row.workforce_login);
@@ -91,32 +128,68 @@ function assertIdentity(row, pilotLogin) {
   const metadata = (() => {
     try { return JSON.parse(String(row.metadata_json || "{}")); } catch { return null; }
   })();
-  const identityUnits = parseUnits(row.identity_units_json);
-  const onboardingUnits = parseUnits(row.onboarding_units_json);
   const currentAccessState = normalize(row.access_state || row.status).toUpperCase();
 
   if (
-    username !== PILOT_USERNAME
-    || !EMAIL.test(login)
-    || login !== normalizedLogin(pilotLogin)
-    || Number(row.identity_active) !== 1
-    || !UUID.test(onboardingId)
-    || normalize(row.account_status).toUpperCase() !== "ACTIVE"
-    || normalize(row.provisioning_state).toUpperCase() !== "COMPLETED"
-    || normalize(row.last_error_code)
-    || !UUID.test(workforceEmployeeId)
-    || workforceEmployeeId !== employeeId
-    || canonicalEmployeeId !== `identity:${onboardingId}`
-    || workforceLogin !== login
+    !UUID.test(employeeId)
+    || employeeId !== identity.workforceEmployeeId
+    || canonicalEmployeeId !== `identity:${identity.onboardingId}`
+    || workforceLogin !== identity.login
     || normalize(row.status).toUpperCase() !== "ACTIVE"
     || currentAccessState !== "ACTIVE"
-    || metadata?.identityOnboardingId !== onboardingId
+    || metadata?.identityOnboardingId !== identity.onboardingId
     || !unitId
-    || !identityUnits.includes(unitId)
-    || !onboardingUnits.includes(unitId)
+    || !identity.identityUnits.includes(unitId)
+    || !identity.onboardingUnits.includes(unitId)
   ) throw failure("PILOT_COHORT_IDENTITY_INVALID");
 
-  return { username, login, onboardingId, canonicalEmployeeId, unitId };
+  return { ...identity, canonicalEmployeeId, unitId };
+}
+
+function identityQuery() {
+  return `SELECT
+      u.username AS username,
+      lower(trim(u.email)) AS identity_login,
+      u.role AS identity_role,
+      u.ativo AS identity_active,
+      u.allowed_units_json AS identity_units_json,
+      o.id AS onboarding_id,
+      o.account_status AS account_status,
+      o.provisioning_state AS provisioning_state,
+      o.last_error_code AS last_error_code,
+      o.workforce_employee_id AS workforce_employee_id,
+      o.units_json AS onboarding_units_json,
+      l.crm_username AS link_username,
+      l.onboarding_id AS link_onboarding_id,
+      l.workforce_employee_id AS link_workforce_employee_id,
+      l.review_status AS link_review_status
+    FROM crm_users u
+    JOIN crm_employee_onboarding o ON lower(o.requested_username) = lower(u.username)
+    JOIN crm_employee_account_links l ON l.onboarding_id = o.id
+      AND l.workforce_employee_id = o.workforce_employee_id
+      AND lower(l.crm_username) = lower(u.username)
+    WHERE lower(u.username) = '${PILOT_USERNAME}'
+      AND upper(l.review_status) = 'CONFIRMED'
+    ORDER BY o.updated_at DESC, o.id ASC`;
+}
+
+function workforceQuery(workforceEmployeeId) {
+  const employeeId = normalize(workforceEmployeeId).toLowerCase();
+  if (!UUID.test(employeeId)) throw failure("PILOT_COHORT_IDENTITY_INVALID");
+  return `SELECT
+      e.id AS employee_id,
+      e.canonical_employee_id AS canonical_employee_id,
+      lower(trim(e.login_email)) AS workforce_login,
+      e.status AS status,
+      e.access_state AS access_state,
+      e.metadata_json AS metadata_json,
+      tu.unit_id AS unit_id
+    FROM workforce_employees e
+    JOIN timekeeping_employee_units tu ON tu.employee_id = e.id
+      AND tu.effective_from <= date('now')
+      AND (tu.effective_to IS NULL OR tu.effective_to >= date('now'))
+    WHERE e.id = '${employeeId}'
+    ORDER BY tu.effective_from DESC, tu.unit_id ASC`;
 }
 
 export function derivePilotCohort({ releaseSha, idempotencyKey, identity, egressAddress }) {
@@ -130,7 +203,7 @@ export function derivePilotCohort({ releaseSha, idempotencyKey, identity, egress
   const cohort = {
     pilotEmployeeRefs: [opaque(actorKey, `ponto-canary-employee/v1.${source}.${identity.canonicalEmployeeId}`)],
     pilotIdentityLoginRefs: [opaque(actorKey, `ponto-canary-login/v1.${source}.${identity.login}`)],
-    pilotIdentityRefs: [opaque(actorKey, `ponto-canary-identity/v1.${source}.${identity.username}`)],
+    pilotIdentityRefs: [opaque(actorKey, `ponto-canary-identity/v1.${source}.${identity.actorId}`)],
     pilotNetworkContexts: [opaque(networkKey, `ponto-network/v1.${source}.${egressAddress}`)],
     pilotUnits: [identity.unitId],
   };
@@ -150,50 +223,37 @@ export async function materializePilotCohort({ env = process.env, fetchImpl = fe
   const releaseSha = required(env, "PONTO_RELEASE_SHA").toLowerCase();
   const accountId = required(env, "CLOUDFLARE_ACCOUNT_ID").toLowerCase();
   const apiToken = required(env, "CLOUDFLARE_API_TOKEN");
+  const identityDatabaseId = required(env, "PONTO_IDENTITY_D1_PRODUCTION_ID").toLowerCase();
   const databaseId = required(env, "PONTO_TIMEKEEPING_D1_PRODUCTION_ID").toLowerCase();
   const pilotLogin = required(env, "PONTO_PILOT_LOGIN");
   const idempotencyKey = required(env, "PONTO_IDEMPOTENCY_KEY");
   if (!FULL_SHA.test(releaseSha)) throw failure("PILOT_COHORT_RELEASE_INVALID");
   if (!/^[0-9a-f]{32}$/.test(accountId)) throw failure("PILOT_COHORT_ACCOUNT_INVALID");
+  if (!UUID.test(identityDatabaseId)) throw failure("PILOT_COHORT_DATABASE_INVALID");
   if (!UUID.test(databaseId)) throw failure("PILOT_COHORT_DATABASE_INVALID");
+  if (identityDatabaseId === databaseId) throw failure("PILOT_COHORT_DATABASE_INVALID");
   if (!EMAIL.test(pilotLogin)) throw failure("PILOT_COHORT_LOGIN_INVALID");
 
-  const rows = await queryD1({
+  const identityRows = await queryD1({
+    fetchImpl,
+    accountId,
+    apiToken,
+    databaseId: identityDatabaseId,
+    sql: identityQuery(),
+  });
+  if (identityRows.length !== 1) throw failure("PILOT_COHORT_IDENTITY_INVALID");
+  const identity = assertIdentity(identityRows[0], pilotLogin);
+  const workforceRows = await queryD1({
     fetchImpl,
     accountId,
     apiToken,
     databaseId,
-    sql: `SELECT
-      u.username AS username,
-      lower(trim(u.email)) AS identity_login,
-      u.ativo AS identity_active,
-      u.allowed_units_json AS identity_units_json,
-      o.id AS onboarding_id,
-      o.account_status AS account_status,
-      o.provisioning_state AS provisioning_state,
-      o.last_error_code AS last_error_code,
-      o.workforce_employee_id AS workforce_employee_id,
-      o.units_json AS onboarding_units_json,
-      e.id AS employee_id,
-      e.canonical_employee_id AS canonical_employee_id,
-      lower(trim(e.login_email)) AS workforce_login,
-      e.status AS status,
-      e.access_state AS access_state,
-      e.metadata_json AS metadata_json,
-      tu.unit_id AS unit_id
-    FROM insumos_users u
-    JOIN crm_employee_onboarding o ON lower(o.requested_username) = lower(u.username)
-    JOIN workforce_employees e ON e.id = o.workforce_employee_id
-    JOIN timekeeping_employee_units tu ON tu.employee_id = e.id
-      AND tu.effective_from <= date('now')
-      AND (tu.effective_to IS NULL OR tu.effective_to >= date('now'))
-    WHERE lower(u.username) = '${PILOT_USERNAME}'
-    ORDER BY tu.effective_from DESC, tu.unit_id ASC`,
+    sql: workforceQuery(identity.workforceEmployeeId),
   });
-  if (rows.length !== 1) throw failure("PILOT_COHORT_IDENTITY_INVALID");
-  const identity = assertIdentity(rows[0], pilotLogin);
+  if (workforceRows.length !== 1) throw failure("PILOT_COHORT_IDENTITY_INVALID");
+  const candidate = assertWorkforce(workforceRows[0], identity);
   const egressAddress = await observedEgressAddress({ fetchImpl });
-  return derivePilotCohort({ releaseSha, idempotencyKey, identity, egressAddress });
+  return derivePilotCohort({ releaseSha, idempotencyKey, identity: candidate, egressAddress });
 }
 
 const invokedDirectly = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1].replaceAll("\\", "/")}`).href;

--- a/scripts/runtime/materialize-pilot-cohort.mjs
+++ b/scripts/runtime/materialize-pilot-cohort.mjs
@@ -1,0 +1,207 @@
+import crypto from "node:crypto";
+
+const FULL_SHA = /^[0-9a-f]{40}$/i;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const OPAQUE_REF = /^v1:[A-Za-z0-9_-]{43}$/;
+const EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const EGRESS_ADDRESS = /^[0-9A-Fa-f:.]{3,64}$/;
+const PILOT_USERNAME = "novohamburgo";
+const TRACE_URL = "https://cloudflare.com/cdn-cgi/trace";
+
+const failure = (code) => {
+  const error = new Error(code);
+  error.code = code;
+  return error;
+};
+
+const required = (env, name) => {
+  const value = String(env?.[name] || "").trim();
+  if (!value) throw failure("PILOT_COHORT_CUSTODY_UNAVAILABLE");
+  return value;
+};
+
+const normalize = (value) => String(value || "").trim();
+const normalizedLogin = (value) => normalize(value).toLowerCase();
+
+const parseUnits = (value) => {
+  try {
+    const parsed = JSON.parse(String(value || ""));
+    if (!Array.isArray(parsed)) return [];
+    return [...new Set(parsed.map((unit) => normalize(unit)).filter(Boolean))];
+  } catch {
+    return [];
+  }
+};
+
+const hmac = (key, message) => crypto.createHmac("sha256", key).update(message).digest("base64url");
+const opaque = (key, message) => `v1:${hmac(key, message)}`;
+
+function d1Rows(payload) {
+  const result = payload?.result;
+  const entries = Array.isArray(result) ? result : [result];
+  const rows = entries.flatMap((entry) => {
+    if (Array.isArray(entry?.results)) return entry.results;
+    if (Array.isArray(entry?.result?.results)) return entry.result.results;
+    return [];
+  });
+  return rows.filter((row) => row && typeof row === "object" && !Array.isArray(row));
+}
+
+export async function queryD1({ fetchImpl = fetch, accountId, apiToken, databaseId, sql }) {
+  const response = await fetchImpl(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/d1/database/${databaseId}/query`,
+    {
+      method: "POST",
+      redirect: "error",
+      signal: AbortSignal.timeout(30_000),
+      headers: {
+        authorization: `Bearer ${apiToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ sql }),
+    },
+  );
+  const payload = await response.json().catch(() => null);
+  if (!response.ok || payload?.success !== true) throw failure("PILOT_COHORT_D1_QUERY_FAILED");
+  return d1Rows(payload);
+}
+
+export async function observedEgressAddress({ fetchImpl = fetch } = {}) {
+  const response = await fetchImpl(TRACE_URL, {
+    method: "GET",
+    redirect: "error",
+    signal: AbortSignal.timeout(30_000),
+    headers: { accept: "text/plain" },
+  });
+  const text = await response.text();
+  const address = text.split(/\r?\n/).find((line) => line.startsWith("ip="))?.slice(3).trim() || "";
+  if (!response.ok || !EGRESS_ADDRESS.test(address)) throw failure("PILOT_COHORT_EGRESS_UNAVAILABLE");
+  return address;
+}
+
+function assertIdentity(row, pilotLogin) {
+  const username = normalize(row.username).toLowerCase();
+  const login = normalizedLogin(row.identity_login);
+  const onboardingId = normalize(row.onboarding_id);
+  const workforceEmployeeId = normalize(row.workforce_employee_id);
+  const employeeId = normalize(row.employee_id);
+  const canonicalEmployeeId = normalize(row.canonical_employee_id);
+  const workforceLogin = normalizedLogin(row.workforce_login);
+  const unitId = normalize(row.unit_id);
+  const metadata = (() => {
+    try { return JSON.parse(String(row.metadata_json || "{}")); } catch { return null; }
+  })();
+  const identityUnits = parseUnits(row.identity_units_json);
+  const onboardingUnits = parseUnits(row.onboarding_units_json);
+  const currentAccessState = normalize(row.access_state || row.status).toUpperCase();
+
+  if (
+    username !== PILOT_USERNAME
+    || !EMAIL.test(login)
+    || login !== normalizedLogin(pilotLogin)
+    || Number(row.identity_active) !== 1
+    || !UUID.test(onboardingId)
+    || normalize(row.account_status).toUpperCase() !== "ACTIVE"
+    || normalize(row.provisioning_state).toUpperCase() !== "COMPLETED"
+    || normalize(row.last_error_code)
+    || !UUID.test(workforceEmployeeId)
+    || workforceEmployeeId !== employeeId
+    || canonicalEmployeeId !== `identity:${onboardingId}`
+    || workforceLogin !== login
+    || normalize(row.status).toUpperCase() !== "ACTIVE"
+    || currentAccessState !== "ACTIVE"
+    || metadata?.identityOnboardingId !== onboardingId
+    || !unitId
+    || !identityUnits.includes(unitId)
+    || !onboardingUnits.includes(unitId)
+  ) throw failure("PILOT_COHORT_IDENTITY_INVALID");
+
+  return { username, login, onboardingId, canonicalEmployeeId, unitId };
+}
+
+export function derivePilotCohort({ releaseSha, idempotencyKey, identity, egressAddress }) {
+  const source = normalize(releaseSha).toLowerCase();
+  const root = normalize(idempotencyKey);
+  if (!FULL_SHA.test(source) || !root || !EGRESS_ADDRESS.test(normalize(egressAddress))) {
+    throw failure("PILOT_COHORT_DERIVATION_INVALID");
+  }
+  const actorKey = hmac(root, "skincos/ponto/actor/v1");
+  const networkKey = hmac(root, "skincos/ponto/network-context/v1");
+  const cohort = {
+    pilotEmployeeRefs: [opaque(actorKey, `ponto-canary-employee/v1.${source}.${identity.canonicalEmployeeId}`)],
+    pilotIdentityLoginRefs: [opaque(actorKey, `ponto-canary-login/v1.${source}.${identity.login}`)],
+    pilotIdentityRefs: [opaque(actorKey, `ponto-canary-identity/v1.${source}.${identity.username}`)],
+    pilotNetworkContexts: [opaque(networkKey, `ponto-network/v1.${source}.${egressAddress}`)],
+    pilotUnits: [identity.unitId],
+  };
+  if (
+    Object.values(cohort).some((entries) => !Array.isArray(entries) || entries.length !== 1)
+    || [
+      ...cohort.pilotEmployeeRefs,
+      ...cohort.pilotIdentityLoginRefs,
+      ...cohort.pilotIdentityRefs,
+      ...cohort.pilotNetworkContexts,
+    ].some((value) => !OPAQUE_REF.test(value))
+  ) throw failure("PILOT_COHORT_DERIVATION_INVALID");
+  return cohort;
+}
+
+export async function materializePilotCohort({ env = process.env, fetchImpl = fetch } = {}) {
+  const releaseSha = required(env, "PONTO_RELEASE_SHA").toLowerCase();
+  const accountId = required(env, "CLOUDFLARE_ACCOUNT_ID").toLowerCase();
+  const apiToken = required(env, "CLOUDFLARE_API_TOKEN");
+  const databaseId = required(env, "PONTO_TIMEKEEPING_D1_PRODUCTION_ID").toLowerCase();
+  const pilotLogin = required(env, "PONTO_PILOT_LOGIN");
+  const idempotencyKey = required(env, "PONTO_IDEMPOTENCY_KEY");
+  if (!FULL_SHA.test(releaseSha)) throw failure("PILOT_COHORT_RELEASE_INVALID");
+  if (!/^[0-9a-f]{32}$/.test(accountId)) throw failure("PILOT_COHORT_ACCOUNT_INVALID");
+  if (!UUID.test(databaseId)) throw failure("PILOT_COHORT_DATABASE_INVALID");
+  if (!EMAIL.test(pilotLogin)) throw failure("PILOT_COHORT_LOGIN_INVALID");
+
+  const rows = await queryD1({
+    fetchImpl,
+    accountId,
+    apiToken,
+    databaseId,
+    sql: `SELECT
+      u.username AS username,
+      lower(trim(u.email)) AS identity_login,
+      u.ativo AS identity_active,
+      u.allowed_units_json AS identity_units_json,
+      o.id AS onboarding_id,
+      o.account_status AS account_status,
+      o.provisioning_state AS provisioning_state,
+      o.last_error_code AS last_error_code,
+      o.workforce_employee_id AS workforce_employee_id,
+      o.units_json AS onboarding_units_json,
+      e.id AS employee_id,
+      e.canonical_employee_id AS canonical_employee_id,
+      lower(trim(e.login_email)) AS workforce_login,
+      e.status AS status,
+      e.access_state AS access_state,
+      e.metadata_json AS metadata_json,
+      tu.unit_id AS unit_id
+    FROM insumos_users u
+    JOIN crm_employee_onboarding o ON lower(o.requested_username) = lower(u.username)
+    JOIN workforce_employees e ON e.id = o.workforce_employee_id
+    JOIN timekeeping_employee_units tu ON tu.employee_id = e.id
+      AND tu.effective_from <= date('now')
+      AND (tu.effective_to IS NULL OR tu.effective_to >= date('now'))
+    WHERE lower(u.username) = '${PILOT_USERNAME}'
+    ORDER BY tu.effective_from DESC, tu.unit_id ASC`,
+  });
+  if (rows.length !== 1) throw failure("PILOT_COHORT_IDENTITY_INVALID");
+  const identity = assertIdentity(rows[0], pilotLogin);
+  const egressAddress = await observedEgressAddress({ fetchImpl });
+  return derivePilotCohort({ releaseSha, idempotencyKey, identity, egressAddress });
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1].replaceAll("\\", "/")}`).href;
+if (invokedDirectly) {
+  materializePilotCohort().then((cohort) => {
+    process.stdout.write(JSON.stringify(cohort));
+  }).catch((error) => {
+    process.stderr.write(`${String(error?.code || "PILOT_COHORT_MATERIALIZATION_FAILED")}\n`);
+    process.exitCode = 78;
+  });
+}

--- a/scripts/tests/materialize-pilot-cohort.test.mjs
+++ b/scripts/tests/materialize-pilot-cohort.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { derivePilotCohort, materializePilotCohort } from "../runtime/materialize-pilot-cohort.mjs";
+
+const releaseSha = "a".repeat(40);
+const environment = {
+  PONTO_RELEASE_SHA: releaseSha,
+  CLOUDFLARE_ACCOUNT_ID: "b".repeat(32),
+  CLOUDFLARE_API_TOKEN: "synthetic-cloudflare-token",
+  PONTO_TIMEKEEPING_D1_PRODUCTION_ID: "11111111-1111-4111-8111-111111111111",
+  PONTO_PILOT_LOGIN: "novohamburgo@example.test",
+  PONTO_IDEMPOTENCY_KEY: "synthetic-idempotency-root",
+};
+
+const row = (overrides = {}) => ({
+  username: "novohamburgo",
+  identity_login: "novohamburgo@example.test",
+  identity_active: 1,
+  identity_units_json: JSON.stringify(["novo-hamburgo"]),
+  onboarding_id: "22222222-2222-4222-8222-222222222222",
+  account_status: "ACTIVE",
+  provisioning_state: "COMPLETED",
+  last_error_code: null,
+  workforce_employee_id: "33333333-3333-4333-8333-333333333333",
+  onboarding_units_json: JSON.stringify(["novo-hamburgo"]),
+  employee_id: "33333333-3333-4333-8333-333333333333",
+  canonical_employee_id: "identity:22222222-2222-4222-8222-222222222222",
+  workforce_login: "novohamburgo@example.test",
+  status: "ACTIVE",
+  access_state: "ACTIVE",
+  metadata_json: JSON.stringify({ identityOnboardingId: "22222222-2222-4222-8222-222222222222" }),
+  unit_id: "novo-hamburgo",
+  ...overrides,
+});
+
+const response = (payload, status = 200) => new Response(JSON.stringify(payload), { status });
+
+function fetchFor(rows = [row()]) {
+  let calls = 0;
+  return async (url) => {
+    calls += 1;
+    if (String(url).includes("/d1/database/")) {
+      return response({ success: true, result: [{ results: rows }] });
+    }
+    assert.equal(String(url), "https://cloudflare.com/cdn-cgi/trace");
+    return new Response("fl=1\nip=198.51.100.10\n", { status: 200 });
+  };
+}
+
+test("materializes one opaque cohort from the exact active identity", async () => {
+  const cohort = await materializePilotCohort({ env: environment, fetchImpl: fetchFor() });
+  assert.deepEqual(Object.keys(cohort).sort(), [
+    "pilotEmployeeRefs",
+    "pilotIdentityLoginRefs",
+    "pilotIdentityRefs",
+    "pilotNetworkContexts",
+    "pilotUnits",
+  ].sort());
+  assert.equal(cohort.pilotUnits[0], "novo-hamburgo");
+  for (const key of ["pilotEmployeeRefs", "pilotIdentityLoginRefs", "pilotIdentityRefs", "pilotNetworkContexts"]) {
+    assert.equal(cohort[key].length, 1);
+    assert.match(cohort[key][0], /^v1:[A-Za-z0-9_-]{43}$/);
+  }
+});
+
+test("refuses a mismatched account, error state, or duplicate unit row", async () => {
+  for (const rows of [
+    [row({ provisioning_state: "FAILED" })],
+    [row({ last_error_code: "WORKFORCE_SYNC_FAILED" })],
+    [row(), row()],
+  ]) {
+    await assert.rejects(
+      () => materializePilotCohort({ env: environment, fetchImpl: fetchFor(rows) }),
+      /PILOT_COHORT_IDENTITY_INVALID/,
+    );
+  }
+});
+
+test("derivation is bound to the immutable release source and canonical identity", () => {
+  const cohort = derivePilotCohort({
+    releaseSha,
+    idempotencyKey: environment.PONTO_IDEMPOTENCY_KEY,
+    identity: {
+      username: "novohamburgo",
+      login: environment.PONTO_PILOT_LOGIN,
+      canonicalEmployeeId: "identity:22222222-2222-4222-8222-222222222222",
+      unitId: "novo-hamburgo",
+    },
+    egressAddress: "198.51.100.10",
+  });
+  assert.equal(JSON.stringify(cohort).includes(environment.PONTO_IDEMPOTENCY_KEY), false);
+  assert.equal(JSON.stringify(cohort).includes("198.51.100.10"), false);
+});

--- a/scripts/tests/materialize-pilot-cohort.test.mjs
+++ b/scripts/tests/materialize-pilot-cohort.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
 import test from "node:test";
 import { derivePilotCohort, materializePilotCohort } from "../runtime/materialize-pilot-cohort.mjs";
 
@@ -7,14 +8,16 @@ const environment = {
   PONTO_RELEASE_SHA: releaseSha,
   CLOUDFLARE_ACCOUNT_ID: "b".repeat(32),
   CLOUDFLARE_API_TOKEN: "synthetic-cloudflare-token",
+  PONTO_IDENTITY_D1_PRODUCTION_ID: "44444444-4444-4444-8444-444444444444",
   PONTO_TIMEKEEPING_D1_PRODUCTION_ID: "11111111-1111-4111-8111-111111111111",
   PONTO_PILOT_LOGIN: "novohamburgo@example.test",
   PONTO_IDEMPOTENCY_KEY: "synthetic-idempotency-root",
 };
 
-const row = (overrides = {}) => ({
+const identityRow = (overrides = {}) => ({
   username: "novohamburgo",
   identity_login: "novohamburgo@example.test",
+  identity_role: "CONSULTOR",
   identity_active: 1,
   identity_units_json: JSON.stringify(["novo-hamburgo"]),
   onboarding_id: "22222222-2222-4222-8222-222222222222",
@@ -23,6 +26,14 @@ const row = (overrides = {}) => ({
   last_error_code: null,
   workforce_employee_id: "33333333-3333-4333-8333-333333333333",
   onboarding_units_json: JSON.stringify(["novo-hamburgo"]),
+  link_username: "novohamburgo",
+  link_onboarding_id: "22222222-2222-4222-8222-222222222222",
+  link_workforce_employee_id: "33333333-3333-4333-8333-333333333333",
+  link_review_status: "CONFIRMED",
+  ...overrides,
+});
+
+const workforceRow = (overrides = {}) => ({
   employee_id: "33333333-3333-4333-8333-333333333333",
   canonical_employee_id: "identity:22222222-2222-4222-8222-222222222222",
   workforce_login: "novohamburgo@example.test",
@@ -35,20 +46,38 @@ const row = (overrides = {}) => ({
 
 const response = (payload, status = 200) => new Response(JSON.stringify(payload), { status });
 
-function fetchFor(rows = [row()]) {
-  let calls = 0;
-  return async (url) => {
-    calls += 1;
-    if (String(url).includes("/d1/database/")) {
-      return response({ success: true, result: [{ results: rows }] });
+function fetchFor({ identityRows = [identityRow()], workforceRows = [workforceRow()] } = {}) {
+  const fetchImpl = async (url, init = {}) => {
+    const endpoint = String(url);
+    if (endpoint.includes(`/d1/database/${environment.PONTO_IDENTITY_D1_PRODUCTION_ID}/query`)) {
+      fetchImpl.d1DatabaseIds.push(environment.PONTO_IDENTITY_D1_PRODUCTION_ID);
+      const sql = JSON.parse(String(init.body || "{}")).sql || "";
+      assert.match(sql, /FROM crm_users u/);
+      assert.match(sql, /crm_employee_account_links l/);
+      assert.match(sql, /upper\(l\.review_status\) = 'CONFIRMED'/);
+      return response({ success: true, result: [{ results: identityRows }] });
     }
-    assert.equal(String(url), "https://cloudflare.com/cdn-cgi/trace");
+    if (endpoint.includes(`/d1/database/${environment.PONTO_TIMEKEEPING_D1_PRODUCTION_ID}/query`)) {
+      fetchImpl.d1DatabaseIds.push(environment.PONTO_TIMEKEEPING_D1_PRODUCTION_ID);
+      const sql = JSON.parse(String(init.body || "{}")).sql || "";
+      assert.match(sql, /FROM workforce_employees e/);
+      assert.doesNotMatch(sql, /crm_users|crm_employee_onboarding|crm_employee_account_links/);
+      return response({ success: true, result: [{ results: workforceRows }] });
+    }
+    assert.equal(endpoint, "https://cloudflare.com/cdn-cgi/trace");
     return new Response("fl=1\nip=198.51.100.10\n", { status: 200 });
   };
+  fetchImpl.d1DatabaseIds = [];
+  return fetchImpl;
 }
 
-test("materializes one opaque cohort from the exact active identity", async () => {
-  const cohort = await materializePilotCohort({ env: environment, fetchImpl: fetchFor() });
+test("materializes one opaque cohort from the exact active identity across both authoritative D1 databases", async () => {
+  const fetchImpl = fetchFor();
+  const cohort = await materializePilotCohort({ env: environment, fetchImpl });
+  assert.deepEqual(fetchImpl.d1DatabaseIds, [
+    environment.PONTO_IDENTITY_D1_PRODUCTION_ID,
+    environment.PONTO_TIMEKEEPING_D1_PRODUCTION_ID,
+  ]);
   assert.deepEqual(Object.keys(cohort).sort(), [
     "pilotEmployeeRefs",
     "pilotIdentityLoginRefs",
@@ -63,24 +92,27 @@ test("materializes one opaque cohort from the exact active identity", async () =
   }
 });
 
-test("refuses a mismatched account, error state, or duplicate unit row", async () => {
-  for (const rows of [
-    [row({ provisioning_state: "FAILED" })],
-    [row({ last_error_code: "WORKFORCE_SYNC_FAILED" })],
-    [row(), row()],
+test("refuses an unauthorized role, unconfirmed link, invalid lifecycle, or workforce mismatch", async () => {
+  for (const fixture of [
+    { identityRows: [identityRow({ identity_role: "SUPERVISOR" })] },
+    { identityRows: [identityRow({ link_review_status: "PENDING_REVIEW" })] },
+    { identityRows: [identityRow({ provisioning_state: "FAILED" })] },
+    { workforceRows: [workforceRow({ access_state: "SUSPENDED" })] },
+    { workforceRows: [workforceRow(), workforceRow()] },
   ]) {
     await assert.rejects(
-      () => materializePilotCohort({ env: environment, fetchImpl: fetchFor(rows) }),
+      () => materializePilotCohort({ env: environment, fetchImpl: fetchFor(fixture) }),
       /PILOT_COHORT_IDENTITY_INVALID/,
     );
   }
 });
 
-test("derivation is bound to the immutable release source and canonical identity", () => {
+test("derivation matches the Ponto runtime HMAC contract and never serializes custody inputs", () => {
   const cohort = derivePilotCohort({
     releaseSha,
     idempotencyKey: environment.PONTO_IDEMPOTENCY_KEY,
     identity: {
+      actorId: "novohamburgo",
       username: "novohamburgo",
       login: environment.PONTO_PILOT_LOGIN,
       canonicalEmployeeId: "identity:22222222-2222-4222-8222-222222222222",
@@ -88,6 +120,17 @@ test("derivation is bound to the immutable release source and canonical identity
     },
     egressAddress: "198.51.100.10",
   });
+  const actorKey = createHmac("sha256", environment.PONTO_IDEMPOTENCY_KEY)
+    .update("skincos/ponto/actor/v1")
+    .digest("base64url");
+  const networkKey = createHmac("sha256", environment.PONTO_IDEMPOTENCY_KEY)
+    .update("skincos/ponto/network-context/v1")
+    .digest("base64url");
+  const opaque = (key, message) => `v1:${createHmac("sha256", key).update(message).digest("base64url")}`;
+  assert.equal(cohort.pilotEmployeeRefs[0], opaque(actorKey, `ponto-canary-employee/v1.${releaseSha}.identity:22222222-2222-4222-8222-222222222222`));
+  assert.equal(cohort.pilotIdentityRefs[0], opaque(actorKey, `ponto-canary-identity/v1.${releaseSha}.novohamburgo`));
+  assert.equal(cohort.pilotIdentityLoginRefs[0], opaque(actorKey, `ponto-canary-login/v1.${releaseSha}.${environment.PONTO_PILOT_LOGIN}`));
+  assert.equal(cohort.pilotNetworkContexts[0], opaque(networkKey, `ponto-network/v1.${releaseSha}.198.51.100.10`));
   assert.equal(JSON.stringify(cohort).includes(environment.PONTO_IDEMPOTENCY_KEY), false);
   assert.equal(JSON.stringify(cohort).includes("198.51.100.10"), false);
 });

--- a/scripts/tests/materialize-pilot-cohort.test.mjs
+++ b/scripts/tests/materialize-pilot-cohort.test.mjs
@@ -90,6 +90,11 @@ test("materializes one opaque cohort from the exact active identity across both 
     assert.equal(cohort[key].length, 1);
     assert.match(cohort[key][0], /^v1:[A-Za-z0-9_-]{43}$/);
   }
+  const legacyRoleCohort = await materializePilotCohort({
+    env: environment,
+    fetchImpl: fetchFor({ identityRows: [identityRow({ identity_role: "EMPLOYEE" })] }),
+  });
+  assert.deepEqual(legacyRoleCohort, cohort);
 });
 
 test("refuses an unauthorized role, unconfirmed link, invalid lifecycle, or workforce mismatch", async () => {


### PR DESCRIPTION
Adds a dispatch-only native custody workflow that validates the pinned existing pilot identity, derives the cohort inside production custody, and writes it directly to the scoped environment without artifacts or value disclosure.`n`nValidation: focused Node contract tests passed.