### PR TITLE
fix(crm): route Atendimento Pages to isolated runtime

### DIFF
--- a/crm/console/tests/atendimentoReleaseConfig.test.ts
+++ b/crm/console/tests/atendimentoReleaseConfig.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const wranglerConfig = readFileSync(new URL('../wrangler.toml', import.meta.url), 'utf8')
+const productionVars = wranglerConfig.split('[env.preview.r2_buckets]', 1)[0]
+
+describe('Atendimento Pages release target', () => {
+  it('routes production only to the dedicated isolated runtime', () => {
+    expect(productionVars).toContain('ATENDIMENTO_API_TARGET = "https://crm-atendimento.skincos.com.br"')
+    expect(productionVars).not.toContain('ATENDIMENTO_API_TARGET = "https://cs-api.skincos.com.br"')
+  })
+
+  it('does not invent a public staging runtime target', () => {
+    const previewVars = wranglerConfig.split('[env.preview.vars]', 2)[1] || ''
+    expect(previewVars).not.toContain('ATENDIMENTO_API_TARGET =')
+  })
+})

--- a/crm/console/wrangler.toml
+++ b/crm/console/wrangler.toml
@@ -20,7 +20,10 @@ binding = "MODULE_CONTROL"
 id = "__CONFIGURE_MODULE_CONTROL_PRODUCTION_KV_ID__"
 
 [env.production.vars]
-ATENDIMENTO_API_TARGET = "https://cs-api.skincos.com.br"
+# Keep the isolated Atendimento proxy on its dedicated runtime. The shared
+# cs-api gateway uses a different authentication contract and is not a valid
+# target for the v2 actor signature emitted by this Pages bundle.
+ATENDIMENTO_API_TARGET = "https://crm-atendimento.skincos.com.br"
 INSUMOS_API_TARGET = "https://api.skincos.com.br"
 ESCALA_API_TARGET = "https://escala-api.skincos.com.br"
 PONTO_API_TARGET = "https://api.skincos.com.br"


### PR DESCRIPTION
# Summary

Route the production CRM Pages Atendimento proxy to the dedicated isolated runtime required by the HMAC v2 actor contract. The previous `cs-api.skincos.com.br` target caused authenticated Atendimento requests to return `401`; `/api/auth/me` remained `200`.

## Type of change
- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Performance
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (README, API refs, diagrams)
- [x] Security review (focused diff scan; no reportable findings)
- [ ] Performance impact measured

## Links
- Incident: CRM Atendimento authenticated CONSULTOR/Novo Hamburgo
- Runtime SHA: `e45a170e1008c43ff16461c93c436cae97e4d4a4`
- Dedicated production health: `https://crm-atendimento.skincos.com.br/health`

## Screenshots / Evidence
- Focused Vitest: 14/14 passed.
- Console build passed through the WSL boundary.
- Preview intentionally has no public Atendimento target; staging remains loopback-qualified.
- No production deployment is part of this PR.