### PR TITLE
fix: classify Ponto pilot cohort projection failures

### DIFF
--- a/scripts/runtime/materialize-pilot-cohort.mjs
+++ b/scripts/runtime/materialize-pilot-cohort.mjs
@@ -14,6 +14,15 @@ const failure = (code) => {
   return error;
 };
 
+// These codes intentionally identify only the failed contract predicate. They
+// never serialize rows, identifiers, email addresses, or custody material into
+// the native-custody workflow log.
+const identityInvalid = (predicate) => failure(`PILOT_COHORT_IDENTITY_INVALID_${predicate}`);
+const exactlyOne = (rows, scope) => {
+  if (rows.length === 1) return;
+  throw identityInvalid(`${scope}_${rows.length === 0 ? "MISSING" : "AMBIGUOUS"}`);
+};
+
 const required = (env, name) => {
   const value = String(env?.[name] || "").trim();
   if (!value) throw failure("PILOT_COHORT_CUSTODY_UNAVAILABLE");
@@ -96,22 +105,19 @@ function assertIdentity(row, pilotLogin) {
   const identityUnits = parseUnits(row.identity_units_json);
   const onboardingUnits = parseUnits(row.onboarding_units_json);
 
-  if (
-    username !== PILOT_USERNAME
-    || !EMAIL.test(login)
-    || login !== normalizedLogin(pilotLogin)
-    || Number(row.identity_active) !== 1
-    || identityRole !== "CONSULTOR"
-    || !UUID.test(onboardingId)
-    || normalize(row.account_status).toUpperCase() !== "ACTIVE"
-    || normalize(row.provisioning_state).toUpperCase() !== "COMPLETED"
-    || normalize(row.last_error_code)
-    || !UUID.test(workforceEmployeeId)
-    || linkUsername !== username
-    || linkOnboardingId !== onboardingId
-    || linkWorkforceEmployeeId !== workforceEmployeeId
-    || linkReviewStatus !== "CONFIRMED"
-  ) throw failure("PILOT_COHORT_IDENTITY_INVALID");
+  if (username !== PILOT_USERNAME) throw identityInvalid("USERNAME");
+  if (!EMAIL.test(login) || login !== normalizedLogin(pilotLogin)) throw identityInvalid("LOGIN");
+  if (Number(row.identity_active) !== 1) throw identityInvalid("ACTIVE");
+  if (identityRole !== "CONSULTOR") throw identityInvalid("ROLE");
+  if (!UUID.test(onboardingId)) throw identityInvalid("ONBOARDING_ID");
+  if (normalize(row.account_status).toUpperCase() !== "ACTIVE") throw identityInvalid("ACCOUNT_STATUS");
+  if (normalize(row.provisioning_state).toUpperCase() !== "COMPLETED") throw identityInvalid("PROVISIONING_STATE");
+  if (normalize(row.last_error_code)) throw identityInvalid("LAST_ERROR");
+  if (!UUID.test(workforceEmployeeId)) throw identityInvalid("WORKFORCE_ID");
+  if (linkUsername !== username) throw identityInvalid("LINK_USERNAME");
+  if (linkOnboardingId !== onboardingId) throw identityInvalid("LINK_ONBOARDING_ID");
+  if (linkWorkforceEmployeeId !== workforceEmployeeId) throw identityInvalid("LINK_WORKFORCE_ID");
+  if (linkReviewStatus !== "CONFIRMED") throw identityInvalid("LINK_REVIEW_STATUS");
 
   return {
     actorId: username,
@@ -134,18 +140,15 @@ function assertWorkforce(row, identity) {
   })();
   const currentAccessState = normalize(row.access_state || row.status).toUpperCase();
 
-  if (
-    !UUID.test(employeeId)
-    || employeeId !== identity.workforceEmployeeId
-    || canonicalEmployeeId !== `identity:${identity.onboardingId}`
-    || workforceLogin !== identity.login
-    || normalize(row.status).toUpperCase() !== "ACTIVE"
-    || currentAccessState !== "ACTIVE"
-    || metadata?.identityOnboardingId !== identity.onboardingId
-    || !unitId
-    || !identity.identityUnits.includes(unitId)
-    || !identity.onboardingUnits.includes(unitId)
-  ) throw failure("PILOT_COHORT_IDENTITY_INVALID");
+  if (!UUID.test(employeeId) || employeeId !== identity.workforceEmployeeId) throw identityInvalid("WORKFORCE_EMPLOYEE_ID");
+  if (canonicalEmployeeId !== `identity:${identity.onboardingId}`) throw identityInvalid("WORKFORCE_CANONICAL_ID");
+  if (workforceLogin !== identity.login) throw identityInvalid("WORKFORCE_LOGIN");
+  if (normalize(row.status).toUpperCase() !== "ACTIVE") throw identityInvalid("WORKFORCE_STATUS");
+  if (currentAccessState !== "ACTIVE") throw identityInvalid("WORKFORCE_ACCESS_STATE");
+  if (metadata?.identityOnboardingId !== identity.onboardingId) throw identityInvalid("WORKFORCE_ONBOARDING_METADATA");
+  if (!unitId) throw identityInvalid("WORKFORCE_CURRENT_UNIT");
+  if (!identity.identityUnits.includes(unitId)) throw identityInvalid("WORKFORCE_IDENTITY_UNIT");
+  if (!identity.onboardingUnits.includes(unitId)) throw identityInvalid("WORKFORCE_ONBOARDING_UNIT");
 
   return { ...identity, canonicalEmployeeId, unitId };
 }
@@ -179,7 +182,7 @@ function identityQuery() {
 
 function workforceQuery(workforceEmployeeId) {
   const employeeId = normalize(workforceEmployeeId).toLowerCase();
-  if (!UUID.test(employeeId)) throw failure("PILOT_COHORT_IDENTITY_INVALID");
+  if (!UUID.test(employeeId)) throw identityInvalid("WORKFORCE_ID");
   return `SELECT
       e.id AS employee_id,
       e.canonical_employee_id AS canonical_employee_id,
@@ -245,7 +248,7 @@ export async function materializePilotCohort({ env = process.env, fetchImpl = fe
     databaseId: identityDatabaseId,
     sql: identityQuery(),
   });
-  if (identityRows.length !== 1) throw failure("PILOT_COHORT_IDENTITY_INVALID");
+  exactlyOne(identityRows, "IDENTITY_ROWS");
   const identity = assertIdentity(identityRows[0], pilotLogin);
   const workforceRows = await queryD1({
     fetchImpl,
@@ -254,7 +257,7 @@ export async function materializePilotCohort({ env = process.env, fetchImpl = fe
     databaseId,
     sql: workforceQuery(identity.workforceEmployeeId),
   });
-  if (workforceRows.length !== 1) throw failure("PILOT_COHORT_IDENTITY_INVALID");
+  exactlyOne(workforceRows, "WORKFORCE_ROWS");
   const candidate = assertWorkforce(workforceRows[0], identity);
   const egressAddress = await observedEgressAddress({ fetchImpl });
   return derivePilotCohort({ releaseSha, idempotencyKey, identity: candidate, egressAddress });

--- a/scripts/tests/materialize-pilot-cohort.test.mjs
+++ b/scripts/tests/materialize-pilot-cohort.test.mjs
@@ -97,17 +97,20 @@ test("materializes one opaque cohort from the exact active identity across both 
   assert.deepEqual(legacyRoleCohort, cohort);
 });
 
-test("refuses an unauthorized role, unconfirmed link, invalid lifecycle, or workforce mismatch", async () => {
-  for (const fixture of [
-    { identityRows: [identityRow({ identity_role: "SUPERVISOR" })] },
-    { identityRows: [identityRow({ link_review_status: "PENDING_REVIEW" })] },
-    { identityRows: [identityRow({ provisioning_state: "FAILED" })] },
-    { workforceRows: [workforceRow({ access_state: "SUSPENDED" })] },
-    { workforceRows: [workforceRow(), workforceRow()] },
+test("classifies the exact non-sensitive identity or Workforce predicate that rejects a cohort", async () => {
+  for (const [fixture, expectedCode] of [
+    [{ identityRows: [] }, "PILOT_COHORT_IDENTITY_INVALID_IDENTITY_ROWS_MISSING"],
+    [{ identityRows: [identityRow({ identity_role: "SUPERVISOR" })] }, "PILOT_COHORT_IDENTITY_INVALID_ROLE"],
+    [{ identityRows: [identityRow({ link_review_status: "PENDING_REVIEW" })] }, "PILOT_COHORT_IDENTITY_INVALID_LINK_REVIEW_STATUS"],
+    [{ identityRows: [identityRow({ provisioning_state: "FAILED" })] }, "PILOT_COHORT_IDENTITY_INVALID_PROVISIONING_STATE"],
+    [{ workforceRows: [workforceRow({ access_state: "SUSPENDED" })] }, "PILOT_COHORT_IDENTITY_INVALID_WORKFORCE_ACCESS_STATE"],
+    [{ workforceRows: [workforceRow(), workforceRow()] }, "PILOT_COHORT_IDENTITY_INVALID_WORKFORCE_ROWS_AMBIGUOUS"],
   ]) {
     await assert.rejects(
       () => materializePilotCohort({ env: environment, fetchImpl: fetchFor(fixture) }),
-      /PILOT_COHORT_IDENTITY_INVALID/,
+      (error) => error?.code === expectedCode
+        && error?.message === expectedCode
+        && !String(error?.message || "").includes(environment.PONTO_PILOT_LOGIN),
     );
   }
 });


### PR DESCRIPTION
## Summary
- classify the single failed pilot-cohort validation predicate without emitting identity, workforce, email, or custody values
- preserve the existing fail-closed cohort contract and opaque derivation

## Validation
- `node --test scripts/tests/materialize-pilot-cohort.test.mjs`
- `node --check scripts/runtime/materialize-pilot-cohort.mjs`
- `node .github/scripts/validate-cloudflare-single-writer.mjs`
- `node .github/scripts/validate-deploy-topology.mjs`