### PR TITLE
fix(ci): publish Atendimento staging promotion evidence

### DIFF
--- a/.github/workflows/deploy-atendimento.yml
+++ b/.github/workflows/deploy-atendimento.yml
@@ -151,6 +151,29 @@ jobs:
           path: ${{ runner.temp }}/atendimento-deployment-contract/preflight.json
           retention-days: 30
           if-no-files-found: warn
+      - name: Write immutable Atendimento staging promotion evidence
+        if: ${{ inputs.target == 'staging' }}
+        env:
+          PROMOTION_UNIT: atendimento
+          PROMOTION_TARGET: staging
+          PROMOTION_SOURCE_SHA: ${{ needs.promotion.outputs.source_sha }}
+          PROMOTION_RELEASE_INPUT_DIGEST: ${{ needs.promotion.outputs.release_input_digest }}
+          PROMOTION_DEPENDENCY_CLOSURE_DIGEST: ${{ needs.promotion.outputs.dependency_closure_digest }}
+          EVIDENCE_ROOT: ${{ runner.temp }}/atendimento-staging-evidence
+        run: |
+          set -euo pipefail
+          git -C control fetch --no-tags origin "$PROMOTION_SOURCE_SHA"
+          PROMOTION_SOURCE_TREE="$(git -C control rev-parse "${PROMOTION_SOURCE_SHA}^{tree}")" \
+            node control/.github/scripts/promotion-evidence.mjs write \
+            "$EVIDENCE_ROOT/promotion-evidence.json"
+      - name: Upload immutable Atendimento staging promotion evidence
+        if: ${{ inputs.target == 'staging' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: promotion-evidence-atendimento
+          path: ${{ runner.temp }}/atendimento-staging-evidence/promotion-evidence.json
+          retention-days: 14
+          if-no-files-found: error
       # Staging is deliberately loopback-only until a separately reviewed
       # dedicated tunnel exists. A hosted runner cannot attest that private
       # listener, so it must not probe or imply a public staging route.


### PR DESCRIPTION
## Objetivo

Corrigir o contrato do fluxo governado de Atendimento para que um run `target=staging` publique a evidência imutável exigida pelo gate de produção.

## Causa

`deploy-atendimento.yml` validava o predecessor de preview, mas o job de configuração de staging não anexava `promotion-evidence-atendimento` com `target=staging`. A promoção de produção, portanto, não podia verificar o `staging_run_id` sem reutilizar indevidamente evidência de preview.

## Alteração

- Gera evidência somente em `target=staging`.
- Usa o SHA, tree, release-input digest e dependency-closure digest emitidos pelo gate.
- Faz upload com o nome exato consumido pelo `promotion-gate`.
- Não altera runtime, flags de módulo, banco, API ou produção.

## Validação

- `promotion-evidence.test.mjs`: 2/2.
- YAML parse válido.
- `git diff --check` limpo.
- O próximo staging deverá produzir `promotion-evidence-atendimento` com `target=staging`, SHA `e45a170e1008c43ff16461c93c436cae97e4d4a4` e identidade verificável.

## Rollback

Reverter este commit remove apenas a publicação do artefato de evidência; não reinicia serviços nem altera releases.