### PR TITLE
fix(meta-ads): attest candidate appsecret proof

### DIFF
--- a/.github/governance/cloudflare-single-writer-policy.json
+++ b/.github/governance/cloudflare-single-writer-policy.json
@@ -186,6 +186,7 @@
       "coordinationGroup": "token-vault-writer",
       "mutationWorkflows": [
         ".github/workflows/deploy-token-vault.yml",
+        ".github/workflows/attest-meta-ads-candidate-appsecret.yml",
         ".github/workflows/influencer-intelligence-staging-shadow.yml"
       ]
     },

--- a/.github/workflows/attest-meta-ads-candidate-appsecret.yml
+++ b/.github/workflows/attest-meta-ads-candidate-appsecret.yml
@@ -1,0 +1,225 @@
+name: Attest Meta Ads Candidate Appsecret Proof
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # This creates an immutable Worker version, so share the exact staging lane
+  # and durable lease used by the governed Token Vault publisher.
+  group: deploy-token-vault-staging
+  cancel-in-progress: false
+
+jobs:
+  attest:
+    if: github.ref == 'refs/heads/main'
+    name: Verify the inherited candidate appsecret proof without promotion
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    environment: staging
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Pin manual dispatch to the current main source
+        env:
+          EXPECTED_REF: refs/heads/main
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_REF" == "$EXPECTED_REF" ]] || { echo 'Candidate appsecret-proof attestation can run only from main.' >&2; exit 1; }
+          [[ "$(git rev-parse HEAD)" == "$SOURCE_SHA" ]] || { echo 'Checkout does not match the dispatched source SHA.' >&2; exit 1; }
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          [[ "$(git rev-parse refs/remotes/origin/main)" == "$SOURCE_SHA" ]] || { echo 'main advanced before the candidate appsecret-proof attestation; redispatch the current source.' >&2; exit 1; }
+
+      - name: Guard staging candidate-proof custody
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
+          META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
+          META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
+          META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
+          ENABLE_TOKEN_VAULT_DEPLOY_STAGING: ${{ vars.ENABLE_TOKEN_VAULT_DEPLOY_STAGING }}
+        run: |
+          set -euo pipefail
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID META_ADS_ACCESS_TOKEN META_PIXEL_ID META_ADS_ACCOUNT_ID META_ADS_API_VERSION; do
+            [[ -n "${!name:-}" ]] || { echo 'Candidate appsecret-proof custody is unavailable.' >&2; exit 1; }
+          done
+          [[ "$ENABLE_TOKEN_VAULT_DEPLOY_STAGING" == true ]] || { echo 'Staging Token Vault candidate proof is disabled.' >&2; exit 1; }
+          [[ "$META_PIXEL_ID" =~ ^[0-9]{5,30}$ ]] || { echo 'Candidate appsecret-proof source contract is invalid.' >&2; exit 1; }
+          normalized_account="${META_ADS_ACCOUNT_ID#act_}"
+          [[ "$normalized_account" =~ ^[0-9]{5,30}$ ]] || { echo 'Candidate appsecret-proof source contract is invalid.' >&2; exit 1; }
+          [[ "$META_ADS_API_VERSION" =~ ^v(2[5-9]|[3-9][0-9])\.0$ ]] || { echo 'Candidate appsecret-proof source contract is invalid.' >&2; exit 1; }
+
+      - name: Acquire Token Vault release lease for candidate proof
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || '' }}
+          resource: release:token-vault
+          module: token-vault
+          source_sha: ${{ github.sha }}
+          proof_file: ${{ runner.temp }}/token-vault-candidate-appsecret-proof-lease.json
+          inputs_json: '{"target":"staging","mode":"candidate-appsecret-proof"}'
+
+      - name: Revalidate Token Vault release lease before candidate upload
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/token-vault-candidate-appsecret-proof-lease.json
+          resource: release:token-vault
+          module: token-vault
+          source_sha: ${{ github.sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || '' }}
+
+      - name: Upload one immutable candidate and require its appsecret proof
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
+          META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
+          META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
+          META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          [[ "$(git rev-parse refs/remotes/origin/main)" == "$SOURCE_SHA" ]] || { echo 'main advanced before the candidate upload; redispatch the current source.' >&2; exit 1; }
+
+          proof_root="$RUNNER_TEMP/token-vault-candidate-appsecret-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          seed_file="$proof_root/seed-bearer"
+          secrets_file="$proof_root/candidate-secrets.json"
+          mkdir -p "$proof_root"
+          trap 'rm -f -- "$seed_file" "$secrets_file"; rmdir "$proof_root" 2>/dev/null || true; unset seed_token upload_output' EXIT
+
+          umask 077
+          node --input-type=module -e "import { randomBytes } from 'node:crypto'; process.stdout.write(randomBytes(48).toString('base64url'));" > "$seed_file"
+          [[ "$(wc -c < "$seed_file")" -ge 64 ]] || { echo 'Candidate seed bearer generation failed.' >&2; exit 1; }
+          chmod 600 "$seed_file"
+          SEED_FILE="$seed_file" SECRETS_FILE="$secrets_file" node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+
+          const seedToken = fs.readFileSync(process.env.SEED_FILE, 'utf8').trim();
+          if (!/^[A-Za-z0-9_-]{64,}$/.test(seedToken)) throw new Error('candidate seed bearer is invalid');
+          fs.writeFileSync(
+            process.env.SECRETS_FILE,
+            `${JSON.stringify({ TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN: seedToken })}\n`,
+            { mode: 0o600 },
+          );
+          NODE
+          chmod 600 "$secrets_file"
+
+          if ! upload_output="$(npx --yes wrangler@4.120.0 versions upload \
+            --config platform/security/token-vault/wrangler.toml \
+            --env staging \
+            --keep-vars \
+            --strict \
+            --secrets-file "$secrets_file" \
+            --message "token-vault:candidate-appsecret-proof:${SOURCE_SHA}" 2>&1)"; then
+            echo 'Immutable Token Vault candidate upload failed.' >&2
+            exit 1
+          fi
+
+          version_id="$(printf '%s\n' "$upload_output" | sed -n 's/^Worker Version ID: //p' | tail -n 1 | tr '[:upper:]' '[:lower:]')"
+          [[ "$version_id" =~ ^[0-9a-f-]{36}$ ]] || { echo 'Candidate Worker version ID is invalid.' >&2; exit 1; }
+          expected_preview="https://${version_id%%-*}-skincos-token-vault-staging.skincos.workers.dev"
+          preview="$(printf '%s\n' "$upload_output" | sed -n 's/^Version Preview URL: //p' | sed 's:/*$::' | grep -F -x "$expected_preview" || true)"
+          [[ "$preview" == "$expected_preview" ]] || { echo 'Candidate preview URL is invalid.' >&2; exit 1; }
+
+          SEED_FILE="$seed_file" \
+          CANDIDATE_PREVIEW_URL="$preview" \
+          META_ADS_ACCESS_TOKEN="$META_ADS_ACCESS_TOKEN" \
+          META_PIXEL_ID="$META_PIXEL_ID" \
+          META_ADS_ACCOUNT_ID="$META_ADS_ACCOUNT_ID" \
+          META_ADS_API_VERSION="$META_ADS_API_VERSION" \
+          SOURCE_SHA="$SOURCE_SHA" \
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+
+          const seedToken = fs.readFileSync(process.env.SEED_FILE, 'utf8').trim();
+          const preview = String(process.env.CANDIDATE_PREVIEW_URL || '').replace(/\/$/, '');
+          const sourceToken = String(process.env.META_ADS_ACCESS_TOKEN || '');
+          const pixelId = String(process.env.META_PIXEL_ID || '').trim();
+          const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
+          const apiVersion = String(process.env.META_ADS_API_VERSION || '').trim();
+          const sourceSha = String(process.env.SOURCE_SHA || '').trim();
+          if (
+            !/^[A-Za-z0-9_-]{64,}$/.test(seedToken) ||
+            !/^https:\/\/[0-9a-f]{8}-skincos-token-vault-staging\.skincos\.workers\.dev$/.test(preview) ||
+            !sourceToken ||
+            !/^\d{5,30}$/.test(pixelId) ||
+            !/^\d{5,30}$/.test(accountId) ||
+            !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion) ||
+            !/^[0-9a-f]{40}$/.test(sourceSha)
+          ) {
+            throw new Error('candidate appsecret-proof source contract is invalid');
+          }
+          const operationKey = `meta-ads-staging-seed:appsecret-proof:${sourceSha.slice(0, 12)}:${process.env.GITHUB_RUN_ID}:${process.env.GITHUB_RUN_ATTEMPT}`;
+          let response;
+          try {
+            response = await fetch(`${preview}/internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/attest-appsecret-proof`, {
+              method: 'POST',
+              headers: {
+                Authorization: `Bearer ${seedToken}`,
+                'content-type': 'application/json',
+              },
+              body: JSON.stringify({
+                operation_key: operationKey,
+                access_token: sourceToken,
+                account_id: accountId,
+                pixel_id: pixelId,
+                api_version: apiVersion,
+              }),
+              cache: 'no-store',
+              redirect: 'error',
+              signal: AbortSignal.timeout(30_000),
+            });
+          } catch {
+            throw new Error('candidate appsecret-proof attestation failed: unavailable');
+          }
+          let payload = null;
+          try { payload = await response.json(); } catch {}
+          const error = /^[a-z0-9_:-]{1,120}$/i.test(String(payload?.error || '')) ? String(payload.error) : 'unknown';
+          const allowedKeys = new Set(['ok', 'attestation', 'contract_version', 'requestId']);
+          const valid = response.status === 200 && payload?.ok === true &&
+            Object.keys(payload).every((key) => allowedKeys.has(key)) &&
+            payload?.attestation === 'appsecret_proof_verified' &&
+            payload?.contract_version === 'meta-ads-tracking-v20/staging-synthetic-seed/v1' &&
+            typeof payload?.requestId === 'string';
+          if (!valid) throw new Error(`candidate appsecret-proof attestation failed: ${response.status} ${error}`);
+          process.stdout.write('candidate_appsecret_proof=verified\n');
+          NODE
+
+      - name: Remove candidate-only proof files
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          proof_root="$RUNNER_TEMP/token-vault-candidate-appsecret-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          case "$proof_root" in
+            "$RUNNER_TEMP"/token-vault-candidate-appsecret-[0-9]*-[0-9]*) ;;
+            *) echo 'Candidate proof cleanup target is invalid.' >&2; exit 1 ;;
+          esac
+          rm -f -- "$proof_root/seed-bearer" "$proof_root/candidate-secrets.json"
+          rmdir "$proof_root" 2>/dev/null || true
+
+      - name: Release Token Vault release lease after candidate proof
+        if: always()
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || '' }}
+          proof_file: ${{ runner.temp }}/token-vault-candidate-appsecret-proof-lease.json

--- a/ops/governance/global-concurrency-policy.json
+++ b/ops/governance/global-concurrency-policy.json
@@ -157,6 +157,7 @@
                     "ops/runtime/github-actions-runner/skincos-native-custody.sudoers",
                     "ops/runtime/units/skincos-native-custody-runner.service",
         ".github/workflows/deploy-token-vault.yml",
+        ".github/workflows/attest-meta-ads-candidate-appsecret.yml",
         ".github/workflows/influencer-intelligence-staging-shadow.yml",
         ".github/governance/cloudflare-single-writer-policy.json",
         ".github/scripts/promotion-evidence.mjs",

--- a/platform/deploy/operational-units.json
+++ b/platform/deploy/operational-units.json
@@ -101,7 +101,7 @@
       "workflow": ".github/workflows/deploy-token-vault.yml",
       "concurrencyPrefix": "deploy-token-vault-",
       "publishes": ["Worker:skincos-token-vault", "Worker:skincos-token-vault-staging"],
-      "resources": ["Token Vault Worker", "skincos-token-vault D1", "skincos-token-vault-staging D1", "Token Vault route and auth bindings", "Governed Meta Ads staging synthetic source attestation, seed, bootstrap derivation, rollback journal and paused creative fixture"],
+      "resources": ["Token Vault Worker", "skincos-token-vault D1", "skincos-token-vault-staging D1", "Token Vault route and auth bindings", "Governed Meta Ads staging synthetic source and appsecret-proof attestations, seed, bootstrap derivation, rollback journal and paused creative fixture"],
       "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "TOKEN_VAULT_API_TOKEN", "TOKEN_VAULT_N8N_API_TOKEN", "TOKEN_VAULT_ANALYTICS_API_TOKEN", "TOKEN_VAULT_ENCRYPTION_KEY", "TOKEN_VAULT_META_ADS_CONFIG_TOKEN", "TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST", "META_ADS_ACCESS_TOKEN", "META_PIXEL_ID"],
       "migrationPaths": ["platform/security/token-vault/migrations"],
       "environments": ["preview", "staging", "production"],

--- a/platform/security/token-vault/README.md
+++ b/platform/security/token-vault/README.md
@@ -16,6 +16,7 @@ Worker interno para substituir a aba `Credencial` do Google Sheets usada pelo wo
 - `POST /internal/token-vault/v1/meta-ads-publish/config/bootstrap/derive`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/bootstrap/rollback`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/attest`
+- `POST /internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/attest-appsecret-proof`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/rollback`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/staging-exercise`
@@ -27,7 +28,7 @@ O bearer restrito `TOKEN_VAULT_META_ADS_CONFIG_TOKEN` só pode consultar
 bootstrap governados, o rollback desse bootstrap e o exercício de staging. Ele
 não lista/altera tokens, não cria runs e não publica anúncios.
 O bearer efêmero distinto `TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN` só alcança
-os três endpoints de atestação, seed e rollback sintéticos, exclusivamente no
+os quatro endpoints de atestação, prova de `appsecret_proof`, seed e rollback sintéticos, exclusivamente no
 Worker staging; ele não ganha as permissões do bearer de configuração,
 operacional ou administrativo.
 O endpoint de analytics exige o secret separado
@@ -150,6 +151,14 @@ uma conta/pixel, uma Página+Instagram elegível e um dataset offline unívocos,
 cria somente recursos `PAUSED` nomeados para staging e sela duas credenciais
 internas cifradas. Não seleciona campanhas, conjuntos ou anúncios comerciais,
 nem torna o token Meta um binding do Worker.
+
+O workflow manual separado de prova candidata cria somente uma versão imutável
+não promovida e chama `POST .../staging-synthetic-seed/attest-appsecret-proof`.
+Esse endpoint exige que a própria versão candidata tenha gerado
+`appsecret_proof` a partir do binding herdado; ele repete as leituras Graph
+delimitadas, não toca D1 nem tráfego, e devolve apenas
+`appsecret_proof_verified` ou um código sanitizado. Ele não cria, copia nem
+revela `META_APP_SECRET`.
 
 O endpoint responde apenas `sealed` ou `not_required` e uma identidade opaca
 de operação. Se qualquer passo subsequente falhar antes do tráfego, ou se a

--- a/platform/security/token-vault/src/index.js
+++ b/platform/security/token-vault/src/index.js
@@ -17,6 +17,7 @@ const META_ADS_PUBLISH_CONFIG_BOOTSTRAP_DERIVE_PATH = `${META_ADS_PUBLISH_CONFIG
 const META_ADS_PUBLISH_CONFIG_STAGING_EXERCISE_PATH = `${META_ADS_PUBLISH_CONFIG_PATH}/staging-exercise`;
 const META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH = `${META_ADS_PUBLISH_CONFIG_PATH}/staging-synthetic-seed`;
 const META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ATTEST_PATH = `${META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH}/attest`;
+const META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ATTEST_APPSECRET_PROOF_PATH = `${META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH}/attest-appsecret-proof`;
 const META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ROLLBACK_PATH = `${META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH}/rollback`;
 const JSON_HEADERS = {
   'content-type': 'application/json; charset=utf-8',
@@ -67,6 +68,7 @@ export async function handleRequest(request, env) {
       if (
         request.method !== 'POST' || ![
           META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ATTEST_PATH,
+          META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ATTEST_APPSECRET_PROOF_PATH,
           META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH,
           META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ROLLBACK_PATH,
         ].includes(pathname)
@@ -89,6 +91,7 @@ export async function handleRequest(request, env) {
     // can call these routes, and only with POST.
     if ([
       META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ATTEST_PATH,
+      META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ATTEST_APPSECRET_PROOF_PATH,
       META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH,
       META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ROLLBACK_PATH,
     ].includes(pathname)) {
@@ -651,7 +654,7 @@ function contract(requestId) {
       meta_ads_config_secret: 'TOKEN_VAULT_META_ADS_CONFIG_TOKEN',
       meta_ads_config_scope: 'health|contract|meta-ads-config-read|meta-ads-config-bootstrap|meta-ads-config-bootstrap-rollback|meta-ads-config-bootstrap-derive-plan|meta-ads-config-bootstrap-derive|meta-ads-config-staging-exercise',
       meta_ads_staging_seed_secret: 'TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN',
-      meta_ads_staging_seed_scope: 'meta-ads-config-staging-synthetic-seed-attest|meta-ads-config-staging-synthetic-seed|meta-ads-config-staging-synthetic-seed-rollback',
+      meta_ads_staging_seed_scope: 'meta-ads-config-staging-synthetic-seed-attest|meta-ads-config-staging-synthetic-seed-attest-appsecret-proof|meta-ads-config-staging-synthetic-seed|meta-ads-config-staging-synthetic-seed-rollback',
     },
     storage: {
       d1_binding: 'TOKEN_VAULT_DB',

--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -203,6 +203,7 @@ const STAGING_SYNTHETIC_SEED_ATTESTATION_FAILURES = Object.freeze({
   sourceAuthRejected: 'meta_ads_publish_staging_seed_graph_source_auth_rejected',
   pixelAccessDenied: 'meta_ads_publish_staging_seed_graph_pixel_access_denied',
   appSecretProofMismatch: 'meta_ads_publish_staging_seed_graph_appsecret_proof_mismatch',
+  appSecretProofUnavailable: 'meta_ads_publish_staging_seed_graph_appsecret_proof_unavailable',
   pageAccessDenied: 'meta_ads_publish_staging_seed_graph_page_access_denied',
   datasetAccessDenied: 'meta_ads_publish_staging_seed_graph_dataset_access_denied',
   identityMismatch: 'meta_ads_publish_staging_seed_graph_identity_mismatch',
@@ -379,6 +380,10 @@ export async function handleMetaAdsPublishRequest(input) {
 
   if (request.method === 'POST' && pathname === `${PREFIX}/config/staging-synthetic-seed/attest`) {
     return attestStagingSyntheticMetaAdsTracking({ request, env, requestId });
+  }
+
+  if (request.method === 'POST' && pathname === `${PREFIX}/config/staging-synthetic-seed/attest-appsecret-proof`) {
+    return attestStagingSyntheticMetaAdsTrackingAppSecretProof({ request, env, requestId });
   }
 
   if (request.method === 'POST' && pathname === `${PREFIX}/config/staging-synthetic-seed`) {
@@ -1263,10 +1268,38 @@ export async function bootstrapMetaAdsPublishConfigFromDerivedPlan({
 // available to the operational/config/admin gateway roles; index.js exposes it
 // only to a release-scoped, candidate-only bearer.
 export async function attestStagingSyntheticMetaAdsTracking({ request, env, requestId }) {
+  return runStagingSyntheticMetaAdsTrackingAttestation({ request, env, requestId });
+}
+
+// This separate candidate-only diagnostic is intentionally stricter than the
+// regular source attestation: success proves the inherited Worker binding did
+// generate an appsecret_proof for the same bounded Graph reads. It remains
+// read-only and never becomes a generic secret-presence oracle.
+export async function attestStagingSyntheticMetaAdsTrackingAppSecretProof({ request, env, requestId }) {
+  return runStagingSyntheticMetaAdsTrackingAttestation({
+    request,
+    env,
+    requestId,
+    requireAppSecretProof: true,
+  });
+}
+
+async function runStagingSyntheticMetaAdsTrackingAttestation({
+  request,
+  env,
+  requestId,
+  requireAppSecretProof = false,
+}) {
   try {
     assertStagingSyntheticSeedAttestationEnvironment(env);
     const input = await readStagingSyntheticSeedInput(request);
     const auth = await buildStagingSyntheticSeedGraphAuth(input, env);
+    if (requireAppSecretProof && !clean(auth.appSecretProof)) {
+      throw stagingSyntheticSeedFailure(
+        STAGING_SYNTHETIC_SEED_ATTESTATION_FAILURES.appSecretProofUnavailable,
+        409,
+      );
+    }
     await discoverStagingSyntheticSeedFacts({
       input,
       auth,
@@ -1275,7 +1308,9 @@ export async function attestStagingSyntheticMetaAdsTracking({ request, env, requ
       maxGraphAttempts: STAGING_SYNTHETIC_SEED_ATTEST_MAX_GRAPH_ATTEMPTS,
       probeAppSecretProof: true,
     });
-    return stagingSyntheticSeedAttestationSuccess({ requestId, operationKey: input.operationKey });
+    return requireAppSecretProof
+      ? stagingSyntheticSeedAppSecretProofAttestationSuccess({ requestId })
+      : stagingSyntheticSeedAttestationSuccess({ requestId, operationKey: input.operationKey });
   } catch (error) {
     return stagingSyntheticSeedFailureResponse(normalizeStagingSyntheticSeedError(error), requestId);
   }
@@ -1587,6 +1622,7 @@ function stagingSyntheticSeedFailureResponse(error, requestId) {
     'meta_ads_publish_staging_seed_graph_source_auth_rejected',
     'meta_ads_publish_staging_seed_graph_pixel_access_denied',
     'meta_ads_publish_staging_seed_graph_appsecret_proof_mismatch',
+    'meta_ads_publish_staging_seed_graph_appsecret_proof_unavailable',
     'meta_ads_publish_staging_seed_graph_page_access_denied',
     'meta_ads_publish_staging_seed_graph_dataset_access_denied',
     'meta_ads_publish_staging_seed_graph_identity_mismatch',
@@ -1637,6 +1673,15 @@ function stagingSyntheticSeedAttestationSuccess({ requestId, operationKey }) {
     ok: true,
     attestation: 'match',
     operation_key: operationKey,
+    contract_version: STAGING_SYNTHETIC_SEED_CONTRACT,
+    requestId,
+  });
+}
+
+function stagingSyntheticSeedAppSecretProofAttestationSuccess({ requestId }) {
+  return response({
+    ok: true,
+    attestation: 'appsecret_proof_verified',
     contract_version: STAGING_SYNTHETIC_SEED_CONTRACT,
     requestId,
   });

--- a/platform/security/token-vault/tests/index.test.js
+++ b/platform/security/token-vault/tests/index.test.js
@@ -230,7 +230,7 @@ test('configured worker secrets must remain pairwise distinct', async () => {
   assert.equal((await response.json()).error, 'invalid_worker_secret_configuration');
 });
 
-test('Meta Ads staging seed bearer is staging-only, pairwise distinct, and exclusive to its three POST routes', async () => {
+test('Meta Ads staging seed bearer is staging-only, pairwise distinct, and exclusive to its four POST routes', async () => {
   const disabledDb = new FakeDb();
   const disabledEnvironment = env(disabledDb);
   disabledEnvironment.ENVIRONMENT = 'production';
@@ -273,6 +273,9 @@ test('Meta Ads staging seed bearer is staging-only, pairwise distinct, and exclu
     new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/attest', {
       headers: metaAdsStagingSeedAuthHeaders(),
     }),
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/attest-appsecret-proof', {
+      headers: metaAdsStagingSeedAuthHeaders(),
+    }),
   ]) {
     const response = await handleRequest(request, environment);
     assert.equal(response.status, 403);
@@ -281,6 +284,7 @@ test('Meta Ads staging seed bearer is staging-only, pairwise distinct, and exclu
 
   for (const pathname of [
     '/v1/meta-ads-publish/config/staging-synthetic-seed/attest',
+    '/v1/meta-ads-publish/config/staging-synthetic-seed/attest-appsecret-proof',
     '/v1/meta-ads-publish/config/staging-synthetic-seed',
     '/v1/meta-ads-publish/config/staging-synthetic-seed/rollback',
   ]) {
@@ -298,6 +302,7 @@ test('Meta Ads staging seed bearer is staging-only, pairwise distinct, and exclu
 
   for (const pathname of [
     '/v1/meta-ads-publish/config/staging-synthetic-seed/attest',
+    '/v1/meta-ads-publish/config/staging-synthetic-seed/attest-appsecret-proof',
     '/v1/meta-ads-publish/config/staging-synthetic-seed',
     '/v1/meta-ads-publish/config/staging-synthetic-seed/rollback',
   ]) {
@@ -314,6 +319,32 @@ test('Meta Ads staging seed bearer is staging-only, pairwise distinct, and exclu
       assert.equal((await response.json()).error, 'meta_ads_staging_seed_credential_required');
     }
   }
+  assert.equal(db.tokens.length, 0);
+});
+
+test('Meta Ads staging seed bearer dispatches the candidate proof route without exposing the source input', async () => {
+  const db = new FakeDb();
+  const environment = env(db);
+  environment.ENVIRONMENT = 'staging';
+  environment.TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN = TEST_META_ADS_STAGING_SEED_TOKEN;
+  const response = await handleRequest(
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/attest-appsecret-proof', {
+      method: 'POST',
+      headers: { ...metaAdsStagingSeedAuthHeaders(), 'content-type': 'application/json' },
+      body: JSON.stringify({
+        operation_key: 'meta-ads-staging-seed:index-candidate-proof-route-001',
+        access_token: 'unit-test-source-access-token-not-a-real-secret',
+        account_id: '17841400000000001',
+        pixel_id: '99444000000000001',
+        api_version: 'v25.0',
+      }),
+    }),
+    environment,
+  );
+  const body = await response.json();
+  assert.equal(response.status, 409);
+  assert.equal(body.error, 'meta_ads_publish_staging_seed_graph_appsecret_proof_unavailable');
+  assert.equal(JSON.stringify(body).includes('unit-test-source-access-token-not-a-real-secret'), false);
   assert.equal(db.tokens.length, 0);
 });
 

--- a/platform/security/token-vault/tests/meta-ads-candidate-appsecret-proof-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-candidate-appsecret-proof-workflow.test.js
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const workflow = fs.readFileSync(
+  new URL(
+    "../../../../.github/workflows/attest-meta-ads-candidate-appsecret.yml",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+test("candidate appsecret-proof attestation is manual, main-pinned, and serialized with Token Vault releases", () => {
+  assert.match(workflow, /^name: Attest Meta Ads Candidate Appsecret Proof$/m);
+  assert.match(workflow, /^\s+workflow_dispatch:\s*$/m);
+  assert.match(workflow, /if: github\.ref == 'refs\/heads\/main'/);
+  assert.match(workflow, /group: deploy-token-vault-staging/);
+  assert.match(workflow, /cancel-in-progress: false/);
+  assert.match(workflow, /environment: staging/);
+  assert.match(workflow, /timeout-minutes: 8/);
+  assert.match(workflow, /ref: \$\{\{ github\.sha \}\}/);
+  assert.match(
+    workflow,
+    /git fetch --no-tags origin main:refs\/remotes\/origin\/main/,
+  );
+  assert.match(
+    workflow,
+    /main advanced before the candidate upload; redispatch the current source/,
+  );
+
+  assert.equal(
+    (workflow.match(/global-coordination-acquire/g) || []).length,
+    1,
+  );
+  assert.equal((workflow.match(/global-coordination-check/g) || []).length, 1);
+  assert.equal(
+    (workflow.match(/global-coordination-release/g) || []).length,
+    1,
+  );
+  assert.equal(
+    (workflow.match(/resource: release:token-vault/g) || []).length,
+    2,
+  );
+  assert.match(workflow, /module: token-vault/);
+  assert.match(workflow, /token-vault-candidate-appsecret-proof-lease\.json/);
+});
+
+test("candidate appsecret-proof workflow uploads exactly one non-promoted candidate with a private ephemeral bearer", () => {
+  assert.match(workflow, /randomBytes\(48\)\.toString\('base64url'\)/);
+  assert.match(workflow, /umask 077/);
+  assert.match(workflow, /chmod 600 "\$seed_file"/);
+  assert.match(workflow, /chmod 600 "\$secrets_file"/);
+  assert.match(workflow, /TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN: seedToken/);
+  assert.match(
+    workflow,
+    /upload_output="\$\(npx --yes wrangler@4\.120\.0 versions upload/,
+  );
+  assert.match(workflow, /--env staging/);
+  assert.match(workflow, /--keep-vars/);
+  assert.match(workflow, /--strict/);
+  assert.match(workflow, /--secrets-file "\$secrets_file"/);
+  assert.match(
+    workflow,
+    /token-vault:candidate-appsecret-proof:\$\{SOURCE_SHA\}/,
+  );
+  assert.match(
+    workflow,
+    /expected_preview="https:\/\/\$\{version_id%%-\*\}-skincos-token-vault-staging\.skincos\.workers\.dev"/,
+  );
+  assert.match(workflow, /grep -F -x "\$expected_preview"/);
+  assert.match(workflow, /attest-appsecret-proof/);
+  assert.match(workflow, /cache: 'no-store'/);
+  assert.match(workflow, /redirect: 'error'/);
+  assert.match(workflow, /AbortSignal\.timeout\(30_000\)/);
+  assert.match(workflow, /candidate_appsecret_proof=verified/);
+  assert.match(workflow, /Remove candidate-only proof files/);
+  assert.match(workflow, /rm -f -- "\$proof_root\/seed-bearer"/);
+
+  assert.doesNotMatch(workflow, /META_APP_SECRET/);
+  assert.doesNotMatch(workflow, /versions deploy/);
+  assert.doesNotMatch(workflow, /wrangler deploy/);
+  assert.doesNotMatch(workflow, /\bd1\b/i);
+  assert.doesNotMatch(workflow, /migration/i);
+  assert.doesNotMatch(workflow, /bootstrap/i);
+  assert.doesNotMatch(workflow, /fixture/i);
+  assert.doesNotMatch(workflow, /\borb\b/i);
+  assert.doesNotMatch(workflow, /upload-artifact/i);
+  assert.doesNotMatch(workflow, /GITHUB_OUTPUT/);
+  assert.doesNotMatch(workflow, /secret put/i);
+  assert.doesNotMatch(workflow, /gh secret/i);
+});
+
+test("candidate appsecret-proof request keeps source inputs and bearer private while validating a closed response shape", () => {
+  assert.match(workflow, /Authorization: `Bearer \$\{seedToken\}`/);
+  assert.match(workflow, /access_token: sourceToken/);
+  assert.match(workflow, /account_id: accountId/);
+  assert.match(workflow, /pixel_id: pixelId/);
+  assert.match(workflow, /api_version: apiVersion/);
+  assert.match(
+    workflow,
+    /const allowedKeys = new Set\(\['ok', 'attestation', 'contract_version', 'requestId'\]\)/,
+  );
+  assert.match(
+    workflow,
+    /payload\?\.attestation === 'appsecret_proof_verified'/,
+  );
+  assert.match(
+    workflow,
+    /candidate appsecret-proof attestation failed: \$\{response\.status\} \$\{error\}/,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /process\.stdout\.write\([^\n]*(?:seedToken|sourceToken|pixelId|accountId|preview)/,
+  );
+  assert.doesNotMatch(workflow, /operation_key=.*GITHUB_OUTPUT/);
+});

--- a/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
   attestStagingSyntheticMetaAdsTracking,
+  attestStagingSyntheticMetaAdsTrackingAppSecretProof,
   rollbackStagingSyntheticMetaAdsTracking,
   seedStagingSyntheticMetaAdsTracking,
 } from '../src/meta-ads-publish.js';
@@ -498,6 +499,29 @@ async function attest({ db, graph, operationKey, env = {}, requestOverrides = {}
   });
 }
 
+function appSecretProofAttestRequest(operationKey, overrides = {}) {
+  return new Request('https://token-vault.invalid/v1/meta-ads-publish/config/staging-synthetic-seed/attest-appsecret-proof', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      operation_key: operationKey,
+      access_token: SOURCE_ACCESS_TOKEN,
+      account_id: ACCOUNT_ID,
+      pixel_id: PIXEL_ID,
+      api_version: 'v25.0',
+      ...overrides,
+    }),
+  });
+}
+
+async function attestAppSecretProof({ db, graph, operationKey, env = {}, requestOverrides = {} }) {
+  return attestStagingSyntheticMetaAdsTrackingAppSecretProof({
+    request: appSecretProofAttestRequest(operationKey, requestOverrides),
+    env: environment(db, graph, env),
+    requestId: 'seed-appsecret-proof-attestation-test-request-id',
+  });
+}
+
 function rollbackRequest(operationKey, overrides = {}) {
   return new Request('https://token-vault.invalid/v1/meta-ads-publish/config/staging-synthetic-seed/rollback', {
     method: 'POST',
@@ -783,6 +807,143 @@ test('staging seed attestation identifies a rejected appsecret proof without mut
   assert.equal(db.tokens.length, 0);
   assert.equal(db.locks.size, 0);
   assert.equal(db.adsetLocks.size, 0);
+  const serialized = JSON.stringify(body);
+  for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID]) {
+    assert.equal(serialized.includes(value), false);
+  }
+});
+
+test('candidate appsecret-proof attestation fails closed before Graph or D1 when the inherited proof binding is unavailable', async () => {
+  const db = new SeedDb();
+  db.prepare = () => {
+    throw new Error('D1 must remain untouched by candidate proof attestation');
+  };
+  const graph = new FakeGraph();
+  const response = await attestAppSecretProof({
+    db,
+    graph,
+    operationKey: 'meta-ads-staging-seed:candidate-proof-unavailable-001',
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 409);
+  assert.equal(body.error, 'meta_ads_publish_staging_seed_graph_appsecret_proof_unavailable');
+  assert.equal(graph.calls.length, 0);
+  assert.equal(graph.postCalls.length, 0);
+  const serialized = JSON.stringify(body);
+  for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID]) {
+    assert.equal(serialized.includes(value), false);
+  }
+});
+
+test('candidate appsecret-proof attestation remains staging-only before it reads Graph or D1', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph();
+  const response = await attestAppSecretProof({
+    db,
+    graph,
+    operationKey: 'meta-ads-staging-seed:candidate-proof-production-denied-001',
+    env: {
+      ENVIRONMENT: 'production',
+      META_APP_SECRET: 'unit-test-app-secret-not-a-real-secret',
+    },
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 503);
+  assert.equal(body.error, 'meta_ads_publish_staging_seed_disabled');
+  assert.equal(graph.calls.length, 0);
+  assert.equal(graph.postCalls.length, 0);
+  assert.equal(db.operations.size, 0);
+  assert.equal(db.tokens.length, 0);
+  assert.equal(db.locks.size, 0);
+  assert.equal(db.adsetLocks.size, 0);
+});
+
+test('candidate appsecret-proof attestation verifies only bounded proof-bearing Graph reads without D1', async () => {
+  const db = new SeedDb();
+  db.prepare = () => {
+    throw new Error('D1 must remain untouched by candidate proof attestation');
+  };
+  const graph = new FakeGraph();
+  const observedReads = [];
+  const response = await attestAppSecretProof({
+    db,
+    graph,
+    operationKey: 'meta-ads-staging-seed:candidate-proof-verified-001',
+    env: {
+      META_APP_SECRET: 'unit-test-app-secret-not-a-real-secret',
+      META_GRAPH_FETCH: async (url, init) => {
+        const target = new URL(url);
+        observedReads.push({
+          path: target.pathname.replace(/^\/v\d+\.0\//, ''),
+          method: String(init.method || 'GET').toUpperCase(),
+          hasProof: target.searchParams.has('appsecret_proof'),
+        });
+        return graph.fetch(url, init);
+      },
+    },
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(body, {
+    ok: true,
+    attestation: 'appsecret_proof_verified',
+    contract_version: 'meta-ads-tracking-v20/staging-synthetic-seed/v1',
+    requestId: 'seed-appsecret-proof-attestation-test-request-id',
+  });
+  assert.deepEqual(observedReads.map((read) => read.path), [
+    PIXEL_ID,
+    'me/accounts',
+    PAGE_ID,
+    `act_${ACCOUNT_ID}/offline_conversion_data_sets`,
+  ]);
+  assert.ok(observedReads.every((read) => read.method === 'GET' && read.hasProof));
+  assert.equal(graph.calls.length, 4);
+  assert.equal(graph.postCalls.length, 0);
+  const serialized = JSON.stringify(body);
+  for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID]) {
+    assert.equal(serialized.includes(value), false);
+  }
+});
+
+test('candidate appsecret-proof attestation preserves the sanitized proof mismatch without D1 or Graph mutation', async () => {
+  const db = new SeedDb();
+  db.prepare = () => {
+    throw new Error('D1 must remain untouched by candidate proof attestation');
+  };
+  const graph = new FakeGraph();
+  const observedReads = [];
+  const response = await attestAppSecretProof({
+    db,
+    graph,
+    operationKey: 'meta-ads-staging-seed:candidate-proof-mismatch-001',
+    env: {
+      META_APP_SECRET: 'unit-test-app-secret-not-a-real-secret',
+      META_GRAPH_FETCH: async (url, init) => {
+        const target = new URL(url);
+        observedReads.push({
+          path: target.pathname.replace(/^\/v\d+\.0\//, ''),
+          method: String(init.method || 'GET').toUpperCase(),
+          hasProof: target.searchParams.has('appsecret_proof'),
+        });
+        if (target.searchParams.has('appsecret_proof')) {
+          return graphResponse({ error: { message: 'proof rejected', code: 10 } }, 403);
+        }
+        return graph.fetch(url, init);
+      },
+    },
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 409);
+  assert.equal(body.error, 'meta_ads_publish_staging_seed_graph_appsecret_proof_mismatch');
+  assert.deepEqual(observedReads, [
+    { path: PIXEL_ID, method: 'GET', hasProof: true },
+    { path: PIXEL_ID, method: 'GET', hasProof: false },
+  ]);
+  assert.equal(graph.postCalls.length, 0);
   const serialized = JSON.stringify(body);
   for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID]) {
     assert.equal(serialized.includes(value), false);

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -71,6 +71,7 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
   assert.equal(surface?.coordinationGroup, "token-vault-writer");
   assert.deepEqual(surface?.mutationWorkflows, [
     ".github/workflows/deploy-token-vault.yml",
+    ".github/workflows/attest-meta-ads-candidate-appsecret.yml",
     ".github/workflows/influencer-intelligence-staging-shadow.yml",
   ]);
 
@@ -78,7 +79,7 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
   const tokenVaultUnit = catalog.units.find((unit) => unit.id === "token-vault");
   assert.ok(tokenVaultUnit);
   assert.ok(!catalog.nonPublishingSurfaces.some((entry) => entry.id === "token-vault"));
-  assert.ok(tokenVaultUnit.resources.includes("Governed Meta Ads staging synthetic source attestation, seed, bootstrap derivation, rollback journal and paused creative fixture"));
+  assert.ok(tokenVaultUnit.resources.includes("Governed Meta Ads staging synthetic source and appsecret-proof attestations, seed, bootstrap derivation, rollback journal and paused creative fixture"));
   assert.ok(tokenVaultUnit.secrets.includes("TOKEN_VAULT_META_ADS_CONFIG_TOKEN"));
   assert.ok(tokenVaultUnit.secrets.includes("TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST"));
   assert.ok(tokenVaultUnit.secrets.includes("META_ADS_ACCESS_TOKEN"));
@@ -274,6 +275,7 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
   assert.ok(globalPolicy.releaseClosures["token-vault"].patterns.includes("scripts/runtime/test-native-custody-contract.sh"));
   assert.ok(globalPolicy.releaseClosures["token-vault"].patterns.includes("scripts/runtime/promote-native-source-release.sh"));
   assert.ok(globalPolicy.releaseClosures["token-vault"].patterns.includes("scripts/runtime/test-promote-native-source-release.sh"));
+  assert.ok(globalPolicy.releaseClosures["token-vault"].patterns.includes(".github/workflows/attest-meta-ads-candidate-appsecret.yml"));
   assert.ok(globalPolicy.releaseClosures["token-vault"].patterns.includes(".github/workflows/influencer-intelligence-staging-shadow.yml"));
   const shadow = read(".github/workflows/influencer-intelligence-staging-shadow.yml");
   assert.match(shadow, /group: deploy-token-vault-staging/);


### PR DESCRIPTION
## Objetivo

Discriminar, sem promoção de tráfego, se a versão candidata do Token Vault consegue produzir e usar o `appsecret_proof` herdado antes de retomar o rollout Meta Ads v20.

## Mudança

- adiciona uma rota candidata, staging-only e POST-only sob o bearer efêmero de seed;
- adiciona workflow manual que cria apenas uma versão imutável **não promovida**, prova o binding e remove o bearer local;
- registra o workflow na governança single-writer/closure do Token Vault;
- amplia testes de isolamento de papel, ausência de D1/Graph write, redaction, URL candidata e limpeza.

## Superfícies, risco e contenção

- **Superfícies:** Token Vault Worker staging candidato, GitHub Actions staging e Meta Graph somente em leituras delimitadas.
- **Risco:** alto por tocar autenticação/bindings; reduzido por rota exclusiva, fonte imutável, URL HTTPS estrita, timeout/no-store/no-redirect e resposta sanitizada.
- **Flag/coorte:** não aplicável. O workflow é manual e não promove tráfego.
- **Migration:** não aplicável. O workflow proíbe D1/migrations.
- **Produção:** fora de escopo; não cria elegibilidade de produção.

## Validação

- `npm --prefix platform/security/token-vault test` — 155/155.
- `node --test scripts/tests/global-concurrency-governance-static.test.mjs` — 19/19.
- `node .github/scripts/validate-cloudflare-single-writer.mjs` — OK.
- revisão de segurança de diff concluída sem P0/P1; cobertura do fluxo de rota, segredo efêmero, URL candidata e no-leak.

## Rollback

Nenhuma rota ativa ou tráfego é alterado. Se o workflow provar ausência/mismatch, ele falha fechado e remove apenas os arquivos efêmeros locais. Para reverter o código, revert deste commit remove a rota e o workflow; versões candidatas criadas pelo diagnóstico permanecem não promovidas e não devem ser usadas como evidência de rollout.

## Próximo gate

Após merge, executar somente a attestation candidata. Não repetir staging até o resultado discriminar `verified`, `proof_unavailable`, `proof_mismatch` ou uma falha de acesso ao ativo.