### PR TITLE
feat(meta-ads): validate dual staging destination pages

### DIFF
--- a/.github/workflows/attest-meta-ads-candidate-appsecret.yml
+++ b/.github/workflows/attest-meta-ads-candidate-appsecret.yml
@@ -42,18 +42,21 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
           META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
-          META_ADS_PAGE_ID: ${{ secrets.META_ADS_PAGE_ID }}
+          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ secrets.novohamburgo_page_id }}
+          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ secrets.barrashopppingsul_page_id }}
           META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
           META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
           ENABLE_TOKEN_VAULT_DEPLOY_STAGING: ${{ vars.ENABLE_TOKEN_VAULT_DEPLOY_STAGING }}
         run: |
           set -euo pipefail
-          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID META_ADS_ACCESS_TOKEN META_PIXEL_ID META_ADS_PAGE_ID META_ADS_ACCOUNT_ID META_ADS_API_VERSION; do
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID META_ADS_ACCESS_TOKEN META_PIXEL_ID META_ADS_NOVOHAMBURGO_PAGE_ID META_ADS_BARRASHOPPPINGSUL_PAGE_ID META_ADS_ACCOUNT_ID META_ADS_API_VERSION; do
             [[ -n "${!name:-}" ]] || { echo 'Candidate appsecret-proof custody is unavailable.' >&2; exit 1; }
           done
           [[ "$ENABLE_TOKEN_VAULT_DEPLOY_STAGING" == true ]] || { echo 'Staging Token Vault candidate proof is disabled.' >&2; exit 1; }
           [[ "$META_PIXEL_ID" =~ ^[0-9]{5,30}$ ]] || { echo 'Candidate appsecret-proof source contract is invalid.' >&2; exit 1; }
-          [[ "$META_ADS_PAGE_ID" =~ ^[0-9]{5,30}$ ]] || { echo 'Candidate appsecret-proof source contract is invalid.' >&2; exit 1; }
+          [[ "$META_ADS_NOVOHAMBURGO_PAGE_ID" =~ ^[0-9]{5,30}$ ]] || { echo 'Candidate appsecret-proof source contract is invalid.' >&2; exit 1; }
+          [[ "$META_ADS_BARRASHOPPPINGSUL_PAGE_ID" =~ ^[0-9]{5,30}$ ]] || { echo 'Candidate appsecret-proof source contract is invalid.' >&2; exit 1; }
+          [[ "$META_ADS_NOVOHAMBURGO_PAGE_ID" != "$META_ADS_BARRASHOPPPINGSUL_PAGE_ID" ]] || { echo 'Candidate appsecret-proof source contract is invalid.' >&2; exit 1; }
           normalized_account="${META_ADS_ACCOUNT_ID#act_}"
           [[ "$normalized_account" =~ ^[0-9]{5,30}$ ]] || { echo 'Candidate appsecret-proof source contract is invalid.' >&2; exit 1; }
           [[ "$META_ADS_API_VERSION" =~ ^v(2[5-9]|[3-9][0-9])\.0$ ]] || { echo 'Candidate appsecret-proof source contract is invalid.' >&2; exit 1; }
@@ -91,7 +94,8 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
           META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
-          META_ADS_PAGE_ID: ${{ secrets.META_ADS_PAGE_ID }}
+          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ secrets.novohamburgo_page_id }}
+          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ secrets.barrashopppingsul_page_id }}
           META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
           META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
           SOURCE_SHA: ${{ github.sha }}
@@ -144,7 +148,8 @@ jobs:
           CANDIDATE_PREVIEW_URL="$preview" \
           META_ADS_ACCESS_TOKEN="$META_ADS_ACCESS_TOKEN" \
           META_PIXEL_ID="$META_PIXEL_ID" \
-          META_ADS_PAGE_ID="$META_ADS_PAGE_ID" \
+          META_ADS_NOVOHAMBURGO_PAGE_ID="$META_ADS_NOVOHAMBURGO_PAGE_ID" \
+          META_ADS_BARRASHOPPPINGSUL_PAGE_ID="$META_ADS_BARRASHOPPPINGSUL_PAGE_ID" \
           META_ADS_ACCOUNT_ID="$META_ADS_ACCOUNT_ID" \
           META_ADS_API_VERSION="$META_ADS_API_VERSION" \
           SOURCE_SHA="$SOURCE_SHA" \
@@ -155,7 +160,10 @@ jobs:
           const preview = String(process.env.CANDIDATE_PREVIEW_URL || '').replace(/\/$/, '');
           const sourceToken = String(process.env.META_ADS_ACCESS_TOKEN || '');
           const pixelId = String(process.env.META_PIXEL_ID || '').trim();
-          const pageId = String(process.env.META_ADS_PAGE_ID || '').trim();
+          const destinationPageIds = {
+            novo_hamburgo: String(process.env.META_ADS_NOVOHAMBURGO_PAGE_ID || '').trim(),
+            barra_shopping_sul: String(process.env.META_ADS_BARRASHOPPPINGSUL_PAGE_ID || '').trim(),
+          };
           const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
           const apiVersion = String(process.env.META_ADS_API_VERSION || '').trim();
           const sourceSha = String(process.env.SOURCE_SHA || '').trim();
@@ -164,7 +172,8 @@ jobs:
             !/^https:\/\/[0-9a-f]{8}-skincos-token-vault-staging\.skincos\.workers\.dev$/.test(preview) ||
             !sourceToken ||
             !/^\d{5,30}$/.test(pixelId) ||
-            !/^\d{5,30}$/.test(pageId) ||
+            !Object.values(destinationPageIds).every((pageId) => /^\d{5,30}$/.test(pageId)) ||
+            destinationPageIds.novo_hamburgo === destinationPageIds.barra_shopping_sul ||
             !/^\d{5,30}$/.test(accountId) ||
             !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion) ||
             !/^[0-9a-f]{40}$/.test(sourceSha)
@@ -185,7 +194,7 @@ jobs:
                 access_token: sourceToken,
                 account_id: accountId,
                 pixel_id: pixelId,
-                page_id: pageId,
+                destination_page_ids: destinationPageIds,
                 api_version: apiVersion,
               }),
               cache: 'no-store',
@@ -202,7 +211,7 @@ jobs:
           const valid = response.status === 200 && payload?.ok === true &&
             Object.keys(payload).every((key) => allowedKeys.has(key)) &&
             payload?.attestation === 'appsecret_proof_verified' &&
-            payload?.contract_version === 'meta-ads-tracking-v20/staging-synthetic-seed/v1' &&
+            payload?.contract_version === 'meta-ads-tracking-v20/staging-synthetic-seed/v2' &&
             typeof payload?.requestId === 'string';
           if (!valid) throw new Error(`candidate appsecret-proof attestation failed: ${response.status} ${error}`);
           process.stdout.write('candidate_appsecret_proof=verified\n');

--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -18,11 +18,12 @@ jobs:
     timeout-minutes: 3
     environment: staging
     steps:
-      - name: Attest raw staging seed source reads without the Worker app proof
+      - name: Attest both raw staging destination pairs without the Worker app proof
         env:
           META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
           META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
-          META_ADS_PAGE_ID: ${{ secrets.META_ADS_PAGE_ID }}
+          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ secrets.novohamburgo_page_id }}
+          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ secrets.barrashopppingsul_page_id }}
           META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
           META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
         shell: bash
@@ -31,18 +32,22 @@ jobs:
           node --input-type=module <<'NODE'
           const token = String(process.env.META_ADS_ACCESS_TOKEN || '');
           const pixelId = String(process.env.META_PIXEL_ID || '').trim();
-          const pageSelector = String(process.env.META_ADS_PAGE_ID || '').trim();
           const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
           const apiVersion = String(process.env.META_ADS_API_VERSION || '');
+          const destinationSelectors = {
+            novo_hamburgo: String(process.env.META_ADS_NOVOHAMBURGO_PAGE_ID || '').trim(),
+            barra_shopping_sul: String(process.env.META_ADS_BARRASHOPPPINGSUL_PAGE_ID || '').trim(),
+          };
 
           const fail = (code) => {
             console.error(`Meta Ads source-access attestation failed: ${code}`);
             process.exit(1);
           };
+          const numericId = (value) => {
+            const normalized = String(value || '').trim().replace(/^act_/, '');
+            return /^\d{5,30}$/.test(normalized) ? normalized : '';
+          };
 
-          if (pageSelector && !/^\d{5,30}$/.test(pageSelector)) {
-            fail('source_page_selector_invalid');
-          }
           if (
             !token ||
             !/^\d{5,30}$/.test(pixelId) ||
@@ -50,6 +55,15 @@ jobs:
             !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion)
           ) {
             fail('source_contract_invalid');
+          }
+          if (
+            !/^\d{5,30}$/.test(destinationSelectors.novo_hamburgo) ||
+            !/^\d{5,30}$/.test(destinationSelectors.barra_shopping_sul)
+          ) {
+            fail('source_destination_page_selector_invalid');
+          }
+          if (destinationSelectors.novo_hamburgo === destinationSelectors.barra_shopping_sul) {
+            fail('source_destination_page_selector_duplicate');
           }
 
           const graphGet = async (path) => {
@@ -89,16 +103,12 @@ jobs:
             }
             return { state: 'ok', payload };
           };
-
-          const numericId = (value) => {
-            const normalized = String(value || '').trim().replace(/^act_/, '');
-            return /^\d{5,30}$/.test(normalized) ? normalized : '';
-          };
           const directRead = async (path, phase) => {
             const result = await graphGet(path);
             if (result.state !== 'ok') fail(`${phase}_${result.state}`);
             return result.payload;
           };
+          const hasNextPage = (payload) => String(payload?.paging?.next ?? '').trim() !== '';
           const validLanding = (value) => {
             try {
               const url = new URL(String(value || '').trim());
@@ -124,43 +134,24 @@ jobs:
               return false;
             }
           };
-          const selectEligiblePage = (data, phase, selector = '') => {
-            const pageFacts = data.map((page) => {
-              const tasks = new Set(Array.isArray(page?.tasks) ? page.tasks.map((task) => String(task || '').trim().toUpperCase()) : []);
-              const hasAdvertiseTask = tasks.has('ADVERTISE') || tasks.has('PROFILE_PLUS_ADVERTISE');
-              const hasInstagramLink = Boolean(numericId(page?.instagram_business_account?.id));
-              return {
-                page,
-                hasAdvertiseTask,
-                hasInstagramLink,
-                eligible: hasAdvertiseTask && hasInstagramLink,
-              };
-            });
-            const eligiblePages = pageFacts.filter((fact) => fact.eligible).map((fact) => fact.page);
-            const selectedPages = selector
-              ? eligiblePages.filter((page) => numericId(page?.id) === selector)
-              : eligiblePages;
-            if (selector && selectedPages.length === 0) fail(`${phase}_selector_mismatch`);
-            if (eligiblePages.length === 0) {
-              if (pageFacts.length === 0) fail(`${phase}_none_visible`);
-              const hasAdvertiseTask = pageFacts.some((fact) => fact.hasAdvertiseTask);
-              const hasInstagramLink = pageFacts.some((fact) => fact.hasInstagramLink);
-              if (!hasAdvertiseTask && !hasInstagramLink) fail(`${phase}_advertise_and_instagram_missing`);
-              if (!hasAdvertiseTask) fail(`${phase}_advertise_task_missing`);
-              if (!hasInstagramLink) fail(`${phase}_instagram_link_missing`);
-              fail(`${phase}_task_instagram_unpaired`);
+          const selectDestinationPair = (assignedPages, destinationKey, selector) => {
+            const selected = assignedPages.filter((page) => numericId(page?.id) === selector);
+            if (selected.length === 0) fail('source_destination_page_assignment_unassigned');
+            if (selected.length > 1) fail('source_destination_page_selector_ambiguous');
+            const page = selected[0];
+            if (!Array.isArray(page?.tasks)) fail('source_destination_page_assignment_malformed');
+            const tasks = new Set(page.tasks.map((task) => String(task || '').trim().toUpperCase()));
+            if (!tasks.has('ADVERTISE') && !tasks.has('PROFILE_PLUS_ADVERTISE')) {
+              fail('source_destination_page_assignment_advertise_task_missing');
             }
-            if (selectedPages.length > 1) fail(selector ? `${phase}_selector_ambiguous` : `${phase}_multiple_eligible`);
-            const pageId = numericId(selectedPages[0].id);
-            const instagramId = numericId(selectedPages[0].instagram_business_account.id);
-            if (!pageId || !instagramId) fail(`${phase}_malformed`);
-            return { pageId, instagramId };
+            const pageId = numericId(page?.id);
+            const instagramId = numericId(page?.instagram_business_account?.id);
+            if (!pageId || !instagramId) fail('source_destination_page_assignment_instagram_link_missing');
+            return { destinationKey, pageId, instagramId };
           };
 
-          // Keep the bare asset read separate from the account membership
-          // relation. A Pixel may be shared with the configured account without
-          // that account owning it, so membership is the contract needed by the
-          // later promoted_object.
+          // Keep the bare Pixel read separate from account membership: a Pixel
+          // can be shared with an account without being owned by it.
           const pixel = await directRead(`${pixelId}?fields=id`, 'source_pixel');
           if (numericId(pixel?.id) !== pixelId) fail('source_pixel_mismatch');
 
@@ -173,75 +164,48 @@ jobs:
           if (associatedPixels.some((id) => !id)) fail('source_pixel_account_relation_malformed');
           const targetMemberships = associatedPixels.filter((id) => id === pixelId).length;
           if (targetMemberships === 1 && new Set(associatedPixels).size === associatedPixels.length) {
-            // The bounded page proves the exact association. Do not follow the
-            // opaque Graph pagination URL or reject an account just because it
-            // has more associated Pixels than this diagnostic page limit.
-          } else if (String(accountPixels?.paging?.next ?? '').trim()) {
+            // The target membership is proven by this bounded page. Other
+            // associated Pixels do not make the configured relation ambiguous.
+          } else if (hasNextPage(accountPixels)) {
             fail('source_pixel_account_relation_ambiguous');
           } else {
             fail('source_pixel_account_relation_mismatch');
           }
 
-          let pageSelection;
-          let pageDiscovery;
-          if (pageSelector) {
-            // A configured selector must be proved through the authenticated
-            // System User's own bounded assignment relation. Never pick a
-            // Page by order or by a user-centric discovery edge.
-            const sourcePrincipal = await directRead('me?fields=id', 'source_system_user');
-            const sourcePrincipalId = numericId(sourcePrincipal?.id);
-            if (!sourcePrincipalId) fail('source_system_user_malformed');
-            const assignedPages = await directRead(
-              `${sourcePrincipalId}/assigned_pages?fields=id,tasks,instagram_business_account{id}&limit=100`,
-              'source_system_user_pages',
-            );
-            if (!Array.isArray(assignedPages?.data)) fail('source_system_user_pages_malformed');
-            if (String(assignedPages?.paging?.next ?? '').trim()) {
-              fail('source_system_user_pages_paging_ambiguous');
-            }
-            pageSelection = selectEligiblePage(assignedPages.data, 'source_system_user_pages', pageSelector);
-            pageDiscovery = 'system_user_configured';
-          } else {
-            const pages = await directRead(
-              'me/accounts?fields=id,tasks,instagram_business_account{id}&limit=100',
-              'source_pages',
-            );
-            if (!Array.isArray(pages?.data)) fail('source_pages_malformed');
-            if (String(pages?.paging?.next ?? '').trim()) fail('source_pages_paging_ambiguous');
-            pageDiscovery = 'me_accounts';
-            if (pages.data.length === 0) {
-              // `/me/accounts` is a user-token-centric Page listing. Keep its
-              // empty result distinct from a System User's explicit Page
-              // assignment, and inspect only the authenticated principal's
-              // own bounded relation before any direct Page read.
-              const sourcePrincipal = await directRead('me?fields=id', 'source_system_user');
-              const sourcePrincipalId = numericId(sourcePrincipal?.id);
-              if (!sourcePrincipalId) fail('source_system_user_malformed');
-              const assignedPages = await directRead(
-                `${sourcePrincipalId}/assigned_pages?fields=id,tasks,instagram_business_account{id}&limit=100`,
-                'source_system_user_pages',
-              );
-              if (!Array.isArray(assignedPages?.data)) fail('source_system_user_pages_malformed');
-              if (String(assignedPages?.paging?.next ?? '').trim()) {
-                fail('source_system_user_pages_paging_ambiguous');
-              }
-              pageSelection = selectEligiblePage(assignedPages.data, 'source_system_user_pages');
-              pageDiscovery = 'system_user_assigned';
-            } else {
-              pageSelection = selectEligiblePage(pages.data, 'source_pages');
-            }
-          }
-          const { pageId, instagramId } = pageSelection;
-
-          const page = await directRead(
-            `${pageId}?fields=id,instagram_business_account{id},website,picture{url}`,
-            'source_page',
+          const sourcePrincipal = await directRead('me?fields=id', 'source_system_user');
+          const sourcePrincipalId = numericId(sourcePrincipal?.id);
+          if (!sourcePrincipalId) fail('source_system_user_malformed');
+          const assignedPages = await directRead(
+            `${sourcePrincipalId}/assigned_pages?fields=id,tasks,instagram_business_account{id}&limit=100`,
+            'source_system_user_pages',
           );
-          if (numericId(page?.id) !== pageId || numericId(page?.instagram_business_account?.id) !== instagramId) {
-            fail('source_page_mismatch');
+          if (!Array.isArray(assignedPages?.data)) fail('source_system_user_pages_malformed');
+          if (hasNextPage(assignedPages)) fail('source_system_user_pages_paging_ambiguous');
+
+          const destinationPairs = Object.entries(destinationSelectors).map(([destinationKey, selector]) =>
+            selectDestinationPair(assignedPages.data, destinationKey, selector),
+          );
+          if (
+            new Set(destinationPairs.map((pair) => pair.pageId)).size !== destinationPairs.length ||
+            new Set(destinationPairs.map((pair) => pair.instagramId)).size !== destinationPairs.length
+          ) {
+            fail('source_destination_page_pair_duplicate');
           }
-          if (!validLanding(page?.website) || !validPicture(page?.picture)) {
-            fail('source_landing_or_media_unavailable');
+
+          for (const pair of destinationPairs) {
+            const page = await directRead(
+              `${pair.pageId}?fields=id,instagram_business_account{id},website,picture{url}`,
+              `source_destination_page_${pair.destinationKey}`,
+            );
+            if (
+              numericId(page?.id) !== pair.pageId ||
+              numericId(page?.instagram_business_account?.id) !== pair.instagramId
+            ) {
+              fail('source_destination_page_pair_mismatch');
+            }
+            if (!validLanding(page?.website) || !validPicture(page?.picture)) {
+              fail('source_destination_landing_or_media_unavailable');
+            }
           }
 
           const datasets = await directRead(
@@ -249,9 +213,7 @@ jobs:
             'source_dataset',
           );
           if (!Array.isArray(datasets?.data)) fail('source_dataset_malformed');
-          if (String(datasets?.paging?.next ?? '').trim() || datasets.data.length !== 1) {
-            fail('source_dataset_ambiguous');
-          }
+          if (hasNextPage(datasets) || datasets.data.length !== 1) fail('source_dataset_ambiguous');
           if (!numericId(datasets.data[0]?.id)) fail('source_dataset_malformed');
 
           process.stdout.write([
@@ -259,8 +221,8 @@ jobs:
             'source_access_runtime_proof=unverified',
             'source_access_pixel=allowed',
             'source_access_pixel_account_relation=allowed',
-            `source_access_page_discovery=${pageDiscovery}`,
-            'source_access_page=eligible',
+            'source_access_novohamburgo_page_instagram=eligible',
+            'source_access_barrashopppingsul_page_instagram=eligible',
             'source_access_dataset=eligible',
             'source_access_landing_media=eligible',
           ].join('\n') + '\n');

--- a/.github/workflows/deploy-token-vault.yml
+++ b/.github/workflows/deploy-token-vault.yml
@@ -987,10 +987,12 @@ jobs:
           TOKEN_VAULT_PRODUCTION_BASE_URL: ${{ vars.TOKEN_VAULT_PRODUCTION_BASE_URL }}
           ENABLE_TOKEN_VAULT_DEPLOY_STAGING: ${{ vars.ENABLE_TOKEN_VAULT_DEPLOY_STAGING }}
           ENABLE_TOKEN_VAULT_PRODUCTION_DEPLOY: ${{ vars.ENABLE_TOKEN_VAULT_PRODUCTION_DEPLOY }}
-          # This private staging-only selector is an exact Page identity, never
-          # a Worker binding. It must be proved against the System User before
-          # the synthetic seed may create any Meta or D1 resources.
-          META_ADS_PAGE_ID: ${{ inputs.target == 'staging' && secrets.META_ADS_PAGE_ID || '' }}
+          # These private staging-only selectors are exact Page identities,
+          # never Worker bindings. Each must be proved with its own Instagram
+          # pair against the System User before the synthetic seed may create
+          # any Meta or D1 resources.
+          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ inputs.target == 'staging' && secrets.novohamburgo_page_id || '' }}
+          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ inputs.target == 'staging' && secrets.barrashopppingsul_page_id || '' }}
           META_ADS_API_VERSION: ${{ inputs.target == 'staging' && vars.META_ADS_API_VERSION || '' }}
           TARGET: ${{ inputs.target }}
           OPERATION: ${{ inputs.operation }}
@@ -1006,7 +1008,9 @@ jobs:
             [[ "$ENABLE_TOKEN_VAULT_DEPLOY_STAGING" == true ]] || { echo 'ENABLE_TOKEN_VAULT_DEPLOY_STAGING must be true'; exit 1; }
             [[ "$CONFIRM_STAGING_TRACKING_FIXTURE" == true ]] || { echo 'An isolated synthetic tracking fixture must be confirmed for staging'; exit 1; }
             [[ "$TOKEN_VAULT_STAGING_BASE_URL" =~ ^https://[^/]+$ ]] || { echo 'TOKEN_VAULT_STAGING_BASE_URL must be an HTTPS origin'; exit 1; }
-            [[ "$META_ADS_PAGE_ID" =~ ^[0-9]{5,30}$ ]] || { echo 'META_ADS_PAGE_ID must be a numeric staging Environment secret for the governed staging seed'; exit 1; }
+            [[ "$META_ADS_NOVOHAMBURGO_PAGE_ID" =~ ^[0-9]{5,30}$ ]] || { echo 'Novo Hamburgo Page selector must be a numeric staging Environment secret for the governed staging seed'; exit 1; }
+            [[ "$META_ADS_BARRASHOPPPINGSUL_PAGE_ID" =~ ^[0-9]{5,30}$ ]] || { echo 'Barra Shopping Sul Page selector must be a numeric staging Environment secret for the governed staging seed'; exit 1; }
+            [[ "$META_ADS_NOVOHAMBURGO_PAGE_ID" != "$META_ADS_BARRASHOPPPINGSUL_PAGE_ID" ]] || { echo 'Staging Page selectors must be distinct for the governed staging seed'; exit 1; }
             [[ "$META_ADS_API_VERSION" =~ ^v(2[5-9]|[3-9][0-9])\.0$ ]] || { echo 'META_ADS_API_VERSION must be v25.0 or a newer supported Graph API version for the governed staging seed'; exit 1; }
           else
             [[ "$ENABLE_TOKEN_VAULT_PRODUCTION_DEPLOY" == true ]] || { echo 'ENABLE_TOKEN_VAULT_PRODUCTION_DEPLOY must be true'; exit 1; }
@@ -1334,7 +1338,8 @@ jobs:
         env:
           META_ADS_ACCESS_TOKEN: ${{ inputs.target == 'staging' && secrets.META_ADS_ACCESS_TOKEN || '' }}
           META_PIXEL_ID: ${{ inputs.target == 'staging' && secrets.META_PIXEL_ID || '' }}
-          META_ADS_PAGE_ID: ${{ inputs.target == 'staging' && secrets.META_ADS_PAGE_ID || '' }}
+          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ inputs.target == 'staging' && secrets.novohamburgo_page_id || '' }}
+          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ inputs.target == 'staging' && secrets.barrashopppingsul_page_id || '' }}
           META_ADS_ACCOUNT_ID: ${{ inputs.target == 'staging' && vars.META_ADS_ACCOUNT_ID || '' }}
           META_ADS_API_VERSION: ${{ inputs.target == 'staging' && vars.META_ADS_API_VERSION || '' }}
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
@@ -1347,7 +1352,10 @@ jobs:
           const seedFile = String(process.env.TOKEN_VAULT_STAGING_SYNTHETIC_SEED_FILE || '');
           const accessToken = String(process.env.META_ADS_ACCESS_TOKEN || '');
           const pixelId = String(process.env.META_PIXEL_ID || '').trim();
-          const pageId = String(process.env.META_ADS_PAGE_ID || '').trim();
+          const destinationPageIds = {
+            novo_hamburgo: String(process.env.META_ADS_NOVOHAMBURGO_PAGE_ID || '').trim(),
+            barra_shopping_sul: String(process.env.META_ADS_BARRASHOPPPINGSUL_PAGE_ID || '').trim(),
+          };
           const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
           const apiVersion = String(process.env.META_ADS_API_VERSION || '').trim();
           const releaseSha = String(process.env.RELEASE_SHA || '').toLowerCase();
@@ -1356,7 +1364,7 @@ jobs:
           if (!/^https:\/\/(?:[a-z0-9-]+\.)+workers\.dev$/.test(preview) || !seedFile) {
             throw new Error('immutable staging synthetic-seed candidate endpoint is unavailable');
           }
-          if (!accessToken || !/^\d{5,30}$/.test(pixelId) || !/^\d{5,30}$/.test(pageId) || !/^\d{5,30}$/.test(accountId) || !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion)) {
+          if (!accessToken || !/^\d{5,30}$/.test(pixelId) || !Object.values(destinationPageIds).every((pageId) => /^\d{5,30}$/.test(pageId)) || destinationPageIds.novo_hamburgo === destinationPageIds.barra_shopping_sul || !/^\d{5,30}$/.test(accountId) || !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion)) {
             throw new Error('staging synthetic Meta source custody is unavailable or malformed');
           }
           if (!/^[a-f0-9]{40}$/.test(releaseSha) || !/^\d+$/.test(runId) || !/^\d+$/.test(runAttempt)) {
@@ -1376,7 +1384,7 @@ jobs:
               access_token: accessToken,
               account_id: accountId,
               pixel_id: pixelId,
-              page_id: pageId,
+              destination_page_ids: destinationPageIds,
               api_version: apiVersion,
             }),
             cache: 'no-store',
@@ -1391,7 +1399,7 @@ jobs:
             Object.keys(payload).every((key) => allowedKeys.has(key)) &&
             String(payload?.attestation || '') === 'match' &&
             String(payload?.operation_key || '') === operationKey &&
-            String(payload?.contract_version || '') === 'meta-ads-tracking-v20/staging-synthetic-seed/v1' &&
+            String(payload?.contract_version || '') === 'meta-ads-tracking-v20/staging-synthetic-seed/v2' &&
             typeof payload?.requestId === 'string';
           if (!valid) throw new Error(`staging synthetic-seed source attestation failed: ${response.status} ${error}`);
           NODE
@@ -1406,7 +1414,8 @@ jobs:
         env:
           META_ADS_ACCESS_TOKEN: ${{ inputs.target == 'staging' && secrets.META_ADS_ACCESS_TOKEN || '' }}
           META_PIXEL_ID: ${{ inputs.target == 'staging' && secrets.META_PIXEL_ID || '' }}
-          META_ADS_PAGE_ID: ${{ inputs.target == 'staging' && secrets.META_ADS_PAGE_ID || '' }}
+          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ inputs.target == 'staging' && secrets.novohamburgo_page_id || '' }}
+          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ inputs.target == 'staging' && secrets.barrashopppingsul_page_id || '' }}
           META_ADS_ACCOUNT_ID: ${{ inputs.target == 'staging' && vars.META_ADS_ACCOUNT_ID || '' }}
           META_ADS_API_VERSION: ${{ inputs.target == 'staging' && vars.META_ADS_API_VERSION || '' }}
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
@@ -1419,7 +1428,10 @@ jobs:
           const seedFile = String(process.env.TOKEN_VAULT_STAGING_SYNTHETIC_SEED_FILE || '');
           const accessToken = String(process.env.META_ADS_ACCESS_TOKEN || '');
           const pixelId = String(process.env.META_PIXEL_ID || '').trim();
-          const pageId = String(process.env.META_ADS_PAGE_ID || '').trim();
+          const destinationPageIds = {
+            novo_hamburgo: String(process.env.META_ADS_NOVOHAMBURGO_PAGE_ID || '').trim(),
+            barra_shopping_sul: String(process.env.META_ADS_BARRASHOPPPINGSUL_PAGE_ID || '').trim(),
+          };
           const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
           const apiVersion = String(process.env.META_ADS_API_VERSION || '').trim();
           const releaseSha = String(process.env.RELEASE_SHA || '').toLowerCase();
@@ -1428,7 +1440,7 @@ jobs:
           if (!/^https:\/\/(?:[a-z0-9-]+\.)+workers\.dev$/.test(preview) || !seedFile) {
             throw new Error('immutable staging synthetic-seed candidate endpoint is unavailable');
           }
-          if (!accessToken || !/^\d{5,30}$/.test(pixelId) || !/^\d{5,30}$/.test(pageId) || !/^\d{5,30}$/.test(accountId) || !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion)) {
+          if (!accessToken || !/^\d{5,30}$/.test(pixelId) || !Object.values(destinationPageIds).every((pageId) => /^\d{5,30}$/.test(pageId)) || destinationPageIds.novo_hamburgo === destinationPageIds.barra_shopping_sul || !/^\d{5,30}$/.test(accountId) || !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion)) {
             throw new Error('staging synthetic Meta source custody is unavailable or malformed');
           }
           if (!/^[a-f0-9]{40}$/.test(releaseSha) || !/^\d+$/.test(runId) || !/^\d+$/.test(runAttempt)) {
@@ -1452,7 +1464,7 @@ jobs:
               access_token: accessToken,
               account_id: accountId,
               pixel_id: pixelId,
-              page_id: pageId,
+              destination_page_ids: destinationPageIds,
               api_version: apiVersion,
             }),
             cache: 'no-store',
@@ -1468,7 +1480,7 @@ jobs:
             String(payload?.operation_status || '') === seed &&
             typeof payload?.replayed === 'boolean' &&
             String(payload?.operation_key || '') === operationKey &&
-            String(payload?.contract_version || '') === 'meta-ads-tracking-v20/staging-synthetic-seed/v1';
+            String(payload?.contract_version || '') === 'meta-ads-tracking-v20/staging-synthetic-seed/v2';
           if (!valid) throw new Error(`staging synthetic-seed failed: ${response.status} ${error}`);
           fs.appendFileSync(process.env.GITHUB_OUTPUT, seed === 'sealed'
             ? `did_seed=true\nseed_status=${seed}\n`
@@ -1722,7 +1734,7 @@ jobs:
           try { payload = await response.json(); } catch {}
           const error = /^[a-z0-9_:-]{1,120}$/i.test(String(payload?.error || '')) ? String(payload.error) : 'unknown';
           const absent = response.status === 409 && payload?.ok === false && payload?.error === 'meta_ads_publish_staging_seed_operation_not_found';
-          if (!absent && (!response.ok || payload?.ok !== true || payload?.rolled_back !== true || String(payload?.operation_status || '') !== 'rolled_back' || typeof payload?.replayed !== 'boolean' || String(payload?.operation_key || '') !== operationKey || String(payload?.contract_version || '') !== 'meta-ads-tracking-v20/staging-synthetic-seed/v1')) {
+          if (!absent && (!response.ok || payload?.ok !== true || payload?.rolled_back !== true || String(payload?.operation_status || '') !== 'rolled_back' || typeof payload?.replayed !== 'boolean' || String(payload?.operation_key || '') !== operationKey || String(payload?.contract_version || '') !== 'meta-ads-tracking-v20/staging-synthetic-seed/v2')) {
             throw new Error(`staging synthetic-seed pre-traffic rollback failed: ${response.status} ${error}`);
           }
           NODE
@@ -1786,7 +1798,7 @@ jobs:
           try { payload = await response.json(); } catch {}
           const error = /^[a-z0-9_:-]{1,120}$/i.test(String(payload?.error || '')) ? String(payload.error) : 'unknown';
           const absent = response.status === 409 && payload?.ok === false && payload?.error === 'meta_ads_publish_staging_seed_operation_not_found';
-          if (!absent && (!response.ok || payload?.ok !== true || payload?.rolled_back !== true || String(payload?.operation_status || '') !== 'rolled_back' || typeof payload?.replayed !== 'boolean' || String(payload?.operation_key || '') !== operationKey || String(payload?.contract_version || '') !== 'meta-ads-tracking-v20/staging-synthetic-seed/v1')) {
+          if (!absent && (!response.ok || payload?.ok !== true || payload?.rolled_back !== true || String(payload?.operation_status || '') !== 'rolled_back' || typeof payload?.replayed !== 'boolean' || String(payload?.operation_key || '') !== operationKey || String(payload?.contract_version || '') !== 'meta-ads-tracking-v20/staging-synthetic-seed/v2')) {
             throw new Error(`staging synthetic-seed activation-lease rollback failed: ${response.status} ${error}`);
           }
           NODE
@@ -2201,7 +2213,7 @@ jobs:
           let payload = null;
           try { payload = await response.json(); } catch {}
           const error = /^[a-z0-9_:-]{1,120}$/i.test(String(payload?.error || '')) ? String(payload.error) : 'unknown';
-          if (!response.ok || payload?.ok !== true || payload?.rolled_back !== true || String(payload?.operation_status || '') !== 'rolled_back' || typeof payload?.replayed !== 'boolean' || String(payload?.operation_key || '') !== operationKey || String(payload?.contract_version || '') !== 'meta-ads-tracking-v20/staging-synthetic-seed/v1') {
+          if (!response.ok || payload?.ok !== true || payload?.rolled_back !== true || String(payload?.operation_status || '') !== 'rolled_back' || typeof payload?.replayed !== 'boolean' || String(payload?.operation_key || '') !== operationKey || String(payload?.contract_version || '') !== 'meta-ads-tracking-v20/staging-synthetic-seed/v2') {
             throw new Error(`staging synthetic-seed rollback failed: ${response.status} ${error}`);
           }
           NODE

--- a/platform/deploy/operational-units.json
+++ b/platform/deploy/operational-units.json
@@ -102,7 +102,7 @@
       "concurrencyPrefix": "deploy-token-vault-",
       "publishes": ["Worker:skincos-token-vault", "Worker:skincos-token-vault-staging"],
       "resources": ["Token Vault Worker", "skincos-token-vault D1", "skincos-token-vault-staging D1", "Token Vault route and auth bindings", "Governed Meta Ads staging synthetic source and appsecret-proof attestations, seed, bootstrap derivation, rollback journal and paused creative fixture"],
-      "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "TOKEN_VAULT_API_TOKEN", "TOKEN_VAULT_N8N_API_TOKEN", "TOKEN_VAULT_ANALYTICS_API_TOKEN", "TOKEN_VAULT_ENCRYPTION_KEY", "TOKEN_VAULT_META_ADS_CONFIG_TOKEN", "TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST", "META_ADS_ACCESS_TOKEN", "META_PIXEL_ID", "META_ADS_PAGE_ID"],
+      "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "TOKEN_VAULT_API_TOKEN", "TOKEN_VAULT_N8N_API_TOKEN", "TOKEN_VAULT_ANALYTICS_API_TOKEN", "TOKEN_VAULT_ENCRYPTION_KEY", "TOKEN_VAULT_META_ADS_CONFIG_TOKEN", "TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST", "META_ADS_ACCESS_TOKEN", "META_PIXEL_ID", "novohamburgo_page_id", "barrashopppingsul_page_id"],
       "migrationPaths": ["platform/security/token-vault/migrations"],
       "environments": ["preview", "staging", "production"],
       "promotion": {

--- a/platform/security/token-vault/README.md
+++ b/platform/security/token-vault/README.md
@@ -146,15 +146,19 @@ fonte, acesso ao Pixel, Página ou dataset, e indisponibilidade transitória. S�
 então o workflow chama
 `POST .../config/staging-synthetic-seed`. Os fatos externos entram somente no
 corpo dessas chamadas privadas: o token Meta Ads já custodiado,
-`META_PIXEL_ID`, `META_ADS_ACCOUNT_ID`, `META_ADS_API_VERSION` e o segredo de
-Environment staging `META_ADS_PAGE_ID`. Esse último é um seletor privado de
-identidade factual, nunca um bearer: o Vault o prova pela relação limitada de
-Páginas atribuídas ao System User, exige exatamente uma associação elegível e
-confirma o mesmo par Página+Instagram por leitura direta. Ele não é um binding
-do Worker, não entra no `--secrets-file`, artefato, log ou output do workflow.
-O Vault exige então uma conta/pixel, uma Página+Instagram provada e um dataset
-offline unívocos, cria somente recursos `PAUSED` nomeados para staging e sela
-duas credenciais internas cifradas. Não seleciona campanhas, conjuntos ou
+`META_PIXEL_ID`, `META_ADS_ACCOUNT_ID`, `META_ADS_API_VERSION` e os segredos
+privados do GitHub Environment `staging` `novohamburgo_page_id` e
+`barrashopppingsul_page_id`. Os dois últimos são seletores factuais de
+identidade, nunca bearers, e seus valores não aparecem em logs, outputs,
+artefatos ou PRs. O fluxo associa o primeiro exclusivamente à unidade Novo
+Hamburgo e o segundo exclusivamente à unidade Barra Shopping Sul; para cada
+unidade, prova pela relação limitada de Páginas atribuídas ao System User uma
+única associação elegível e confirma o mesmo par Página+Instagram por leitura
+direta. Os pares devem ser distintos. Os seletores não são bindings do Worker
+e não entram no `--secrets-file`, artefato, log ou output do workflow. O Vault
+exige então uma conta/pixel, os dois pares Página+Instagram provados e um
+dataset offline unívoco, cria somente recursos `PAUSED` nomeados para staging e
+sela duas credenciais internas cifradas. Não seleciona campanhas, conjuntos ou
 anúncios comerciais, nem torna o token Meta um binding do Worker.
 
 O workflow manual separado de prova candidata cria somente uma versão imutável
@@ -327,13 +331,17 @@ ou argv. A atestação é estritamente somente leitura; a seed é estritamente
 `staging`, ocorre antes da autenticação/derivação de configuração e possui
 rollback explícito antes de qualquer ativação quando o planejamento falha.
 `META_ADS_ACCESS_TOKEN` continua uma credencial externa de fonte: não é copiado
-de production nem inventado pelo fluxo. `META_ADS_PAGE_ID` deve ser escolhido
-na fonte Meta autorizada e gravado somente no Environment `staging`. No deploy
-governado de staging, ausência, formato inválido, relação não atribuída ou par
-Página/Instagram divergente interrompem o job antes de migrations, D1, seed ou
-tráfego. A API candidata mantém `page_id` opcional para compatibilidade com
-clientes governados existentes; não a invoque diretamente como substituta desse
-preflight.
+de production nem inventado pelo fluxo. Os seletores privados
+`novohamburgo_page_id` e `barrashopppingsul_page_id` devem ser escolhidos na
+fonte Meta autorizada e gravados somente no GitHub Environment `staging`, cada
+um para sua própria unidade e respectivo par Página+Instagram. No deploy
+governado de staging, os dois seletores são exigidos, devem ser numéricos e
+distintos; ausência, formato inválido, relação não atribuída ou par
+Página/Instagram divergente interrompem o preflight antes de migrations, D1,
+seed ou tráfego. Essa garantia é do preflight governado: uma chamada direta à
+API candidata não é substituta dele e não deve ser usada para inferir que uma
+falha de seletor ocorrerá antes de qualquer journal interno. A API candidata
+aceita somente o mapa completo `destination_page_ids` para as duas unidades.
 
 Antes da primeira promoção, disponibilize em cada GitHub Environment os
 segredos independentes exigidos pelo workflow, em especial

--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -176,7 +176,7 @@ const BOOTSTRAP_OPERATION_KEY_PATTERN = /^[A-Za-z0-9_.:-]{8,160}$/;
 const STAGING_EXERCISE_OPERATION_KEY_PATTERN = /^staging-tracking-fixture:[A-Za-z0-9_.:-]{8,120}$/;
 const STAGING_SYNTHETIC_SEED_OPERATION_KEY_PATTERN = /^meta-ads-staging-seed:[A-Za-z0-9_.:-]{8,140}$/;
 const STAGING_SYNTHETIC_SEED_MAX_REQUEST_BYTES = 16 * 1024;
-const STAGING_SYNTHETIC_SEED_CONTRACT = 'meta-ads-tracking-v20/staging-synthetic-seed/v1';
+const STAGING_SYNTHETIC_SEED_CONTRACT = 'meta-ads-tracking-v20/staging-synthetic-seed/v2';
 const STAGING_SYNTHETIC_SEED_ATTEST_MAX_GRAPH_ATTEMPTS = 1;
 const STAGING_SYNTHETIC_SEED_UNIT = 'meta-ads-tracking-staging-synthetic';
 const STAGING_SYNTHETIC_SEED_SOURCE_TOKEN_TYPE = 'staging_synthetic_source';
@@ -186,6 +186,25 @@ const STAGING_SYNTHETIC_SEED_MAX_GRAPH_OBJECTS = 5;
 const STAGING_SYNTHETIC_SEED_LANDING_GROUP = 'staging_tracking_fixture';
 const STAGING_SYNTHETIC_SEED_CREATIVE_MESSAGE = 'SKINCOS staging tracking verification';
 const STAGING_SYNTHETIC_SEED_CREATIVE_CTA = 'LEARN_MORE';
+// The staging seed has two independently governed Website destinations. Their
+// selectors are supplied only in the candidate request body, never as Worker
+// bindings. Keep the source/target seed lineage stable while assigning its
+// resulting configuration rows deterministically to the two destinations.
+const STAGING_SYNTHETIC_SEED_DESTINATIONS = Object.freeze([
+  Object.freeze({
+    key: 'novo_hamburgo',
+    credentialKey: 'source',
+    destinationGroup: 'meta-ads-tracking-staging-novo-hamburgo',
+  }),
+  Object.freeze({
+    key: 'barra_shopping_sul',
+    credentialKey: 'target',
+    destinationGroup: 'meta-ads-tracking-staging-barra-shopping-sul',
+  }),
+]);
+const STAGING_SYNTHETIC_SEED_DESTINATION_KEYS = new Set(
+  STAGING_SYNTHETIC_SEED_DESTINATIONS.map((destination) => destination.key),
+);
 // Meta's current Page API can return either the legacy ADVERTISE task or its
 // Profile Plus equivalent for the same narrow creative/advertising capability.
 // Do not broaden this to other PROFILE_PLUS_* tasks: the seed needs an
@@ -1515,7 +1534,7 @@ function assertStagingSyntheticSeedAttestationEnvironment(env) {
 
 async function readStagingSyntheticSeedInput(request) {
   const body = await readStagingSyntheticSeedBody(request, new Set([
-    'operation_key', 'access_token', 'account_id', 'pixel_id', 'page_id', 'api_version',
+    'operation_key', 'access_token', 'account_id', 'pixel_id', 'destination_page_ids', 'api_version',
   ]));
   const operationKey = clean(body.operation_key);
   if (!STAGING_SYNTHETIC_SEED_OPERATION_KEY_PATTERN.test(operationKey)) {
@@ -1527,9 +1546,7 @@ async function readStagingSyntheticSeedInput(request) {
     accessToken,
     accountId: normalizeStagingSyntheticSeedNumericId(body.account_id, 'account_id'),
     pixelId: normalizeStagingSyntheticSeedNumericId(body.pixel_id, 'pixel_id'),
-    pageId: Object.hasOwn(body, 'page_id')
-      ? normalizeStagingSyntheticSeedNumericId(body.page_id, 'page_id')
-      : '',
+    destinationPages: normalizeStagingSyntheticSeedDestinationPages(body.destination_page_ids),
     apiVersion: normalizeStagingSyntheticSeedApiVersion(body.api_version),
   };
 }
@@ -1578,6 +1595,30 @@ function normalizeStagingSyntheticSeedAccessToken(value) {
     throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_request_invalid', 400);
   }
   return token;
+}
+
+function normalizeStagingSyntheticSeedDestinationPages(value) {
+  if (!isJsonObject(value)) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_request_invalid', 400);
+  }
+  const keys = Object.keys(value);
+  if (
+    keys.length !== STAGING_SYNTHETIC_SEED_DESTINATIONS.length ||
+    keys.some((key) => !STAGING_SYNTHETIC_SEED_DESTINATION_KEYS.has(key))
+  ) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_request_invalid', 400);
+  }
+  const destinationPages = {};
+  for (const destination of STAGING_SYNTHETIC_SEED_DESTINATIONS) {
+    destinationPages[destination.key] = normalizeStagingSyntheticSeedNumericId(
+      value[destination.key],
+      `${destination.key}_page_id`,
+    );
+  }
+  if (new Set(Object.values(destinationPages)).size !== STAGING_SYNTHETIC_SEED_DESTINATIONS.length) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_request_invalid', 400);
+  }
+  return destinationPages;
 }
 
 function normalizeStagingSyntheticSeedNumericId(value, label) {
@@ -1815,7 +1856,7 @@ async function createInitialStagingSyntheticSeedState(input) {
       operation_key: input.operationKey,
       account_id: input.accountId,
       pixel_id: input.pixelId,
-      page_id: input.pageId || '',
+      destination_pages: { ...input.destinationPages },
       api_version: input.apiVersion,
     },
     marker,
@@ -1886,7 +1927,7 @@ async function stagingSyntheticSeedRequestHash(input) {
     operation_key: input.operationKey,
     account_id: input.accountId,
     pixel_id: input.pixelId || '',
-    page_id: input.pageId || '',
+    destination_pages: input.destinationPages,
     api_version: input.apiVersion,
   }));
 }
@@ -1936,11 +1977,18 @@ async function persistStagingSyntheticSeedState({ env, operation, state, status,
 
 function summarizeStagingSyntheticSeedState(state) {
   const resources = asObject(state?.resources);
+  const destinationFacts = asObject(asObject(state?.facts).destinations);
   return {
     contract: STAGING_SYNTHETIC_SEED_CONTRACT,
     phase: clean(state?.phase) || 'unknown',
     reconciliation_required: state?.reconciliation_required === true,
-    graph_facts_verified: Boolean(clean(asObject(state?.facts).page_id) && clean(asObject(state?.facts).dataset_id)),
+    graph_facts_verified:
+      clean(asObject(state?.facts).dataset_id) !== '' &&
+      STAGING_SYNTHETIC_SEED_DESTINATIONS.every((destination) => {
+        const facts = asObject(destinationFacts[destination.key]);
+        return Boolean(clean(facts.page_id) && clean(facts.instagram_user_id));
+      }),
+    destination_count: STAGING_SYNTHETIC_SEED_DESTINATIONS.length,
     campaign_created: Boolean(clean(asObject(resources.campaign).id)),
     adset_count: ['source_adset', 'target_adset'].filter((key) => clean(asObject(resources[key]).id)).length,
     creative_created: Boolean(clean(asObject(resources.source_creative).id)),
@@ -2127,115 +2175,99 @@ async function discoverStagingSyntheticSeedFacts({
     throw stagingSyntheticSeedFailure(failureCodes.identityMismatch, 409);
   }
 
+  // Both destination selectors are explicit staging facts. Prove each through
+  // the authenticated System User's own bounded assignment relation before a
+  // direct Page read. Never select by list order or fall back to user-centric
+  // `/me/accounts` discovery when the deployment has declared two units.
   const pageDiscoveryFields = 'id,tasks,instagram_business_account{id}';
-  let selectedPage;
-  if (input.pageId) {
-    // An explicit staging selector must be proved through the authenticated
-    // System User's own relation. Do not use a user-centric Page listing or
-    // choose by ordering when a selector is available.
-    const sourcePrincipal = await read(
-      'me',
-      'id',
-      {},
-      failureCodes.pageAccessDenied,
-      failureCodes.identityMalformed,
-    );
-    const sourcePrincipalId = normalizeStagingSyntheticSeedGraphId(
-      sourcePrincipal.id,
-      'source_principal_id',
-      failureCodes.identityMalformed,
-    );
-    const assignedPages = await read(
-      `${sourcePrincipalId}/assigned_pages`,
-      pageDiscoveryFields,
-      { limit: '100' },
-      failureCodes.pageAccessDenied,
-      failureCodes.identityMalformed,
-    );
-    if (!Array.isArray(assignedPages.data)) {
-      throw stagingSyntheticSeedFailure(failureCodes.identityMalformed, 409);
-    }
-    if (clean(asObject(assignedPages.paging).next)) {
-      throw stagingSyntheticSeedFailure(failureCodes.pageAmbiguous, 409);
-    }
-    selectedPage = selectStagingSyntheticSeedPage(
-      assignedPages.data,
-      input.pageId,
-      failureCodes,
-    );
-  } else {
-    const pages = await read(
-      'me/accounts',
-      pageDiscoveryFields,
-      { limit: '100' },
-      failureCodes.pageAccessDenied,
-    );
-    if (clean(asObject(pages.paging).next)) {
-      throw stagingSyntheticSeedFailure(failureCodes.pageAmbiguous, 409);
-    }
-    let pageCandidates = pages.data;
-    // `/me/accounts` is a user-token-centric Page discovery edge. A System
-    // User can have an explicitly assigned Page while this list is empty. Use
-    // the System User's own bounded relation only for that exact empty-list
-    // case; never mask a nonempty direct result that lacks the required task
-    // or IG relationship.
-    if (Array.isArray(pages.data) && pages.data.length === 0) {
-      const sourcePrincipal = await read(
-        'me',
-        'id',
-        {},
-        failureCodes.pageAccessDenied,
-        failureCodes.identityMalformed,
-      );
-      const sourcePrincipalId = normalizeStagingSyntheticSeedGraphId(
-        sourcePrincipal.id,
-        'source_principal_id',
-        failureCodes.identityMalformed,
-      );
-      const assignedPages = await read(
-        `${sourcePrincipalId}/assigned_pages`,
-        pageDiscoveryFields,
-        { limit: '100' },
-        failureCodes.pageAccessDenied,
-        failureCodes.identityMalformed,
-      );
-      if (!Array.isArray(assignedPages.data)) {
-        throw stagingSyntheticSeedFailure(failureCodes.identityMalformed, 409);
-      }
-      if (clean(asObject(assignedPages.paging).next)) {
-        throw stagingSyntheticSeedFailure(failureCodes.pageAmbiguous, 409);
-      }
-      pageCandidates = assignedPages.data;
-    }
-    selectedPage = selectStagingSyntheticSeedPage(pageCandidates, '', failureCodes);
-  }
-  const selectedPageId = normalizeStagingSyntheticSeedGraphId(selectedPage.id, 'page_id', failureCodes.identityMalformed);
-  const page = await read(
-    selectedPageId,
-    'id,instagram_business_account{id},website,picture{url}',
+  const sourcePrincipal = await read(
+    'me',
+    'id',
     {},
     failureCodes.pageAccessDenied,
-  );
-  const pageId = normalizeStagingSyntheticSeedGraphId(page.id, 'page_id', failureCodes.identityMalformed);
-  const instagramUserId = normalizeStagingSyntheticSeedGraphId(
-    asObject(page.instagram_business_account).id,
-    'instagram_user_id',
     failureCodes.identityMalformed,
   );
-  if (
-    pageId !== selectedPageId ||
-    instagramUserId !== normalizeStagingSyntheticSeedGraphId(
-      asObject(selectedPage.instagram_business_account).id,
-      'instagram_user_id',
-      failureCodes.identityMalformed,
-    )
-  ) {
-    throw stagingSyntheticSeedFailure(failureCodes.identityMismatch, 409);
+  const sourcePrincipalId = normalizeStagingSyntheticSeedGraphId(
+    sourcePrincipal.id,
+    'source_principal_id',
+    failureCodes.identityMalformed,
+  );
+  const assignedPages = await read(
+    `${sourcePrincipalId}/assigned_pages`,
+    pageDiscoveryFields,
+    { limit: '100' },
+    failureCodes.pageAccessDenied,
+    failureCodes.identityMalformed,
+  );
+  if (!Array.isArray(assignedPages.data)) {
+    throw stagingSyntheticSeedFailure(failureCodes.identityMalformed, 409);
   }
-  const landing = normalizeStagingSyntheticSeedLanding(page.website);
-  const pictureUrl = normalizeStagingSyntheticSeedPicture(page.picture);
-  if (!landing || !pictureUrl) {
-    throw stagingSyntheticSeedFailure(failureCodes.landingOrMediaUnavailable, 409);
+  if (clean(asObject(assignedPages.paging).next)) {
+    throw stagingSyntheticSeedFailure(failureCodes.pageAmbiguous, 409);
+  }
+  const selectedDestinations = [];
+  const seenPageIds = new Set();
+  const seenInstagramUserIds = new Set();
+  for (const destination of STAGING_SYNTHETIC_SEED_DESTINATIONS) {
+    const selectedPage = selectStagingSyntheticSeedPage(
+      assignedPages.data,
+      input.destinationPages[destination.key],
+      failureCodes,
+    );
+    const selectedPageId = normalizeStagingSyntheticSeedGraphId(
+      selectedPage.id,
+      `${destination.key}_page_id`,
+      failureCodes.identityMalformed,
+    );
+    const selectedInstagramUserId = normalizeStagingSyntheticSeedGraphId(
+      asObject(selectedPage.instagram_business_account).id,
+      `${destination.key}_instagram_user_id`,
+      failureCodes.identityMalformed,
+    );
+    if (seenPageIds.has(selectedPageId) || seenInstagramUserIds.has(selectedInstagramUserId)) {
+      throw stagingSyntheticSeedFailure(failureCodes.identityMismatch, 409);
+    }
+    seenPageIds.add(selectedPageId);
+    seenInstagramUserIds.add(selectedInstagramUserId);
+    selectedDestinations.push({
+      destination,
+      selectedPageId,
+      selectedInstagramUserId,
+    });
+  }
+  const destinations = {};
+  for (const { destination, selectedPageId, selectedInstagramUserId } of selectedDestinations) {
+    const page = await read(
+      selectedPageId,
+      'id,instagram_business_account{id},website,picture{url}',
+      {},
+      failureCodes.pageAccessDenied,
+    );
+    const pageId = normalizeStagingSyntheticSeedGraphId(
+      page.id,
+      `${destination.key}_page_id`,
+      failureCodes.identityMalformed,
+    );
+    const instagramUserId = normalizeStagingSyntheticSeedGraphId(
+      asObject(page.instagram_business_account).id,
+      `${destination.key}_instagram_user_id`,
+      failureCodes.identityMalformed,
+    );
+    if (pageId !== selectedPageId || instagramUserId !== selectedInstagramUserId) {
+      throw stagingSyntheticSeedFailure(failureCodes.identityMismatch, 409);
+    }
+    const landing = normalizeStagingSyntheticSeedLanding(page.website);
+    const pictureUrl = normalizeStagingSyntheticSeedPicture(page.picture);
+    if (!landing || !pictureUrl) {
+      throw stagingSyntheticSeedFailure(failureCodes.landingOrMediaUnavailable, 409);
+    }
+    destinations[destination.key] = {
+      page_id: pageId,
+      instagram_user_id: instagramUserId,
+      landing_url: landing.url,
+      landing_host: landing.host,
+      page_picture_url: pictureUrl,
+    };
   }
 
   const datasets = await read(
@@ -2253,11 +2285,7 @@ async function discoverStagingSyntheticSeedFacts({
     failureCodes.identityMalformed,
   );
   return {
-    page_id: pageId,
-    instagram_user_id: instagramUserId,
-    landing_url: landing.url,
-    landing_host: landing.host,
-    page_picture_url: pictureUrl,
+    destinations,
     dataset_id: datasetId,
   };
 }
@@ -2359,6 +2387,7 @@ async function createStagingSyntheticSeedResources({ input, auth, facts, operati
   state.phase = 'creating_resources';
   await persistStagingSyntheticSeedState({ env: context.env, operation, state, status: 'creating', encryptToken, context });
   const marker = stagingSyntheticSeedMarker(state);
+  const sourceDestinationFacts = stagingSyntheticSeedDestinationFacts(facts, 'source');
 
   const campaign = await createStagingSyntheticSeedGraphResource({
     key: 'campaign',
@@ -2439,15 +2468,15 @@ async function createStagingSyntheticSeedResources({ input, auth, facts, operati
     create: () => seedGraphCreate(auth, `act_${input.accountId}/adcreatives`, {
       name: `${marker} Source Creative`,
       object_story_spec: {
-        page_id: facts.page_id,
-        instagram_actor_id: facts.instagram_user_id,
+        page_id: sourceDestinationFacts.page_id,
+        instagram_actor_id: sourceDestinationFacts.instagram_user_id,
         link_data: {
-          link: facts.landing_url,
-          picture: facts.page_picture_url,
+          link: sourceDestinationFacts.landing_url,
+          picture: sourceDestinationFacts.page_picture_url,
           message: STAGING_SYNTHETIC_SEED_CREATIVE_MESSAGE,
           call_to_action: {
             type: STAGING_SYNTHETIC_SEED_CREATIVE_CTA,
-            value: { link: facts.landing_url },
+            value: { link: sourceDestinationFacts.landing_url },
           },
         },
       },
@@ -2478,6 +2507,31 @@ async function createStagingSyntheticSeedResources({ input, auth, facts, operati
 
 function stagingSyntheticSeedMarker(state) {
   return `[SKINCOS-STAGING-V20:${clean(state?.marker).slice(0, 24)}]`;
+}
+
+function stagingSyntheticSeedDestinationForCredential(credentialKey) {
+  const destination = STAGING_SYNTHETIC_SEED_DESTINATIONS.find((candidate) => candidate.credentialKey === credentialKey);
+  if (!destination) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+  return destination;
+}
+
+function stagingSyntheticSeedDestinationFacts(value, credentialKey) {
+  const destination = stagingSyntheticSeedDestinationForCredential(credentialKey);
+  const facts = asObject(asObject(value).destinations)[destination.key];
+  const normalized = asObject(facts);
+  const required = [
+    clean(normalized.page_id),
+    clean(normalized.instagram_user_id),
+    clean(normalized.landing_url),
+    clean(normalized.landing_host),
+    clean(normalized.page_picture_url),
+  ];
+  if (required.some((entry) => !entry)) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+  return normalized;
 }
 
 async function createStagingSyntheticSeedGraphResource({ key, name, operation, state, encryptToken, context, create, read }) {
@@ -2647,14 +2701,18 @@ async function readStagingSyntheticSeedAd(auth, adId, expectedAdsetId, expectedC
 async function sealStagingSyntheticSeedCredentials({ input, env, operation, state, encryptToken, requestId, context }) {
   const resources = asObject(state.resources);
   const facts = asObject(state.facts);
+  const sourceDestinationFacts = stagingSyntheticSeedDestinationFacts(facts, 'source');
+  const targetDestinationFacts = stagingSyntheticSeedDestinationFacts(facts, 'target');
   const required = [
     clean(asObject(resources.campaign).id),
     clean(asObject(resources.source_adset).id),
     clean(asObject(resources.target_adset).id),
     clean(asObject(resources.source_creative).id),
     clean(asObject(resources.source_ad).id),
-    clean(facts.page_id),
-    clean(facts.instagram_user_id),
+    clean(sourceDestinationFacts.page_id),
+    clean(sourceDestinationFacts.instagram_user_id),
+    clean(targetDestinationFacts.page_id),
+    clean(targetDestinationFacts.instagram_user_id),
     clean(facts.dataset_id),
   ];
   if (required.some((value) => !/^\d{5,30}$/.test(value))) {
@@ -2755,31 +2813,35 @@ async function sealStagingSyntheticSeedCredentials({ input, env, operation, stat
 function buildStagingSyntheticSeedCredentialMetadata({ input, state }) {
   const facts = asObject(state.facts);
   const resources = asObject(state.resources);
-  const common = {
-    destination_group: STAGING_SYNTHETIC_SEED_UNIT,
-    api_version: input.apiVersion,
-    account_id: input.accountId,
-    campaign_id: clean(asObject(resources.campaign).id),
-    page_id: clean(facts.page_id),
-    instagram_user_id: clean(facts.instagram_user_id),
-    allowed_link_hosts: [clean(facts.landing_host)],
-    landing_pages_by_creative_group: { [STAGING_SYNTHETIC_SEED_LANDING_GROUP]: clean(facts.landing_url) },
-    freshness_window_days: 7,
-    destination_type: 'website',
-    fixture_source_ad_id: clean(asObject(resources.source_ad).id),
-    url_tags: normalizeUrlTags(state.url_tags, { required: true }),
+  const common = (credentialKey) => {
+    const destination = stagingSyntheticSeedDestinationForCredential(credentialKey);
+    const destinationFacts = stagingSyntheticSeedDestinationFacts(facts, credentialKey);
+    return {
+      destination_group: destination.destinationGroup,
+      api_version: input.apiVersion,
+      account_id: input.accountId,
+      campaign_id: clean(asObject(resources.campaign).id),
+      page_id: clean(destinationFacts.page_id),
+      instagram_user_id: clean(destinationFacts.instagram_user_id),
+      allowed_link_hosts: [clean(destinationFacts.landing_host)],
+      landing_pages_by_creative_group: { [STAGING_SYNTHETIC_SEED_LANDING_GROUP]: clean(destinationFacts.landing_url) },
+      freshness_window_days: 7,
+      destination_type: 'website',
+      fixture_source_ad_id: clean(asObject(resources.source_ad).id),
+      url_tags: normalizeUrlTags(state.url_tags, { required: true }),
+    };
   };
   return {
     source: {
       meta_ads_publish: {
-        ...common,
+        ...common('source'),
         adset_id: clean(asObject(resources.source_adset).id),
         source_adset_id: clean(asObject(resources.source_adset).id),
       },
     },
     target: {
       meta_ads_publish: {
-        ...common,
+        ...common('target'),
         adset_id: clean(asObject(resources.target_adset).id),
         source_config_token_id: clean(state.credential_ids.source),
       },

--- a/platform/security/token-vault/tests/deploy-token-vault-staging-synthetic-seed-workflow.test.js
+++ b/platform/security/token-vault/tests/deploy-token-vault-staging-synthetic-seed-workflow.test.js
@@ -73,17 +73,29 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
   assert.match(upload, /TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN = seedToken/);
   assert.doesNotMatch(
     upload,
-    /META_ADS_ACCESS_TOKEN|META_PIXEL_ID|META_ADS_PAGE_ID|META_ADS_ACCOUNT_ID|META_ADS_API_VERSION/,
+    /META_ADS_ACCESS_TOKEN|META_PIXEL_ID|META_ADS_NOVOHAMBURGO_PAGE_ID|META_ADS_BARRASHOPPPINGSUL_PAGE_ID|META_ADS_ACCOUNT_ID|META_ADS_API_VERSION/,
   );
   assert.doesNotMatch(workflow, /\bwrangler\s+secret\s+put\b/i);
 
   assert.match(
     authorization,
-    /META_ADS_PAGE_ID: \$\{\{ inputs\.target == 'staging' && secrets\.META_ADS_PAGE_ID \|\| '' \}\}/,
+    /META_ADS_NOVOHAMBURGO_PAGE_ID: \$\{\{ inputs\.target == 'staging' && secrets\.novohamburgo_page_id \|\| '' \}\}/,
   );
   assert.match(
     authorization,
-    /META_ADS_PAGE_ID must be a numeric staging Environment secret for the governed staging seed/,
+    /META_ADS_BARRASHOPPPINGSUL_PAGE_ID: \$\{\{ inputs\.target == 'staging' && secrets\.barrashopppingsul_page_id \|\| '' \}\}/,
+  );
+  assert.match(
+    authorization,
+    /Novo Hamburgo Page selector must be a numeric staging Environment secret for the governed staging seed/,
+  );
+  assert.match(
+    authorization,
+    /Barra Shopping Sul Page selector must be a numeric staging Environment secret for the governed staging seed/,
+  );
+  assert.match(
+    authorization,
+    /META_ADS_NOVOHAMBURGO_PAGE_ID" != "\$META_ADS_BARRASHOPPPINGSUL_PAGE_ID/,
   );
   assert.match(
     authorization,
@@ -106,7 +118,8 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
   for (const sourceName of [
     "META_ADS_ACCESS_TOKEN",
     "META_PIXEL_ID",
-    "META_ADS_PAGE_ID",
+    "META_ADS_NOVOHAMBURGO_PAGE_ID",
+    "META_ADS_BARRASHOPPPINGSUL_PAGE_ID",
     "META_ADS_ACCOUNT_ID",
     "META_ADS_API_VERSION",
   ]) {
@@ -123,10 +136,14 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
   );
   assert.match(
     attestation,
-    /operation_key: operationKey,[\s\S]*access_token: accessToken,[\s\S]*account_id: accountId,[\s\S]*pixel_id: pixelId,[\s\S]*page_id: pageId,[\s\S]*api_version: apiVersion/,
+    /operation_key: operationKey,[\s\S]*access_token: accessToken,[\s\S]*account_id: accountId,[\s\S]*pixel_id: pixelId,[\s\S]*destination_page_ids: destinationPageIds,[\s\S]*api_version: apiVersion/,
+  );
+  assert.match(
+    attestation,
+    /destinationPageIds\.novo_hamburgo === destinationPageIds\.barra_shopping_sul/,
   );
   assert.match(attestation, /attestation \|\| ''\) === 'match'/);
-  assert.match(attestation, /meta-ads-tracking-v20\/staging-synthetic-seed\/v1/);
+  assert.match(attestation, /meta-ads-tracking-v20\/staging-synthetic-seed\/v2/);
   assert.match(attestation, /AbortSignal\.timeout\(30_000\)/);
   assert.doesNotMatch(attestation, /GITHUB_OUTPUT|console\.log|process\.stdout\.write/);
 
@@ -139,7 +156,8 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
     /META_ADS_ACCESS_TOKEN: \$\{\{ inputs\.target == 'staging'/,
   );
   assert.match(seed, /META_PIXEL_ID: \$\{\{ inputs\.target == 'staging'/);
-  assert.match(seed, /META_ADS_PAGE_ID: \$\{\{ inputs\.target == 'staging'/);
+  assert.match(seed, /META_ADS_NOVOHAMBURGO_PAGE_ID: \$\{\{ inputs\.target == 'staging'/);
+  assert.match(seed, /META_ADS_BARRASHOPPPINGSUL_PAGE_ID: \$\{\{ inputs\.target == 'staging'/);
   assert.match(seed, /META_ADS_ACCOUNT_ID: \$\{\{ inputs\.target == 'staging'/);
   assert.match(
     seed,
@@ -153,9 +171,13 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
   assert.doesNotMatch(seed, /TOKEN_VAULT_STAGING_BASE_URL/);
   assert.match(
     seed,
-    /operation_key: operationKey,[\s\S]*access_token: accessToken,[\s\S]*account_id: accountId,[\s\S]*pixel_id: pixelId,[\s\S]*page_id: pageId,[\s\S]*api_version: apiVersion/,
+    /operation_key: operationKey,[\s\S]*access_token: accessToken,[\s\S]*account_id: accountId,[\s\S]*pixel_id: pixelId,[\s\S]*destination_page_ids: destinationPageIds,[\s\S]*api_version: apiVersion/,
   );
-  assert.match(seed, /meta-ads-tracking-v20\/staging-synthetic-seed\/v1/);
+  assert.match(
+    seed,
+    /destinationPageIds\.novo_hamburgo === destinationPageIds\.barra_shopping_sul/,
+  );
+  assert.match(seed, /meta-ads-tracking-v20\/staging-synthetic-seed\/v2/);
   assert.match(seed, /\^v\(\?:2\[5-9\]\|\[3-9\]\[0-9\]\)\\\.0\$/);
   assert.match(
     seed,
@@ -240,14 +262,17 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
       /fetch\(`\$\{preview\}\/internal\/token-vault\/v1\/meta-ads-publish\/config\/staging-synthetic-seed\/rollback`/,
     );
     assert.doesNotMatch(rollback, /TOKEN_VAULT_STAGING_BASE_URL/);
-    assert.doesNotMatch(rollback, /META_ADS_PAGE_ID|page_id/);
+    assert.doesNotMatch(
+      rollback,
+      /META_ADS_NOVOHAMBURGO_PAGE_ID|META_ADS_BARRASHOPPPINGSUL_PAGE_ID|destination_page_ids|page_id/,
+    );
     assert.match(rollback, /staging-synthetic-seed\/rollback/);
     assert.match(
       rollback,
       /operation_key: operationKey,[\s\S]*access_token: accessToken,[\s\S]*account_id: accountId,[\s\S]*api_version: apiVersion/,
     );
     assert.match(rollback, /payload\?\.rolled_back !== true/);
-    assert.match(rollback, /meta-ads-tracking-v20\/staging-synthetic-seed\/v1/);
+    assert.match(rollback, /meta-ads-tracking-v20\/staging-synthetic-seed\/v2/);
     assert.match(rollback, /\^v\(\?:2\[5-9\]\|\[3-9\]\[0-9\]\)\\\.0\$/);
   }
   for (const rollback of [pretrafficRollback, activationLeaseRollback]) {
@@ -265,13 +290,16 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
   for (const sourceName of [
     "META_ADS_ACCESS_TOKEN",
     "META_PIXEL_ID",
-    "META_ADS_PAGE_ID",
+    "META_ADS_NOVOHAMBURGO_PAGE_ID",
+    "META_ADS_BARRASHOPPPINGSUL_PAGE_ID",
     "META_ADS_ACCOUNT_ID",
     "META_ADS_API_VERSION",
   ]) {
     const total = [...workflow.matchAll(new RegExp(sourceName, "g"))].length;
     const allowedScopes =
-      sourceName === "META_ADS_API_VERSION" || sourceName === "META_ADS_PAGE_ID"
+      sourceName === "META_ADS_API_VERSION" ||
+      sourceName === "META_ADS_NOVOHAMBURGO_PAGE_ID" ||
+      sourceName === "META_ADS_BARRASHOPPPINGSUL_PAGE_ID"
         ? [...sourceScopes, authorization]
         : sourceScopes;
     const scoped = allowedScopes.reduce(
@@ -290,4 +318,5 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
     /\$RUNNER_TEMP"\/token-vault-staging-synthetic-seed-\*/,
   );
   assert.match(cleanup, /rm -f -- "\$seed_file"/);
+  assert.doesNotMatch(workflow, /META_ADS_PAGE_ID|page_id: pageId/);
 });

--- a/platform/security/token-vault/tests/index.test.js
+++ b/platform/security/token-vault/tests/index.test.js
@@ -336,6 +336,10 @@ test('Meta Ads staging seed bearer dispatches the candidate proof route without 
         access_token: 'unit-test-source-access-token-not-a-real-secret',
         account_id: '17841400000000001',
         pixel_id: '99444000000000001',
+        destination_page_ids: {
+          novo_hamburgo: '12000000000000001',
+          barra_shopping_sul: '12000000000000003',
+        },
         api_version: 'v25.0',
       }),
     }),
@@ -345,6 +349,8 @@ test('Meta Ads staging seed bearer dispatches the candidate proof route without 
   assert.equal(response.status, 409);
   assert.equal(body.error, 'meta_ads_publish_staging_seed_graph_appsecret_proof_unavailable');
   assert.equal(JSON.stringify(body).includes('unit-test-source-access-token-not-a-real-secret'), false);
+  assert.equal(JSON.stringify(body).includes('12000000000000001'), false);
+  assert.equal(JSON.stringify(body).includes('12000000000000003'), false);
   assert.equal(db.tokens.length, 0);
 });
 

--- a/platform/security/token-vault/tests/meta-ads-candidate-appsecret-proof-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-candidate-appsecret-proof-workflow.test.js
@@ -55,7 +55,10 @@ test("candidate appsecret-proof workflow uploads exactly one non-promoted candid
     workflow.indexOf('SEED_FILE="$seed_file" SECRETS_FILE="$secrets_file"'),
     workflow.indexOf('chmod 600 "$secrets_file"'),
   );
-  assert.doesNotMatch(privateSecretsFileWriter, /META_ADS_PAGE_ID|pageId/);
+  assert.doesNotMatch(
+    privateSecretsFileWriter,
+    /META_ADS_NOVOHAMBURGO_PAGE_ID|META_ADS_BARRASHOPPPINGSUL_PAGE_ID|destinationPageIds|pageId/,
+  );
   assert.match(
     workflow,
     /upload_output="\$\(npx --yes wrangler@4\.120\.0 versions upload/,
@@ -100,9 +103,23 @@ test("candidate appsecret-proof request keeps source inputs and bearer private w
   assert.match(workflow, /access_token: sourceToken/);
   assert.match(workflow, /account_id: accountId/);
   assert.match(workflow, /pixel_id: pixelId/);
-  assert.match(workflow, /META_ADS_PAGE_ID: \$\{\{ secrets\.META_ADS_PAGE_ID \}\}/);
-  assert.match(workflow, /const pageId = String\(process\.env\.META_ADS_PAGE_ID \|\| ''\)\.trim\(\)/);
-  assert.match(workflow, /page_id: pageId/);
+  assert.match(
+    workflow,
+    /META_ADS_NOVOHAMBURGO_PAGE_ID: \$\{\{ secrets\.novohamburgo_page_id \}\}/,
+  );
+  assert.match(
+    workflow,
+    /META_ADS_BARRASHOPPPINGSUL_PAGE_ID: \$\{\{ secrets\.barrashopppingsul_page_id \}\}/,
+  );
+  assert.match(
+    workflow,
+    /const destinationPageIds = \{[\s\S]*novo_hamburgo: String\(process\.env\.META_ADS_NOVOHAMBURGO_PAGE_ID \|\| ''\)\.trim\(\),[\s\S]*barra_shopping_sul: String\(process\.env\.META_ADS_BARRASHOPPPINGSUL_PAGE_ID \|\| ''\)\.trim\(\),/,
+  );
+  assert.match(
+    workflow,
+    /destinationPageIds\.novo_hamburgo === destinationPageIds\.barra_shopping_sul/,
+  );
+  assert.match(workflow, /destination_page_ids: destinationPageIds/);
   assert.match(workflow, /api_version: apiVersion/);
   assert.match(
     workflow,
@@ -114,11 +131,16 @@ test("candidate appsecret-proof request keeps source inputs and bearer private w
   );
   assert.match(
     workflow,
+    /payload\?\.contract_version === 'meta-ads-tracking-v20\/staging-synthetic-seed\/v2'/,
+  );
+  assert.match(
+    workflow,
     /candidate appsecret-proof attestation failed: \$\{response\.status\} \$\{error\}/,
   );
   assert.doesNotMatch(
     workflow,
-    /process\.stdout\.write\([^\n]*(?:seedToken|sourceToken|pixelId|pageId|accountId|preview)/,
+    /process\.stdout\.write\([^\n]*(?:seedToken|sourceToken|pixelId|destinationPageIds|pageId|accountId|preview)/,
   );
+  assert.doesNotMatch(workflow, /META_ADS_PAGE_ID|page_id:/);
   assert.doesNotMatch(workflow, /operation_key=.*GITHUB_OUTPUT/);
 });

--- a/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
@@ -11,6 +11,12 @@ const ACCOUNT_ID = '17841400000000001';
 const PIXEL_ID = '99444000000000001';
 const PAGE_ID = '12000000000000001';
 const INSTAGRAM_ID = '17841400000000002';
+const BARRA_SHOPPING_SUL_PAGE_ID = '12000000000000003';
+const BARRA_SHOPPING_SUL_INSTAGRAM_ID = '17841400000000004';
+const DESTINATION_PAGE_IDS = Object.freeze({
+  novo_hamburgo: PAGE_ID,
+  barra_shopping_sul: BARRA_SHOPPING_SUL_PAGE_ID,
+});
 const DATASET_ID = '19944000000000001';
 const SYSTEM_USER_ID = '15500000000000001';
 const SOURCE_ACCESS_TOKEN = 'unit-test-source-access-token-not-a-real-secret';
@@ -348,6 +354,21 @@ class FakeGraph {
     if (path === `act_${ACCOUNT_ID}/adspixels`) {
       return graphResponse({ data: [{ id: PIXEL_ID }] });
     }
+    if (path === 'me') {
+      return graphResponse({ id: SYSTEM_USER_ID });
+    }
+    if (path === `${SYSTEM_USER_ID}/assigned_pages`) {
+      return graphResponse({
+        data: [
+          { id: PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
+          {
+            id: BARRA_SHOPPING_SUL_PAGE_ID,
+            tasks: ['PROFILE_PLUS_ADVERTISE'],
+            instagram_business_account: { id: BARRA_SHOPPING_SUL_INSTAGRAM_ID },
+          },
+        ],
+      });
+    }
     if (path === 'me/accounts') {
       return graphResponse({ data: [{ id: PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } }] });
     }
@@ -357,6 +378,14 @@ class FakeGraph {
         instagram_business_account: { id: INSTAGRAM_ID },
         website: 'https://staging.example.invalid/tracking-fixture',
         picture: { data: { url: 'https://cdn.example.invalid/staging-fixture.jpg' } },
+      });
+    }
+    if (path === BARRA_SHOPPING_SUL_PAGE_ID) {
+      return graphResponse({
+        id: BARRA_SHOPPING_SUL_PAGE_ID,
+        instagram_business_account: { id: BARRA_SHOPPING_SUL_INSTAGRAM_ID },
+        website: 'https://staging-barra.example.invalid/tracking-fixture',
+        picture: { data: { url: 'https://cdn.example.invalid/staging-barra-fixture.jpg' } },
       });
     }
     if (path === `act_${ACCOUNT_ID}/offline_conversion_data_sets`) {
@@ -455,6 +484,7 @@ function request(operationKey, overrides = {}) {
       access_token: SOURCE_ACCESS_TOKEN,
       account_id: ACCOUNT_ID,
       pixel_id: PIXEL_ID,
+      destination_page_ids: DESTINATION_PAGE_IDS,
       api_version: 'v25.0',
       ...overrides,
     }),
@@ -489,6 +519,7 @@ function attestRequest(operationKey, overrides = {}) {
       access_token: SOURCE_ACCESS_TOKEN,
       account_id: ACCOUNT_ID,
       pixel_id: PIXEL_ID,
+      destination_page_ids: DESTINATION_PAGE_IDS,
       api_version: 'v25.0',
       ...overrides,
     }),
@@ -512,6 +543,7 @@ function appSecretProofAttestRequest(operationKey, overrides = {}) {
       access_token: SOURCE_ACCESS_TOKEN,
       account_id: ACCOUNT_ID,
       pixel_id: PIXEL_ID,
+      destination_page_ids: DESTINATION_PAGE_IDS,
       api_version: 'v25.0',
       ...overrides,
     }),
@@ -553,7 +585,7 @@ async function rollback({ db, graph, operationKey, env = {} }) {
 
 async function pendingSeedState(operationKey) {
   return {
-    contract: 'meta-ads-tracking-v20/staging-synthetic-seed/v1',
+    contract: 'meta-ads-tracking-v20/staging-synthetic-seed/v2',
     phase: 'pending',
     reconciliation_required: false,
     input: {
@@ -637,10 +669,10 @@ test('staging seed attestation bounds Graph discovery and returns no source fact
     ok: true,
     attestation: 'match',
     operation_key: operationKey,
-    contract_version: 'meta-ads-tracking-v20/staging-synthetic-seed/v1',
+    contract_version: 'meta-ads-tracking-v20/staging-synthetic-seed/v2',
     requestId: 'seed-attestation-test-request-id',
   });
-  assert.equal(graph.calls.length, 5);
+  assert.equal(graph.calls.length, 7);
   assert.ok(graph.calls.every((call) => call.method === 'GET'));
   assert.equal(graph.postCalls.length, 0);
   assert.equal(db.operations.size, 0);
@@ -648,83 +680,32 @@ test('staging seed attestation bounds Graph discovery and returns no source fact
   assert.equal(db.locks.size, 0);
   assert.equal(db.adsetLocks.size, 0);
   const serialized = JSON.stringify(body);
-  for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID]) {
+  for (const value of [
+    SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID,
+    BARRA_SHOPPING_SUL_PAGE_ID, BARRA_SHOPPING_SUL_INSTAGRAM_ID, DATASET_ID,
+  ]) {
     assert.equal(serialized.includes(value), false);
   }
 });
 
-test('staging seed attestation falls back to one explicit System User Page only after an empty direct Page list', async () => {
+test('staging seed attestation proves two explicitly selected System User Page and Instagram pairs before any mutation', async () => {
   const db = new SeedDb();
   db.prepare = () => {
-    throw new Error('D1 must remain untouched by System User Page discovery');
-  };
-  const graph = new FakeGraph({
-    readResponses: {
-      'me/accounts': { body: { data: [] } },
-      me: { body: { id: SYSTEM_USER_ID } },
-      [`${SYSTEM_USER_ID}/assigned_pages`]: {
-        body: {
-          data: [{
-            id: PAGE_ID,
-            tasks: ['ADVERTISE'],
-            instagram_business_account: { id: INSTAGRAM_ID },
-          }],
-        },
-      },
-    },
-  });
-  const response = await attest({
-    db,
-    graph,
-    operationKey: 'meta-ads-staging-seed:attestation-system-user-page-001',
-  });
-  const body = await response.json();
-
-  assert.equal(response.status, 200);
-  assert.equal(body.attestation, 'match');
-  assert.deepEqual(graph.calls.map((call) => call.path), [
-    PIXEL_ID,
-    `act_${ACCOUNT_ID}/adspixels`,
-    'me/accounts',
-    'me',
-    `${SYSTEM_USER_ID}/assigned_pages`,
-    PAGE_ID,
-    `act_${ACCOUNT_ID}/offline_conversion_data_sets`,
-  ]);
-  assert.ok(graph.calls.every((call) => call.method === 'GET'));
-  assert.equal(graph.postCalls.length, 0);
-  assert.equal(db.operations.size, 0);
-  assert.equal(db.tokens.length, 0);
-  assert.equal(db.locks.size, 0);
-  assert.equal(db.adsetLocks.size, 0);
-  const serialized = JSON.stringify(body);
-  for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID, SYSTEM_USER_ID]) {
-    assert.equal(serialized.includes(value), false);
-  }
-});
-
-test('staging seed attestation proves only the exact configured System User Page before Page or dataset reads', async () => {
-  const db = new SeedDb();
-  db.prepare = () => {
-    throw new Error('D1 must remain untouched by configured Page attestation');
+    throw new Error('D1 must remain untouched by two-destination source attestation');
   };
   const alternatePageId = '12000000000000009';
   const alternateInstagramId = '17841400000000009';
   const graph = new FakeGraph({
     readResponses: {
-      me: { body: { id: SYSTEM_USER_ID } },
       [`${SYSTEM_USER_ID}/assigned_pages`]: {
         body: {
           data: [
+            { id: alternatePageId, tasks: ['ADVERTISE'], instagram_business_account: { id: alternateInstagramId } },
+            { id: PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
             {
-              id: alternatePageId,
-              tasks: ['ADVERTISE'],
-              instagram_business_account: { id: alternateInstagramId },
-            },
-            {
-              id: PAGE_ID,
+              id: BARRA_SHOPPING_SUL_PAGE_ID,
               tasks: ['PROFILE_PLUS_ADVERTISE'],
-              instagram_business_account: { id: INSTAGRAM_ID },
+              instagram_business_account: { id: BARRA_SHOPPING_SUL_INSTAGRAM_ID },
             },
           ],
         },
@@ -734,8 +715,7 @@ test('staging seed attestation proves only the exact configured System User Page
   const response = await attest({
     db,
     graph,
-    operationKey: 'meta-ads-staging-seed:attestation-configured-page-001',
-    requestOverrides: { page_id: PAGE_ID },
+    operationKey: 'meta-ads-staging-seed:attestation-two-destination-pages-001',
   });
   const body = await response.json();
 
@@ -747,6 +727,7 @@ test('staging seed attestation proves only the exact configured System User Page
     'me',
     `${SYSTEM_USER_ID}/assigned_pages`,
     PAGE_ID,
+    BARRA_SHOPPING_SUL_PAGE_ID,
     `act_${ACCOUNT_ID}/offline_conversion_data_sets`,
   ]);
   assert.ok(graph.calls.every((call) => call.method === 'GET'));
@@ -756,171 +737,114 @@ test('staging seed attestation proves only the exact configured System User Page
   assert.equal(db.locks.size, 0);
   assert.equal(db.adsetLocks.size, 0);
   const serialized = JSON.stringify(body);
-  for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, alternatePageId, alternateInstagramId, DATASET_ID, SYSTEM_USER_ID]) {
+  for (const value of [
+    SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID,
+    BARRA_SHOPPING_SUL_PAGE_ID, BARRA_SHOPPING_SUL_INSTAGRAM_ID,
+    alternatePageId, alternateInstagramId, DATASET_ID, SYSTEM_USER_ID,
+  ]) {
     assert.equal(serialized.includes(value), false);
   }
 });
 
-test('staging seed attestation rejects a configured Page selector before Page, dataset, D1, or Graph mutation', async () => {
-  const db = new SeedDb();
-  db.prepare = () => {
-    throw new Error('D1 must remain untouched by configured Page attestation');
-  };
-  const graph = new FakeGraph({
-    readResponses: {
-      me: { body: { id: SYSTEM_USER_ID } },
-      [`${SYSTEM_USER_ID}/assigned_pages`]: {
-        body: {
-          data: [{
-            id: PAGE_ID,
-            tasks: ['ADVERTISE'],
-            instagram_business_account: { id: INSTAGRAM_ID },
-          }],
-        },
-      },
-    },
-  });
-  const configuredPageId = '12000000000000009';
-  const response = await attest({
-    db,
-    graph,
-    operationKey: 'meta-ads-staging-seed:attestation-configured-page-mismatch-001',
-    requestOverrides: { page_id: configuredPageId },
-  });
-  const body = await response.json();
-
-  assert.equal(response.status, 409);
-  assert.equal(body.error, 'meta_ads_publish_staging_seed_graph_page_ambiguous');
-  assert.deepEqual(graph.calls.map((call) => call.path), [
-    PIXEL_ID,
-    `act_${ACCOUNT_ID}/adspixels`,
-    'me',
-    `${SYSTEM_USER_ID}/assigned_pages`,
-  ]);
-  assert.equal(graph.postCalls.length, 0);
-  assert.equal(db.operations.size, 0);
-  assert.equal(db.tokens.length, 0);
-  assert.equal(db.locks.size, 0);
-  assert.equal(db.adsetLocks.size, 0);
-  const serialized = JSON.stringify(body);
-  for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, configuredPageId, DATASET_ID, SYSTEM_USER_ID]) {
-    assert.equal(serialized.includes(value), false);
-  }
-});
-
-test('staging seed attestation rejects duplicate or paged configured Page membership before it reads a Page', async () => {
+test('staging seed rejects missing, malformed, or duplicate destination selectors before it creates a mutation journal', async () => {
   const cases = [
-    {
-      label: 'duplicate',
-      payload: {
-        data: [
-          { id: PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
-          { id: PAGE_ID, tasks: ['PROFILE_PLUS_ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
-        ],
-      },
-    },
-    {
-      label: 'paged',
-      payload: {
-        data: [{ id: PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } }],
-        paging: { next: false },
-      },
-    },
+    { label: 'missing', value: undefined },
+    { label: 'malformed', value: { ...DESTINATION_PAGE_IDS, barra_shopping_sul: 'not-a-page-id' } },
+    { label: 'duplicate', value: { novo_hamburgo: PAGE_ID, barra_shopping_sul: PAGE_ID } },
   ];
   for (const entry of cases) {
     const db = new SeedDb();
-    db.prepare = () => {
-      throw new Error('D1 must remain untouched by configured Page attestation');
-    };
-    const graph = new FakeGraph({
-      readResponses: {
-        me: { body: { id: SYSTEM_USER_ID } },
-        [`${SYSTEM_USER_ID}/assigned_pages`]: { body: entry.payload },
-      },
-    });
-    const response = await attest({
+    const graph = new FakeGraph();
+    const response = await seed({
       db,
       graph,
-      operationKey: `meta-ads-staging-seed:attestation-configured-page-${entry.label}-001`,
-      requestOverrides: { page_id: PAGE_ID },
+      operationKey: `meta-ads-staging-seed:destination-selector-${entry.label}-001`,
+      requestOverrides: entry.value === undefined
+        ? { destination_page_ids: undefined }
+        : { destination_page_ids: entry.value },
     });
     const body = await response.json();
 
-    assert.equal(response.status, 409, entry.label);
-    assert.equal(body.error, 'meta_ads_publish_staging_seed_graph_page_ambiguous', entry.label);
-    assert.deepEqual(graph.calls.map((call) => call.path), [
-      PIXEL_ID,
-      `act_${ACCOUNT_ID}/adspixels`,
-      'me',
-      `${SYSTEM_USER_ID}/assigned_pages`,
-    ], entry.label);
+    assert.equal(response.status, 400, entry.label);
+    assert.equal(body.error, 'meta_ads_publish_staging_seed_request_invalid', entry.label);
+    assert.equal(graph.calls.length, 0, entry.label);
     assert.equal(graph.postCalls.length, 0, entry.label);
     assert.equal(db.operations.size, 0, entry.label);
     assert.equal(db.tokens.length, 0, entry.label);
-    assert.equal(db.locks.size, 0, entry.label);
-    assert.equal(db.adsetLocks.size, 0, entry.label);
-    const serialized = JSON.stringify(body);
-    for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID, SYSTEM_USER_ID]) {
-      assert.equal(serialized.includes(value), false, entry.label);
-    }
+    assert.equal(JSON.stringify(body).includes('not-a-page-id'), false, entry.label);
   }
 });
 
-test('staging seed rejects a malformed configured Page selector before it creates a mutation journal', async () => {
-  const db = new SeedDb();
-  const graph = new FakeGraph();
-  const response = await seed({
-    db,
-    graph,
-    operationKey: 'meta-ads-staging-seed:configured-page-invalid-001',
-    requestOverrides: { page_id: 'not-a-page-id' },
-  });
-  const body = await response.json();
-
-  assert.equal(response.status, 400);
-  assert.equal(body.error, 'meta_ads_publish_staging_seed_request_invalid');
-  assert.equal(graph.calls.length, 0);
-  assert.equal(graph.postCalls.length, 0);
-  assert.equal(db.operations.size, 0);
-  assert.equal(db.tokens.length, 0);
-  assert.equal(JSON.stringify(body).includes('not-a-page-id'), false);
-});
-
-test('staging seed attestation rejects malformed or nonunique System User Page assignments before Page or dataset reads', async () => {
+test('staging seed attestation rejects ambiguous, malformed, or unassigned destination Page pairs before Page or dataset reads', async () => {
   const cases = [
+    {
+      label: 'unassigned',
+      payload: { data: [{ id: PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } }] },
+      expectedError: 'meta_ads_publish_staging_seed_graph_page_ambiguous',
+    },
+    {
+      label: 'target-task-missing',
+      payload: {
+        data: [
+          { id: PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
+          {
+            id: BARRA_SHOPPING_SUL_PAGE_ID,
+            tasks: ['PROFILE_PLUS_READ'],
+            instagram_business_account: { id: BARRA_SHOPPING_SUL_INSTAGRAM_ID },
+          },
+        ],
+      },
+      expectedError: 'meta_ads_publish_staging_seed_graph_page_ambiguous',
+    },
+    {
+      label: 'target-instagram-missing',
+      payload: {
+        data: [
+          { id: PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
+          { id: BARRA_SHOPPING_SUL_PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: {} },
+        ],
+      },
+      expectedError: 'meta_ads_publish_staging_seed_graph_page_ambiguous',
+    },
+    {
+      label: 'duplicate-instagram',
+      payload: {
+        data: [
+          { id: PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
+          { id: BARRA_SHOPPING_SUL_PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
+        ],
+      },
+      expectedError: 'meta_ads_publish_staging_seed_graph_identity_mismatch',
+    },
     {
       label: 'malformed',
       payload: { data: false },
       expectedError: 'meta_ads_publish_staging_seed_graph_identity_malformed',
     },
     {
-      label: 'multiple',
+      label: 'paged',
       payload: {
         data: [
           { id: PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
-          { id: MISMATCH_ACCOUNT_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
+          { id: BARRA_SHOPPING_SUL_PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: BARRA_SHOPPING_SUL_INSTAGRAM_ID } },
         ],
+        paging: { next: false },
       },
       expectedError: 'meta_ads_publish_staging_seed_graph_page_ambiguous',
     },
   ];
-
   for (const entry of cases) {
     const db = new SeedDb();
     db.prepare = () => {
-      throw new Error('D1 must remain untouched by System User Page discovery');
+      throw new Error('D1 must remain untouched by destination Page attestation');
     };
     const graph = new FakeGraph({
-      readResponses: {
-        'me/accounts': { body: { data: [] } },
-        me: { body: { id: SYSTEM_USER_ID } },
-        [`${SYSTEM_USER_ID}/assigned_pages`]: { body: entry.payload },
-      },
+      readResponses: { [`${SYSTEM_USER_ID}/assigned_pages`]: { body: entry.payload } },
     });
     const response = await attest({
       db,
       graph,
-      operationKey: `meta-ads-staging-seed:attestation-system-user-page-${entry.label}-001`,
+      operationKey: `meta-ads-staging-seed:destination-pages-${entry.label}-001`,
     });
     const body = await response.json();
 
@@ -929,7 +853,6 @@ test('staging seed attestation rejects malformed or nonunique System User Page a
     assert.deepEqual(graph.calls.map((call) => call.path), [
       PIXEL_ID,
       `act_${ACCOUNT_ID}/adspixels`,
-      'me/accounts',
       'me',
       `${SYSTEM_USER_ID}/assigned_pages`,
     ], entry.label);
@@ -938,57 +861,22 @@ test('staging seed attestation rejects malformed or nonunique System User Page a
     assert.equal(db.tokens.length, 0, entry.label);
     assert.equal(db.locks.size, 0, entry.label);
     assert.equal(db.adsetLocks.size, 0, entry.label);
-    const serialized = JSON.stringify(body);
-    for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID, SYSTEM_USER_ID]) {
-      assert.equal(serialized.includes(value), false, entry.label);
-    }
   }
 });
 
-test('staging seed attestation rejects a malformed System User identity before it reads assigned Pages', async () => {
+test('staging seed attestation rejects a direct Page and Instagram pair swap before dataset or mutation', async () => {
   const db = new SeedDb();
+  db.prepare = () => {
+    throw new Error('D1 must remain untouched by direct Page pair validation');
+  };
   const graph = new FakeGraph({
     readResponses: {
-      'me/accounts': { body: { data: [] } },
-      me: { body: { id: false } },
-    },
-  });
-  const response = await attest({
-    db,
-    graph,
-    operationKey: 'meta-ads-staging-seed:attestation-system-user-malformed-001',
-  });
-  const body = await response.json();
-
-  assert.equal(response.status, 409);
-  assert.equal(body.error, 'meta_ads_publish_staging_seed_graph_identity_malformed');
-  assert.deepEqual(graph.calls.map((call) => call.path), [
-    PIXEL_ID,
-    `act_${ACCOUNT_ID}/adspixels`,
-    'me/accounts',
-    'me',
-  ]);
-  assert.equal(graph.postCalls.length, 0);
-  assert.equal(db.operations.size, 0);
-  assert.equal(db.tokens.length, 0);
-  assert.equal(db.locks.size, 0);
-  assert.equal(db.adsetLocks.size, 0);
-  const serialized = JSON.stringify(body);
-  for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, SYSTEM_USER_ID]) {
-    assert.equal(serialized.includes(value), false);
-  }
-});
-
-test('staging seed attestation rejects a paged System User Page relation before it reads a Page or dataset', async () => {
-  const db = new SeedDb();
-  const graph = new FakeGraph({
-    readResponses: {
-      'me/accounts': { body: { data: [] } },
-      me: { body: { id: SYSTEM_USER_ID } },
-      [`${SYSTEM_USER_ID}/assigned_pages`]: {
+      [BARRA_SHOPPING_SUL_PAGE_ID]: {
         body: {
-          data: [],
-          paging: { next: false },
+          id: BARRA_SHOPPING_SUL_PAGE_ID,
+          instagram_business_account: { id: INSTAGRAM_ID },
+          website: 'https://staging-barra.example.invalid/tracking-fixture',
+          picture: { data: { url: 'https://cdn.example.invalid/staging-barra-fixture.jpg' } },
         },
       },
     },
@@ -996,28 +884,23 @@ test('staging seed attestation rejects a paged System User Page relation before 
   const response = await attest({
     db,
     graph,
-    operationKey: 'meta-ads-staging-seed:attestation-system-user-page-paged-001',
+    operationKey: 'meta-ads-staging-seed:destination-page-pair-swap-001',
   });
   const body = await response.json();
 
   assert.equal(response.status, 409);
-  assert.equal(body.error, 'meta_ads_publish_staging_seed_graph_page_ambiguous');
+  assert.equal(body.error, 'meta_ads_publish_staging_seed_graph_identity_mismatch');
   assert.deepEqual(graph.calls.map((call) => call.path), [
     PIXEL_ID,
     `act_${ACCOUNT_ID}/adspixels`,
-    'me/accounts',
     'me',
     `${SYSTEM_USER_ID}/assigned_pages`,
+    PAGE_ID,
+    BARRA_SHOPPING_SUL_PAGE_ID,
   ]);
   assert.equal(graph.postCalls.length, 0);
   assert.equal(db.operations.size, 0);
   assert.equal(db.tokens.length, 0);
-  assert.equal(db.locks.size, 0);
-  assert.equal(db.adsetLocks.size, 0);
-  const serialized = JSON.stringify(body);
-  for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID, SYSTEM_USER_ID]) {
-    assert.equal(serialized.includes(value), false);
-  }
 });
 
 test('staging seed attestation accepts an exact account Pixel membership on a bounded page with more results', async () => {
@@ -1038,7 +921,7 @@ test('staging seed attestation accepts an exact account Pixel membership on a bo
 
   assert.equal(response.status, 200);
   assert.equal(body.attestation, 'match');
-  assert.equal(graph.calls.length, 5);
+  assert.equal(graph.calls.length, 7);
   assert.ok(graph.calls.every((call) => call.method === 'GET'));
   assert.equal(graph.postCalls.length, 0);
   assert.equal(db.operations.size, 0);
@@ -1051,13 +934,16 @@ test('staging seed attestation accepts the explicit Profile Plus advertising tas
   const db = new SeedDb();
   const graph = new FakeGraph({
     readResponses: {
-      'me/accounts': {
+      [`${SYSTEM_USER_ID}/assigned_pages`]: {
         body: {
-          data: [{
-            id: PAGE_ID,
-            tasks: ['PROFILE_PLUS_ADVERTISE'],
-            instagram_business_account: { id: INSTAGRAM_ID },
-          }],
+          data: [
+            { id: PAGE_ID, tasks: ['PROFILE_PLUS_ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
+            {
+              id: BARRA_SHOPPING_SUL_PAGE_ID,
+              tasks: ['ADVERTISE'],
+              instagram_business_account: { id: BARRA_SHOPPING_SUL_INSTAGRAM_ID },
+            },
+          ],
         },
       },
     },
@@ -1071,7 +957,7 @@ test('staging seed attestation accepts the explicit Profile Plus advertising tas
 
   assert.equal(response.status, 200);
   assert.equal(body.attestation, 'match');
-  assert.equal(graph.calls.length, 5);
+  assert.equal(graph.calls.length, 7);
   assert.ok(graph.calls.every((call) => call.method === 'GET'));
   assert.equal(graph.postCalls.length, 0);
   assert.equal(db.operations.size, 0);
@@ -1088,13 +974,16 @@ test('staging seed attestation does not broaden unrelated Profile Plus tasks int
   const db = new SeedDb();
   const graph = new FakeGraph({
     readResponses: {
-      'me/accounts': {
+      [`${SYSTEM_USER_ID}/assigned_pages`]: {
         body: {
-          data: [{
-            id: PAGE_ID,
-            tasks: ['PROFILE_PLUS_ANALYZE'],
-            instagram_business_account: { id: INSTAGRAM_ID },
-          }],
+          data: [
+            { id: PAGE_ID, tasks: ['PROFILE_PLUS_ANALYZE'], instagram_business_account: { id: INSTAGRAM_ID } },
+            {
+              id: BARRA_SHOPPING_SUL_PAGE_ID,
+              tasks: ['ADVERTISE'],
+              instagram_business_account: { id: BARRA_SHOPPING_SUL_INSTAGRAM_ID },
+            },
+          ],
         },
       },
     },
@@ -1108,7 +997,7 @@ test('staging seed attestation does not broaden unrelated Profile Plus tasks int
 
   assert.equal(response.status, 409);
   assert.equal(body.error, 'meta_ads_publish_staging_seed_graph_page_ambiguous');
-  assert.equal(graph.calls.length, 3);
+  assert.equal(graph.calls.length, 4);
   assert.ok(graph.calls.every((call) => call.method === 'GET'));
   assert.equal(graph.postCalls.length, 0);
   assert.equal(db.operations.size, 0);
@@ -1211,8 +1100,8 @@ test('staging seed attestation returns a finite resource stage for permanent Gra
       code: 100,
     },
     {
-      label: 'page-list',
-      path: 'me/accounts',
+      label: 'system-user',
+      path: 'me',
       expectedError: 'meta_ads_publish_staging_seed_graph_page_access_denied',
       expectedReads: 3,
       status: 403,
@@ -1221,14 +1110,14 @@ test('staging seed attestation returns a finite resource stage for permanent Gra
       label: 'page-read',
       path: PAGE_ID,
       expectedError: 'meta_ads_publish_staging_seed_graph_page_access_denied',
-      expectedReads: 4,
+      expectedReads: 5,
       status: 403,
     },
     {
       label: 'dataset',
       path: `act_${ACCOUNT_ID}/offline_conversion_data_sets`,
       expectedError: 'meta_ads_publish_staging_seed_graph_dataset_access_denied',
-      expectedReads: 5,
+      expectedReads: 7,
       // Graph can return a 2xx envelope containing an error. It remains a
       // permanent source capability failure and must not become a success.
       status: 200,
@@ -1366,11 +1255,14 @@ test('candidate appsecret-proof attestation verifies only bounded proof-bearing 
       me: { body: { id: SYSTEM_USER_ID } },
       [`${SYSTEM_USER_ID}/assigned_pages`]: {
         body: {
-          data: [{
-            id: PAGE_ID,
-            tasks: ['ADVERTISE'],
-            instagram_business_account: { id: INSTAGRAM_ID },
-          }],
+          data: [
+            { id: PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
+            {
+              id: BARRA_SHOPPING_SUL_PAGE_ID,
+              tasks: ['ADVERTISE'],
+              instagram_business_account: { id: BARRA_SHOPPING_SUL_INSTAGRAM_ID },
+            },
+          ],
         },
       },
     },
@@ -1380,7 +1272,6 @@ test('candidate appsecret-proof attestation verifies only bounded proof-bearing 
     db,
     graph,
     operationKey: 'meta-ads-staging-seed:candidate-proof-verified-001',
-    requestOverrides: { page_id: PAGE_ID },
     env: {
       META_APP_SECRET: 'unit-test-app-secret-not-a-real-secret',
       META_GRAPH_FETCH: async (url, init) => {
@@ -1400,7 +1291,7 @@ test('candidate appsecret-proof attestation verifies only bounded proof-bearing 
   assert.deepEqual(body, {
     ok: true,
     attestation: 'appsecret_proof_verified',
-    contract_version: 'meta-ads-tracking-v20/staging-synthetic-seed/v1',
+    contract_version: 'meta-ads-tracking-v20/staging-synthetic-seed/v2',
     requestId: 'seed-appsecret-proof-attestation-test-request-id',
   });
   assert.deepEqual(observedReads.map((read) => read.path), [
@@ -1409,10 +1300,11 @@ test('candidate appsecret-proof attestation verifies only bounded proof-bearing 
     'me',
     `${SYSTEM_USER_ID}/assigned_pages`,
     PAGE_ID,
+    BARRA_SHOPPING_SUL_PAGE_ID,
     `act_${ACCOUNT_ID}/offline_conversion_data_sets`,
   ]);
   assert.ok(observedReads.every((read) => read.method === 'GET' && read.hasProof));
-  assert.equal(graph.calls.length, 6);
+  assert.equal(graph.calls.length, 7);
   assert.equal(graph.postCalls.length, 0);
   const serialized = JSON.stringify(body);
   for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID]) {
@@ -1517,24 +1409,29 @@ test('staging seed attestation preserves finite non-identity source eligibility 
     },
     {
       label: 'page-ambiguous',
-      path: 'me/accounts',
+      path: `${SYSTEM_USER_ID}/assigned_pages`,
       response: {
         body: {
           data: [
             { id: PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
-            { id: MISMATCH_ACCOUNT_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
+            { id: PAGE_ID, tasks: ['PROFILE_PLUS_ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
+            {
+              id: BARRA_SHOPPING_SUL_PAGE_ID,
+              tasks: ['ADVERTISE'],
+              instagram_business_account: { id: BARRA_SHOPPING_SUL_INSTAGRAM_ID },
+            },
           ],
         },
       },
       expectedError: 'meta_ads_publish_staging_seed_graph_page_ambiguous',
-      expectedReads: 3,
+      expectedReads: 4,
     },
     {
       label: 'dataset-ambiguous',
       path: `act_${ACCOUNT_ID}/offline_conversion_data_sets`,
       response: { body: { data: [] } },
       expectedError: 'meta_ads_publish_staging_seed_graph_dataset_ambiguous',
-      expectedReads: 5,
+      expectedReads: 7,
     },
     {
       label: 'landing-unavailable',
@@ -1548,7 +1445,7 @@ test('staging seed attestation preserves finite non-identity source eligibility 
         },
       },
       expectedError: 'meta_ads_publish_staging_seed_landing_or_media_unavailable',
-      expectedReads: 4,
+      expectedReads: 5,
     },
   ];
 
@@ -1612,7 +1509,7 @@ test('staging seed creates exactly two distinct active Facebook credentials from
     operation_status: 'sealed',
     replayed: false,
     operation_key: operationKey,
-    contract_version: 'meta-ads-tracking-v20/staging-synthetic-seed/v1',
+    contract_version: 'meta-ads-tracking-v20/staging-synthetic-seed/v2',
     requestId: 'seed-test-request-id',
   });
   assert.equal(JSON.stringify(body).includes(SOURCE_ACCESS_TOKEN), false);
@@ -1634,6 +1531,17 @@ test('staging seed creates exactly two distinct active Facebook credentials from
   assert.equal(metadata.filter((entry) => entry.source_adset_id).length, 1);
   assert.ok(metadata.every((entry) => entry.destination_type === 'website'));
   assert.ok(metadata.every((entry) => entry.url_tags.startsWith('skincos_staging_v20=')));
+  const sourceMetadata = metadata.find((entry) => entry.source_adset_id);
+  const targetMetadata = metadata.find((entry) => entry.source_config_token_id);
+  assert.deepEqual(
+    { page_id: sourceMetadata.page_id, instagram_user_id: sourceMetadata.instagram_user_id },
+    { page_id: PAGE_ID, instagram_user_id: INSTAGRAM_ID },
+  );
+  assert.deepEqual(
+    { page_id: targetMetadata.page_id, instagram_user_id: targetMetadata.instagram_user_id },
+    { page_id: BARRA_SHOPPING_SUL_PAGE_ID, instagram_user_id: BARRA_SHOPPING_SUL_INSTAGRAM_ID },
+  );
+  assert.notEqual(sourceMetadata.destination_group, targetMetadata.destination_group);
 
   assert.deepEqual(graph.postCalls, [
     `act_${ACCOUNT_ID}/campaigns`,
@@ -1656,11 +1564,14 @@ test('staging seed seals a configured Page only after the System User assignment
       me: { body: { id: SYSTEM_USER_ID } },
       [`${SYSTEM_USER_ID}/assigned_pages`]: {
         body: {
-          data: [{
-            id: PAGE_ID,
-            tasks: ['ADVERTISE'],
-            instagram_business_account: { id: INSTAGRAM_ID },
-          }],
+          data: [
+            { id: PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } },
+            {
+              id: BARRA_SHOPPING_SUL_PAGE_ID,
+              tasks: ['ADVERTISE'],
+              instagram_business_account: { id: BARRA_SHOPPING_SUL_INSTAGRAM_ID },
+            },
+          ],
         },
       },
     },
@@ -1670,18 +1581,18 @@ test('staging seed seals a configured Page only after the System User assignment
     db,
     graph,
     operationKey,
-    requestOverrides: { page_id: PAGE_ID },
   });
   const body = await response.json();
 
   assert.equal(response.status, 201);
   assert.equal(body.seed, 'sealed');
-  assert.deepEqual(graph.calls.slice(0, 6).map((call) => call.path), [
+  assert.deepEqual(graph.calls.slice(0, 7).map((call) => call.path), [
     PIXEL_ID,
     `act_${ACCOUNT_ID}/adspixels`,
     'me',
     `${SYSTEM_USER_ID}/assigned_pages`,
     PAGE_ID,
+    BARRA_SHOPPING_SUL_PAGE_ID,
     `act_${ACCOUNT_ID}/offline_conversion_data_sets`,
   ]);
   assert.ok(graph.calls.every((call) => call.path !== 'me/accounts'));
@@ -1771,7 +1682,7 @@ test('normal rollback archives every delivery object, deactivates both credentia
     operation_status: 'rolled_back',
     replayed: false,
     operation_key: operationKey,
-    contract_version: 'meta-ads-tracking-v20/staging-synthetic-seed/v1',
+    contract_version: 'meta-ads-tracking-v20/staging-synthetic-seed/v2',
     requestId: 'seed-rollback-test-request-id',
   });
   assert.equal(db.operations.get(operationKey).status, 'rolled_back');

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -22,13 +22,20 @@ const syntheticToken = "synthetic-source-bearer-not-a-secret";
 const syntheticPixelId = "1234567890";
 const syntheticAccountId = "9876543210";
 const syntheticSystemUserId = "6677889900";
-const syntheticPageId = "1122334455";
-const syntheticInstagramId = "5544332211";
-const syntheticOtherPageId = "2233445566";
-const syntheticOtherInstagramId = "6655443322";
+const syntheticNovoPageId = "1122334455";
+const syntheticNovoInstagramId = "5544332211";
+const syntheticBarraPageId = "2233445566";
+const syntheticBarraInstagramId = "6655443322";
 const syntheticDatasetId = "9988776655";
 
-function runVerifier(responses, expectedRequests = responses.length, pageSelector = "") {
+function runVerifier(
+  responses,
+  {
+    expectedRequests = responses.length,
+    novoPageId = syntheticNovoPageId,
+    barraPageId = syntheticBarraPageId,
+  } = {},
+) {
   const harness = `
     const scenario = ${JSON.stringify(responses)};
     let cursor = 0;
@@ -36,11 +43,19 @@ function runVerifier(responses, expectedRequests = responses.length, pageSelecto
       const expected = scenario[cursor++];
       if (!expected) throw new Error('unexpected Graph request');
       const url = new URL(String(value));
-      if (url.origin !== 'https://graph.facebook.com' || url.pathname !== expected.pathname) throw new Error('unexpected Graph request');
-      if (String(options.method || '') !== 'GET' || String(options.cache || '') !== 'no-store' || String(options.redirect || '') !== 'error') throw new Error('unexpected Graph request');
-      if (String(options.headers?.Authorization || '') !== 'Bearer ${syntheticToken}') throw new Error('unexpected Graph request');
-      for (const [key, expectedValue] of Object.entries(expected.query || {})) {
-        if (url.searchParams.get(key) !== expectedValue) throw new Error('unexpected Graph request');
+      if (url.origin !== 'https://graph.facebook.com' || url.pathname !== expected.pathname) {
+        throw new Error('unexpected Graph request');
+      }
+      if (String(options.method || '') !== 'GET' || String(options.cache || '') !== 'no-store' || String(options.redirect || '') !== 'error') {
+        throw new Error('unexpected Graph request');
+      }
+      if (String(options.headers?.Authorization || '') !== 'Bearer ${syntheticToken}') {
+        throw new Error('unexpected Graph request');
+      }
+      const actualQuery = [...url.searchParams.entries()].sort();
+      const expectedQuery = Object.entries(expected.query || {}).sort();
+      if (JSON.stringify(actualQuery) !== JSON.stringify(expectedQuery)) {
+        throw new Error('unexpected Graph request');
       }
       return new Response(JSON.stringify(expected.payload), { status: expected.status ?? 200 });
     };
@@ -64,21 +79,18 @@ function runVerifier(responses, expectedRequests = responses.length, pageSelecto
     process.stdout.write(\`__synthetic_request_count=\${cursor}\\n\`);
     if (verifierExitCode !== null) process.exitCode = verifierExitCode;
   `;
-  const result = spawnSync(
-    process.execPath,
-    ["--input-type=module", "--eval", harness],
-    {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        META_ADS_ACCESS_TOKEN: syntheticToken,
-        META_PIXEL_ID: syntheticPixelId,
-        META_ADS_PAGE_ID: pageSelector,
-        META_ADS_ACCOUNT_ID: syntheticAccountId,
-        META_ADS_API_VERSION: "v25.0",
-      },
+  const result = spawnSync(process.execPath, ["--input-type=module", "--eval", harness], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      META_ADS_ACCESS_TOKEN: syntheticToken,
+      META_PIXEL_ID: syntheticPixelId,
+      META_ADS_NOVOHAMBURGO_PAGE_ID: novoPageId,
+      META_ADS_BARRASHOPPPINGSUL_PAGE_ID: barraPageId,
+      META_ADS_ACCOUNT_ID: syntheticAccountId,
+      META_ADS_API_VERSION: "v25.0",
     },
-  );
+  });
   const stdout = String(result.stdout || "");
   const requestCount = /^__synthetic_request_count=(\d+)$/m.exec(stdout);
   return {
@@ -88,88 +100,18 @@ function runVerifier(responses, expectedRequests = responses.length, pageSelecto
   };
 }
 
-const happyResponses = [
-  {
-    pathname: `/v25.0/${syntheticPixelId}`,
-    query: { fields: "id" },
-    payload: {
-      id: syntheticPixelId,
-    },
-  },
-  {
-    pathname: `/v25.0/act_${syntheticAccountId}/adspixels`,
-    query: { fields: "id", limit: "5" },
-    payload: {
-      data: [{ id: syntheticPixelId }],
-    },
-  },
-  {
-    pathname: "/v25.0/me/accounts",
-    query: { fields: "id,tasks,instagram_business_account{id}", limit: "100" },
-    payload: {
-      data: [
-        {
-          id: syntheticPageId,
-          tasks: ["ADVERTISE"],
-          instagram_business_account: { id: syntheticInstagramId },
-        },
-      ],
-    },
-  },
-  {
-    pathname: `/v25.0/${syntheticPageId}`,
-    query: { fields: "id,instagram_business_account{id},website,picture{url}" },
-    payload: {
-      id: syntheticPageId,
-      instagram_business_account: { id: syntheticInstagramId },
-      website: "https://staging.example.test",
-      picture: { data: { url: "https://cdn.example.test/picture.jpg" } },
-    },
-  },
-  {
-    pathname: `/v25.0/act_${syntheticAccountId}/offline_conversion_data_sets`,
-    query: { fields: "id", limit: "2" },
-    payload: { data: [{ id: syntheticDatasetId }] },
-  },
-];
-
-function systemUserAssignedPageResponses(assignedPages = structuredClone(happyResponses[2].payload.data)) {
-  const responses = structuredClone(happyResponses);
-  responses[2].payload.data = [];
-  responses.splice(
-    3,
-    0,
-    {
-      pathname: "/v25.0/me",
-      query: { fields: "id" },
-      payload: { id: syntheticSystemUserId },
-    },
-    {
-      pathname: `/v25.0/${syntheticSystemUserId}/assigned_pages`,
-      query: { fields: "id,tasks,instagram_business_account{id}", limit: "100" },
-      payload: { data: assignedPages },
-    },
-  );
-  return responses;
-}
-
-function configuredSystemUserPageResponses(
-  assignedPages = [
-    {
-      id: syntheticOtherPageId,
-      tasks: ["ADVERTISE"],
-      instagram_business_account: { id: syntheticOtherInstagramId },
-    },
-    {
-      id: syntheticPageId,
-      tasks: ["ADVERTISE"],
-      instagram_business_account: { id: syntheticInstagramId },
-    },
-  ],
-) {
+function happyResponses() {
   return [
-    structuredClone(happyResponses[0]),
-    structuredClone(happyResponses[1]),
+    {
+      pathname: `/v25.0/${syntheticPixelId}`,
+      query: { fields: "id" },
+      payload: { id: syntheticPixelId },
+    },
+    {
+      pathname: `/v25.0/act_${syntheticAccountId}/adspixels`,
+      query: { fields: "id", limit: "5" },
+      payload: { data: [{ id: syntheticPixelId }] },
+    },
     {
       pathname: "/v25.0/me",
       query: { fields: "id" },
@@ -178,14 +120,66 @@ function configuredSystemUserPageResponses(
     {
       pathname: `/v25.0/${syntheticSystemUserId}/assigned_pages`,
       query: { fields: "id,tasks,instagram_business_account{id}", limit: "100" },
-      payload: { data: assignedPages },
+      payload: {
+        data: [
+          {
+            id: syntheticNovoPageId,
+            tasks: ["ADVERTISE"],
+            instagram_business_account: { id: syntheticNovoInstagramId },
+          },
+          {
+            id: syntheticBarraPageId,
+            tasks: ["ADVERTISE"],
+            instagram_business_account: { id: syntheticBarraInstagramId },
+          },
+        ],
+      },
     },
-    structuredClone(happyResponses[3]),
-    structuredClone(happyResponses[4]),
+    {
+      pathname: `/v25.0/${syntheticNovoPageId}`,
+      query: { fields: "id,instagram_business_account{id},website,picture{url}" },
+      payload: {
+        id: syntheticNovoPageId,
+        instagram_business_account: { id: syntheticNovoInstagramId },
+        website: "https://novo.example.test",
+        picture: { data: { url: "https://cdn.example.test/novo.jpg" } },
+      },
+    },
+    {
+      pathname: `/v25.0/${syntheticBarraPageId}`,
+      query: { fields: "id,instagram_business_account{id},website,picture{url}" },
+      payload: {
+        id: syntheticBarraPageId,
+        instagram_business_account: { id: syntheticBarraInstagramId },
+        website: "https://barra.example.test",
+        picture: { data: { url: "https://cdn.example.test/barra.jpg" } },
+      },
+    },
+    {
+      pathname: `/v25.0/act_${syntheticAccountId}/offline_conversion_data_sets`,
+      query: { fields: "id", limit: "2" },
+      payload: { data: [{ id: syntheticDatasetId }] },
+    },
   ];
 }
 
-test("Meta Ads source-access attestation is manual, bounded, and non-deploying", () => {
+const sensitiveValues = [
+  syntheticToken,
+  syntheticPixelId,
+  syntheticAccountId,
+  syntheticSystemUserId,
+  syntheticNovoPageId,
+  syntheticNovoInstagramId,
+  syntheticBarraPageId,
+  syntheticBarraInstagramId,
+  syntheticDatasetId,
+];
+
+function assertNoSyntheticInputs(output) {
+  for (const value of sensitiveValues) assert.doesNotMatch(output, new RegExp(value));
+}
+
+test("Meta Ads source-access attestation is manual, GET-only, and bound to two staging selectors", () => {
   assert.match(workflow, /^name: Attest Raw Meta Ads Staging Source Access$/m);
   assert.match(workflow, /^\s+workflow_dispatch:\s*$/m);
   assert.match(workflow, /if: github\.ref == 'refs\/heads\/main'/);
@@ -193,117 +187,43 @@ test("Meta Ads source-access attestation is manual, bounded, and non-deploying",
   assert.match(workflow, /timeout-minutes: 3/);
   assert.match(
     workflow,
-    /META_ADS_ACCESS_TOKEN: \$\{\{ secrets\.META_ADS_ACCESS_TOKEN \}\}/,
-  );
-  assert.match(workflow, /META_PIXEL_ID: \$\{\{ secrets\.META_PIXEL_ID \}\}/);
-  assert.match(
-    workflow,
-    /META_ADS_PAGE_ID: \$\{\{ secrets\.META_ADS_PAGE_ID \}\}/,
+    /META_ADS_NOVOHAMBURGO_PAGE_ID: \$\{\{ secrets\.novohamburgo_page_id \}\}/,
   );
   assert.match(
     workflow,
-    /META_ADS_ACCOUNT_ID: \$\{\{ vars\.META_ADS_ACCOUNT_ID \}\}/,
+    /META_ADS_BARRASHOPPPINGSUL_PAGE_ID: \$\{\{ secrets\.barrashopppingsul_page_id \}\}/,
   );
-  assert.match(
-    workflow,
-    /META_ADS_API_VERSION: \$\{\{ vars\.META_ADS_API_VERSION \}\}/,
-  );
-  assert.match(workflow, /payload\?\.error\?\.is_transient === true/);
-  assert.match(
-    workflow,
-    /const graphErrorCode = Number\(payload\?\.error\?\.code\)/,
-  );
-  assert.match(
-    workflow,
-    /const pageSelector = String\(process\.env\.META_ADS_PAGE_ID \|\| ''\)\.trim\(\)/,
-  );
-  assert.match(workflow, /source_page_selector_invalid/);
-  assert.match(workflow, /response\.status === 401/);
-  assert.match(workflow, /response\.status === 403/);
-  assert.match(workflow, /graphErrorCode === 10/);
-  assert.match(workflow, /graphErrorCode === 102/);
-  assert.match(workflow, /graphErrorCode === 190/);
-  assert.match(workflow, /graphErrorCode === 200/);
-  assert.match(workflow, /authorizationError \? 'denied' : 'malformed'/);
-  assert.match(workflow, /\$\{pixelId\}\?fields=id/);
-  assert.match(workflow, /act_\$\{accountId\}\/adspixels\?fields=id&limit=5/);
-  assert.match(workflow, /source_pixel_account_relation/);
-  assert.match(workflow, /targetMemberships === 1/);
-  assert.match(workflow, /source_pixel_account_relation_ambiguous/);
-  assert.doesNotMatch(workflow, /owner_ad_account/);
-  assert.match(
-    workflow,
-    /me\/accounts\?fields=id,tasks,instagram_business_account\{id\}&limit=100/,
-  );
-  assert.match(workflow, /me\?fields=id/);
-  assert.match(
-    workflow,
-    /assigned_pages\?fields=id,tasks,instagram_business_account\{id\}&limit=100/,
-  );
-  assert.match(
-    workflow,
-    /\$\{pageId\}\?fields=id,instagram_business_account\{id\},website,picture\{url\}/,
-  );
-  assert.match(
-    workflow,
-    /act_\$\{accountId\}\/offline_conversion_data_sets\?fields=id&limit=2/,
-  );
-  assert.match(workflow, /tasks\.has\('ADVERTISE'\)/);
-  assert.match(workflow, /tasks\.has\('PROFILE_PLUS_ADVERTISE'\)/);
-  assert.doesNotMatch(workflow, /PROFILE_PLUS_FULL_CONTROL/);
-  assert.match(workflow, /selectEligiblePage\(pages\.data, 'source_pages'\)/);
-  assert.match(workflow, /selectEligiblePage\(assignedPages\.data, 'source_system_user_pages'\)/);
-  assert.match(workflow, /selectEligiblePage\(assignedPages\.data, 'source_system_user_pages', pageSelector\)/);
-  assert.match(workflow, /pageDiscovery = 'system_user_configured'/);
-  assert.match(workflow, /\$\{phase\}_selector_mismatch/);
-  assert.match(workflow, /source_system_user_malformed/);
-  assert.match(workflow, /source_system_user_pages_paging_ambiguous/);
-  assert.match(workflow, /eligiblePages\.length === 0/);
-  assert.match(workflow, /selectedPages\.length > 1/);
-  assert.match(workflow, /datasets\.data\.length !== 1/);
-  assert.match(workflow, /source_landing_or_media_unavailable/);
-  assert.match(workflow, /method: 'GET'/);
-  assert.match(workflow, /Authorization: `Bearer \$\{token\}`/);
-  assert.match(workflow, /cache: 'no-store'/);
-  assert.match(workflow, /redirect: 'error'/);
-  assert.match(workflow, /AbortSignal\.timeout\(12_000\)/);
-  assert.match(workflow, /source_access_raw=verified/);
-  assert.match(workflow, /source_access_runtime_proof=unverified/);
-  assert.match(workflow, /source_access_pixel=allowed/);
-  assert.match(workflow, /source_access_pixel_account_relation=allowed/);
-  assert.match(workflow, /source_access_page_discovery=\$\{pageDiscovery\}/);
-  assert.match(workflow, /source_access_page=eligible/);
-  assert.match(workflow, /source_access_dataset=eligible/);
-  assert.match(workflow, /source_access_landing_media=eligible/);
-  assert.ok(
-    workflow.indexOf("source_pixel_account_relation_mismatch") <
-      workflow.indexOf("source_access_raw=verified"),
-    "raw success output must be unreachable until the exact source reads pass",
-  );
+  assert.match(workflow, /destinationSelectors = \{[\s\S]*novo_hamburgo:[\s\S]*barra_shopping_sul:/);
+  assert.match(workflow, /source_destination_page_selector_invalid/);
+  assert.match(workflow, /source_destination_page_selector_duplicate/);
+  assert.match(workflow, /source_destination_page_assignment_unassigned/);
+  assert.match(workflow, /source_destination_page_selector_ambiguous/);
+  assert.match(workflow, /source_destination_page_pair_duplicate/);
+  assert.match(workflow, /source_destination_page_pair_mismatch/);
+  assert.match(workflow, /source_access_novohamburgo_page_instagram=eligible/);
+  assert.match(workflow, /source_access_barrashopppingsul_page_instagram=eligible/);
 
-  assert.doesNotMatch(workflow, /access_token=/i);
-  assert.doesNotMatch(workflow, /debug_token/i);
-  assert.doesNotMatch(workflow, /META_APP_SECRET/);
-  assert.doesNotMatch(workflow, /appsecret_proof/);
+  assert.doesNotMatch(workflow, /META_ADS_PAGE_ID/);
+  assert.doesNotMatch(workflow, /me\/accounts/);
   assert.doesNotMatch(workflow, /method: 'POST'/);
   assert.doesNotMatch(workflow, /upload-artifact/i);
   assert.doesNotMatch(workflow, /wrangler/i);
-  assert.doesNotMatch(workflow, /gh secret/i);
-  assert.doesNotMatch(workflow, /secret put/i);
   assert.doesNotMatch(workflow, /GITHUB_OUTPUT/);
-  assert.doesNotMatch(workflow, /me\/permissions/);
-  assert.doesNotMatch(workflow, /pages_manage_ads/);
+  assert.doesNotMatch(workflow, /META_APP_SECRET/);
+  assert.doesNotMatch(workflow, /appsecret_proof/);
+  assert.doesNotMatch(workflow, /access_token=/i);
+  assert.doesNotMatch(workflow, /console\.log/);
   assert.doesNotMatch(
     workflow,
     /source_access_(?:pixel_id|page_id|dataset_id|landing_url|picture_url|system_user_id)/i,
   );
-  assert.doesNotMatch(workflow, /D1|Cloudflare|Orb|n8n/);
 });
 
-test("Meta Ads source-access verifier executes the bounded raw-read contract without revealing inputs", () => {
-  const result = runVerifier(happyResponses);
+test("Meta Ads source-access verifier proves both assigned Page and Instagram pairs without revealing inputs", () => {
+  const result = runVerifier(happyResponses());
   const combined = `${result.stdout}${result.stderr}`;
   assert.equal(result.status, 0, combined);
+  assert.equal(result.requestCount, 7);
   assert.equal(
     result.stdout,
     [
@@ -311,436 +231,141 @@ test("Meta Ads source-access verifier executes the bounded raw-read contract wit
       "source_access_runtime_proof=unverified",
       "source_access_pixel=allowed",
       "source_access_pixel_account_relation=allowed",
-      "source_access_page_discovery=me_accounts",
-      "source_access_page=eligible",
+      "source_access_novohamburgo_page_instagram=eligible",
+      "source_access_barrashopppingsul_page_instagram=eligible",
       "source_access_dataset=eligible",
       "source_access_landing_media=eligible",
       "",
     ].join("\n"),
   );
-  assert.equal(result.requestCount, 5);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
-  );
+  assertNoSyntheticInputs(combined);
 });
 
-test("Meta Ads source-access verifier rejects a malformed private Page selector before Graph reads", () => {
-  const result = runVerifier([], 0, "not-a-page-id");
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.equal(result.requestCount, 0);
-  assert.match(combined, /source_page_selector_invalid/);
-  assert.doesNotMatch(combined, /not-a-page-id|source_access_raw=verified/);
+test("Meta Ads source-access verifier rejects invalid or duplicate destination selectors before Graph reads", () => {
+  const invalid = runVerifier([], {
+    expectedRequests: 0,
+    novoPageId: "not-a-page-id",
+  });
+  const invalidCombined = `${invalid.stdout}${invalid.stderr}`;
+  assert.notEqual(invalid.status, 0);
+  assert.equal(invalid.requestCount, 0);
+  assert.match(invalidCombined, /source_destination_page_selector_invalid/);
+  assert.doesNotMatch(invalidCombined, /not-a-page-id|source_access_raw=verified/);
+
+  const duplicate = runVerifier([], {
+    expectedRequests: 0,
+    barraPageId: syntheticNovoPageId,
+  });
+  const duplicateCombined = `${duplicate.stdout}${duplicate.stderr}`;
+  assert.notEqual(duplicate.status, 0);
+  assert.equal(duplicate.requestCount, 0);
+  assert.match(duplicateCombined, /source_destination_page_selector_duplicate/);
+  assertNoSyntheticInputs(duplicateCombined);
 });
 
-test("Meta Ads source-access verifier accepts an exact membership on a bounded account Pixel page", () => {
-  const responses = structuredClone(happyResponses);
+test("Meta Ads source-access verifier accepts Profile Plus advertising and exact Pixel membership on a paged bounded relation", () => {
+  const responses = happyResponses();
   responses[1].payload.paging = { next: "https://graph.example.invalid/opaque" };
+  responses[3].payload.data[1].tasks = ["PROFILE_PLUS_ADVERTISE"];
   const result = runVerifier(responses);
   const combined = `${result.stdout}${result.stderr}`;
   assert.equal(result.status, 0, combined);
-  assert.equal(result.requestCount, 5);
+  assert.equal(result.requestCount, 7);
   assert.match(result.stdout, /source_access_raw=verified/);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
-  );
+  assertNoSyntheticInputs(combined);
 });
 
-test("Meta Ads source-access verifier accepts the explicit Profile Plus advertising task", () => {
-  const responses = structuredClone(happyResponses);
-  responses[2].payload.data[0].tasks = ["PROFILE_PLUS_ADVERTISE"];
-  const result = runVerifier(responses);
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.equal(result.status, 0, combined);
-  assert.equal(result.requestCount, 5);
-  assert.match(result.stdout, /source_access_raw=verified/);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
-  );
-});
-
-test("Meta Ads source-access verifier does not treat other Profile Plus tasks as advertising", () => {
-  const responses = structuredClone(happyResponses);
-  responses[2].payload.data[0].tasks = ["PROFILE_PLUS_ANALYZE"];
-  const result = runVerifier(responses, 3);
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.match(combined, /source_pages_advertise_task_missing/);
-  assert.equal(result.requestCount, 3);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
-  );
-});
-
-test("Meta Ads source-access verifier fails closed when target membership is beyond the bounded page", () => {
-  const responses = structuredClone(happyResponses);
+test("Meta Ads source-access verifier keeps an absent target Pixel fail-closed when its bounded relation is paged", () => {
+  const responses = happyResponses();
   responses[1].payload = {
     data: [],
     paging: { next: "https://graph.example.invalid/opaque" },
   };
-  const result = runVerifier(responses, 2);
+  const result = runVerifier(responses, { expectedRequests: 2 });
   const combined = `${result.stdout}${result.stderr}`;
   assert.notEqual(result.status, 0);
+  assert.equal(result.requestCount, 2);
   assert.match(combined, /source_pixel_account_relation_ambiguous/);
-  assert.equal(result.requestCount, 2);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
-  );
+  assertNoSyntheticInputs(combined);
 });
 
-test("Meta Ads source-access verifier classifies malformed bounded account Pixel entries before membership", () => {
-  const responses = structuredClone(happyResponses);
-  responses[1].payload = { data: [{ id: false }] };
-  const result = runVerifier(responses, 2);
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.match(combined, /source_pixel_account_relation_malformed/);
-  assert.equal(result.requestCount, 2);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
-  );
+test("Meta Ads source-access verifier rejects an unassigned, non-advertising, or Instagram-less destination before direct Page reads", () => {
+  const unassignedResponses = happyResponses();
+  unassignedResponses[3].payload.data = [];
+  const unassigned = runVerifier(unassignedResponses, { expectedRequests: 4 });
+  assert.notEqual(unassigned.status, 0);
+  assert.equal(unassigned.requestCount, 4);
+  assert.match(`${unassigned.stdout}${unassigned.stderr}`, /source_destination_page_assignment_unassigned/);
+
+  const taskResponses = happyResponses();
+  taskResponses[3].payload.data[1].tasks = ["PROFILE_PLUS_ANALYZE"];
+  const task = runVerifier(taskResponses, { expectedRequests: 4 });
+  assert.notEqual(task.status, 0);
+  assert.equal(task.requestCount, 4);
+  assert.match(`${task.stdout}${task.stderr}`, /source_destination_page_assignment_advertise_task_missing/);
+
+  const instagramResponses = happyResponses();
+  delete instagramResponses[3].payload.data[1].instagram_business_account;
+  const instagram = runVerifier(instagramResponses, { expectedRequests: 4 });
+  assert.notEqual(instagram.status, 0);
+  assert.equal(instagram.requestCount, 4);
+  assert.match(`${instagram.stdout}${instagram.stderr}`, /source_destination_page_assignment_instagram_link_missing/);
+
+  const malformedResponses = happyResponses();
+  malformedResponses[3].payload.data[1].tasks = "ADVERTISE";
+  const malformed = runVerifier(malformedResponses, { expectedRequests: 4 });
+  assert.notEqual(malformed.status, 0);
+  assert.equal(malformed.requestCount, 4);
+  assert.match(`${malformed.stdout}${malformed.stderr}`, /source_destination_page_assignment_malformed/);
 });
 
-test("Meta Ads source-access verifier distinguishes multiple eligible Pages", () => {
-  const responses = structuredClone(happyResponses);
-  responses[2].payload.data.unshift({
-    id: "6655443322",
+test("Meta Ads source-access verifier rejects duplicate, paged, and swapped destination pairs before unsafe continuation", () => {
+  const duplicateResponses = happyResponses();
+  duplicateResponses[3].payload.data[1].instagram_business_account.id = syntheticNovoInstagramId;
+  const duplicate = runVerifier(duplicateResponses, { expectedRequests: 4 });
+  assert.notEqual(duplicate.status, 0);
+  assert.equal(duplicate.requestCount, 4);
+  assert.match(`${duplicate.stdout}${duplicate.stderr}`, /source_destination_page_pair_duplicate/);
+
+  const ambiguousResponses = happyResponses();
+  ambiguousResponses[3].payload.data.push({
+    id: syntheticNovoPageId,
     tasks: ["ADVERTISE"],
-    instagram_business_account: { id: "2233445566" },
+    instagram_business_account: { id: syntheticNovoInstagramId },
   });
-  const result = runVerifier(responses, 3);
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.match(combined, /source_pages_multiple_eligible/);
-  assert.equal(result.requestCount, 3);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
-  );
+  const ambiguous = runVerifier(ambiguousResponses, { expectedRequests: 4 });
+  assert.notEqual(ambiguous.status, 0);
+  assert.equal(ambiguous.requestCount, 4);
+  assert.match(`${ambiguous.stdout}${ambiguous.stderr}`, /source_destination_page_selector_ambiguous/);
+
+  const pagedResponses = happyResponses();
+  pagedResponses[3].payload.paging = { next: false };
+  const paged = runVerifier(pagedResponses, { expectedRequests: 4 });
+  assert.notEqual(paged.status, 0);
+  assert.equal(paged.requestCount, 4);
+  assert.match(`${paged.stdout}${paged.stderr}`, /source_system_user_pages_paging_ambiguous/);
+
+  const swappedResponses = happyResponses();
+  swappedResponses[5].payload.instagram_business_account.id = syntheticNovoInstagramId;
+  const swapped = runVerifier(swappedResponses, { expectedRequests: 6 });
+  assert.notEqual(swapped.status, 0);
+  assert.equal(swapped.requestCount, 6);
+  assert.match(`${swapped.stdout}${swapped.stderr}`, /source_destination_page_pair_mismatch/);
 });
 
-test("Meta Ads source-access verifier distinguishes a paged Page listing", () => {
-  const responses = structuredClone(happyResponses);
-  responses[2].payload.paging = { next: false };
-  const result = runVerifier(responses, 3);
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.match(combined, /source_pages_paging_ambiguous/);
-  assert.equal(result.requestCount, 3);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
-  );
-});
-
-test("Meta Ads source-access verifier falls back to the bounded System User Page relation after an empty direct list", () => {
-  const result = runVerifier(systemUserAssignedPageResponses());
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.equal(result.status, 0, combined);
-  assert.equal(result.requestCount, 7);
-  assert.match(result.stdout, /source_access_page_discovery=system_user_assigned/);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}|${syntheticSystemUserId}|${syntheticPageId}|${syntheticInstagramId}|${syntheticDatasetId}`),
-  );
-});
-
-test("Meta Ads source-access verifier proves only the configured System User Page relation", () => {
-  const result = runVerifier(
-    configuredSystemUserPageResponses(),
-    6,
-    syntheticPageId,
-  );
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.equal(result.status, 0, combined);
-  assert.equal(result.requestCount, 6);
-  assert.match(result.stdout, /source_access_page_discovery=system_user_configured/);
-  assert.doesNotMatch(result.stdout, /me_accounts|system_user_assigned/);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}|${syntheticSystemUserId}|${syntheticPageId}|${syntheticInstagramId}|${syntheticOtherPageId}|${syntheticOtherInstagramId}|${syntheticDatasetId}`),
-  );
-});
-
-test("Meta Ads source-access verifier rejects a configured Page selector that is not an eligible assigned Page", () => {
-  const result = runVerifier(
-    configuredSystemUserPageResponses(),
-    4,
-    "7788990011",
-  );
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.equal(result.requestCount, 4);
-  assert.match(combined, /source_system_user_pages_selector_mismatch/);
-  assert.doesNotMatch(combined, /source_access_raw=verified/);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}|${syntheticSystemUserId}|${syntheticPageId}|${syntheticInstagramId}|${syntheticOtherPageId}|${syntheticOtherInstagramId}|${syntheticDatasetId}`),
-  );
-});
-
-test("Meta Ads source-access verifier rejects duplicate configured Page membership before Page access", () => {
-  const assignedPages = [
-    {
-      id: syntheticPageId,
-      tasks: ["ADVERTISE"],
-      instagram_business_account: { id: syntheticInstagramId },
-    },
-    {
-      id: syntheticPageId,
-      tasks: ["PROFILE_PLUS_ADVERTISE"],
-      instagram_business_account: { id: syntheticInstagramId },
-    },
-  ];
-  const result = runVerifier(
-    configuredSystemUserPageResponses(assignedPages),
-    4,
-    syntheticPageId,
-  );
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.equal(result.requestCount, 4);
-  assert.match(combined, /source_system_user_pages_selector_ambiguous/);
-  assert.doesNotMatch(combined, /source_access_raw=verified/);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}|${syntheticSystemUserId}|${syntheticPageId}|${syntheticInstagramId}|${syntheticDatasetId}`),
-  );
-});
-
-test("Meta Ads source-access verifier rejects paging before selecting a configured Page", () => {
-  const responses = configuredSystemUserPageResponses();
-  responses[3].payload.paging = { next: false };
-  const result = runVerifier(responses, 4, syntheticPageId);
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.equal(result.requestCount, 4);
-  assert.match(combined, /source_system_user_pages_paging_ambiguous/);
-  assert.doesNotMatch(combined, /source_access_raw=verified/);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}|${syntheticSystemUserId}|${syntheticPageId}|${syntheticInstagramId}|${syntheticDatasetId}`),
-  );
-});
-
-test("Meta Ads source-access verifier keeps an empty System User Page relation fail-closed", () => {
-  const result = runVerifier(systemUserAssignedPageResponses([]), 5);
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.match(combined, /source_system_user_pages_none_visible/);
-  assert.equal(result.requestCount, 5);
-  assert.doesNotMatch(combined, /source_access_raw=verified/);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}|${syntheticSystemUserId}`),
-  );
-});
-
-test("Meta Ads source-access verifier preserves ambiguity when no private Page selector is configured", () => {
-  const assignedPages = [
-    {
-      id: syntheticPageId,
-      tasks: ["ADVERTISE"],
-      instagram_business_account: { id: syntheticInstagramId },
-    },
-    {
-      id: syntheticOtherPageId,
-      tasks: ["PROFILE_PLUS_ADVERTISE"],
-      instagram_business_account: { id: syntheticOtherInstagramId },
-    },
-  ];
-  const result = runVerifier(systemUserAssignedPageResponses(assignedPages), 5);
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.equal(result.requestCount, 5);
-  assert.match(combined, /source_system_user_pages_multiple_eligible/);
-  assert.doesNotMatch(combined, /source_access_raw=verified/);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}|${syntheticSystemUserId}|${syntheticPageId}|${syntheticInstagramId}|${syntheticOtherPageId}|${syntheticOtherInstagramId}|${syntheticDatasetId}`),
-  );
-});
-
-test("Meta Ads source-access verifier rejects pagination on the bounded System User Page relation", () => {
-  const responses = systemUserAssignedPageResponses();
-  responses[4].payload.paging = { next: false };
-  const result = runVerifier(responses, 5);
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.match(combined, /source_system_user_pages_paging_ambiguous/);
-  assert.equal(result.requestCount, 5);
-  assert.doesNotMatch(combined, /source_access_raw=verified/);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}|${syntheticSystemUserId}`),
-  );
-});
-
-test("Meta Ads source-access verifier rejects a malformed System User identity before its Page relation", () => {
-  const responses = systemUserAssignedPageResponses();
-  responses[3].payload = { id: false };
-  const result = runVerifier(responses, 4);
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.match(combined, /source_system_user_malformed/);
-  assert.equal(result.requestCount, 4);
-  assert.doesNotMatch(combined, /source_access_raw=verified/);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}|${syntheticSystemUserId}`),
-  );
-});
-
-test("Meta Ads source-access verifier distinguishes an absent advertising task from a missing Page", () => {
-  const responses = structuredClone(happyResponses);
-  responses[2].payload.data[0].tasks = [];
-  const result = runVerifier(responses, 3);
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.match(combined, /source_pages_advertise_task_missing/);
-  assert.equal(result.requestCount, 3);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
-  );
-});
-
-test("Meta Ads source-access verifier distinguishes a missing Instagram link from a missing Page", () => {
-  const responses = structuredClone(happyResponses);
-  delete responses[2].payload.data[0].instagram_business_account;
-  const result = runVerifier(responses, 3);
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.match(combined, /source_pages_instagram_link_missing/);
-  assert.equal(result.requestCount, 3);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
-  );
-});
-
-test("Meta Ads source-access verifier distinguishes Page task and Instagram facts that do not belong to the same Page", () => {
-  const responses = structuredClone(happyResponses);
-  responses[2].payload.data = [
-    { id: "6655443322", tasks: ["ADVERTISE"] },
-    { id: "2233445566", tasks: [], instagram_business_account: { id: "5544332211" } },
-  ];
-  const result = runVerifier(responses, 3);
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.match(combined, /source_pages_task_instagram_unpaired/);
-  assert.equal(result.requestCount, 3);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
-  );
-});
-
-test("Meta Ads source-access verifier keeps a unique eligible Page despite unrelated Pages", () => {
-  const responses = structuredClone(happyResponses);
-  responses[2].payload.data.unshift({
-    id: "6655443322",
-    tasks: [],
-  });
-  const result = runVerifier(responses);
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.equal(result.status, 0, combined);
-  assert.equal(result.requestCount, 5);
-  assert.match(result.stdout, /source_access_raw=verified/);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
-  );
-});
-
-test("Meta Ads source-access verifier classifies a selected malformed Page before Page access", () => {
-  const responses = structuredClone(happyResponses);
-  responses[2].payload.data[0].id = false;
-  const result = runVerifier(responses, 3);
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.match(combined, /source_pages_malformed/);
-  assert.equal(result.requestCount, 3);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
-  );
-});
-
-test("Meta Ads source-access verifier distinguishes bare Pixel denial before relation access", () => {
+test("Meta Ads source-access verifier reports only classified Graph failures", () => {
   const result = runVerifier([
     {
       pathname: `/v25.0/${syntheticPixelId}`,
       query: { fields: "id" },
       status: 403,
-      payload: { error: { code: 10, message: "synthetic denial" } },
+      payload: { error: { code: 10, message: "synthetic denial detail" } },
     },
   ]);
   const combined = `${result.stdout}${result.stderr}`;
   assert.notEqual(result.status, 0);
-  assert.match(combined, /source_pixel_denied/);
-  assert.doesNotMatch(combined, /source_pixel_account_relation/);
-  assert.doesNotMatch(combined, /synthetic denial/);
   assert.equal(result.requestCount, 1);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
-  );
-});
-
-test("Meta Ads source-access verifier distinguishes account-membership denial after Pixel access", () => {
-  const result = runVerifier([
-    {
-      pathname: `/v25.0/${syntheticPixelId}`,
-      query: { fields: "id" },
-      payload: { id: syntheticPixelId },
-    },
-    {
-      pathname: `/v25.0/act_${syntheticAccountId}/adspixels`,
-      query: { fields: "id", limit: "5" },
-      status: 403,
-      payload: { error: { code: 10, message: "synthetic denial" } },
-    },
-  ]);
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.match(combined, /source_pixel_account_relation_denied/);
-  assert.doesNotMatch(combined, /source_access_raw=verified/);
-  assert.doesNotMatch(combined, /synthetic denial/);
-  assert.equal(result.requestCount, 2);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
-  );
-});
-
-test("Meta Ads source-access verifier classifies an account-membership contract error without leaking Graph details", () => {
-  const result = runVerifier([
-    {
-      pathname: `/v25.0/${syntheticPixelId}`,
-      query: { fields: "id" },
-      payload: { id: syntheticPixelId },
-    },
-    {
-      pathname: `/v25.0/act_${syntheticAccountId}/adspixels`,
-      query: { fields: "id", limit: "5" },
-      status: 200,
-      payload: { error: { code: 100, message: "synthetic contract error" } },
-    },
-  ]);
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.match(combined, /source_pixel_account_relation_malformed/);
-  assert.doesNotMatch(combined, /synthetic contract error/);
-  assert.equal(result.requestCount, 2);
-  assert.doesNotMatch(
-    combined,
-    new RegExp(`${syntheticToken}|${syntheticPixelId}|${syntheticAccountId}`),
-  );
+  assert.match(combined, /source_pixel_denied/);
+  assert.doesNotMatch(combined, /synthetic denial detail|source_access_raw=verified/);
+  assertNoSyntheticInputs(combined);
 });

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -84,7 +84,9 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
   assert.ok(tokenVaultUnit.secrets.includes("TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST"));
   assert.ok(tokenVaultUnit.secrets.includes("META_ADS_ACCESS_TOKEN"));
   assert.ok(tokenVaultUnit.secrets.includes("META_PIXEL_ID"));
-  assert.ok(tokenVaultUnit.secrets.includes("META_ADS_PAGE_ID"));
+  assert.ok(tokenVaultUnit.secrets.includes("novohamburgo_page_id"));
+  assert.ok(tokenVaultUnit.secrets.includes("barrashopppingsul_page_id"));
+  assert.ok(!tokenVaultUnit.secrets.includes("META_ADS_PAGE_ID"));
   assert.ok(!tokenVaultUnit.secrets.includes("TOKEN_VAULT_BACKUP_PASSPHRASE"));
   assert.equal(tokenVaultUnit.promotion.trackingFixture, "synthetic authorized ad-set profile required before staging");
   assert.equal(tokenVaultUnit.promotion.trackingBootstrap, "empty staging authority uses a candidate-only Graph-read attestation before a restricted one-shot synthetic seed; legacy authority uses restricted config bearer plus hash-bound internal derivation or protected entries override");


### PR DESCRIPTION
## What changed

- Replaces the staging singleton Page selector with the two existing Environment secrets `novohamburgo_page_id` and `barrashopppingsul_page_id`.
- Validates each selector against the authenticated System User assignment, advertising task, linked Instagram identity, direct Page readback, and distinct Page/Instagram pairs.
- Carries the fixed `destination_page_ids` map only in private candidate attestation/seed requests; it is excluded from Worker bindings, upload secrets files, outputs, artifacts, logs, and rollback requests.
- Preserves the two credential rows and one staging fixture, mapping source metadata to Novo Hamburgo and target metadata to Barra Shopping Sul.

## Safety and rollback

This is staging-only source validation and seed-contract plumbing. Raw and candidate attestations remain GET-only before any D1 or Graph POST. Production behavior is unchanged. No feature flag or migration is introduced (`flag=n/a`, `migration=n/a`). Rollback is the existing protected Git revert/PR path; seed rollback requests remain selector-free.

## Validation

- Token Vault suite: 167/167
- Dual-selector focused tests: 40/40
- Global concurrency governance: 19/19
- Cloudflare single-writer: 7/7
- Deploy topology, YAML parse, Node syntax, and `git diff --check`: pass
- Formal Codex Security diff scan: 0 findings

No Page selector values or bearer values are included in this PR.