### PR TITLE
feat(meta-ads): require explicit staging Page selector

### DIFF
--- a/.github/workflows/attest-meta-ads-candidate-appsecret.yml
+++ b/.github/workflows/attest-meta-ads-candidate-appsecret.yml
@@ -42,16 +42,18 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
           META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
+          META_ADS_PAGE_ID: ${{ secrets.META_ADS_PAGE_ID }}
           META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
           META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
           ENABLE_TOKEN_VAULT_DEPLOY_STAGING: ${{ vars.ENABLE_TOKEN_VAULT_DEPLOY_STAGING }}
         run: |
           set -euo pipefail
-          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID META_ADS_ACCESS_TOKEN META_PIXEL_ID META_ADS_ACCOUNT_ID META_ADS_API_VERSION; do
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID META_ADS_ACCESS_TOKEN META_PIXEL_ID META_ADS_PAGE_ID META_ADS_ACCOUNT_ID META_ADS_API_VERSION; do
             [[ -n "${!name:-}" ]] || { echo 'Candidate appsecret-proof custody is unavailable.' >&2; exit 1; }
           done
           [[ "$ENABLE_TOKEN_VAULT_DEPLOY_STAGING" == true ]] || { echo 'Staging Token Vault candidate proof is disabled.' >&2; exit 1; }
           [[ "$META_PIXEL_ID" =~ ^[0-9]{5,30}$ ]] || { echo 'Candidate appsecret-proof source contract is invalid.' >&2; exit 1; }
+          [[ "$META_ADS_PAGE_ID" =~ ^[0-9]{5,30}$ ]] || { echo 'Candidate appsecret-proof source contract is invalid.' >&2; exit 1; }
           normalized_account="${META_ADS_ACCOUNT_ID#act_}"
           [[ "$normalized_account" =~ ^[0-9]{5,30}$ ]] || { echo 'Candidate appsecret-proof source contract is invalid.' >&2; exit 1; }
           [[ "$META_ADS_API_VERSION" =~ ^v(2[5-9]|[3-9][0-9])\.0$ ]] || { echo 'Candidate appsecret-proof source contract is invalid.' >&2; exit 1; }
@@ -89,6 +91,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
           META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
+          META_ADS_PAGE_ID: ${{ secrets.META_ADS_PAGE_ID }}
           META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
           META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
           SOURCE_SHA: ${{ github.sha }}
@@ -141,6 +144,7 @@ jobs:
           CANDIDATE_PREVIEW_URL="$preview" \
           META_ADS_ACCESS_TOKEN="$META_ADS_ACCESS_TOKEN" \
           META_PIXEL_ID="$META_PIXEL_ID" \
+          META_ADS_PAGE_ID="$META_ADS_PAGE_ID" \
           META_ADS_ACCOUNT_ID="$META_ADS_ACCOUNT_ID" \
           META_ADS_API_VERSION="$META_ADS_API_VERSION" \
           SOURCE_SHA="$SOURCE_SHA" \
@@ -151,6 +155,7 @@ jobs:
           const preview = String(process.env.CANDIDATE_PREVIEW_URL || '').replace(/\/$/, '');
           const sourceToken = String(process.env.META_ADS_ACCESS_TOKEN || '');
           const pixelId = String(process.env.META_PIXEL_ID || '').trim();
+          const pageId = String(process.env.META_ADS_PAGE_ID || '').trim();
           const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
           const apiVersion = String(process.env.META_ADS_API_VERSION || '').trim();
           const sourceSha = String(process.env.SOURCE_SHA || '').trim();
@@ -159,6 +164,7 @@ jobs:
             !/^https:\/\/[0-9a-f]{8}-skincos-token-vault-staging\.skincos\.workers\.dev$/.test(preview) ||
             !sourceToken ||
             !/^\d{5,30}$/.test(pixelId) ||
+            !/^\d{5,30}$/.test(pageId) ||
             !/^\d{5,30}$/.test(accountId) ||
             !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion) ||
             !/^[0-9a-f]{40}$/.test(sourceSha)
@@ -179,6 +185,7 @@ jobs:
                 access_token: sourceToken,
                 account_id: accountId,
                 pixel_id: pixelId,
+                page_id: pageId,
                 api_version: apiVersion,
               }),
               cache: 'no-store',

--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -22,6 +22,7 @@ jobs:
         env:
           META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
           META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
+          META_ADS_PAGE_ID: ${{ secrets.META_ADS_PAGE_ID }}
           META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
           META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
         shell: bash
@@ -30,6 +31,7 @@ jobs:
           node --input-type=module <<'NODE'
           const token = String(process.env.META_ADS_ACCESS_TOKEN || '');
           const pixelId = String(process.env.META_PIXEL_ID || '').trim();
+          const pageSelector = String(process.env.META_ADS_PAGE_ID || '').trim();
           const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
           const apiVersion = String(process.env.META_ADS_API_VERSION || '');
 
@@ -38,6 +40,9 @@ jobs:
             process.exit(1);
           };
 
+          if (pageSelector && !/^\d{5,30}$/.test(pageSelector)) {
+            fail('source_page_selector_invalid');
+          }
           if (
             !token ||
             !/^\d{5,30}$/.test(pixelId) ||
@@ -119,7 +124,7 @@ jobs:
               return false;
             }
           };
-          const selectEligiblePage = (data, phase) => {
+          const selectEligiblePage = (data, phase, selector = '') => {
             const pageFacts = data.map((page) => {
               const tasks = new Set(Array.isArray(page?.tasks) ? page.tasks.map((task) => String(task || '').trim().toUpperCase()) : []);
               const hasAdvertiseTask = tasks.has('ADVERTISE') || tasks.has('PROFILE_PLUS_ADVERTISE');
@@ -132,6 +137,10 @@ jobs:
               };
             });
             const eligiblePages = pageFacts.filter((fact) => fact.eligible).map((fact) => fact.page);
+            const selectedPages = selector
+              ? eligiblePages.filter((page) => numericId(page?.id) === selector)
+              : eligiblePages;
+            if (selector && selectedPages.length === 0) fail(`${phase}_selector_mismatch`);
             if (eligiblePages.length === 0) {
               if (pageFacts.length === 0) fail(`${phase}_none_visible`);
               const hasAdvertiseTask = pageFacts.some((fact) => fact.hasAdvertiseTask);
@@ -141,9 +150,9 @@ jobs:
               if (!hasInstagramLink) fail(`${phase}_instagram_link_missing`);
               fail(`${phase}_task_instagram_unpaired`);
             }
-            if (eligiblePages.length > 1) fail(`${phase}_multiple_eligible`);
-            const pageId = numericId(eligiblePages[0].id);
-            const instagramId = numericId(eligiblePages[0].instagram_business_account.id);
+            if (selectedPages.length > 1) fail(selector ? `${phase}_selector_ambiguous` : `${phase}_multiple_eligible`);
+            const pageId = numericId(selectedPages[0].id);
+            const instagramId = numericId(selectedPages[0].instagram_business_account.id);
             if (!pageId || !instagramId) fail(`${phase}_malformed`);
             return { pageId, instagramId };
           };
@@ -173,19 +182,12 @@ jobs:
             fail('source_pixel_account_relation_mismatch');
           }
 
-          const pages = await directRead(
-            'me/accounts?fields=id,tasks,instagram_business_account{id}&limit=100',
-            'source_pages',
-          );
-          if (!Array.isArray(pages?.data)) fail('source_pages_malformed');
-          if (String(pages?.paging?.next ?? '').trim()) fail('source_pages_paging_ambiguous');
           let pageSelection;
-          let pageDiscovery = 'me_accounts';
-          if (pages.data.length === 0) {
-            // `/me/accounts` is a user-token-centric Page listing. Keep its
-            // empty result distinct from a System User's explicit Page
-            // assignment, and inspect only the authenticated principal's own
-            // bounded relation before any direct Page read.
+          let pageDiscovery;
+          if (pageSelector) {
+            // A configured selector must be proved through the authenticated
+            // System User's own bounded assignment relation. Never pick a
+            // Page by order or by a user-centric discovery edge.
             const sourcePrincipal = await directRead('me?fields=id', 'source_system_user');
             const sourcePrincipalId = numericId(sourcePrincipal?.id);
             if (!sourcePrincipalId) fail('source_system_user_malformed');
@@ -197,10 +199,37 @@ jobs:
             if (String(assignedPages?.paging?.next ?? '').trim()) {
               fail('source_system_user_pages_paging_ambiguous');
             }
-            pageSelection = selectEligiblePage(assignedPages.data, 'source_system_user_pages');
-            pageDiscovery = 'system_user_assigned';
+            pageSelection = selectEligiblePage(assignedPages.data, 'source_system_user_pages', pageSelector);
+            pageDiscovery = 'system_user_configured';
           } else {
-            pageSelection = selectEligiblePage(pages.data, 'source_pages');
+            const pages = await directRead(
+              'me/accounts?fields=id,tasks,instagram_business_account{id}&limit=100',
+              'source_pages',
+            );
+            if (!Array.isArray(pages?.data)) fail('source_pages_malformed');
+            if (String(pages?.paging?.next ?? '').trim()) fail('source_pages_paging_ambiguous');
+            pageDiscovery = 'me_accounts';
+            if (pages.data.length === 0) {
+              // `/me/accounts` is a user-token-centric Page listing. Keep its
+              // empty result distinct from a System User's explicit Page
+              // assignment, and inspect only the authenticated principal's
+              // own bounded relation before any direct Page read.
+              const sourcePrincipal = await directRead('me?fields=id', 'source_system_user');
+              const sourcePrincipalId = numericId(sourcePrincipal?.id);
+              if (!sourcePrincipalId) fail('source_system_user_malformed');
+              const assignedPages = await directRead(
+                `${sourcePrincipalId}/assigned_pages?fields=id,tasks,instagram_business_account{id}&limit=100`,
+                'source_system_user_pages',
+              );
+              if (!Array.isArray(assignedPages?.data)) fail('source_system_user_pages_malformed');
+              if (String(assignedPages?.paging?.next ?? '').trim()) {
+                fail('source_system_user_pages_paging_ambiguous');
+              }
+              pageSelection = selectEligiblePage(assignedPages.data, 'source_system_user_pages');
+              pageDiscovery = 'system_user_assigned';
+            } else {
+              pageSelection = selectEligiblePage(pages.data, 'source_pages');
+            }
           }
           const { pageId, instagramId } = pageSelection;
 

--- a/.github/workflows/deploy-token-vault.yml
+++ b/.github/workflows/deploy-token-vault.yml
@@ -987,6 +987,10 @@ jobs:
           TOKEN_VAULT_PRODUCTION_BASE_URL: ${{ vars.TOKEN_VAULT_PRODUCTION_BASE_URL }}
           ENABLE_TOKEN_VAULT_DEPLOY_STAGING: ${{ vars.ENABLE_TOKEN_VAULT_DEPLOY_STAGING }}
           ENABLE_TOKEN_VAULT_PRODUCTION_DEPLOY: ${{ vars.ENABLE_TOKEN_VAULT_PRODUCTION_DEPLOY }}
+          # This private staging-only selector is an exact Page identity, never
+          # a Worker binding. It must be proved against the System User before
+          # the synthetic seed may create any Meta or D1 resources.
+          META_ADS_PAGE_ID: ${{ inputs.target == 'staging' && secrets.META_ADS_PAGE_ID || '' }}
           META_ADS_API_VERSION: ${{ inputs.target == 'staging' && vars.META_ADS_API_VERSION || '' }}
           TARGET: ${{ inputs.target }}
           OPERATION: ${{ inputs.operation }}
@@ -1002,6 +1006,7 @@ jobs:
             [[ "$ENABLE_TOKEN_VAULT_DEPLOY_STAGING" == true ]] || { echo 'ENABLE_TOKEN_VAULT_DEPLOY_STAGING must be true'; exit 1; }
             [[ "$CONFIRM_STAGING_TRACKING_FIXTURE" == true ]] || { echo 'An isolated synthetic tracking fixture must be confirmed for staging'; exit 1; }
             [[ "$TOKEN_VAULT_STAGING_BASE_URL" =~ ^https://[^/]+$ ]] || { echo 'TOKEN_VAULT_STAGING_BASE_URL must be an HTTPS origin'; exit 1; }
+            [[ "$META_ADS_PAGE_ID" =~ ^[0-9]{5,30}$ ]] || { echo 'META_ADS_PAGE_ID must be a numeric staging Environment secret for the governed staging seed'; exit 1; }
             [[ "$META_ADS_API_VERSION" =~ ^v(2[5-9]|[3-9][0-9])\.0$ ]] || { echo 'META_ADS_API_VERSION must be v25.0 or a newer supported Graph API version for the governed staging seed'; exit 1; }
           else
             [[ "$ENABLE_TOKEN_VAULT_PRODUCTION_DEPLOY" == true ]] || { echo 'ENABLE_TOKEN_VAULT_PRODUCTION_DEPLOY must be true'; exit 1; }
@@ -1329,6 +1334,7 @@ jobs:
         env:
           META_ADS_ACCESS_TOKEN: ${{ inputs.target == 'staging' && secrets.META_ADS_ACCESS_TOKEN || '' }}
           META_PIXEL_ID: ${{ inputs.target == 'staging' && secrets.META_PIXEL_ID || '' }}
+          META_ADS_PAGE_ID: ${{ inputs.target == 'staging' && secrets.META_ADS_PAGE_ID || '' }}
           META_ADS_ACCOUNT_ID: ${{ inputs.target == 'staging' && vars.META_ADS_ACCOUNT_ID || '' }}
           META_ADS_API_VERSION: ${{ inputs.target == 'staging' && vars.META_ADS_API_VERSION || '' }}
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
@@ -1341,6 +1347,7 @@ jobs:
           const seedFile = String(process.env.TOKEN_VAULT_STAGING_SYNTHETIC_SEED_FILE || '');
           const accessToken = String(process.env.META_ADS_ACCESS_TOKEN || '');
           const pixelId = String(process.env.META_PIXEL_ID || '').trim();
+          const pageId = String(process.env.META_ADS_PAGE_ID || '').trim();
           const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
           const apiVersion = String(process.env.META_ADS_API_VERSION || '').trim();
           const releaseSha = String(process.env.RELEASE_SHA || '').toLowerCase();
@@ -1349,7 +1356,7 @@ jobs:
           if (!/^https:\/\/(?:[a-z0-9-]+\.)+workers\.dev$/.test(preview) || !seedFile) {
             throw new Error('immutable staging synthetic-seed candidate endpoint is unavailable');
           }
-          if (!accessToken || !/^\d{5,30}$/.test(pixelId) || !/^\d{5,30}$/.test(accountId) || !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion)) {
+          if (!accessToken || !/^\d{5,30}$/.test(pixelId) || !/^\d{5,30}$/.test(pageId) || !/^\d{5,30}$/.test(accountId) || !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion)) {
             throw new Error('staging synthetic Meta source custody is unavailable or malformed');
           }
           if (!/^[a-f0-9]{40}$/.test(releaseSha) || !/^\d+$/.test(runId) || !/^\d+$/.test(runAttempt)) {
@@ -1369,6 +1376,7 @@ jobs:
               access_token: accessToken,
               account_id: accountId,
               pixel_id: pixelId,
+              page_id: pageId,
               api_version: apiVersion,
             }),
             cache: 'no-store',
@@ -1398,6 +1406,7 @@ jobs:
         env:
           META_ADS_ACCESS_TOKEN: ${{ inputs.target == 'staging' && secrets.META_ADS_ACCESS_TOKEN || '' }}
           META_PIXEL_ID: ${{ inputs.target == 'staging' && secrets.META_PIXEL_ID || '' }}
+          META_ADS_PAGE_ID: ${{ inputs.target == 'staging' && secrets.META_ADS_PAGE_ID || '' }}
           META_ADS_ACCOUNT_ID: ${{ inputs.target == 'staging' && vars.META_ADS_ACCOUNT_ID || '' }}
           META_ADS_API_VERSION: ${{ inputs.target == 'staging' && vars.META_ADS_API_VERSION || '' }}
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
@@ -1410,6 +1419,7 @@ jobs:
           const seedFile = String(process.env.TOKEN_VAULT_STAGING_SYNTHETIC_SEED_FILE || '');
           const accessToken = String(process.env.META_ADS_ACCESS_TOKEN || '');
           const pixelId = String(process.env.META_PIXEL_ID || '').trim();
+          const pageId = String(process.env.META_ADS_PAGE_ID || '').trim();
           const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
           const apiVersion = String(process.env.META_ADS_API_VERSION || '').trim();
           const releaseSha = String(process.env.RELEASE_SHA || '').toLowerCase();
@@ -1418,7 +1428,7 @@ jobs:
           if (!/^https:\/\/(?:[a-z0-9-]+\.)+workers\.dev$/.test(preview) || !seedFile) {
             throw new Error('immutable staging synthetic-seed candidate endpoint is unavailable');
           }
-          if (!accessToken || !/^\d{5,30}$/.test(pixelId) || !/^\d{5,30}$/.test(accountId) || !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion)) {
+          if (!accessToken || !/^\d{5,30}$/.test(pixelId) || !/^\d{5,30}$/.test(pageId) || !/^\d{5,30}$/.test(accountId) || !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion)) {
             throw new Error('staging synthetic Meta source custody is unavailable or malformed');
           }
           if (!/^[a-f0-9]{40}$/.test(releaseSha) || !/^\d+$/.test(runId) || !/^\d+$/.test(runAttempt)) {
@@ -1442,6 +1452,7 @@ jobs:
               access_token: accessToken,
               account_id: accountId,
               pixel_id: pixelId,
+              page_id: pageId,
               api_version: apiVersion,
             }),
             cache: 'no-store',

--- a/platform/deploy/operational-units.json
+++ b/platform/deploy/operational-units.json
@@ -102,7 +102,7 @@
       "concurrencyPrefix": "deploy-token-vault-",
       "publishes": ["Worker:skincos-token-vault", "Worker:skincos-token-vault-staging"],
       "resources": ["Token Vault Worker", "skincos-token-vault D1", "skincos-token-vault-staging D1", "Token Vault route and auth bindings", "Governed Meta Ads staging synthetic source and appsecret-proof attestations, seed, bootstrap derivation, rollback journal and paused creative fixture"],
-      "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "TOKEN_VAULT_API_TOKEN", "TOKEN_VAULT_N8N_API_TOKEN", "TOKEN_VAULT_ANALYTICS_API_TOKEN", "TOKEN_VAULT_ENCRYPTION_KEY", "TOKEN_VAULT_META_ADS_CONFIG_TOKEN", "TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST", "META_ADS_ACCESS_TOKEN", "META_PIXEL_ID"],
+      "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "TOKEN_VAULT_API_TOKEN", "TOKEN_VAULT_N8N_API_TOKEN", "TOKEN_VAULT_ANALYTICS_API_TOKEN", "TOKEN_VAULT_ENCRYPTION_KEY", "TOKEN_VAULT_META_ADS_CONFIG_TOKEN", "TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST", "META_ADS_ACCESS_TOKEN", "META_PIXEL_ID", "META_ADS_PAGE_ID"],
       "migrationPaths": ["platform/security/token-vault/migrations"],
       "environments": ["preview", "staging", "production"],
       "promotion": {

--- a/platform/security/token-vault/README.md
+++ b/platform/security/token-vault/README.md
@@ -146,11 +146,16 @@ fonte, acesso ao Pixel, Página ou dataset, e indisponibilidade transitória. S�
 então o workflow chama
 `POST .../config/staging-synthetic-seed`. Os fatos externos entram somente no
 corpo dessas chamadas privadas: o token Meta Ads já custodiado,
-`META_PIXEL_ID`, `META_ADS_ACCOUNT_ID` e `META_ADS_API_VERSION`. O Vault exige
-uma conta/pixel, uma Página+Instagram elegível e um dataset offline unívocos,
-cria somente recursos `PAUSED` nomeados para staging e sela duas credenciais
-internas cifradas. Não seleciona campanhas, conjuntos ou anúncios comerciais,
-nem torna o token Meta um binding do Worker.
+`META_PIXEL_ID`, `META_ADS_ACCOUNT_ID`, `META_ADS_API_VERSION` e o segredo de
+Environment staging `META_ADS_PAGE_ID`. Esse último é um seletor privado de
+identidade factual, nunca um bearer: o Vault o prova pela relação limitada de
+Páginas atribuídas ao System User, exige exatamente uma associação elegível e
+confirma o mesmo par Página+Instagram por leitura direta. Ele não é um binding
+do Worker, não entra no `--secrets-file`, artefato, log ou output do workflow.
+O Vault exige então uma conta/pixel, uma Página+Instagram provada e um dataset
+offline unívocos, cria somente recursos `PAUSED` nomeados para staging e sela
+duas credenciais internas cifradas. Não seleciona campanhas, conjuntos ou
+anúncios comerciais, nem torna o token Meta um binding do Worker.
 
 O workflow manual separado de prova candidata cria somente uma versão imutável
 não promovida e chama `POST .../staging-synthetic-seed/attest-appsecret-proof`.
@@ -322,7 +327,13 @@ ou argv. A atestação é estritamente somente leitura; a seed é estritamente
 `staging`, ocorre antes da autenticação/derivação de configuração e possui
 rollback explícito antes de qualquer ativação quando o planejamento falha.
 `META_ADS_ACCESS_TOKEN` continua uma credencial externa de fonte: não é copiado
-de production nem inventado pelo fluxo.
+de production nem inventado pelo fluxo. `META_ADS_PAGE_ID` deve ser escolhido
+na fonte Meta autorizada e gravado somente no Environment `staging`. No deploy
+governado de staging, ausência, formato inválido, relação não atribuída ou par
+Página/Instagram divergente interrompem o job antes de migrations, D1, seed ou
+tráfego. A API candidata mantém `page_id` opcional para compatibilidade com
+clientes governados existentes; não a invoque diretamente como substituta desse
+preflight.
 
 Antes da primeira promoção, disponibilize em cada GitHub Environment os
 segredos independentes exigidos pelo workflow, em especial

--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -1515,7 +1515,7 @@ function assertStagingSyntheticSeedAttestationEnvironment(env) {
 
 async function readStagingSyntheticSeedInput(request) {
   const body = await readStagingSyntheticSeedBody(request, new Set([
-    'operation_key', 'access_token', 'account_id', 'pixel_id', 'api_version',
+    'operation_key', 'access_token', 'account_id', 'pixel_id', 'page_id', 'api_version',
   ]));
   const operationKey = clean(body.operation_key);
   if (!STAGING_SYNTHETIC_SEED_OPERATION_KEY_PATTERN.test(operationKey)) {
@@ -1527,6 +1527,9 @@ async function readStagingSyntheticSeedInput(request) {
     accessToken,
     accountId: normalizeStagingSyntheticSeedNumericId(body.account_id, 'account_id'),
     pixelId: normalizeStagingSyntheticSeedNumericId(body.pixel_id, 'pixel_id'),
+    pageId: Object.hasOwn(body, 'page_id')
+      ? normalizeStagingSyntheticSeedNumericId(body.page_id, 'page_id')
+      : '',
     apiVersion: normalizeStagingSyntheticSeedApiVersion(body.api_version),
   };
 }
@@ -1812,6 +1815,7 @@ async function createInitialStagingSyntheticSeedState(input) {
       operation_key: input.operationKey,
       account_id: input.accountId,
       pixel_id: input.pixelId,
+      page_id: input.pageId || '',
       api_version: input.apiVersion,
     },
     marker,
@@ -1882,6 +1886,7 @@ async function stagingSyntheticSeedRequestHash(input) {
     operation_key: input.operationKey,
     account_id: input.accountId,
     pixel_id: input.pixelId || '',
+    page_id: input.pageId || '',
     api_version: input.apiVersion,
   }));
 }
@@ -2123,22 +2128,11 @@ async function discoverStagingSyntheticSeedFacts({
   }
 
   const pageDiscoveryFields = 'id,tasks,instagram_business_account{id}';
-  const pages = await read(
-    'me/accounts',
-    pageDiscoveryFields,
-    { limit: '100' },
-    failureCodes.pageAccessDenied,
-  );
-  if (clean(asObject(pages.paging).next)) {
-    throw stagingSyntheticSeedFailure(failureCodes.pageAmbiguous, 409);
-  }
-  let eligiblePages = stagingSyntheticSeedEligiblePages(pages.data);
-  // `/me/accounts` is a user-token-centric Page discovery edge. A System User
-  // can have an explicitly assigned Page while this list is empty. Only use
-  // the System User's own bounded relation for that exact empty-list case;
-  // never mask a nonempty direct result that lacks the required task or IG
-  // relationship.
-  if (Array.isArray(pages.data) && pages.data.length === 0) {
+  let selectedPage;
+  if (input.pageId) {
+    // An explicit staging selector must be proved through the authenticated
+    // System User's own relation. Do not use a user-centric Page listing or
+    // choose by ordering when a selector is available.
     const sourcePrincipal = await read(
       'me',
       'id',
@@ -2164,12 +2158,58 @@ async function discoverStagingSyntheticSeedFacts({
     if (clean(asObject(assignedPages.paging).next)) {
       throw stagingSyntheticSeedFailure(failureCodes.pageAmbiguous, 409);
     }
-    eligiblePages = stagingSyntheticSeedEligiblePages(assignedPages.data);
+    selectedPage = selectStagingSyntheticSeedPage(
+      assignedPages.data,
+      input.pageId,
+      failureCodes,
+    );
+  } else {
+    const pages = await read(
+      'me/accounts',
+      pageDiscoveryFields,
+      { limit: '100' },
+      failureCodes.pageAccessDenied,
+    );
+    if (clean(asObject(pages.paging).next)) {
+      throw stagingSyntheticSeedFailure(failureCodes.pageAmbiguous, 409);
+    }
+    let pageCandidates = pages.data;
+    // `/me/accounts` is a user-token-centric Page discovery edge. A System
+    // User can have an explicitly assigned Page while this list is empty. Use
+    // the System User's own bounded relation only for that exact empty-list
+    // case; never mask a nonempty direct result that lacks the required task
+    // or IG relationship.
+    if (Array.isArray(pages.data) && pages.data.length === 0) {
+      const sourcePrincipal = await read(
+        'me',
+        'id',
+        {},
+        failureCodes.pageAccessDenied,
+        failureCodes.identityMalformed,
+      );
+      const sourcePrincipalId = normalizeStagingSyntheticSeedGraphId(
+        sourcePrincipal.id,
+        'source_principal_id',
+        failureCodes.identityMalformed,
+      );
+      const assignedPages = await read(
+        `${sourcePrincipalId}/assigned_pages`,
+        pageDiscoveryFields,
+        { limit: '100' },
+        failureCodes.pageAccessDenied,
+        failureCodes.identityMalformed,
+      );
+      if (!Array.isArray(assignedPages.data)) {
+        throw stagingSyntheticSeedFailure(failureCodes.identityMalformed, 409);
+      }
+      if (clean(asObject(assignedPages.paging).next)) {
+        throw stagingSyntheticSeedFailure(failureCodes.pageAmbiguous, 409);
+      }
+      pageCandidates = assignedPages.data;
+    }
+    selectedPage = selectStagingSyntheticSeedPage(pageCandidates, '', failureCodes);
   }
-  if (eligiblePages.length !== 1) {
-    throw stagingSyntheticSeedFailure(failureCodes.pageAmbiguous, 409);
-  }
-  const selectedPageId = normalizeStagingSyntheticSeedGraphId(eligiblePages[0].id, 'page_id', failureCodes.identityMalformed);
+  const selectedPageId = normalizeStagingSyntheticSeedGraphId(selectedPage.id, 'page_id', failureCodes.identityMalformed);
   const page = await read(
     selectedPageId,
     'id,instagram_business_account{id},website,picture{url}',
@@ -2185,7 +2225,7 @@ async function discoverStagingSyntheticSeedFacts({
   if (
     pageId !== selectedPageId ||
     instagramUserId !== normalizeStagingSyntheticSeedGraphId(
-      asObject(eligiblePages[0].instagram_business_account).id,
+      asObject(selectedPage.instagram_business_account).id,
       'instagram_user_id',
       failureCodes.identityMalformed,
     )
@@ -2228,6 +2268,17 @@ function stagingSyntheticSeedEligiblePages(value) {
     return [...STAGING_SYNTHETIC_SEED_PAGE_ADVERTISE_TASKS].some((task) => tasks.has(task)) &&
       /^\d{5,30}$/.test(clean(asObject(page.instagram_business_account).id));
   });
+}
+
+function selectStagingSyntheticSeedPage(value, selectedPageId, failureCodes) {
+  const eligiblePages = stagingSyntheticSeedEligiblePages(value);
+  const candidates = selectedPageId
+    ? eligiblePages.filter((page) => clean(page.id) === selectedPageId)
+    : eligiblePages;
+  if (candidates.length !== 1) {
+    throw stagingSyntheticSeedFailure(failureCodes.pageAmbiguous, 409);
+  }
+  return candidates[0];
 }
 
 async function seedGraphRead(auth, path, fields, context, query = {}, {

--- a/platform/security/token-vault/tests/deploy-token-vault-staging-synthetic-seed-workflow.test.js
+++ b/platform/security/token-vault/tests/deploy-token-vault-staging-synthetic-seed-workflow.test.js
@@ -73,10 +73,18 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
   assert.match(upload, /TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN = seedToken/);
   assert.doesNotMatch(
     upload,
-    /META_ADS_ACCESS_TOKEN|META_PIXEL_ID|META_ADS_ACCOUNT_ID|META_ADS_API_VERSION/,
+    /META_ADS_ACCESS_TOKEN|META_PIXEL_ID|META_ADS_PAGE_ID|META_ADS_ACCOUNT_ID|META_ADS_API_VERSION/,
   );
   assert.doesNotMatch(workflow, /\bwrangler\s+secret\s+put\b/i);
 
+  assert.match(
+    authorization,
+    /META_ADS_PAGE_ID: \$\{\{ inputs\.target == 'staging' && secrets\.META_ADS_PAGE_ID \|\| '' \}\}/,
+  );
+  assert.match(
+    authorization,
+    /META_ADS_PAGE_ID must be a numeric staging Environment secret for the governed staging seed/,
+  );
   assert.match(
     authorization,
     /META_ADS_API_VERSION: \$\{\{ inputs\.target == 'staging' && vars\.META_ADS_API_VERSION \|\| '' \}\}/,
@@ -98,6 +106,7 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
   for (const sourceName of [
     "META_ADS_ACCESS_TOKEN",
     "META_PIXEL_ID",
+    "META_ADS_PAGE_ID",
     "META_ADS_ACCOUNT_ID",
     "META_ADS_API_VERSION",
   ]) {
@@ -114,7 +123,7 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
   );
   assert.match(
     attestation,
-    /operation_key: operationKey,[\s\S]*access_token: accessToken,[\s\S]*account_id: accountId,[\s\S]*pixel_id: pixelId,[\s\S]*api_version: apiVersion/,
+    /operation_key: operationKey,[\s\S]*access_token: accessToken,[\s\S]*account_id: accountId,[\s\S]*pixel_id: pixelId,[\s\S]*page_id: pageId,[\s\S]*api_version: apiVersion/,
   );
   assert.match(attestation, /attestation \|\| ''\) === 'match'/);
   assert.match(attestation, /meta-ads-tracking-v20\/staging-synthetic-seed\/v1/);
@@ -130,6 +139,7 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
     /META_ADS_ACCESS_TOKEN: \$\{\{ inputs\.target == 'staging'/,
   );
   assert.match(seed, /META_PIXEL_ID: \$\{\{ inputs\.target == 'staging'/);
+  assert.match(seed, /META_ADS_PAGE_ID: \$\{\{ inputs\.target == 'staging'/);
   assert.match(seed, /META_ADS_ACCOUNT_ID: \$\{\{ inputs\.target == 'staging'/);
   assert.match(
     seed,
@@ -143,7 +153,7 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
   assert.doesNotMatch(seed, /TOKEN_VAULT_STAGING_BASE_URL/);
   assert.match(
     seed,
-    /operation_key: operationKey,[\s\S]*access_token: accessToken,[\s\S]*account_id: accountId,[\s\S]*pixel_id: pixelId,[\s\S]*api_version: apiVersion/,
+    /operation_key: operationKey,[\s\S]*access_token: accessToken,[\s\S]*account_id: accountId,[\s\S]*pixel_id: pixelId,[\s\S]*page_id: pageId,[\s\S]*api_version: apiVersion/,
   );
   assert.match(seed, /meta-ads-tracking-v20\/staging-synthetic-seed\/v1/);
   assert.match(seed, /\^v\(\?:2\[5-9\]\|\[3-9\]\[0-9\]\)\\\.0\$/);
@@ -230,6 +240,7 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
       /fetch\(`\$\{preview\}\/internal\/token-vault\/v1\/meta-ads-publish\/config\/staging-synthetic-seed\/rollback`/,
     );
     assert.doesNotMatch(rollback, /TOKEN_VAULT_STAGING_BASE_URL/);
+    assert.doesNotMatch(rollback, /META_ADS_PAGE_ID|page_id/);
     assert.match(rollback, /staging-synthetic-seed\/rollback/);
     assert.match(
       rollback,
@@ -254,12 +265,13 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
   for (const sourceName of [
     "META_ADS_ACCESS_TOKEN",
     "META_PIXEL_ID",
+    "META_ADS_PAGE_ID",
     "META_ADS_ACCOUNT_ID",
     "META_ADS_API_VERSION",
   ]) {
     const total = [...workflow.matchAll(new RegExp(sourceName, "g"))].length;
     const allowedScopes =
-      sourceName === "META_ADS_API_VERSION"
+      sourceName === "META_ADS_API_VERSION" || sourceName === "META_ADS_PAGE_ID"
         ? [...sourceScopes, authorization]
         : sourceScopes;
     const scoped = allowedScopes.reduce(

--- a/platform/security/token-vault/tests/meta-ads-candidate-appsecret-proof-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-candidate-appsecret-proof-workflow.test.js
@@ -51,6 +51,11 @@ test("candidate appsecret-proof workflow uploads exactly one non-promoted candid
   assert.match(workflow, /chmod 600 "\$seed_file"/);
   assert.match(workflow, /chmod 600 "\$secrets_file"/);
   assert.match(workflow, /TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN: seedToken/);
+  const privateSecretsFileWriter = workflow.slice(
+    workflow.indexOf('SEED_FILE="$seed_file" SECRETS_FILE="$secrets_file"'),
+    workflow.indexOf('chmod 600 "$secrets_file"'),
+  );
+  assert.doesNotMatch(privateSecretsFileWriter, /META_ADS_PAGE_ID|pageId/);
   assert.match(
     workflow,
     /upload_output="\$\(npx --yes wrangler@4\.120\.0 versions upload/,
@@ -95,6 +100,9 @@ test("candidate appsecret-proof request keeps source inputs and bearer private w
   assert.match(workflow, /access_token: sourceToken/);
   assert.match(workflow, /account_id: accountId/);
   assert.match(workflow, /pixel_id: pixelId/);
+  assert.match(workflow, /META_ADS_PAGE_ID: \$\{\{ secrets\.META_ADS_PAGE_ID \}\}/);
+  assert.match(workflow, /const pageId = String\(process\.env\.META_ADS_PAGE_ID \|\| ''\)\.trim\(\)/);
+  assert.match(workflow, /page_id: pageId/);
   assert.match(workflow, /api_version: apiVersion/);
   assert.match(
     workflow,
@@ -110,7 +118,7 @@ test("candidate appsecret-proof request keeps source inputs and bearer private w
   );
   assert.doesNotMatch(
     workflow,
-    /process\.stdout\.write\([^\n]*(?:seedToken|sourceToken|pixelId|accountId|preview)/,
+    /process\.stdout\.write\([^\n]*(?:seedToken|sourceToken|pixelId|pageId|accountId|preview)/,
   );
   assert.doesNotMatch(workflow, /operation_key=.*GITHUB_OUTPUT/);
 });

--- a/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
@@ -470,9 +470,9 @@ async function decrypt(value) {
   return Buffer.from(String(value).slice(4), 'base64').toString();
 }
 
-async function seed({ db, graph, operationKey, env = {} }) {
+async function seed({ db, graph, operationKey, env = {}, requestOverrides = {} }) {
   return seedStagingSyntheticMetaAdsTracking({
-    request: request(operationKey),
+    request: request(operationKey, requestOverrides),
     env: environment(db, graph, env),
     requestId: 'seed-test-request-id',
     encryptToken: encrypt,
@@ -701,6 +701,189 @@ test('staging seed attestation falls back to one explicit System User Page only 
   for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID, SYSTEM_USER_ID]) {
     assert.equal(serialized.includes(value), false);
   }
+});
+
+test('staging seed attestation proves only the exact configured System User Page before Page or dataset reads', async () => {
+  const db = new SeedDb();
+  db.prepare = () => {
+    throw new Error('D1 must remain untouched by configured Page attestation');
+  };
+  const alternatePageId = '12000000000000009';
+  const alternateInstagramId = '17841400000000009';
+  const graph = new FakeGraph({
+    readResponses: {
+      me: { body: { id: SYSTEM_USER_ID } },
+      [`${SYSTEM_USER_ID}/assigned_pages`]: {
+        body: {
+          data: [
+            {
+              id: alternatePageId,
+              tasks: ['ADVERTISE'],
+              instagram_business_account: { id: alternateInstagramId },
+            },
+            {
+              id: PAGE_ID,
+              tasks: ['PROFILE_PLUS_ADVERTISE'],
+              instagram_business_account: { id: INSTAGRAM_ID },
+            },
+          ],
+        },
+      },
+    },
+  });
+  const response = await attest({
+    db,
+    graph,
+    operationKey: 'meta-ads-staging-seed:attestation-configured-page-001',
+    requestOverrides: { page_id: PAGE_ID },
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.attestation, 'match');
+  assert.deepEqual(graph.calls.map((call) => call.path), [
+    PIXEL_ID,
+    `act_${ACCOUNT_ID}/adspixels`,
+    'me',
+    `${SYSTEM_USER_ID}/assigned_pages`,
+    PAGE_ID,
+    `act_${ACCOUNT_ID}/offline_conversion_data_sets`,
+  ]);
+  assert.ok(graph.calls.every((call) => call.method === 'GET'));
+  assert.equal(graph.postCalls.length, 0);
+  assert.equal(db.operations.size, 0);
+  assert.equal(db.tokens.length, 0);
+  assert.equal(db.locks.size, 0);
+  assert.equal(db.adsetLocks.size, 0);
+  const serialized = JSON.stringify(body);
+  for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, alternatePageId, alternateInstagramId, DATASET_ID, SYSTEM_USER_ID]) {
+    assert.equal(serialized.includes(value), false);
+  }
+});
+
+test('staging seed attestation rejects a configured Page selector before Page, dataset, D1, or Graph mutation', async () => {
+  const db = new SeedDb();
+  db.prepare = () => {
+    throw new Error('D1 must remain untouched by configured Page attestation');
+  };
+  const graph = new FakeGraph({
+    readResponses: {
+      me: { body: { id: SYSTEM_USER_ID } },
+      [`${SYSTEM_USER_ID}/assigned_pages`]: {
+        body: {
+          data: [{
+            id: PAGE_ID,
+            tasks: ['ADVERTISE'],
+            instagram_business_account: { id: INSTAGRAM_ID },
+          }],
+        },
+      },
+    },
+  });
+  const configuredPageId = '12000000000000009';
+  const response = await attest({
+    db,
+    graph,
+    operationKey: 'meta-ads-staging-seed:attestation-configured-page-mismatch-001',
+    requestOverrides: { page_id: configuredPageId },
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 409);
+  assert.equal(body.error, 'meta_ads_publish_staging_seed_graph_page_ambiguous');
+  assert.deepEqual(graph.calls.map((call) => call.path), [
+    PIXEL_ID,
+    `act_${ACCOUNT_ID}/adspixels`,
+    'me',
+    `${SYSTEM_USER_ID}/assigned_pages`,
+  ]);
+  assert.equal(graph.postCalls.length, 0);
+  assert.equal(db.operations.size, 0);
+  assert.equal(db.tokens.length, 0);
+  assert.equal(db.locks.size, 0);
+  assert.equal(db.adsetLocks.size, 0);
+  const serialized = JSON.stringify(body);
+  for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, configuredPageId, DATASET_ID, SYSTEM_USER_ID]) {
+    assert.equal(serialized.includes(value), false);
+  }
+});
+
+test('staging seed attestation rejects duplicate or paged configured Page membership before it reads a Page', async () => {
+  const cases = [
+    {
+      label: 'duplicate',
+      payload: {
+        data: [
+          { id: PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
+          { id: PAGE_ID, tasks: ['PROFILE_PLUS_ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
+        ],
+      },
+    },
+    {
+      label: 'paged',
+      payload: {
+        data: [{ id: PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } }],
+        paging: { next: false },
+      },
+    },
+  ];
+  for (const entry of cases) {
+    const db = new SeedDb();
+    db.prepare = () => {
+      throw new Error('D1 must remain untouched by configured Page attestation');
+    };
+    const graph = new FakeGraph({
+      readResponses: {
+        me: { body: { id: SYSTEM_USER_ID } },
+        [`${SYSTEM_USER_ID}/assigned_pages`]: { body: entry.payload },
+      },
+    });
+    const response = await attest({
+      db,
+      graph,
+      operationKey: `meta-ads-staging-seed:attestation-configured-page-${entry.label}-001`,
+      requestOverrides: { page_id: PAGE_ID },
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 409, entry.label);
+    assert.equal(body.error, 'meta_ads_publish_staging_seed_graph_page_ambiguous', entry.label);
+    assert.deepEqual(graph.calls.map((call) => call.path), [
+      PIXEL_ID,
+      `act_${ACCOUNT_ID}/adspixels`,
+      'me',
+      `${SYSTEM_USER_ID}/assigned_pages`,
+    ], entry.label);
+    assert.equal(graph.postCalls.length, 0, entry.label);
+    assert.equal(db.operations.size, 0, entry.label);
+    assert.equal(db.tokens.length, 0, entry.label);
+    assert.equal(db.locks.size, 0, entry.label);
+    assert.equal(db.adsetLocks.size, 0, entry.label);
+    const serialized = JSON.stringify(body);
+    for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID, SYSTEM_USER_ID]) {
+      assert.equal(serialized.includes(value), false, entry.label);
+    }
+  }
+});
+
+test('staging seed rejects a malformed configured Page selector before it creates a mutation journal', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph();
+  const response = await seed({
+    db,
+    graph,
+    operationKey: 'meta-ads-staging-seed:configured-page-invalid-001',
+    requestOverrides: { page_id: 'not-a-page-id' },
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(body.error, 'meta_ads_publish_staging_seed_request_invalid');
+  assert.equal(graph.calls.length, 0);
+  assert.equal(graph.postCalls.length, 0);
+  assert.equal(db.operations.size, 0);
+  assert.equal(db.tokens.length, 0);
+  assert.equal(JSON.stringify(body).includes('not-a-page-id'), false);
 });
 
 test('staging seed attestation rejects malformed or nonunique System User Page assignments before Page or dataset reads', async () => {
@@ -1178,12 +1361,26 @@ test('candidate appsecret-proof attestation verifies only bounded proof-bearing 
   db.prepare = () => {
     throw new Error('D1 must remain untouched by candidate proof attestation');
   };
-  const graph = new FakeGraph();
+  const graph = new FakeGraph({
+    readResponses: {
+      me: { body: { id: SYSTEM_USER_ID } },
+      [`${SYSTEM_USER_ID}/assigned_pages`]: {
+        body: {
+          data: [{
+            id: PAGE_ID,
+            tasks: ['ADVERTISE'],
+            instagram_business_account: { id: INSTAGRAM_ID },
+          }],
+        },
+      },
+    },
+  });
   const observedReads = [];
   const response = await attestAppSecretProof({
     db,
     graph,
     operationKey: 'meta-ads-staging-seed:candidate-proof-verified-001',
+    requestOverrides: { page_id: PAGE_ID },
     env: {
       META_APP_SECRET: 'unit-test-app-secret-not-a-real-secret',
       META_GRAPH_FETCH: async (url, init) => {
@@ -1209,12 +1406,13 @@ test('candidate appsecret-proof attestation verifies only bounded proof-bearing 
   assert.deepEqual(observedReads.map((read) => read.path), [
     PIXEL_ID,
     `act_${ACCOUNT_ID}/adspixels`,
-    'me/accounts',
+    'me',
+    `${SYSTEM_USER_ID}/assigned_pages`,
     PAGE_ID,
     `act_${ACCOUNT_ID}/offline_conversion_data_sets`,
   ]);
   assert.ok(observedReads.every((read) => read.method === 'GET' && read.hasProof));
-  assert.equal(graph.calls.length, 5);
+  assert.equal(graph.calls.length, 6);
   assert.equal(graph.postCalls.length, 0);
   const serialized = JSON.stringify(body);
   for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID]) {
@@ -1449,6 +1647,50 @@ test('staging seed creates exactly two distinct active Facebook credentials from
   assert.ok(deliveryResources.every((resource) => resource.body.status === 'PAUSED'));
   assert.equal(db.operations.get(operationKey).status, 'sealed');
   assert.equal(JSON.stringify({ operations: [...db.operations.values()], tokens: db.tokens }).includes(SOURCE_ACCESS_TOKEN), false);
+});
+
+test('staging seed seals a configured Page only after the System User assignment proves the exact Page and IG pair', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph({
+    readResponses: {
+      me: { body: { id: SYSTEM_USER_ID } },
+      [`${SYSTEM_USER_ID}/assigned_pages`]: {
+        body: {
+          data: [{
+            id: PAGE_ID,
+            tasks: ['ADVERTISE'],
+            instagram_business_account: { id: INSTAGRAM_ID },
+          }],
+        },
+      },
+    },
+  });
+  const operationKey = 'meta-ads-staging-seed:configured-page-happy-path-001';
+  const response = await seed({
+    db,
+    graph,
+    operationKey,
+    requestOverrides: { page_id: PAGE_ID },
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.equal(body.seed, 'sealed');
+  assert.deepEqual(graph.calls.slice(0, 6).map((call) => call.path), [
+    PIXEL_ID,
+    `act_${ACCOUNT_ID}/adspixels`,
+    'me',
+    `${SYSTEM_USER_ID}/assigned_pages`,
+    PAGE_ID,
+    `act_${ACCOUNT_ID}/offline_conversion_data_sets`,
+  ]);
+  assert.ok(graph.calls.every((call) => call.path !== 'me/accounts'));
+  assert.equal(db.tokens.length, 2);
+  assert.equal(db.operations.get(operationKey).status, 'sealed');
+  const persisted = JSON.stringify(db.operations.get(operationKey));
+  for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID, SYSTEM_USER_ID]) {
+    assert.equal(persisted.includes(value), false);
+  }
 });
 
 test('a matching sealed operation replays idempotently without another Graph mutation', async () => {

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -24,9 +24,11 @@ const syntheticAccountId = "9876543210";
 const syntheticSystemUserId = "6677889900";
 const syntheticPageId = "1122334455";
 const syntheticInstagramId = "5544332211";
+const syntheticOtherPageId = "2233445566";
+const syntheticOtherInstagramId = "6655443322";
 const syntheticDatasetId = "9988776655";
 
-function runVerifier(responses, expectedRequests = responses.length) {
+function runVerifier(responses, expectedRequests = responses.length, pageSelector = "") {
   const harness = `
     const scenario = ${JSON.stringify(responses)};
     let cursor = 0;
@@ -71,6 +73,7 @@ function runVerifier(responses, expectedRequests = responses.length) {
         ...process.env,
         META_ADS_ACCESS_TOKEN: syntheticToken,
         META_PIXEL_ID: syntheticPixelId,
+        META_ADS_PAGE_ID: pageSelector,
         META_ADS_ACCOUNT_ID: syntheticAccountId,
         META_ADS_API_VERSION: "v25.0",
       },
@@ -150,6 +153,38 @@ function systemUserAssignedPageResponses(assignedPages = structuredClone(happyRe
   return responses;
 }
 
+function configuredSystemUserPageResponses(
+  assignedPages = [
+    {
+      id: syntheticOtherPageId,
+      tasks: ["ADVERTISE"],
+      instagram_business_account: { id: syntheticOtherInstagramId },
+    },
+    {
+      id: syntheticPageId,
+      tasks: ["ADVERTISE"],
+      instagram_business_account: { id: syntheticInstagramId },
+    },
+  ],
+) {
+  return [
+    structuredClone(happyResponses[0]),
+    structuredClone(happyResponses[1]),
+    {
+      pathname: "/v25.0/me",
+      query: { fields: "id" },
+      payload: { id: syntheticSystemUserId },
+    },
+    {
+      pathname: `/v25.0/${syntheticSystemUserId}/assigned_pages`,
+      query: { fields: "id,tasks,instagram_business_account{id}", limit: "100" },
+      payload: { data: assignedPages },
+    },
+    structuredClone(happyResponses[3]),
+    structuredClone(happyResponses[4]),
+  ];
+}
+
 test("Meta Ads source-access attestation is manual, bounded, and non-deploying", () => {
   assert.match(workflow, /^name: Attest Raw Meta Ads Staging Source Access$/m);
   assert.match(workflow, /^\s+workflow_dispatch:\s*$/m);
@@ -163,6 +198,10 @@ test("Meta Ads source-access attestation is manual, bounded, and non-deploying",
   assert.match(workflow, /META_PIXEL_ID: \$\{\{ secrets\.META_PIXEL_ID \}\}/);
   assert.match(
     workflow,
+    /META_ADS_PAGE_ID: \$\{\{ secrets\.META_ADS_PAGE_ID \}\}/,
+  );
+  assert.match(
+    workflow,
     /META_ADS_ACCOUNT_ID: \$\{\{ vars\.META_ADS_ACCOUNT_ID \}\}/,
   );
   assert.match(
@@ -174,6 +213,11 @@ test("Meta Ads source-access attestation is manual, bounded, and non-deploying",
     workflow,
     /const graphErrorCode = Number\(payload\?\.error\?\.code\)/,
   );
+  assert.match(
+    workflow,
+    /const pageSelector = String\(process\.env\.META_ADS_PAGE_ID \|\| ''\)\.trim\(\)/,
+  );
+  assert.match(workflow, /source_page_selector_invalid/);
   assert.match(workflow, /response\.status === 401/);
   assert.match(workflow, /response\.status === 403/);
   assert.match(workflow, /graphErrorCode === 10/);
@@ -209,10 +253,13 @@ test("Meta Ads source-access attestation is manual, bounded, and non-deploying",
   assert.doesNotMatch(workflow, /PROFILE_PLUS_FULL_CONTROL/);
   assert.match(workflow, /selectEligiblePage\(pages\.data, 'source_pages'\)/);
   assert.match(workflow, /selectEligiblePage\(assignedPages\.data, 'source_system_user_pages'\)/);
+  assert.match(workflow, /selectEligiblePage\(assignedPages\.data, 'source_system_user_pages', pageSelector\)/);
+  assert.match(workflow, /pageDiscovery = 'system_user_configured'/);
+  assert.match(workflow, /\$\{phase\}_selector_mismatch/);
   assert.match(workflow, /source_system_user_malformed/);
   assert.match(workflow, /source_system_user_pages_paging_ambiguous/);
   assert.match(workflow, /eligiblePages\.length === 0/);
-  assert.match(workflow, /eligiblePages\.length > 1/);
+  assert.match(workflow, /selectedPages\.length > 1/);
   assert.match(workflow, /datasets\.data\.length !== 1/);
   assert.match(workflow, /source_landing_or_media_unavailable/);
   assert.match(workflow, /method: 'GET'/);
@@ -276,6 +323,15 @@ test("Meta Ads source-access verifier executes the bounded raw-read contract wit
     combined,
     new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
   );
+});
+
+test("Meta Ads source-access verifier rejects a malformed private Page selector before Graph reads", () => {
+  const result = runVerifier([], 0, "not-a-page-id");
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0);
+  assert.equal(result.requestCount, 0);
+  assert.match(combined, /source_page_selector_invalid/);
+  assert.doesNotMatch(combined, /not-a-page-id|source_access_raw=verified/);
 });
 
 test("Meta Ads source-access verifier accepts an exact membership on a bounded account Pixel page", () => {
@@ -395,6 +451,84 @@ test("Meta Ads source-access verifier falls back to the bounded System User Page
   );
 });
 
+test("Meta Ads source-access verifier proves only the configured System User Page relation", () => {
+  const result = runVerifier(
+    configuredSystemUserPageResponses(),
+    6,
+    syntheticPageId,
+  );
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.equal(result.status, 0, combined);
+  assert.equal(result.requestCount, 6);
+  assert.match(result.stdout, /source_access_page_discovery=system_user_configured/);
+  assert.doesNotMatch(result.stdout, /me_accounts|system_user_assigned/);
+  assert.doesNotMatch(
+    combined,
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}|${syntheticSystemUserId}|${syntheticPageId}|${syntheticInstagramId}|${syntheticOtherPageId}|${syntheticOtherInstagramId}|${syntheticDatasetId}`),
+  );
+});
+
+test("Meta Ads source-access verifier rejects a configured Page selector that is not an eligible assigned Page", () => {
+  const result = runVerifier(
+    configuredSystemUserPageResponses(),
+    4,
+    "7788990011",
+  );
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0);
+  assert.equal(result.requestCount, 4);
+  assert.match(combined, /source_system_user_pages_selector_mismatch/);
+  assert.doesNotMatch(combined, /source_access_raw=verified/);
+  assert.doesNotMatch(
+    combined,
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}|${syntheticSystemUserId}|${syntheticPageId}|${syntheticInstagramId}|${syntheticOtherPageId}|${syntheticOtherInstagramId}|${syntheticDatasetId}`),
+  );
+});
+
+test("Meta Ads source-access verifier rejects duplicate configured Page membership before Page access", () => {
+  const assignedPages = [
+    {
+      id: syntheticPageId,
+      tasks: ["ADVERTISE"],
+      instagram_business_account: { id: syntheticInstagramId },
+    },
+    {
+      id: syntheticPageId,
+      tasks: ["PROFILE_PLUS_ADVERTISE"],
+      instagram_business_account: { id: syntheticInstagramId },
+    },
+  ];
+  const result = runVerifier(
+    configuredSystemUserPageResponses(assignedPages),
+    4,
+    syntheticPageId,
+  );
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0);
+  assert.equal(result.requestCount, 4);
+  assert.match(combined, /source_system_user_pages_selector_ambiguous/);
+  assert.doesNotMatch(combined, /source_access_raw=verified/);
+  assert.doesNotMatch(
+    combined,
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}|${syntheticSystemUserId}|${syntheticPageId}|${syntheticInstagramId}|${syntheticDatasetId}`),
+  );
+});
+
+test("Meta Ads source-access verifier rejects paging before selecting a configured Page", () => {
+  const responses = configuredSystemUserPageResponses();
+  responses[3].payload.paging = { next: false };
+  const result = runVerifier(responses, 4, syntheticPageId);
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0);
+  assert.equal(result.requestCount, 4);
+  assert.match(combined, /source_system_user_pages_paging_ambiguous/);
+  assert.doesNotMatch(combined, /source_access_raw=verified/);
+  assert.doesNotMatch(
+    combined,
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}|${syntheticSystemUserId}|${syntheticPageId}|${syntheticInstagramId}|${syntheticDatasetId}`),
+  );
+});
+
 test("Meta Ads source-access verifier keeps an empty System User Page relation fail-closed", () => {
   const result = runVerifier(systemUserAssignedPageResponses([]), 5);
   const combined = `${result.stdout}${result.stderr}`;
@@ -405,6 +539,31 @@ test("Meta Ads source-access verifier keeps an empty System User Page relation f
   assert.doesNotMatch(
     combined,
     new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}|${syntheticSystemUserId}`),
+  );
+});
+
+test("Meta Ads source-access verifier preserves ambiguity when no private Page selector is configured", () => {
+  const assignedPages = [
+    {
+      id: syntheticPageId,
+      tasks: ["ADVERTISE"],
+      instagram_business_account: { id: syntheticInstagramId },
+    },
+    {
+      id: syntheticOtherPageId,
+      tasks: ["PROFILE_PLUS_ADVERTISE"],
+      instagram_business_account: { id: syntheticOtherInstagramId },
+    },
+  ];
+  const result = runVerifier(systemUserAssignedPageResponses(assignedPages), 5);
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0);
+  assert.equal(result.requestCount, 5);
+  assert.match(combined, /source_system_user_pages_multiple_eligible/);
+  assert.doesNotMatch(combined, /source_access_raw=verified/);
+  assert.doesNotMatch(
+    combined,
+    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}|${syntheticSystemUserId}|${syntheticPageId}|${syntheticInstagramId}|${syntheticOtherPageId}|${syntheticOtherInstagramId}|${syntheticDatasetId}`),
   );
 });
 

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -84,6 +84,7 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
   assert.ok(tokenVaultUnit.secrets.includes("TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST"));
   assert.ok(tokenVaultUnit.secrets.includes("META_ADS_ACCESS_TOKEN"));
   assert.ok(tokenVaultUnit.secrets.includes("META_PIXEL_ID"));
+  assert.ok(tokenVaultUnit.secrets.includes("META_ADS_PAGE_ID"));
   assert.ok(!tokenVaultUnit.secrets.includes("TOKEN_VAULT_BACKUP_PASSPHRASE"));
   assert.equal(tokenVaultUnit.promotion.trackingFixture, "synthetic authorized ad-set profile required before staging");
   assert.equal(tokenVaultUnit.promotion.trackingBootstrap, "empty staging authority uses a candidate-only Graph-read attestation before a restricted one-shot synthetic seed; legacy authority uses restricted config bearer plus hash-bound internal derivation or protected entries override");


### PR DESCRIPTION
## Objetivo

Exigir uma seleção privada e explícita de Página para o seed Meta Ads v20 de staging, eliminando a escolha automática quando o System User possui múltiplas Páginas elegíveis.

## Mudança

- Adiciona `META_ADS_PAGE_ID` como segredo exclusivo do Environment `staging`.
- Prova a Página selecionada pela relação limitada do System User, exige tarefa de anúncio permitida, par Página/Instagram coerente e readback direto.
- Propaga o seletor apenas em memória para as atestações candidatas e a seed; ele não entra em bindings do Worker, `--secrets-file`, artefatos, outputs ou rollbacks.
- Exige o segredo antes de migrations/upload no deploy governado e registra a superfície no catálogo de custody.
- Mantém o comportamento genérico compatível e fail-closed; sem seletor, a ambiguidade não é resolvida automaticamente.

## Superfícies e risco

Token Vault staging, workflows GitHub e chamadas Graph somente de leitura antes da seed. Risco alto por envolver tracking/credenciais externas, mitigado por validação numérica, seleção exata, recusa de paginação/duplicidade/mismatch, redaction e testes de ausência de mutação.

## Flag / migration

- Flag: não aplicável; o fluxo de staging existente continua governado e bloqueado até a prova.
- Migration: não aplicável.

## Validação

- `npm --prefix platform/security/token-vault test` — 190/190.
- Governança de concorrência, topologia de deploy, single-writer Cloudflare, arquitetura e sincronização Orb validadas.
- Security diff scan `8a9b1340-561a-49a5-88e8-a69a555ed4d3`: cobertura completa, zero achados.
- Nenhum deploy, D1, Graph write, tráfego de staging, Ponto ou CRM foi executado.

## Rollback

Reverter este commit/PR restaura a descoberta anterior. Não há migration, secret gravado, versão ativada ou dado remoto para desfazer. Após merge, o próximo passo permanece manual e privado: escolher a Página canônica na fonte Meta e registrar somente seu ID no segredo `META_ADS_PAGE_ID` do Environment `staging`; não colar o valor em chat, PR ou logs.