### PR TITLE
fix(crm): remove department from unified users contract

### DIFF
--- a/crm/api/server.js
+++ b/crm/api/server.js
@@ -1388,7 +1388,6 @@ if (DEV_AUTH_ENABLED) {
         workforceEmployeeId: member.workforceEmployeeId || null,
         profile: member.profile,
         jobTitle: member.jobTitle,
-        department: member.department,
         units: member.units,
         accountStatus: member.accountStatus,
         crmAccountLinked: Boolean(member.crmAccountLinked),
@@ -1545,7 +1544,10 @@ if (DEV_AUTH_ENABLED) {
         const mobilePhone = body.mobilePhone === undefined && body.phone === undefined
             ? localNormalizePhone(current?.mobilePhone)
             : localNormalizePhone(body.mobilePhone ?? body.phone)
-        const department = String(body.department ?? current?.department ?? '').trim().replace(/\s+/g, ' ').slice(0, 120)
+        // Unified Team no longer accepts department as an access or identity
+        // attribute. Preserve a legacy value on edits for backward
+        // compatibility, but do not create or mutate it from the new contract.
+        const department = String(current?.department ?? '').trim().replace(/\s+/g, ' ').slice(0, 120)
         const jobTitle = String(body.jobTitle ?? current?.jobTitle ?? '').trim()
         const profile = localProfileForTitle(jobTitle) || String(current?.profile || '').toUpperCase()
         const rawUnits = body.units ?? current?.units
@@ -1684,7 +1686,7 @@ if (DEV_AUTH_ENABLED) {
               : requestedStatus === 'ACTIVE'
                   ? ['INVITED', 'ACTIVE'].includes(String(member.accountStatus || '').toUpperCase())
                   : String(member.accountStatus || '').toUpperCase() === requestedStatus)
-          .filter((member) => !query || [member.fullName, member.username, member.corporateEmail, member.department, member.jobTitle, ...member.units]
+          .filter((member) => !query || [member.fullName, member.username, member.corporateEmail, member.jobTitle, ...member.units]
               .some((value) => String(value || '').toLowerCase().includes(query)))
           .filter((member) => role === 'ADMIN' || localTeamUnitsVisible(session, member))
         const total = filtered.length
@@ -2325,7 +2327,7 @@ if (DEV_AUTH_ENABLED) {
         const query = String(req.query?.q || '').trim().toLowerCase()
         const data = store.team
             .filter((member) => requestedStatus === 'ALL' || String(member.accountStatus || '').toUpperCase() === requestedStatus)
-            .filter((member) => !query || [member.fullName, member.username, member.corporateEmail, member.department, member.jobTitle, ...member.units].some((value) => String(value || '').toLowerCase().includes(query)))
+            .filter((member) => !query || [member.fullName, member.username, member.corporateEmail, member.jobTitle, ...member.units].some((value) => String(value || '').toLowerCase().includes(query)))
             .filter((member) => role === 'ADMIN' || localTeamUnitsVisible(session, member))
             .map(localPublicTeamMember)
         res.status(200).set('cache-control', 'no-store').json({ success: true, data, activeOnly: false, status: requestedStatus, summary: { members: data.length, pendingInvites: data.filter((member) => member.accountStatus === 'INVITED').length, pendingAccountLinks: data.filter((member) => !member.crmAccountLinked && ['ACTIVE', 'SUSPENDED', 'TERMINATED'].includes(String(member.accountStatus || '').toUpperCase())).length } })

--- a/crm/console/UsersModule.tsx
+++ b/crm/console/UsersModule.tsx
@@ -15,7 +15,7 @@ import { TooltipButton } from '@/tooltip'
 import { unitBadgeClass, unitSelectedClass } from '@/unitVisuals'
 
 type Me = { success?: boolean; user?: { username?: string; role?: string; allowedUnits?: string[] }; csrfToken?: string }
-type Onboarding = { id: string; fullName: string; username?: string | null; corporateEmail: string; workforceEmployeeId?: string | null; profile: string; jobTitle: string; department: string; units: string[]; accountStatus: string; createdAt?: string; updatedAt?: string }
+type Onboarding = { id: string; fullName: string; username?: string | null; corporateEmail: string; workforceEmployeeId?: string | null; profile: string; jobTitle: string; units: string[]; accountStatus: string; createdAt?: string; updatedAt?: string }
 type ApiError = { error?: string; message?: string; code?: string }
 type RequestOptions = { method?: string; body?: unknown; csrf?: string | null; headers?: Record<string, string> }
 type TeamSummary = { members?: number; pendingInvites?: number }
@@ -108,7 +108,6 @@ const initialForm = {
   corporateEmailOverride: '',
   personalEmail: '',
   mobilePhone: '',
-  department: '',
   jobTitle: 'Consultor',
   units: [] as string[],
   scheduleProfessionalId: '',
@@ -165,6 +164,7 @@ async function api<T>(path: string, opts: RequestOptions = {}): Promise<T> {
     headers,
     credentials: 'include',
     body: opts.body === undefined ? undefined : JSON.stringify(opts.body),
+    cache: 'no-store',
   })
   const payload = await res.json().catch(() => ({})) as T & ApiError
   if (!res.ok) throw new RequestError(payload.error || payload.message || `HTTP ${res.status}`, payload.code)
@@ -182,7 +182,6 @@ function emptyTeamForm(row?: UnifiedTeamMember) {
     corporateEmailOverride: row?.corporateEmail || '',
     personalEmail: '',
     mobilePhone: row?.schedule?.phone || '',
-    department: row?.department || '',
     jobTitle: row?.jobTitle || 'Consultor',
     units: row?.units || [],
     scheduleProfessionalId: row?.schedule?.professionalId || '',
@@ -523,7 +522,6 @@ export function UsersModule() {
         corporateEmail: effectiveEmail,
         ...(form.personalEmail.trim() ? { personalEmail: form.personalEmail } : {}),
         ...(normalizedMobilePhone ? { mobilePhone: normalizedMobilePhone } : {}),
-        department: form.department,
         jobTitle: form.jobTitle,
         units: form.units,
         ...(form.jobTitle === 'Injetor' ? {
@@ -546,9 +544,16 @@ export function UsersModule() {
         headers: editingId ? {} : { 'idempotency-key': `crm-team-${Date.now()}-${Math.random().toString(16).slice(2)}` },
         body,
       })
+      const savedMember = result.data as UnifiedTeamMember | undefined
       let escalaSynced = true
       if (result.data && teamConfig.enabled && form.jobTitle === 'Injetor' && !result.replayed) {
         escalaSynced = (await syncEscala(result.data as UnifiedTeamMember, !editingId)) !== false
+      }
+      if (editingId && savedMember?.id) {
+        // Reflect the authoritative PUT response immediately. The follow-up
+        // GET reconciles the page, but the row must not remain stale while a
+        // projection or cache is catching up.
+        setTeamRows((current) => current.map((row) => row.id === savedMember.id ? { ...row, ...savedMember } : row))
       }
       setCollisionRequired(false)
       setSubmitBlockedMessage('')
@@ -559,6 +564,11 @@ export function UsersModule() {
         ? (editingId ? 'Membro atualizado.' : 'Cadastro criado; convite enviado para o e-mail pessoal.')
         : (editingId ? 'Membro atualizado; vínculo com a Escala pendente.' : 'Cadastro criado; vínculo com a Escala pendente.'))
       await load()
+      if (editingId && savedMember?.id) {
+        // A projection may lag the successful write. Keep the table aligned
+        // with the response that authorized the save after reconciliation too.
+        setTeamRows((current) => current.map((row) => row.id === savedMember.id ? { ...row, ...savedMember } : row))
+      }
     } catch (error: any) {
       if (error instanceof RequestError && (error.code === 'EMAIL_TAKEN' || error.code === 'CORPORATE_EMAIL_OVERRIDE_REQUIRES_COLLISION')) {
         setCollisionRequired(true)
@@ -738,13 +748,12 @@ export function UsersModule() {
                 <table className="w-full table-fixed text-sm">
                   <colgroup>
                   <col className="w-[6%]" />
-                  <col className="w-[17%]" />
-                  <col className="w-[12%]" />
-                  <col className="w-[10%]" />
-                  <col className="w-[11%]" />
-                  <col className="w-[13%]" />
+                  <col className="w-[20%]" />
                   <col className="w-[14%]" />
-                  <col className="w-[9%]" />
+                  <col className="w-[14%]" />
+                  <col className="w-[18%]" />
+                  <col className="w-[16%]" />
+                  <col className="w-[12%]" />
                 </colgroup>
                 <thead className="bg-black/25 text-[11px] uppercase tracking-[0.12em] text-blue-100/60">
                   <tr>
@@ -752,7 +761,6 @@ export function UsersModule() {
                     <th className="p-3 text-left" scope="col">Nome</th>
                     <th className="p-3 text-left" scope="col">Usuário</th>
                     <th className="p-3 text-left" scope="col">Cargo</th>
-                    <th className="p-3 text-left" scope="col">Departamento</th>
                     <th className="p-3 text-left" scope="col">Unidades</th>
                     <th className="p-3 text-left" scope="col">Status</th>
                     <th className="p-3 text-right" scope="col">Ações</th>
@@ -775,7 +783,6 @@ export function UsersModule() {
                       </td>
                       <td className="min-w-0 p-3 align-middle font-mono text-xs break-words text-blue-100/80">{row.username || '—'}</td>
                       <td className="min-w-0 p-3 align-middle"><Badge variant={titleBadgeVariant(row.jobTitle)} className={compactTableBadgeClass}>{row.jobTitle}</Badge></td>
-                      <td className="min-w-0 p-3 align-middle break-words text-blue-100/80">{row.department || '—'}</td>
                       <td className="p-3 align-middle">
                         <div className="flex min-w-0 flex-wrap gap-1">
                           {row.units.length ? row.units.map((unit) => (
@@ -794,7 +801,7 @@ export function UsersModule() {
                     </tr>
                   ))}
                   {!teamRows.length && (
-                    <tr><td className="p-5 text-blue-100/70" colSpan={8}>{loading ? 'Carregando…' : teamConfig.enabled ? (searchQuery || statusFilter !== 'ACTIVE' ? 'Nenhum membro corresponde aos filtros.' : 'Nenhum integrante ativo.') : 'A lista aparecerá após a liberação da centralização.'}</td></tr>
+                    <tr><td className="p-5 text-blue-100/70" colSpan={7}>{loading ? 'Carregando…' : teamConfig.enabled ? (searchQuery || statusFilter !== 'ACTIVE' ? 'Nenhum membro corresponde aos filtros.' : 'Nenhum integrante ativo.') : 'A lista aparecerá após a liberação da centralização.'}</td></tr>
                   )}
                 </tbody>
               </table>
@@ -820,7 +827,6 @@ export function UsersModule() {
                   </div>
                   <div className="mt-4 grid grid-cols-2 gap-x-4 gap-y-4 border-t border-white/[0.07] pt-4 text-xs">
                     <div><p className="mb-1 text-[10px] uppercase tracking-[0.12em] text-blue-100/45">Cargo</p><Badge variant={titleBadgeVariant(row.jobTitle)} className="px-2 py-1 text-[11px]">{row.jobTitle}</Badge></div>
-                    <div><p className="mb-1 text-[10px] uppercase tracking-[0.12em] text-blue-100/45">Departamento</p><p className="text-blue-100/80">{row.department || '—'}</p></div>
                     <div className="col-span-2"><p className="mb-1 text-[10px] uppercase tracking-[0.12em] text-blue-100/45">Unidades</p><div className="flex flex-wrap gap-1">{row.units.length ? row.units.map((unit) => <Badge key={unit} variant="outline" className={`${unitBadgeClass(unit)} px-2 py-1 text-[11px]`}>{unitLabels[unit] || unit}</Badge>) : <Badge variant="outline" className="px-2 py-1 text-[11px]">Sem unidade</Badge>}</div></div>
                     <div><p className="mb-1 text-[10px] uppercase tracking-[0.12em] text-blue-100/45">Status</p><Badge variant={statusBadgeVariant(row.accountStatus)} className="px-2 py-1 text-[11px]">{statusLabel(row.accountStatus)}</Badge></div>
                   </div>

--- a/crm/console/e2e/users-module-fixtures.ts
+++ b/crm/console/e2e/users-module-fixtures.ts
@@ -8,7 +8,6 @@ export type MockTeamMember = {
   workforceEmployeeId: string
   profile: string
   jobTitle: string
-  department: string
   units: string[]
   accountStatus: string
   personalEmail?: string
@@ -25,17 +24,17 @@ export type MockTeamMember = {
 
 export const syntheticTeam: MockTeamMember[] = [
   {
-    id: 'e2e-ana', fullName: 'Ana Ribeiro', username: 'anaribeiro', corporateEmail: 'anaribeiro@espacofacial.com', personalEmail: 'ana.pessoal@example.com', mobilePhone: '+5551999999999', workforceEmployeeId: 'e2e-wf-ana', profile: 'INJETOR', jobTitle: 'Injetor', department: 'Atendimento Local', units: ['novo-hamburgo'], accountStatus: 'ACTIVE', provisioningState: 'COMPLETED',
+    id: 'e2e-ana', fullName: 'Ana Ribeiro', username: 'anaribeiro', corporateEmail: 'anaribeiro@espacofacial.com', personalEmail: 'ana.pessoal@example.com', mobilePhone: '+5551999999999', workforceEmployeeId: 'e2e-wf-ana', profile: 'INJETOR', jobTitle: 'Injetor', units: ['novo-hamburgo'], accountStatus: 'ACTIVE', provisioningState: 'COMPLETED',
     schedule: { professionalId: 'e2e-escala-ana', status: 'Ativo', role: 'Injetor', shift: 'Integral', nickname: 'Ana', instagram: 'ana.ribeiro', color: '#22c55e', units: ['novo-hamburgo'] }, scheduleSync: { state: 'SYNCED', professionalId: 'e2e-escala-ana', attempt: 1 },
     identityLinks: [{ id: 'e2e-link-ana', source: 'ATENDIMENTO', sourceId: 'e2e-atendimento-ana', reviewStatus: 'CONFIRMED', matchMethod: 'EXPLICIT_WORKFORCE_ID', confidence: 'HIGH' }],
   },
   {
-    id: 'e2e-lucas', fullName: 'Lucas Mendes', username: 'lucasmendes', corporateEmail: 'lucasmendes@espacofacial.com', workforceEmployeeId: 'e2e-wf-lucas', profile: 'CONSULTOR', jobTitle: 'Consultor', department: 'Comercial', units: ['novo-hamburgo', 'barra-shopping-sul'], accountStatus: 'INVITED', provisioningState: 'COMPLETED',
+    id: 'e2e-lucas', fullName: 'Lucas Mendes', username: 'lucasmendes', corporateEmail: 'lucasmendes@espacofacial.com', workforceEmployeeId: 'e2e-wf-lucas', profile: 'CONSULTOR', jobTitle: 'Consultor', units: ['novo-hamburgo', 'barra-shopping-sul'], accountStatus: 'INVITED', provisioningState: 'COMPLETED',
     schedule: { professionalId: null, status: 'Ativo', role: 'Consultor', shift: 'Comercial', nickname: 'Lucas', instagram: 'lucas.mendes', color: '#6d9eeb', units: ['novo-hamburgo', 'barra-shopping-sul'] }, scheduleSync: { state: 'PENDING', attempt: 1 },
     identityLinks: [],
   },
   {
-    id: 'e2e-carla', fullName: 'Carla Souza', username: 'carlasouza', corporateEmail: 'carlasouza@espacofacial.com', workforceEmployeeId: 'e2e-wf-carla', profile: 'SUPERVISOR', jobTitle: 'Coordenador', department: 'Operações', units: ['barra-shopping-sul'], accountStatus: 'SUSPENDED', crmAccountLinked: false, crmAccountUsername: 'legacycarla', crmAccountReviewStatus: 'PENDING_REVIEW', crmAccountLinkId: 'e2e-account-link-carla', provisioningState: 'COMPLETED',
+    id: 'e2e-carla', fullName: 'Carla Souza', username: 'carlasouza', corporateEmail: 'carlasouza@espacofacial.com', workforceEmployeeId: 'e2e-wf-carla', profile: 'SUPERVISOR', jobTitle: 'Coordenador', units: ['barra-shopping-sul'], accountStatus: 'SUSPENDED', crmAccountLinked: false, crmAccountUsername: 'legacycarla', crmAccountReviewStatus: 'PENDING_REVIEW', crmAccountLinkId: 'e2e-account-link-carla', provisioningState: 'COMPLETED',
     schedule: { professionalId: null, status: 'Ativo', role: 'Coordenador', shift: 'Tarde', nickname: 'Carla', instagram: 'carla.souza', color: '#f97316', units: ['barra-shopping-sul'] }, scheduleSync: { state: 'FAILED', errorCode: 'ESCALA_API_ERROR', attempt: 2 },
     identityLinks: [{ id: 'e2e-link-carla', source: 'ESCALA', sourceId: 'e2e-escala-carla', reviewStatus: 'PENDING_REVIEW', matchMethod: 'EXPLICIT_WORKFORCE_ID', confidence: 'LOW' }],
   },
@@ -45,7 +44,7 @@ function cloneRows() {
   return syntheticTeam.map((row) => ({ ...row, units: [...row.units], schedule: { ...row.schedule, units: [...row.schedule.units] }, scheduleSync: row.scheduleSync ? { ...row.scheduleSync } : undefined, identityLinks: row.identityLinks.map((link) => ({ ...link })) }))
 }
 
-type MockUsersOptions = { degraded?: boolean; failedActivationFor?: string; failedScheduleFor?: string; paginated?: boolean; unifiedEnabled?: boolean }
+type MockUsersOptions = { degraded?: boolean; failedActivationFor?: string; failedScheduleFor?: string; paginated?: boolean; staleGetAfterPut?: boolean; unifiedEnabled?: boolean }
 
 export async function mockUsersApi(page: Page, role = 'GESTOR', options: MockUsersOptions = {}) {
   const rows = cloneRows()
@@ -90,7 +89,7 @@ export async function mockUsersApi(page: Page, role = 'GESTOR', options: MockUse
     if (path.endsWith('/api/crm/admin/team') && request.method() === 'GET') {
       const status = (url.searchParams.get('status') || 'ACTIVE').toUpperCase()
       const query = (url.searchParams.get('q') || '').toLowerCase()
-      const filtered = rows.filter((row) => status === 'ALL' ? true : status === 'ACTIVE' ? ['ACTIVE', 'INVITED'].includes(row.accountStatus) : row.accountStatus === status).filter((row) => !query || [row.fullName, row.username, row.corporateEmail, row.department, row.jobTitle, ...row.units].some((value) => value.toLowerCase().includes(query)))
+      const filtered = rows.filter((row) => status === 'ALL' ? true : status === 'ACTIVE' ? ['ACTIVE', 'INVITED'].includes(row.accountStatus) : row.accountStatus === status).filter((row) => !query || [row.fullName, row.username, row.corporateEmail, row.jobTitle, ...row.units].some((value) => value.toLowerCase().includes(query)))
       const page = Number(url.searchParams.get('page') || '1')
       const limit = Number(url.searchParams.get('limit') || '50')
       const data = options.paginated ? filtered.slice((page - 1) * limit, page * limit) : filtered
@@ -178,8 +177,9 @@ export async function mockUsersApi(page: Page, role = 'GESTOR', options: MockUse
     const memberMatch = path.match(/\/api\/crm\/admin\/team\/([^/]+)$/)
     if (memberMatch && request.method() === 'PUT') {
       const body = await json(); const row = rows.find((item) => item.id === decodeURIComponent(memberMatch[1]))
-      if (row) Object.assign(row, { fullName: body.fullName || row.fullName, department: body.department || row.department, units: body.units || row.units, jobTitle: body.jobTitle || row.jobTitle })
-      return send({ success: true, data: row })
+      const updated = row ? { ...row, fullName: body.fullName ?? row.fullName, units: body.units ?? row.units, jobTitle: body.jobTitle ?? row.jobTitle } : row
+      if (row && !options.staleGetAfterPut) Object.assign(row, updated)
+      return send({ success: true, data: updated })
     }
     return send({ ok: true, success: true, data: [], total: 0, summary: {} })
   })

--- a/crm/console/e2e/users-module.spec.ts
+++ b/crm/console/e2e/users-module.spec.ts
@@ -9,6 +9,7 @@ test.describe('Usuários e Equipe', () => {
     await expect(page.getByRole('heading', { name: 'Equipe' })).toBeVisible()
     await expect(page.getByRole('table').getByText('Ana Ribeiro', { exact: true })).toBeVisible()
     await expect(page.getByRole('table').getByText('Convite enviado', { exact: true })).toBeVisible()
+    await expect(page.getByRole('columnheader', { name: 'Departamento' })).toHaveCount(0)
 
     await page.getByLabel('Buscar equipe').fill('barra-shopping-sul')
     await expect(page.getByRole('table').getByText('Lucas Mendes', { exact: true })).toBeVisible()
@@ -149,6 +150,17 @@ test.describe('Usuários e Equipe', () => {
     await page.getByRole('button', { name: 'Salvar alterações' }).click()
     await expect(page.getByRole('dialog')).toBeHidden()
     await expect(page.getByRole('row').filter({ hasText: 'Lucas Mendes' })).toBeVisible()
+  })
+
+  test('keeps the edited member current when the follow-up list is stale', async ({ page }) => {
+    await mockUsersApi(page, 'GESTOR', { staleGetAfterPut: true })
+    await page.goto('/?module=users')
+    await page.getByRole('button', { name: 'Editar Lucas Mendes' }).click()
+    await page.getByLabel('Nome completo').fill('Lucas Mendes Atualizado')
+    await page.getByRole('button', { name: 'Salvar alterações' }).click()
+    await expect(page.getByRole('dialog')).toBeHidden()
+    await expect(page.getByRole('row').filter({ hasText: 'Lucas Mendes Atualizado' })).toBeVisible()
+    await expect(page.getByText('Lucas Mendes', { exact: true })).toHaveCount(0)
   })
 
   test('blocks unified edits while the server feature flag is off without using legacy PUT', async ({ page }) => {

--- a/crm/console/teamApi.ts
+++ b/crm/console/teamApi.ts
@@ -25,7 +25,6 @@ export type UnifiedTeamMember = {
   workforceEmployeeId?: string | null
   profile: string
   jobTitle: string
-  department: string
   units: string[]
   accountStatus: string
   crmAccountLinked?: boolean

--- a/inventory/src/routes/admin.js
+++ b/inventory/src/routes/admin.js
@@ -214,7 +214,7 @@ function publicTeamMember(row, links = [], scheduleSync = null) {
     : fallback;
   const crmAccountReviewStatus = String(row.crm_account_review_status || '').trim().toUpperCase() || null;
   return {
-    ...publicOnboarding(row),
+    ...publicTeamOnboarding(row),
     workforceEmployeeId: row.workforce_employee_id || null,
     crmAccountLinked: crmAccountReviewStatus === 'CONFIRMED'
       && Boolean(String(row.crm_account_link_id || '').trim())
@@ -241,6 +241,17 @@ function publicTeamMember(row, links = [], scheduleSync = null) {
     },
     identityLinks: links,
   };
+}
+
+// Unified Team no longer treats department as an access or permission
+// attribute. Keep the legacy onboarding field private until its shared ledger
+// can be retired through a separate expand/contract migration with rollback.
+function publicTeamOnboarding(row) {
+  const data = publicOnboarding(row);
+  if (!data) return data;
+  const teamData = { ...data };
+  delete teamData.department;
+  return teamData;
 }
 
 function publicIdentityLink(row) {
@@ -347,12 +358,11 @@ function teamListSqlFilters(auth, requestedStatus, query) {
       lower(COALESCE(o.full_name, '')) LIKE ?
       OR lower(COALESCE(o.requested_username, '')) LIKE ?
       OR lower(COALESCE(o.corporate_email, '')) LIKE ?
-      OR lower(COALESCE(o.department_name, '')) LIKE ?
       OR lower(COALESCE(o.job_title, '')) LIKE ?
       OR lower(COALESCE(t.schedule_role, '')) LIKE ?
       OR lower(COALESCE(o.units_json, '')) LIKE ?
     )`);
-    params.push(like, like, like, like, like, like, like);
+    params.push(like, like, like, like, like, like);
   }
   return { clauses, params };
 }
@@ -813,7 +823,7 @@ export async function handleAdminRoutes({
     let localPersistenceStage = 'PREPARATION';
     try {
       const body = await request.json().catch(() => ({}));
-      const input = validateOnboardingInput(body, {
+      const input = validateOnboardingInput(url.pathname === '/admin/team' ? { ...body, department: '' } : body, {
         unified: url.pathname === '/admin/team',
         requireCorporateDomain: url.pathname === '/admin/team',
       });
@@ -854,7 +864,7 @@ export async function handleAdminRoutes({
         if (existing && url.pathname === '/admin/team' && (!existing.request_fingerprint || existing.request_fingerprint !== requestFingerprint)) {
           throw new Error(existing.request_fingerprint ? 'ONBOARDING_IDEMPOTENCY_CONFLICT' : 'ONBOARDING_IDEMPOTENCY_FINGERPRINT_REQUIRED');
         }
-        if (existing?.provisioning_state === 'COMPLETED') return withCORS(JSON.stringify({ success: true, data: publicOnboarding(existing), replayed: true }), { status: 200 }, appOrigin);
+        if (existing?.provisioning_state === 'COMPLETED') return withCORS(JSON.stringify({ success: true, data: url.pathname === '/admin/team' ? publicTeamOnboarding(existing) : publicOnboarding(existing), replayed: true }), { status: 200 }, appOrigin);
       }
       const id = await sha256Hex(`employee-onboarding:v1:${input.corporateEmail}`);
       onboardingId = id;
@@ -906,7 +916,7 @@ export async function handleAdminRoutes({
         }
         const existingTeam = await env.DB.prepare('SELECT onboarding_id FROM crm_employee_team WHERE onboarding_id=? LIMIT 1').bind(existingOnboarding.id).first();
         if (existingTeam?.onboarding_id) {
-          return withCORS(JSON.stringify({ success: true, data: publicOnboarding(existingOnboarding), replayed: true }), { status: 200 }, appOrigin);
+          return withCORS(JSON.stringify({ success: true, data: publicTeamOnboarding(existingOnboarding), replayed: true }), { status: 200 }, appOrigin);
         }
         // A prior request may have completed Identity and the invite while
         // failing before the canonical team projection was persisted. Keep the
@@ -1061,7 +1071,7 @@ export async function handleAdminRoutes({
       const created = await env.DB.prepare('SELECT * FROM crm_employee_onboarding WHERE id=?').bind(id).first();
       await appendAuditLog?.({ env, actor: auth.user.username, role: auth.user.role, ip, userAgent, idempotencyKey: idempotency, action: 'EMPLOYEE_ONBOARDING_CREATE', entity: 'EMPLOYEE_ONBOARDING', entityId: id, unidade: input.units.join(','), after: { profile: input.profile, jobTitle: displayJobTitle(input.profile), department: input.department, units: input.units, accountStatus: input.accountStatus, inviteIssued: !!inviteId, workforceEmployeeId: workforce?.employeeId || null, provisioningState: 'COMPLETED', scheduleSyncState: scheduleSync?.scheduleSync?.state || (url.pathname === '/admin/team' ? 'PENDING' : null) } });
       await recordTeamTelemetry({ env, eventName: 'EMPLOYEE_TEAM_CREATED', actorRole: auth.user.role, itemCount: 1, unitCount: input.units.length });
-      return withCORS(JSON.stringify({ success: true, data: publicOnboarding(created), team: url.pathname === '/admin/team' ? { ...normalizeTeamData(teamData, input.units), scheduleSync: publicScheduleSync(scheduleSync?.scheduleSync || { state: hasScheduleIntent(teamData) ? 'PENDING' : 'NOT_CONFIGURED' }, '') } : undefined }), { status: existingOnboarding ? 200 : 201 }, appOrigin);
+      return withCORS(JSON.stringify({ success: true, data: url.pathname === '/admin/team' ? publicTeamOnboarding(created) : publicOnboarding(created), team: url.pathname === '/admin/team' ? { ...normalizeTeamData(teamData, input.units), scheduleSync: publicScheduleSync(scheduleSync?.scheduleSync || { state: hasScheduleIntent(teamData) ? 'PENDING' : 'NOT_CONFIGURED' }, '') } : undefined }), { status: existingOnboarding ? 200 : 201 }, appOrigin);
     } catch (error) {
       const message = String(error?.message || 'ONBOARDING_FAILED');
       if (url.pathname === '/admin/team' && workforceSynchronized && onboardingId && ['ONBOARDING_COMPLETE', 'TEAM_CREATE'].includes(localPersistenceStage)) {
@@ -1113,7 +1123,7 @@ export async function handleAdminRoutes({
         return withCORS(JSON.stringify({ success: false, error: 'Hierarquia não permite ativar este membro', code: hierarchyDenied }), { status: 403 }, appOrigin);
       }
       if (String(onboarding.account_status).toUpperCase() === 'ACTIVE') {
-        return withCORS(JSON.stringify({ success: true, data: publicOnboarding(onboarding), replayed: true }), { status: 200 }, appOrigin);
+        return withCORS(JSON.stringify({ success: true, data: activationMatch[1] === 'team' ? publicTeamOnboarding(onboarding) : publicOnboarding(onboarding), replayed: true }), { status: 200 }, appOrigin);
       }
       if (activationMatch[1] === 'team') {
         const accountScope = await loadExplicitCrmAccountScope(onboardingId);
@@ -1141,7 +1151,7 @@ export async function handleAdminRoutes({
       ]);
       const activated = await env.DB.prepare('SELECT * FROM crm_employee_onboarding WHERE id=?').bind(onboardingId).first();
       await appendAuditLog?.({ env, actor: auth.user.username, role: auth.user.role, ip, userAgent, action: 'EMPLOYEE_ONBOARDING_ACTIVATION_RETRY', entity: 'EMPLOYEE_ONBOARDING', entityId: onboardingId, unidade: normalizeAllowedUnits(onboarding.units_json).join(','), before: { accountStatus: onboarding.account_status }, after: { accountStatus: 'ACTIVE', requestId } });
-      return withCORS(JSON.stringify({ success: true, data: publicOnboarding(activated) }), { status: 200 }, appOrigin);
+      return withCORS(JSON.stringify({ success: true, data: activationMatch[1] === 'team' ? publicTeamOnboarding(activated) : publicOnboarding(activated) }), { status: 200 }, appOrigin);
     } catch (error) {
       const message = String(error?.message || 'ONBOARDING_ACTIVATION_FAILED');
       return withCORS(JSON.stringify({ success: false, error: 'ACCOUNT_ACTIVATION_PENDING', code: message }), { status: 503 }, appOrigin);
@@ -1252,7 +1262,7 @@ export async function handleAdminRoutes({
       const updated = await env.DB.prepare('SELECT * FROM crm_employee_onboarding WHERE id=? LIMIT 1').bind(onboardingId).first();
       await appendAuditLog?.({ env, actor: auth.user.username, role: auth.user.role, ip, userAgent, action: 'EMPLOYEE_ONBOARDING_STATUS_CHANGED', entity: 'EMPLOYEE_ONBOARDING', entityId: onboardingId, unidade: normalizeAllowedUnits(onboarding.units_json).join(','), before: { accountStatus: currentStatus }, after: { accountStatus: nextStatus, inviteRevoked: Boolean(revokeInvite && onboarding.invite_id), sessionVersionIncremented: currentStatus !== nextStatus, terminationReasonProvided: nextStatus === 'TERMINATED', terminationReason: nextStatus === 'TERMINATED' ? terminationReason : null, requestId } });
       await recordTeamTelemetry({ env, eventName: 'EMPLOYEE_TEAM_STATUS_CHANGED', actorRole: auth.user.role, itemCount: 1, unitCount: normalizeAllowedUnits(onboarding.units_json).length });
-      return withCORS(JSON.stringify({ success: true, data: publicOnboarding(updated), replayed: currentStatus === nextStatus }), { status: 200 }, appOrigin);
+      return withCORS(JSON.stringify({ success: true, data: statusMatch[1] === 'team' ? publicTeamOnboarding(updated) : publicOnboarding(updated), replayed: currentStatus === nextStatus }), { status: 200 }, appOrigin);
     } catch (error) {
       return withCORS(JSON.stringify({ success: false, error: 'ACCOUNT_STATUS_PENDING', code: String(error?.message || 'ONBOARDING_STATUS_FAILED').slice(0, 120) }), { status: 503 }, appOrigin);
     }
@@ -1420,7 +1430,7 @@ export async function handleAdminRoutes({
       });
       await appendAuditLog?.({ env, actor: auth.user.username, role: auth.user.role, ip, userAgent, action: 'EMPLOYEE_TEAM_WORKFORCE_RECONCILED', entity: 'EMPLOYEE_ONBOARDING', entityId: onboardingId, unidade: units.join(','), before: { workforceEmployeeId: existingEmployeeId || null, accountStatus }, after: { workforceEmployeeId, accountStatus, provisioningState, workforceReconciled, inviteDeliveryChanged: false, requestId } });
       await recordTeamTelemetry({ env, eventName: 'EMPLOYEE_TEAM_WORKFORCE_RECONCILED', actorRole: auth.user.role, itemCount: 1, unitCount: units.length });
-      return withCORS(JSON.stringify({ success: true, data: publicOnboarding(updated), replayed: !workforceReconciled }), { status: 200 }, appOrigin);
+      return withCORS(JSON.stringify({ success: true, data: publicTeamOnboarding(updated), replayed: !workforceReconciled }), { status: 200 }, appOrigin);
     } catch (error) {
       const code = String(error?.message || 'TEAM_WORKFORCE_RECONCILE_FAILED').slice(0, 120);
       const dependencyFailure = isOnboardingDependencyError(code) || /^(WORKFORCE_|IDENTITY_WORKFORCE_|TIMEKEEPING_|RELEASE_AFFINITY_|RUNTIME_BINDINGS_)/.test(code);
@@ -1491,7 +1501,7 @@ export async function handleAdminRoutes({
       const updated = await env.DB.prepare('SELECT * FROM crm_employee_onboarding WHERE id=? LIMIT 1').bind(onboardingId).first();
       await appendAuditLog?.({ env, actor: auth.user.username, role: auth.user.role, ip, userAgent, action: 'EMPLOYEE_TEAM_INVITE_RESENT', entity: 'EMPLOYEE_ONBOARDING', entityId: onboardingId, unidade: units.join(','), before: { accountStatus: onboarding.account_status }, after: { inviteIssued: true, inviteId, accountStatus: 'INVITED', requestId } });
       await recordTeamTelemetry({ env, eventName: 'EMPLOYEE_TEAM_INVITE_RESENT', actorRole: auth.user.role, itemCount: 1, unitCount: units.length });
-      return withCORS(JSON.stringify({ success: true, data: publicOnboarding(updated) }), { status: 200 }, appOrigin);
+      return withCORS(JSON.stringify({ success: true, data: publicTeamOnboarding(updated) }), { status: 200 }, appOrigin);
     } catch (error) {
       return withCORS(JSON.stringify({ success: false, error: 'Não foi possível reenviar o convite', code: String(error?.message || 'TEAM_INVITE_RESEND_FAILED').slice(0, 120) }), { status: 503 }, appOrigin);
     }
@@ -1524,7 +1534,7 @@ export async function handleAdminRoutes({
       const updated = await env.DB.prepare('SELECT * FROM crm_employee_onboarding WHERE id=? LIMIT 1').bind(onboardingId).first();
       await appendAuditLog?.({ env, actor: auth.user.username, role: auth.user.role, ip, userAgent, action: 'EMPLOYEE_TEAM_INVITE_REVOKED', entity: 'EMPLOYEE_ONBOARDING', entityId: onboardingId, unidade: normalizeAllowedUnits(onboarding.units_json).join(','), before: { accountStatus: onboarding.account_status }, after: { inviteRevoked: true, accountStatus: 'PENDING_ACCESS', requestId } });
       await recordTeamTelemetry({ env, eventName: 'EMPLOYEE_TEAM_INVITE_REVOKED', actorRole: auth.user.role, itemCount: 1, unitCount: normalizeAllowedUnits(onboarding.units_json).length });
-      return withCORS(JSON.stringify({ success: true, data: publicOnboarding(updated) }), { status: 200 }, appOrigin);
+      return withCORS(JSON.stringify({ success: true, data: publicTeamOnboarding(updated) }), { status: 200 }, appOrigin);
     } catch (error) {
       return withCORS(JSON.stringify({ success: false, error: 'Não foi possível revogar o convite', code: String(error?.message || 'TEAM_INVITE_REVOKE_FAILED').slice(0, 120) }), { status: 503 }, appOrigin);
     }
@@ -1915,7 +1925,10 @@ export async function handleAdminRoutes({
       }
 
       const nextName = String(body.fullName ?? current.full_name).trim().replace(/\s+/g, ' ');
-      const nextDepartment = String(body.department ?? current.department_name).trim().replace(/\s+/g, ' ').slice(0, 120);
+      // `department_name` is retained only as a legacy storage field until a
+      // separately gated expand/contract migration can remove it safely. The
+      // unified-team API no longer accepts or changes it.
+      const nextDepartment = String(current.department_name || '').trim().replace(/\s+/g, ' ').slice(0, 120);
       const nextTitle = String(body.jobTitle ?? current.job_title).trim();
       const nextProfile = body.jobTitle === undefined ? current.profile : resolveEmployeeProfile(nextTitle);
       if (!nextName || !nextProfile) return withCORS(JSON.stringify({ success: false, error: 'Dados de edição inválidos', code: 'TEAM_UPDATE_INVALID' }), { status: 400 }, appOrigin);
@@ -2095,7 +2108,7 @@ export async function handleAdminRoutes({
         ${fromSql} ORDER BY o.created_at DESC, o.id DESC LIMIT ? OFFSET ?`).bind(...filters.params, limit, offset).all();
       const visible = (rows?.results || [])
         .filter((row) => teamUnitsVisible(auth, row.units_json))
-        .filter((row) => !query || [row.full_name, row.requested_username, row.corporate_email, row.department_name, row.job_title, ...normalizeAllowedUnits(row.units_json)]
+        .filter((row) => !query || [row.full_name, row.requested_username, row.corporate_email, row.job_title, ...normalizeAllowedUnits(row.units_json)]
           .some((value) => String(value || '').toLowerCase().includes(query)));
       const employeeIds = visible.map((row) => String(row.workforce_employee_id || '').trim()).filter(Boolean);
       const linkRows = employeeIds.length

--- a/inventory/tests/teamPagination.test.mjs
+++ b/inventory/tests/teamPagination.test.mjs
@@ -22,10 +22,17 @@ test('unified team listing is paginated and scoped before the database limit', a
   assert.match(admin, /\.bind\(\.\.\.onboardingIds, Math\.min\(onboardingIds\.length \* 10, 1000\)\)/);
   assert.match(admin, /const effectivePage = Math\.min\(page, pages\)/);
   assert.doesNotMatch(admin, /ORDER BY o\.created_at DESC LIMIT 500/);
+  assert.match(admin, /function publicTeamOnboarding\(row\)/);
+  assert.match(admin, /delete teamData\.department/);
+  assert.match(admin, /url\.pathname === '\/admin\/team' \? \{ \.\.\.body, department: '' \} : body/);
+  assert.match(admin, /const nextDepartment = String\(current\.department_name \|\| ''\)/);
 
   assert.match(localApi, /const filtered = store\.team/);
   assert.match(localApi, /const data = filtered\.slice\([^\n]+\.map\(localPublicTeamMember\)/);
   assert.match(localApi, /pagination: \{ page, limit, total, pages, hasMore: page < pages \}/);
+  const localPublicTeamBlock = localApi.slice(localApi.indexOf('const localPublicTeamMember'), localApi.indexOf('const localPendingItems'));
+  assert.doesNotMatch(localPublicTeamBlock, /department:/);
+  assert.match(localApi, /const department = String\(current\?\.department \?\? ''\)/);
 
   assert.match(migration, /CREATE INDEX IF NOT EXISTS idx_crm_employee_onboarding_status_created/);
   assert.match(migration, /CREATE INDEX IF NOT EXISTS idx_crm_employee_onboarding_created/);
@@ -40,4 +47,5 @@ test('users UI carries the page boundary and exposes accessible navigation', asy
   assert.match(users, /aria-label="Página anterior"/);
   assert.match(users, /aria-label="Próxima página"/);
   assert.match(users, /setPage\(1\)/);
+  assert.doesNotMatch(users, /Departamento/);
 });


### PR DESCRIPTION
## Objetivo
Remover `department` do contrato público do módulo Usuários e corrigir a atualização da linha após salvar um membro.

## O que mudou
- Remove a coluna Departamento da tabela desktop/mobile e do tipo/submit do console.
- `GET/POST/PUT /admin/team` deixa de expor, aceitar ou alterar departamento no contrato Unified Team.
- O runtime local segue o mesmo contrato e não cria/edita o valor legado.
- A coluna legada `department_name` permanece preservada internamente; nenhuma remoção destrutiva de dados faz parte deste PR.
- A tabela reaplica a resposta autoritativa do `PUT` após o `GET` de reconciliação, cobrindo projeções/listagens atrasadas.

## Causa
O formulário já não distinguia departamento, mas o tipo da equipe, a tabela, a projeção pública do Worker, a busca e os adaptadores locais ainda carregavam o campo. O save também dependia do GET posterior para refletir a linha, permitindo que uma projeção stale sobrescrevesse a resposta do PUT.

## Validação
- CRM console typecheck
- CRM console build e bundle budget
- CRM Users E2E: 12/12, incluindo GET stale após PUT
- Inventory tests: 92/92
- contrato local de equipe: 2/2
- lint: 0 erros (avisos preexistentes de hooks)

## Rollout e rollback
- Promover Pages e Worker somente pelos workflows governados, primeiro em staging.
- Validar a jornada autenticada de Usuários antes da produção.
- Rollback de código: release/deployment anterior ao SHA deste PR; desativar a mudança de contrato e restaurar o artefato anterior se o smoke falhar.
- Não há migration destrutiva, alteração de flag, banco remoto ou grant neste PR.