### PR TITLE
fix(ci): use production custody for Users smoke

### DIFF
--- a/.github/workflows/insumos-production-smoke-identity.yml
+++ b/.github/workflows/insumos-production-smoke-identity.yml
@@ -49,8 +49,9 @@ jobs:
         with:
           required: true
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
-          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
           resource: global:ponto-workers-writer
           module: core
           source_sha: ${{ inputs.release_sha }}
@@ -149,8 +150,9 @@ jobs:
           module: core
           source_sha: ${{ inputs.release_sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
-          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
 
       - name: Read collision state after lease check
         if: ${{ inputs.action == 'provision' }}
@@ -214,8 +216,9 @@ jobs:
           module: core
           source_sha: ${{ inputs.release_sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
-          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
 
       - name: Apply exact synthetic identity mutation
         env:
@@ -288,8 +291,9 @@ jobs:
         uses: ./.github/actions/global-coordination-release
         with:
           required: true
-          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
           proof_file: ${{ runner.temp }}/skincos-global-coordination-users-production-smoke.json
 
       - name: Upload sanitized identity evidence

--- a/.github/workflows/insumos-production-smoke-identity.yml
+++ b/.github/workflows/insumos-production-smoke-identity.yml
@@ -42,6 +42,11 @@ jobs:
           set -euo pipefail
           [[ "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]]
           [[ "$(git rev-parse HEAD)" == "${RELEASE_SHA}" ]]
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "${RELEASE_SHA}" origin/main || {
+            echo "The production smoke workflow must run only from a SHA already integrated into origin/main."
+            exit 1
+          }
           [[ "${ACTION}" == "provision" || "${ACTION}" == "cleanup" ]]
 
       - name: Acquire production Identity/D1 coordination lease

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -465,6 +465,24 @@ test("the staging RBAC journey recovers synthetic teardown under a fresh lease",
   );
 });
 
+test("production Users smoke identity uses production custody and the active coordination key", () => {
+  const workflow = read(".github/workflows/insumos-production-smoke-identity.yml");
+  assert.equal(
+    (workflow.match(/coordinator_url: \$\{\{ vars\.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL \}\}/g) || []).length,
+    4,
+  );
+  assert.equal(
+    (workflow.match(/key_id: \$\{\{ vars\.SKINCOS_GLOBAL_COORDINATION_KEY_ID \}\}/g) || []).length,
+    4,
+  );
+  assert.equal(
+    (workflow.match(/shared_secret: \$\{\{ secrets\.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY \}\}/g) || []).length,
+    4,
+  );
+  assert.doesNotMatch(workflow, /SKINCOS_GLOBAL_COORDINATOR_URL \}\}/);
+  assert.doesNotMatch(workflow, /SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET/);
+});
+
 test("the Ponto composite lease protects only non-preview stages while preview keeps separate writer custody", () => {
   const workflow = read(".github/workflows/ponto-progressive-release.yml");
   const acquire = workflow.indexOf("Acquire the composite Ponto release lease before gate settlement");

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -481,6 +481,7 @@ test("production Users smoke identity uses production custody and the active coo
   );
   assert.doesNotMatch(workflow, /SKINCOS_GLOBAL_COORDINATOR_URL \}\}/);
   assert.doesNotMatch(workflow, /SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET/);
+  assert.match(workflow, /git merge-base --is-ancestor "\$\{RELEASE_SHA\}" origin\/main/);
 });
 
 test("the Ponto composite lease protects only non-preview stages while preview keeps separate writer custody", () => {


### PR DESCRIPTION
# Summary

Correct the governed production Users smoke identity lifecycle so its D1 mutation uses the production coordination endpoint, the active epoch-fence custody secret, and the current coordination key ID. The previous workflow still targeted the staging coordinator with the legacy secret and could not provide a valid production revalidation path.

## Type of change
- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (README, API refs, diagrams)
- [x] Security review (coordination custody wiring)
- [ ] Performance impact measured

## Links
- Issue: production Users authenticated smoke prerequisite after the unified-team contact guard release
- Design/ADR: epoch-fence-v1 global coordination
- Migration steps: none

## Screenshots / Evidence
- Production smoke lease acquire/check/release now pins `vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID`.
- All four custody calls use `secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY`.
- All four custody calls use `vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL`.
- Focused governance static suite: 19/19 passing.
- No application code, production flag, database, or deployment was changed by this PR.
- The untracked synthetic Users smoke file remains preserved and is intentionally not part of this PR.