### PR TITLE
fix(meta-ads): honor AdsDataset edge parameters

### DIFF
--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -210,7 +210,7 @@ jobs:
             const businessId = numericId(account?.business?.id);
             if (!businessId) fail('source_dataset_business_malformed');
             const modernDatasetResult = await graphGet(
-              `${businessId}/ads_dataset?fields=id&limit=5`,
+              `${businessId}/ads_dataset?fields=id`,
             );
             if (modernDatasetResult.state !== 'ok') {
               fail(`source_dataset_ads_dataset_response_${modernDatasetResult.state}`);

--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -2282,7 +2282,7 @@ async function discoverStagingSyntheticSeedFacts({
   const datasets = await read(
     `${businessId}/ads_dataset`,
     'id',
-    { limit: String(STAGING_SYNTHETIC_SEED_MAX_GRAPH_OBJECTS) },
+    {},
     failureCodes.datasetAccessDenied,
     failureCodes.identityMalformed,
   );

--- a/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
@@ -695,7 +695,7 @@ test('staging seed attestation bounds Graph discovery and returns no source fact
   assert.ok(graph.calls.every((call) => call.method === 'GET'));
   assert.deepEqual(
     graph.calls.find((call) => call.path === `${BUSINESS_ID}/ads_dataset`).query,
-    { fields: 'id', limit: '5' },
+    { fields: 'id' },
   );
   assert.equal(graph.postCalls.length, 0);
   assert.equal(db.operations.size, 0);

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -192,7 +192,8 @@ test("Meta Ads source-access attestation is manual, GET-only, and bound to two s
   assert.match(workflow, /source_destination_page_pair_duplicate/);
   assert.match(workflow, /offline_conversion_data_sets\?fields=id&limit=2/);
   assert.match(workflow, /act_\$\{accountId\}\?fields=id,business\{id\}/);
-  assert.match(workflow, /\$\{businessId\}\/ads_dataset\?fields=id&limit=5/);
+  assert.match(workflow, /\$\{businessId\}\/ads_dataset\?fields=id/);
+  assert.doesNotMatch(workflow, /ads_dataset\?fields=id&limit=/);
   assert.doesNotMatch(workflow, /ads_dataset\?fields=id,dataset_id/);
   assert.match(workflow, /source_dataset_ads_dataset_response_\$\{modernDatasetResult\.state\}/);
   assert.match(workflow, /source_dataset_legacy_contract_invalid/);
@@ -405,7 +406,7 @@ test("Meta Ads source-access verifier probes the current Business AdsDataset con
     });
     responses.push({
       pathname: `/v25.0/${syntheticBusinessId}/ads_dataset`,
-      query: { fields: "id", limit: "5" },
+      query: { fields: "id" },
       payload: { data: [{ id: syntheticModernDatasetId }] },
     });
     responses[4] = {


### PR DESCRIPTION
## Objetivo

Ajustar o contrato Graph do AdsDataset após a atestação raw confirmar que o edge rejeita o parâmetro `limit` usado pelo diagnóstico e pelo Worker.

## Mudança

- Remove `limit` da leitura Business `ads_dataset`; o SDK oficial define somente `id_filter`, `name_filter` e `sort_by` para esse edge.
- Mantém a projeção mínima `fields=id`, normalização numérica, cardinalidade/paginação fail-closed e classificação redigida de resposta Graph.

## Escopo e risco

Somente Meta Ads/Token Vault source discovery e testes. Sem Ponto, CRM, produção, Orb, D1 schema, migrations, secrets, tráfego ou Graph POST. O risco é limitado à compatibilidade de leitura do AdsDataset; falhas de acesso, shape, cardinalidade ou identidade continuam bloqueando.

Flag/coorte: não aplicável; staging-only/diagnóstico permanece fail-closed.
Migration: não aplicável.

## Validação

- suíte Token Vault: 169/169
- atestação raw focal: 10/10
- atestação sintética focal: 28/28
- `node --check`, `git diff --check` e validação de worktree

## Rollback

Reverter este commit restaura o parâmetro anterior; nenhuma alteração de schema ou dado exige rollback.