### PR TITLE
fix(meta-ads): discover assigned System User Pages

### DIFF
--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -119,6 +119,34 @@ jobs:
               return false;
             }
           };
+          const selectEligiblePage = (data, phase) => {
+            const pageFacts = data.map((page) => {
+              const tasks = new Set(Array.isArray(page?.tasks) ? page.tasks.map((task) => String(task || '').trim().toUpperCase()) : []);
+              const hasAdvertiseTask = tasks.has('ADVERTISE') || tasks.has('PROFILE_PLUS_ADVERTISE');
+              const hasInstagramLink = Boolean(numericId(page?.instagram_business_account?.id));
+              return {
+                page,
+                hasAdvertiseTask,
+                hasInstagramLink,
+                eligible: hasAdvertiseTask && hasInstagramLink,
+              };
+            });
+            const eligiblePages = pageFacts.filter((fact) => fact.eligible).map((fact) => fact.page);
+            if (eligiblePages.length === 0) {
+              if (pageFacts.length === 0) fail(`${phase}_none_visible`);
+              const hasAdvertiseTask = pageFacts.some((fact) => fact.hasAdvertiseTask);
+              const hasInstagramLink = pageFacts.some((fact) => fact.hasInstagramLink);
+              if (!hasAdvertiseTask && !hasInstagramLink) fail(`${phase}_advertise_and_instagram_missing`);
+              if (!hasAdvertiseTask) fail(`${phase}_advertise_task_missing`);
+              if (!hasInstagramLink) fail(`${phase}_instagram_link_missing`);
+              fail(`${phase}_task_instagram_unpaired`);
+            }
+            if (eligiblePages.length > 1) fail(`${phase}_multiple_eligible`);
+            const pageId = numericId(eligiblePages[0].id);
+            const instagramId = numericId(eligiblePages[0].instagram_business_account.id);
+            if (!pageId || !instagramId) fail(`${phase}_malformed`);
+            return { pageId, instagramId };
+          };
 
           // Keep the bare asset read separate from the account membership
           // relation. A Pixel may be shared with the configured account without
@@ -151,31 +179,30 @@ jobs:
           );
           if (!Array.isArray(pages?.data)) fail('source_pages_malformed');
           if (String(pages?.paging?.next ?? '').trim()) fail('source_pages_paging_ambiguous');
-          const pageFacts = pages.data.map((page) => {
-            const tasks = new Set(Array.isArray(page?.tasks) ? page.tasks.map((task) => String(task || '').trim().toUpperCase()) : []);
-            const hasAdvertiseTask = tasks.has('ADVERTISE') || tasks.has('PROFILE_PLUS_ADVERTISE');
-            const hasInstagramLink = Boolean(numericId(page?.instagram_business_account?.id));
-            return {
-              page,
-              hasAdvertiseTask,
-              hasInstagramLink,
-              eligible: hasAdvertiseTask && hasInstagramLink,
-            };
-          });
-          const eligiblePages = pageFacts.filter((fact) => fact.eligible).map((fact) => fact.page);
-          if (eligiblePages.length === 0) {
-            if (pageFacts.length === 0) fail('source_pages_none_visible');
-            const hasAdvertiseTask = pageFacts.some((fact) => fact.hasAdvertiseTask);
-            const hasInstagramLink = pageFacts.some((fact) => fact.hasInstagramLink);
-            if (!hasAdvertiseTask && !hasInstagramLink) fail('source_pages_advertise_and_instagram_missing');
-            if (!hasAdvertiseTask) fail('source_pages_advertise_task_missing');
-            if (!hasInstagramLink) fail('source_pages_instagram_link_missing');
-            fail('source_pages_task_instagram_unpaired');
+          let pageSelection;
+          let pageDiscovery = 'me_accounts';
+          if (pages.data.length === 0) {
+            // `/me/accounts` is a user-token-centric Page listing. Keep its
+            // empty result distinct from a System User's explicit Page
+            // assignment, and inspect only the authenticated principal's own
+            // bounded relation before any direct Page read.
+            const sourcePrincipal = await directRead('me?fields=id', 'source_system_user');
+            const sourcePrincipalId = numericId(sourcePrincipal?.id);
+            if (!sourcePrincipalId) fail('source_system_user_malformed');
+            const assignedPages = await directRead(
+              `${sourcePrincipalId}/assigned_pages?fields=id,tasks,instagram_business_account{id}&limit=100`,
+              'source_system_user_pages',
+            );
+            if (!Array.isArray(assignedPages?.data)) fail('source_system_user_pages_malformed');
+            if (String(assignedPages?.paging?.next ?? '').trim()) {
+              fail('source_system_user_pages_paging_ambiguous');
+            }
+            pageSelection = selectEligiblePage(assignedPages.data, 'source_system_user_pages');
+            pageDiscovery = 'system_user_assigned';
+          } else {
+            pageSelection = selectEligiblePage(pages.data, 'source_pages');
           }
-          if (eligiblePages.length > 1) fail('source_pages_multiple_eligible');
-          const pageId = numericId(eligiblePages[0].id);
-          const instagramId = numericId(eligiblePages[0].instagram_business_account.id);
-          if (!pageId || !instagramId) fail('source_pages_malformed');
+          const { pageId, instagramId } = pageSelection;
 
           const page = await directRead(
             `${pageId}?fields=id,instagram_business_account{id},website,picture{url}`,
@@ -203,6 +230,7 @@ jobs:
             'source_access_runtime_proof=unverified',
             'source_access_pixel=allowed',
             'source_access_pixel_account_relation=allowed',
+            `source_access_page_discovery=${pageDiscovery}`,
             'source_access_page=eligible',
             'source_access_dataset=eligible',
             'source_access_landing_media=eligible',

--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -2122,20 +2122,50 @@ async function discoverStagingSyntheticSeedFacts({
     throw stagingSyntheticSeedFailure(failureCodes.identityMismatch, 409);
   }
 
+  const pageDiscoveryFields = 'id,tasks,instagram_business_account{id}';
   const pages = await read(
     'me/accounts',
-    'id,tasks,instagram_business_account{id}',
+    pageDiscoveryFields,
     { limit: '100' },
     failureCodes.pageAccessDenied,
   );
   if (clean(asObject(pages.paging).next)) {
     throw stagingSyntheticSeedFailure(failureCodes.pageAmbiguous, 409);
   }
-  const eligiblePages = safeArray(pages.data).map(asObject).filter((page) => {
-    const tasks = new Set(safeArray(page.tasks).map((task) => clean(task).toUpperCase()));
-    return [...STAGING_SYNTHETIC_SEED_PAGE_ADVERTISE_TASKS].some((task) => tasks.has(task)) &&
-      /^\d{5,30}$/.test(clean(asObject(page.instagram_business_account).id));
-  });
+  let eligiblePages = stagingSyntheticSeedEligiblePages(pages.data);
+  // `/me/accounts` is a user-token-centric Page discovery edge. A System User
+  // can have an explicitly assigned Page while this list is empty. Only use
+  // the System User's own bounded relation for that exact empty-list case;
+  // never mask a nonempty direct result that lacks the required task or IG
+  // relationship.
+  if (Array.isArray(pages.data) && pages.data.length === 0) {
+    const sourcePrincipal = await read(
+      'me',
+      'id',
+      {},
+      failureCodes.pageAccessDenied,
+      failureCodes.identityMalformed,
+    );
+    const sourcePrincipalId = normalizeStagingSyntheticSeedGraphId(
+      sourcePrincipal.id,
+      'source_principal_id',
+      failureCodes.identityMalformed,
+    );
+    const assignedPages = await read(
+      `${sourcePrincipalId}/assigned_pages`,
+      pageDiscoveryFields,
+      { limit: '100' },
+      failureCodes.pageAccessDenied,
+      failureCodes.identityMalformed,
+    );
+    if (!Array.isArray(assignedPages.data)) {
+      throw stagingSyntheticSeedFailure(failureCodes.identityMalformed, 409);
+    }
+    if (clean(asObject(assignedPages.paging).next)) {
+      throw stagingSyntheticSeedFailure(failureCodes.pageAmbiguous, 409);
+    }
+    eligiblePages = stagingSyntheticSeedEligiblePages(assignedPages.data);
+  }
   if (eligiblePages.length !== 1) {
     throw stagingSyntheticSeedFailure(failureCodes.pageAmbiguous, 409);
   }
@@ -2190,6 +2220,14 @@ async function discoverStagingSyntheticSeedFacts({
     page_picture_url: pictureUrl,
     dataset_id: datasetId,
   };
+}
+
+function stagingSyntheticSeedEligiblePages(value) {
+  return safeArray(value).map(asObject).filter((page) => {
+    const tasks = new Set(safeArray(page.tasks).map((task) => clean(task).toUpperCase()));
+    return [...STAGING_SYNTHETIC_SEED_PAGE_ADVERTISE_TASKS].some((task) => tasks.has(task)) &&
+      /^\d{5,30}$/.test(clean(asObject(page.instagram_business_account).id));
+  });
 }
 
 async function seedGraphRead(auth, path, fields, context, query = {}, {

--- a/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
@@ -12,6 +12,7 @@ const PIXEL_ID = '99444000000000001';
 const PAGE_ID = '12000000000000001';
 const INSTAGRAM_ID = '17841400000000002';
 const DATASET_ID = '19944000000000001';
+const SYSTEM_USER_ID = '15500000000000001';
 const SOURCE_ACCESS_TOKEN = 'unit-test-source-access-token-not-a-real-secret';
 const MISMATCH_ACCOUNT_ID = '17841400000000009';
 
@@ -652,6 +653,190 @@ test('staging seed attestation bounds Graph discovery and returns no source fact
   }
 });
 
+test('staging seed attestation falls back to one explicit System User Page only after an empty direct Page list', async () => {
+  const db = new SeedDb();
+  db.prepare = () => {
+    throw new Error('D1 must remain untouched by System User Page discovery');
+  };
+  const graph = new FakeGraph({
+    readResponses: {
+      'me/accounts': { body: { data: [] } },
+      me: { body: { id: SYSTEM_USER_ID } },
+      [`${SYSTEM_USER_ID}/assigned_pages`]: {
+        body: {
+          data: [{
+            id: PAGE_ID,
+            tasks: ['ADVERTISE'],
+            instagram_business_account: { id: INSTAGRAM_ID },
+          }],
+        },
+      },
+    },
+  });
+  const response = await attest({
+    db,
+    graph,
+    operationKey: 'meta-ads-staging-seed:attestation-system-user-page-001',
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.attestation, 'match');
+  assert.deepEqual(graph.calls.map((call) => call.path), [
+    PIXEL_ID,
+    `act_${ACCOUNT_ID}/adspixels`,
+    'me/accounts',
+    'me',
+    `${SYSTEM_USER_ID}/assigned_pages`,
+    PAGE_ID,
+    `act_${ACCOUNT_ID}/offline_conversion_data_sets`,
+  ]);
+  assert.ok(graph.calls.every((call) => call.method === 'GET'));
+  assert.equal(graph.postCalls.length, 0);
+  assert.equal(db.operations.size, 0);
+  assert.equal(db.tokens.length, 0);
+  assert.equal(db.locks.size, 0);
+  assert.equal(db.adsetLocks.size, 0);
+  const serialized = JSON.stringify(body);
+  for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID, SYSTEM_USER_ID]) {
+    assert.equal(serialized.includes(value), false);
+  }
+});
+
+test('staging seed attestation rejects malformed or nonunique System User Page assignments before Page or dataset reads', async () => {
+  const cases = [
+    {
+      label: 'malformed',
+      payload: { data: false },
+      expectedError: 'meta_ads_publish_staging_seed_graph_identity_malformed',
+    },
+    {
+      label: 'multiple',
+      payload: {
+        data: [
+          { id: PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
+          { id: MISMATCH_ACCOUNT_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
+        ],
+      },
+      expectedError: 'meta_ads_publish_staging_seed_graph_page_ambiguous',
+    },
+  ];
+
+  for (const entry of cases) {
+    const db = new SeedDb();
+    db.prepare = () => {
+      throw new Error('D1 must remain untouched by System User Page discovery');
+    };
+    const graph = new FakeGraph({
+      readResponses: {
+        'me/accounts': { body: { data: [] } },
+        me: { body: { id: SYSTEM_USER_ID } },
+        [`${SYSTEM_USER_ID}/assigned_pages`]: { body: entry.payload },
+      },
+    });
+    const response = await attest({
+      db,
+      graph,
+      operationKey: `meta-ads-staging-seed:attestation-system-user-page-${entry.label}-001`,
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 409, entry.label);
+    assert.equal(body.error, entry.expectedError, entry.label);
+    assert.deepEqual(graph.calls.map((call) => call.path), [
+      PIXEL_ID,
+      `act_${ACCOUNT_ID}/adspixels`,
+      'me/accounts',
+      'me',
+      `${SYSTEM_USER_ID}/assigned_pages`,
+    ], entry.label);
+    assert.equal(graph.postCalls.length, 0, entry.label);
+    assert.equal(db.operations.size, 0, entry.label);
+    assert.equal(db.tokens.length, 0, entry.label);
+    assert.equal(db.locks.size, 0, entry.label);
+    assert.equal(db.adsetLocks.size, 0, entry.label);
+    const serialized = JSON.stringify(body);
+    for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID, SYSTEM_USER_ID]) {
+      assert.equal(serialized.includes(value), false, entry.label);
+    }
+  }
+});
+
+test('staging seed attestation rejects a malformed System User identity before it reads assigned Pages', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph({
+    readResponses: {
+      'me/accounts': { body: { data: [] } },
+      me: { body: { id: false } },
+    },
+  });
+  const response = await attest({
+    db,
+    graph,
+    operationKey: 'meta-ads-staging-seed:attestation-system-user-malformed-001',
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 409);
+  assert.equal(body.error, 'meta_ads_publish_staging_seed_graph_identity_malformed');
+  assert.deepEqual(graph.calls.map((call) => call.path), [
+    PIXEL_ID,
+    `act_${ACCOUNT_ID}/adspixels`,
+    'me/accounts',
+    'me',
+  ]);
+  assert.equal(graph.postCalls.length, 0);
+  assert.equal(db.operations.size, 0);
+  assert.equal(db.tokens.length, 0);
+  assert.equal(db.locks.size, 0);
+  assert.equal(db.adsetLocks.size, 0);
+  const serialized = JSON.stringify(body);
+  for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, SYSTEM_USER_ID]) {
+    assert.equal(serialized.includes(value), false);
+  }
+});
+
+test('staging seed attestation rejects a paged System User Page relation before it reads a Page or dataset', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph({
+    readResponses: {
+      'me/accounts': { body: { data: [] } },
+      me: { body: { id: SYSTEM_USER_ID } },
+      [`${SYSTEM_USER_ID}/assigned_pages`]: {
+        body: {
+          data: [],
+          paging: { next: false },
+        },
+      },
+    },
+  });
+  const response = await attest({
+    db,
+    graph,
+    operationKey: 'meta-ads-staging-seed:attestation-system-user-page-paged-001',
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 409);
+  assert.equal(body.error, 'meta_ads_publish_staging_seed_graph_page_ambiguous');
+  assert.deepEqual(graph.calls.map((call) => call.path), [
+    PIXEL_ID,
+    `act_${ACCOUNT_ID}/adspixels`,
+    'me/accounts',
+    'me',
+    `${SYSTEM_USER_ID}/assigned_pages`,
+  ]);
+  assert.equal(graph.postCalls.length, 0);
+  assert.equal(db.operations.size, 0);
+  assert.equal(db.tokens.length, 0);
+  assert.equal(db.locks.size, 0);
+  assert.equal(db.adsetLocks.size, 0);
+  const serialized = JSON.stringify(body);
+  for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID, SYSTEM_USER_ID]) {
+    assert.equal(serialized.includes(value), false);
+  }
+});
+
 test('staging seed attestation accepts an exact account Pixel membership on a bounded page with more results', async () => {
   const db = new SeedDb();
   const graph = new FakeGraph({
@@ -1135,7 +1320,14 @@ test('staging seed attestation preserves finite non-identity source eligibility 
     {
       label: 'page-ambiguous',
       path: 'me/accounts',
-      response: { body: { data: [] } },
+      response: {
+        body: {
+          data: [
+            { id: PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
+            { id: MISMATCH_ACCOUNT_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
+          ],
+        },
+      },
       expectedError: 'meta_ads_publish_staging_seed_graph_page_ambiguous',
       expectedReads: 3,
     },

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -21,6 +21,10 @@ assert.ok(
 const syntheticToken = "synthetic-source-bearer-not-a-secret";
 const syntheticPixelId = "1234567890";
 const syntheticAccountId = "9876543210";
+const syntheticSystemUserId = "6677889900";
+const syntheticPageId = "1122334455";
+const syntheticInstagramId = "5544332211";
+const syntheticDatasetId = "9988776655";
 
 function runVerifier(responses, expectedRequests = responses.length) {
   const harness = `
@@ -102,19 +106,19 @@ const happyResponses = [
     payload: {
       data: [
         {
-          id: "1122334455",
+          id: syntheticPageId,
           tasks: ["ADVERTISE"],
-          instagram_business_account: { id: "5544332211" },
+          instagram_business_account: { id: syntheticInstagramId },
         },
       ],
     },
   },
   {
-    pathname: "/v25.0/1122334455",
+    pathname: `/v25.0/${syntheticPageId}`,
     query: { fields: "id,instagram_business_account{id},website,picture{url}" },
     payload: {
-      id: "1122334455",
-      instagram_business_account: { id: "5544332211" },
+      id: syntheticPageId,
+      instagram_business_account: { id: syntheticInstagramId },
       website: "https://staging.example.test",
       picture: { data: { url: "https://cdn.example.test/picture.jpg" } },
     },
@@ -122,9 +126,29 @@ const happyResponses = [
   {
     pathname: `/v25.0/act_${syntheticAccountId}/offline_conversion_data_sets`,
     query: { fields: "id", limit: "2" },
-    payload: { data: [{ id: "9988776655" }] },
+    payload: { data: [{ id: syntheticDatasetId }] },
   },
 ];
+
+function systemUserAssignedPageResponses(assignedPages = structuredClone(happyResponses[2].payload.data)) {
+  const responses = structuredClone(happyResponses);
+  responses[2].payload.data = [];
+  responses.splice(
+    3,
+    0,
+    {
+      pathname: "/v25.0/me",
+      query: { fields: "id" },
+      payload: { id: syntheticSystemUserId },
+    },
+    {
+      pathname: `/v25.0/${syntheticSystemUserId}/assigned_pages`,
+      query: { fields: "id,tasks,instagram_business_account{id}", limit: "100" },
+      payload: { data: assignedPages },
+    },
+  );
+  return responses;
+}
 
 test("Meta Ads source-access attestation is manual, bounded, and non-deploying", () => {
   assert.match(workflow, /^name: Attest Raw Meta Ads Staging Source Access$/m);
@@ -167,6 +191,11 @@ test("Meta Ads source-access attestation is manual, bounded, and non-deploying",
     workflow,
     /me\/accounts\?fields=id,tasks,instagram_business_account\{id\}&limit=100/,
   );
+  assert.match(workflow, /me\?fields=id/);
+  assert.match(
+    workflow,
+    /assigned_pages\?fields=id,tasks,instagram_business_account\{id\}&limit=100/,
+  );
   assert.match(
     workflow,
     /\$\{pageId\}\?fields=id,instagram_business_account\{id\},website,picture\{url\}/,
@@ -178,12 +207,10 @@ test("Meta Ads source-access attestation is manual, bounded, and non-deploying",
   assert.match(workflow, /tasks\.has\('ADVERTISE'\)/);
   assert.match(workflow, /tasks\.has\('PROFILE_PLUS_ADVERTISE'\)/);
   assert.doesNotMatch(workflow, /PROFILE_PLUS_FULL_CONTROL/);
-  assert.match(workflow, /source_pages_paging_ambiguous/);
-  assert.match(workflow, /source_pages_none_visible/);
-  assert.match(workflow, /source_pages_advertise_and_instagram_missing/);
-  assert.match(workflow, /source_pages_advertise_task_missing/);
-  assert.match(workflow, /source_pages_instagram_link_missing/);
-  assert.match(workflow, /source_pages_task_instagram_unpaired/);
+  assert.match(workflow, /selectEligiblePage\(pages\.data, 'source_pages'\)/);
+  assert.match(workflow, /selectEligiblePage\(assignedPages\.data, 'source_system_user_pages'\)/);
+  assert.match(workflow, /source_system_user_malformed/);
+  assert.match(workflow, /source_system_user_pages_paging_ambiguous/);
   assert.match(workflow, /eligiblePages\.length === 0/);
   assert.match(workflow, /eligiblePages\.length > 1/);
   assert.match(workflow, /datasets\.data\.length !== 1/);
@@ -197,6 +224,7 @@ test("Meta Ads source-access attestation is manual, bounded, and non-deploying",
   assert.match(workflow, /source_access_runtime_proof=unverified/);
   assert.match(workflow, /source_access_pixel=allowed/);
   assert.match(workflow, /source_access_pixel_account_relation=allowed/);
+  assert.match(workflow, /source_access_page_discovery=\$\{pageDiscovery\}/);
   assert.match(workflow, /source_access_page=eligible/);
   assert.match(workflow, /source_access_dataset=eligible/);
   assert.match(workflow, /source_access_landing_media=eligible/);
@@ -220,7 +248,7 @@ test("Meta Ads source-access attestation is manual, bounded, and non-deploying",
   assert.doesNotMatch(workflow, /pages_manage_ads/);
   assert.doesNotMatch(
     workflow,
-    /source_access_(?:pixel_id|page_id|dataset_id|landing_url|picture_url)/i,
+    /source_access_(?:pixel_id|page_id|dataset_id|landing_url|picture_url|system_user_id)/i,
   );
   assert.doesNotMatch(workflow, /D1|Cloudflare|Orb|n8n/);
 });
@@ -236,6 +264,7 @@ test("Meta Ads source-access verifier executes the bounded raw-read contract wit
       "source_access_runtime_proof=unverified",
       "source_access_pixel=allowed",
       "source_access_pixel_account_relation=allowed",
+      "source_access_page_discovery=me_accounts",
       "source_access_page=eligible",
       "source_access_dataset=eligible",
       "source_access_landing_media=eligible",
@@ -354,17 +383,58 @@ test("Meta Ads source-access verifier distinguishes a paged Page listing", () =>
   );
 });
 
-test("Meta Ads source-access verifier distinguishes no visible Page", () => {
-  const responses = structuredClone(happyResponses);
-  responses[2].payload.data = [];
-  const result = runVerifier(responses, 3);
+test("Meta Ads source-access verifier falls back to the bounded System User Page relation after an empty direct list", () => {
+  const result = runVerifier(systemUserAssignedPageResponses());
   const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.match(combined, /source_pages_none_visible/);
-  assert.equal(result.requestCount, 3);
+  assert.equal(result.status, 0, combined);
+  assert.equal(result.requestCount, 7);
+  assert.match(result.stdout, /source_access_page_discovery=system_user_assigned/);
   assert.doesNotMatch(
     combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}|${syntheticSystemUserId}|${syntheticPageId}|${syntheticInstagramId}|${syntheticDatasetId}`),
+  );
+});
+
+test("Meta Ads source-access verifier keeps an empty System User Page relation fail-closed", () => {
+  const result = runVerifier(systemUserAssignedPageResponses([]), 5);
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0);
+  assert.match(combined, /source_system_user_pages_none_visible/);
+  assert.equal(result.requestCount, 5);
+  assert.doesNotMatch(combined, /source_access_raw=verified/);
+  assert.doesNotMatch(
+    combined,
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}|${syntheticSystemUserId}`),
+  );
+});
+
+test("Meta Ads source-access verifier rejects pagination on the bounded System User Page relation", () => {
+  const responses = systemUserAssignedPageResponses();
+  responses[4].payload.paging = { next: false };
+  const result = runVerifier(responses, 5);
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0);
+  assert.match(combined, /source_system_user_pages_paging_ambiguous/);
+  assert.equal(result.requestCount, 5);
+  assert.doesNotMatch(combined, /source_access_raw=verified/);
+  assert.doesNotMatch(
+    combined,
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}|${syntheticSystemUserId}`),
+  );
+});
+
+test("Meta Ads source-access verifier rejects a malformed System User identity before its Page relation", () => {
+  const responses = systemUserAssignedPageResponses();
+  responses[3].payload = { id: false };
+  const result = runVerifier(responses, 4);
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0);
+  assert.match(combined, /source_system_user_malformed/);
+  assert.equal(result.requestCount, 4);
+  assert.doesNotMatch(combined, /source_access_raw=verified/);
+  assert.doesNotMatch(
+    combined,
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}|${syntheticSystemUserId}`),
   );
 });
 


### PR DESCRIPTION
## Objective

Diagnose a literal-empty Page list for the staging Meta Ads source without treating it as proof that the System User has no assigned Pages.

## What changed

- Fall back from an empty, unpaged `/me/accounts` result to the authenticated System User's bounded `assigned_pages` relation.
- Preserve the exact advertising-task allowlist, unique Page/Instagram selection, direct Page readback, bounded pagination rejection, and fixed redacted outcomes.
- Add Worker and workflow behavioral coverage for fallback success, malformed principal/relation data, paging, multiple candidates, no fallback on nonempty direct data, and no D1/Graph-write access.

## Root cause

`/me/accounts` is a user-centric Page listing. A System User can have an assigned Page while that list is literally empty, so the prior diagnostic could not distinguish absent visibility from the System User asset relation.

## Surfaces and risk

Token Vault discovery and the dispatch-only staging source-attestation workflow. The change is Graph GET-only and can handle a source bearer plus opaque identifiers; it is bounded to the authenticated System User only after the direct list is literally empty. Paging, malformed data, and nonunique candidates fail closed; no value is emitted.

## Flag

Not applicable.

## Migration

Not applicable. No D1 schema or data change.

## Validation

- Focused behavioral tests: 48/48
- Token Vault package suite: 178/178
- Global concurrency governance: 19/19
- Cloudflare single-writer policy: 7/7
- Deployment-topology validation, YAML parse, and `git diff --check`
- Formal security diff scan `3e981e4e-8831-4d6c-91dc-e9685ae4739b`: 0 findings

## Rollback

Revert this commit. It creates no D1 data, Meta resource, staging traffic change, migration, or feature flag state.