### PR TITLE
diag(meta-ads): verify Page fields through assigned_pages

### DIFF
--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -147,6 +147,9 @@ jobs:
             const pageId = numericId(page?.id);
             const instagramId = numericId(page?.instagram_business_account?.id);
             if (!pageId || !instagramId) fail('source_destination_page_assignment_instagram_link_missing');
+            if (!validLanding(page?.website) || !validPicture(page?.picture)) {
+              fail('source_destination_landing_or_media_unavailable');
+            }
             return { destinationKey, pageId, instagramId };
           };
 
@@ -176,7 +179,7 @@ jobs:
           const sourcePrincipalId = numericId(sourcePrincipal?.id);
           if (!sourcePrincipalId) fail('source_system_user_malformed');
           const assignedPages = await directRead(
-            `${sourcePrincipalId}/assigned_pages?fields=id,tasks,instagram_business_account{id}&limit=100`,
+            `${sourcePrincipalId}/assigned_pages?fields=id,tasks,instagram_business_account{id},website,picture{url}&limit=100`,
             'source_system_user_pages',
           );
           if (!Array.isArray(assignedPages?.data)) fail('source_system_user_pages_malformed');
@@ -192,35 +195,9 @@ jobs:
             fail('source_destination_page_pair_duplicate');
           }
 
-          for (const pair of destinationPairs) {
-            const pageIdentity = await directRead(
-              `${pair.pageId}?fields=id`,
-              `source_destination_page_${pair.destinationKey}_identity`,
-            );
-            if (!numericId(pageIdentity?.id)) {
-              fail(`source_destination_page_${pair.destinationKey}_identity_malformed`);
-            }
-            if (numericId(pageIdentity.id) !== pair.pageId) {
-              fail('source_destination_page_pair_mismatch');
-            }
-            const pageInstagram = await directRead(
-              `${pair.pageId}?fields=instagram_business_account{id}`,
-              `source_destination_page_${pair.destinationKey}_instagram`,
-            );
-            if (!numericId(pageInstagram?.instagram_business_account?.id)) {
-              fail(`source_destination_page_${pair.destinationKey}_instagram_malformed`);
-            }
-            if (numericId(pageInstagram.instagram_business_account.id) !== pair.instagramId) {
-              fail('source_destination_page_pair_mismatch');
-            }
-            const pagePresentation = await directRead(
-              `${pair.pageId}?fields=website,picture{url}`,
-              `source_destination_page_${pair.destinationKey}_presentation`,
-            );
-            if (!validLanding(pagePresentation?.website) || !validPicture(pagePresentation?.picture)) {
-              fail('source_destination_landing_or_media_unavailable');
-            }
-          }
+          // The System User's assigned_pages edge returns Page objects. Keep
+          // this read on that edge instead of issuing a Page-node GET with a
+          // bearer whose contract is Business/Marketing scoped.
 
           const datasets = await directRead(
             `act_${accountId}/offline_conversion_data_sets?fields=id&limit=2`,

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -119,56 +119,27 @@ function happyResponses() {
     },
     {
       pathname: `/v25.0/${syntheticSystemUserId}/assigned_pages`,
-      query: { fields: "id,tasks,instagram_business_account{id}", limit: "100" },
+      query: {
+        fields: "id,tasks,instagram_business_account{id},website,picture{url}",
+        limit: "100",
+      },
       payload: {
         data: [
           {
             id: syntheticNovoPageId,
             tasks: ["ADVERTISE"],
             instagram_business_account: { id: syntheticNovoInstagramId },
+            website: "https://novo.example.test",
+            picture: { data: { url: "https://cdn.example.test/novo.jpg" } },
           },
           {
             id: syntheticBarraPageId,
             tasks: ["ADVERTISE"],
             instagram_business_account: { id: syntheticBarraInstagramId },
+            website: "https://barra.example.test",
+            picture: { data: { url: "https://cdn.example.test/barra.jpg" } },
           },
         ],
-      },
-    },
-    {
-      pathname: `/v25.0/${syntheticNovoPageId}`,
-      query: { fields: "id" },
-      payload: { id: syntheticNovoPageId },
-    },
-    {
-      pathname: `/v25.0/${syntheticNovoPageId}`,
-      query: { fields: "instagram_business_account{id}" },
-      payload: { instagram_business_account: { id: syntheticNovoInstagramId } },
-    },
-    {
-      pathname: `/v25.0/${syntheticNovoPageId}`,
-      query: { fields: "website,picture{url}" },
-      payload: {
-        website: "https://novo.example.test",
-        picture: { data: { url: "https://cdn.example.test/novo.jpg" } },
-      },
-    },
-    {
-      pathname: `/v25.0/${syntheticBarraPageId}`,
-      query: { fields: "id" },
-      payload: { id: syntheticBarraPageId },
-    },
-    {
-      pathname: `/v25.0/${syntheticBarraPageId}`,
-      query: { fields: "instagram_business_account{id}" },
-      payload: { instagram_business_account: { id: syntheticBarraInstagramId } },
-    },
-    {
-      pathname: `/v25.0/${syntheticBarraPageId}`,
-      query: { fields: "website,picture{url}" },
-      payload: {
-        website: "https://barra.example.test",
-        picture: { data: { url: "https://cdn.example.test/barra.jpg" } },
       },
     },
     {
@@ -215,10 +186,11 @@ test("Meta Ads source-access attestation is manual, GET-only, and bound to two s
   assert.match(workflow, /source_destination_page_assignment_unassigned/);
   assert.match(workflow, /source_destination_page_selector_ambiguous/);
   assert.match(workflow, /source_destination_page_pair_duplicate/);
-  assert.match(workflow, /source_destination_page_pair_mismatch/);
-  assert.match(workflow, /source_destination_page_\$\{pair\.destinationKey\}_identity/);
-  assert.match(workflow, /source_destination_page_\$\{pair\.destinationKey\}_instagram/);
-  assert.match(workflow, /source_destination_page_\$\{pair\.destinationKey\}_presentation/);
+  assert.match(
+    workflow,
+    /assigned_pages\?fields=id,tasks,instagram_business_account\{id\},website,picture\{url\}&limit=100/,
+  );
+  assert.doesNotMatch(workflow, /\$\{pair\.pageId\}\?fields=/);
   assert.match(workflow, /source_access_novohamburgo_page_instagram=eligible/);
   assert.match(workflow, /source_access_barrashopppingsul_page_instagram=eligible/);
 
@@ -242,7 +214,7 @@ test("Meta Ads source-access verifier proves both assigned Page and Instagram pa
   const result = runVerifier(happyResponses());
   const combined = `${result.stdout}${result.stderr}`;
   assert.equal(result.status, 0, combined);
-  assert.equal(result.requestCount, 11);
+  assert.equal(result.requestCount, 5);
   assert.equal(
     result.stdout,
     [
@@ -289,7 +261,7 @@ test("Meta Ads source-access verifier accepts Profile Plus advertising and exact
   const result = runVerifier(responses);
   const combined = `${result.stdout}${result.stderr}`;
   assert.equal(result.status, 0, combined);
-  assert.equal(result.requestCount, 11);
+  assert.equal(result.requestCount, 5);
   assert.match(result.stdout, /source_access_raw=verified/);
   assertNoSyntheticInputs(combined);
 });
@@ -364,56 +336,32 @@ test("Meta Ads source-access verifier rejects duplicate, paged, and swapped dest
   assert.equal(paged.requestCount, 4);
   assert.match(`${paged.stdout}${paged.stderr}`, /source_system_user_pages_paging_ambiguous/);
 
-  const swappedResponses = happyResponses();
-  swappedResponses[8].payload.instagram_business_account.id = syntheticNovoInstagramId;
-  const swapped = runVerifier(swappedResponses, { expectedRequests: 9 });
-  assert.notEqual(swapped.status, 0);
-  assert.equal(swapped.requestCount, 9);
-  assert.match(`${swapped.stdout}${swapped.stderr}`, /source_destination_page_pair_mismatch/);
 });
 
-test("Meta Ads source-access verifier separates Page identity, Instagram relation, and presentation failures", () => {
-  const identityResponses = happyResponses();
-  identityResponses[4] = {
-    ...identityResponses[4],
-    status: 400,
-    payload: { error: { code: 100, message: "synthetic identity field detail" } },
-  };
-  const identity = runVerifier(identityResponses, { expectedRequests: 5 });
-  const identityCombined = `${identity.stdout}${identity.stderr}`;
-  assert.notEqual(identity.status, 0);
-  assert.equal(identity.requestCount, 5);
-  assert.match(identityCombined, /source_destination_page_novo_hamburgo_identity_malformed/);
-  assert.doesNotMatch(identityCombined, /synthetic identity field detail|source_access_raw=verified/);
-  assertNoSyntheticInputs(identityCombined);
-
-  const instagramResponses = happyResponses();
-  instagramResponses[5] = {
-    ...instagramResponses[5],
-    status: 400,
-    payload: { error: { code: 100, message: "synthetic Instagram field detail" } },
-  };
-  const instagram = runVerifier(instagramResponses, { expectedRequests: 6 });
-  const instagramCombined = `${instagram.stdout}${instagram.stderr}`;
-  assert.notEqual(instagram.status, 0);
-  assert.equal(instagram.requestCount, 6);
-  assert.match(instagramCombined, /source_destination_page_novo_hamburgo_instagram_malformed/);
-  assert.doesNotMatch(instagramCombined, /synthetic Instagram field detail|source_access_raw=verified/);
-  assertNoSyntheticInputs(instagramCombined);
-
+test("Meta Ads source-access verifier uses assigned_pages Page fields and stops before dataset on field failures", () => {
   const presentationResponses = happyResponses();
-  presentationResponses[6] = {
-    ...presentationResponses[6],
-    status: 400,
-    payload: { error: { code: 100, message: "synthetic presentation field detail" } },
-  };
-  const presentation = runVerifier(presentationResponses, { expectedRequests: 7 });
+  delete presentationResponses[3].payload.data[0].website;
+  const presentation = runVerifier(presentationResponses, { expectedRequests: 4 });
   const presentationCombined = `${presentation.stdout}${presentation.stderr}`;
   assert.notEqual(presentation.status, 0);
-  assert.equal(presentation.requestCount, 7);
-  assert.match(presentationCombined, /source_destination_page_novo_hamburgo_presentation_malformed/);
-  assert.doesNotMatch(presentationCombined, /synthetic presentation field detail|source_access_raw=verified/);
+  assert.equal(presentation.requestCount, 4);
+  assert.match(presentationCombined, /source_destination_landing_or_media_unavailable/);
+  assert.doesNotMatch(presentationCombined, /source_access_raw=verified/);
   assertNoSyntheticInputs(presentationCombined);
+
+  const assignedFields = happyResponses();
+  assignedFields[3] = {
+    ...assignedFields[3],
+    status: 400,
+    payload: { error: { code: 100, message: "synthetic assigned Page field detail" } },
+  };
+  const malformed = runVerifier(assignedFields, { expectedRequests: 4 });
+  const malformedCombined = `${malformed.stdout}${malformed.stderr}`;
+  assert.notEqual(malformed.status, 0);
+  assert.equal(malformed.requestCount, 4);
+  assert.match(malformedCombined, /source_system_user_pages_malformed/);
+  assert.doesNotMatch(malformedCombined, /synthetic assigned Page field detail|source_access_raw=verified/);
+  assertNoSyntheticInputs(malformedCombined);
 });
 
 test("Meta Ads source-access verifier reports only classified Graph failures", () => {


### PR DESCRIPTION
## Objetivo

Validar o contrato Graph da attestation raw para Páginas selecionadas sem usar o GET direto /{page-id}. A workflow passa a solicitar id, tarefas, Instagram vinculado, website e picture na relação /{system-user}/assigned_pages, que é a relação já usada para provar a atribuição do System User.

## Motivo

A attestation repetidamente falhou no GET mínimo fields=id da Página Novo Hamburgo, embora a Página já tivesse sido encontrada e aceita na relação de atribuição. O experimento separa contrato de endpoint/campos de uma mudança de permissão Meta.

## Superfícies e impacto

- Alterados somente .github/workflows/attest-meta-ads-source-access.yml e seu teste focal.
- Attestation continua manual, main-only, staging-scoped e GET-only.
- Não altera Worker, candidate proof, D1, seed, Graph POST, bootstrap, traffic, fixture, Orb, Ponto ou CRM.
- Nenhum bearer, selector, ID, payload Graph ou URL sensível é emitido em logs, outputs ou artifacts.

## Risco, flag e migration

- Risco: a resposta assigned_pages pode não projetar todos os campos esperados; nesse caso a attestation falha fechado antes do dataset.
- Flag/coorte: não aplicável; esta é uma verificação diagnóstica manual e não libera staging.
- Migration: não aplicável; nenhum banco ou Worker binding é alterado.

## Validação

- Attestation workflow focal: 9/9.
- Suíte Token Vault: 168/168.
- git diff --check: passou.
- Preflight operacional: failures=0; somente aviso não bloqueante de OAuth local do Wrangler.
- Codex Security diff scan 2bf10556-e6f7-4962-8538-a44803b2859d: 0 findings, cobertura completa dos dois arquivos.

## Rollback

Reverter este commit/PR para restaurar a attestation anterior; como não há mutação externa, não há dados, tráfego ou versão Worker para restaurar. Não executar staging com base apenas nesta PR: candidate runtime proof e a paridade do Worker permanecem gates separados.
