### PR TITLE
diag(meta-ads): separate AdsDataset edge contract classes

### DIFF
--- a/.github/workflows/diagnose-meta-ads-pixel-dataset-id-projection.yml
+++ b/.github/workflows/diagnose-meta-ads-pixel-dataset-id-projection.yml
@@ -55,6 +55,7 @@ jobs:
             'pixel_dataset_denied',
             'pixel_dataset_unavailable',
             'pixel_dataset_parameter_contract',
+            'pixel_dataset_edge_contract',
             'pixel_dataset_response_contract',
             'pixel_dataset_response_shape',
             'pixel_dataset_account_contract',
@@ -97,7 +98,12 @@ jobs:
                 graphErrorCode === 190 ||
                 graphErrorCode === 200;
               if (denied) return { state: 'denied' };
-              if (graphErrorCode === 100) return { state: 'parameter_contract' };
+              // With fields=id only, a non-auth 400 is the remaining
+              // parameter/edge contract boundary (most importantly id_filter);
+              // keep 404/405 separate from a valid HTTP response carrying an
+              // incompatible Graph envelope.
+              if (response.status === 400 || graphErrorCode === 100) return { state: 'parameter_contract' };
+              if (response.status === 404 || response.status === 405) return { state: 'edge_contract' };
               return { state: 'response_contract' };
             }
             return { state: 'ok', payload };
@@ -131,6 +137,7 @@ jobs:
             if (datasetResult.state === 'denied') fail('pixel_dataset_denied');
             if (datasetResult.state === 'unavailable') fail('pixel_dataset_unavailable');
             if (datasetResult.state === 'parameter_contract') fail('pixel_dataset_parameter_contract');
+            if (datasetResult.state === 'edge_contract') fail('pixel_dataset_edge_contract');
             if (datasetResult.state === 'response_contract') fail('pixel_dataset_response_contract');
             if (datasetResult.state !== 'ok') fail('pixel_dataset_response_shape');
 

--- a/platform/security/token-vault/tests/meta-ads-pixel-dataset-id-projection-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-pixel-dataset-id-projection-workflow.test.js
@@ -116,6 +116,7 @@ test("ID projection diagnostic is manual, staging-read-only, and separate from t
   assert.match(workflow, /fields: 'id'/);
   assert.match(workflow, /id_filter: pixelId/);
   assert.match(workflow, /pixel_dataset_parameter_contract/);
+  assert.match(workflow, /pixel_dataset_edge_contract/);
   assert.match(workflow, /pixel_dataset_response_contract/);
   assert.match(workflow, /pixel_dataset_response_shape/);
   assert.match(workflow, /pixel_dataset_match/);
@@ -194,6 +195,18 @@ test("ID-only projection separates parameter/shape failures from permission fail
   assert.equal(parameter.requestCount, 2);
   assert.match(`${parameter.stdout}${parameter.stderr}`, /pixel_dataset_parameter_contract/);
   assertNoSensitiveValues(`${parameter.stdout}${parameter.stderr}`);
+
+  const edgeResponses = baseResponses();
+  edgeResponses[1] = {
+    ...edgeResponses[1],
+    status: 404,
+    payload: { error: { code: 33, message: syntheticGraphMessage } },
+  };
+  const edge = runVerifier(edgeResponses);
+  assert.notEqual(edge.status, 0);
+  assert.equal(edge.requestCount, 2);
+  assert.match(`${edge.stdout}${edge.stderr}`, /pixel_dataset_edge_contract/);
+  assertNoSensitiveValues(`${edge.stdout}${edge.stderr}`);
 
   const shapeResponses = baseResponses();
   shapeResponses[1].payload = { data: [{ id: "not-an-id" }] };


### PR DESCRIPTION
## What changed
Refines the already-merged ID-only AdsDataset diagnostic so non-auth Graph failures are separated by contract boundary: HTTP 400/parameter rejection, HTTP 404/405 edge rejection, and valid-response/envelope drift. The request itself remains unchanged and bounded.

## Why
The live ID-only probe returned the sanitized `pixel_dataset_response_contract`. The previous classifier grouped all non-auth errors together, so it could not distinguish a parameter rejection (`id_filter`/request contract) from an edge/path rejection or a 2xx shape drift. This patch makes that distinction without logging Graph details or broadening reads.

## Safety and scope
- Manual `main`-only staging read; GET-only with Authorization header, timeout, no-store, and redirect rejection.
- No Graph POST, D1, Wrangler, seed, candidate proof, staging, traffic, Orb, Ponto, CRM, artifact, or output mutation.
- Only fixed sanitized codes are emitted; no IDs, bearer, Graph body, or URL is printed.

## Validation
- Focused ID-projection workflow test: 5/5.
- YAML parse and `git diff --check` pass.
- The prior merged commit already passed Token Vault 181/181 and governance 19/19.

## Rollback
Revert this commit or remove the diagnostic-only classification refinement; no Meta state is changed.