### PR TITLE
diag(meta-ads): split destination Page reads

### DIFF
--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -193,17 +193,21 @@ jobs:
           }
 
           for (const pair of destinationPairs) {
-            const page = await directRead(
-              `${pair.pageId}?fields=id,instagram_business_account{id},website,picture{url}`,
-              `source_destination_page_${pair.destinationKey}`,
+            const pageIdentity = await directRead(
+              `${pair.pageId}?fields=id,instagram_business_account{id}`,
+              `source_destination_page_${pair.destinationKey}_identity`,
             );
             if (
-              numericId(page?.id) !== pair.pageId ||
-              numericId(page?.instagram_business_account?.id) !== pair.instagramId
+              numericId(pageIdentity?.id) !== pair.pageId ||
+              numericId(pageIdentity?.instagram_business_account?.id) !== pair.instagramId
             ) {
               fail('source_destination_page_pair_mismatch');
             }
-            if (!validLanding(page?.website) || !validPicture(page?.picture)) {
+            const pagePresentation = await directRead(
+              `${pair.pageId}?fields=website,picture{url}`,
+              `source_destination_page_${pair.destinationKey}_presentation`,
+            );
+            if (!validLanding(pagePresentation?.website) || !validPicture(pagePresentation?.picture)) {
               fail('source_destination_landing_or_media_unavailable');
             }
           }

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -137,20 +137,32 @@ function happyResponses() {
     },
     {
       pathname: `/v25.0/${syntheticNovoPageId}`,
-      query: { fields: "id,instagram_business_account{id},website,picture{url}" },
+      query: { fields: "id,instagram_business_account{id}" },
       payload: {
         id: syntheticNovoPageId,
         instagram_business_account: { id: syntheticNovoInstagramId },
+      },
+    },
+    {
+      pathname: `/v25.0/${syntheticNovoPageId}`,
+      query: { fields: "website,picture{url}" },
+      payload: {
         website: "https://novo.example.test",
         picture: { data: { url: "https://cdn.example.test/novo.jpg" } },
       },
     },
     {
       pathname: `/v25.0/${syntheticBarraPageId}`,
-      query: { fields: "id,instagram_business_account{id},website,picture{url}" },
+      query: { fields: "id,instagram_business_account{id}" },
       payload: {
         id: syntheticBarraPageId,
         instagram_business_account: { id: syntheticBarraInstagramId },
+      },
+    },
+    {
+      pathname: `/v25.0/${syntheticBarraPageId}`,
+      query: { fields: "website,picture{url}" },
+      payload: {
         website: "https://barra.example.test",
         picture: { data: { url: "https://cdn.example.test/barra.jpg" } },
       },
@@ -200,6 +212,8 @@ test("Meta Ads source-access attestation is manual, GET-only, and bound to two s
   assert.match(workflow, /source_destination_page_selector_ambiguous/);
   assert.match(workflow, /source_destination_page_pair_duplicate/);
   assert.match(workflow, /source_destination_page_pair_mismatch/);
+  assert.match(workflow, /source_destination_page_\$\{pair\.destinationKey\}_identity/);
+  assert.match(workflow, /source_destination_page_\$\{pair\.destinationKey\}_presentation/);
   assert.match(workflow, /source_access_novohamburgo_page_instagram=eligible/);
   assert.match(workflow, /source_access_barrashopppingsul_page_instagram=eligible/);
 
@@ -223,7 +237,7 @@ test("Meta Ads source-access verifier proves both assigned Page and Instagram pa
   const result = runVerifier(happyResponses());
   const combined = `${result.stdout}${result.stderr}`;
   assert.equal(result.status, 0, combined);
-  assert.equal(result.requestCount, 7);
+  assert.equal(result.requestCount, 9);
   assert.equal(
     result.stdout,
     [
@@ -270,7 +284,7 @@ test("Meta Ads source-access verifier accepts Profile Plus advertising and exact
   const result = runVerifier(responses);
   const combined = `${result.stdout}${result.stderr}`;
   assert.equal(result.status, 0, combined);
-  assert.equal(result.requestCount, 7);
+  assert.equal(result.requestCount, 9);
   assert.match(result.stdout, /source_access_raw=verified/);
   assertNoSyntheticInputs(combined);
 });
@@ -346,11 +360,41 @@ test("Meta Ads source-access verifier rejects duplicate, paged, and swapped dest
   assert.match(`${paged.stdout}${paged.stderr}`, /source_system_user_pages_paging_ambiguous/);
 
   const swappedResponses = happyResponses();
-  swappedResponses[5].payload.instagram_business_account.id = syntheticNovoInstagramId;
-  const swapped = runVerifier(swappedResponses, { expectedRequests: 6 });
+  swappedResponses[6].payload.instagram_business_account.id = syntheticNovoInstagramId;
+  const swapped = runVerifier(swappedResponses, { expectedRequests: 7 });
   assert.notEqual(swapped.status, 0);
-  assert.equal(swapped.requestCount, 6);
+  assert.equal(swapped.requestCount, 7);
   assert.match(`${swapped.stdout}${swapped.stderr}`, /source_destination_page_pair_mismatch/);
+});
+
+test("Meta Ads source-access verifier separates Page identity and presentation failures", () => {
+  const identityResponses = happyResponses();
+  identityResponses[4] = {
+    ...identityResponses[4],
+    status: 400,
+    payload: { error: { code: 100, message: "synthetic identity field detail" } },
+  };
+  const identity = runVerifier(identityResponses, { expectedRequests: 5 });
+  const identityCombined = `${identity.stdout}${identity.stderr}`;
+  assert.notEqual(identity.status, 0);
+  assert.equal(identity.requestCount, 5);
+  assert.match(identityCombined, /source_destination_page_novo_hamburgo_identity_malformed/);
+  assert.doesNotMatch(identityCombined, /synthetic identity field detail|source_access_raw=verified/);
+  assertNoSyntheticInputs(identityCombined);
+
+  const presentationResponses = happyResponses();
+  presentationResponses[5] = {
+    ...presentationResponses[5],
+    status: 400,
+    payload: { error: { code: 100, message: "synthetic presentation field detail" } },
+  };
+  const presentation = runVerifier(presentationResponses, { expectedRequests: 6 });
+  const presentationCombined = `${presentation.stdout}${presentation.stderr}`;
+  assert.notEqual(presentation.status, 0);
+  assert.equal(presentation.requestCount, 6);
+  assert.match(presentationCombined, /source_destination_page_novo_hamburgo_presentation_malformed/);
+  assert.doesNotMatch(presentationCombined, /synthetic presentation field detail|source_access_raw=verified/);
+  assertNoSyntheticInputs(presentationCombined);
 });
 
 test("Meta Ads source-access verifier reports only classified Graph failures", () => {


### PR DESCRIPTION
## Summary\n- Split each selected staging Page read into an identity GET and a presentation GET.\n- Keep the raw attestation manual, main-only, GET-only, fixed-origin, redacted, and non-deploying.\n- Add behavioral coverage for identity-vs-presentation malformed responses and exact early-stop counts.\n\n## Why\nThe post-merge raw attestation passed selector, Pixel, account-membership, and System User assignment checks, then stopped on the first destination with the safe source_destination_page_novo_hamburgo_malformed classification. The previous combined Page request could not distinguish an identity-field contract issue from a website/picture-field issue. This diagnostic split makes that distinction without reading or logging any Graph error details.\n\n## Safety and scope\n- No Worker, D1, Meta Graph POST, staging promotion, traffic, fixture, Orb, Ponto, or CRM changes.\n- All requests remain bounded GETs with fixed Graph origin, timeout, no redirects, and no raw response output.\n- Selector/token/IDs remain absent from logs, outputs, and artifacts.\n- Rollback: revert this two-file diagnostic commit; no external state was mutated.\n\n## Validation\n- Token Vault full suite: 168/168.\n- git diff --check: passed.\n- Codex Security diff scan 9ebea7ee-3bb8-49c0-9bd9-01a878bdaa84: complete, 0 findings, complete coverage.