### PR TITLE
diag(meta-ads): classify AdsDataset contract rejection

### DIFF
--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -66,7 +66,7 @@ jobs:
             fail('source_destination_page_selector_duplicate');
           }
 
-          const graphGet = async (path) => {
+          const graphGet = async (path, { classifyContract = false } = {}) => {
             let response;
             try {
               response = await fetch(`https://graph.facebook.com/${apiVersion}/${path}`, {
@@ -99,7 +99,18 @@ jobs:
                 graphErrorCode === 102 ||
                 graphErrorCode === 190 ||
                 graphErrorCode === 200;
-              return { state: authorizationError ? 'denied' : 'malformed' };
+              // Meta's code 100 is the bounded contract/parameter failure
+              // class. Keep it distinct from an unknown malformed envelope so
+              // the diagnostic can distinguish an unsupported edge/field from
+              // an access denial without exposing the Graph code or body.
+              const contractError = classifyContract && graphErrorCode === 100;
+              return {
+                state: authorizationError
+                  ? 'denied'
+                  : contractError
+                    ? 'contract'
+                    : 'malformed',
+              };
             }
             return { state: 'ok', payload };
           };
@@ -211,6 +222,7 @@ jobs:
             if (!businessId) fail('source_dataset_business_malformed');
             const modernDatasetResult = await graphGet(
               `${businessId}/ads_dataset?fields=id`,
+              { classifyContract: true },
             );
             if (modernDatasetResult.state !== 'ok') {
               fail(`source_dataset_ads_dataset_response_${modernDatasetResult.state}`);

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -392,6 +392,36 @@ test("Meta Ads source-access verifier reports only classified Graph failures", (
   assertNoSyntheticInputs(combined);
 });
 
+test("Meta Ads source-access verifier classifies Graph contract rejection without exposing Graph details", () => {
+  const responses = happyResponses();
+  responses[4] = {
+    ...responses[4],
+    status: 400,
+    payload: { error: { code: 100, message: "synthetic legacy dataset edge drift" } },
+  };
+  responses.push({
+    pathname: `/v25.0/act_${syntheticAccountId}`,
+    query: { fields: "id,business{id}" },
+    payload: { id: syntheticAccountId, business: { id: syntheticBusinessId } },
+  });
+  responses.push({
+    pathname: `/v25.0/${syntheticBusinessId}/ads_dataset`,
+    query: { fields: "id" },
+    status: 400,
+    payload: { error: { code: 100, message: "synthetic modern contract detail" } },
+  });
+  const result = runVerifier(responses, { expectedRequests: 7 });
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.notEqual(result.status, 0);
+  assert.equal(result.requestCount, 7);
+  assert.match(combined, /source_dataset_ads_dataset_response_contract/);
+  assert.doesNotMatch(
+    combined,
+    /synthetic legacy dataset edge drift|synthetic modern contract detail|source_access_raw=verified/,
+  );
+  assertNoSyntheticInputs(combined);
+});
+
 test("Meta Ads source-access verifier probes the current Business AdsDataset contract after a legacy dataset shape failure", () => {
   for (const legacyPayload of [
     { error: { code: 100, message: "synthetic legacy dataset edge drift" } },


### PR DESCRIPTION
## Summary
- classify Meta Graph code-100 responses from the modern `Business/ads_dataset` probe as a fixed contract diagnostic state
- keep all other Graph error classes unchanged and redact status codes, bodies, IDs, and tokens
- add a regression proving contract rejection stops the GET-only attestation before any staging action

## Scope and safety
- Meta Ads / Token Vault source attestation only
- no Meta permission or asset changes
- no Worker upload, D1 migration/query, Graph POST, Orb, traffic, fixture, artifact, or production action
- the workflow remains manual, `main`-only, staging-environment, bounded GET-only, and fail-closed

## Validation
- Token Vault package: 170/170
- `git diff --check`
- Codex Security diff scan: 0 findings
- rollback: revert this commit/PR; no runtime state is mutated by the workflow