### PR TITLE
fix(crm): route Atendimento auth through canonical upstream

### DIFF
--- a/crm/console/functions/_lib/crmAuth.ts
+++ b/crm/console/functions/_lib/crmAuth.ts
@@ -129,24 +129,14 @@ export async function getCrmUser(context: any): Promise<CrmAuthUser | null> {
   }
 
   const env = context?.env || {}
-  const requestOrigin = (() => {
-    try {
-      const url = context?.request?.url
-      if (!url) return ''
-      return new URL(url).origin
-    } catch {
-      return ''
-    }
-  })()
   const targetOrigin =
     (env.AUTH_API_TARGET as string | undefined) ||
-    requestOrigin ||
     (env.INSUMOS_API_TARGET as string | undefined) ||
     'https://api.skincos.com.br'
 
   const normalizeAuthPrefix = (value: unknown) => {
     let prefix = String(value ?? '').trim()
-    if (!prefix) return '/api/auth'
+    if (!prefix) return '/insumos/auth'
     if (!prefix.startsWith('/')) prefix = `/${prefix}`
     return prefix.replace(/\/$/, '')
   }

--- a/crm/console/tests/crmAuth.test.ts
+++ b/crm/console/tests/crmAuth.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getCrmUser } from '../functions/_lib/crmAuth'
+
+function context(env: Record<string, unknown> = {}) {
+  return {
+    request: new Request('https://crm.skincos.com.br/api/atendimento/conversations', {
+      headers: { cookie: 'session=test-session; csrfToken=test-csrf' },
+    }),
+    env,
+  }
+}
+
+describe('CRM auth adapter', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('resolves the session against the canonical auth backend instead of the CRM Pages origin', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      ok: true,
+      user: {
+        username: 'consultor-nh',
+        displayName: 'Consultor NH',
+        role: 'CONSULTOR',
+        allowedUnits: ['Novo Hamburgo'],
+        allowedModules: ['atendimento'],
+      },
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const user = await getCrmUser(context({
+      INSUMOS_API_TARGET: 'https://api.skincos.com.br',
+    }))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('https://api.skincos.com.br/insumos/auth/me')
+    expect((init as RequestInit).headers).toBeInstanceOf(Headers)
+    expect(((init as RequestInit).headers as Headers).get('cookie')).toContain('session=test-session')
+    expect(user).toMatchObject({
+      id: 'consultor-nh',
+      role: 'CONSULTOR',
+      allowedUnits: ['Novo Hamburgo'],
+      allowedModules: ['atendimento'],
+    })
+  })
+
+  it('keeps explicit auth target and path overrides authoritative', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      user: { id: 'gestor-1', role: 'GESTOR' },
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await getCrmUser(context({
+      AUTH_API_TARGET: 'https://auth.internal.test',
+      AUTH_PATH_PREFIX: '/custom/auth/',
+      INSUMOS_API_TARGET: 'https://api.skincos.com.br',
+    }))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toBe('https://auth.internal.test/custom/auth/me')
+  })
+
+  it('falls back to legacy auth mounts only when the canonical mount is absent', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        user: { id: 'legacy-user', role: 'CONSULTOR' },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const user = await getCrmUser(context())
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      'https://api.skincos.com.br/insumos/auth/me',
+      'https://api.skincos.com.br/auth/me',
+    ])
+    expect(user?.id).toBe('legacy-user')
+  })
+})


### PR DESCRIPTION
## Contexto
As rotas `/api/atendimento/*` estavam retornando 401 apesar de `/api/auth/me` comprovar uma sessão válida de CONSULTOR com módulo `atendimento` e unidade permitida.

## Causa
`getCrmUser` preferia o origin do próprio Pages antes de `INSUMOS_API_TARGET` e usava `/api/auth` como prefixo padrão. Isso divergia do proxy canônico de autenticação, que encaminha para o backend em `/insumos/auth`.

## Mudança
- remove o fallback implícito para o origin do CRM Pages;
- usa `AUTH_API_TARGET`, depois `INSUMOS_API_TARGET`, depois `https://api.skincos.com.br`;
- restaura `/insumos/auth` como prefixo padrão;
- preserva overrides explícitos e mounts legados como fallback;
- adiciona regressões cobrindo destino canônico, overrides e fallback legado.

## Validação esperada
`crm/console/tests/crmAuth.test.ts` cobre especificamente o cenário de uma requisição de Atendimento originada em `crm.skincos.com.br`, garantindo que a resolução da sessão ocorra no upstream canônico e mantenha cookie/role/unidade/módulo.