### PR TITLE
diag(meta-ads): classify AdsDataset response shape

### DIFF
--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -221,6 +221,10 @@ const STAGING_SYNTHETIC_SEED_DISCOVERY_FAILURES = Object.freeze({
   pixelAccountRelationAmbiguous: 'meta_ads_publish_staging_seed_graph_identity_invalid',
   pageAccessDenied: 'meta_ads_publish_staging_seed_graph_identity_invalid',
   datasetAccessDenied: 'meta_ads_publish_staging_seed_graph_identity_invalid',
+  // Keep the mutation-capable seed's historical generic response, while
+  // allowing the read-only attestation to classify a successful but
+  // schema-incompatible AdsDataset envelope separately.
+  datasetContractInvalid: 'meta_ads_publish_staging_seed_graph_identity_invalid',
   identityMismatch: 'meta_ads_publish_staging_seed_graph_identity_invalid',
   identityMalformed: 'meta_ads_publish_staging_seed_graph_identity_invalid',
   pageAmbiguous: 'meta_ads_publish_staging_seed_graph_page_ambiguous',
@@ -2296,14 +2300,21 @@ async function discoverStagingSyntheticSeedFacts({
     failureCodes.identityMalformed,
     failureCodes.datasetContractInvalid,
   );
-  if (clean(asObject(datasets.paging).next) || safeArray(datasets.data).length !== 1) {
+  const datasetContractFailure = failureCodes.datasetContractInvalid || failureCodes.identityMalformed;
+  if (!Array.isArray(datasets.data)) {
+    throw stagingSyntheticSeedFailure(datasetContractFailure, 409);
+  }
+  if (clean(asObject(datasets.paging).next) || datasets.data.length !== 1) {
     throw stagingSyntheticSeedFailure(failureCodes.datasetAmbiguous, 409);
   }
-  const datasetEntry = asObject(safeArray(datasets.data)[0]);
+  const datasetEntry = asObject(datasets.data[0]);
+  if (!clean(datasetEntry.id)) {
+    throw stagingSyntheticSeedFailure(datasetContractFailure, 409);
+  }
   const datasetId = normalizeStagingSyntheticSeedGraphId(
     datasetEntry.id,
     'offline_dataset_id',
-    failureCodes.identityMalformed,
+    datasetContractFailure,
   );
   return {
     destinations,

--- a/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
@@ -1557,6 +1557,50 @@ test('staging seed attestation preserves finite non-identity source eligibility 
   }
 });
 
+test('staging seed attestation classifies successful AdsDataset shape drift as a contract failure', async () => {
+  const cases = [
+    {
+      label: 'missing-data-array',
+      body: { id: DATASET_ID },
+    },
+    {
+      label: 'missing-stable-id',
+      body: { data: [{ dataset_id: DATASET_ID }] },
+    },
+  ];
+
+  for (const entry of cases) {
+    const db = new SeedDb();
+    db.prepare = () => {
+      throw new Error('D1 must remain untouched by contract diagnostics');
+    };
+    const graph = new FakeGraph({
+      readResponses: {
+        [`${BUSINESS_ID}/ads_dataset`]: { body: entry.body },
+      },
+    });
+    const response = await attest({
+      db,
+      graph,
+      operationKey: `meta-ads-staging-seed:attestation-${entry.label}-001`,
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 409, entry.label);
+    assert.equal(body.error, 'meta_ads_publish_staging_seed_graph_contract_invalid', entry.label);
+    assert.equal(graph.calls.length, 6, entry.label);
+    assert.ok(graph.calls.every((call) => call.method === 'GET'), entry.label);
+    assert.equal(graph.postCalls.length, 0, entry.label);
+    assert.equal(db.operations.size, 0, entry.label);
+    assert.equal(db.tokens.length, 0, entry.label);
+    assert.equal(db.locks.size, 0, entry.label);
+    const serialized = JSON.stringify(body);
+    for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, DATASET_ID]) {
+      assert.equal(serialized.includes(value), false, entry.label);
+    }
+  }
+});
+
 test('staging seed attestation keeps transient source failures retryable and bounded', async () => {
   const db = new SeedDb();
   const graph = new FakeGraph({


### PR DESCRIPTION
## Summary\n- classify successful but schema-incompatible Business ds_dataset responses as a fixed contract diagnostic\n- preserve the historical generic response for mutation-capable seed calls\n- add read-only regression coverage for missing data arrays and missing stable dataset IDs\n\n## Scope\n- Meta Ads / Token Vault staging synthetic-seed attestation only\n- no Ponto, CRM, Orb workflow, production, or traffic changes\n\n## Risk and controls\n- attestation remains GET-only, staging-only, bounded, and redacted\n- no D1, Graph POST, credential rows, locks, artifacts, or source values are touched\n- contract failures remain fail-closed before seed or traffic\n\n## Operational\n- feature flag: n/a\n- migration: n/a\n- rollback: revert this commit/PR; no runtime state was mutated\n\n## Validation\n- Token Vault package suite: 171/171\n- git diff --check: passed