### PR TITLE
fix(meta-ads): request stable AdsDataset id field

### DIFF
--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -209,16 +209,19 @@ jobs:
             );
             const businessId = numericId(account?.business?.id);
             if (!businessId) fail('source_dataset_business_malformed');
-            const modernDatasets = await directRead(
-              `${businessId}/ads_dataset?fields=id,dataset_id&limit=5`,
-              'source_dataset_ads_dataset',
+            const modernDatasetResult = await graphGet(
+              `${businessId}/ads_dataset?fields=id&limit=5`,
             );
+            if (modernDatasetResult.state !== 'ok') {
+              fail(`source_dataset_ads_dataset_response_${modernDatasetResult.state}`);
+            }
+            const modernDatasets = modernDatasetResult.payload;
             if (!Array.isArray(modernDatasets?.data)) fail('source_dataset_ads_dataset_malformed');
             if (hasNextPage(modernDatasets)) fail('source_dataset_ads_dataset_paging_ambiguous');
             if (modernDatasets.data.length === 0) fail('source_dataset_ads_dataset_empty');
             if (modernDatasets.data.length > 1) fail('source_dataset_ads_dataset_ambiguous');
             const modernDataset = modernDatasets.data[0];
-            if (!numericId(modernDataset?.id) && !numericId(modernDataset?.dataset_id)) {
+            if (!numericId(modernDataset?.id)) {
               fail('source_dataset_ads_dataset_malformed');
             }
             // The Worker still seals offline_conversion_data_set_id today;

--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -2257,6 +2257,8 @@ async function discoverStagingSyntheticSeedFacts({
   // The legacy ad-account Offline Conversions edge is no longer the current
   // AdsDataset contract. Resolve the account's owning Business, then use the
   // bounded Business `ads_dataset` edge exposed by Meta's current SDK schema.
+  // Ask only for the stable node id: some Graph versions reject the optional
+  // dataset_id projection even though the SDK exposes it as a model field.
   const account = await read(
     `act_${input.accountId}`,
     'id,business{id}',
@@ -2279,7 +2281,7 @@ async function discoverStagingSyntheticSeedFacts({
   );
   const datasets = await read(
     `${businessId}/ads_dataset`,
-    'id,dataset_id',
+    'id',
     { limit: String(STAGING_SYNTHETIC_SEED_MAX_GRAPH_OBJECTS) },
     failureCodes.datasetAccessDenied,
     failureCodes.identityMalformed,
@@ -2288,11 +2290,8 @@ async function discoverStagingSyntheticSeedFacts({
     throw stagingSyntheticSeedFailure(failureCodes.datasetAmbiguous, 409);
   }
   const datasetEntry = asObject(safeArray(datasets.data)[0]);
-  const datasetIdentifier = /^\d{5,30}$/.test(clean(datasetEntry.id))
-    ? datasetEntry.id
-    : datasetEntry.dataset_id;
   const datasetId = normalizeStagingSyntheticSeedGraphId(
-    datasetIdentifier,
+    datasetEntry.id,
     'offline_dataset_id',
     failureCodes.identityMalformed,
   );

--- a/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
@@ -320,7 +320,11 @@ class FakeGraph {
     const target = new URL(url);
     const path = target.pathname.replace(/^\/v\d+\.0\//, '');
     const method = String(init.method || 'GET').toUpperCase();
-    this.calls.push({ path, method });
+    this.calls.push({
+      path,
+      method,
+      query: Object.fromEntries(target.searchParams.entries()),
+    });
     if (init.headers?.get?.('Authorization') !== `Bearer ${SOURCE_ACCESS_TOKEN}`) {
       return graphResponse({ error: { message: 'invalid auth' } }, 401);
     }
@@ -689,6 +693,10 @@ test('staging seed attestation bounds Graph discovery and returns no source fact
   });
   assert.equal(graph.calls.length, 6);
   assert.ok(graph.calls.every((call) => call.method === 'GET'));
+  assert.deepEqual(
+    graph.calls.find((call) => call.path === `${BUSINESS_ID}/ads_dataset`).query,
+    { fields: 'id', limit: '5' },
+  );
   assert.equal(graph.postCalls.length, 0);
   assert.equal(db.operations.size, 0);
   assert.equal(db.tokens.length, 0);

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -192,7 +192,9 @@ test("Meta Ads source-access attestation is manual, GET-only, and bound to two s
   assert.match(workflow, /source_destination_page_pair_duplicate/);
   assert.match(workflow, /offline_conversion_data_sets\?fields=id&limit=2/);
   assert.match(workflow, /act_\$\{accountId\}\?fields=id,business\{id\}/);
-  assert.match(workflow, /\$\{businessId\}\/ads_dataset\?fields=id,dataset_id&limit=5/);
+  assert.match(workflow, /\$\{businessId\}\/ads_dataset\?fields=id&limit=5/);
+  assert.doesNotMatch(workflow, /ads_dataset\?fields=id,dataset_id/);
+  assert.match(workflow, /source_dataset_ads_dataset_response_\$\{modernDatasetResult\.state\}/);
   assert.match(workflow, /source_dataset_legacy_contract_invalid/);
   assert.match(
     workflow,
@@ -403,8 +405,8 @@ test("Meta Ads source-access verifier probes the current Business AdsDataset con
     });
     responses.push({
       pathname: `/v25.0/${syntheticBusinessId}/ads_dataset`,
-      query: { fields: "id,dataset_id", limit: "5" },
-      payload: { data: [{ id: syntheticModernDatasetId, dataset_id: syntheticModernDatasetId }] },
+      query: { fields: "id", limit: "5" },
+      payload: { data: [{ id: syntheticModernDatasetId }] },
     });
     responses[4] = {
       ...responses[4],


### PR DESCRIPTION
## Objetivo

Corrigir a leitura do AdsDataset no diagnóstico Meta Ads/Token Vault staging depois que a atestação passou por Pixel e Pages e parou no contrato de dataset.

## Mudança

- O Worker e a atestação raw consultam somente `fields=id` no edge Business `ads_dataset`, evitando a projeção opcional `dataset_id` que pode ser rejeitada pelo Graph.
- O Worker normaliza o `id` retornado como o dataset usado pelo contrato existente de seed.
- A atestação raw classifica separadamente uma resposta Graph inválida do shape de resposta, mantendo GET-only, redaction e fail-closed.

## Escopo e risco

Somente Meta Ads/Token Vault source discovery e seus testes. Sem Ponto, CRM, produção, Orb, D1 schema, migrations, secrets, tráfego ou Graph POST. O risco é uma mudança de compatibilidade de leitura; respostas ausentes, não numéricas, ambíguas ou paginadas continuam bloqueadas.

Flag/coorte: não aplicável; o fluxo permanece staging-only e diagnóstico.
Migration: não aplicável.

## Validação

- suíte Token Vault: 169/169
- atestação raw focal: 10/10
- atestação sintética focal: 28/28
- `node --check` e `git diff --check`

## Rollback

Reverter este commit para restaurar a projeção anterior; nenhuma alteração de schema ou dado exige rollback.