### PR TITLE
diag: classify filtered Pixel AdsDataset

### DIFF
--- a/.github/workflows/diagnose-meta-ads-pixel-dataset-filtered.yml
+++ b/.github/workflows/diagnose-meta-ads-pixel-dataset-filtered.yml
@@ -1,0 +1,146 @@
+name: Diagnose Filtered Meta Ads Pixel Dataset
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: meta-ads-pixel-dataset-filtered-diagnostic-staging
+  cancel-in-progress: false
+
+jobs:
+  diagnose:
+    if: github.ref == 'refs/heads/main'
+    name: Read the filtered AdsDataset edge without deployment
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    environment: staging
+    steps:
+      - name: Classify the Pixel-filtered AdsDataset response
+        env:
+          META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
+          META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
+          META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
+          META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          const token = String(process.env.META_ADS_ACCESS_TOKEN || '');
+          const pixelId = String(process.env.META_PIXEL_ID || '').trim();
+          const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
+          const apiVersion = String(process.env.META_ADS_API_VERSION || '').trim();
+
+          class DiagnosticFailure extends Error {
+            constructor(code) {
+              super(code);
+              this.code = code;
+            }
+          }
+
+          const fail = (code) => {
+            throw new DiagnosticFailure(code);
+          };
+          const numericId = (value) => {
+            const normalized = String(value || '').trim().replace(/^act_/, '');
+            return /^\d{5,30}$/.test(normalized) ? normalized : '';
+          };
+          const safeCodes = new Set([
+            'pixel_dataset_match',
+            'pixel_dataset_absent',
+            'pixel_dataset_ambiguous',
+            'pixel_dataset_denied',
+            'pixel_dataset_contract',
+          ]);
+
+          const graphGet = async (path, query) => {
+            const url = new URL(`https://graph.facebook.com/${apiVersion}/${path}`);
+            for (const [key, value] of Object.entries(query)) url.searchParams.set(key, String(value));
+            let response;
+            try {
+              response = await fetch(url, {
+                method: 'GET',
+                headers: { Authorization: `Bearer ${token}` },
+                cache: 'no-store',
+                redirect: 'error',
+                signal: AbortSignal.timeout(12_000),
+              });
+            } catch {
+              return { state: 'unavailable' };
+            }
+            if (!response || response.status === 408 || response.status === 429 || response.status >= 500) {
+              return { state: 'unavailable' };
+            }
+            let payload;
+            try {
+              payload = await response.json();
+            } catch {
+              return { state: 'malformed' };
+            }
+            if (payload?.error?.is_transient === true) return { state: 'unavailable' };
+            if (!response.ok || payload?.error) {
+              const graphErrorCode = Number(payload?.error?.code);
+              const denied =
+                response.status === 401 ||
+                response.status === 403 ||
+                graphErrorCode === 10 ||
+                graphErrorCode === 102 ||
+                graphErrorCode === 190 ||
+                graphErrorCode === 200;
+              return { state: denied ? 'denied' : 'contract' };
+            }
+            return { state: 'ok', payload };
+          };
+
+          const main = async () => {
+            if (
+              !token ||
+              !/^\d{5,30}$/.test(pixelId) ||
+              !/^\d{5,30}$/.test(accountId) ||
+              !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion)
+            ) {
+              fail('pixel_dataset_contract');
+            }
+
+            const accountResult = await graphGet(`act_${accountId}`, { fields: 'id,business{id}' });
+            if (accountResult.state === 'denied') fail('pixel_dataset_denied');
+            if (accountResult.state !== 'ok') fail('pixel_dataset_contract');
+            if (numericId(accountResult.payload?.id) !== accountId) fail('pixel_dataset_contract');
+            const businessId = numericId(accountResult.payload?.business?.id);
+            if (!businessId) fail('pixel_dataset_contract');
+
+            const datasetResult = await graphGet(`${businessId}/ads_dataset`, {
+              fields: 'id,dataset_id',
+              id_filter: pixelId,
+            });
+            if (datasetResult.state === 'denied') fail('pixel_dataset_denied');
+            if (datasetResult.state !== 'ok') fail('pixel_dataset_contract');
+
+            const datasets = datasetResult.payload;
+            if (!Array.isArray(datasets?.data)) fail('pixel_dataset_contract');
+            if (String(datasets?.paging?.next ?? '').trim() !== '') fail('pixel_dataset_ambiguous');
+            if (datasets.data.length === 0) fail('pixel_dataset_absent');
+            if (datasets.data.length > 1) fail('pixel_dataset_ambiguous');
+
+            const entry = datasets.data[0];
+            const presentIds = [entry?.id, entry?.dataset_id].filter(
+              (value) => value !== undefined && value !== null && String(value).trim() !== '',
+            );
+            const normalizedIds = presentIds.map(numericId);
+            if (!normalizedIds.length || normalizedIds.some((value) => !value)) fail('pixel_dataset_contract');
+            if (!normalizedIds.includes(pixelId)) fail('pixel_dataset_contract');
+            process.stdout.write('pixel_dataset_match\n');
+          };
+
+          try {
+            await main();
+          } catch (error) {
+            const code = error instanceof DiagnosticFailure && safeCodes.has(error.code)
+              ? error.code
+              : 'pixel_dataset_contract';
+            console.error(`Meta Ads filtered AdsDataset diagnostic: ${code}`);
+            process.exitCode = 1;
+          }
+          NODE

--- a/platform/security/token-vault/tests/meta-ads-pixel-dataset-filtered-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-pixel-dataset-filtered-workflow.test.js
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import test from "node:test";
+
+const workflow = fs.readFileSync(
+  new URL(
+    "../../../../.github/workflows/diagnose-meta-ads-pixel-dataset-filtered.yml",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const embeddedProgram = workflow.match(
+  /node --input-type=module <<'NODE'\n([\s\S]*?)\n\s+NODE/m,
+  )?.[1];
+assert.ok(embeddedProgram, "the filtered AdsDataset workflow must embed its Node verifier");
+
+const syntheticToken = "synthetic-filtered-dataset-bearer-not-a-secret";
+const syntheticPixelId = "1234567890";
+const syntheticAccountId = "9876543210";
+const syntheticBusinessId = "7788990011";
+const syntheticDatasetId = "1234567890";
+const syntheticOtherDatasetId = "8899001122";
+const syntheticGraphMessage = "synthetic Graph body must never be emitted";
+
+function runVerifier(responses, expectedRequests = responses.length) {
+  const harness = `
+    const scenario = ${JSON.stringify(responses)};
+    let cursor = 0;
+    globalThis.fetch = async (value, options = {}) => {
+      const expected = scenario[cursor++];
+      if (!expected) throw new Error('unexpected Graph request');
+      const url = new URL(String(value));
+      if (url.origin !== 'https://graph.facebook.com' || url.pathname !== expected.pathname) {
+        throw new Error('unexpected Graph request');
+      }
+      if (
+        String(options.method || '') !== 'GET' ||
+        String(options.cache || '') !== 'no-store' ||
+        String(options.redirect || '') !== 'error'
+      ) {
+        throw new Error('unexpected Graph request');
+      }
+      if (String(options.headers?.Authorization || '') !== 'Bearer ${syntheticToken}') {
+        throw new Error('unexpected Graph request');
+      }
+      const actualQuery = [...url.searchParams.entries()].sort();
+      const expectedQuery = Object.entries(expected.query || {}).sort();
+      if (JSON.stringify(actualQuery) !== JSON.stringify(expectedQuery)) {
+        throw new Error('unexpected Graph request');
+      }
+      return new Response(JSON.stringify(expected.payload), { status: expected.status ?? 200 });
+    };
+    await (async () => {
+      ${embeddedProgram}
+    })();
+    if (cursor !== ${expectedRequests}) throw new Error('unexpected Graph request count');
+    process.stdout.write('__synthetic_request_count=' + cursor + '\\n');
+  `;
+  const result = spawnSync(process.execPath, ["--input-type=module", "--eval", harness], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      META_ADS_ACCESS_TOKEN: syntheticToken,
+      META_PIXEL_ID: syntheticPixelId,
+      META_ADS_ACCOUNT_ID: syntheticAccountId,
+      META_ADS_API_VERSION: "v25.0",
+    },
+  });
+  const stdout = String(result.stdout || "");
+  const requestCount = /^__synthetic_request_count=(\d+)$/m.exec(stdout);
+  return {
+    ...result,
+    stdout: stdout.replace(/^__synthetic_request_count=\d+\r?\n?/m, ""),
+    requestCount: requestCount ? Number(requestCount[1]) : null,
+  };
+}
+
+function baseResponses() {
+  return [
+    {
+      pathname: `/v25.0/act_${syntheticAccountId}`,
+      query: { fields: "id,business{id}" },
+      payload: { id: syntheticAccountId, business: { id: syntheticBusinessId } },
+    },
+    {
+      pathname: `/v25.0/${syntheticBusinessId}/ads_dataset`,
+      query: { fields: "id,dataset_id", id_filter: syntheticPixelId },
+      payload: { data: [{ id: syntheticDatasetId, dataset_id: syntheticDatasetId }] },
+    },
+  ];
+}
+
+const sensitiveValues = [
+  syntheticToken,
+  syntheticPixelId,
+  syntheticAccountId,
+  syntheticBusinessId,
+  syntheticDatasetId,
+  syntheticOtherDatasetId,
+  syntheticGraphMessage,
+];
+
+function assertNoSensitiveValues(output) {
+  for (const value of sensitiveValues) assert.doesNotMatch(output, new RegExp(value));
+  assert.doesNotMatch(output, /graph\.facebook\.com/);
+}
+
+test("filtered AdsDataset diagnostic is manual, staging-read-only, and no-mutation", () => {
+  assert.match(workflow, /^name: Diagnose Filtered Meta Ads Pixel Dataset$/m);
+  assert.match(workflow, /^\s+workflow_dispatch:\s*$/m);
+  assert.match(workflow, /if: github\.ref == 'refs\/heads\/main'/);
+  assert.match(workflow, /environment: staging/);
+  assert.match(workflow, /timeout-minutes: 3/);
+  assert.match(workflow, /META_ADS_ACCESS_TOKEN: \$\{\{ secrets\.META_ADS_ACCESS_TOKEN \}\}/);
+  assert.match(workflow, /META_PIXEL_ID: \$\{\{ secrets\.META_PIXEL_ID \}\}/);
+  assert.match(workflow, /META_ADS_ACCOUNT_ID: \$\{\{ vars\.META_ADS_ACCOUNT_ID \}\}/);
+  assert.match(workflow, /META_ADS_API_VERSION: \$\{\{ vars\.META_ADS_API_VERSION \}\}/);
+  assert.match(workflow, /ads_dataset/);
+  assert.match(workflow, /fields: 'id,dataset_id'/);
+  assert.match(workflow, /id_filter: pixelId/);
+  assert.match(workflow, /method: 'GET'/);
+  assert.match(workflow, /pixel_dataset_match/);
+  assert.match(workflow, /pixel_dataset_absent/);
+  assert.match(workflow, /pixel_dataset_ambiguous/);
+  assert.match(workflow, /pixel_dataset_denied/);
+  assert.match(workflow, /pixel_dataset_contract/);
+  assert.doesNotMatch(workflow, /offline_conversion_data_sets/);
+  assert.doesNotMatch(workflow, /fields=id&limit=/);
+  assert.doesNotMatch(workflow, /wrangler|deploy-token-vault|upload-artifact|GITHUB_OUTPUT/i);
+  assert.doesNotMatch(workflow, /D1|d1|method: 'POST'|appsecret_proof|META_APP_SECRET/);
+  assert.doesNotMatch(workflow, /console\.log/);
+  assert.doesNotMatch(workflow, /pixel_dataset_(?:id|dataset_id|business_id)/);
+});
+
+test("filtered AdsDataset diagnostic proves one Pixel-matching result without disclosure", () => {
+  const result = runVerifier(baseResponses());
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.equal(result.status, 0, combined);
+  assert.equal(result.requestCount, 2);
+  assert.equal(result.stdout, "pixel_dataset_match\n");
+  assertNoSensitiveValues(combined);
+});
+
+test("filtered AdsDataset diagnostic classifies zero, multiple, and paged results", () => {
+  const absentResponses = baseResponses();
+  absentResponses[1].payload = { data: [] };
+  const absent = runVerifier(absentResponses);
+  assert.notEqual(absent.status, 0);
+  assert.equal(absent.requestCount, 2);
+  assert.match(`${absent.stdout}${absent.stderr}`, /pixel_dataset_absent/);
+  assertNoSensitiveValues(`${absent.stdout}${absent.stderr}`);
+
+  const ambiguousResponses = baseResponses();
+  ambiguousResponses[1].payload = {
+    data: [
+      { id: syntheticDatasetId, dataset_id: syntheticDatasetId },
+      { id: syntheticOtherDatasetId, dataset_id: syntheticOtherDatasetId },
+    ],
+  };
+  const ambiguous = runVerifier(ambiguousResponses);
+  assert.notEqual(ambiguous.status, 0);
+  assert.equal(ambiguous.requestCount, 2);
+  assert.match(`${ambiguous.stdout}${ambiguous.stderr}`, /pixel_dataset_ambiguous/);
+  assertNoSensitiveValues(`${ambiguous.stdout}${ambiguous.stderr}`);
+
+  const pagedResponses = baseResponses();
+  pagedResponses[1].payload.paging = { next: "https://graph.example.invalid/opaque" };
+  const paged = runVerifier(pagedResponses);
+  assert.notEqual(paged.status, 0);
+  assert.equal(paged.requestCount, 2);
+  assert.match(`${paged.stdout}${paged.stderr}`, /pixel_dataset_ambiguous/);
+  assertNoSensitiveValues(`${paged.stdout}${paged.stderr}`);
+});
+
+test("filtered AdsDataset diagnostic distinguishes denial from contract and shape drift", () => {
+  const deniedResponses = baseResponses();
+  deniedResponses[1] = {
+    ...deniedResponses[1],
+    status: 403,
+    payload: { error: { code: 10, message: syntheticGraphMessage } },
+  };
+  const denied = runVerifier(deniedResponses);
+  assert.notEqual(denied.status, 0);
+  assert.equal(denied.requestCount, 2);
+  assert.match(`${denied.stdout}${denied.stderr}`, /pixel_dataset_denied/);
+  assertNoSensitiveValues(`${denied.stdout}${denied.stderr}`);
+
+  for (const payload of [
+    { error: { code: 100, message: syntheticGraphMessage } },
+    { data: [{ id: "not-an-id", dataset_id: syntheticOtherDatasetId }] },
+    { data: [{ id: syntheticOtherDatasetId, dataset_id: syntheticOtherDatasetId }] },
+  ]) {
+    const contractResponses = baseResponses();
+    contractResponses[1] = { ...contractResponses[1], status: payload.error ? 400 : 200, payload };
+    const contract = runVerifier(contractResponses);
+    assert.notEqual(contract.status, 0);
+    assert.equal(contract.requestCount, 2);
+    assert.match(`${contract.stdout}${contract.stderr}`, /pixel_dataset_contract/);
+    assertNoSensitiveValues(`${contract.stdout}${contract.stderr}`);
+  }
+});
+
+test("filtered AdsDataset diagnostic classifies account-side denial and does not broaden reads", () => {
+  const deniedResponses = baseResponses();
+  deniedResponses[0] = {
+    ...deniedResponses[0],
+    status: 403,
+    payload: { error: { code: 200, message: syntheticGraphMessage } },
+  };
+  const denied = runVerifier(deniedResponses, 1);
+  assert.notEqual(denied.status, 0);
+  assert.equal(denied.requestCount, 1);
+  assert.match(`${denied.stdout}${denied.stderr}`, /pixel_dataset_denied/);
+  assertNoSensitiveValues(`${denied.stdout}${denied.stderr}`);
+});


### PR DESCRIPTION
## Summary

- Add a manual, main-only staging-environment diagnostic for the filtered Business AdsDataset edge.
- Resolve the Business from the configured ad account, then issue exactly one GET to the business AdsDataset edge with fields id,dataset_id and the already-custodied Pixel as id_filter.
- Emit only one fixed result class: pixel_dataset_match, pixel_dataset_absent, pixel_dataset_ambiguous, pixel_dataset_denied, or pixel_dataset_contract.

## Scope and safety

- Read-only Graph GETs only; no Graph POST, D1, Wrangler, Worker upload/deploy, staging activation, fixture, Orb, Ponto, or CRM.
- Source token, Pixel ID, Dataset ID, Graph body, and complete URLs never enter logs, outputs, artifacts, or PR text.
- The existing broad offline-dataset read is not retried by this workflow.

## Validation

- Token Vault suite: 176/176.
- Focused diagnostic behavior: 5/5, covering match, absent, multiple/paging ambiguity, denial, and contract/shape drift.
- YAML parse in WSL, diff check, and Cloudflare single-writer governance: green.

## Migration / rollback

- Migration: none.
- Rollback: revert this diagnostic-only commit/PR; no remote state was changed by the workflow.

## Next gate

Only a live pixel_dataset_match will authorize the follow-up raw-attestation/seed contract change. A non-match will be reported as the exact sanitized class and will stop the Meta Ads path. Candidate appsecret-proof and staging remain untouched.