### PR TITLE
diag(meta-ads): probe current dataset Graph contract

### DIFF
--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -199,13 +199,42 @@ jobs:
           // this read on that edge instead of issuing a Page-node GET with a
           // bearer whose contract is Business/Marketing scoped.
 
-          const datasets = await directRead(
-            `act_${accountId}/offline_conversion_data_sets?fields=id&limit=2`,
-            'source_dataset',
-          );
-          if (!Array.isArray(datasets?.data)) fail('source_dataset_malformed');
-          if (hasNextPage(datasets) || datasets.data.length !== 1) fail('source_dataset_ambiguous');
-          if (!numericId(datasets.data[0]?.id)) fail('source_dataset_malformed');
+          const legacyDatasetPath = `act_${accountId}/offline_conversion_data_sets?fields=id&limit=2`;
+          const legacyDatasetResult = await graphGet(legacyDatasetPath);
+          if (legacyDatasetResult.state === 'ok') {
+            const datasets = legacyDatasetResult.payload;
+            if (!Array.isArray(datasets?.data)) fail('source_dataset_malformed');
+            if (hasNextPage(datasets) || datasets.data.length !== 1) fail('source_dataset_ambiguous');
+            if (!numericId(datasets.data[0]?.id)) fail('source_dataset_malformed');
+          } else if (legacyDatasetResult.state === 'malformed') {
+            // The legacy Offline Conversions edge is still present in older
+            // Meta examples, but current SDKs expose AdsDataset from the
+            // Business /ads_dataset edge. Probe that read-only contract only
+            // after the legacy response is structurally invalid; never mark
+            // the raw source eligible from the modern shape because the
+            // Worker still seals offline_conversion_data_set_id today.
+            const account = await directRead(
+              `act_${accountId}?fields=id,business{id}`,
+              'source_dataset_account',
+            );
+            const businessId = numericId(account?.business?.id);
+            if (!businessId) fail('source_dataset_business_malformed');
+            const modernDatasets = await directRead(
+              `${businessId}/ads_dataset?fields=id,dataset_id&limit=5`,
+              'source_dataset_ads_dataset',
+            );
+            if (!Array.isArray(modernDatasets?.data)) fail('source_dataset_ads_dataset_malformed');
+            if (hasNextPage(modernDatasets)) fail('source_dataset_ads_dataset_paging_ambiguous');
+            if (modernDatasets.data.length === 0) fail('source_dataset_ads_dataset_empty');
+            if (modernDatasets.data.length > 1) fail('source_dataset_ads_dataset_ambiguous');
+            const modernDataset = modernDatasets.data[0];
+            if (!numericId(modernDataset?.id) && !numericId(modernDataset?.dataset_id)) {
+              fail('source_dataset_ads_dataset_malformed');
+            }
+            fail('source_dataset_legacy_contract_invalid');
+          } else {
+            fail(`source_dataset_${legacyDatasetResult.state}`);
+          }
 
           process.stdout.write([
             'source_access_raw=verified',

--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -199,20 +199,10 @@ jobs:
           // this read on that edge instead of issuing a Page-node GET with a
           // bearer whose contract is Business/Marketing scoped.
 
-          const legacyDatasetPath = `act_${accountId}/offline_conversion_data_sets?fields=id&limit=2`;
-          const legacyDatasetResult = await graphGet(legacyDatasetPath);
-          if (legacyDatasetResult.state === 'ok') {
-            const datasets = legacyDatasetResult.payload;
-            if (!Array.isArray(datasets?.data)) fail('source_dataset_malformed');
-            if (hasNextPage(datasets) || datasets.data.length !== 1) fail('source_dataset_ambiguous');
-            if (!numericId(datasets.data[0]?.id)) fail('source_dataset_malformed');
-          } else if (legacyDatasetResult.state === 'malformed') {
-            // The legacy Offline Conversions edge is still present in older
-            // Meta examples, but current SDKs expose AdsDataset from the
-            // Business /ads_dataset edge. Probe that read-only contract only
-            // after the legacy response is structurally invalid; never mark
-            // the raw source eligible from the modern shape because the
-            // Worker still seals offline_conversion_data_set_id today.
+          const probeModernDatasetContract = async () => {
+            // A successful HTTP response can still violate the legacy edge's
+            // shape contract. Treat that the same as a malformed Graph error
+            // and continue the bounded modern-edge probe below.
             const account = await directRead(
               `act_${accountId}?fields=id,business{id}`,
               'source_dataset_account',
@@ -231,7 +221,32 @@ jobs:
             if (!numericId(modernDataset?.id) && !numericId(modernDataset?.dataset_id)) {
               fail('source_dataset_ads_dataset_malformed');
             }
+            // The Worker still seals offline_conversion_data_set_id today;
+            // the modern shape is diagnostic evidence, not eligibility.
             fail('source_dataset_legacy_contract_invalid');
+          };
+
+          const legacyDatasetPath = `act_${accountId}/offline_conversion_data_sets?fields=id&limit=2`;
+          const legacyDatasetResult = await graphGet(legacyDatasetPath);
+          if (legacyDatasetResult.state === 'ok') {
+            const datasets = legacyDatasetResult.payload;
+            const malformedShape =
+              !Array.isArray(datasets?.data) ||
+              (datasets.data.length === 1 && !numericId(datasets.data[0]?.id));
+            if (malformedShape) {
+              await probeModernDatasetContract();
+            } else {
+              if (hasNextPage(datasets) || datasets.data.length !== 1) fail('source_dataset_ambiguous');
+              if (!numericId(datasets.data[0]?.id)) fail('source_dataset_malformed');
+            }
+          } else if (legacyDatasetResult.state === 'malformed') {
+            // The legacy Offline Conversions edge is still present in older
+            // Meta examples, but current SDKs expose AdsDataset from the
+            // Business /ads_dataset edge. Probe that read-only contract only
+            // after the legacy response is structurally invalid; never mark
+            // the raw source eligible from the modern shape because the
+            // Worker still seals offline_conversion_data_set_id today.
+            await probeModernDatasetContract();
           } else {
             fail(`source_dataset_${legacyDatasetResult.state}`);
           }

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -22,11 +22,13 @@ const syntheticToken = "synthetic-source-bearer-not-a-secret";
 const syntheticPixelId = "1234567890";
 const syntheticAccountId = "9876543210";
 const syntheticSystemUserId = "6677889900";
+const syntheticBusinessId = "7788990011";
 const syntheticNovoPageId = "1122334455";
 const syntheticNovoInstagramId = "5544332211";
 const syntheticBarraPageId = "2233445566";
 const syntheticBarraInstagramId = "6655443322";
 const syntheticDatasetId = "9988776655";
+const syntheticModernDatasetId = "8899001122";
 
 function runVerifier(
   responses,
@@ -155,11 +157,13 @@ const sensitiveValues = [
   syntheticPixelId,
   syntheticAccountId,
   syntheticSystemUserId,
+  syntheticBusinessId,
   syntheticNovoPageId,
   syntheticNovoInstagramId,
   syntheticBarraPageId,
   syntheticBarraInstagramId,
   syntheticDatasetId,
+  syntheticModernDatasetId,
 ];
 
 function assertNoSyntheticInputs(output) {
@@ -186,6 +190,10 @@ test("Meta Ads source-access attestation is manual, GET-only, and bound to two s
   assert.match(workflow, /source_destination_page_assignment_unassigned/);
   assert.match(workflow, /source_destination_page_selector_ambiguous/);
   assert.match(workflow, /source_destination_page_pair_duplicate/);
+  assert.match(workflow, /offline_conversion_data_sets\?fields=id&limit=2/);
+  assert.match(workflow, /act_\$\{accountId\}\?fields=id,business\{id\}/);
+  assert.match(workflow, /\$\{businessId\}\/ads_dataset\?fields=id,dataset_id&limit=5/);
+  assert.match(workflow, /source_dataset_legacy_contract_invalid/);
   assert.match(
     workflow,
     /assigned_pages\?fields=id,tasks,instagram_business_account\{id\},website,picture\{url\}&limit=100/,
@@ -378,5 +386,31 @@ test("Meta Ads source-access verifier reports only classified Graph failures", (
   assert.equal(result.requestCount, 1);
   assert.match(combined, /source_pixel_denied/);
   assert.doesNotMatch(combined, /synthetic denial detail|source_access_raw=verified/);
+  assertNoSyntheticInputs(combined);
+});
+
+test("Meta Ads source-access verifier probes the current Business AdsDataset contract after a legacy dataset shape failure", () => {
+  const responses = happyResponses();
+  responses.push({
+    pathname: `/v25.0/act_${syntheticAccountId}`,
+    query: { fields: "id,business{id}" },
+    payload: { id: syntheticAccountId, business: { id: syntheticBusinessId } },
+  });
+  responses.push({
+    pathname: `/v25.0/${syntheticBusinessId}/ads_dataset`,
+    query: { fields: "id,dataset_id", limit: "5" },
+    payload: { data: [{ id: syntheticModernDatasetId, dataset_id: syntheticModernDatasetId }] },
+  });
+  responses[4] = {
+    ...responses[4],
+    status: 400,
+    payload: { error: { code: 100, message: "synthetic legacy dataset edge drift" } },
+  };
+  const result = runVerifier(responses, { expectedRequests: 7 });
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0);
+  assert.equal(result.requestCount, 7);
+  assert.match(combined, /source_dataset_legacy_contract_invalid/);
+  assert.doesNotMatch(combined, /synthetic legacy dataset edge drift|source_access_raw=verified/);
   assertNoSyntheticInputs(combined);
 });

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -390,27 +390,33 @@ test("Meta Ads source-access verifier reports only classified Graph failures", (
 });
 
 test("Meta Ads source-access verifier probes the current Business AdsDataset contract after a legacy dataset shape failure", () => {
-  const responses = happyResponses();
-  responses.push({
-    pathname: `/v25.0/act_${syntheticAccountId}`,
-    query: { fields: "id,business{id}" },
-    payload: { id: syntheticAccountId, business: { id: syntheticBusinessId } },
-  });
-  responses.push({
-    pathname: `/v25.0/${syntheticBusinessId}/ads_dataset`,
-    query: { fields: "id,dataset_id", limit: "5" },
-    payload: { data: [{ id: syntheticModernDatasetId, dataset_id: syntheticModernDatasetId }] },
-  });
-  responses[4] = {
-    ...responses[4],
-    status: 400,
-    payload: { error: { code: 100, message: "synthetic legacy dataset edge drift" } },
-  };
-  const result = runVerifier(responses, { expectedRequests: 7 });
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.equal(result.requestCount, 7);
-  assert.match(combined, /source_dataset_legacy_contract_invalid/);
-  assert.doesNotMatch(combined, /synthetic legacy dataset edge drift|source_access_raw=verified/);
-  assertNoSyntheticInputs(combined);
+  for (const legacyPayload of [
+    { error: { code: 100, message: "synthetic legacy dataset edge drift" } },
+    {},
+    { data: { invalid: true } },
+  ]) {
+    const responses = happyResponses();
+    responses.push({
+      pathname: `/v25.0/act_${syntheticAccountId}`,
+      query: { fields: "id,business{id}" },
+      payload: { id: syntheticAccountId, business: { id: syntheticBusinessId } },
+    });
+    responses.push({
+      pathname: `/v25.0/${syntheticBusinessId}/ads_dataset`,
+      query: { fields: "id,dataset_id", limit: "5" },
+      payload: { data: [{ id: syntheticModernDatasetId, dataset_id: syntheticModernDatasetId }] },
+    });
+    responses[4] = {
+      ...responses[4],
+      status: legacyPayload.error ? 400 : 200,
+      payload: legacyPayload,
+    };
+    const result = runVerifier(responses, { expectedRequests: 7 });
+    const combined = `${result.stdout}${result.stderr}`;
+    assert.notEqual(result.status, 0);
+    assert.equal(result.requestCount, 7);
+    assert.match(combined, /source_dataset_legacy_contract_invalid/);
+    assert.doesNotMatch(combined, /synthetic legacy dataset edge drift|source_access_raw=verified/);
+    assertNoSyntheticInputs(combined);
+  }
 });


### PR DESCRIPTION
## Objective
Diagnose the first raw Meta Ads source blocker after Page/Instagram validation: `source_dataset_malformed`.

## Change surface
- Raw-only manual staging attestation workflow.
- Token Vault source-access verifier test harness.

## Behavior
- Preserve the legacy `act_<account>/offline_conversion_data_sets` read when it is structurally valid.
- If that legacy response is structurally malformed, perform bounded read-only account-business resolution and probe the current Business `ads_dataset` edge.
- The modern shape is diagnostic only and still fails closed with `source_dataset_legacy_contract_invalid`; it does not make staging or the Worker eligible.
- No Graph POST, Worker upload, D1, seed, bootstrap, fixture, traffic, Orb, artifact, output, or secret change.

## Risk / flag / migration
- Risk: one or two additional bounded Graph GETs only after the existing legacy dataset read is malformed; fixed redacted codes only.
- Flag: none; manual `main` + `staging` environment workflow remains fail-closed.
- Migration: none.

## Validation
- Focused raw verifier: 10/10.
- Token Vault suite: 169/169.
- `git diff --check` and `codex:preflight` (0 failures; local Wrangler OAuth warning only).
- Codex Security diff scan: no findings on the two changed files.

## Rollback
Revert this commit/PR. The previous raw verifier remains fail-closed on `source_dataset_malformed`; no D1, Worker, Meta mutation, or traffic rollback is required.
