### PR TITLE
fix(meta-ads): attest Pixel account membership

### DIFF
--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -120,18 +120,29 @@ jobs:
             }
           };
 
-          // Keep the bare asset read separate from the owner relation. A denial
-          // now identifies whether the source cannot read the Pixel at all or
-          // cannot read the relation required by the staging seed contract.
+          // Keep the bare asset read separate from the account membership
+          // relation. A Pixel may be shared with the configured account without
+          // that account owning it, so membership is the contract needed by the
+          // later promoted_object.
           const pixel = await directRead(`${pixelId}?fields=id`, 'source_pixel');
           if (numericId(pixel?.id) !== pixelId) fail('source_pixel_mismatch');
 
-          const pixelOwner = await directRead(
-            `${pixelId}?fields=owner_ad_account{id}`,
-            'source_pixel_owner_relation',
+          const accountPixels = await directRead(
+            `act_${accountId}/adspixels?fields=id&limit=5`,
+            'source_pixel_account_relation',
           );
-          if (numericId(pixelOwner?.owner_ad_account?.id) !== accountId) {
-            fail('source_pixel_owner_relation_mismatch');
+          if (!Array.isArray(accountPixels?.data)) fail('source_pixel_account_relation_malformed');
+          const associatedPixels = accountPixels.data.map((entry) => numericId(entry?.id));
+          if (associatedPixels.some((id) => !id)) fail('source_pixel_account_relation_malformed');
+          const targetMemberships = associatedPixels.filter((id) => id === pixelId).length;
+          if (targetMemberships === 1 && new Set(associatedPixels).size === associatedPixels.length) {
+            // The bounded page proves the exact association. Do not follow the
+            // opaque Graph pagination URL or reject an account just because it
+            // has more associated Pixels than this diagnostic page limit.
+          } else if (String(accountPixels?.paging?.next ?? '').trim()) {
+            fail('source_pixel_account_relation_ambiguous');
+          } else {
+            fail('source_pixel_account_relation_mismatch');
           }
 
           const pages = await directRead(
@@ -174,7 +185,7 @@ jobs:
             'source_access_raw=verified',
             'source_access_runtime_proof=unverified',
             'source_access_pixel=allowed',
-            'source_access_ad_account=allowed',
+            'source_access_pixel_account_relation=allowed',
             'source_access_page=eligible',
             'source_access_dataset=eligible',
             'source_access_landing_media=eligible',

--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -190,6 +190,8 @@ const STAGING_SYNTHETIC_SEED_DISCOVERY_FAILURES = Object.freeze({
   sourceUnavailable: 'meta_ads_publish_staging_seed_graph_identity_invalid',
   sourceAuthRejected: 'meta_ads_publish_staging_seed_graph_identity_invalid',
   pixelAccessDenied: 'meta_ads_publish_staging_seed_graph_identity_invalid',
+  pixelAccountRelationAccessDenied: 'meta_ads_publish_staging_seed_graph_identity_invalid',
+  pixelAccountRelationAmbiguous: 'meta_ads_publish_staging_seed_graph_identity_invalid',
   pageAccessDenied: 'meta_ads_publish_staging_seed_graph_identity_invalid',
   datasetAccessDenied: 'meta_ads_publish_staging_seed_graph_identity_invalid',
   identityMismatch: 'meta_ads_publish_staging_seed_graph_identity_invalid',
@@ -202,6 +204,8 @@ const STAGING_SYNTHETIC_SEED_ATTESTATION_FAILURES = Object.freeze({
   sourceUnavailable: 'meta_ads_publish_staging_seed_graph_source_unavailable',
   sourceAuthRejected: 'meta_ads_publish_staging_seed_graph_source_auth_rejected',
   pixelAccessDenied: 'meta_ads_publish_staging_seed_graph_pixel_access_denied',
+  pixelAccountRelationAccessDenied: 'meta_ads_publish_staging_seed_graph_pixel_account_relation_denied',
+  pixelAccountRelationAmbiguous: 'meta_ads_publish_staging_seed_graph_pixel_account_relation_ambiguous',
   appSecretProofMismatch: 'meta_ads_publish_staging_seed_graph_appsecret_proof_mismatch',
   appSecretProofUnavailable: 'meta_ads_publish_staging_seed_graph_appsecret_proof_unavailable',
   pageAccessDenied: 'meta_ads_publish_staging_seed_graph_page_access_denied',
@@ -1621,6 +1625,8 @@ function stagingSyntheticSeedFailureResponse(error, requestId) {
     'meta_ads_publish_staging_seed_graph_source_unavailable',
     'meta_ads_publish_staging_seed_graph_source_auth_rejected',
     'meta_ads_publish_staging_seed_graph_pixel_access_denied',
+    'meta_ads_publish_staging_seed_graph_pixel_account_relation_denied',
+    'meta_ads_publish_staging_seed_graph_pixel_account_relation_ambiguous',
     'meta_ads_publish_staging_seed_graph_appsecret_proof_mismatch',
     'meta_ads_publish_staging_seed_graph_appsecret_proof_unavailable',
     'meta_ads_publish_staging_seed_graph_page_access_denied',
@@ -2034,15 +2040,16 @@ async function discoverStagingSyntheticSeedFacts({
   maxGraphAttempts = MAX_GRAPH_ATTEMPTS,
   probeAppSecretProof = false,
 }) {
-  const read = (path, fields, query = {}, failureCode = failureCodes.sourceUnavailable) => seedGraphRead(auth, path, fields, context, query, {
+  const read = (path, fields, query = {}, failureCode = failureCodes.sourceUnavailable, malformedFailureCode = '') => seedGraphRead(auth, path, fields, context, query, {
     maxAttempts: maxGraphAttempts,
     failureCode,
     authFailureCode: failureCodes.sourceAuthRejected,
+    malformedFailureCode,
   });
   const readPixel = (candidateAuth) => seedGraphRead(
     candidateAuth,
     input.pixelId,
-    'id,owner_ad_account{id}',
+    'id',
     context,
     {},
     {
@@ -2074,15 +2081,36 @@ async function discoverStagingSyntheticSeedFacts({
     }
     throw stagingSyntheticSeedFailure(appSecretProofMismatch, 409);
   }
-  const pixelOwner = normalizeStagingSyntheticSeedGraphId(
-    asObject(pixel.owner_ad_account).id,
-    'pixel_owner_account',
+  if (normalizeStagingSyntheticSeedGraphId(pixel.id, 'pixel_id', failureCodes.identityMalformed) !== input.pixelId) {
+    throw stagingSyntheticSeedFailure(failureCodes.identityMismatch, 409);
+  }
+
+  // A Pixel may be shared with an ad account without that account owning it.
+  // Validate the association required by the later promoted_object instead of
+  // requiring ownership, while bounding the account's visible Pixel list.
+  const accountPixels = await read(
+    `act_${input.accountId}/adspixels`,
+    'id',
+    { limit: String(STAGING_SYNTHETIC_SEED_MAX_GRAPH_OBJECTS) },
+    failureCodes.pixelAccountRelationAccessDenied,
     failureCodes.identityMalformed,
   );
-  if (
-    normalizeStagingSyntheticSeedGraphId(pixel.id, 'pixel_id', failureCodes.identityMalformed) !== input.pixelId ||
-    pixelOwner !== input.accountId
-  ) {
+  if (!Array.isArray(accountPixels.data)) {
+    throw stagingSyntheticSeedFailure(failureCodes.identityMalformed, 409);
+  }
+  const associatedPixelIds = accountPixels.data.map((entry) => normalizeStagingSyntheticSeedGraphId(
+    asObject(entry).id,
+    'account_pixel_id',
+    failureCodes.identityMalformed,
+  ));
+  const matchingPixelCount = associatedPixelIds.filter((pixelId) => pixelId === input.pixelId).length;
+  if (matchingPixelCount === 1 && new Set(associatedPixelIds).size === associatedPixelIds.length) {
+    // Membership is proven by an exact target on this bounded page. Do not
+    // follow opaque pagination URLs or reject an otherwise valid account just
+    // because it has more associated Pixels than the diagnostic page limit.
+  } else if (clean(asObject(accountPixels.paging).next)) {
+    throw stagingSyntheticSeedFailure(failureCodes.pixelAccountRelationAmbiguous, 409);
+  } else {
     throw stagingSyntheticSeedFailure(failureCodes.identityMismatch, 409);
   }
 
@@ -2159,6 +2187,7 @@ async function seedGraphRead(auth, path, fields, context, query = {}, {
   maxAttempts = MAX_GRAPH_ATTEMPTS,
   failureCode = 'meta_ads_publish_staging_seed_graph_identity_invalid',
   authFailureCode = failureCode,
+  malformedFailureCode = '',
 } = {}) {
   try {
     const result = await graphRequest(
@@ -2176,6 +2205,9 @@ async function seedGraphRead(auth, path, fields, context, query = {}, {
     }
     if (isStagingSyntheticSeedSourceAuthFailure(normalized)) {
       throw stagingSyntheticSeedFailure(authFailureCode, 409);
+    }
+    if (clean(malformedFailureCode) && clean(normalized.classification) === 'permanent') {
+      throw stagingSyntheticSeedFailure(malformedFailureCode, 409);
     }
     throw stagingSyntheticSeedFailure(failureCode, 409);
   }

--- a/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
@@ -342,7 +342,10 @@ class FakeGraph {
 
   read(path) {
     if (path === PIXEL_ID) {
-      return graphResponse({ id: PIXEL_ID, owner_ad_account: { id: ACCOUNT_ID } });
+      return graphResponse({ id: PIXEL_ID });
+    }
+    if (path === `act_${ACCOUNT_ID}/adspixels`) {
+      return graphResponse({ data: [{ id: PIXEL_ID }] });
     }
     if (path === 'me/accounts') {
       return graphResponse({ data: [{ id: PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } }] });
@@ -636,7 +639,7 @@ test('staging seed attestation bounds Graph discovery and returns no source fact
     contract_version: 'meta-ads-tracking-v20/staging-synthetic-seed/v1',
     requestId: 'seed-attestation-test-request-id',
   });
-  assert.equal(graph.calls.length, 4);
+  assert.equal(graph.calls.length, 5);
   assert.ok(graph.calls.every((call) => call.method === 'GET'));
   assert.equal(graph.postCalls.length, 0);
   assert.equal(db.operations.size, 0);
@@ -649,35 +652,69 @@ test('staging seed attestation bounds Graph discovery and returns no source fact
   }
 });
 
+test('staging seed attestation accepts an exact account Pixel membership on a bounded page with more results', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph({
+    readResponses: {
+      [`act_${ACCOUNT_ID}/adspixels`]: {
+        body: { data: [{ id: PIXEL_ID }], paging: { next: 'https://graph.example.invalid/opaque' } },
+      },
+    },
+  });
+  const response = await attest({
+    db,
+    graph,
+    operationKey: 'meta-ads-staging-seed:attestation-membership-first-page-001',
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.attestation, 'match');
+  assert.equal(graph.calls.length, 5);
+  assert.ok(graph.calls.every((call) => call.method === 'GET'));
+  assert.equal(graph.postCalls.length, 0);
+  assert.equal(db.operations.size, 0);
+  assert.equal(db.tokens.length, 0);
+  assert.equal(db.locks.size, 0);
+  assert.equal(db.adsetLocks.size, 0);
+});
+
 test('staging seed attestation exposes only finite mismatch, malformed, and source-auth outcomes', async () => {
   const mismatchDb = new SeedDb();
-  const mismatchGraph = new FakeGraph();
+  const mismatchGraph = new FakeGraph({
+    readResponses: {
+      [`act_${ACCOUNT_ID}/adspixels`]: { body: { data: [{ id: MISMATCH_ACCOUNT_ID }] } },
+    },
+  });
   const mismatch = await attest({
     db: mismatchDb,
     graph: mismatchGraph,
     operationKey: 'meta-ads-staging-seed:attestation-mismatch-001',
-    requestOverrides: { account_id: MISMATCH_ACCOUNT_ID },
   });
   const mismatchBody = await mismatch.json();
   assert.equal(mismatch.status, 409);
   assert.equal(mismatchBody.error, 'meta_ads_publish_staging_seed_graph_identity_mismatch');
-  assert.equal(mismatchGraph.calls.length, 1);
+  assert.equal(mismatchGraph.calls.length, 2);
   assert.equal(mismatchGraph.postCalls.length, 0);
   assert.equal(mismatchDb.operations.size, 0);
   assert.equal(mismatchDb.tokens.length, 0);
 
   const malformedDb = new SeedDb();
+  const malformedGraph = new FakeGraph({
+    readResponses: {
+      [`act_${ACCOUNT_ID}/adspixels`]: { body: { data: [{ id: 'not-a-graph-id' }] } },
+    },
+  });
   const malformed = await attest({
     db: malformedDb,
-    graph: new FakeGraph(),
+    graph: malformedGraph,
     operationKey: 'meta-ads-staging-seed:attestation-malformed-001',
-    env: {
-      META_GRAPH_FETCH: async () => graphResponse({ id: PIXEL_ID, owner_ad_account: { id: 'not-a-graph-id' } }),
-    },
   });
   const malformedBody = await malformed.json();
   assert.equal(malformed.status, 409);
   assert.equal(malformedBody.error, 'meta_ads_publish_staging_seed_graph_identity_malformed');
+  assert.equal(malformedGraph.calls.length, 2);
+  assert.equal(malformedGraph.postCalls.length, 0);
   assert.equal(malformedDb.operations.size, 0);
   assert.equal(malformedDb.tokens.length, 0);
 
@@ -715,24 +752,41 @@ test('staging seed attestation returns a finite resource stage for permanent Gra
       status: 403,
     },
     {
+      label: 'pixel-account-relation',
+      path: `act_${ACCOUNT_ID}/adspixels`,
+      expectedError: 'meta_ads_publish_staging_seed_graph_pixel_account_relation_denied',
+      expectedReads: 2,
+      status: 403,
+    },
+    {
+      label: 'pixel-account-relation-contract',
+      path: `act_${ACCOUNT_ID}/adspixels`,
+      expectedError: 'meta_ads_publish_staging_seed_graph_identity_malformed',
+      expectedReads: 2,
+      // Graph can return a 2xx envelope carrying a permanent code-100 error.
+      // It is a contract incompatibility, never evidence for an asset grant.
+      status: 200,
+      code: 100,
+    },
+    {
       label: 'page-list',
       path: 'me/accounts',
       expectedError: 'meta_ads_publish_staging_seed_graph_page_access_denied',
-      expectedReads: 2,
+      expectedReads: 3,
       status: 403,
     },
     {
       label: 'page-read',
       path: PAGE_ID,
       expectedError: 'meta_ads_publish_staging_seed_graph_page_access_denied',
-      expectedReads: 3,
+      expectedReads: 4,
       status: 403,
     },
     {
       label: 'dataset',
       path: `act_${ACCOUNT_ID}/offline_conversion_data_sets`,
       expectedError: 'meta_ads_publish_staging_seed_graph_dataset_access_denied',
-      expectedReads: 4,
+      expectedReads: 5,
       // Graph can return a 2xx envelope containing an error. It remains a
       // permanent source capability failure and must not become a success.
       status: 200,
@@ -742,7 +796,7 @@ test('staging seed attestation returns a finite resource stage for permanent Gra
   for (const entry of cases) {
     const db = new SeedDb();
     const graph = new FakeGraph({
-      readFailures: { [entry.path]: { status: entry.status, code: 10 } },
+      readFailures: { [entry.path]: { status: entry.status, code: entry.code ?? 10 } },
     });
     const response = await attest({
       db,
@@ -895,12 +949,13 @@ test('candidate appsecret-proof attestation verifies only bounded proof-bearing 
   });
   assert.deepEqual(observedReads.map((read) => read.path), [
     PIXEL_ID,
+    `act_${ACCOUNT_ID}/adspixels`,
     'me/accounts',
     PAGE_ID,
     `act_${ACCOUNT_ID}/offline_conversion_data_sets`,
   ]);
   assert.ok(observedReads.every((read) => read.method === 'GET' && read.hasProof));
-  assert.equal(graph.calls.length, 4);
+  assert.equal(graph.calls.length, 5);
   assert.equal(graph.postCalls.length, 0);
   const serialized = JSON.stringify(body);
   for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID]) {
@@ -997,18 +1052,25 @@ test('staging seed attestation keeps pixel access denied when proofless retry al
 test('staging seed attestation preserves finite non-identity source eligibility outcomes', async () => {
   const cases = [
     {
+      label: 'pixel-account-relation-ambiguous',
+      path: `act_${ACCOUNT_ID}/adspixels`,
+      response: { body: { data: [], paging: { next: 'https://graph.example.invalid/opaque' } } },
+      expectedError: 'meta_ads_publish_staging_seed_graph_pixel_account_relation_ambiguous',
+      expectedReads: 2,
+    },
+    {
       label: 'page-ambiguous',
       path: 'me/accounts',
       response: { body: { data: [] } },
       expectedError: 'meta_ads_publish_staging_seed_graph_page_ambiguous',
-      expectedReads: 2,
+      expectedReads: 3,
     },
     {
       label: 'dataset-ambiguous',
       path: `act_${ACCOUNT_ID}/offline_conversion_data_sets`,
       response: { body: { data: [] } },
       expectedError: 'meta_ads_publish_staging_seed_graph_dataset_ambiguous',
-      expectedReads: 4,
+      expectedReads: 5,
     },
     {
       label: 'landing-unavailable',
@@ -1022,7 +1084,7 @@ test('staging seed attestation preserves finite non-identity source eligibility 
         },
       },
       expectedError: 'meta_ads_publish_staging_seed_landing_or_media_unavailable',
-      expectedReads: 3,
+      expectedReads: 4,
     },
   ];
 

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -90,10 +90,10 @@ const happyResponses = [
     },
   },
   {
-    pathname: `/v25.0/${syntheticPixelId}`,
-    query: { fields: "owner_ad_account{id}" },
+    pathname: `/v25.0/act_${syntheticAccountId}/adspixels`,
+    query: { fields: "id", limit: "5" },
     payload: {
-      owner_ad_account: { id: syntheticAccountId },
+      data: [{ id: syntheticPixelId }],
     },
   },
   {
@@ -158,8 +158,11 @@ test("Meta Ads source-access attestation is manual, bounded, and non-deploying",
   assert.match(workflow, /graphErrorCode === 200/);
   assert.match(workflow, /authorizationError \? 'denied' : 'malformed'/);
   assert.match(workflow, /\$\{pixelId\}\?fields=id/);
-  assert.match(workflow, /\$\{pixelId\}\?fields=owner_ad_account\{id\}/);
-  assert.match(workflow, /source_pixel_owner_relation/);
+  assert.match(workflow, /act_\$\{accountId\}\/adspixels\?fields=id&limit=5/);
+  assert.match(workflow, /source_pixel_account_relation/);
+  assert.match(workflow, /targetMemberships === 1/);
+  assert.match(workflow, /source_pixel_account_relation_ambiguous/);
+  assert.doesNotMatch(workflow, /owner_ad_account/);
   assert.match(
     workflow,
     /me\/accounts\?fields=id,tasks,instagram_business_account\{id\}&limit=100/,
@@ -184,12 +187,12 @@ test("Meta Ads source-access attestation is manual, bounded, and non-deploying",
   assert.match(workflow, /source_access_raw=verified/);
   assert.match(workflow, /source_access_runtime_proof=unverified/);
   assert.match(workflow, /source_access_pixel=allowed/);
-  assert.match(workflow, /source_access_ad_account=allowed/);
+  assert.match(workflow, /source_access_pixel_account_relation=allowed/);
   assert.match(workflow, /source_access_page=eligible/);
   assert.match(workflow, /source_access_dataset=eligible/);
   assert.match(workflow, /source_access_landing_media=eligible/);
   assert.ok(
-    workflow.indexOf("source_pixel_owner_relation_mismatch") <
+    workflow.indexOf("source_pixel_account_relation_mismatch") <
       workflow.indexOf("source_access_raw=verified"),
     "raw success output must be unreachable until the exact source reads pass",
   );
@@ -223,7 +226,7 @@ test("Meta Ads source-access verifier executes the bounded raw-read contract wit
       "source_access_raw=verified",
       "source_access_runtime_proof=unverified",
       "source_access_pixel=allowed",
-      "source_access_ad_account=allowed",
+      "source_access_pixel_account_relation=allowed",
       "source_access_page=eligible",
       "source_access_dataset=eligible",
       "source_access_landing_media=eligible",
@@ -231,6 +234,51 @@ test("Meta Ads source-access verifier executes the bounded raw-read contract wit
     ].join("\n"),
   );
   assert.equal(result.requestCount, 5);
+  assert.doesNotMatch(
+    combined,
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
+  );
+});
+
+test("Meta Ads source-access verifier accepts an exact membership on a bounded account Pixel page", () => {
+  const responses = structuredClone(happyResponses);
+  responses[1].payload.paging = { next: "https://graph.example.invalid/opaque" };
+  const result = runVerifier(responses);
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.equal(result.status, 0, combined);
+  assert.equal(result.requestCount, 5);
+  assert.match(result.stdout, /source_access_raw=verified/);
+  assert.doesNotMatch(
+    combined,
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
+  );
+});
+
+test("Meta Ads source-access verifier fails closed when target membership is beyond the bounded page", () => {
+  const responses = structuredClone(happyResponses);
+  responses[1].payload = {
+    data: [],
+    paging: { next: "https://graph.example.invalid/opaque" },
+  };
+  const result = runVerifier(responses, 2);
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0);
+  assert.match(combined, /source_pixel_account_relation_ambiguous/);
+  assert.equal(result.requestCount, 2);
+  assert.doesNotMatch(
+    combined,
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
+  );
+});
+
+test("Meta Ads source-access verifier classifies malformed bounded account Pixel entries before membership", () => {
+  const responses = structuredClone(happyResponses);
+  responses[1].payload = { data: [{ id: false }] };
+  const result = runVerifier(responses, 2);
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0);
+  assert.match(combined, /source_pixel_account_relation_malformed/);
+  assert.equal(result.requestCount, 2);
   assert.doesNotMatch(
     combined,
     new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
@@ -281,7 +329,7 @@ test("Meta Ads source-access verifier distinguishes bare Pixel denial before rel
   const combined = `${result.stdout}${result.stderr}`;
   assert.notEqual(result.status, 0);
   assert.match(combined, /source_pixel_denied/);
-  assert.doesNotMatch(combined, /source_pixel_owner_relation/);
+  assert.doesNotMatch(combined, /source_pixel_account_relation/);
   assert.doesNotMatch(combined, /synthetic denial/);
   assert.equal(result.requestCount, 1);
   assert.doesNotMatch(
@@ -290,7 +338,7 @@ test("Meta Ads source-access verifier distinguishes bare Pixel denial before rel
   );
 });
 
-test("Meta Ads source-access verifier distinguishes owner-relation denial after Pixel access", () => {
+test("Meta Ads source-access verifier distinguishes account-membership denial after Pixel access", () => {
   const result = runVerifier([
     {
       pathname: `/v25.0/${syntheticPixelId}`,
@@ -298,17 +346,42 @@ test("Meta Ads source-access verifier distinguishes owner-relation denial after 
       payload: { id: syntheticPixelId },
     },
     {
-      pathname: `/v25.0/${syntheticPixelId}`,
-      query: { fields: "owner_ad_account{id}" },
+      pathname: `/v25.0/act_${syntheticAccountId}/adspixels`,
+      query: { fields: "id", limit: "5" },
       status: 403,
       payload: { error: { code: 10, message: "synthetic denial" } },
     },
   ]);
   const combined = `${result.stdout}${result.stderr}`;
   assert.notEqual(result.status, 0);
-  assert.match(combined, /source_pixel_owner_relation_denied/);
+  assert.match(combined, /source_pixel_account_relation_denied/);
   assert.doesNotMatch(combined, /source_access_raw=verified/);
   assert.doesNotMatch(combined, /synthetic denial/);
+  assert.equal(result.requestCount, 2);
+  assert.doesNotMatch(
+    combined,
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
+  );
+});
+
+test("Meta Ads source-access verifier classifies an account-membership contract error without leaking Graph details", () => {
+  const result = runVerifier([
+    {
+      pathname: `/v25.0/${syntheticPixelId}`,
+      query: { fields: "id" },
+      payload: { id: syntheticPixelId },
+    },
+    {
+      pathname: `/v25.0/act_${syntheticAccountId}/adspixels`,
+      query: { fields: "id", limit: "5" },
+      status: 200,
+      payload: { error: { code: 100, message: "synthetic contract error" } },
+    },
+  ]);
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0);
+  assert.match(combined, /source_pixel_account_relation_malformed/);
+  assert.doesNotMatch(combined, /synthetic contract error/);
   assert.equal(result.requestCount, 2);
   assert.doesNotMatch(
     combined,


### PR DESCRIPTION
# Summary

Corrige o pré-gate de Meta Ads Tracking v20: a origem agora comprova a associação utilizável entre a conta de anúncios configurada e o Pixel, em vez de exigir que essa conta seja a proprietária do Pixel. Isso suporta Pixels compartilhados sem ampliar permissões, sem seguir URLs de paginação do Graph e sem iniciar staging.

A leitura continua somente GET e fail-closed:
- Pixel ausente/duplicado/malformado bloqueia;
- Pixel fora da página limitada com próxima página bloqueia como ambíguo;
- negação de acesso e incompatibilidade de contrato ficam em códigos sanitizados distintos;
- nenhum token, ID bruto, corpo Graph ou URL de paginação é emitido.

## Type of change

- [x] Fix
- [x] Security
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [ ] Breaking change

## Operational contract

- **Surfaces:** Token Vault staging source-attestation Worker path and the dispatch-only raw source-access workflow.
- **Risk:** Médio. Altera somente uma validação read-only anterior ao seed; não há D1, deploy, tráfego, Orb/n8n ou mutação Meta neste PR.
- **Flag/cohort:** N/A. A workflow é manual, vinculada a `main` e ao Environment `staging`.
- **Migration:** N/A.
- **Rollback:** reverter este commit restaura a verificação de ownership anterior; nenhuma alteração de dado ou ativo externo foi criada.
- **Pre-production validation:** executar a atestação raw no `main` após merge. Staging permanece proibido até o resultado discriminar sucesso ou um bloqueio sanitizado.

## Checklist

- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (README, API refs, diagrams) — contrato interno e workflow já descrevem a superfície; sem documentação pública aplicável.
- [x] Security review — scan completo do diff, zero findings.
- [x] Performance impact measured — cinco GETs Graph no máximo; não segue paginação.

## Validation

- `npm --prefix platform/security/token-vault test` — 162 passing
- `node --test scripts/tests/global-concurrency-governance-static.test.mjs` — 19 passing
- Workflow YAML parseado
- `codex:preflight` — success (aviso esperado: OAuth local do Wrangler expirado; nenhum deploy executado)

## Links

- Issue: N/A
- Design/ADR: N/A
- Migration steps: N/A

## Evidence

- Security diff scan `f89db96c-5188-4248-b1c4-0fe14fcd8a56`: cobertura completa, zero findings.
