### PR TITLE
docs(livia): require QA validation from immutable bundle

### DIFF
--- a/docs/runbooks/livia-isolated-promotion.md
+++ b/docs/runbooks/livia-isolated-promotion.md
@@ -46,7 +46,14 @@ sudo -u postgres node /opt/skincos/releases/"$SKINCOS_RELEASE_ID"/source/orb/eng
   --release-root /opt/skincos/releases/"$SKINCOS_RELEASE_ID"/source/orb/engine
 sudo -u postgres node /opt/skincos/releases/"$SKINCOS_RELEASE_ID"/source/orb/engine/scripts/validate-livia-workflow.js \
   /var/tmp/livia-candidate.json
+sudo node /opt/skincos/releases/"$SKINCOS_RELEASE_ID"/source/orb/engine/scripts/livia/qa-runner.js \
+  validate
 ```
+
+O `qa-runner` precisa ser executado a partir do bundle candidato, não do
+checkout compartilhado nem de uma release anterior. Ele é somente leitura e
+deve reprovar contratos editoriais, de acessibilidade ou de preflight que não
+correspondam à versão que será promovida.
 
 Antes da escrita versionada, faça o smoke autenticado read-only do CRM com o
 token protegido já carregado no runtime. O endpoint deve aceitar apenas Bearer,
@@ -80,7 +87,8 @@ sudo -u postgres node /opt/skincos/releases/"$SKINCOS_RELEASE_ID"/source/orb/eng
 
 Depois, rode `workflow-runtime-manifest.js audit-live`, confira os hashes dos
 entrypoints e os healthchecks local (`http://127.0.0.1:5678/healthz`) e público
-(`https://orb.skincos.com.br/healthz`). Uma nova versão histórica de Livia não
+(`https://orb.skincos.com.br/healthz`), e execute novamente o `qa-runner`
+diretamente do bundle promovido. Uma nova versão histórica de Livia não
 requer restart. Se uma promoção de ponteiro global for excepcionalmente
 necessária, use somente `scripts/runtime/promote-native-source-release.sh`;
 ele cria a janela de manutenção, aguarda execuções ativas e verifica o CWD do


### PR DESCRIPTION
## Summary

- Carries forward only the still-required Livia runbook gate from historical PR #900.
- Requires read-only `qa-runner validate` from the immutable candidate bundle before versioned publication.
- Requires the same `qa-runner` validation directly from the promoted bundle after publication.
- Does not copy the historical PR #897 promotion snapshot; later Livia evidence on `main` supersedes that record.

## Type of change

- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [x] Docs
- [ ] Performance
- [ ] Security
- [ ] Breaking change

## Checklist

- [x] Conventional Commits applied
- [ ] Tests added/updated and passing
- [x] Docs updated
- [ ] Security review (CodeQL, gitleaks)
- [ ] Performance impact measured

## Links

- Superseded historical PR: #900
- Policy: `docs/decisions/operational-change-policy.md`

## Evidence

- Base: `8d568ef6`
- Commit: `51a9c289`
- Validation: `git diff --check`
- Documentation-only; no runtime, workflow, deployment, secret, or data mutation performed.
