### PR TITLE
feat(meta-ads): attest staging source access

### DIFF
--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -78,17 +78,45 @@ jobs:
             'pages_manage_ads',
             'instagram_basic',
           ];
-          const permissions = await graphGet('me/permissions');
           const scopeStates = Object.fromEntries(scopeNames.map((name) => [name, 'unknown']));
-          if (permissions.state === 'ok') {
-            const granted = new Set(
-              Array.isArray(permissions.payload?.data)
-                ? permissions.payload.data
-                  .filter((entry) => entry && entry.status === 'granted')
-                  .map((entry) => String(entry.permission || ''))
-                : [],
-            );
+          const granted = new Set();
+          let permissionsState = 'ok';
+          let permissionCoverage = 'bounded';
+          let permissionCursor = '';
+          const maxPermissionPages = 5;
+          for (let page = 0; page < maxPermissionPages; page += 1) {
+            const cursorQuery = permissionCursor
+              ? `&after=${encodeURIComponent(permissionCursor)}`
+              : '';
+            const permissions = await graphGet(`me/permissions?limit=100${cursorQuery}`);
+            if (permissions.state !== 'ok') {
+              permissionsState = permissions.state;
+              break;
+            }
+            if (Array.isArray(permissions.payload?.data)) {
+              for (const entry of permissions.payload.data) {
+                if (entry?.status === 'granted') granted.add(String(entry.permission || ''));
+              }
+            }
+            const unresolved = scopeNames.filter((name) => !granted.has(name));
+            const nextCursor = String(permissions.payload?.paging?.cursors?.after || '').trim();
+            if (unresolved.length === 0 || !nextCursor) {
+              permissionCoverage = 'complete';
+              break;
+            }
+            if (nextCursor.length > 2_048 || nextCursor === permissionCursor) {
+              permissionsState = 'malformed';
+              break;
+            }
+            permissionCursor = nextCursor;
+          }
+          if (permissionsState === 'ok') {
             for (const name of scopeNames) scopeStates[name] = granted.has(name) ? 'granted' : 'missing';
+            if (permissionCoverage !== 'complete') {
+              for (const name of scopeNames) {
+                if (!granted.has(name)) scopeStates[name] = 'unknown';
+              }
+            }
           }
 
           const adAccount = await graphGet(`act_${accountId}?fields=id`);
@@ -98,7 +126,7 @@ jobs:
 
           process.stdout.write([
             'source_access_attestation=verified',
-            `source_access_permissions=${permissions.state === 'ok' ? 'available' : permissions.state}`,
+            `source_access_permissions=${permissionsState === 'ok' ? permissionCoverage : permissionsState}`,
             `source_access_ads_read=${scopeStates.ads_read}`,
             `source_access_ads_management=${scopeStates.ads_management}`,
             `source_access_business_management=${scopeStates.business_management}`,

--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -1,0 +1,111 @@
+name: Attest Meta Ads Staging Source Access
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: meta-ads-source-access-attestation-staging
+  cancel-in-progress: false
+
+jobs:
+  attest:
+    if: github.ref == 'refs/heads/main'
+    name: Read the staging source capability without deployment
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    environment: staging
+    steps:
+      - name: Attest Meta Ads source scopes and ad-account access without exposing them
+        env:
+          META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
+          META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
+          META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          const token = String(process.env.META_ADS_ACCESS_TOKEN || '');
+          const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
+          const apiVersion = String(process.env.META_ADS_API_VERSION || '');
+
+          const fail = (code) => {
+            console.error(`Meta Ads source-access attestation failed: ${code}`);
+            process.exit(1);
+          };
+
+          if (!token || !/^\d{5,30}$/.test(accountId) || !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion)) {
+            fail('source_contract_invalid');
+          }
+
+          const graphGet = async (path) => {
+            let response;
+            try {
+              response = await fetch(`https://graph.facebook.com/${apiVersion}/${path}`, {
+                method: 'GET',
+                headers: { Authorization: `Bearer ${token}` },
+                cache: 'no-store',
+                redirect: 'error',
+                signal: AbortSignal.timeout(12_000),
+              });
+            } catch {
+              return { state: 'unavailable' };
+            }
+
+            if (!response || response.status === 408 || response.status === 429 || response.status >= 500) {
+              return { state: 'unavailable' };
+            }
+            if (!response.ok) return { state: 'denied' };
+
+            let payload;
+            try {
+              payload = await response.json();
+            } catch {
+              return { state: 'malformed' };
+            }
+            if (payload?.error) return { state: 'denied' };
+            return { state: 'ok', payload };
+          };
+
+          const scopeNames = [
+            'ads_read',
+            'ads_management',
+            'business_management',
+            'pages_show_list',
+            'pages_read_engagement',
+            'pages_manage_ads',
+            'instagram_basic',
+          ];
+          const permissions = await graphGet('me/permissions');
+          const scopeStates = Object.fromEntries(scopeNames.map((name) => [name, 'unknown']));
+          if (permissions.state === 'ok') {
+            const granted = new Set(
+              Array.isArray(permissions.payload?.data)
+                ? permissions.payload.data
+                  .filter((entry) => entry && entry.status === 'granted')
+                  .map((entry) => String(entry.permission || ''))
+                : [],
+            );
+            for (const name of scopeNames) scopeStates[name] = granted.has(name) ? 'granted' : 'missing';
+          }
+
+          const adAccount = await graphGet(`act_${accountId}?fields=id`);
+          const adAccountState = adAccount.state === 'ok'
+            ? (String(adAccount.payload?.id || '') === accountId ? 'allowed' : 'malformed')
+            : adAccount.state;
+
+          process.stdout.write([
+            'source_access_attestation=verified',
+            `source_access_permissions=${permissions.state === 'ok' ? 'available' : permissions.state}`,
+            `source_access_ads_read=${scopeStates.ads_read}`,
+            `source_access_ads_management=${scopeStates.ads_management}`,
+            `source_access_business_management=${scopeStates.business_management}`,
+            `source_access_pages_show_list=${scopeStates.pages_show_list}`,
+            `source_access_pages_read_engagement=${scopeStates.pages_read_engagement}`,
+            `source_access_pages_manage_ads=${scopeStates.pages_manage_ads}`,
+            `source_access_instagram_basic=${scopeStates.instagram_basic}`,
+            `source_access_ad_account=${adAccountState}`,
+          ].join('\n') + '\n');
+          NODE

--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -64,7 +64,17 @@ jobs:
               return { state: 'malformed' };
             }
             if (payload?.error?.is_transient === true) return { state: 'unavailable' };
-            if (!response.ok || payload?.error) return { state: 'denied' };
+            if (!response.ok || payload?.error) {
+              const graphErrorCode = Number(payload?.error?.code);
+              const authorizationError =
+                response.status === 401 ||
+                response.status === 403 ||
+                graphErrorCode === 10 ||
+                graphErrorCode === 102 ||
+                graphErrorCode === 190 ||
+                graphErrorCode === 200;
+              return { state: authorizationError ? 'denied' : 'malformed' };
+            }
             return { state: 'ok', payload };
           };
 

--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -57,15 +57,14 @@ jobs:
             if (!response || response.status === 408 || response.status === 429 || response.status >= 500) {
               return { state: 'unavailable' };
             }
-            if (!response.ok) return { state: 'denied' };
-
             let payload;
             try {
               payload = await response.json();
             } catch {
               return { state: 'malformed' };
             }
-            if (payload?.error) return { state: 'denied' };
+            if (payload?.error?.is_transient === true) return { state: 'unavailable' };
+            if (!response.ok || payload?.error) return { state: 'denied' };
             return { state: 'ok', payload };
           };
 
@@ -93,14 +92,27 @@ jobs:
               permissionsState = permissions.state;
               break;
             }
-            if (Array.isArray(permissions.payload?.data)) {
-              for (const entry of permissions.payload.data) {
-                if (entry?.status === 'granted') granted.add(String(entry.permission || ''));
-              }
+            if (!Array.isArray(permissions.payload?.data)) {
+              permissionsState = 'malformed';
+              break;
+            }
+            for (const entry of permissions.payload.data) {
+              if (entry?.status === 'granted') granted.add(String(entry.permission || ''));
             }
             const unresolved = scopeNames.filter((name) => !granted.has(name));
-            const nextCursor = String(permissions.payload?.paging?.cursors?.after || '').trim();
-            if (unresolved.length === 0 || !nextCursor) {
+            const rawNextPage = permissions.payload?.paging?.next;
+            if (rawNextPage != null && typeof rawNextPage !== 'string') {
+              permissionsState = 'malformed';
+              break;
+            }
+            const hasNextPage = typeof rawNextPage === 'string' && rawNextPage.length > 0;
+            const rawNextCursor = permissions.payload?.paging?.cursors?.after;
+            if (hasNextPage && typeof rawNextCursor !== 'string') {
+              permissionsState = 'malformed';
+              break;
+            }
+            const nextCursor = typeof rawNextCursor === 'string' ? rawNextCursor.trim() : '';
+            if (unresolved.length === 0 || !hasNextPage) {
               permissionCoverage = 'complete';
               break;
             }

--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -93,7 +93,7 @@ jobs:
 
           const adAccount = await graphGet(`act_${accountId}?fields=id`);
           const adAccountState = adAccount.state === 'ok'
-            ? (String(adAccount.payload?.id || '') === accountId ? 'allowed' : 'malformed')
+            ? (String(adAccount.payload?.id || '').trim().replace(/^act_/, '') === accountId ? 'allowed' : 'malformed')
             : adAccount.state;
 
           process.stdout.write([

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const workflow = fs.readFileSync(
+  new URL(
+    "../../../../.github/workflows/attest-meta-ads-source-access.yml",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+test("Meta Ads source-access attestation is manual, bounded, and non-deploying", () => {
+  assert.match(workflow, /^name: Attest Meta Ads Staging Source Access$/m);
+  assert.match(workflow, /^\s+workflow_dispatch:\s*$/m);
+  assert.match(workflow, /if: github\.ref == 'refs\/heads\/main'/);
+  assert.match(workflow, /environment: staging/);
+  assert.match(workflow, /timeout-minutes: 3/);
+  assert.match(workflow, /META_ADS_ACCESS_TOKEN: \$\{\{ secrets\.META_ADS_ACCESS_TOKEN \}\}/);
+  assert.match(workflow, /META_ADS_ACCOUNT_ID: \$\{\{ vars\.META_ADS_ACCOUNT_ID \}\}/);
+  assert.match(workflow, /META_ADS_API_VERSION: \$\{\{ vars\.META_ADS_API_VERSION \}\}/);
+  assert.match(workflow, /graphGet\('me\/permissions'\)/);
+  assert.match(workflow, /graphGet\(`act_\$\{accountId\}\?fields=id`\)/);
+  assert.match(workflow, /method: 'GET'/);
+  assert.match(workflow, /Authorization: `Bearer \$\{token\}`/);
+  assert.match(workflow, /cache: 'no-store'/);
+  assert.match(workflow, /redirect: 'error'/);
+  assert.match(workflow, /AbortSignal\.timeout\(12_000\)/);
+  assert.match(workflow, /source_access_attestation=verified/);
+  assert.match(workflow, /source_access_ads_read=/);
+  assert.match(workflow, /source_access_ads_management=/);
+  assert.match(workflow, /source_access_business_management=/);
+  assert.match(workflow, /source_access_pages_show_list=/);
+  assert.match(workflow, /source_access_pages_read_engagement=/);
+  assert.match(workflow, /source_access_pages_manage_ads=/);
+  assert.match(workflow, /source_access_instagram_basic=/);
+  assert.match(workflow, /source_access_ad_account=/);
+
+  assert.doesNotMatch(workflow, /access_token=/i);
+  assert.doesNotMatch(workflow, /debug_token/i);
+  assert.doesNotMatch(workflow, /method: 'POST'/);
+  assert.doesNotMatch(workflow, /upload-artifact/i);
+  assert.doesNotMatch(workflow, /wrangler/i);
+  assert.doesNotMatch(workflow, /gh secret/i);
+  assert.doesNotMatch(workflow, /secret put/i);
+  assert.doesNotMatch(workflow, /GITHUB_OUTPUT/);
+  assert.doesNotMatch(workflow, /META_PIXEL_ID/);
+  assert.doesNotMatch(workflow, /D1|Cloudflare|Orb|n8n/);
+});

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -28,7 +28,14 @@ test("Meta Ads source-access attestation is manual, bounded, and non-deploying",
     workflow,
     /META_ADS_API_VERSION: \$\{\{ vars\.META_ADS_API_VERSION \}\}/,
   );
-  assert.match(workflow, /graphGet\('me\/permissions'\)/);
+  assert.match(workflow, /const maxPermissionPages = 5/);
+  assert.match(
+    workflow,
+    /graphGet\(`me\/permissions\?limit=100\$\{cursorQuery\}`\)/,
+  );
+  assert.match(workflow, /paging\?\.cursors\?\.after/);
+  assert.match(workflow, /encodeURIComponent\(permissionCursor\)/);
+  assert.match(workflow, /unresolved\.length === 0 \|\| !nextCursor/);
   assert.match(workflow, /graphGet\(`act_\$\{accountId\}\?fields=id`\)/);
   assert.match(
     workflow,

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -44,6 +44,17 @@ test("Meta Ads source-access attestation is manual, bounded, and non-deploying",
   assert.match(workflow, /unresolved\.length === 0 \|\| !hasNextPage/);
   assert.match(workflow, /!Array\.isArray\(permissions\.payload\?\.data\)/);
   assert.match(workflow, /payload\?\.error\?\.is_transient === true/);
+  assert.match(
+    workflow,
+    /const graphErrorCode = Number\(payload\?\.error\?\.code\)/,
+  );
+  assert.match(workflow, /response\.status === 401/);
+  assert.match(workflow, /response\.status === 403/);
+  assert.match(workflow, /graphErrorCode === 10/);
+  assert.match(workflow, /graphErrorCode === 102/);
+  assert.match(workflow, /graphErrorCode === 190/);
+  assert.match(workflow, /graphErrorCode === 200/);
+  assert.match(workflow, /authorizationError \? 'denied' : 'malformed'/);
   assert.match(workflow, /graphGet\(`act_\$\{accountId\}\?fields=id`\)/);
   assert.match(
     workflow,

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -16,11 +16,24 @@ test("Meta Ads source-access attestation is manual, bounded, and non-deploying",
   assert.match(workflow, /if: github\.ref == 'refs\/heads\/main'/);
   assert.match(workflow, /environment: staging/);
   assert.match(workflow, /timeout-minutes: 3/);
-  assert.match(workflow, /META_ADS_ACCESS_TOKEN: \$\{\{ secrets\.META_ADS_ACCESS_TOKEN \}\}/);
-  assert.match(workflow, /META_ADS_ACCOUNT_ID: \$\{\{ vars\.META_ADS_ACCOUNT_ID \}\}/);
-  assert.match(workflow, /META_ADS_API_VERSION: \$\{\{ vars\.META_ADS_API_VERSION \}\}/);
+  assert.match(
+    workflow,
+    /META_ADS_ACCESS_TOKEN: \$\{\{ secrets\.META_ADS_ACCESS_TOKEN \}\}/,
+  );
+  assert.match(
+    workflow,
+    /META_ADS_ACCOUNT_ID: \$\{\{ vars\.META_ADS_ACCOUNT_ID \}\}/,
+  );
+  assert.match(
+    workflow,
+    /META_ADS_API_VERSION: \$\{\{ vars\.META_ADS_API_VERSION \}\}/,
+  );
   assert.match(workflow, /graphGet\('me\/permissions'\)/);
   assert.match(workflow, /graphGet\(`act_\$\{accountId\}\?fields=id`\)/);
+  assert.match(
+    workflow,
+    /payload\?\.id \|\| ''\)\.trim\(\)\.replace\(\/\^act_\//,
+  );
   assert.match(workflow, /method: 'GET'/);
   assert.match(workflow, /Authorization: `Bearer \$\{token\}`/);
   assert.match(workflow, /cache: 'no-store'/);

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -34,8 +34,16 @@ test("Meta Ads source-access attestation is manual, bounded, and non-deploying",
     /graphGet\(`me\/permissions\?limit=100\$\{cursorQuery\}`\)/,
   );
   assert.match(workflow, /paging\?\.cursors\?\.after/);
+  assert.match(workflow, /paging\?\.next/);
+  assert.match(
+    workflow,
+    /rawNextPage != null && typeof rawNextPage !== 'string'/,
+  );
+  assert.match(workflow, /hasNextPage && typeof rawNextCursor !== 'string'/);
   assert.match(workflow, /encodeURIComponent\(permissionCursor\)/);
-  assert.match(workflow, /unresolved\.length === 0 \|\| !nextCursor/);
+  assert.match(workflow, /unresolved\.length === 0 \|\| !hasNextPage/);
+  assert.match(workflow, /!Array\.isArray\(permissions\.payload\?\.data\)/);
+  assert.match(workflow, /payload\?\.error\?\.is_transient === true/);
   assert.match(workflow, /graphGet\(`act_\$\{accountId\}\?fields=id`\)/);
   assert.match(
     workflow,


### PR DESCRIPTION
## What changed
- Adds a manual, staging-scoped Meta Ads source-access attestation.
- Reads only granted scopes and configured ad-account access using bounded Graph GET requests.

## Why
The governed staging rollout remains blocked before mutation at the Pixel source attestation. This diagnostic separates token scope/account access from Pixel asset assignment without retrying a deployment.

## Safety
- No Worker, D1, Orb, n8n, Cloudflare, GitHub-secret, or Meta write path.
- No token, payload, account identifier, or Graph response output.

## Validation
- `npm --prefix platform/security/token-vault test` (144/144)
- Focused workflow test
- Prettier workflow check
- Global concurrency governance static tests (18/18)