### PR TITLE
fix(meta-ads): classify malformed dataset responses

### DIFF
--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -2354,13 +2354,13 @@ async function seedGraphRead(auth, path, fields, context, query = {}, {
     if (isStagingSyntheticSeedSourceAuthFailure(normalized)) {
       throw stagingSyntheticSeedFailure(authFailureCode, 409);
     }
-    // Graph code 100 is a bounded contract/parameter rejection. Keep it
-    // separate from identity/asset failures so a caller does not grant Meta
-    // permissions for an unsupported edge or field projection.
+    // Non-auth permanent/unknown failures on an explicitly classified edge
+    // are bounded contract/response rejections. Keep them separate from
+    // identity/asset failures so a caller does not grant Meta permissions for
+    // an unsupported edge, field projection, or malformed error envelope.
     if (
       clean(contractFailureCode) &&
-      clean(normalized.classification) === 'permanent' &&
-      Number(normalized.code) === 100
+      ['permanent', 'unknown'].includes(clean(normalized.classification))
     ) {
       throw stagingSyntheticSeedFailure(contractFailureCode, 409);
     }

--- a/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
@@ -1176,6 +1176,16 @@ test('staging seed attestation returns a finite resource stage for permanent Gra
       status: 200,
       code: 100,
     },
+    {
+      label: 'dataset-contract-envelope',
+      path: `${BUSINESS_ID}/ads_dataset`,
+      expectedError: 'meta_ads_publish_staging_seed_graph_contract_invalid',
+      expectedReads: 6,
+      // A non-auth 4xx envelope without a usable Graph code is still a
+      // contract/response failure, not an asset-permission verdict.
+      status: 400,
+      code: 0,
+    },
   ];
 
   for (const entry of cases) {


### PR DESCRIPTION
## Summary

- classify non-auth permanent/unknown responses from the modern AdsDataset edge as a bounded Graph contract/response rejection
- preserve authentication failures as dataset access denied
- extend the staging synthetic-seed attestation regression for code-100 and malformed 4xx envelopes

## Safety and scope

- Token Vault source and focused test only
- no Ponto, CRM, Orb, migration, deployment, or production changes
- fixed sanitized response only; no Graph body, identifier, bearer, or app secret is exposed
- no Graph POST or D1 mutation is introduced; staging attestation remains read-only

## Validation

- `npm --prefix platform/security/token-vault test` via Ubuntu-24.04 WSL: 170/170
- `node --check platform/security/token-vault/src/meta-ads-publish.js`
- `git diff --check`

## Rollback

Revert this PR/commit. No external staging or production mutation is part of this change.
