### PR TITLE
fix(meta-ads): bind canonical staging selector secrets

### DIFF
--- a/.github/workflows/attest-meta-ads-candidate-appsecret.yml
+++ b/.github/workflows/attest-meta-ads-candidate-appsecret.yml
@@ -42,8 +42,8 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
           META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
-          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ secrets.novohamburgo_page_id }}
-          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ secrets.barrashopppingsul_page_id }}
+          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ secrets.NOVOHAMBURGO_PAGE_ID }}
+          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ secrets.BARRASHOPPPINGSUL_PAGE_ID }}
           META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
           META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
           ENABLE_TOKEN_VAULT_DEPLOY_STAGING: ${{ vars.ENABLE_TOKEN_VAULT_DEPLOY_STAGING }}
@@ -94,8 +94,8 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
           META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
-          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ secrets.novohamburgo_page_id }}
-          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ secrets.barrashopppingsul_page_id }}
+          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ secrets.NOVOHAMBURGO_PAGE_ID }}
+          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ secrets.BARRASHOPPPINGSUL_PAGE_ID }}
           META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
           META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
           SOURCE_SHA: ${{ github.sha }}

--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -22,8 +22,8 @@ jobs:
         env:
           META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
           META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
-          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ secrets.novohamburgo_page_id }}
-          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ secrets.barrashopppingsul_page_id }}
+          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ secrets.NOVOHAMBURGO_PAGE_ID }}
+          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ secrets.BARRASHOPPPINGSUL_PAGE_ID }}
           META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
           META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
         shell: bash

--- a/.github/workflows/deploy-token-vault.yml
+++ b/.github/workflows/deploy-token-vault.yml
@@ -991,8 +991,8 @@ jobs:
           # never Worker bindings. Each must be proved with its own Instagram
           # pair against the System User before the synthetic seed may create
           # any Meta or D1 resources.
-          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ inputs.target == 'staging' && secrets.novohamburgo_page_id || '' }}
-          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ inputs.target == 'staging' && secrets.barrashopppingsul_page_id || '' }}
+          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ inputs.target == 'staging' && secrets.NOVOHAMBURGO_PAGE_ID || '' }}
+          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ inputs.target == 'staging' && secrets.BARRASHOPPPINGSUL_PAGE_ID || '' }}
           META_ADS_API_VERSION: ${{ inputs.target == 'staging' && vars.META_ADS_API_VERSION || '' }}
           TARGET: ${{ inputs.target }}
           OPERATION: ${{ inputs.operation }}
@@ -1338,8 +1338,8 @@ jobs:
         env:
           META_ADS_ACCESS_TOKEN: ${{ inputs.target == 'staging' && secrets.META_ADS_ACCESS_TOKEN || '' }}
           META_PIXEL_ID: ${{ inputs.target == 'staging' && secrets.META_PIXEL_ID || '' }}
-          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ inputs.target == 'staging' && secrets.novohamburgo_page_id || '' }}
-          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ inputs.target == 'staging' && secrets.barrashopppingsul_page_id || '' }}
+          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ inputs.target == 'staging' && secrets.NOVOHAMBURGO_PAGE_ID || '' }}
+          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ inputs.target == 'staging' && secrets.BARRASHOPPPINGSUL_PAGE_ID || '' }}
           META_ADS_ACCOUNT_ID: ${{ inputs.target == 'staging' && vars.META_ADS_ACCOUNT_ID || '' }}
           META_ADS_API_VERSION: ${{ inputs.target == 'staging' && vars.META_ADS_API_VERSION || '' }}
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
@@ -1414,8 +1414,8 @@ jobs:
         env:
           META_ADS_ACCESS_TOKEN: ${{ inputs.target == 'staging' && secrets.META_ADS_ACCESS_TOKEN || '' }}
           META_PIXEL_ID: ${{ inputs.target == 'staging' && secrets.META_PIXEL_ID || '' }}
-          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ inputs.target == 'staging' && secrets.novohamburgo_page_id || '' }}
-          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ inputs.target == 'staging' && secrets.barrashopppingsul_page_id || '' }}
+          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ inputs.target == 'staging' && secrets.NOVOHAMBURGO_PAGE_ID || '' }}
+          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ inputs.target == 'staging' && secrets.BARRASHOPPPINGSUL_PAGE_ID || '' }}
           META_ADS_ACCOUNT_ID: ${{ inputs.target == 'staging' && vars.META_ADS_ACCOUNT_ID || '' }}
           META_ADS_API_VERSION: ${{ inputs.target == 'staging' && vars.META_ADS_API_VERSION || '' }}
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}

--- a/platform/security/token-vault/tests/deploy-token-vault-staging-synthetic-seed-workflow.test.js
+++ b/platform/security/token-vault/tests/deploy-token-vault-staging-synthetic-seed-workflow.test.js
@@ -79,11 +79,11 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
 
   assert.match(
     authorization,
-    /META_ADS_NOVOHAMBURGO_PAGE_ID: \$\{\{ inputs\.target == 'staging' && secrets\.novohamburgo_page_id \|\| '' \}\}/,
+    /META_ADS_NOVOHAMBURGO_PAGE_ID: \$\{\{ inputs\.target == 'staging' && secrets\.NOVOHAMBURGO_PAGE_ID \|\| '' \}\}/,
   );
   assert.match(
     authorization,
-    /META_ADS_BARRASHOPPPINGSUL_PAGE_ID: \$\{\{ inputs\.target == 'staging' && secrets\.barrashopppingsul_page_id \|\| '' \}\}/,
+    /META_ADS_BARRASHOPPPINGSUL_PAGE_ID: \$\{\{ inputs\.target == 'staging' && secrets\.BARRASHOPPPINGSUL_PAGE_ID \|\| '' \}\}/,
   );
   assert.match(
     authorization,

--- a/platform/security/token-vault/tests/meta-ads-candidate-appsecret-proof-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-candidate-appsecret-proof-workflow.test.js
@@ -105,11 +105,11 @@ test("candidate appsecret-proof request keeps source inputs and bearer private w
   assert.match(workflow, /pixel_id: pixelId/);
   assert.match(
     workflow,
-    /META_ADS_NOVOHAMBURGO_PAGE_ID: \$\{\{ secrets\.novohamburgo_page_id \}\}/,
+    /META_ADS_NOVOHAMBURGO_PAGE_ID: \$\{\{ secrets\.NOVOHAMBURGO_PAGE_ID \}\}/,
   );
   assert.match(
     workflow,
-    /META_ADS_BARRASHOPPPINGSUL_PAGE_ID: \$\{\{ secrets\.barrashopppingsul_page_id \}\}/,
+    /META_ADS_BARRASHOPPPINGSUL_PAGE_ID: \$\{\{ secrets\.BARRASHOPPPINGSUL_PAGE_ID \}\}/,
   );
   assert.match(
     workflow,

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -187,11 +187,11 @@ test("Meta Ads source-access attestation is manual, GET-only, and bound to two s
   assert.match(workflow, /timeout-minutes: 3/);
   assert.match(
     workflow,
-    /META_ADS_NOVOHAMBURGO_PAGE_ID: \$\{\{ secrets\.novohamburgo_page_id \}\}/,
+    /META_ADS_NOVOHAMBURGO_PAGE_ID: \$\{\{ secrets\.NOVOHAMBURGO_PAGE_ID \}\}/,
   );
   assert.match(
     workflow,
-    /META_ADS_BARRASHOPPPINGSUL_PAGE_ID: \$\{\{ secrets\.barrashopppingsul_page_id \}\}/,
+    /META_ADS_BARRASHOPPPINGSUL_PAGE_ID: \$\{\{ secrets\.BARRASHOPPPINGSUL_PAGE_ID \}\}/,
   );
   assert.match(workflow, /destinationSelectors = \{[\s\S]*novo_hamburgo:[\s\S]*barra_shopping_sul:/);
   assert.match(workflow, /source_destination_page_selector_invalid/);


### PR DESCRIPTION
## What changed

- Corrects the three staging workflow bindings to use GitHub's canonical uppercase storage names for the two existing Page-ID Environment secrets.
- No secret values, secret names, custody records, request shapes, or destination mappings changed; this is only an expression-level binding correction.

## Why

The first post-merge raw attestation stopped at the fixed `source_destination_page_selector_invalid` contract guard before any Graph read. GitHub metadata shows the provisioned Environment secret names are stored uppercase regardless of their lowercase creation spelling. The workflow now references those canonical names without asking for a rename or reading a value.

## Safety and rollback

Staging-only. Raw and candidate attestation remain GET-only before any D1 or Graph POST, and selectors remain absent from logs, outputs, artifacts, Worker secrets files, and rollback bodies. Production is unchanged (`flag=n/a`, `migration=n/a`). Rollback is the protected revert/PR path.

## Validation

- Focused workflow tests: 12/12
- Token Vault suite: 167/167
- Formal Codex Security diff scan: 0 findings
- `git diff --check`: pass

No secret values or Page IDs are included in this PR.