### PR TITLE
fix(meta-ads): accept Profile Plus Page advertising task

### DIFF
--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -153,7 +153,8 @@ jobs:
           if (String(pages?.paging?.next ?? '').trim()) fail('source_pages_paging_ambiguous');
           const eligiblePages = pages.data.filter((page) => {
             const tasks = new Set(Array.isArray(page?.tasks) ? page.tasks.map((task) => String(task || '').trim().toUpperCase()) : []);
-            return tasks.has('ADVERTISE') && Boolean(numericId(page?.instagram_business_account?.id));
+            return (tasks.has('ADVERTISE') || tasks.has('PROFILE_PLUS_ADVERTISE')) &&
+              Boolean(numericId(page?.instagram_business_account?.id));
           });
           if (eligiblePages.length === 0) fail('source_pages_none_eligible');
           if (eligiblePages.length > 1) fail('source_pages_multiple_eligible');

--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -186,6 +186,14 @@ const STAGING_SYNTHETIC_SEED_MAX_GRAPH_OBJECTS = 5;
 const STAGING_SYNTHETIC_SEED_LANDING_GROUP = 'staging_tracking_fixture';
 const STAGING_SYNTHETIC_SEED_CREATIVE_MESSAGE = 'SKINCOS staging tracking verification';
 const STAGING_SYNTHETIC_SEED_CREATIVE_CTA = 'LEARN_MORE';
+// Meta's current Page API can return either the legacy ADVERTISE task or its
+// Profile Plus equivalent for the same narrow creative/advertising capability.
+// Do not broaden this to other PROFILE_PLUS_* tasks: the seed needs an
+// explicit advertising grant and must remain fail-closed for every other task.
+const STAGING_SYNTHETIC_SEED_PAGE_ADVERTISE_TASKS = new Set([
+  'ADVERTISE',
+  'PROFILE_PLUS_ADVERTISE',
+]);
 const STAGING_SYNTHETIC_SEED_DISCOVERY_FAILURES = Object.freeze({
   sourceUnavailable: 'meta_ads_publish_staging_seed_graph_identity_invalid',
   sourceAuthRejected: 'meta_ads_publish_staging_seed_graph_identity_invalid',
@@ -2125,7 +2133,8 @@ async function discoverStagingSyntheticSeedFacts({
   }
   const eligiblePages = safeArray(pages.data).map(asObject).filter((page) => {
     const tasks = new Set(safeArray(page.tasks).map((task) => clean(task).toUpperCase()));
-    return tasks.has('ADVERTISE') && /^\d{5,30}$/.test(clean(asObject(page.instagram_business_account).id));
+    return [...STAGING_SYNTHETIC_SEED_PAGE_ADVERTISE_TASKS].some((task) => tasks.has(task)) &&
+      /^\d{5,30}$/.test(clean(asObject(page.instagram_business_account).id));
   });
   if (eligiblePages.length !== 1) {
     throw stagingSyntheticSeedFailure(failureCodes.pageAmbiguous, 409);

--- a/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
@@ -679,6 +679,80 @@ test('staging seed attestation accepts an exact account Pixel membership on a bo
   assert.equal(db.adsetLocks.size, 0);
 });
 
+test('staging seed attestation accepts the explicit Profile Plus advertising task', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph({
+    readResponses: {
+      'me/accounts': {
+        body: {
+          data: [{
+            id: PAGE_ID,
+            tasks: ['PROFILE_PLUS_ADVERTISE'],
+            instagram_business_account: { id: INSTAGRAM_ID },
+          }],
+        },
+      },
+    },
+  });
+  const response = await attest({
+    db,
+    graph,
+    operationKey: 'meta-ads-staging-seed:attestation-profile-plus-advertise-001',
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.attestation, 'match');
+  assert.equal(graph.calls.length, 5);
+  assert.ok(graph.calls.every((call) => call.method === 'GET'));
+  assert.equal(graph.postCalls.length, 0);
+  assert.equal(db.operations.size, 0);
+  assert.equal(db.tokens.length, 0);
+  assert.equal(db.locks.size, 0);
+  assert.equal(db.adsetLocks.size, 0);
+  const serialized = JSON.stringify(body);
+  for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID]) {
+    assert.equal(serialized.includes(value), false);
+  }
+});
+
+test('staging seed attestation does not broaden unrelated Profile Plus tasks into advertising', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph({
+    readResponses: {
+      'me/accounts': {
+        body: {
+          data: [{
+            id: PAGE_ID,
+            tasks: ['PROFILE_PLUS_ANALYZE'],
+            instagram_business_account: { id: INSTAGRAM_ID },
+          }],
+        },
+      },
+    },
+  });
+  const response = await attest({
+    db,
+    graph,
+    operationKey: 'meta-ads-staging-seed:attestation-profile-plus-non-advertise-001',
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 409);
+  assert.equal(body.error, 'meta_ads_publish_staging_seed_graph_page_ambiguous');
+  assert.equal(graph.calls.length, 3);
+  assert.ok(graph.calls.every((call) => call.method === 'GET'));
+  assert.equal(graph.postCalls.length, 0);
+  assert.equal(db.operations.size, 0);
+  assert.equal(db.tokens.length, 0);
+  assert.equal(db.locks.size, 0);
+  assert.equal(db.adsetLocks.size, 0);
+  const serialized = JSON.stringify(body);
+  for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID]) {
+    assert.equal(serialized.includes(value), false);
+  }
+});
+
 test('staging seed attestation exposes only finite mismatch, malformed, and source-auth outcomes', async () => {
   const mismatchDb = new SeedDb();
   const mismatchGraph = new FakeGraph({

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -176,6 +176,8 @@ test("Meta Ads source-access attestation is manual, bounded, and non-deploying",
     /act_\$\{accountId\}\/offline_conversion_data_sets\?fields=id&limit=2/,
   );
   assert.match(workflow, /tasks\.has\('ADVERTISE'\)/);
+  assert.match(workflow, /tasks\.has\('PROFILE_PLUS_ADVERTISE'\)/);
+  assert.doesNotMatch(workflow, /PROFILE_PLUS_FULL_CONTROL/);
   assert.match(workflow, /source_pages_paging_ambiguous/);
   assert.match(workflow, /eligiblePages\.length === 0/);
   assert.match(workflow, /eligiblePages\.length > 1/);
@@ -250,6 +252,34 @@ test("Meta Ads source-access verifier accepts an exact membership on a bounded a
   assert.equal(result.status, 0, combined);
   assert.equal(result.requestCount, 5);
   assert.match(result.stdout, /source_access_raw=verified/);
+  assert.doesNotMatch(
+    combined,
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
+  );
+});
+
+test("Meta Ads source-access verifier accepts the explicit Profile Plus advertising task", () => {
+  const responses = structuredClone(happyResponses);
+  responses[2].payload.data[0].tasks = ["PROFILE_PLUS_ADVERTISE"];
+  const result = runVerifier(responses);
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.equal(result.status, 0, combined);
+  assert.equal(result.requestCount, 5);
+  assert.match(result.stdout, /source_access_raw=verified/);
+  assert.doesNotMatch(
+    combined,
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
+  );
+});
+
+test("Meta Ads source-access verifier does not treat other Profile Plus tasks as advertising", () => {
+  const responses = structuredClone(happyResponses);
+  responses[2].payload.data[0].tasks = ["PROFILE_PLUS_ANALYZE"];
+  const result = runVerifier(responses, 3);
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0);
+  assert.match(combined, /source_pages_none_eligible/);
+  assert.equal(result.requestCount, 3);
   assert.doesNotMatch(
     combined,
     new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),


### PR DESCRIPTION
## Objetivo

Aceita o equivalente atual `PROFILE_PLUS_ADVERTISE` junto ao legado `ADVERTISE` ao selecionar a única Página/Instagram elegível para a atestação e o seed governado de Meta Ads.

## Causa

O seletor aceitava apenas a tarefa legada. A documentação atual da coleção oficial da Meta mostra `PROFILE_PLUS_ADVERTISE` no retorno de Pages gerenciadas, portanto esse vocabulário podia produzir um falso negativo `source_pages_none_eligible`.

## Superfícies e risco

- Token Vault: descoberta pré-mutação de Página/Instagram no staging.
- Workflow manual de atestação raw: somente Graph GETs redigidos.
- Risco: elevado por envolver contrato Meta, mas sem flag, migration, deploy, D1 ou alteração de tráfego nesta PR.

## Garantias

A allowlist é deliberadamente exata: somente `ADVERTISE` e `PROFILE_PLUS_ADVERTISE`. Todas as demais tarefas `PROFILE_PLUS_*` continuam inelegíveis; paginação, unicidade e readback Page/Instagram permanecem fail-closed.

## Validação

- Testes focais de source access + seed: 38/38.
- Suíte completa Token Vault: 169/169.
- Governança global: 19/19.
- Single-writer Cloudflare: 7/7.
- YAML parse e `git diff --check`.
- Revisões independentes de contrato e segurança: sem P0/P1.

## Rollback

Reverter este commit restaura a allowlist legada. Não há dados, flags, versões ativas ou recursos Meta para desfazer. Após merge, o único follow-up é uma nova atestação raw; staging continua bloqueado até ela ficar verde.