### PR TITLE
fix(meta-ads): discriminate Page source eligibility

### DIFF
--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -151,12 +151,27 @@ jobs:
           );
           if (!Array.isArray(pages?.data)) fail('source_pages_malformed');
           if (String(pages?.paging?.next ?? '').trim()) fail('source_pages_paging_ambiguous');
-          const eligiblePages = pages.data.filter((page) => {
+          const pageFacts = pages.data.map((page) => {
             const tasks = new Set(Array.isArray(page?.tasks) ? page.tasks.map((task) => String(task || '').trim().toUpperCase()) : []);
-            return (tasks.has('ADVERTISE') || tasks.has('PROFILE_PLUS_ADVERTISE')) &&
-              Boolean(numericId(page?.instagram_business_account?.id));
+            const hasAdvertiseTask = tasks.has('ADVERTISE') || tasks.has('PROFILE_PLUS_ADVERTISE');
+            const hasInstagramLink = Boolean(numericId(page?.instagram_business_account?.id));
+            return {
+              page,
+              hasAdvertiseTask,
+              hasInstagramLink,
+              eligible: hasAdvertiseTask && hasInstagramLink,
+            };
           });
-          if (eligiblePages.length === 0) fail('source_pages_none_eligible');
+          const eligiblePages = pageFacts.filter((fact) => fact.eligible).map((fact) => fact.page);
+          if (eligiblePages.length === 0) {
+            if (pageFacts.length === 0) fail('source_pages_none_visible');
+            const hasAdvertiseTask = pageFacts.some((fact) => fact.hasAdvertiseTask);
+            const hasInstagramLink = pageFacts.some((fact) => fact.hasInstagramLink);
+            if (!hasAdvertiseTask && !hasInstagramLink) fail('source_pages_advertise_and_instagram_missing');
+            if (!hasAdvertiseTask) fail('source_pages_advertise_task_missing');
+            if (!hasInstagramLink) fail('source_pages_instagram_link_missing');
+            fail('source_pages_task_instagram_unpaired');
+          }
           if (eligiblePages.length > 1) fail('source_pages_multiple_eligible');
           const pageId = numericId(eligiblePages[0].id);
           const instagramId = numericId(eligiblePages[0].instagram_business_account.id);

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -179,6 +179,11 @@ test("Meta Ads source-access attestation is manual, bounded, and non-deploying",
   assert.match(workflow, /tasks\.has\('PROFILE_PLUS_ADVERTISE'\)/);
   assert.doesNotMatch(workflow, /PROFILE_PLUS_FULL_CONTROL/);
   assert.match(workflow, /source_pages_paging_ambiguous/);
+  assert.match(workflow, /source_pages_none_visible/);
+  assert.match(workflow, /source_pages_advertise_and_instagram_missing/);
+  assert.match(workflow, /source_pages_advertise_task_missing/);
+  assert.match(workflow, /source_pages_instagram_link_missing/);
+  assert.match(workflow, /source_pages_task_instagram_unpaired/);
   assert.match(workflow, /eligiblePages\.length === 0/);
   assert.match(workflow, /eligiblePages\.length > 1/);
   assert.match(workflow, /datasets\.data\.length !== 1/);
@@ -278,7 +283,7 @@ test("Meta Ads source-access verifier does not treat other Profile Plus tasks as
   const result = runVerifier(responses, 3);
   const combined = `${result.stdout}${result.stderr}`;
   assert.notEqual(result.status, 0);
-  assert.match(combined, /source_pages_none_eligible/);
+  assert.match(combined, /source_pages_advertise_task_missing/);
   assert.equal(result.requestCount, 3);
   assert.doesNotMatch(
     combined,
@@ -349,13 +354,58 @@ test("Meta Ads source-access verifier distinguishes a paged Page listing", () =>
   );
 });
 
-test("Meta Ads source-access verifier distinguishes no eligible Page", () => {
+test("Meta Ads source-access verifier distinguishes no visible Page", () => {
   const responses = structuredClone(happyResponses);
   responses[2].payload.data = [];
   const result = runVerifier(responses, 3);
   const combined = `${result.stdout}${result.stderr}`;
   assert.notEqual(result.status, 0);
-  assert.match(combined, /source_pages_none_eligible/);
+  assert.match(combined, /source_pages_none_visible/);
+  assert.equal(result.requestCount, 3);
+  assert.doesNotMatch(
+    combined,
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
+  );
+});
+
+test("Meta Ads source-access verifier distinguishes an absent advertising task from a missing Page", () => {
+  const responses = structuredClone(happyResponses);
+  responses[2].payload.data[0].tasks = [];
+  const result = runVerifier(responses, 3);
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0);
+  assert.match(combined, /source_pages_advertise_task_missing/);
+  assert.equal(result.requestCount, 3);
+  assert.doesNotMatch(
+    combined,
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
+  );
+});
+
+test("Meta Ads source-access verifier distinguishes a missing Instagram link from a missing Page", () => {
+  const responses = structuredClone(happyResponses);
+  delete responses[2].payload.data[0].instagram_business_account;
+  const result = runVerifier(responses, 3);
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0);
+  assert.match(combined, /source_pages_instagram_link_missing/);
+  assert.equal(result.requestCount, 3);
+  assert.doesNotMatch(
+    combined,
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
+  );
+});
+
+test("Meta Ads source-access verifier distinguishes Page task and Instagram facts that do not belong to the same Page", () => {
+  const responses = structuredClone(happyResponses);
+  responses[2].payload.data = [
+    { id: "6655443322", tasks: ["ADVERTISE"] },
+    { id: "2233445566", tasks: [], instagram_business_account: { id: "5544332211" } },
+  ];
+  const result = runVerifier(responses, 3);
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0);
+  assert.match(combined, /source_pages_task_instagram_unpaired/);
   assert.equal(result.requestCount, 3);
   assert.doesNotMatch(
     combined,


### PR DESCRIPTION
## Objetivo

Transformar o diagnóstico `source_pages_none_eligible` em estados operacionais redigidos: nenhuma Página visível, tarefa de anúncio ausente, vínculo Instagram ausente, ou tarefa e vínculo pertencentes a Páginas diferentes.

## Causa

O resultado anterior agrupava quatro condições distintas sob um único código, impedindo escolher a correção mínima do ativo Meta sem inferir IDs, tarefas ou vínculos a partir do navegador.

## Superfícies e risco

- Apenas `.github/workflows/attest-meta-ads-source-access.yml` e seu harness comportamental.
- Risco elevado por envolver uma credencial Meta, mas a workflow continua manual, main-gated e somente Graph GET.
- Flag: n/a. Migration: n/a. Não há deploy, D1, Worker, seed, fixture, Orb ou tráfego nesta alteração.

## Garantias

- Mantém paginação, unicidade, ordem e seleção do contrato existente.
- Emite apenas códigos fixos sem IDs, tokens, URLs, payloads ou contagens.
- Falha antes da leitura direta de Página/dataset quando a seleção não é única.

## Validação

- Harness comportamental: 18/18.
- Suíte completa Token Vault: 172/172.
- Governança global: 19/19.
- Single-writer Cloudflare: 7/7.
- YAML parse e `git diff --check`.
- Security diff scan: 0 achados.

## Rollback

Reverter este commit restaura o código agregado anterior. Não há dados, flags, versões ativas ou recursos Meta para desfazer. Após merge, disparar somente a atestação raw e manter staging bloqueado até ela ser verde.