### PR TITLE
fix(inventory): gate unified team contact decryption

### DIFF
--- a/inventory/src/routes/admin.js
+++ b/inventory/src/routes/admin.js
@@ -728,6 +728,20 @@ export async function handleAdminRoutes({
     inviteMailer: Boolean(hasAuthMailerConfig(env)),
   });
 
+  // Every unified-team route that can read or mutate team data must pass the
+  // rollout and schema gates before it can touch a member row. In particular,
+  // the scoped contact endpoint must not decrypt private data while the
+  // feature is disabled or its identity migration is incomplete.
+  const teamRouteGateResponse = () => {
+    if (!unifiedTeamEnabled(env)) {
+      return withCORS(JSON.stringify({ success: false, error: 'Gestão centralizada da equipe ainda não está liberada', code: 'TEAM_UNIFIED_DISABLED' }), { status: 404 }, appOrigin);
+    }
+    if (!onboardingHasUsername || !onboardingHasRequestFingerprint || !invitesHasUsername || !invitesHasCorporateEmail || !onboardingHasSaga || !teamTablesReady) {
+      return withCORS(JSON.stringify({ success: false, error: 'Migração da equipe unificada pendente', code: 'TEAM_MIGRATION_REQUIRED' }), { status: 503 }, appOrigin);
+    }
+    return null;
+  };
+
   // Account scope follows only an already confirmed, explicit relationship.
   // A team username alone must never create or infer a CRM account link.
   const loadExplicitCrmAccountScope = async (onboardingId) => {
@@ -752,6 +766,8 @@ export async function handleAdminRoutes({
     if (!teamWriteRoleAllowed(auth)) {
       return withCORS(JSON.stringify({ success: false, error: 'Apenas gestores podem consultar dados de contato', code: 'TEAM_CONTACT_ROLE_DENIED' }), { status: 403 }, appOrigin);
     }
+    const gateResponse = teamRouteGateResponse();
+    if (gateResponse) return gateResponse;
     try {
       const onboardingId = decodeURIComponent(teamContactMatch[1] || '').trim();
       const onboarding = await env.DB.prepare('SELECT id, units_json, personal_email_encrypted, mobile_phone_encrypted FROM crm_employee_onboarding WHERE id=? LIMIT 1').bind(onboardingId).first();
@@ -782,12 +798,9 @@ export async function handleAdminRoutes({
     }), { status: 200 }, appOrigin);
   }
 
-  if (isTeamRoute && !unifiedTeamEnabled(env)) {
-    return withCORS(JSON.stringify({ success: false, error: 'Gestão centralizada da equipe ainda não está liberada', code: 'TEAM_UNIFIED_DISABLED' }), { status: 404 }, appOrigin);
-  }
-
-  if (isTeamRoute && (!onboardingHasUsername || !onboardingHasRequestFingerprint || !invitesHasUsername || !invitesHasCorporateEmail || !onboardingHasSaga || !teamTablesReady)) {
-    return withCORS(JSON.stringify({ success: false, error: 'Migração da equipe unificada pendente', code: 'TEAM_MIGRATION_REQUIRED' }), { status: 503 }, appOrigin);
+  if (isTeamRoute) {
+    const gateResponse = teamRouteGateResponse();
+    if (gateResponse) return gateResponse;
   }
 
   // POST /admin/onboarding

--- a/inventory/tests/unifiedTeamAccountScope.test.mjs
+++ b/inventory/tests/unifiedTeamAccountScope.test.mjs
@@ -103,6 +103,29 @@ function routeEnv({ workforce = workforceBinding(true), unifiedTeamEnabled = 'tr
   };
 }
 
+function dbWithMissingTable(tableName) {
+  const database = env.DB;
+  return new Proxy(database, {
+    get(target, property) {
+      if (property !== 'prepare') {
+        const value = target[property];
+        return typeof value === 'function' ? value.bind(target) : value;
+      }
+      return (sql) => {
+        const statement = target.prepare(sql);
+        const normalizedSql = String(sql).replace(/\s+/g, ' ').trim().toLowerCase();
+        if (normalizedSql !== "select name from sqlite_master where type='table' and name=? limit 1") return statement;
+        return {
+          bind(...params) {
+            if (String(params[0] || '') === tableName) return { first: async () => null };
+            return statement.bind(...params);
+          },
+        };
+      };
+    },
+  });
+}
+
 async function callRoute(path, { body = {}, envOverride = {}, method = 'PUT' } = {}) {
   const url = new URL(path, appOrigin);
   const request = new Request(url, {
@@ -269,6 +292,36 @@ test('manager contact inspection decrypts only the scoped edit payload', async (
   assert.equal(listed.response.status, 200);
   assert.equal('personalEmail' in listed.body.data[0], false);
   assert.equal('mobilePhone' in listed.body.data[0], false);
+});
+
+test('manager contact inspection is blocked before decryption when unified team is disabled', async () => {
+  const personalEmail = await encryptPii('blocked@example.com');
+  const mobilePhone = await encryptPii('+5551888888888');
+  await env.DB.prepare('UPDATE crm_employee_onboarding SET personal_email_encrypted=?, mobile_phone_encrypted=? WHERE id=?')
+    .bind(personalEmail, mobilePhone, 'hellenmelo-employee').run();
+
+  const result = await callRoute('/admin/team/hellenmelo-employee/contact', {
+    method: 'GET',
+    envOverride: { unifiedTeamEnabled: 'false' },
+  });
+  assert.equal(result.response.status, 404);
+  assert.equal(result.body.code, 'TEAM_UNIFIED_DISABLED');
+  assert.equal('data' in result.body, false);
+});
+
+test('manager contact inspection is blocked before decryption when the team migration is incomplete', async () => {
+  const personalEmail = await encryptPii('migration-blocked@example.com');
+  const mobilePhone = await encryptPii('+5551777777777');
+  await env.DB.prepare('UPDATE crm_employee_onboarding SET personal_email_encrypted=?, mobile_phone_encrypted=? WHERE id=?')
+    .bind(personalEmail, mobilePhone, 'hellenmelo-employee').run();
+
+  const result = await callRoute('/admin/team/hellenmelo-employee/contact', {
+    method: 'GET',
+    envOverride: { DB: dbWithMissingTable('crm_employee_team') },
+  });
+  assert.equal(result.response.status, 503);
+  assert.equal(result.body.code, 'TEAM_MIGRATION_REQUIRED');
+  assert.equal('data' in result.body, false);
 });
 
 test('failed effective-scope write is not reported as success and rolls back the D1 batch', async () => {


### PR DESCRIPTION
## Summary

- Apply the unified-team rollout and migration gates before `GET /admin/team/:id/contact` can read or decrypt personal contact data.
- Reuse the same gate for the remaining unified-team route handling.
- Add negative coverage for the flag-disabled and incomplete-migration states while preserving the scoped manager success path.

## Security context

This closes the medium finding from scan `2b6176d0-4178-4ffa-a307-6adc1434f458`, reproduced against `898c052` / PR #1477. The prior isolated synthetic reproduction showed contact data could be decrypted while `UNIFIED_TEAM_ENABLED=false`.

No production, staging data, feature flag, database, or public API mutation was performed by this change.

## Validation

- Focused unified-team tests: 14/14 passed.
- Inventory test suite: 92/92 passed.
- JavaScript syntax checks passed for the route and test.
- `quality:security` passed.
- The staging smoke `crm/console/scripts/users-staging-smoke.cjs` remains preserved and uncommitted.