### PR TITLE
fix(meta-ads): attest exact raw staging source access

### DIFF
--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -1,4 +1,4 @@
-name: Attest Meta Ads Staging Source Access
+name: Attest Raw Meta Ads Staging Source Access
 
 on:
   workflow_dispatch:
@@ -13,14 +13,15 @@ concurrency:
 jobs:
   attest:
     if: github.ref == 'refs/heads/main'
-    name: Read the staging source capability without deployment
+    name: Read raw staging source capability without deployment
     runs-on: ubuntu-latest
     timeout-minutes: 3
     environment: staging
     steps:
-      - name: Attest Meta Ads source scopes and ad-account access without exposing them
+      - name: Attest raw staging seed source reads without the Worker app proof
         env:
           META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
+          META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
           META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
           META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
         shell: bash
@@ -28,6 +29,7 @@ jobs:
           set -euo pipefail
           node --input-type=module <<'NODE'
           const token = String(process.env.META_ADS_ACCESS_TOKEN || '');
+          const pixelId = String(process.env.META_PIXEL_ID || '').trim();
           const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
           const apiVersion = String(process.env.META_ADS_API_VERSION || '');
 
@@ -36,7 +38,12 @@ jobs:
             process.exit(1);
           };
 
-          if (!token || !/^\d{5,30}$/.test(accountId) || !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion)) {
+          if (
+            !token ||
+            !/^\d{5,30}$/.test(pixelId) ||
+            !/^\d{5,30}$/.test(accountId) ||
+            !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion)
+          ) {
             fail('source_contract_invalid');
           }
 
@@ -78,95 +85,89 @@ jobs:
             return { state: 'ok', payload };
           };
 
-          const scopeNames = [
-            'ads_read',
-            'ads_management',
-            'business_management',
-            'pages_show_list',
-            'pages_read_engagement',
-            'pages_manage_ads',
-            'instagram_basic',
-          ];
-          const scopeStates = Object.fromEntries(scopeNames.map((name) => [name, 'unknown']));
-          const granted = new Set();
-          let permissionsState = 'ok';
-          let permissionCoverage = 'bounded';
-          let permissionCursor = '';
-          const maxPermissionPages = 5;
-          for (let page = 0; page < maxPermissionPages; page += 1) {
-            const cursorQuery = permissionCursor
-              ? `&after=${encodeURIComponent(permissionCursor)}`
-              : '';
-            const permissions = await graphGet(`me/permissions?limit=100${cursorQuery}`);
-            if (permissions.state !== 'ok') {
-              permissionsState = permissions.state;
-              break;
+          const numericId = (value) => {
+            const normalized = String(value || '').trim().replace(/^act_/, '');
+            return /^\d{5,30}$/.test(normalized) ? normalized : '';
+          };
+          const directRead = async (path, phase) => {
+            const result = await graphGet(path);
+            if (result.state !== 'ok') fail(`${phase}_${result.state}`);
+            return result.payload;
+          };
+          const validLanding = (value) => {
+            try {
+              const url = new URL(String(value || '').trim());
+              return (
+                url.protocol === 'https:' &&
+                Boolean(url.hostname) &&
+                !url.username &&
+                !url.password &&
+                !url.hash &&
+                !url.search &&
+                !/(?:facebook|instagram|whatsapp)\.com$/i.test(url.hostname)
+              );
+            } catch {
+              return false;
             }
-            if (!Array.isArray(permissions.payload?.data)) {
-              permissionsState = 'malformed';
-              break;
+          };
+          const validPicture = (value) => {
+            const candidate = String(value?.url || value?.data?.url || '').trim();
+            try {
+              const url = new URL(candidate);
+              return url.protocol === 'https:' && Boolean(url.hostname) && !url.username && !url.password;
+            } catch {
+              return false;
             }
-            for (const entry of permissions.payload.data) {
-              if (entry?.status === 'granted') granted.add(String(entry.permission || ''));
-            }
-            const unresolved = scopeNames.filter((name) => !granted.has(name));
-            const rawNextPage = permissions.payload?.paging?.next;
-            if (rawNextPage != null && typeof rawNextPage !== 'string') {
-              permissionsState = 'malformed';
-              break;
-            }
-            const hasNextPage = typeof rawNextPage === 'string' && rawNextPage.length > 0;
-            const rawNextCursor = permissions.payload?.paging?.cursors?.after;
-            if (hasNextPage && typeof rawNextCursor !== 'string') {
-              permissionsState = 'malformed';
-              break;
-            }
-            const nextCursor = typeof rawNextCursor === 'string' ? rawNextCursor.trim() : '';
-            if (unresolved.length === 0 || !hasNextPage) {
-              permissionCoverage = 'complete';
-              break;
-            }
-            if (nextCursor.length > 2_048 || nextCursor === permissionCursor) {
-              permissionsState = 'malformed';
-              break;
-            }
-            permissionCursor = nextCursor;
-          }
-          if (permissionsState === 'ok') {
-            for (const name of scopeNames) scopeStates[name] = granted.has(name) ? 'granted' : 'missing';
-            if (permissionCoverage !== 'complete') {
-              for (const name of scopeNames) {
-                if (!granted.has(name)) scopeStates[name] = 'unknown';
-              }
-          }
+          };
+
+          const pixel = await directRead(`${pixelId}?fields=id,owner_ad_account{id}`, 'source_pixel');
+          if (numericId(pixel?.id) !== pixelId || numericId(pixel?.owner_ad_account?.id) !== accountId) {
+            fail('source_pixel_mismatch');
           }
 
-          const adAccount = await graphGet(`act_${accountId}?fields=id`);
-          const adAccountState = adAccount.state === 'ok'
-            ? (String(adAccount.payload?.id || '').trim().replace(/^act_/, '') === accountId ? 'allowed' : 'malformed')
-            : adAccount.state;
+          const pages = await directRead(
+            'me/accounts?fields=id,tasks,instagram_business_account{id}&limit=100',
+            'source_pages',
+          );
+          if (!Array.isArray(pages?.data)) fail('source_pages_malformed');
+          if (String(pages?.paging?.next ?? '').trim()) fail('source_pages_ambiguous');
+          const eligiblePages = pages.data.filter((page) => {
+            const tasks = new Set(Array.isArray(page?.tasks) ? page.tasks.map((task) => String(task || '').trim().toUpperCase()) : []);
+            return tasks.has('ADVERTISE') && Boolean(numericId(page?.instagram_business_account?.id));
+          });
+          if (eligiblePages.length !== 1) fail('source_pages_ambiguous');
+          const pageId = numericId(eligiblePages[0].id);
+          const instagramId = numericId(eligiblePages[0].instagram_business_account.id);
+          if (!pageId || !instagramId) fail('source_pages_malformed');
 
-          const missingScopes = scopeNames.filter((name) => scopeStates[name] !== 'granted');
-          if (permissionsState !== 'ok') {
-            fail(`source_permissions_${permissionsState}`);
+          const page = await directRead(
+            `${pageId}?fields=id,instagram_business_account{id},website,picture{url}`,
+            'source_page',
+          );
+          if (numericId(page?.id) !== pageId || numericId(page?.instagram_business_account?.id) !== instagramId) {
+            fail('source_page_mismatch');
           }
-          if (missingScopes.length > 0) {
-            fail(`source_permissions_missing:${missingScopes.join(',')}`);
+          if (!validLanding(page?.website) || !validPicture(page?.picture)) {
+            fail('source_landing_or_media_unavailable');
           }
-          if (adAccountState !== 'allowed') {
-            fail(`source_ad_account_${adAccountState}`);
+
+          const datasets = await directRead(
+            `act_${accountId}/offline_conversion_data_sets?fields=id&limit=2`,
+            'source_dataset',
+          );
+          if (!Array.isArray(datasets?.data)) fail('source_dataset_malformed');
+          if (String(datasets?.paging?.next ?? '').trim() || datasets.data.length !== 1) {
+            fail('source_dataset_ambiguous');
           }
+          if (!numericId(datasets.data[0]?.id)) fail('source_dataset_malformed');
 
           process.stdout.write([
-            'source_access_attestation=verified',
-            `source_access_permissions=${permissionsState === 'ok' ? permissionCoverage : permissionsState}`,
-            `source_access_ads_read=${scopeStates.ads_read}`,
-            `source_access_ads_management=${scopeStates.ads_management}`,
-            `source_access_business_management=${scopeStates.business_management}`,
-            `source_access_pages_show_list=${scopeStates.pages_show_list}`,
-            `source_access_pages_read_engagement=${scopeStates.pages_read_engagement}`,
-            `source_access_pages_manage_ads=${scopeStates.pages_manage_ads}`,
-            `source_access_instagram_basic=${scopeStates.instagram_basic}`,
-            `source_access_ad_account=${adAccountState}`,
+            'source_access_raw=verified',
+            'source_access_runtime_proof=unverified',
+            'source_access_pixel=allowed',
+            'source_access_ad_account=allowed',
+            'source_access_page=eligible',
+            'source_access_dataset=eligible',
+            'source_access_landing_media=eligible',
           ].join('\n') + '\n');
           NODE

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import test from "node:test";
 
@@ -9,9 +10,94 @@ const workflow = fs.readFileSync(
   ),
   "utf8",
 );
+const embeddedProgram = workflow.match(
+  /node --input-type=module <<'NODE'\n([\s\S]*?)\n\s+NODE/m,
+)?.[1];
+assert.ok(
+  embeddedProgram,
+  "the source-access workflow must embed its Node verifier",
+);
+
+const syntheticToken = "synthetic-source-bearer-not-a-secret";
+const syntheticPixelId = "1234567890";
+const syntheticAccountId = "9876543210";
+
+function runVerifier(responses) {
+  const harness = `
+    const scenario = ${JSON.stringify(responses)};
+    let cursor = 0;
+    globalThis.fetch = async (value, options = {}) => {
+      const expected = scenario[cursor++];
+      if (!expected) throw new Error('unexpected Graph request');
+      const url = new URL(String(value));
+      if (url.origin !== 'https://graph.facebook.com' || url.pathname !== expected.pathname) throw new Error('unexpected Graph request');
+      if (String(options.method || '') !== 'GET' || String(options.cache || '') !== 'no-store' || String(options.redirect || '') !== 'error') throw new Error('unexpected Graph request');
+      if (String(options.headers?.Authorization || '') !== 'Bearer ${syntheticToken}') throw new Error('unexpected Graph request');
+      for (const [key, expectedValue] of Object.entries(expected.query || {})) {
+        if (url.searchParams.get(key) !== expectedValue) throw new Error('unexpected Graph request');
+      }
+      return new Response(JSON.stringify(expected.payload), { status: expected.status ?? 200 });
+    };
+    ${embeddedProgram}
+    if (cursor !== scenario.length) throw new Error('missing Graph request');
+  `;
+  return spawnSync(
+    process.execPath,
+    ["--input-type=module", "--eval", harness],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        META_ADS_ACCESS_TOKEN: syntheticToken,
+        META_PIXEL_ID: syntheticPixelId,
+        META_ADS_ACCOUNT_ID: syntheticAccountId,
+        META_ADS_API_VERSION: "v25.0",
+      },
+    },
+  );
+}
+
+const happyResponses = [
+  {
+    pathname: `/v25.0/${syntheticPixelId}`,
+    query: { fields: "id,owner_ad_account{id}" },
+    payload: {
+      id: syntheticPixelId,
+      owner_ad_account: { id: syntheticAccountId },
+    },
+  },
+  {
+    pathname: "/v25.0/me/accounts",
+    query: { fields: "id,tasks,instagram_business_account{id}", limit: "100" },
+    payload: {
+      data: [
+        {
+          id: "1122334455",
+          tasks: ["ADVERTISE"],
+          instagram_business_account: { id: "5544332211" },
+        },
+      ],
+    },
+  },
+  {
+    pathname: "/v25.0/1122334455",
+    query: { fields: "id,instagram_business_account{id},website,picture{url}" },
+    payload: {
+      id: "1122334455",
+      instagram_business_account: { id: "5544332211" },
+      website: "https://staging.example.test",
+      picture: { data: { url: "https://cdn.example.test/picture.jpg" } },
+    },
+  },
+  {
+    pathname: `/v25.0/act_${syntheticAccountId}/offline_conversion_data_sets`,
+    query: { fields: "id", limit: "2" },
+    payload: { data: [{ id: "9988776655" }] },
+  },
+];
 
 test("Meta Ads source-access attestation is manual, bounded, and non-deploying", () => {
-  assert.match(workflow, /^name: Attest Meta Ads Staging Source Access$/m);
+  assert.match(workflow, /^name: Attest Raw Meta Ads Staging Source Access$/m);
   assert.match(workflow, /^\s+workflow_dispatch:\s*$/m);
   assert.match(workflow, /if: github\.ref == 'refs\/heads\/main'/);
   assert.match(workflow, /environment: staging/);
@@ -20,6 +106,7 @@ test("Meta Ads source-access attestation is manual, bounded, and non-deploying",
     workflow,
     /META_ADS_ACCESS_TOKEN: \$\{\{ secrets\.META_ADS_ACCESS_TOKEN \}\}/,
   );
+  assert.match(workflow, /META_PIXEL_ID: \$\{\{ secrets\.META_PIXEL_ID \}\}/);
   assert.match(
     workflow,
     /META_ADS_ACCOUNT_ID: \$\{\{ vars\.META_ADS_ACCOUNT_ID \}\}/,
@@ -28,21 +115,6 @@ test("Meta Ads source-access attestation is manual, bounded, and non-deploying",
     workflow,
     /META_ADS_API_VERSION: \$\{\{ vars\.META_ADS_API_VERSION \}\}/,
   );
-  assert.match(workflow, /const maxPermissionPages = 5/);
-  assert.match(
-    workflow,
-    /graphGet\(`me\/permissions\?limit=100\$\{cursorQuery\}`\)/,
-  );
-  assert.match(workflow, /paging\?\.cursors\?\.after/);
-  assert.match(workflow, /paging\?\.next/);
-  assert.match(
-    workflow,
-    /rawNextPage != null && typeof rawNextPage !== 'string'/,
-  );
-  assert.match(workflow, /hasNextPage && typeof rawNextCursor !== 'string'/);
-  assert.match(workflow, /encodeURIComponent\(permissionCursor\)/);
-  assert.match(workflow, /unresolved\.length === 0 \|\| !hasNextPage/);
-  assert.match(workflow, /!Array\.isArray\(permissions\.payload\?\.data\)/);
   assert.match(workflow, /payload\?\.error\?\.is_transient === true/);
   assert.match(
     workflow,
@@ -55,48 +127,109 @@ test("Meta Ads source-access attestation is manual, bounded, and non-deploying",
   assert.match(workflow, /graphErrorCode === 190/);
   assert.match(workflow, /graphErrorCode === 200/);
   assert.match(workflow, /authorizationError \? 'denied' : 'malformed'/);
-  assert.match(workflow, /graphGet\(`act_\$\{accountId\}\?fields=id`\)/);
+  assert.match(workflow, /\$\{pixelId\}\?fields=id,owner_ad_account\{id\}/);
   assert.match(
     workflow,
-    /payload\?\.id \|\| ''\)\.trim\(\)\.replace\(\/\^act_\//,
+    /me\/accounts\?fields=id,tasks,instagram_business_account\{id\}&limit=100/,
   );
+  assert.match(
+    workflow,
+    /\$\{pageId\}\?fields=id,instagram_business_account\{id\},website,picture\{url\}/,
+  );
+  assert.match(
+    workflow,
+    /act_\$\{accountId\}\/offline_conversion_data_sets\?fields=id&limit=2/,
+  );
+  assert.match(workflow, /tasks\.has\('ADVERTISE'\)/);
+  assert.match(workflow, /eligiblePages\.length !== 1/);
+  assert.match(workflow, /datasets\.data\.length !== 1/);
+  assert.match(workflow, /source_landing_or_media_unavailable/);
   assert.match(workflow, /method: 'GET'/);
   assert.match(workflow, /Authorization: `Bearer \$\{token\}`/);
   assert.match(workflow, /cache: 'no-store'/);
   assert.match(workflow, /redirect: 'error'/);
   assert.match(workflow, /AbortSignal\.timeout\(12_000\)/);
-  assert.match(workflow, /source_access_attestation=verified/);
-  assert.match(workflow, /source_access_ads_read=/);
-  assert.match(workflow, /source_access_ads_management=/);
-  assert.match(workflow, /source_access_business_management=/);
-  assert.match(workflow, /source_access_pages_show_list=/);
-  assert.match(workflow, /source_access_pages_read_engagement=/);
-  assert.match(workflow, /source_access_pages_manage_ads=/);
-  assert.match(workflow, /source_access_instagram_basic=/);
-  assert.match(workflow, /source_access_ad_account=/);
-
-  assert.match(
-    workflow,
-    /const missingScopes = scopeNames\.filter\(\(name\) => scopeStates\[name\] !== 'granted'\)/,
-  );
-  assert.match(workflow, /if \(permissionsState !== 'ok'\)/);
-  assert.match(workflow, /source_permissions_missing:/);
-  assert.match(workflow, /if \(adAccountState !== 'allowed'\)/);
-  assert.match(workflow, /source_ad_account_\$\{adAccountState\}/);
+  assert.match(workflow, /source_access_raw=verified/);
+  assert.match(workflow, /source_access_runtime_proof=unverified/);
+  assert.match(workflow, /source_access_pixel=allowed/);
+  assert.match(workflow, /source_access_ad_account=allowed/);
+  assert.match(workflow, /source_access_page=eligible/);
+  assert.match(workflow, /source_access_dataset=eligible/);
+  assert.match(workflow, /source_access_landing_media=eligible/);
   assert.ok(
-    workflow.indexOf("source_permissions_missing:") <
-      workflow.indexOf("source_access_attestation=verified"),
-    "verified output must be unreachable until missing permissions fail closed",
+    workflow.indexOf("source_pixel_mismatch") <
+      workflow.indexOf("source_access_raw=verified"),
+    "raw success output must be unreachable until the exact source reads pass",
   );
 
   assert.doesNotMatch(workflow, /access_token=/i);
   assert.doesNotMatch(workflow, /debug_token/i);
+  assert.doesNotMatch(workflow, /META_APP_SECRET/);
+  assert.doesNotMatch(workflow, /appsecret_proof/);
   assert.doesNotMatch(workflow, /method: 'POST'/);
   assert.doesNotMatch(workflow, /upload-artifact/i);
   assert.doesNotMatch(workflow, /wrangler/i);
   assert.doesNotMatch(workflow, /gh secret/i);
   assert.doesNotMatch(workflow, /secret put/i);
   assert.doesNotMatch(workflow, /GITHUB_OUTPUT/);
-  assert.doesNotMatch(workflow, /META_PIXEL_ID/);
+  assert.doesNotMatch(workflow, /me\/permissions/);
+  assert.doesNotMatch(workflow, /pages_manage_ads/);
+  assert.doesNotMatch(
+    workflow,
+    /source_access_(?:pixel_id|page_id|dataset_id|landing_url|picture_url)/i,
+  );
   assert.doesNotMatch(workflow, /D1|Cloudflare|Orb|n8n/);
+});
+
+test("Meta Ads source-access verifier executes the bounded raw-read contract without revealing inputs", () => {
+  const result = runVerifier(happyResponses);
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.equal(result.status, 0, combined);
+  assert.equal(
+    result.stdout,
+    [
+      "source_access_raw=verified",
+      "source_access_runtime_proof=unverified",
+      "source_access_pixel=allowed",
+      "source_access_ad_account=allowed",
+      "source_access_page=eligible",
+      "source_access_dataset=eligible",
+      "source_access_landing_media=eligible",
+      "",
+    ].join("\n"),
+  );
+  assert.doesNotMatch(
+    combined,
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
+  );
+});
+
+test("Meta Ads source-access verifier fails closed for an additional malformed eligible Page", () => {
+  const responses = structuredClone(happyResponses);
+  responses[1].payload.data.unshift({
+    id: false,
+    tasks: ["ADVERTISE"],
+    instagram_business_account: { id: "6655443322" },
+  });
+  const result = runVerifier(responses);
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0);
+  assert.match(combined, /source_pages_ambiguous/);
+  assert.doesNotMatch(
+    combined,
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
+  );
+});
+
+test("Meta Ads source-access verifier fails closed for falsy paging metadata", () => {
+  const responses = structuredClone(happyResponses);
+  responses[1].payload.paging = { next: false };
+  const result = runVerifier(responses);
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0);
+  assert.match(combined, /source_pages_ambiguous/);
+  assert.doesNotMatch(
+    combined,
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
+  );
 });


### PR DESCRIPTION
## Objetivo

Substitui a inspeção ampla de escopos por uma atestação diagnóstica que reproduz as quatro leituras Graph de fonte exigidas pela seed sintética de staging: Pixel/conta, Página/Instagram, configuração de landing/media e dataset offline.

## Motivo

A verificação anterior tratava permissões de Página como um bloqueio do bearer de system user sem provar as chamadas que o seed realmente usa. Esta mudança produz um resultado mínimo, redigido e útil para corrigir somente o ativo Meta que falhar.

## Contrato operacional

- **Superfície:** workflow manual de diagnóstico no GitHub Environment `staging` e quatro leituras `GET` ao Meta Graph; não há superfície Worker, D1, Cloudflare, Orb/n8n ou publicação Meta.
- **Risco:** alto por usar uma credencial externa, mitigado por origem fixa, timeout, `no-store`, sem redirects e sem qualquer saída de segredo/identificador.
- **Flag/coorte:** não aplicável; o workflow não altera flags, grants ou tráfego.
- **Migration:** não aplicável; não há escrita de banco.
- **Rollback:** nenhuma mutação remota precisa ser revertida. Reverter este único commit restaura a rotina diagnóstica anterior.

## Segurança e limites

- Apenas `GET` para origem Graph fixa; não há Worker, D1, Cloudflare, Orb/n8n, artefato ou mutação Meta.
- Nenhum segredo, identificador, URL ou corpo Graph é emitido.
- O resultado declara `source_access_runtime_proof=unverified`: aprovação desta rotina não autoriza staging e não substitui a atestação protegida do candidato.

## Validação

- `npm --prefix platform/security/token-vault test` — 147/147
- Prettier nos dois arquivos alterados
- Harness executável para contrato de leituras, redação, cardinalidade malformada e paginação falsy fail-closed