### PR TITLE
ops(crm): reconcile Atendimento Pages actor secret

### DIFF
--- a/.github/governance/cloudflare-single-writer-policy.json
+++ b/.github/governance/cloudflare-single-writer-policy.json
@@ -100,6 +100,7 @@
         ".github/workflows/cloudflare-pages-sync-ponto.yml",
         ".github/workflows/cloudflare-pages-sync-escala.yml",
         ".github/workflows/cloudflare-pages-sync-meta-ads-report-secret.yml",
+        ".github/workflows/cloudflare-pages-sync-atendimento.yml",
         ".github/workflows/cloudflare-sync-integrations-encryption-secret.yml"
       ],
       "automaticDeploymentsRequired": false

--- a/.github/scripts/atendimento-pages-secret-custody.test.mjs
+++ b/.github/scripts/atendimento-pages-secret-custody.test.mjs
@@ -1,0 +1,27 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+const workflow = fs.readFileSync(path.join(root, '.github', 'workflows', 'cloudflare-pages-sync-atendimento.yml'), 'utf8')
+const runbook = fs.readFileSync(path.join(root, 'docs', 'runbooks', 'atendimento-pages-secret-custody.md'), 'utf8')
+
+test('Atendimento Pages secret reconciliation is manual, gated and environment-scoped', () => {
+  assert.match(workflow, /workflow_dispatch:/)
+  assert.doesNotMatch(workflow, /schedule:/)
+  assert.match(workflow, /ENABLE_CRM_GENERAL_PAGES_DEPLOY/)
+  assert.match(workflow, /global-coordination-acquire/)
+  assert.match(workflow, /global-coordination-check/)
+  assert.match(workflow, /global-coordination-release/)
+  assert.match(workflow, /global:crm-cloudflare-writer/)
+  assert.match(workflow, /ATENDIMENTO_ACTOR_HMAC_KEY/)
+  assert.match(workflow, /pages secret put ATENDIMENTO_ACTOR_HMAC_KEY --project-name "\$PROJECT" --env "\$env_name"/)
+  assert.match(workflow, /for env_name in production preview/)
+  assert.match(workflow, /binding\.get\('type'\) != 'secret_text'/)
+  assert.match(workflow, /PROJECT: \$\{\{ vars\.CRM_GENERAL_PAGES_PROJECT \}\}/)
+  assert.match(runbook, /mesma `ATENDIMENTO_ACTOR_HMAC_KEY`/i)
+  assert.match(runbook, /Health e presença de secret não provam/i)
+  assert.doesNotMatch(workflow, /echo .*ATENDIMENTO_ACTOR_HMAC_KEY\}/)
+})

--- a/.github/workflows/cloudflare-pages-sync-atendimento.yml
+++ b/.github/workflows/cloudflare-pages-sync-atendimento.yml
@@ -1,0 +1,129 @@
+name: Sync Atendimento actor secret (Pages)
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: Governed reason for reconciling the Pages actor secret with the isolated runtime
+        required: true
+        type: string
+
+concurrency:
+  group: global:crm-cloudflare-writer
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Guard Cloudflare credentials, production gate and Atendimento secret
+        id: guard
+        env:
+          TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT: ${{ vars.CRM_GENERAL_PAGES_PROJECT }}
+          ENABLE_PRODUCTION: ${{ vars.ENABLE_CRM_GENERAL_PAGES_DEPLOY }}
+          ATENDIMENTO_ACTOR_HMAC_KEY: ${{ secrets.ATENDIMENTO_ACTOR_HMAC_KEY }}
+          REASON: ${{ inputs.reason }}
+        run: |
+          set -euo pipefail
+          [[ -n "${TOKEN:-}" && -n "${ACCOUNT_ID:-}" ]] || { echo 'Cloudflare credentials are required.'; exit 1; }
+          [[ "${ENABLE_PRODUCTION:-}" == true ]] || { echo 'ENABLE_CRM_GENERAL_PAGES_DEPLOY must be true for this production secret reconciliation.'; exit 1; }
+          [[ "${PROJECT:-}" == skincos ]] || { echo 'Atendimento production secret reconciliation requires the canonical skincos Pages project.'; exit 1; }
+          [[ "${REASON:-}" =~ ^[^[:space:]][^[:cntrl:]]{7,239}$ ]] || { echo 'A bounded non-secret reason is required.'; exit 1; }
+          [[ -n "${ATENDIMENTO_ACTOR_HMAC_KEY:-}" ]] || { echo 'Missing GitHub secret ATENDIMENTO_ACTOR_HMAC_KEY.'; exit 1; }
+          [[ "${#ATENDIMENTO_ACTOR_HMAC_KEY}" -ge 32 ]] || { echo 'ATENDIMENTO_ACTOR_HMAC_KEY must contain at least 32 characters.'; exit 1; }
+          [[ "${ATENDIMENTO_ACTOR_HMAC_KEY}" != __*__ ]] || { echo 'ATENDIMENTO_ACTOR_HMAC_KEY is a placeholder.'; exit 1; }
+          echo "project=$PROJECT" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout reviewed workflow source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "22.12.0"
+
+      - name: Acquire CRM Cloudflare writer lease
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY || secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || 'legacy-v1' }}
+          resource: global:crm-cloudflare-writer
+          module: crm-pages
+          source_sha: ${{ github.sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-atendimento-pages-secret.json
+
+      - name: Check CRM Cloudflare writer lease before secret mutation
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY || secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || 'legacy-v1' }}
+          resource: global:crm-cloudflare-writer
+          module: crm-pages
+          source_sha: ${{ github.sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-atendimento-pages-secret.json
+
+      - name: Sync Atendimento actor secret to Pages environments
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT: ${{ steps.guard.outputs.project }}
+          ATENDIMENTO_ACTOR_HMAC_KEY: ${{ secrets.ATENDIMENTO_ACTOR_HMAC_KEY }}
+        run: |
+          set -euo pipefail
+          for env_name in production preview; do
+            printf '%s' "$ATENDIMENTO_ACTOR_HMAC_KEY" | npx --yes wrangler@4.112.0 pages secret put ATENDIMENTO_ACTOR_HMAC_KEY --project-name "$PROJECT" --env "$env_name" >/dev/null
+            echo "Synced ATENDIMENTO_ACTOR_HMAC_KEY for env=$env_name"
+          done
+
+      - name: Verify remote Pages secret metadata
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT: ${{ steps.guard.outputs.project }}
+        run: |
+          set -euo pipefail
+          project_json="$RUNNER_TEMP/atendimento-pages-project.json"
+          curl --fail --silent --show-error \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            -H 'Content-Type: application/json' \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT" \
+            > "$project_json"
+          PROJECT_JSON="$project_json" python - <<'PY'
+          import json
+          import os
+          with open(os.environ['PROJECT_JSON'], 'r', encoding='utf-8') as handle:
+              payload = json.load(handle)
+          if payload.get('success') is not True:
+              raise SystemExit('Cloudflare API returned success=false')
+          configs = (payload.get('result') or {}).get('deployment_configs') or {}
+          missing = []
+          for environment in ('production', 'preview'):
+              binding = ((configs.get(environment) or {}).get('env_vars') or {}).get('ATENDIMENTO_ACTOR_HMAC_KEY')
+              if not isinstance(binding, dict) or binding.get('type') != 'secret_text':
+                  missing.append(environment)
+          if missing:
+              raise SystemExit('ATENDIMENTO_ACTOR_HMAC_KEY is not a secret binding in: ' + ', '.join(missing))
+          print('ATENDIMENTO_ACTOR_HMAC_KEY secret binding present in production/preview.')
+          PY
+
+      - name: Release CRM Cloudflare writer lease
+        if: ${{ always() }}
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: 'true'
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY || secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || 'legacy-v1' }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-atendimento-pages-secret.json

--- a/docs/runbooks/atendimento-pages-secret-custody.md
+++ b/docs/runbooks/atendimento-pages-secret-custody.md
@@ -1,0 +1,27 @@
+# Atendimento — custódia da assinatura Pages → runtime
+
+O Pages Function de Atendimento e o runtime nativo isolado precisam usar a
+mesma `ATENDIMENTO_ACTOR_HMAC_KEY` para a assinatura v2. A chave é um segredo
+interno gerado, não deve entrar no Git, em logs ou em artefatos.
+
+## Reconciliação governada
+
+O workflow manual
+`.github/workflows/cloudflare-pages-sync-atendimento.yml` propaga a chave
+privada do GitHub Environment para as configurações `production` e `preview`
+do projeto Pages canônico `skincos`. Ele exige o gate geral de Pages, o lease
+`global:crm-cloudflare-writer` e verifica somente a presença do binding como
+`secret_text`; o valor nunca é lido de volta.
+
+Antes de executar:
+
+1. confirme que o valor em `ATENDIMENTO_ACTOR_HMAC_KEY` é exatamente o valor
+   atualmente aceito pelo runtime nativo, sem gerar uma segunda chave;
+2. registre o motivo operacional sem incluir segredo, PII ou token;
+3. mantenha o runtime em `active`, read-only e no SHA qualificado;
+4. após o workflow, execute o smoke assinado do runtime e a jornada autenticada
+   do CRM. Health e presença de secret não provam a assinatura funcional.
+
+O rollback desta reconciliação é a contenção do módulo para `maintenance` e o
+retorno do Pages ao deployment imutável anterior. Não há fallback para
+`CRM_API_TARGET`, `ESCALA_ACTOR_HMAC_KEY` ou o gateway compartilhado.


### PR DESCRIPTION
Ajusta a governança e cria a reconciliação manual da chave HMAC dedicada que o Pages Function usa para assinar os atores do Atendimento. O runtime nativo já está qualificado no SHA e45a170e1008c43ff16461c93c436cae97e4d4a4; a validação autenticada mostrou que o Pages alcança o runtime, mas as assinaturas são rejeitadas por divergência de custódia.

Incluído:
- workflow manual e fail-closed para propagar ATENDIMENTO_ACTOR_HMAC_KEY aos ambientes production/preview do Pages `skincos`;
- gate ENABLE_CRM_GENERAL_PAGES_DEPLOY, lease/check/release global `crm-cloudflare-writer` e readback somente de metadados `secret_text`;
- classificação na política oficial single-writer;
- teste estático e runbook com rollback e sem exposição do valor.

Validação local:
- validate-cloudflare-single-writer.mjs e .test.mjs;
- atendimento-deployment-contract.test.mjs;
- atendimento-pages-secret-custody.test.mjs;
- git diff --check.

Limites:
- nenhum deploy de produção, flag, banco ou runtime foi alterado por este PR;
- o clone compartilhado permaneceu intocado;
- após merge, a execução manual exigirá a chave privada já aceita pelo runtime e repetição do smoke autenticado; o deployment Pages atual permanece rollbackável.
