### PR TITLE
fix(beauty-movement): consolidate latest interaction refinements

### DIFF
--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -2691,6 +2691,11 @@
   color: var(--bm-ink);
 }
 
+.progressItemCurrent .progressButton:disabled {
+  cursor: default;
+  opacity: 1;
+}
+
 .progressTransfer {
   border-radius: 0;
   background: var(--bm-yellow);

--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -1074,10 +1074,11 @@ export default function BeautyMovementExperience({
     useEffect(() => {
         if (!reducedMotion) return;
         cancelScrollAnimation();
+        stopInitialDealScroll();
         // Keep the dependency-list shape stable for Fast Refresh. The
         // auto-advance cancellation was intentionally removed; this
         // dependency remains only to avoid a dev-time hook signature change.
-    }, [reducedMotion, cancelAutoAdvance, cancelScrollAnimation]);
+    }, [reducedMotion, cancelAutoAdvance, cancelScrollAnimation, stopInitialDealScroll]);
 
     useEffect(() => {
         if (handStage !== "expand") return;

--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -300,6 +300,8 @@ export default function BeautyMovementExperience({
     const progressMotionTimerRef = useRef<number | null>(null);
     const scrollAnimationFrameRef = useRef<number | null>(null);
     const scrollInterruptCleanupRef = useRef<(() => void) | null>(null);
+    const initialDealScrollFrameRef = useRef<number | null>(null);
+    const initialDealScrollActiveRef = useRef(false);
     const tableRef = useRef<HTMLElement | null>(null);
     const tableSurfaceRef = useRef<HTMLDivElement | null>(null);
     const progressListRef = useRef<HTMLOListElement | null>(null);
@@ -482,6 +484,10 @@ export default function BeautyMovementExperience({
             if (scrollAnimationFrameRef.current !== null) {
                 window.cancelAnimationFrame(scrollAnimationFrameRef.current);
             }
+            if (initialDealScrollFrameRef.current !== null) {
+                window.cancelAnimationFrame(initialDealScrollFrameRef.current);
+            }
+            initialDealScrollActiveRef.current = false;
             scrollInterruptCleanupRef.current?.();
         };
     }, []);
@@ -625,6 +631,78 @@ export default function BeautyMovementExperience({
         scrollInterruptCleanupRef.current = null;
     }, []);
 
+    function getTableScrollTarget(): number | null {
+        const target = tableRef.current;
+        if (!target) return null;
+
+        const title = document.getElementById("beauty-movement-title");
+        const titlePeek =
+            title instanceof HTMLElement
+                ? Math.min(184, Math.max(0, Math.round(title.getBoundingClientRect().height - 2)))
+                : 0;
+        const stickyHeader = document.querySelector("header");
+        const scrollOffset = (stickyHeader instanceof HTMLElement ? stickyHeader.getBoundingClientRect().height + 4 : 32) + titlePeek;
+        const editorialTarget = window.scrollY + target.getBoundingClientRect().top - scrollOffset;
+        const deck = target.querySelector<HTMLElement>(`.${styles.deckStage}`);
+        const deckRect = deck?.getBoundingClientRect();
+        const deckBottomPadding = Math.max(28, Math.round(window.innerHeight * 0.08));
+        const deckTarget = deckRect
+            ? window.scrollY + deckRect.bottom - (window.innerHeight - deckBottomPadding)
+            : editorialTarget;
+
+        // The surface grows downward while the deck travels with it. Keep the
+        // deck fully in the lower half of the viewport instead of leaving its
+        // final card cut off below the fold. The editorial anchor remains the
+        // floor so the first scroll still starts from the hero/table handoff.
+        return Math.max(0, Math.max(editorialTarget, deckTarget));
+    }
+
+    function stopInitialDealScroll() {
+        initialDealScrollActiveRef.current = false;
+        if (initialDealScrollFrameRef.current !== null) {
+            window.cancelAnimationFrame(initialDealScrollFrameRef.current);
+            initialDealScrollFrameRef.current = null;
+        }
+    }
+
+    function startInitialDealScroll() {
+        stopInitialDealScroll();
+
+        if (reducedMotion) {
+            scrollToTable();
+            return;
+        }
+
+        // Keep the table's editorial anchor in the viewport while its surface
+        // grows and the deck travels down into the dealt hand. Re-measuring on
+        // every frame avoids a one-time target becoming stale during layout
+        // transitions and lets the scroll itself trigger the header collapse.
+        initialDealScrollActiveRef.current = true;
+        let previousTime = performance.now();
+        const follow = (now: number) => {
+            if (!initialDealScrollActiveRef.current || !mountedRef.current) {
+                initialDealScrollFrameRef.current = null;
+                return;
+            }
+
+            const targetTop = getTableScrollTarget();
+            if (targetTop !== null) {
+                const currentTop = window.scrollY;
+                const elapsed = Math.max(0, now - previousTime);
+                const easing = 1 - Math.exp(-Math.min(48, elapsed) / 180);
+                const nextTop = currentTop + (targetTop - currentTop) * easing;
+                if (Math.abs(targetTop - currentTop) > 0.25) {
+                    window.scrollTo(0, nextTop);
+                }
+            }
+
+            previousTime = now;
+            initialDealScrollFrameRef.current = window.requestAnimationFrame(follow);
+        };
+
+        initialDealScrollFrameRef.current = window.requestAnimationFrame(follow);
+    }
+
     function scrollToElement(target: HTMLElement | null, extraOffset = 0) {
         cancelScrollAnimation();
         if (!target) return;
@@ -676,13 +754,15 @@ export default function BeautyMovementExperience({
     }
 
     function scrollToTable() {
-        cancelAutoAdvance();
+        const target = tableRef.current;
+        if (!target) return;
+
         const title = document.getElementById("beauty-movement-title");
         const titlePeek =
             title instanceof HTMLElement
                 ? Math.min(184, Math.max(0, Math.round(title.getBoundingClientRect().height - 2)))
                 : 0;
-        scrollToElement(tableRef.current, titlePeek);
+        scrollToElement(target, titlePeek);
     }
 
     function clearHandTransitionTimer() {
@@ -816,6 +896,7 @@ export default function BeautyMovementExperience({
         const introToken = beginIntroTransition();
         setTableIntroHeight(0);
         setCurrentIntroStage("entering");
+        startInitialDealScroll();
         scheduleIntroTransition(introToken, promptEntryDuration(initialExperienceText), () => {
             setCurrentIntroStage("holding");
             scheduleIntroTransition(introToken, BEAUTY_MOVEMENT_MOTION.initialIntroHoldMs, () => {
@@ -829,7 +910,10 @@ export default function BeautyMovementExperience({
                             scheduleDealSequence(handToken, () => {
                                 transitionInFlightRef.current = false;
                                 setCurrentHandStage("ready");
-                                window.requestAnimationFrame(scrollToTable);
+                                // Let the ready-state DOM commit once before
+                                // releasing the follow loop, so the final
+                                // card-grid layout is included in the anchor.
+                                window.requestAnimationFrame(stopInitialDealScroll);
                             });
                         });
                     }, true);
@@ -988,24 +1072,11 @@ export default function BeautyMovementExperience({
     }
 
     useEffect(() => {
-        if (!autoAdvanceActive) return;
-
-        const cancelOnReadingIntent = () => cancelAutoAdvance();
-        window.addEventListener("wheel", cancelOnReadingIntent, { passive: true });
-        window.addEventListener("touchmove", cancelOnReadingIntent, { passive: true });
-        window.addEventListener("keydown", cancelOnReadingIntent);
-
-        return () => {
-            window.removeEventListener("wheel", cancelOnReadingIntent);
-            window.removeEventListener("touchmove", cancelOnReadingIntent);
-            window.removeEventListener("keydown", cancelOnReadingIntent);
-        };
-    }, [autoAdvanceActive, cancelAutoAdvance]);
-
-    useEffect(() => {
         if (!reducedMotion) return;
-        cancelAutoAdvance();
         cancelScrollAnimation();
+        // Keep the dependency-list shape stable for Fast Refresh. The
+        // auto-advance cancellation was intentionally removed; this
+        // dependency remains only to avoid a dev-time hook signature change.
     }, [reducedMotion, cancelAutoAdvance, cancelScrollAnimation]);
 
     useEffect(() => {
@@ -1056,16 +1127,10 @@ export default function BeautyMovementExperience({
         };
     }, [handStage, introStage]);
 
-    useEffect(() => {
-        const cancelWhenBackgrounded = () => {
-            if (document.visibilityState === "hidden") cancelAutoAdvance();
-        };
-
-        document.addEventListener("visibilitychange", cancelWhenBackgrounded);
-        return () => document.removeEventListener("visibilitychange", cancelWhenBackgrounded);
-    }, [cancelAutoAdvance]);
-
     function handleProgressClick(index: number) {
+        // Once the automatic handoff is armed, progress controls are passive:
+        // user input must never turn a visible countdown into a cancellation.
+        if (autoAdvanceActive) return;
         if (index !== displayedActIndexRef.current || !isActUnlocked(index)) return;
 
         const act = BEAUTY_MOVEMENT_ACTS[index];
@@ -1582,7 +1647,7 @@ export default function BeautyMovementExperience({
                                                     ref={(element) => {
                                                         progressButtonRefs.current[index] = element;
                                                     }}
-                                                    disabled={!isCurrent || Boolean(progressMotion)}
+                                                    disabled={!isCurrent || Boolean(progressMotion) || autoAdvanceActive}
                                                 aria-current={isCurrent ? "step" : undefined}
                                                 aria-label={progressActionLabel}
                                             >

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -39,7 +39,17 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.match(experience, /scrollIntoView\(\{ behavior: "auto"/);
     assert.match(experience, /function scrollToElement\(target: HTMLElement \| null, extraOffset = 0\)/);
     assert.match(experience, /const titlePeek =/);
-    assert.match(experience, /scrollToElement\(tableRef\.current, titlePeek\)/);
+    assert.match(experience, /function getTableScrollTarget\(\): number \| null/);
+    assert.match(experience, /const deck = target\.querySelector<HTMLElement>\(`\.\$\{styles\.deckStage\}`\)/);
+    assert.match(experience, /const deckBottomPadding = Math\.max\(28, Math\.round\(window\.innerHeight \* 0\.08\)\)/);
+    assert.match(experience, /const deckTarget = deckRect/);
+    assert.match(experience, /Math\.max\(editorialTarget, deckTarget\)/);
+    assert.match(experience, /const initialDealScrollFrameRef = useRef<number \| null>\(null\)/);
+    assert.match(experience, /const initialDealScrollActiveRef = useRef\(false\)/);
+    assert.match(experience, /function startInitialDealScroll\(\)/);
+    assert.match(experience, /window\.requestAnimationFrame\(follow\)/);
+    assert.match(experience, /function stopInitialDealScroll\(\)/);
+    assert.match(experience, /scrollToElement\(target, titlePeek\)/);
     assert.match(experience, /prefers-reduced-motion/);
     assert.match(experience, /import \{ BEAUTY_MOVEMENT_MOTION, createBeautyMovementMotionGate \}/);
     assert.match(experience, /AUTO_ADVANCE_SECONDS = BEAUTY_MOVEMENT_MOTION\.autoAdvanceMs \/ 1_000/);
@@ -85,7 +95,7 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.match(experience, /automática em \{AUTO_ADVANCE_SECONDS\} segundos/);
     assert.doesNotMatch(experience, /confirmationTriggerRef/);
     assert.match(experience, /className=\{styles\.progressButton\}/);
-    assert.match(experience, /disabled=\{!isCurrent \|\| Boolean\(progressMotion\)\}/);
+    assert.match(experience, /disabled=\{!isCurrent \|\| Boolean\(progressMotion\) \|\| autoAdvanceActive\}/);
     assert.match(experience, /onClick=\{\(\) => handleProgressClick\(index\)\}/);
     assert.match(experience, /className=\{styles\.progressCopy\}/);
     assert.match(experience, /className=\{styles\.progressTransfer\}/);
@@ -189,6 +199,13 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.match(experience, /const targetHeight = Math\.max\(\s*startHeight,/);
     assert.match(experience, /"held"/);
     assert.match(experience, /function startInitialDeal\(\)/);
+    const initialDeal = experience.slice(
+        experience.indexOf("function startInitialDeal()"),
+        experience.indexOf("function handleDeckKeyDown"),
+    );
+    assert.match(initialDeal, /setCurrentIntroStage\("entering"\);\s*startInitialDealScroll\(\);/);
+    assert.match(initialDeal, /setCurrentHandStage\("ready"\);\s*\/\/ Let the ready-state DOM commit once before[\s\S]*window\.requestAnimationFrame\(stopInitialDealScroll\)/);
+    assert.doesNotMatch(initialDeal, /addEventListener\("(?:wheel|touchstart|pointerdown|keydown)"/);
     assert.match(experience, /function handleDeckKeyDown\(event: ReactKeyboardEvent<HTMLButtonElement>\)/);
     assert.match(experience, /event\.key !== "Enter" && event\.key !== " " && event\.key !== "Spacebar"/);
     assert.equal((experience.match(/onKeyDown=\{handleDeckKeyDown\}/g) ?? []).length, 1);

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -49,6 +49,7 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.match(experience, /function startInitialDealScroll\(\)/);
     assert.match(experience, /window\.requestAnimationFrame\(follow\)/);
     assert.match(experience, /function stopInitialDealScroll\(\)/);
+    assert.match(experience, /cancelScrollAnimation\(\);\s*stopInitialDealScroll\(\);/);
     assert.match(experience, /scrollToElement\(target, titlePeek\)/);
     assert.match(experience, /prefers-reduced-motion/);
     assert.match(experience, /import \{ BEAUTY_MOVEMENT_MOTION, createBeautyMovementMotionGate \}/);

--- a/website/tests/beautyMovementProgress.test.ts
+++ b/website/tests/beautyMovementProgress.test.ts
@@ -43,5 +43,6 @@ test("the active category keeps its yellow state and the countdown is armed with
         /\.progressItemCurrent \.progressButton \{[\s\S]*background: var\(--bm-yellow\);[\s\S]*color: var\(--bm-ink\);/,
     );
     assert.match(rhythmLayer, /\.progressItemCurrent \.progressButton:hover \{[\s\S]*background: var\(--bm-yellow\);/);
+    assert.match(rhythmLayer, /\.progressItemCurrent \.progressButton:disabled \{[\s\S]*opacity: 1;/);
     assert.match(rhythmLayer, /\.autoAdvance::after \{[\s\S]*background: var\(--bm-ink\);/);
 });

--- a/website/tests/beautyMovementProgress.test.ts
+++ b/website/tests/beautyMovementProgress.test.ts
@@ -25,6 +25,11 @@ test("the active category keeps its yellow state and the countdown is armed with
 
     assert.match(experience, /const autoAdvanceScheduledRef = useRef\(false\)/);
     assert.match(experience, /const autoAdvancePendingRef = useRef\(false\)/);
+    assert.doesNotMatch(experience, /window\.addEventListener\("(wheel|touchmove|keydown)", cancelOnReadingIntent/);
+    assert.doesNotMatch(experience, /document\.addEventListener\("visibilitychange", cancelWhenBackgrounded\)/);
+    assert.doesNotMatch(experience, /if \(!reducedMotion\) return;\s*cancelAutoAdvance\(\)/);
+    assert.match(experience, /function handleProgressClick\(index: number\) \{\s*\/\/ Once the automatic handoff is armed[\s\S]*if \(autoAdvanceActive\) return;/);
+    assert.match(experience, /disabled=\{!isCurrent \|\| Boolean\(progressMotion\) \|\| autoAdvanceActive\}/);
     assert.ok(start.indexOf("setAutoAdvanceActive(true)") < start.indexOf("window.requestAnimationFrame"));
     assert.match(start, /handStageRef\.current !== "reveal" && handStageRef\.current !== "held"/);
     assert.match(start, /autoAdvancePendingRef\.current = true/);


### PR DESCRIPTION
## Objetivo
Consolidar os refinamentos funcionais da campanha Beleza em Movimento sobre o `origin/main` atual, preservando integralmente o redesign já integrado.

## O que mudou
- Mantém a identidade visual de papel/marfim, mesa verde profunda, filetes champagne e ilustrações já presentes na main.
- Impede que teclas, wheel, touch, visibilidade ou controles de progresso cancelem indevidamente o auto-advance.
- Mantém o countdown durante mudanças de preferência de movimento e Fast Refresh.
- Faz o primeiro clique no baralho iniciar uma rolagem RAF contínua, acompanhando a expansão da mesa e mantendo o baralho visível; o cabeçalho recolhe pelo scroll.

## Causa raiz
A main estava no estado funcional de `#1468` (`733d8534`), enquanto refinamentos posteriores ficaram em worktree paralelo. A branch histórica também carregava mudanças não relacionadas; este PR foi reconstruído a partir de `origin/main` e porta somente os três arquivos da campanha necessários.

## Validação
- 22 testes focados verdes: campanha, progresso, Action/launcher v2, fingerprint, materialização, runner WSL e contrato Next.
- `git diff --check` verde.
- Sem flags, migrations ou efeitos externos; a mudança é reversível por revert deste commit.

## Rollback
Reverter o commit do PR e reiniciar a preview canônica pelo mesmo Action/manifesto v2.

<!-- automerge/enabled -->