### PR TITLE
fix(crm): reject self-referential auth target

### DIFF
--- a/crm/console/functions/_lib/crmAuth.ts
+++ b/crm/console/functions/_lib/crmAuth.ts
@@ -129,8 +129,19 @@ export async function getCrmUser(context: any): Promise<CrmAuthUser | null> {
   }
 
   const env = context?.env || {}
+  const configuredAuthTarget = String(env.AUTH_API_TARGET ?? '').trim()
+  const requestUrl = String(context?.request?.url ?? '').trim()
+  let authTargetIsRequestOrigin = false
+  if (configuredAuthTarget && requestUrl) {
+    try {
+      authTargetIsRequestOrigin = new URL(configuredAuthTarget).origin === new URL(requestUrl).origin
+    } catch {
+      // Preserve the existing invalid-target behavior below; this guard only
+      // rejects a configured target that points back at the current request.
+    }
+  }
   const targetOrigin =
-    (env.AUTH_API_TARGET as string | undefined) ||
+    (!authTargetIsRequestOrigin ? configuredAuthTarget : '') ||
     (env.INSUMOS_API_TARGET as string | undefined) ||
     'https://api.skincos.com.br'
 

--- a/crm/console/tests/crmAuth.test.ts
+++ b/crm/console/tests/crmAuth.test.ts
@@ -65,6 +65,25 @@ describe('CRM auth adapter', () => {
     expect(fetchMock.mock.calls[0][0]).toBe('https://auth.internal.test/custom/auth/me')
   })
 
+  it('ignores an auth target that points back at the current CRM request origin', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      user: { id: 'gestor-1', role: 'GESTOR' },
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const user = await getCrmUser(context({
+      AUTH_API_TARGET: 'https://crm.skincos.com.br',
+      INSUMOS_API_TARGET: 'https://api.skincos.com.br',
+    }))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.skincos.com.br/insumos/auth/me')
+    expect(user).toMatchObject({ id: 'gestor-1', role: 'GESTOR' })
+  })
+
   it('falls back to legacy auth mounts only when the canonical mount is absent', async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(new Response(null, { status: 404 }))


### PR DESCRIPTION
## Summary

Reject a configured `AUTH_API_TARGET` when it points back to the current CRM request origin. The proxy then falls back to the canonical `INSUMOS_API_TARGET` instead of recursively authenticating against the CRM Pages origin.

This is a follow-up to #1483. It addresses the live residual observed after production release `1c324ce`: `/api/auth/me` returned 200 while Atendimento data routes still returned 401 with a valid browser session.

## Change

- Preserve explicit external/internal auth targets.
- Ignore only a same-origin `AUTH_API_TARGET` relative to the current request.
- Add a regression test proving the request uses `https://api.skincos.com.br/insumos/auth/me` in that case.

## Validation

- `crm/console`: typecheck passed.
- `tests/crmAuth.test.ts`: 4/4 passed.
- `tests/atendimentoProxy.test.ts`: 12/12 passed.
- `inventory/tests/unifiedTeamAccountScope.test.mjs`: 14/14 passed on the clean release worktree, including the pre-decryption negative gates.

## Release safety

- No deploy, flag, database, user grant, or public API change was performed.
- Do not merge/promote until a staging deployment of this SHA passes the authenticated Atendimento journey with a private synthetic fixture.
- The shared clone and the pre-existing Users smoke worktree were not modified.