### PR TITLE
fix(livia): use supported CRM catalog auth

### DIFF
--- a/docs/runbooks/livia-isolated-promotion.md
+++ b/docs/runbooks/livia-isolated-promotion.md
@@ -35,9 +35,10 @@ isolados manualmente: o construtor inclui, como unidade atômica de candidato,
 o catálogo comercial oficial CRM read-only, as marcas Drive por fonte, o
 preflight do Token Vault, o contrato de alt text, o contrato de carrossel
 Facebook e o pin/runtime semanticamente idempotente. O patch comercial valida
-que a tool usa GET/Bearer sem placeholder, que `bss` e `nh` são derivados de
-`Get Credential Tokens`, que Documents permanece editorial e que `crmPricing`
-falha fechado fora de `crm|none`.
+que a tool usa GET com `httpHeaderAuth` suportado pelo `toolHttpRequest`, sem
+placeholder, que `bss` e `nh` são derivados de `Get Credential Tokens`, que
+Documents permanece editorial e que `crmPricing` falha fechado fora de
+`crm|none`.
 
 ```bash
 sudo -u postgres node /opt/skincos/releases/"$SKINCOS_RELEASE_ID"/source/orb/engine/scripts/prepare-livia-production-candidate.js \

--- a/orb/engine/scripts/lib/crm-commercial-catalog-contract.js
+++ b/orb/engine/scripts/lib/crm-commercial-catalog-contract.js
@@ -10,6 +10,14 @@ const CRM_COMMERCIAL_CATALOG_UNIT_QUERY_URL = `${CRM_COMMERCIAL_CATALOG_URL}?uni
 const CRM_COMMERCIAL_CATALOG_SCHEMA_VERSION = 'crm-commercial-catalog/v1';
 const CRM_COMMERCIAL_CATALOG_TOOL_NAME = 'CRM Commercial Catalog';
 const CRM_COMMERCIAL_CATALOG_TOOL_ID = 'crm-commercial-catalog';
+// n8n's LangChain toolHttpRequest does not implement httpBearerAuth. The
+// existing CRM credential stores the bearer value as an Authorization header,
+// which is the supported generic credential shape for this node type.
+const CRM_COMMERCIAL_CATALOG_AUTH_TYPE = 'httpHeaderAuth';
+const CRM_COMMERCIAL_CATALOG_CREDENTIAL = Object.freeze({
+  id: 'metaPublishCrmOfferContextHeader',
+  name: 'Meta Ads Publish - CRM Offer Context Header',
+});
 const CRM_COMMERCIAL_CATALOG_UNITS = Object.freeze({
   bss: 'barra-shopping-sul',
   nh: 'novo-hamburgo',
@@ -23,5 +31,7 @@ module.exports = {
   CRM_COMMERCIAL_CATALOG_SCHEMA_VERSION,
   CRM_COMMERCIAL_CATALOG_TOOL_NAME,
   CRM_COMMERCIAL_CATALOG_TOOL_ID,
+  CRM_COMMERCIAL_CATALOG_AUTH_TYPE,
+  CRM_COMMERCIAL_CATALOG_CREDENTIAL,
   CRM_COMMERCIAL_CATALOG_UNITS,
 };

--- a/orb/engine/scripts/patch-livia-commercial-catalog.js
+++ b/orb/engine/scripts/patch-livia-commercial-catalog.js
@@ -7,6 +7,8 @@
 const fs = require('fs');
 const path = require('path');
 const {
+  CRM_COMMERCIAL_CATALOG_AUTH_TYPE,
+  CRM_COMMERCIAL_CATALOG_CREDENTIAL,
   CRM_COMMERCIAL_CATALOG_PATH,
   CRM_COMMERCIAL_CATALOG_SCHEMA_VERSION,
   CRM_COMMERCIAL_CATALOG_TOOL_ID,
@@ -100,14 +102,11 @@ const CONTEXT_CODE = [
 function clone(value) { return JSON.parse(JSON.stringify(value)); }
 function nodeByName(workflow, name) { return workflow.nodes.find((node) => node.name === name); }
 
-function resolveCrmBearerCredential() {
-  const metaPath = path.join(__dirname, '..', 'workflows', 'meta-ads-publish.current.json');
-  if (!fs.existsSync(metaPath)) throw new Error('CRM bearer credential source artifact is missing.');
-  const metaWorkflow = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
-  const fetchNode = metaWorkflow.nodes.find((node) => node.name === 'Fetch CRM Offer Context');
-  const credential = fetchNode?.credentials?.httpBearerAuth;
-  if (!credential?.id || !credential?.name) throw new Error('Existing CRM bearer credential could not be resolved from the Meta Ads adapter.');
-  return { id: credential.id, name: credential.name };
+function resolveCrmHeaderCredential() {
+  // Keep this explicit: deriving the credential from the Meta Ads workflow was
+  // both cross-workflow coupling and the source of the unsupported Bearer
+  // shape. The credential is provisioned in n8n as an httpHeaderAuth record.
+  return { ...CRM_COMMERCIAL_CATALOG_CREDENTIAL };
 }
 
 function cleanAgentText(value) {
@@ -189,13 +188,13 @@ function createCatalogTool(credential) {
       method: 'GET',
       url: `={{ '${CRM_COMMERCIAL_CATALOG_URL}?units=' + encodeURIComponent($("${CONTEXT_NODE_NAME}").first().json.crmCatalogUnits.map((unit) => unit.crmUnit).join(',')) }}`,
       authentication: 'genericCredentialType',
-      genericAuthType: 'httpBearerAuth',
+      genericAuthType: CRM_COMMERCIAL_CATALOG_AUTH_TYPE,
       sendQuery: false,
       sendHeaders: false,
       sendBody: false,
       options: { timeout: 20000 },
     },
-    credentials: { httpBearerAuth: credential },
+    credentials: { [CRM_COMMERCIAL_CATALOG_AUTH_TYPE]: credential },
   };
 }
 
@@ -225,7 +224,8 @@ function validate(workflow) {
   if (context.type !== 'n8n-nodes-base.code' || !String(context.parameters?.jsCode || '').includes('Get Credential Tokens') || !String(context.parameters?.jsCode || '').includes('barra-shopping-sul') || !String(context.parameters?.jsCode || '').includes('novo-hamburgo')) {
     throw new Error('Livia CRM catalog context is not deterministic or token-backed.');
   }
-  if (tool.type !== '@n8n/n8n-nodes-langchain.toolHttpRequest' || tool.parameters?.method !== 'GET' || tool.parameters?.authentication !== 'genericCredentialType' || tool.parameters?.genericAuthType !== 'httpBearerAuth' || tool.parameters?.sendBody !== false || !tool.credentials?.httpBearerAuth?.id || !String(tool.parameters?.url || '').includes(CRM_COMMERCIAL_CATALOG_PATH)) {
+  const credential = tool.credentials?.[CRM_COMMERCIAL_CATALOG_AUTH_TYPE];
+  if (tool.type !== '@n8n/n8n-nodes-langchain.toolHttpRequest' || tool.parameters?.method !== 'GET' || tool.parameters?.authentication !== 'genericCredentialType' || tool.parameters?.genericAuthType !== CRM_COMMERCIAL_CATALOG_AUTH_TYPE || tool.parameters?.sendBody !== false || !credential?.id || credential.id !== CRM_COMMERCIAL_CATALOG_CREDENTIAL.id || credential.name !== CRM_COMMERCIAL_CATALOG_CREDENTIAL.name || tool.credentials?.httpBearerAuth || !String(tool.parameters?.url || '').includes(CRM_COMMERCIAL_CATALOG_PATH)) {
     throw new Error('Livia CRM Commercial Catalog tool configuration is incomplete.');
   }
   if (/\$fromAI|placeholderDefinitions|\{unit\}/i.test(JSON.stringify(tool.parameters || {}))) throw new Error('CRM catalog tool must not expose a model-controlled unit placeholder.');
@@ -263,7 +263,7 @@ function patchWorkflow(workflow) {
   const candidate = clone(workflow);
   if (candidate?.id !== WORKFLOW_ID) throw new Error('Unexpected Livia workflow id.');
   if (!Array.isArray(candidate.nodes)) throw new Error('Livia workflow nodes are missing.');
-  const credential = resolveCrmBearerCredential();
+  const credential = resolveCrmHeaderCredential();
 
   candidate.nodes = candidate.nodes.filter((entry) => entry.name !== 'Knowledge' && entry.type !== 'n8n-nodes-base.googleSheetsTool' && entry.name !== CONTEXT_NODE_NAME && entry.id !== CONTEXT_NODE_ID && entry.name !== CRM_COMMERCIAL_CATALOG_TOOL_NAME && entry.id !== CRM_COMMERCIAL_CATALOG_TOOL_ID);
   candidate.nodes.push(createContextNode(), createCatalogTool(credential));

--- a/orb/engine/tests/livia-commercial-catalog.test.js
+++ b/orb/engine/tests/livia-commercial-catalog.test.js
@@ -4,6 +4,10 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
+const {
+  CRM_COMMERCIAL_CATALOG_AUTH_TYPE,
+  CRM_COMMERCIAL_CATALOG_CREDENTIAL,
+} = require('../scripts/lib/crm-commercial-catalog-contract');
 const { patchWorkflow, validate } = require('../scripts/patch-livia-commercial-catalog');
 
 const workflowPath = path.join(__dirname, '..', 'workflows', 'livia', 'livia.current.json');
@@ -31,7 +35,9 @@ test('Livia receives one deterministic read-only CRM catalog tool and no legacy 
   assert.match(tool.parameters.url, /\/api\/atendimento\/internal\/commercial\/catalog\?units=/);
   assert.match(tool.parameters.url, /Prepare Livia CRM Catalog Context/);
   assert.doesNotMatch(JSON.stringify(tool.parameters), /\$fromAI|placeholderDefinitions|\{unit\}/i);
-  assert.deepEqual(tool.credentials.httpBearerAuth, { id: '4r0IbVgjAaSOQREF', name: 'Bearer Auth account' });
+  assert.equal(tool.parameters.genericAuthType, CRM_COMMERCIAL_CATALOG_AUTH_TYPE);
+  assert.deepEqual(tool.credentials[CRM_COMMERCIAL_CATALOG_AUTH_TYPE], CRM_COMMERCIAL_CATALOG_CREDENTIAL);
+  assert.equal(tool.credentials.httpBearerAuth, undefined);
   assert.match(context.parameters.jsCode, /Get Credential Tokens/);
   assert.match(context.parameters.jsCode, /bss.*barra-shopping-sul/s);
   assert.match(context.parameters.jsCode, /nh.*novo-hamburgo/s);
@@ -57,6 +63,14 @@ test('Livia commercial catalog patch is idempotent', () => {
   const once = patchWorkflow(fixture());
   const twice = patchWorkflow(once);
   assert.deepEqual(twice, once);
+});
+
+test('Livia commercial catalog validator rejects the unsupported Bearer auth shape', () => {
+  const candidate = patchWorkflow(fixture());
+  const tool = candidate.nodes.find((node) => node.name === 'CRM Commercial Catalog');
+  tool.parameters.genericAuthType = 'httpBearerAuth';
+  tool.credentials = { httpBearerAuth: { id: '4r0IbVgjAaSOQREF', name: 'Bearer Auth account' } };
+  assert.throws(() => validate(candidate), /configuration is incomplete/);
 });
 
 test('Livia commercial guard preserves the live visual assertion return envelope', () => {


### PR DESCRIPTION
Fixes Livia execution 951, where CRM Commercial Catalog failed because toolHttpRequest rejects httpBearerAuth. Switches the read-only GET tool to supported httpHeaderAuth using the existing runtime credential, adds fail-closed validation and regression tests. Validation: livia:qa:test (39 tests) passed; node checks passed; live export candidate validation passed; authenticated CRM read-only smoke returned crm-commercial-catalog/v1 for barra-shopping-sul and novo-hamburgo. Rollback uses the previous versioned workflow via apply-livia-runtime-isolation.js.