### PR TITLE
fix(meta-ads): fail closed on denied source access

### DIFF
--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -96,6 +96,17 @@ jobs:
             ? (String(adAccount.payload?.id || '') === accountId ? 'allowed' : 'malformed')
             : adAccount.state;
 
+          const missingScopes = scopeNames.filter((name) => scopeStates[name] !== 'granted');
+          if (permissions.state !== 'ok') {
+            fail(`source_permissions_${permissions.state}`);
+          }
+          if (missingScopes.length > 0) {
+            fail(`source_permissions_missing:${missingScopes.join(',')}`);
+          }
+          if (adAccountState !== 'allowed') {
+            fail(`source_ad_account_${adAccountState}`);
+          }
+
           process.stdout.write([
             'source_access_attestation=verified',
             `source_access_permissions=${permissions.state === 'ok' ? 'available' : permissions.state}`,

--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -1,0 +1,111 @@
+name: Attest Meta Ads Staging Source Access
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: meta-ads-source-access-attestation-staging
+  cancel-in-progress: false
+
+jobs:
+  attest:
+    if: github.ref == 'refs/heads/main'
+    name: Read the staging source capability without deployment
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    environment: staging
+    steps:
+      - name: Attest Meta Ads source scopes and ad-account access without exposing them
+        env:
+          META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
+          META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
+          META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          const token = String(process.env.META_ADS_ACCESS_TOKEN || '');
+          const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
+          const apiVersion = String(process.env.META_ADS_API_VERSION || '');
+
+          const fail = (code) => {
+            console.error(`Meta Ads source-access attestation failed: ${code}`);
+            process.exit(1);
+          };
+
+          if (!token || !/^\d{5,30}$/.test(accountId) || !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion)) {
+            fail('source_contract_invalid');
+          }
+
+          const graphGet = async (path) => {
+            let response;
+            try {
+              response = await fetch(`https://graph.facebook.com/${apiVersion}/${path}`, {
+                method: 'GET',
+                headers: { Authorization: `Bearer ${token}` },
+                cache: 'no-store',
+                redirect: 'error',
+                signal: AbortSignal.timeout(12_000),
+              });
+            } catch {
+              return { state: 'unavailable' };
+            }
+
+            if (!response || response.status === 408 || response.status === 429 || response.status >= 500) {
+              return { state: 'unavailable' };
+            }
+            if (!response.ok) return { state: 'denied' };
+
+            let payload;
+            try {
+              payload = await response.json();
+            } catch {
+              return { state: 'malformed' };
+            }
+            if (payload?.error) return { state: 'denied' };
+            return { state: 'ok', payload };
+          };
+
+          const scopeNames = [
+            'ads_read',
+            'ads_management',
+            'business_management',
+            'pages_show_list',
+            'pages_read_engagement',
+            'pages_manage_ads',
+            'instagram_basic',
+          ];
+          const permissions = await graphGet('me/permissions');
+          const scopeStates = Object.fromEntries(scopeNames.map((name) => [name, 'unknown']));
+          if (permissions.state === 'ok') {
+            const granted = new Set(
+              Array.isArray(permissions.payload?.data)
+                ? permissions.payload.data
+                  .filter((entry) => entry && entry.status === 'granted')
+                  .map((entry) => String(entry.permission || ''))
+                : [],
+            );
+            for (const name of scopeNames) scopeStates[name] = granted.has(name) ? 'granted' : 'missing';
+          }
+
+          const adAccount = await graphGet(`act_${accountId}?fields=id`);
+          const adAccountState = adAccount.state === 'ok'
+            ? (String(adAccount.payload?.id || '') === accountId ? 'allowed' : 'malformed')
+            : adAccount.state;
+
+          process.stdout.write([
+            'source_access_attestation=verified',
+            `source_access_permissions=${permissions.state === 'ok' ? 'available' : permissions.state}`,
+            `source_access_ads_read=${scopeStates.ads_read}`,
+            `source_access_ads_management=${scopeStates.ads_management}`,
+            `source_access_business_management=${scopeStates.business_management}`,
+            `source_access_pages_show_list=${scopeStates.pages_show_list}`,
+            `source_access_pages_read_engagement=${scopeStates.pages_read_engagement}`,
+            `source_access_pages_manage_ads=${scopeStates.pages_manage_ads}`,
+            `source_access_instagram_basic=${scopeStates.instagram_basic}`,
+            `source_access_ad_account=${adAccountState}`,
+          ].join('\n') + '\n');
+          NODE

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const workflow = fs.readFileSync(
+  new URL(
+    "../../../../.github/workflows/attest-meta-ads-source-access.yml",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+test("Meta Ads source-access attestation is manual, bounded, and non-deploying", () => {
+  assert.match(workflow, /^name: Attest Meta Ads Staging Source Access$/m);
+  assert.match(workflow, /^\s+workflow_dispatch:\s*$/m);
+  assert.match(workflow, /if: github\.ref == 'refs\/heads\/main'/);
+  assert.match(workflow, /environment: staging/);
+  assert.match(workflow, /timeout-minutes: 3/);
+  assert.match(workflow, /META_ADS_ACCESS_TOKEN: \$\{\{ secrets\.META_ADS_ACCESS_TOKEN \}\}/);
+  assert.match(workflow, /META_ADS_ACCOUNT_ID: \$\{\{ vars\.META_ADS_ACCOUNT_ID \}\}/);
+  assert.match(workflow, /META_ADS_API_VERSION: \$\{\{ vars\.META_ADS_API_VERSION \}\}/);
+  assert.match(workflow, /graphGet\('me\/permissions'\)/);
+  assert.match(workflow, /graphGet\(`act_\$\{accountId\}\?fields=id`\)/);
+  assert.match(workflow, /method: 'GET'/);
+  assert.match(workflow, /Authorization: `Bearer \$\{token\}`/);
+  assert.match(workflow, /cache: 'no-store'/);
+  assert.match(workflow, /redirect: 'error'/);
+  assert.match(workflow, /AbortSignal\.timeout\(12_000\)/);
+  assert.match(workflow, /source_access_attestation=verified/);
+  assert.match(workflow, /source_access_ads_read=/);
+  assert.match(workflow, /source_access_ads_management=/);
+  assert.match(workflow, /source_access_business_management=/);
+  assert.match(workflow, /source_access_pages_show_list=/);
+  assert.match(workflow, /source_access_pages_read_engagement=/);
+  assert.match(workflow, /source_access_pages_manage_ads=/);
+  assert.match(workflow, /source_access_instagram_basic=/);
+  assert.match(workflow, /source_access_ad_account=/);
+
+  assert.doesNotMatch(workflow, /access_token=/i);
+  assert.doesNotMatch(workflow, /debug_token/i);
+  assert.doesNotMatch(workflow, /method: 'POST'/);
+  assert.doesNotMatch(workflow, /upload-artifact/i);
+  assert.doesNotMatch(workflow, /wrangler/i);
+  assert.doesNotMatch(workflow, /gh secret/i);
+  assert.doesNotMatch(workflow, /secret put/i);
+  assert.doesNotMatch(workflow, /GITHUB_OUTPUT/);
+  assert.doesNotMatch(workflow, /META_PIXEL_ID/);
+  assert.doesNotMatch(workflow, /D1|Cloudflare|Orb|n8n/);
+});

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -36,6 +36,16 @@ test("Meta Ads source-access attestation is manual, bounded, and non-deploying",
   assert.match(workflow, /source_access_instagram_basic=/);
   assert.match(workflow, /source_access_ad_account=/);
 
+  assert.match(workflow, /const missingScopes = scopeNames\.filter\(\(name\) => scopeStates\[name\] !== 'granted'\)/);
+  assert.match(workflow, /if \(permissions\.state !== 'ok'\)/);
+  assert.match(workflow, /source_permissions_missing:/);
+  assert.match(workflow, /if \(adAccountState !== 'allowed'\)/);
+  assert.match(workflow, /source_ad_account_\$\{adAccountState\}/);
+  assert.ok(
+    workflow.indexOf('source_permissions_missing:') < workflow.indexOf('source_access_attestation=verified'),
+    'verified output must be unreachable until missing permissions fail closed',
+  );
+
   assert.doesNotMatch(workflow, /access_token=/i);
   assert.doesNotMatch(workflow, /debug_token/i);
   assert.doesNotMatch(workflow, /method: 'POST'/);


### PR DESCRIPTION
# Summary

Fail closed when the staging-only Meta Ads source-access attestation cannot prove all required permissions and ad-account access.

The original workflow emitted `source_access_attestation=verified` even when Graph responses were denied, unavailable, malformed, or missing required scopes. This branch keeps the workflow manual, GET-only, staging-scoped, and non-deploying, but exits before the verified marker unless every required scope is granted and the account is allowed. It also preserves the bounded permission pagination and Graph error classification now present in `main`.

## Type of change
- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [x] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated
- [ ] Security review (CodeQL, gitleaks)
- [ ] Performance impact measured

## Validation

- Focused workflow contract test passed in Ubuntu-24.04/WSL.
- Repository preflight passed in Ubuntu-24.04/WSL with zero failures.
- GitHub checks passed on head `6e7b5f606e20602f4028687958081d44cdbb0dab`.
- `git diff --check` passed.
- No deployment, production mutation, or Meta Ads publish action is part of this PR.

## External gate

After the governed merge, run the existing main-only staging attestation on the exact resulting `main` SHA. A successful read-only staging attestation is required before any future Meta Ads publish; it is not a production deployment and does not authorize publishing by itself.