### PR TITLE
diag(meta-ads): isolate AdsDataset ID projection contract

### DIFF
--- a/.github/workflows/diagnose-meta-ads-pixel-dataset-id-projection.yml
+++ b/.github/workflows/diagnose-meta-ads-pixel-dataset-id-projection.yml
@@ -1,0 +1,158 @@
+name: Diagnose Meta Ads Pixel Dataset ID Projection
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: meta-ads-pixel-dataset-id-projection-diagnostic-staging
+  cancel-in-progress: false
+
+jobs:
+  diagnose:
+    if: github.ref == 'refs/heads/main'
+    name: Read the Pixel-filtered AdsDataset ID projection without deployment
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    environment: staging
+    steps:
+      - name: Classify the ID-only Pixel-filtered AdsDataset response
+        env:
+          META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
+          META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
+          META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
+          META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          const token = String(process.env.META_ADS_ACCESS_TOKEN || '');
+          const pixelId = String(process.env.META_PIXEL_ID || '').trim();
+          const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
+          const apiVersion = String(process.env.META_ADS_API_VERSION || '').trim();
+
+          class DiagnosticFailure extends Error {
+            constructor(code) {
+              super(code);
+              this.code = code;
+            }
+          }
+
+          const fail = (code) => {
+            throw new DiagnosticFailure(code);
+          };
+          const numericId = (value) => {
+            const normalized = String(value || '').trim().replace(/^act_/, '');
+            return /^\d{5,30}$/.test(normalized) ? normalized : '';
+          };
+          const safeCodes = new Set([
+            'pixel_dataset_match',
+            'pixel_dataset_absent',
+            'pixel_dataset_ambiguous',
+            'pixel_dataset_mismatch',
+            'pixel_dataset_denied',
+            'pixel_dataset_unavailable',
+            'pixel_dataset_parameter_contract',
+            'pixel_dataset_response_contract',
+            'pixel_dataset_response_shape',
+            'pixel_dataset_account_contract',
+            'pixel_dataset_account_denied',
+            'pixel_dataset_account_unavailable',
+          ]);
+
+          const graphGet = async (path, query) => {
+            const url = new URL(`https://graph.facebook.com/${apiVersion}/${path}`);
+            for (const [key, value] of Object.entries(query)) url.searchParams.set(key, String(value));
+            let response;
+            try {
+              response = await fetch(url, {
+                method: 'GET',
+                headers: { Authorization: `Bearer ${token}` },
+                cache: 'no-store',
+                redirect: 'error',
+                signal: AbortSignal.timeout(12_000),
+              });
+            } catch {
+              return { state: 'unavailable' };
+            }
+            if (!response || response.status === 408 || response.status === 429 || response.status >= 500) {
+              return { state: 'unavailable' };
+            }
+            let payload;
+            try {
+              payload = await response.json();
+            } catch {
+              return { state: 'response_shape' };
+            }
+            if (payload?.error?.is_transient === true) return { state: 'unavailable' };
+            if (!response.ok || payload?.error) {
+              const graphErrorCode = Number(payload?.error?.code);
+              const denied =
+                response.status === 401 ||
+                response.status === 403 ||
+                graphErrorCode === 10 ||
+                graphErrorCode === 102 ||
+                graphErrorCode === 190 ||
+                graphErrorCode === 200;
+              if (denied) return { state: 'denied' };
+              if (graphErrorCode === 100) return { state: 'parameter_contract' };
+              return { state: 'response_contract' };
+            }
+            return { state: 'ok', payload };
+          };
+
+          const main = async () => {
+            if (
+              !token ||
+              !/^\d{5,30}$/.test(pixelId) ||
+              !/^\d{5,30}$/.test(accountId) ||
+              !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion)
+            ) {
+              fail('pixel_dataset_response_contract');
+            }
+
+            const accountResult = await graphGet(`act_${accountId}`, { fields: 'id,business{id}' });
+            if (accountResult.state === 'denied') fail('pixel_dataset_account_denied');
+            if (accountResult.state === 'unavailable') fail('pixel_dataset_account_unavailable');
+            if (accountResult.state !== 'ok') fail('pixel_dataset_account_contract');
+            if (numericId(accountResult.payload?.id) !== accountId) fail('pixel_dataset_account_contract');
+            const businessId = numericId(accountResult.payload?.business?.id);
+            if (!businessId) fail('pixel_dataset_account_contract');
+
+            // This is intentionally a different, projection-only probe from the
+            // prior fields=id,dataset_id diagnostic. It asks only for the stable
+            // node id while retaining the SDK-declared id_filter parameter.
+            const datasetResult = await graphGet(`${businessId}/ads_dataset`, {
+              fields: 'id',
+              id_filter: pixelId,
+            });
+            if (datasetResult.state === 'denied') fail('pixel_dataset_denied');
+            if (datasetResult.state === 'unavailable') fail('pixel_dataset_unavailable');
+            if (datasetResult.state === 'parameter_contract') fail('pixel_dataset_parameter_contract');
+            if (datasetResult.state === 'response_contract') fail('pixel_dataset_response_contract');
+            if (datasetResult.state !== 'ok') fail('pixel_dataset_response_shape');
+
+            const datasets = datasetResult.payload;
+            if (!Array.isArray(datasets?.data)) fail('pixel_dataset_response_shape');
+            if (String(datasets?.paging?.next ?? '').trim() !== '') fail('pixel_dataset_ambiguous');
+            if (datasets.data.length === 0) fail('pixel_dataset_absent');
+            if (datasets.data.length > 1) fail('pixel_dataset_ambiguous');
+
+            const datasetId = numericId(datasets.data[0]?.id);
+            if (!datasetId) fail('pixel_dataset_response_shape');
+            if (datasetId !== pixelId) fail('pixel_dataset_mismatch');
+            process.stdout.write('pixel_dataset_match\n');
+          };
+
+          try {
+            await main();
+          } catch (error) {
+            const code = error instanceof DiagnosticFailure && safeCodes.has(error.code)
+              ? error.code
+              : 'pixel_dataset_response_contract';
+            console.error(`Meta Ads Pixel Dataset ID projection diagnostic: ${code}`);
+            process.exitCode = 1;
+          }
+          NODE

--- a/platform/security/token-vault/tests/meta-ads-pixel-dataset-id-projection-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-pixel-dataset-id-projection-workflow.test.js
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import test from "node:test";
+
+const workflow = fs.readFileSync(
+  new URL(
+    "../../../../.github/workflows/diagnose-meta-ads-pixel-dataset-id-projection.yml",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const embeddedProgram = workflow.match(
+  /node --input-type=module <<'NODE'\n([\s\S]*?)\n\s+NODE/m,
+)?.[1];
+assert.ok(embeddedProgram, "the ID projection workflow must embed its Node verifier");
+
+const syntheticToken = "synthetic-id-projection-bearer-not-a-secret";
+const syntheticPixelId = "1234567890";
+const syntheticAccountId = "9876543210";
+const syntheticBusinessId = "7788990011";
+const syntheticOtherDatasetId = "8899001122";
+const syntheticGraphMessage = "synthetic Graph body must never be emitted";
+
+function runVerifier(responses, expectedRequests = responses.length) {
+  const harness = `
+    const scenario = ${JSON.stringify(responses)};
+    let cursor = 0;
+    globalThis.fetch = async (value, options = {}) => {
+      const expected = scenario[cursor++];
+      if (!expected) throw new Error('unexpected Graph request');
+      const url = new URL(String(value));
+      if (url.origin !== 'https://graph.facebook.com' || url.pathname !== expected.pathname) {
+        throw new Error('unexpected Graph request');
+      }
+      if (
+        String(options.method || '') !== 'GET' ||
+        String(options.cache || '') !== 'no-store' ||
+        String(options.redirect || '') !== 'error'
+      ) {
+        throw new Error('unexpected Graph request');
+      }
+      if (String(options.headers?.Authorization || '') !== 'Bearer ${syntheticToken}') {
+        throw new Error('unexpected Graph request');
+      }
+      const actualQuery = [...url.searchParams.entries()].sort();
+      const expectedQuery = Object.entries(expected.query || {}).sort();
+      if (JSON.stringify(actualQuery) !== JSON.stringify(expectedQuery)) {
+        throw new Error('unexpected Graph request');
+      }
+      return new Response(JSON.stringify(expected.payload), { status: expected.status ?? 200 });
+    };
+    await (async () => {
+      ${embeddedProgram}
+    })();
+    if (cursor !== ${expectedRequests}) throw new Error('unexpected Graph request count');
+    process.stdout.write('__synthetic_request_count=' + cursor + '\\n');
+  `;
+  const result = spawnSync(process.execPath, ["--input-type=module", "--eval", harness], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      META_ADS_ACCESS_TOKEN: syntheticToken,
+      META_PIXEL_ID: syntheticPixelId,
+      META_ADS_ACCOUNT_ID: syntheticAccountId,
+      META_ADS_API_VERSION: "v25.0",
+    },
+  });
+  const stdout = String(result.stdout || "");
+  const requestCount = /^__synthetic_request_count=(\d+)$/m.exec(stdout);
+  return {
+    ...result,
+    stdout: stdout.replace(/^__synthetic_request_count=\d+\r?\n?/m, ""),
+    requestCount: requestCount ? Number(requestCount[1]) : null,
+  };
+}
+
+function baseResponses() {
+  return [
+    {
+      pathname: `/v25.0/act_${syntheticAccountId}`,
+      query: { fields: "id,business{id}" },
+      payload: { id: syntheticAccountId, business: { id: syntheticBusinessId } },
+    },
+    {
+      pathname: `/v25.0/${syntheticBusinessId}/ads_dataset`,
+      query: { fields: "id", id_filter: syntheticPixelId },
+      payload: { data: [{ id: syntheticPixelId }] },
+    },
+  ];
+}
+
+const sensitiveValues = [
+  syntheticToken,
+  syntheticPixelId,
+  syntheticAccountId,
+  syntheticBusinessId,
+  syntheticOtherDatasetId,
+  syntheticGraphMessage,
+];
+
+function assertNoSensitiveValues(output) {
+  for (const value of sensitiveValues) assert.doesNotMatch(output, new RegExp(value));
+  assert.doesNotMatch(output, /graph\.facebook\.com/);
+}
+
+test("ID projection diagnostic is manual, staging-read-only, and separate from the prior fields projection", () => {
+  assert.match(workflow, /^name: Diagnose Meta Ads Pixel Dataset ID Projection$/m);
+  assert.match(workflow, /^\s+workflow_dispatch:\s*$/m);
+  assert.match(workflow, /if: github\.ref == 'refs\/heads\/main'/);
+  assert.match(workflow, /environment: staging/);
+  assert.match(workflow, /META_ADS_ACCESS_TOKEN: \$\{\{ secrets\.META_ADS_ACCESS_TOKEN \}\}/);
+  assert.match(workflow, /META_PIXEL_ID: \$\{\{ secrets\.META_PIXEL_ID \}\}/);
+  assert.match(workflow, /META_ADS_ACCOUNT_ID: \$\{\{ vars\.META_ADS_ACCOUNT_ID \}\}/);
+  assert.match(workflow, /META_ADS_API_VERSION: \$\{\{ vars\.META_ADS_API_VERSION \}\}/);
+  assert.match(workflow, /fields: 'id'/);
+  assert.match(workflow, /id_filter: pixelId/);
+  assert.match(workflow, /pixel_dataset_parameter_contract/);
+  assert.match(workflow, /pixel_dataset_response_contract/);
+  assert.match(workflow, /pixel_dataset_response_shape/);
+  assert.match(workflow, /pixel_dataset_match/);
+  assert.match(workflow, /pixel_dataset_mismatch/);
+  assert.doesNotMatch(workflow, /fields: 'id,dataset_id'/);
+  assert.doesNotMatch(workflow, /offline_conversion_data_sets/);
+  assert.doesNotMatch(workflow, /wrangler|deploy-token-vault|upload-artifact|GITHUB_OUTPUT/i);
+  assert.doesNotMatch(workflow, /D1|d1|method: 'POST'|appsecret_proof|META_APP_SECRET/);
+  assert.doesNotMatch(workflow, /console\.log/);
+});
+
+test("ID-only projection distinguishes a Pixel-matching AdsDataset result", () => {
+  const result = runVerifier(baseResponses());
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.equal(result.status, 0, combined);
+  assert.equal(result.requestCount, 2);
+  assert.equal(result.stdout, "pixel_dataset_match\n");
+  assertNoSensitiveValues(combined);
+});
+
+test("ID-only projection classifies absent, mismatch, ambiguous, and paging results", () => {
+  const absentResponses = baseResponses();
+  absentResponses[1].payload = { data: [] };
+  const absent = runVerifier(absentResponses);
+  assert.notEqual(absent.status, 0);
+  assert.equal(absent.requestCount, 2);
+  assert.match(`${absent.stdout}${absent.stderr}`, /pixel_dataset_absent/);
+  assertNoSensitiveValues(`${absent.stdout}${absent.stderr}`);
+
+  const mismatchResponses = baseResponses();
+  mismatchResponses[1].payload = { data: [{ id: syntheticOtherDatasetId }] };
+  const mismatch = runVerifier(mismatchResponses);
+  assert.notEqual(mismatch.status, 0);
+  assert.equal(mismatch.requestCount, 2);
+  assert.match(`${mismatch.stdout}${mismatch.stderr}`, /pixel_dataset_mismatch/);
+  assertNoSensitiveValues(`${mismatch.stdout}${mismatch.stderr}`);
+
+  const ambiguousResponses = baseResponses();
+  ambiguousResponses[1].payload = { data: [{ id: syntheticPixelId }, { id: syntheticOtherDatasetId }] };
+  const ambiguous = runVerifier(ambiguousResponses);
+  assert.notEqual(ambiguous.status, 0);
+  assert.equal(ambiguous.requestCount, 2);
+  assert.match(`${ambiguous.stdout}${ambiguous.stderr}`, /pixel_dataset_ambiguous/);
+  assertNoSensitiveValues(`${ambiguous.stdout}${ambiguous.stderr}`);
+
+  const pagedResponses = baseResponses();
+  pagedResponses[1].payload.paging = { next: "https://graph.example.invalid/opaque" };
+  const paged = runVerifier(pagedResponses);
+  assert.notEqual(paged.status, 0);
+  assert.equal(paged.requestCount, 2);
+  assert.match(`${paged.stdout}${paged.stderr}`, /pixel_dataset_ambiguous/);
+  assertNoSensitiveValues(`${paged.stdout}${paged.stderr}`);
+});
+
+test("ID-only projection separates parameter/shape failures from permission failures", () => {
+  const deniedResponses = baseResponses();
+  deniedResponses[1] = {
+    ...deniedResponses[1],
+    status: 403,
+    payload: { error: { code: 10, message: syntheticGraphMessage } },
+  };
+  const denied = runVerifier(deniedResponses);
+  assert.notEqual(denied.status, 0);
+  assert.equal(denied.requestCount, 2);
+  assert.match(`${denied.stdout}${denied.stderr}`, /pixel_dataset_denied/);
+  assertNoSensitiveValues(`${denied.stdout}${denied.stderr}`);
+
+  const parameterResponses = baseResponses();
+  parameterResponses[1] = {
+    ...parameterResponses[1],
+    status: 400,
+    payload: { error: { code: 100, message: syntheticGraphMessage } },
+  };
+  const parameter = runVerifier(parameterResponses);
+  assert.notEqual(parameter.status, 0);
+  assert.equal(parameter.requestCount, 2);
+  assert.match(`${parameter.stdout}${parameter.stderr}`, /pixel_dataset_parameter_contract/);
+  assertNoSensitiveValues(`${parameter.stdout}${parameter.stderr}`);
+
+  const shapeResponses = baseResponses();
+  shapeResponses[1].payload = { data: [{ id: "not-an-id" }] };
+  const shape = runVerifier(shapeResponses);
+  assert.notEqual(shape.status, 0);
+  assert.equal(shape.requestCount, 2);
+  assert.match(`${shape.stdout}${shape.stderr}`, /pixel_dataset_response_shape/);
+  assertNoSensitiveValues(`${shape.stdout}${shape.stderr}`);
+});
+
+test("ID projection stops at account-side failure without broadening the read", () => {
+  const accountFailureResponses = baseResponses();
+  accountFailureResponses[0] = {
+    ...accountFailureResponses[0],
+    status: 400,
+    payload: { error: { code: 100, message: syntheticGraphMessage } },
+  };
+  const result = runVerifier(accountFailureResponses, 1);
+  assert.notEqual(result.status, 0);
+  assert.equal(result.requestCount, 1);
+  assert.match(`${result.stdout}${result.stderr}`, /pixel_dataset_account_contract/);
+  assertNoSensitiveValues(`${result.stdout}${result.stderr}`);
+});


### PR DESCRIPTION
## What changed
Adds a manual, staging-only, GET-only discriminator for the Pixel-filtered `Business/ads_dataset` ID projection. It keeps the existing business lookup and `id_filter`, but requests only `fields=id` and classifies parameter rejection, response shape drift, absence, mismatch, ambiguity, transient failure, and explicit auth denial with fixed codes.

## Why
The previous probe requested `id,dataset_id` together and terminated as `pixel_dataset_contract`. The current Meta SDK declares both fields but does not prove that the live Graph projection accepts them together. This narrow probe isolates field/projection drift without broad enumeration, Graph writes, D1, Worker upload, staging, or traffic.

## Safety and scope
- Manual dispatch and `main`-only.
- Staging environment read-only source access only.
- GET requests use Authorization headers, no redirects, no-store cache, and a bounded timeout.
- No Graph POST, D1, Wrangler, artifacts, outputs, staging promotion, Orb, Ponto, or CRM changes.
- Responses/logs emit only fixed sanitized classifications.

## Validation
- Token Vault suite: 181/181.
- Global concurrency governance static suite: 19/19.
- Focused workflow test covers match, absent, mismatch, ambiguous/paged, parameter contract, shape drift, explicit denial, redaction, GET-only behavior, and account cutoff.
- YAML parse and `git diff --check` pass.

## Rollback
Revert this commit or remove the diagnostic workflow; no Meta, D1, Worker, traffic, or production state is changed by it.