### PR TITLE
diag(meta-ads): classify modern dataset edge errors

### DIFF
--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -103,7 +103,14 @@ jobs:
               // class. Keep it distinct from an unknown malformed envelope so
               // the diagnostic can distinguish an unsupported edge/field from
               // an access denial without exposing the Graph code or body.
-              const contractError = classifyContract && graphErrorCode === 100;
+              // On the explicitly probed modern AdsDataset edge, a
+              // non-auth 4xx envelope (including an unknown/zero Graph code)
+              // is evidence that the edge/response contract is incompatible,
+              // not evidence that the configured asset is missing. Keep
+              // malformed JSON/shape failures on their own path below.
+              const contractError = classifyContract &&
+                !authorizationError &&
+                (graphErrorCode === 100 || (response.status >= 400 && response.status < 500) || response.ok);
               return {
                 state: authorizationError
                   ? 'denied'

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -393,33 +393,38 @@ test("Meta Ads source-access verifier reports only classified Graph failures", (
 });
 
 test("Meta Ads source-access verifier classifies Graph contract rejection without exposing Graph details", () => {
-  const responses = happyResponses();
-  responses[4] = {
-    ...responses[4],
-    status: 400,
-    payload: { error: { code: 100, message: "synthetic legacy dataset edge drift" } },
-  };
-  responses.push({
-    pathname: `/v25.0/act_${syntheticAccountId}`,
-    query: { fields: "id,business{id}" },
-    payload: { id: syntheticAccountId, business: { id: syntheticBusinessId } },
-  });
-  responses.push({
-    pathname: `/v25.0/${syntheticBusinessId}/ads_dataset`,
-    query: { fields: "id" },
-    status: 400,
-    payload: { error: { code: 100, message: "synthetic modern contract detail" } },
-  });
-  const result = runVerifier(responses, { expectedRequests: 7 });
-  const combined = `${result.stdout}${result.stderr}`;
-  assert.notEqual(result.status, 0);
-  assert.equal(result.requestCount, 7);
-  assert.match(combined, /source_dataset_ads_dataset_response_contract/);
-  assert.doesNotMatch(
-    combined,
-    /synthetic legacy dataset edge drift|synthetic modern contract detail|source_access_raw=verified/,
-  );
-  assertNoSyntheticInputs(combined);
+  for (const modernError of [
+    { code: 100, message: "synthetic modern contract detail" },
+    { code: 0, message: "synthetic unknown modern contract detail" },
+  ]) {
+    const responses = happyResponses();
+    responses[4] = {
+      ...responses[4],
+      status: 400,
+      payload: { error: { code: 100, message: "synthetic legacy dataset edge drift" } },
+    };
+    responses.push({
+      pathname: `/v25.0/act_${syntheticAccountId}`,
+      query: { fields: "id,business{id}" },
+      payload: { id: syntheticAccountId, business: { id: syntheticBusinessId } },
+    });
+    responses.push({
+      pathname: `/v25.0/${syntheticBusinessId}/ads_dataset`,
+      query: { fields: "id" },
+      status: 400,
+      payload: { error: modernError },
+    });
+    const result = runVerifier(responses, { expectedRequests: 7 });
+    const combined = `${result.stdout}${result.stderr}`;
+    assert.notEqual(result.status, 0);
+    assert.equal(result.requestCount, 7);
+    assert.match(combined, /source_dataset_ads_dataset_response_contract/);
+    assert.doesNotMatch(
+      combined,
+      /synthetic legacy dataset edge drift|synthetic modern contract detail|synthetic unknown modern contract detail|source_access_raw=verified/,
+    );
+    assertNoSyntheticInputs(combined);
+  }
 });
 
 test("Meta Ads source-access verifier probes the current Business AdsDataset contract after a legacy dataset shape failure", () => {


### PR DESCRIPTION
## Summary
- classify non-auth error envelopes from the explicitly probed modern AdsDataset edge as a fixed contract state
- preserve malformed JSON/shape as a separate diagnostic
- cover code 100 and unknown non-auth 4xx envelopes without exposing Graph details

## Scope
- Meta Ads raw source-access attestation only
- no Ponto, CRM, Orb workflow, production, D1, Graph POST, traffic, or artifact changes

## Operational
- feature flag: n/a
- migration: n/a
- rollback: revert this commit/PR; the workflow remains GET-only

## Validation
- Token Vault package suite: 171/171
- git diff --check: passed