### PR TITLE
fix(meta-ads): use converged Pixel Dataset identity

### DIFF
--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -66,7 +66,7 @@ jobs:
             fail('source_destination_page_selector_duplicate');
           }
 
-          const graphGet = async (path, { classifyContract = false } = {}) => {
+          const graphGet = async (path) => {
             let response;
             try {
               response = await fetch(`https://graph.facebook.com/${apiVersion}/${path}`, {
@@ -99,24 +99,10 @@ jobs:
                 graphErrorCode === 102 ||
                 graphErrorCode === 190 ||
                 graphErrorCode === 200;
-              // Meta's code 100 is the bounded contract/parameter failure
-              // class. Keep it distinct from an unknown malformed envelope so
-              // the diagnostic can distinguish an unsupported edge/field from
-              // an access denial without exposing the Graph code or body.
-              // On the explicitly probed modern AdsDataset edge, a
-              // non-auth 4xx envelope (including an unknown/zero Graph code)
-              // is evidence that the edge/response contract is incompatible,
-              // not evidence that the configured asset is missing. Keep
-              // malformed JSON/shape failures on their own path below.
-              const contractError = classifyContract &&
-                !authorizationError &&
-                (graphErrorCode === 100 || (response.status >= 400 && response.status < 500) || response.ok);
               return {
                 state: authorizationError
                   ? 'denied'
-                  : contractError
-                    ? 'contract'
-                    : 'malformed',
+                  : 'malformed',
               };
             }
             return { state: 'ok', payload };
@@ -217,61 +203,13 @@ jobs:
           // this read on that edge instead of issuing a Page-node GET with a
           // bearer whose contract is Business/Marketing scoped.
 
-          const probeModernDatasetContract = async () => {
-            // A successful HTTP response can still violate the legacy edge's
-            // shape contract. Treat that the same as a malformed Graph error
-            // and continue the bounded modern-edge probe below.
-            const account = await directRead(
-              `act_${accountId}?fields=id,business{id}`,
-              'source_dataset_account',
-            );
-            const businessId = numericId(account?.business?.id);
-            if (!businessId) fail('source_dataset_business_malformed');
-            const modernDatasetResult = await graphGet(
-              `${businessId}/ads_dataset?fields=id`,
-              { classifyContract: true },
-            );
-            if (modernDatasetResult.state !== 'ok') {
-              fail(`source_dataset_ads_dataset_response_${modernDatasetResult.state}`);
-            }
-            const modernDatasets = modernDatasetResult.payload;
-            if (!Array.isArray(modernDatasets?.data)) fail('source_dataset_ads_dataset_malformed');
-            if (hasNextPage(modernDatasets)) fail('source_dataset_ads_dataset_paging_ambiguous');
-            if (modernDatasets.data.length === 0) fail('source_dataset_ads_dataset_empty');
-            if (modernDatasets.data.length > 1) fail('source_dataset_ads_dataset_ambiguous');
-            const modernDataset = modernDatasets.data[0];
-            if (!numericId(modernDataset?.id)) {
-              fail('source_dataset_ads_dataset_malformed');
-            }
-            // The Worker still seals offline_conversion_data_set_id today;
-            // the modern shape is diagnostic evidence, not eligibility.
-            fail('source_dataset_legacy_contract_invalid');
-          };
-
-          const legacyDatasetPath = `act_${accountId}/offline_conversion_data_sets?fields=id&limit=2`;
-          const legacyDatasetResult = await graphGet(legacyDatasetPath);
-          if (legacyDatasetResult.state === 'ok') {
-            const datasets = legacyDatasetResult.payload;
-            const malformedShape =
-              !Array.isArray(datasets?.data) ||
-              (datasets.data.length === 1 && !numericId(datasets.data[0]?.id));
-            if (malformedShape) {
-              await probeModernDatasetContract();
-            } else {
-              if (hasNextPage(datasets) || datasets.data.length !== 1) fail('source_dataset_ambiguous');
-              if (!numericId(datasets.data[0]?.id)) fail('source_dataset_malformed');
-            }
-          } else if (legacyDatasetResult.state === 'malformed') {
-            // The legacy Offline Conversions edge is still present in older
-            // Meta examples, but current SDKs expose AdsDataset from the
-            // Business /ads_dataset edge. Probe that read-only contract only
-            // after the legacy response is structurally invalid; never mark
-            // the raw source eligible from the modern shape because the
-            // Worker still seals offline_conversion_data_set_id today.
-            await probeModernDatasetContract();
-          } else {
-            fail(`source_dataset_${legacyDatasetResult.state}`);
-          }
+          // The authenticated Pixel and its exact ad-account membership are
+          // already proven above. Meta's converged website/offline Dataset
+          // uses that same Pixel identity, so the seed can seal
+          // offline_conversion_data_set_id without enumerating either the
+          // legacy Offline Conversions edge or the drifted Business Dataset
+          // edge. Keep the proof GET-only and fail closed on the earlier Pixel
+          // and account-membership checks.
 
           process.stdout.write([
             'source_access_raw=verified',

--- a/platform/security/token-vault/README.md
+++ b/platform/security/token-vault/README.md
@@ -156,8 +156,11 @@ unidade, prova pela relação limitada de Páginas atribuídas ao System User um
 única associação elegível e confirma o mesmo par Página+Instagram por leitura
 direta. Os pares devem ser distintos. Os seletores não são bindings do Worker
 e não entram no `--secrets-file`, artefato, log ou output do workflow. O Vault
-exige então uma conta/pixel, os dois pares Página+Instagram provados e um
-dataset offline unívoco, cria somente recursos `PAUSED` nomeados para staging e
+exige então uma conta/pixel, os dois pares Página+Instagram provados e, no
+contrato de convergência atual, usa a identidade do Pixel já provado como
+`offline_conversion_data_set_id`; não enumera edges legados ou o edge Business
+de AdsDataset para inferir outro identificador. Cria somente recursos `PAUSED`
+nomeados para staging e
 sela duas credenciais internas cifradas. Não seleciona campanhas, conjuntos ou
 anúncios comerciais, nem torna o token Meta um binding do Worker.
 

--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -2267,54 +2267,15 @@ async function discoverStagingSyntheticSeedFacts({
     };
   }
 
-  // The legacy ad-account Offline Conversions edge is no longer the current
-  // AdsDataset contract. Resolve the account's owning Business, then use the
-  // bounded Business `ads_dataset` edge exposed by Meta's current SDK schema.
-  // Ask only for the stable node id: some Graph versions reject the optional
-  // dataset_id projection even though the SDK exposes it as a model field.
-  const account = await read(
-    `act_${input.accountId}`,
-    'id,business{id}',
-    {},
-    failureCodes.datasetAccessDenied,
-    failureCodes.identityMalformed,
-  );
-  const accountId = normalizeStagingSyntheticSeedGraphId(
-    account.id,
-    'dataset_account_id',
-    failureCodes.identityMalformed,
-  );
-  if (accountId !== input.accountId) {
-    throw stagingSyntheticSeedFailure(failureCodes.identityMismatch, 409);
-  }
-  const businessId = normalizeStagingSyntheticSeedGraphId(
-    asObject(account.business).id,
-    'dataset_business_id',
-    failureCodes.identityMalformed,
-  );
-  const datasets = await read(
-    `${businessId}/ads_dataset`,
-    'id',
-    {},
-    failureCodes.datasetAccessDenied,
-    failureCodes.identityMalformed,
-    failureCodes.datasetContractInvalid,
-  );
-  const datasetContractFailure = failureCodes.datasetContractInvalid || failureCodes.identityMalformed;
-  if (!Array.isArray(datasets.data)) {
-    throw stagingSyntheticSeedFailure(datasetContractFailure, 409);
-  }
-  if (clean(asObject(datasets.paging).next) || datasets.data.length !== 1) {
-    throw stagingSyntheticSeedFailure(failureCodes.datasetAmbiguous, 409);
-  }
-  const datasetEntry = asObject(datasets.data[0]);
-  if (!clean(datasetEntry.id)) {
-    throw stagingSyntheticSeedFailure(datasetContractFailure, 409);
-  }
+  // Meta's converged website/offline Dataset uses the Pixel identity as its
+  // Dataset ID. The Pixel node and its exact ad-account membership were
+  // already proven above, so do not enumerate the Business Dataset edge here:
+  // that edge is contract-drifted for this token and is not needed to construct the
+  // later offline_conversion_data_set_id.
   const datasetId = normalizeStagingSyntheticSeedGraphId(
-    datasetEntry.id,
+    input.pixelId,
     'offline_dataset_id',
-    datasetContractFailure,
+    failureCodes.identityMalformed,
   );
   return {
     destinations,

--- a/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
@@ -691,12 +691,10 @@ test('staging seed attestation bounds Graph discovery and returns no source fact
     contract_version: 'meta-ads-tracking-v20/staging-synthetic-seed/v2',
     requestId: 'seed-attestation-test-request-id',
   });
-  assert.equal(graph.calls.length, 6);
+  assert.equal(graph.calls.length, 4);
   assert.ok(graph.calls.every((call) => call.method === 'GET'));
-  assert.deepEqual(
-    graph.calls.find((call) => call.path === `${BUSINESS_ID}/ads_dataset`).query,
-    { fields: 'id' },
-  );
+  assert.equal(graph.calls.some((call) => call.path.includes('ads_dataset')), false);
+  assert.equal(graph.calls.some((call) => call.path.includes('offline_conversion_data_sets')), false);
   assert.equal(graph.postCalls.length, 0);
   assert.equal(db.operations.size, 0);
   assert.equal(db.tokens.length, 0);
@@ -763,8 +761,6 @@ test('staging seed attestation proves two explicitly selected System User Page a
     `act_${ACCOUNT_ID}/adspixels`,
     'me',
     `${SYSTEM_USER_ID}/assigned_pages`,
-    `act_${ACCOUNT_ID}`,
-    `${BUSINESS_ID}/ads_dataset`,
   ]);
   assert.ok(graph.calls.every((call) => call.method === 'GET'));
   assert.equal(graph.postCalls.length, 0);
@@ -931,8 +927,6 @@ test('staging seed attestation uses the assigned Page pair without an incompatib
     `act_${ACCOUNT_ID}/adspixels`,
     'me',
     `${SYSTEM_USER_ID}/assigned_pages`,
-    `act_${ACCOUNT_ID}`,
-    `${BUSINESS_ID}/ads_dataset`,
   ]);
   assert.equal(graph.postCalls.length, 0);
   assert.equal(db.operations.size, 0);
@@ -957,7 +951,7 @@ test('staging seed attestation accepts an exact account Pixel membership on a bo
 
   assert.equal(response.status, 200);
   assert.equal(body.attestation, 'match');
-  assert.equal(graph.calls.length, 6);
+  assert.equal(graph.calls.length, 4);
   assert.ok(graph.calls.every((call) => call.method === 'GET'));
   assert.equal(graph.postCalls.length, 0);
   assert.equal(db.operations.size, 0);
@@ -1001,7 +995,7 @@ test('staging seed attestation accepts the explicit Profile Plus advertising tas
 
   assert.equal(response.status, 200);
   assert.equal(body.attestation, 'match');
-  assert.equal(graph.calls.length, 6);
+  assert.equal(graph.calls.length, 4);
   assert.ok(graph.calls.every((call) => call.method === 'GET'));
   assert.equal(graph.postCalls.length, 0);
   assert.equal(db.operations.size, 0);
@@ -1156,35 +1150,6 @@ test('staging seed attestation returns a finite resource stage for permanent Gra
       expectedError: 'meta_ads_publish_staging_seed_graph_page_access_denied',
       expectedReads: 4,
       status: 403,
-    },
-    {
-      label: 'dataset',
-      path: `${BUSINESS_ID}/ads_dataset`,
-      expectedError: 'meta_ads_publish_staging_seed_graph_dataset_access_denied',
-      expectedReads: 6,
-      // Graph can return a 2xx envelope containing an error. It remains a
-      // permanent source capability failure and must not become a success.
-      status: 200,
-    },
-    {
-      label: 'dataset-contract',
-      path: `${BUSINESS_ID}/ads_dataset`,
-      expectedError: 'meta_ads_publish_staging_seed_graph_contract_invalid',
-      expectedReads: 6,
-      // A code-100 response is a Graph edge/field contract rejection, not
-      // evidence that the configured source lacks an asset permission.
-      status: 200,
-      code: 100,
-    },
-    {
-      label: 'dataset-contract-envelope',
-      path: `${BUSINESS_ID}/ads_dataset`,
-      expectedError: 'meta_ads_publish_staging_seed_graph_contract_invalid',
-      expectedReads: 6,
-      // A non-auth 4xx envelope without a usable Graph code is still a
-      // contract/response failure, not an asset-permission verdict.
-      status: 400,
-      code: 0,
     },
   ];
 
@@ -1371,11 +1336,9 @@ test('candidate appsecret-proof attestation verifies only bounded proof-bearing 
     `act_${ACCOUNT_ID}/adspixels`,
     'me',
     `${SYSTEM_USER_ID}/assigned_pages`,
-    `act_${ACCOUNT_ID}`,
-    `${BUSINESS_ID}/ads_dataset`,
   ]);
   assert.ok(observedReads.every((read) => read.method === 'GET' && read.hasProof));
-  assert.equal(graph.calls.length, 6);
+  assert.equal(graph.calls.length, 4);
   assert.equal(graph.postCalls.length, 0);
   const serialized = JSON.stringify(body);
   for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, PAGE_ID, INSTAGRAM_ID, DATASET_ID]) {
@@ -1498,13 +1461,6 @@ test('staging seed attestation preserves finite non-identity source eligibility 
       expectedReads: 4,
     },
     {
-      label: 'dataset-ambiguous',
-      path: `${BUSINESS_ID}/ads_dataset`,
-      response: { body: { data: [] } },
-      expectedError: 'meta_ads_publish_staging_seed_graph_dataset_ambiguous',
-      expectedReads: 6,
-    },
-    {
       label: 'landing-unavailable',
       path: `${SYSTEM_USER_ID}/assigned_pages`,
       response: {
@@ -1557,48 +1513,31 @@ test('staging seed attestation preserves finite non-identity source eligibility 
   }
 });
 
-test('staging seed attestation classifies successful AdsDataset shape drift as a contract failure', async () => {
-  const cases = [
-    {
-      label: 'missing-data-array',
-      body: { id: DATASET_ID },
-    },
-    {
-      label: 'missing-stable-id',
-      body: { data: [{ dataset_id: DATASET_ID }] },
-    },
-  ];
+test('staging seed attestation seals the converged Dataset identity from the already-proven Pixel', async () => {
+  const db = new SeedDb();
+  db.prepare = () => {
+    throw new Error('D1 must remain untouched by source attestation');
+  };
+  const graph = new FakeGraph();
+  const response = await attest({
+    db,
+    graph,
+    operationKey: 'meta-ads-staging-seed:converged-dataset-identity-001',
+  });
+  const body = await response.json();
 
-  for (const entry of cases) {
-    const db = new SeedDb();
-    db.prepare = () => {
-      throw new Error('D1 must remain untouched by contract diagnostics');
-    };
-    const graph = new FakeGraph({
-      readResponses: {
-        [`${BUSINESS_ID}/ads_dataset`]: { body: entry.body },
-      },
-    });
-    const response = await attest({
-      db,
-      graph,
-      operationKey: `meta-ads-staging-seed:attestation-${entry.label}-001`,
-    });
-    const body = await response.json();
-
-    assert.equal(response.status, 409, entry.label);
-    assert.equal(body.error, 'meta_ads_publish_staging_seed_graph_contract_invalid', entry.label);
-    assert.equal(graph.calls.length, 6, entry.label);
-    assert.ok(graph.calls.every((call) => call.method === 'GET'), entry.label);
-    assert.equal(graph.postCalls.length, 0, entry.label);
-    assert.equal(db.operations.size, 0, entry.label);
-    assert.equal(db.tokens.length, 0, entry.label);
-    assert.equal(db.locks.size, 0, entry.label);
-    const serialized = JSON.stringify(body);
-    for (const value of [SOURCE_ACCESS_TOKEN, ACCOUNT_ID, PIXEL_ID, DATASET_ID]) {
-      assert.equal(serialized.includes(value), false, entry.label);
-    }
-  }
+  assert.equal(response.status, 200);
+  assert.equal(body.attestation, 'match');
+  assert.deepEqual(graph.calls.map((call) => call.path), [
+    PIXEL_ID,
+    `act_${ACCOUNT_ID}/adspixels`,
+    'me',
+    `${SYSTEM_USER_ID}/assigned_pages`,
+  ]);
+  assert.equal(graph.calls.some((call) => call.path.includes('ads_dataset')), false);
+  assert.equal(graph.calls.some((call) => call.path.includes('offline_conversion_data_sets')), false);
+  assert.equal(graph.postCalls.length, 0);
+  assert.equal(db.operations.size, 0);
 });
 
 test('staging seed attestation keeps transient source failures retryable and bounded', async () => {
@@ -1721,14 +1660,19 @@ test('staging seed seals a configured Page only after the System User assignment
 
   assert.equal(response.status, 201);
   assert.equal(body.seed, 'sealed');
-  assert.deepEqual(graph.calls.slice(0, 6).map((call) => call.path), [
+  assert.deepEqual(graph.calls.slice(0, 4).map((call) => call.path), [
     PIXEL_ID,
     `act_${ACCOUNT_ID}/adspixels`,
     'me',
     `${SYSTEM_USER_ID}/assigned_pages`,
-    `act_${ACCOUNT_ID}`,
-    `${BUSINESS_ID}/ads_dataset`,
   ]);
+  assert.equal(graph.calls.some((call) => call.path.includes('ads_dataset')), false);
+  assert.equal(graph.calls.some((call) => call.path.includes('offline_conversion_data_sets')), false);
+  const seededAdsets = [...graph.resources.values()].filter((resource) => resource.kind === 'adset');
+  assert.equal(seededAdsets.length, 2);
+  const sourceAdsets = seededAdsets.filter((resource) => resource.body?.promoted_object);
+  assert.equal(sourceAdsets.length, 1);
+  assert.equal(sourceAdsets[0].body.promoted_object.offline_conversion_data_set_id, PIXEL_ID);
   assert.ok(graph.calls.every((call) => call.path !== 'me/accounts'));
   assert.equal(db.tokens.length, 2);
   assert.equal(db.operations.get(operationKey).status, 'sealed');

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -144,11 +144,6 @@ function happyResponses() {
         ],
       },
     },
-    {
-      pathname: `/v25.0/act_${syntheticAccountId}/offline_conversion_data_sets`,
-      query: { fields: "id", limit: "2" },
-      payload: { data: [{ id: syntheticDatasetId }] },
-    },
   ];
 }
 
@@ -190,13 +185,10 @@ test("Meta Ads source-access attestation is manual, GET-only, and bound to two s
   assert.match(workflow, /source_destination_page_assignment_unassigned/);
   assert.match(workflow, /source_destination_page_selector_ambiguous/);
   assert.match(workflow, /source_destination_page_pair_duplicate/);
-  assert.match(workflow, /offline_conversion_data_sets\?fields=id&limit=2/);
-  assert.match(workflow, /act_\$\{accountId\}\?fields=id,business\{id\}/);
-  assert.match(workflow, /\$\{businessId\}\/ads_dataset\?fields=id/);
-  assert.doesNotMatch(workflow, /ads_dataset\?fields=id&limit=/);
-  assert.doesNotMatch(workflow, /ads_dataset\?fields=id,dataset_id/);
-  assert.match(workflow, /source_dataset_ads_dataset_response_\$\{modernDatasetResult\.state\}/);
-  assert.match(workflow, /source_dataset_legacy_contract_invalid/);
+  assert.doesNotMatch(workflow, /offline_conversion_data_sets/);
+  assert.doesNotMatch(workflow, /ads_dataset/);
+  assert.doesNotMatch(workflow, /source_dataset_ads_dataset_response_/);
+  assert.doesNotMatch(workflow, /source_dataset_legacy_contract_invalid/);
   assert.match(
     workflow,
     /assigned_pages\?fields=id,tasks,instagram_business_account\{id\},website,picture\{url\}&limit=100/,
@@ -225,7 +217,7 @@ test("Meta Ads source-access verifier proves both assigned Page and Instagram pa
   const result = runVerifier(happyResponses());
   const combined = `${result.stdout}${result.stderr}`;
   assert.equal(result.status, 0, combined);
-  assert.equal(result.requestCount, 5);
+  assert.equal(result.requestCount, 4);
   assert.equal(
     result.stdout,
     [
@@ -272,7 +264,7 @@ test("Meta Ads source-access verifier accepts Profile Plus advertising and exact
   const result = runVerifier(responses);
   const combined = `${result.stdout}${result.stderr}`;
   assert.equal(result.status, 0, combined);
-  assert.equal(result.requestCount, 5);
+  assert.equal(result.requestCount, 4);
   assert.match(result.stdout, /source_access_raw=verified/);
   assertNoSyntheticInputs(combined);
 });
@@ -392,69 +384,11 @@ test("Meta Ads source-access verifier reports only classified Graph failures", (
   assertNoSyntheticInputs(combined);
 });
 
-test("Meta Ads source-access verifier classifies Graph contract rejection without exposing Graph details", () => {
-  for (const modernError of [
-    { code: 100, message: "synthetic modern contract detail" },
-    { code: 0, message: "synthetic unknown modern contract detail" },
-  ]) {
-    const responses = happyResponses();
-    responses[4] = {
-      ...responses[4],
-      status: 400,
-      payload: { error: { code: 100, message: "synthetic legacy dataset edge drift" } },
-    };
-    responses.push({
-      pathname: `/v25.0/act_${syntheticAccountId}`,
-      query: { fields: "id,business{id}" },
-      payload: { id: syntheticAccountId, business: { id: syntheticBusinessId } },
-    });
-    responses.push({
-      pathname: `/v25.0/${syntheticBusinessId}/ads_dataset`,
-      query: { fields: "id" },
-      status: 400,
-      payload: { error: modernError },
-    });
-    const result = runVerifier(responses, { expectedRequests: 7 });
-    const combined = `${result.stdout}${result.stderr}`;
-    assert.notEqual(result.status, 0);
-    assert.equal(result.requestCount, 7);
-    assert.match(combined, /source_dataset_ads_dataset_response_contract/);
-    assert.doesNotMatch(
-      combined,
-      /synthetic legacy dataset edge drift|synthetic modern contract detail|synthetic unknown modern contract detail|source_access_raw=verified/,
-    );
-    assertNoSyntheticInputs(combined);
-  }
-});
-
-test("Meta Ads source-access verifier probes the current Business AdsDataset contract after a legacy dataset shape failure", () => {
-  for (const legacyPayload of [
-    { error: { code: 100, message: "synthetic legacy dataset edge drift" } },
-    {},
-    { data: { invalid: true } },
-  ]) {
-    const responses = happyResponses();
-    responses.push({
-      pathname: `/v25.0/act_${syntheticAccountId}`,
-      query: { fields: "id,business{id}" },
-      payload: { id: syntheticAccountId, business: { id: syntheticBusinessId } },
-    });
-    responses.push({
-      pathname: `/v25.0/${syntheticBusinessId}/ads_dataset`,
-      query: { fields: "id" },
-      payload: { data: [{ id: syntheticModernDatasetId }] },
-    });
-    responses[4] = {
-      ...responses[4],
-      status: legacyPayload.error ? 400 : 200,
-      payload: legacyPayload,
-    };
-    const result = runVerifier(responses, { expectedRequests: 7 });
-    const combined = `${result.stdout}${result.stderr}`;
-    assert.notEqual(result.status, 0);
-    assert.equal(result.requestCount, 7);
-    assert.match(combined, /source_dataset_legacy_contract_invalid/);
-    assert.doesNotMatch(combined, /synthetic legacy dataset edge drift|source_access_raw=verified/);
-    assertNoSyntheticInputs(combined);
-  }
+test("Meta Ads source-access verifier uses the already-proven converged Pixel identity as Dataset", () => {
+  const result = runVerifier(happyResponses());
+  const combined = `${result.stdout}${result.stderr}`;
+  assert.equal(result.status, 0, combined);
+  assert.equal(result.requestCount, 4);
+  assert.doesNotMatch(combined, /offline_conversion_data_sets|ads_dataset|source_dataset_/);
+  assertNoSyntheticInputs(combined);
 });


### PR DESCRIPTION
## Summary
- Replace the drifted `Business/{business_id}/ads_dataset` and legacy Offline Conversions enumeration in the staging source proof with the already-proven converged Pixel identity.
- Seal `offline_conversion_data_set_id` from the validated Pixel ID, preserving the dual-destination Page/Instagram contract and fail-closed GET-only attestation.
- Update focused tests and Token Vault documentation; no Ponto/CRM files are touched.

## Root cause
The current Graph contract rejects the dataset enumeration path for the converged Pixel/Dataset model. The authenticated Meta UI evidence establishes that the Dataset identity is the same as the already-proven Pixel, so a second dataset lookup is incompatible and unnecessary.

## Surfaces and risk
- Surfaces: Token Vault discovery/seed, raw source-access attestation, focused tests, README.
- No new permissions, secrets, Graph writes, D1 writes, traffic activation, Orb action, or production flag.
- Staging remains gated by the existing candidate proof, release lease, migration/checkpoint, rollback, and promotion evidence.

## Operational contract
- Flag: N/A (existing staging gates remain fail-closed).
- Migration: N/A for this code change; existing governed staging migrations remain additive and checkpointed.
- Rollback: revert this PR and use the recorded incumbent/immutable Worker release with the existing compensation path; no Meta resource was created by this change.

## Validation
- Token Vault suite: 184/184.
- Architecture, deploy-topology, single-writer, and global-governance checks passed.
- Security diff scan: 0 findings / no P0 or P1.
- `git diff --check` clean.

The next staging run must use a fresh preview for the merged SHA. If the separate candidate appsecret-proof gate remains unavailable, staging must stay blocked; no proof bypass is included here.