### PR TITLE
fix(crm): add dedicated Atendimento source sync

### DIFF
--- a/crm/api/package.json
+++ b/crm/api/package.json
@@ -12,6 +12,7 @@
     "test": "node --test --test-concurrency=1 server/__tests__/*.test.js server/harmonia/__tests__/*.test.js server/atendimento/__tests__/*.test.js server/clinical/__tests__/*.test.js server/caixa/__tests__/*.test.js server/clientes/__tests__/*.test.js services/__tests__/*.test.js scripts/*.test.mjs",
     "import-atendimento-sheet": "node scripts/import-atendimento-sheet.mjs",
     "refresh-atendimento-source": "node scripts/refresh-atendimento-source.mjs",
+    "sync-atendimento-source": "node scripts/run-atendimento-source-sync.mjs",
     "clientes-source-operations": "node scripts/run-clientes-source-operations.mjs",
     "migrate-clientes-source-operations": "node scripts/migrate-clientes-source-operations.mjs",
     "import-gerencia-sheet": "node scripts/import-gerencia-sheet.mjs",

--- a/crm/api/scripts/run-atendimento-source-sync.mjs
+++ b/crm/api/scripts/run-atendimento-source-sync.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+import { readLiteralEnvironment } from '../server/atendimento/runtimeEnv.js'
+import { createPgPool } from '../server/harmonia/store/pg.js'
+import {
+    normalizeAtendimentoSourceSyncAction,
+    runAtendimentoSourceSync,
+} from '../server/atendimento/sourceSync.js'
+
+const ENV_FILE = '/etc/skincos/crm-atendimento-source-sync.env'
+const ENV_KEYS = [
+    'DATABASE_URL',
+    'CRM_ATENDIMENTO_SOURCE_SYNC_TARGET',
+    'CRM_ATENDIMENTO_SOURCE_SYNC_ACTION',
+    'CRM_ATENDIMENTO_SOURCE_SYNC_APPLY_CONFIRMED',
+    'ATENDIMENTO_GOOGLE_SHEET_ID',
+    'ATENDIMENTO_GOOGLE_SA_FILE',
+]
+const args = process.argv.slice(2)
+const actions = args.filter((value) => value === '--dry-run' || value === '--apply')
+if (args.length !== actions.length || actions.length > 1) {
+    throw new Error('Use apenas --dry-run ou --apply.')
+}
+
+const fileEnv = await readLiteralEnvironment(ENV_FILE, { allowedKeys: ENV_KEYS })
+const env = { ...fileEnv, ...process.env }
+const action = normalizeAtendimentoSourceSyncAction(actions[0] ? actions[0].slice(2) : env.CRM_ATENDIMENTO_SOURCE_SYNC_ACTION || 'dry-run')
+const pool = createPgPool(env.DATABASE_URL)
+if (!pool) throw new Error('ATENDIMENTO_SOURCE_SYNC_DATABASE_UNAVAILABLE')
+
+try {
+    const report = await runAtendimentoSourceSync({
+        pool,
+        databaseUrl: env.DATABASE_URL,
+        target: env.CRM_ATENDIMENTO_SOURCE_SYNC_TARGET,
+        action,
+        applyConfirmed: env.CRM_ATENDIMENTO_SOURCE_SYNC_APPLY_CONFIRMED,
+        spreadsheetId: env.ATENDIMENTO_GOOGLE_SHEET_ID,
+        serviceAccountFile: env.ATENDIMENTO_GOOGLE_SA_FILE,
+    })
+    process.stdout.write(`${JSON.stringify(report)}\n`)
+} catch (error) {
+    const code = /^[A-Z][A-Z0-9_]{1,100}$/.test(String(error?.code || ''))
+        ? error.code
+        : 'ATENDIMENTO_SOURCE_SYNC_FAILED'
+    process.stderr.write(`${JSON.stringify({ ok: false, code })}\n`)
+    process.exitCode = 1
+} finally {
+    await pool.end()
+}

--- a/crm/api/server/atendimento/__tests__/sourceRefresh.test.js
+++ b/crm/api/server/atendimento/__tests__/sourceRefresh.test.js
@@ -20,34 +20,35 @@ test('normalizes only the explicit Clientes source refresh targets and actions',
 test('accepts only the target-bound production and staging database URL shapes', () => {
     assert.deepEqual(
         assertClientesSourceRefreshDatabaseUrl(
-            'postgresql://skincos@/skincos_crm_local?host=/var/run/postgresql',
+            'postgresql://skincos_clientes_migrator_login:synthetic@127.0.0.1:5432/skincos_clientes_production?sslmode=require&uselibpqcompat=true',
             'production',
         ),
-        { target: 'production', database: 'skincos_crm_local' },
+        { target: 'production', database: 'skincos_clientes_production' },
     )
     assert.deepEqual(
         assertClientesSourceRefreshDatabaseUrl(
-            'postgresql://skincos_staging_app:secret@127.0.0.1:5432/skincos_staging?sslmode=require',
+            'postgresql://skincos_staging_migrator_login:secret@127.0.0.1:5432/skincos_staging?sslmode=require&uselibpqcompat=true',
             'staging',
         ),
         { target: 'staging', database: 'skincos_staging' },
     )
     assert.throws(() => assertClientesSourceRefreshDatabaseUrl(
-        'postgresql://admin@127.0.0.1:5432/skincos_crm_local?sslmode=require',
+        'postgresql://admin:secret@127.0.0.1:5432/skincos_clientes_production?sslmode=require',
         'production',
     ), { code: 'CLIENTES_SOURCE_REFRESH_PRODUCTION_DATABASE_UNSAFE' })
 })
 
 test('requires the expected database identity before source refresh', () => {
     assert.deepEqual(
-        assertClientesSourceRefreshDatabaseIdentity({ database_name: 'skincos_crm_local', current_user: 'skincos' }, 'production'),
-        { target: 'production', database: 'skincos_crm_local', user: 'skincos' },
+        assertClientesSourceRefreshDatabaseIdentity({ database_name: 'skincos_clientes_production', current_user: 'skincos_clientes_migrator_login' }, 'production'),
+        { target: 'production', database: 'skincos_clientes_production', user: 'skincos_clientes_migrator_login' },
     )
     assert.deepEqual(
-        assertClientesSourceRefreshDatabaseIdentity({ database_name: 'skincos_staging', current_user: 'skincos_staging_app' }, 'staging'),
-        { target: 'staging', database: 'skincos_staging', user: 'skincos_staging_app' },
+        assertClientesSourceRefreshDatabaseIdentity({ database_name: 'skincos_staging', current_user: 'skincos_staging_migrator_login' }, 'staging'),
+        { target: 'staging', database: 'skincos_staging', user: 'skincos_staging_migrator_login' },
     )
     assert.throws(() => assertClientesSourceRefreshDatabaseIdentity({ database_name: 'skincos_staging', current_user: 'postgres' }, 'staging'), { code: 'CLIENTES_SOURCE_REFRESH_STAGING_IDENTITY_UNSAFE' })
+    assert.throws(() => assertClientesSourceRefreshDatabaseIdentity({ database_name: 'skincos_staging', current_user: 'skincos_staging_app' }, 'staging'), { code: 'CLIENTES_SOURCE_REFRESH_STAGING_IDENTITY_UNSAFE' })
 })
 
 test('uses a non-person actor and emits only aggregate refresh evidence', () => {

--- a/crm/api/server/atendimento/__tests__/sourceSync.test.js
+++ b/crm/api/server/atendimento/__tests__/sourceSync.test.js
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+    assertAtendimentoSourceSyncSchema,
+    assertAtendimentoSourceSyncDatabaseIdentity,
+    assertAtendimentoSourceSyncDatabaseUrl,
+    assertPrivateSourceCredentialPath,
+    atendimentoSourceFingerprint,
+    runAtendimentoSourceSync,
+} from '../sourceSync.js'
+
+const PRODUCTION_URL = 'postgresql://skincos_clientes_migrator_login:synthetic@127.0.0.1:5432/skincos_clientes_production?sslmode=require&uselibpqcompat=true&application_name=source-sync'
+const SOURCE_CREDENTIAL_FILE = '/etc/skincos/google-atendimento-source.json'
+
+function fakePool() {
+    const calls = []
+    const client = {
+        async query(sql, params) {
+            calls.push({ sql, params })
+            if (sql.includes('current_database')) {
+                return { rows: [{ database_name: 'skincos_clientes_production', current_user: 'skincos_clientes_migrator_login', session_user: 'skincos_clientes_migrator_login', transaction_read_only: 'off' }] }
+            }
+            return { rows: [{ acquired: true }] }
+        },
+        release() {},
+    }
+    return {
+        calls,
+        async connect() { return client },
+        async query(sql) {
+            calls.push({ sql, params: [] })
+            if (sql.includes('select summary')) return { rows: [] }
+            if (sql.includes('count(*)')) return { rows: [{ total: 0 }] }
+            return { rows: [] }
+        },
+    }
+}
+
+function syntheticSnapshot() {
+    return {
+        spreadsheetId: 'synthetic-sheet-id',
+        tabs: ['Novo Hamburgo', 'BarraShoppingSul'],
+        records: [{
+            date: '2026-08-18',
+            unitSlug: 'novo-hamburgo',
+            unitName: 'Novo Hamburgo',
+            clientName: 'synthetic-client',
+            procedureName: 'synthetic-procedure',
+            code: '#0001',
+            quantity: 1,
+            sourceSheetId: 'synthetic-sheet-id',
+            sourceTab: 'Novo Hamburgo',
+            sourceRow: 3,
+        }],
+        cache: { professionals: [], procedures: [], procedureCodes: [], schedules: [] },
+    }
+}
+
+test('accepts only the dedicated migrator database contract', () => {
+    assert.deepEqual(assertAtendimentoSourceSyncDatabaseUrl(PRODUCTION_URL, 'production'), {
+        target: 'production', database: 'skincos_clientes_production', user: 'skincos_clientes_migrator_login',
+    })
+    assert.throws(
+        () => assertAtendimentoSourceSyncDatabaseUrl('postgresql://skincos_clientes_ro:synthetic@127.0.0.1:5432/skincos_clientes_production?sslmode=require', 'production'),
+        { code: 'ATENDIMENTO_SOURCE_SYNC_DATABASE_URL_UNSAFE' },
+    )
+    assert.throws(() => assertPrivateSourceCredentialPath('/tmp/google-sa.json'), { code: 'ATENDIMENTO_SOURCE_SYNC_SOURCE_CREDENTIAL_UNSAFE' })
+})
+
+test('rejects a read-only or mismatched production identity before source work', () => {
+    assert.deepEqual(assertAtendimentoSourceSyncDatabaseIdentity({
+        database_name: 'skincos_clientes_production',
+        current_user: 'skincos_clientes_migrator_login',
+        session_user: 'skincos_clientes_migrator_login',
+        transaction_read_only: 'off',
+    }, 'production').database, 'skincos_clientes_production')
+    assert.throws(() => assertAtendimentoSourceSyncDatabaseIdentity({
+        database_name: 'skincos_clientes_production',
+        current_user: 'skincos_clientes_ro',
+        session_user: 'skincos_clientes_ro',
+        transaction_read_only: 'on',
+    }, 'production'), { code: 'ATENDIMENTO_SOURCE_SYNC_DATABASE_IDENTITY_UNSAFE' })
+})
+
+test('fails closed when the dedicated schema is not ready', async () => {
+    await assert.rejects(
+        () => assertAtendimentoSourceSyncSchema({
+            async query() {
+                return { rows: [{ relation: 'crm_atendimento.attendances', resolved: null }] }
+            },
+        }),
+        { code: 'ATENDIMENTO_SOURCE_SYNC_SCHEMA_NOT_READY' },
+    )
+})
+
+test('dry-run validates the source without creating a backup or writing attendance rows', async () => {
+    const pool = fakePool()
+    const snapshot = syntheticSnapshot()
+    const calls = []
+    const report = await runAtendimentoSourceSync({
+        pool,
+        databaseUrl: PRODUCTION_URL,
+        target: 'production',
+        action: 'dry-run',
+        sourceReader: async () => snapshot,
+        storeFactory: () => ({
+            async importRecords(input) {
+                calls.push(input)
+                return { dryRun: input.dryRun, records: input.records.length, inserted: 0, updated: 0, skipped: 0 }
+            },
+        }),
+        backupFactory: async () => { throw new Error('backup must not run during dry-run') },
+        checkpointReader: async () => false,
+        schemaReader: async () => {},
+        serviceAccountFile: SOURCE_CREDENTIAL_FILE,
+    })
+    assert.equal(report.ok, true)
+    assert.equal(report.dryRun, true)
+    assert.equal(report.records, 1)
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].dryRun, true)
+    assert.match(report.sourceFingerprint, /^sha256:[a-f0-9]{64}$/)
+    assert.doesNotMatch(JSON.stringify(report), /synthetic-client/)
+})
+
+test('apply requires confirmation, backups first, and writes only after the source validation', async () => {
+    const pool = fakePool()
+    const snapshot = syntheticSnapshot()
+    const order = []
+    const report = await runAtendimentoSourceSync({
+        pool,
+        databaseUrl: PRODUCTION_URL,
+        target: 'production',
+        action: 'apply',
+        applyConfirmed: true,
+        sourceReader: async () => snapshot,
+        storeFactory: () => ({
+            async importRecords(input) {
+                order.push(input.dryRun ? 'validate' : 'apply')
+                return { dryRun: input.dryRun, records: input.records.length, inserted: input.dryRun ? 0 : 1, updated: 0, skipped: 0, importBatchId: input.dryRun ? null : 'batch-synthetic' }
+            },
+        }),
+        backupFactory: async () => {
+            order.push('backup')
+            return { reference: 'atendimento-source-production-synthetic', manifestHash: 'sha256:' + 'a'.repeat(64), private: true, restorable: true }
+        },
+        checkpointReader: async () => false,
+        schemaReader: async () => {},
+        serviceAccountFile: SOURCE_CREDENTIAL_FILE,
+    })
+    assert.deepEqual(order, ['validate', 'backup', 'apply'])
+    assert.equal(report.dryRun, false)
+    assert.equal(report.importBatchId, 'batch-synthetic')
+    assert.equal(report.backupReference, 'atendimento-source-production-synthetic')
+})
+
+test('does not treat a repeated source fingerprint as a new import', async () => {
+    const pool = fakePool()
+    const snapshot = syntheticSnapshot()
+    let writes = 0
+    const fingerprint = atendimentoSourceFingerprint(snapshot)
+    const report = await runAtendimentoSourceSync({
+        pool,
+        databaseUrl: PRODUCTION_URL,
+        target: 'production',
+        action: 'apply',
+        applyConfirmed: true,
+        sourceReader: async () => snapshot,
+        storeFactory: () => ({ async importRecords() { writes += 1; return {} } }),
+        backupFactory: async () => { throw new Error('unchanged source must not be backed up') },
+        checkpointReader: async (_pool, value) => value === fingerprint,
+        schemaReader: async () => {},
+        serviceAccountFile: SOURCE_CREDENTIAL_FILE,
+    })
+    assert.equal(report.skipped, true)
+    assert.equal(writes, 1)
+})

--- a/crm/api/server/atendimento/importer.js
+++ b/crm/api/server/atendimento/importer.js
@@ -391,6 +391,13 @@ async function readTab(sheets, spreadsheetId, tabName) {
     return readPublicGvizTab(spreadsheetId, tabName)
 }
 
+function attachSourceSheetId(records, spreadsheetId) {
+    return (records || []).map((record) => ({
+        ...record,
+        sourceSheetId: spreadsheetId,
+    }))
+}
+
 export async function readAtendimentoSheet(config = {}) {
     const spreadsheetId = String(config.spreadsheetId || process.env.ATENDIMENTO_GOOGLE_SHEET_ID || SOURCE_SHEET_ID).trim()
     const workbookFile = String(config.workbookFile || process.env.ATENDIMENTO_GOOGLE_XLSX_FILE || '').trim()
@@ -400,7 +407,7 @@ export async function readAtendimentoSheet(config = {}) {
         for (const tab of [...OPERATIONAL_TABS, '_CACHE_GERENCIA']) {
             tabs[tab] = workbook[tab]?.values || []
         }
-        const records = buildImportRecords(tabs, config.now || new Date())
+        const records = attachSourceSheetId(buildImportRecords(tabs, config.now || new Date()), spreadsheetId)
         const cache = parseCacheRows(tabs._CACHE_GERENCIA)
         return {
             spreadsheetId,
@@ -418,7 +425,7 @@ export async function readAtendimentoSheet(config = {}) {
         return {
             spreadsheetId,
             tabs: OPERATIONAL_TABS,
-            records: buildImportRecords(tabs, config.now || new Date()),
+            records: attachSourceSheetId(buildImportRecords(tabs, config.now || new Date()), spreadsheetId),
             cache: parseCacheRows(tabs._CACHE_GERENCIA),
         }
     }
@@ -427,7 +434,7 @@ export async function readAtendimentoSheet(config = {}) {
     for (const tab of [...OPERATIONAL_TABS, '_CACHE_GERENCIA']) {
         tabs[tab] = await readTab(sheets, spreadsheetId, tab)
     }
-    const records = buildImportRecords(tabs, config.now || new Date())
+    const records = attachSourceSheetId(buildImportRecords(tabs, config.now || new Date()), spreadsheetId)
     const cache = parseCacheRows(tabs._CACHE_GERENCIA)
     return {
         spreadsheetId,

--- a/crm/api/server/atendimento/sourceRefresh.js
+++ b/crm/api/server/atendimento/sourceRefresh.js
@@ -29,10 +29,13 @@ export function assertClientesSourceRefreshDatabaseUrl(databaseUrl, targetValue)
     if (!raw) throw refreshError('DATABASE_URL_NOT_CONFIGURED')
 
     if (target === CLIENTES_SOURCE_REFRESH_TARGETS.PRODUCTION) {
-        if (!/^postgres(?:ql)?:\/\/skincos@\/skincos_crm_local\?(?:[^#]*&)?host=\/var\/run\/postgresql(?:&|$)/i.test(raw)) {
+        if (!isDedicatedSourceRefreshUrl(raw, {
+            database: 'skincos_clientes_production',
+            user: 'skincos_clientes_migrator_login',
+        })) {
             throw refreshError('CLIENTES_SOURCE_REFRESH_PRODUCTION_DATABASE_UNSAFE')
         }
-        return { target, database: 'skincos_crm_local' }
+        return { target, database: 'skincos_clientes_production' }
     }
 
     let parsed
@@ -42,10 +45,10 @@ export function assertClientesSourceRefreshDatabaseUrl(databaseUrl, targetValue)
         throw refreshError('CLIENTES_SOURCE_REFRESH_DATABASE_URL_INVALID')
     }
     const database = decodeURIComponent(String(parsed.pathname || '').replace(/^\//, ''))
-    if (database !== 'skincos_staging' || parsed.hostname !== '127.0.0.1' ||
-        parsed.port && parsed.port !== '5432' ||
-        !new URLSearchParams(parsed.search).has('sslmode') ||
-        new URLSearchParams(parsed.search).get('sslmode') !== 'require') {
+    if (!isDedicatedSourceRefreshUrl(raw, {
+        database: 'skincos_staging',
+        user: 'skincos_staging_migrator_login',
+    })) {
         throw refreshError('CLIENTES_SOURCE_REFRESH_STAGING_DATABASE_UNSAFE')
     }
     return { target, database }
@@ -56,10 +59,10 @@ export function assertClientesSourceRefreshDatabaseIdentity(identity = {}, targe
     const database = String(identity.database_name || identity.databaseName || '').trim()
     const user = String(identity.current_user || identity.currentUser || '').trim()
     if (target === CLIENTES_SOURCE_REFRESH_TARGETS.PRODUCTION) {
-        if (database !== 'skincos_crm_local' || user !== 'skincos') {
+        if (database !== 'skincos_clientes_production' || user !== 'skincos_clientes_migrator_login') {
             throw refreshError('CLIENTES_SOURCE_REFRESH_PRODUCTION_IDENTITY_UNSAFE')
         }
-    } else if (database !== 'skincos_staging' || !user || user === 'postgres') {
+    } else if (database !== 'skincos_staging' || user !== 'skincos_staging_migrator_login') {
         throw refreshError('CLIENTES_SOURCE_REFRESH_STAGING_IDENTITY_UNSAFE')
     }
     return { target, database, user }
@@ -94,3 +97,23 @@ export function summarizeClientesSourceRefresh({ target, action, identity, resul
 }
 
 export { refreshError }
+
+function isDedicatedSourceRefreshUrl(raw, { database, user }) {
+    let parsed
+    try {
+        parsed = new URL(String(raw || '').replace(/^postgresql:/i, 'postgres:'))
+    } catch {
+        return false
+    }
+    const query = new URLSearchParams(parsed.search)
+    const allowedQueryKeys = new Set(['sslmode', 'uselibpqcompat', 'application_name'])
+    for (const key of query.keys()) if (!allowedQueryKeys.has(key)) return false
+    return parsed.protocol === 'postgres:' &&
+        ['127.0.0.1', 'localhost', '::1'].includes(String(parsed.hostname || '').toLowerCase()) &&
+        (parsed.port || '5432') === '5432' &&
+        decodeURIComponent(parsed.username || '') === user &&
+        Boolean(parsed.password) &&
+        decodeURIComponent(parsed.pathname || '').replace(/^\//, '') === database &&
+        query.get('sslmode') === 'require' &&
+        (!query.has('uselibpqcompat') || query.get('uselibpqcompat') === 'true')
+}

--- a/crm/api/server/atendimento/sourceSync.js
+++ b/crm/api/server/atendimento/sourceSync.js
@@ -1,0 +1,348 @@
+import { createHash, randomUUID } from 'node:crypto'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { spawn } from 'node:child_process'
+
+import { readAtendimentoSheet } from './importer.js'
+import { createAtendimentoStore } from './store.js'
+import { sourceRefreshActor } from './sourceRefresh.js'
+
+export const ATENDIMENTO_SOURCE_SYNC_TARGETS = Object.freeze({
+    PRODUCTION: 'production',
+    STAGING: 'staging',
+})
+
+export const ATENDIMENTO_SOURCE_SYNC_DATABASES = Object.freeze({
+    production: Object.freeze({
+        database: 'skincos_clientes_production',
+        user: 'skincos_clientes_migrator_login',
+        backupRoot: '/var/backups/skincos/clientes/production-source-sync',
+    }),
+    staging: Object.freeze({
+        database: 'skincos_staging',
+        user: 'skincos_staging_migrator_login',
+        backupRoot: '/var/backups/skincos/clientes/staging-source-sync',
+    }),
+})
+
+export const ATENDIMENTO_SOURCE_SYNC_LOCK_KEY = 'skincos:atendimento:source-sync:v1'
+export const ATENDIMENTO_SOURCE_SYNC_REQUIRED_RELATIONS = Object.freeze([
+    'crm_atendimento.units',
+    'crm_atendimento.professionals',
+    'crm_atendimento.procedures',
+    'crm_atendimento.procedure_price_codes',
+    'crm_atendimento.clients',
+    'crm_atendimento.attendances',
+    'crm_atendimento.schedule_days',
+    'crm_atendimento.audit_events',
+    'crm_atendimento.import_batches',
+])
+
+const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on'])
+const PRIVATE_SOURCE_ROOT = '/etc/skincos/'
+
+function syncError(code, statusCode = 409) {
+    const error = new Error(code)
+    error.code = code
+    error.statusCode = statusCode
+    return error
+}
+
+function isTruthy(value) {
+    return TRUE_VALUES.has(String(value || '').trim().toLowerCase())
+}
+
+function normalizedTarget(value) {
+    const target = String(value || '').trim().toLowerCase()
+    if (!Object.prototype.hasOwnProperty.call(ATENDIMENTO_SOURCE_SYNC_DATABASES, target)) {
+        throw syncError('ATENDIMENTO_SOURCE_SYNC_TARGET_INVALID', 400)
+    }
+    return target
+}
+
+export function normalizeAtendimentoSourceSyncTarget(value) {
+    return normalizedTarget(value)
+}
+
+export function normalizeAtendimentoSourceSyncAction(value) {
+    const action = String(value || 'dry-run').trim().toLowerCase()
+    if (!['dry-run', 'apply'].includes(action)) throw syncError('ATENDIMENTO_SOURCE_SYNC_ACTION_INVALID', 400)
+    return action
+}
+
+export function assertAtendimentoSourceSyncDatabaseUrl(databaseUrl, targetValue) {
+    const target = normalizedTarget(targetValue)
+    const expected = ATENDIMENTO_SOURCE_SYNC_DATABASES[target]
+    const raw = String(databaseUrl || '').trim()
+    let parsed
+    try {
+        parsed = new URL(raw.replace(/^postgresql:/i, 'postgres:'))
+    } catch {
+        throw syncError('ATENDIMENTO_SOURCE_SYNC_DATABASE_URL_INVALID', 400)
+    }
+    const query = new URLSearchParams(parsed.search)
+    const allowedQueryKeys = new Set(['sslmode', 'uselibpqcompat', 'application_name'])
+    for (const key of query.keys()) {
+        if (!allowedQueryKeys.has(key)) throw syncError('ATENDIMENTO_SOURCE_SYNC_DATABASE_URL_UNSAFE', 400)
+    }
+    const valid = parsed.protocol === 'postgres:' &&
+        ['127.0.0.1', 'localhost', '::1'].includes(String(parsed.hostname || '').toLowerCase()) &&
+        (parsed.port || '5432') === '5432' &&
+        decodeURIComponent(parsed.username || '') === expected.user &&
+        Boolean(parsed.password) &&
+        decodeURIComponent(parsed.pathname || '').replace(/^\//, '') === expected.database &&
+        query.get('sslmode') === 'require' &&
+        (!query.has('uselibpqcompat') || query.get('uselibpqcompat') === 'true')
+    if (!valid) throw syncError('ATENDIMENTO_SOURCE_SYNC_DATABASE_URL_UNSAFE', 400)
+    return { target, database: expected.database, user: expected.user }
+}
+
+export function assertAtendimentoSourceSyncDatabaseIdentity(identity = {}, targetValue) {
+    const target = normalizedTarget(targetValue)
+    const expected = ATENDIMENTO_SOURCE_SYNC_DATABASES[target]
+    const database = String(identity.database_name || identity.databaseName || '').trim()
+    const user = String(identity.current_user || identity.currentUser || '').trim()
+    const sessionUser = String(identity.session_user || identity.sessionUser || user).trim()
+    const readOnly = String(identity.transaction_read_only || identity.readOnly || '').trim().toLowerCase()
+    if (database !== expected.database || user !== expected.user || sessionUser !== expected.user) {
+        throw syncError('ATENDIMENTO_SOURCE_SYNC_DATABASE_IDENTITY_UNSAFE', 403)
+    }
+    if (readOnly === 'on') throw syncError('ATENDIMENTO_SOURCE_SYNC_DATABASE_READ_ONLY', 403)
+    return { target, database, user, sessionUser }
+}
+
+export function assertPrivateSourceCredentialPath(value) {
+    const filePath = String(value || '').trim()
+    if (!filePath || !filePath.startsWith(PRIVATE_SOURCE_ROOT) || filePath.includes('..') || !filePath.endsWith('.json')) {
+        throw syncError('ATENDIMENTO_SOURCE_SYNC_SOURCE_CREDENTIAL_UNSAFE', 400)
+    }
+    return filePath
+}
+
+function canonicalize(value) {
+    if (value instanceof Date) return value.toISOString()
+    if (Array.isArray(value)) return value.map(canonicalize)
+    if (value && typeof value === 'object') {
+        return Object.fromEntries(Object.keys(value).sort().map((key) => [key, canonicalize(value[key])]))
+    }
+    return value
+}
+
+export function atendimentoSourceFingerprint(snapshot = {}) {
+    return `sha256:${createHash('sha256').update(JSON.stringify(canonicalize({
+        spreadsheetId: snapshot.spreadsheetId || '',
+        records: snapshot.records || [],
+        cache: snapshot.cache || {},
+        tabs: snapshot.tabs || [],
+    }))).digest('hex')}`
+}
+
+export async function assertAtendimentoSourceSyncSchema(client) {
+    const result = await client.query(
+        `select relation, to_regclass(relation) as resolved
+         from unnest($1::text[]) as required(relation)`,
+        [ATENDIMENTO_SOURCE_SYNC_REQUIRED_RELATIONS],
+    )
+    const missing = result.rows
+        .filter((row) => !row?.resolved)
+        .map((row) => String(row?.relation || ''))
+        .filter(Boolean)
+    if (missing.length) throw syncError('ATENDIMENTO_SOURCE_SYNC_SCHEMA_NOT_READY', 503)
+    return { ok: true, relations: ATENDIMENTO_SOURCE_SYNC_REQUIRED_RELATIONS }
+}
+
+async function readExistingCheckpoint(pool, fingerprint) {
+    const latest = await pool.query(`select summary
+        from crm_atendimento.import_batches
+        where source_name = 'Atendimento'
+        order by created_at desc
+        limit 1`)
+    const summary = latest.rows[0]?.summary || {}
+    if (summary.sourceFingerprint !== fingerprint) return false
+    const count = await pool.query(`select count(*)::int as total
+        from crm_atendimento.attendances
+        where deleted_at is null`)
+    return Number(count.rows[0]?.total || 0) > 0
+}
+
+function safeReferencePart(value) {
+    return String(value || '').replace(/[^A-Za-z0-9._:-]/g, '-')
+}
+
+async function runProcess(command, args, envOverrides = {}) {
+    await new Promise((resolve, reject) => {
+        const child = spawn(command, args, {
+            env: { ...process.env, ...envOverrides },
+            stdio: ['ignore', 'ignore', 'pipe'],
+        })
+        let stderr = ''
+        child.stderr.on('data', (chunk) => { stderr += String(chunk) })
+        child.on('error', () => reject(syncError('ATENDIMENTO_SOURCE_SYNC_BACKUP_TOOL_UNAVAILABLE', 503)))
+        child.on('close', (code) => {
+            if (code === 0) return resolve()
+            const error = syncError('ATENDIMENTO_SOURCE_SYNC_BACKUP_FAILED', 503)
+            error.detail = stderr.slice(0, 120)
+            reject(error)
+        })
+    })
+}
+
+async function sha256File(filePath) {
+    const digest = createHash('sha256')
+    digest.update(await fs.readFile(filePath))
+    return digest.digest('hex')
+}
+
+export async function createAtendimentoSourceSyncBackup({
+    databaseUrl,
+    target: targetValue,
+    backupRoot,
+    now = () => new Date(),
+    idFactory = randomUUID,
+    processRunner = runProcess,
+} = {}) {
+    const target = normalizedTarget(targetValue)
+    const expectedRoot = ATENDIMENTO_SOURCE_SYNC_DATABASES[target].backupRoot
+    const identity = assertAtendimentoSourceSyncDatabaseUrl(databaseUrl, target)
+    const parsed = new URL(String(databaseUrl).replace(/^postgresql:/i, 'postgres:'))
+    if (String(backupRoot || expectedRoot) !== expectedRoot) throw syncError('ATENDIMENTO_SOURCE_SYNC_BACKUP_ROOT_UNSAFE', 400)
+    const stamp = now().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z')
+    const reference = safeReferencePart(`atendimento-source-${target}-${stamp}-${idFactory()}`)
+    const partialPath = path.join(expectedRoot, `${reference}.dump.partial`)
+    const outputPath = path.join(expectedRoot, `${reference}.dump`)
+    try {
+        await fs.mkdir(expectedRoot, { recursive: true, mode: 0o750 })
+        await processRunner('/usr/bin/pg_dump', [
+            '--format=custom',
+            '--no-owner',
+            '--no-privileges',
+            '--schema=crm_atendimento',
+            `--file=${partialPath}`,
+            `--dbname=${identity.database}`,
+        ], {
+            PGHOST: String(parsed.hostname || '127.0.0.1'),
+            PGHOSTADDR: String(parsed.hostname || '127.0.0.1'),
+            PGPORT: String(parsed.port || '5432'),
+            PGDATABASE: identity.database,
+            PGUSER: identity.user,
+            PGPASSWORD: decodeURIComponent(parsed.password || ''),
+            PGSSLMODE: 'require',
+            PGAPPNAME: 'crm-atendimento-source-sync',
+            PGCONNECT_TIMEOUT: '10',
+            PGSERVICE: '',
+            PGSERVICEFILE: '',
+            PGPASSFILE: '',
+            PGOPTIONS: '',
+        })
+        const stat = await fs.stat(partialPath)
+        if (!stat.isFile() || stat.size <= 0) throw syncError('ATENDIMENTO_SOURCE_SYNC_BACKUP_EMPTY', 503)
+        await fs.rename(partialPath, outputPath)
+        return {
+            reference,
+            manifestHash: `sha256:${await sha256File(outputPath)}`,
+            private: true,
+            restorable: true,
+        }
+    } catch (error) {
+        await Promise.allSettled([fs.rm(partialPath, { force: true }), fs.rm(outputPath, { force: true })])
+        throw error
+    }
+}
+
+function sourceSummary({ target, action, identity, snapshot, result, skipped = false, backup = null }) {
+    return {
+        ok: true,
+        target,
+        action,
+        database: identity.database,
+        databaseUser: identity.user,
+        skipped,
+        dryRun: action === 'dry-run',
+        records: Number(result?.records ?? snapshot.records.length ?? 0),
+        inserted: Number(result?.inserted || 0),
+        updated: Number(result?.updated || 0),
+        skippedRecords: Number(result?.skipped || 0),
+        importBatchId: result?.importBatchId || null,
+        tabs: Array.isArray(snapshot.tabs) ? snapshot.tabs : [],
+        spreadsheetId: snapshot.spreadsheetId || null,
+        sourceFingerprint: atendimentoSourceFingerprint(snapshot),
+        backupReference: backup?.reference || null,
+        backupManifestHash: backup?.manifestHash || null,
+    }
+}
+
+export async function runAtendimentoSourceSync({
+    pool,
+    databaseUrl,
+    target: targetValue,
+    action: actionValue = 'dry-run',
+    applyConfirmed = false,
+    spreadsheetId = '',
+    serviceAccountFile = '',
+    sourceReader = readAtendimentoSheet,
+    storeFactory = createAtendimentoStore,
+    backupFactory = createAtendimentoSourceSyncBackup,
+    checkpointReader = readExistingCheckpoint,
+    schemaReader = assertAtendimentoSourceSyncSchema,
+} = {}) {
+    const target = normalizedTarget(targetValue)
+    const action = normalizeAtendimentoSourceSyncAction(actionValue)
+    const identityFromUrl = assertAtendimentoSourceSyncDatabaseUrl(databaseUrl, target)
+    if (action === 'apply' && !isTruthy(applyConfirmed)) throw syncError('ATENDIMENTO_SOURCE_SYNC_APPLY_DISABLED', 403)
+    if (!pool || typeof pool.connect !== 'function') throw syncError('ATENDIMENTO_SOURCE_SYNC_DATABASE_UNAVAILABLE', 503)
+
+    const lockClient = await pool.connect()
+    let locked = false
+    try {
+        const identityResult = await lockClient.query(`select current_database() as database_name,
+            current_user, session_user, current_setting('transaction_read_only') as transaction_read_only`)
+        const identity = assertAtendimentoSourceSyncDatabaseIdentity({
+            ...identityResult.rows[0],
+            database_name: identityResult.rows[0]?.database_name || identityFromUrl.database,
+        }, target)
+        const lock = await lockClient.query('select pg_try_advisory_lock(hashtext($1)) as acquired', [ATENDIMENTO_SOURCE_SYNC_LOCK_KEY])
+        if (lock.rows[0]?.acquired !== true) throw syncError('ATENDIMENTO_SOURCE_SYNC_IN_PROGRESS', 409)
+        locked = true
+        await schemaReader(lockClient)
+
+        if (!serviceAccountFile) throw syncError('ATENDIMENTO_SOURCE_SYNC_SOURCE_CREDENTIAL_MISSING', 424)
+        const credentialPath = assertPrivateSourceCredentialPath(serviceAccountFile)
+        const snapshot = await sourceReader({ spreadsheetId: String(spreadsheetId || '').trim() || undefined, serviceAccountFile: credentialPath || undefined })
+        const records = Array.isArray(snapshot?.records) ? snapshot.records : []
+        if (!records.length) throw syncError('ATENDIMENTO_SOURCE_SYNC_SOURCE_EMPTY', 424)
+        const sourceSheetId = String(snapshot?.spreadsheetId || spreadsheetId || '').trim()
+        if (!sourceSheetId) throw syncError('ATENDIMENTO_SOURCE_SYNC_SOURCE_ID_MISSING', 424)
+        const sourceFingerprint = atendimentoSourceFingerprint(snapshot)
+        const store = storeFactory({ pool, databaseUrl, schemaManaged: true, expectedDatabase: identity.database })
+        const actor = sourceRefreshActor(target)
+        const source = {
+            sourceSheetId,
+            sourceName: 'Atendimento',
+            tabs: snapshot.tabs,
+            snapshotComplete: true,
+            sourceFingerprint,
+        }
+        const validation = await store.importRecords({ records, cache: snapshot.cache, actor, dryRun: true, source })
+        if (await checkpointReader(pool, sourceFingerprint)) {
+            return sourceSummary({ target, action, identity, snapshot, result: validation, skipped: true })
+        }
+        if (action === 'dry-run') return sourceSummary({ target, action, identity, snapshot, result: validation })
+
+        const backup = await backupFactory({ databaseUrl, target })
+        const applied = await store.importRecords({ records, cache: snapshot.cache, actor, dryRun: false, source })
+        return sourceSummary({ target, action, identity, snapshot, result: applied, backup })
+    } finally {
+        if (locked) {
+            try { await lockClient.query('select pg_advisory_unlock(hashtext($1))', [ATENDIMENTO_SOURCE_SYNC_LOCK_KEY]) } catch { /* connection cleanup releases it */ }
+        }
+        lockClient.release()
+    }
+}
+
+export const __testables = {
+    canonicalize,
+    isTruthy,
+    normalizedTarget,
+    safeReferencePart,
+    syncError,
+}

--- a/crm/api/server/atendimento/store.js
+++ b/crm/api/server/atendimento/store.js
@@ -8322,6 +8322,9 @@ export function createAtendimentoStore(options = {}) {
                                 skipped,
                                 tabs,
                                 snapshotComplete: source?.snapshotComplete === true,
+                                ...(typeof source?.sourceFingerprint === 'string' && /^sha256:[a-f0-9]{64}$/.test(source.sourceFingerprint)
+                                    ? { sourceFingerprint: source.sourceFingerprint }
+                                    : {}),
                             }),
                         ],
                     )

--- a/docs/runbooks/atendimento-source-sync.md
+++ b/docs/runbooks/atendimento-source-sync.md
@@ -1,0 +1,115 @@
+# Atendimento: sincronização privada da fonte
+
+## Motivo
+
+O runtime online de Atendimento é deliberadamente somente leitura e não
+executa importadores. A API pode responder `200` com catálogo e espelho vazios
+quando a fonte ainda não foi sincronizada; isso não é cache do navegador. O
+antigo refresh genérico foi aposentado porque não tinha backup, checkpoint e
+identidade de banco suficientemente restritos.
+
+O caminho versionado é separado do HTTP:
+
+| Componente | Contrato |
+| --- | --- |
+| `crm-atendimento-production.service` | somente leitura, app role `skincos_clientes_ro`, sem Google, sem DML |
+| `crm-atendimento-source-sync.service` | `oneshot`, usuário `skincos`, somente fonte Google autenticada e banco migrador dedicado |
+| `crm-atendimento-source-sync.timer` | desabilitado por padrão; quando habilitado, tenta a cada 30 minutos |
+| lock | `skincos:atendimento:source-sync:v1` no PostgreSQL, além da idempotência por fingerprint |
+| backup | dump custom privado antes de qualquer `apply`, em `/var/backups/skincos/clientes/production-source-sync` |
+
+O sincronizador nunca reinicia `crm.service`, `crm-jobs.service`, Orb,
+túnel ou Cloudflare. Ele também não ativa rotas comerciais, flags ou grants.
+
+## Pré-requisitos privados
+
+O operador nativo provisiona, fora do Git, o arquivo
+`/etc/skincos/crm-atendimento-source-sync.env` com ownership `root:skincos`,
+modo `0640`, e o JSON da conta de serviço Google com o mesmo limite de leitura.
+O arquivo contém somente variáveis aprovadas pelo runner:
+
+```text
+DATABASE_URL=<URL do migrador dedicado, loopback, TLS, sem copiar a URL do app>
+CRM_ATENDIMENTO_SOURCE_SYNC_TARGET=production
+CRM_ATENDIMENTO_SOURCE_SYNC_ACTION=dry-run
+CRM_ATENDIMENTO_SOURCE_SYNC_APPLY_CONFIRMED=0
+ATENDIMENTO_GOOGLE_SHEET_ID=<planilha aprovada>
+ATENDIMENTO_GOOGLE_SA_FILE=/etc/skincos/google-atendimento-source.json
+```
+
+Para aplicar, a custódia altera a ação para `apply` e a confirmação para `1`
+somente depois do dry-run aprovado. A URL deve usar exatamente o login
+`skincos_clientes_migrator_login` e o banco `skincos_clientes_production`;
+o sincronizador rejeita app role, socket alternativo, host externo e query
+string não permitida. Nenhum valor de senha deve aparecer em logs, PRs ou
+evidência.
+
+## Instalação e execução
+
+A unidade deve ser instalada a partir do mesmo release imutável validado para
+o runtime, nunca de um checkout mutável:
+
+```bash
+scripts/runtime/install-atendimento-source-sync-service.sh \
+  --source-root /opt/skincos/releases/<sha-40>/source \
+  --apply
+```
+
+O instalador exige a closure de coordenação de Atendimento, grava backup das
+unidades anteriores, cria apenas os diretórios privados necessários e executa
+`daemon-reload`. Ele não inicia a unidade. Para habilitar o timer, depois que
+o arquivo privado existir e estiver validado:
+
+```bash
+scripts/runtime/install-atendimento-source-sync-service.sh \
+  --source-root /opt/skincos/releases/<sha-40>/source \
+  --apply --enable
+```
+
+Antes do primeiro `apply`, execute a operação de leitura com o mesmo release:
+
+```bash
+sudo -u skincos /usr/bin/node \
+  /opt/skincos/releases/<sha-40>/source/crm/api/scripts/run-atendimento-source-sync.mjs \
+  --dry-run
+```
+
+O dry-run confirma identidade, schema, acesso à planilha, formato, contagens,
+abas e fingerprint, mas não cria backup nem linha de Atendimento. O `apply`
+faz novamente a validação, adquire o lock, cria o dump privado e só então
+grava unidades, referências, clientes, atendimentos e checkpoint agregado.
+Uma fonte vazia é rejeitada. Um fingerprint já aplicado com atendimentos
+existentes é reportado como `skipped` sem novo backup.
+
+## Validação online
+
+Após um apply bem-sucedido, valide o mesmo SHA e a jornada autenticada:
+
+```text
+GET /api/auth/me                         -> 200
+GET /api/atendimento/health              -> 200
+GET /api/atendimento/local-mirror/status -> 200, syncedAt preenchido
+GET /api/atendimento/management/catalog  -> 200, unidades/referências não vazias
+GET /api/atendimento/attendances         -> 200, total compatível com o relatório
+```
+
+No CRM online, recarregue `?module=atendimento`, confirme que a tabela deixou
+de mostrar `Nenhum atendimento encontrado` e repita o botão de recarregar.
+Registre somente contagens agregadas, fingerprint, import batch, SHA do
+release, identidade do banco e estado do timer. Não registre nomes, contatos,
+payloads, URL com senha ou dump.
+
+## Falhas e rollback
+
+Falha de Google, schema, identidade, lock ou backup interrompe o fluxo antes
+da escrita. O runtime continua servindo o último espelho disponível; se não
+houver espelho, a UI permanece vazia e deve mostrar o erro de fonte, não dados
+sintéticos.
+
+Para conter uma falha, desabilite o timer e mantenha o runtime em
+`maintenance`/somente leitura. O rollback de código usa o SHA anterior
+registrado e reinstala as duas unidades isoladas; não reinicia o CRM
+compartilhado. O dump privado é o checkpoint de dados. Uma restauração só
+deve ser feita pelo procedimento PostgreSQL aprovado, em banco dedicado e
+com verificação posterior; não há reverse migration destrutiva nem exclusão
+automática de linhas históricas.

--- a/docs/runbooks/clientes-source-refresh.md
+++ b/docs/runbooks/clientes-source-refresh.md
@@ -1,4 +1,10 @@
-# Clientes: refresh seguro da fonte de Atendimento
+# Clientes: refresh seguro das fontes
+
+> O entrypoint legado `crm/api/scripts/refresh-atendimento-source.mjs` e seu
+> launcher nativo permanecem apenas como compatibilidade fail-closed e não
+> devem ser reativados. Para sincronizar a fonte de Atendimento, use o
+> [runbook dedicado](atendimento-source-sync.md), que executa em unidade
+> isolada, com credencial Google privada, backup, lock e fingerprint.
 
 O importador de Atendimento lê a planilha Google em modo somente leitura e
 materializa as linhas idempotentes no schema `crm_atendimento`. Cada aplicação
@@ -6,60 +12,25 @@ concluída grava um checkpoint agregado em `crm_atendimento.import_batches`;
 esse checkpoint é suficiente para a fila de qualidade reconhecer a fonte viva
 mesmo quando o espelho local não existe.
 
-## Runner
+## Runner legado (aposentado)
 
-O entrypoint é `crm/api/scripts/refresh-atendimento-source.mjs` e aceita apenas
-`--dry-run` ou `--apply`. O destino é obrigatório em
-`CRM_CLIENTES_SOURCE_REFRESH_TARGET=staging|production`.
+O entrypoint `crm/api/scripts/refresh-atendimento-source.mjs` recusa a execução
+com `CLIENTES_SOURCE_LEGACY_REFRESH_DISABLED`. O destino histórico
+`CRM_CLIENTES_SOURCE_REFRESH_TARGET=staging|production` não é uma autorização
+para importar dados.
 
-- `--dry-run` é a operação padrão: lê a fonte Google, valida o formato do
-  banco-alvo e não abre nenhuma transação de escrita.
-- `--apply` exige também
-  `CRM_CLIENTES_SOURCE_REFRESH_APPLY_CONFIRMED=1`, a identidade correta do
-  banco e o lock advisory `skincos:clientes:source-refresh`.
-- A saída contém somente alvo, identidade agregada, contagens, abas, planilha e
-  `importBatchId`; não inclui nomes, telefones, e-mails, payloads ou segredos.
+O serviço/timer histórico também não deve ser instalado. O caminho v2 de
+Clientes continua reservado às operações explicitamente suportadas em
+`crm-jobs.service`, com alvo e modo próprios; ele não é ponte para o banco
+dedicado de Atendimento.
 
 O launcher nativo
-`scripts/runtime/run-clientes-source-refresh-native.sh` carrega o ambiente
-privado do alvo e o overlay de leitura Google separadamente. A variável
-`DATABASE_URL` do alvo vence qualquer valor acidental no overlay da fonte. Em
-`--apply`, um dump PostgreSQL privado é criado antes da importação em:
+`scripts/runtime/run-clientes-source-refresh-native.sh` permanece como stub
+fail-closed. Em particular, não deve ser usado para escrever no banco de
+produção de Atendimento.
 
-- produção: `/var/backups/skincos/clientes`;
-- staging: `/var/backups/skincos/clientes/staging`.
-
-O dump e seu SHA-256 ficam fora do repositório. A transação do importador é
-atômica; em caso de falha, o checkpoint permanece para investigação e os dados
-da importação são revertidos pelo banco.
-
-## Operação controlada
-
-Antes de qualquer escrita, execute o mesmo release em dry-run:
-
-```bash
-CRM_CLIENTES_SOURCE_REFRESH_TARGET=staging \
-CRM_CLIENTES_SOURCE_REFRESH_ACTION=--dry-run \
-scripts/runtime/run-clientes-source-refresh-native.sh
-```
-
-Depois de revisar apenas as contagens e a identidade do alvo, a aplicação
-controlada usa:
-
-```bash
-CRM_CLIENTES_SOURCE_REFRESH_TARGET=staging \
-CRM_CLIENTES_SOURCE_REFRESH_ACTION=--apply \
-CRM_CLIENTES_SOURCE_REFRESH_APPLY_CONFIRMED=1 \
-scripts/runtime/run-clientes-source-refresh-native.sh
-```
-
-O serviço e o timer em
-`ops/runtime/units/crm-clientes-source-refresh.{service,timer}` são instalados
-por `scripts/runtime/install-clientes-source-refresh-service.sh`. A unidade
-fica em `--dry-run` e desabilitada por padrão; habilitar o timer não inicia
-uma execução imediatamente. Para um ambiente de produção, o arquivo privado
-`crm-clientes-source-refresh.env` deve declarar explicitamente o alvo, a ação e
-a confirmação de escrita. Sem essa declaração o processo falha fechado.
+Não copie as variáveis ou o backup desse contrato para o sincronizador
+dedicado. Os dois caminhos têm schemas, papéis e rollback diferentes.
 
 ## Qualidade e rollback
 

--- a/ops/runtime/units/crm-atendimento-source-sync.service
+++ b/ops/runtime/units/crm-atendimento-source-sync.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Skincos Atendimento private source synchronization
+After=network-online.target postgresql.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=skincos
+Group=skincos
+WorkingDirectory=__REPO_ROOT__
+# The runner reads this fixed private file literally. It is deliberately not
+# an EnvironmentFile here, so the database password is not copied into the
+# systemd manager environment or exposed by `systemctl show`.
+UnsetEnvironment=NODE_OPTIONS NODE_PATH NODE_REPL_EXTERNAL_MODULE NODE_V8_COVERAGE NODE_REDIRECT_WARNINGS LD_PRELOAD LD_LIBRARY_PATH BASH_ENV ENV CDPATH HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY http_proxy https_proxy all_proxy no_proxy DATABASE_URL
+Environment=CRM_ATENDIMENTO_SOURCE_SYNC_TARGET=production
+ExecStart=/usr/bin/node __REPO_ROOT__/crm/api/scripts/run-atendimento-source-sync.mjs
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=__BACKUP_ROOT__ __LOG_ROOT__
+UMask=0027
+TimeoutStartSec=900
+SyslogIdentifier=crm-atendimento-source-sync
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/runtime/units/crm-atendimento-source-sync.timer
+++ b/ops/runtime/units/crm-atendimento-source-sync.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Periodic Skincos Atendimento source synchronization
+
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec=30min
+RandomizedDelaySec=120
+Persistent=true
+Unit=crm-atendimento-source-sync.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/runtime/install-atendimento-source-sync-service.sh
+++ b/scripts/runtime/install-atendimento-source-sync-service.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/bash -p
+set -euo pipefail
+
+# Install only the dedicated source-sync units. This never starts or restarts
+# the HTTP runtime, shared CRM, jobs, Orb, tunnel or Cloudflare unit.
+readonly SAFE_PATH='/usr/sbin:/usr/bin:/sbin:/bin'
+export PATH="$SAFE_PATH"
+unset BASH_ENV ENV CDPATH GLOBIGNORE TMPDIR TMP TEMP \
+  HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY http_proxy https_proxy all_proxy no_proxy
+
+run_sudo_clean() {
+  /usr/bin/sudo -n /usr/bin/env -i "PATH=$SAFE_PATH" 'HOME=/root' 'LANG=C' "$@"
+}
+
+readonly UNIT_DEST='/etc/systemd/system'
+readonly CONFIG_ROOT='/etc/skincos'
+readonly BACKUP_ROOT='/var/backups/skincos/clientes/source-sync-runtime'
+readonly DATA_BACKUP_ROOT='/var/backups/skincos/clientes/production-source-sync'
+readonly LOG_ROOT='/var/log/skincos'
+readonly SERVICE='crm-atendimento-source-sync.service'
+readonly TIMER='crm-atendimento-source-sync.timer'
+readonly SOURCE_ENV="$CONFIG_ROOT/crm-atendimento-source-sync.env"
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && /usr/bin/pwd -P)"
+SOURCE_ROOT="$ROOT_DIR"
+APPLY=0
+ENABLE=0
+COORDINATION_PROOF_FILE=''
+COORDINATION_REUSE=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/runtime/install-atendimento-source-sync-service.sh \
+  [--source-root /opt/skincos/releases/<full-sha>/source] \
+  [--coordination-proof-file <private-proof>] [--coordination-reuse] \
+  [--apply] [--enable]
+
+Without --apply, renders both units and verifies them with systemd-analyze.
+--apply installs the units and reloads systemd; it never starts a service.
+--enable additionally enables the timer, but does not trigger an immediate
+run. The private source environment must already exist before --enable.
+Production source data remains fail-closed until that environment selects
+apply and confirms it explicitly.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source-root)
+      [[ "$#" -ge 2 ]] || { echo '--source-root requires a value' >&2; exit 64; }
+      SOURCE_ROOT="$2"
+      shift 2
+      continue
+      ;;
+    --coordination-proof-file)
+      [[ "$#" -ge 2 ]] || { echo '--coordination-proof-file requires a value' >&2; exit 64; }
+      COORDINATION_PROOF_FILE="$2"
+      shift 2
+      continue
+      ;;
+    --coordination-reuse) COORDINATION_REUSE=1 ;;
+    --apply) APPLY=1 ;;
+    --enable) ENABLE=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 64 ;;
+  esac
+  shift
+done
+
+if [[ "$ENABLE" == '1' && "$APPLY" != '1' ]]; then
+  echo '--enable requires --apply' >&2
+  exit 64
+fi
+
+if [[ "$APPLY" == '1' ]]; then
+  [[ "$SOURCE_ROOT" =~ ^/opt/skincos/releases/([0-9a-f]{40})/source$ ]] || {
+    echo '--apply requires an immutable /opt/skincos/releases/<40-hex-sha>/source path' >&2
+    exit 64
+  }
+else
+  [[ "$SOURCE_ROOT" == "$ROOT_DIR" || "$SOURCE_ROOT" =~ ^/opt/skincos/releases/[0-9a-f]{40}/source$ ]] || {
+    echo '--source-root must be the checkout or an immutable release path' >&2
+    exit 64
+  }
+fi
+
+readonly RELEASE_SHA="$(basename "$(dirname "$SOURCE_ROOT")")"
+if [[ "$SOURCE_ROOT" =~ ^/opt/skincos/releases/[0-9a-f]{40}/source$ ]]; then
+  [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'Immutable release SHA is invalid.' >&2; exit 78; }
+fi
+readonly UNIT_SRC="$SOURCE_ROOT/ops/runtime/units/$SERVICE"
+readonly TIMER_SRC="$SOURCE_ROOT/ops/runtime/units/$TIMER"
+readonly RUNNER="$SOURCE_ROOT/crm/api/scripts/run-atendimento-source-sync.mjs"
+readonly COORDINATION_CLOSURE="$SOURCE_ROOT/.skincos-global-coordination-atendimento.json"
+coordination_proof="${COORDINATION_PROOF_FILE:-${SKINCOS_GLOBAL_COORDINATION_PROOF_FILE:-/var/lib/skincos-runtime/global-coordination/atendimento-source-sync-$RELEASE_SHA-$$.json}}"
+coordination_acquired=0
+coordination_owned=0
+
+for command_path in /usr/bin/sudo /usr/bin/env /usr/bin/sed /usr/bin/systemd-analyze /usr/bin/mktemp /usr/bin/install /usr/bin/chmod /usr/bin/rm /usr/bin/rmdir /usr/bin/date /usr/bin/cp /usr/bin/stat /usr/bin/systemctl /usr/bin/test /usr/bin/bash; do
+  [[ -x "$command_path" ]] || { echo "Missing $command_path" >&2; exit 1; }
+done
+[[ -f "$UNIT_SRC" && -f "$TIMER_SRC" && -f "$RUNNER" ]] || {
+  echo 'Atendimento source-sync unit or runner is unavailable in the selected source.' >&2
+  exit 78
+}
+
+if [[ "$APPLY" == '1' ]]; then
+  /usr/bin/sudo -n true
+  [[ -f "$COORDINATION_CLOSURE" ]] || {
+    echo 'Atendimento dependency-closure attestation is required for production unit mutation.' >&2
+    exit 78
+  }
+  if [[ "$ENABLE" == '1' ]]; then
+    run_sudo_clean /usr/bin/test -f "$SOURCE_ENV" || {
+      echo "Private source environment is required before enabling the timer: $SOURCE_ENV" >&2
+      exit 78
+    }
+    env_metadata="$(run_sudo_clean /usr/bin/stat -c '%U:%G:%a' "$SOURCE_ENV")"
+    [[ "$env_metadata" == 'root:skincos:640' ]] || {
+      echo 'Private source environment must be root:skincos mode 0640.' >&2
+      exit 78
+    }
+  fi
+fi
+
+escape() { printf '%s' "$1" | sed 's/[&|]/\\&/g'; }
+umask 0077
+render_dir="$(/usr/bin/mktemp -d /tmp/atendimento-source-sync-unit.XXXXXX)"
+rendered_service="$render_dir/$SERVICE"
+rendered_timer="$render_dir/$TIMER"
+cleanup_render() {
+  /usr/bin/rm -f "$rendered_service" "$rendered_timer"
+  /usr/bin/rmdir "$render_dir" 2>/dev/null || true
+  if [[ "$coordination_acquired" == '1' && "$coordination_owned" == '1' ]]; then
+    coordination_run release >/dev/null 2>&1 || echo 'Unable to release the Atendimento production surface lease; it will expire fail-closed.' >&2
+  fi
+}
+trap cleanup_render EXIT INT TERM
+/usr/bin/sed \
+  -e "s|__REPO_ROOT__|$(escape "$SOURCE_ROOT")|g" \
+  -e "s|__BACKUP_ROOT__|$(escape "$DATA_BACKUP_ROOT")|g" \
+  -e "s|__LOG_ROOT__|$(escape "$LOG_ROOT")|g" \
+  "$UNIT_SRC" >"$rendered_service"
+/usr/bin/sed \
+  -e "s|__REPO_ROOT__|$(escape "$SOURCE_ROOT")|g" \
+  "$TIMER_SRC" >"$rendered_timer"
+/usr/bin/chmod 0644 "$rendered_service" "$rendered_timer"
+/usr/bin/systemd-analyze verify "$rendered_service" "$rendered_timer"
+
+if [[ "$APPLY" != '1' ]]; then
+  printf 'dry_run=true service=%s timer=%s source=%s shared_restart=false immediate_run=false\n' "$SERVICE" "$TIMER" "$SOURCE_ROOT"
+  exit 0
+fi
+
+coordination_run() {
+  "$SOURCE_ROOT/scripts/runtime/global-coordination-mini-pc.sh" "$@" --proof-file "$coordination_proof"
+}
+if [[ "$COORDINATION_REUSE" == '1' ]]; then
+  export SKINCOS_GLOBAL_COORDINATION_REUSE=1
+  export SKINCOS_GLOBAL_COORDINATION_PROOF_FILE="$coordination_proof"
+  coordination_run check \
+    --resource deploy:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+    --closure-file "$COORDINATION_CLOSURE" >/dev/null
+  coordination_acquired=1
+else
+  coordination_run acquire \
+    --resource deploy:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+    --closure-file "$COORDINATION_CLOSURE" --operation mutation \
+    --idempotency-key "mini-pc:deploy:atendimento:production:source-sync:$RELEASE_SHA:$$" >/dev/null
+  coordination_acquired=1
+  coordination_owned=1
+fi
+coordination_run check \
+  --resource deploy:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
+
+stamp="$(/usr/bin/date -u +%Y%m%dT%H%M%SZ)"
+run_sudo_clean /usr/bin/install -d -m 0700 -o root -g root "$BACKUP_ROOT"
+run_sudo_clean /usr/bin/install -d -m 0770 -o root -g skincos "$DATA_BACKUP_ROOT"
+run_sudo_clean /usr/bin/install -d -m 0750 -o skincos -g skincos "$LOG_ROOT/crm-atendimento-source-sync"
+for pair in "$SERVICE:$rendered_service" "$TIMER:$rendered_timer"; do
+  unit_name="${pair%%:*}"
+  rendered_path="${pair#*:}"
+  current_path="$UNIT_DEST/$unit_name"
+  if run_sudo_clean /usr/bin/test -f "$current_path"; then
+    coordination_run check \
+      --resource deploy:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+      --closure-file "$COORDINATION_CLOSURE" >/dev/null
+    backup_path="$(run_sudo_clean /usr/bin/mktemp "$BACKUP_ROOT/${stamp}-$unit_name.XXXXXX")"
+    run_sudo_clean /usr/bin/cp -p "$current_path" "$backup_path"
+  fi
+  coordination_run check \
+    --resource deploy:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+    --closure-file "$COORDINATION_CLOSURE" >/dev/null
+  run_sudo_clean /usr/bin/install -m 0644 "$rendered_path" "$current_path"
+done
+coordination_run check \
+  --resource deploy:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+  --closure-file "$COORDINATION_CLOSURE" >/dev/null
+run_sudo_clean /usr/bin/systemctl daemon-reload
+if [[ "$ENABLE" == '1' ]]; then
+  coordination_run check \
+    --resource deploy:atendimento:production --module atendimento --source "$RELEASE_SHA" \
+    --closure-file "$COORDINATION_CLOSURE" >/dev/null
+  run_sudo_clean /usr/bin/systemctl enable "$TIMER" >/dev/null
+fi
+printf 'installed=true service=%s timer=%s release_sha=%s enabled=%s shared_restart=false immediate_run=false\n' "$SERVICE" "$TIMER" "$RELEASE_SHA" "$ENABLE"

--- a/scripts/runtime/test-install-atendimento-source-sync-service.sh
+++ b/scripts/runtime/test-install-atendimento-source-sync-service.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INSTALLER="$ROOT_DIR/scripts/runtime/install-atendimento-source-sync-service.sh"
+UNIT="$ROOT_DIR/ops/runtime/units/crm-atendimento-source-sync.service"
+TIMER="$ROOT_DIR/ops/runtime/units/crm-atendimento-source-sync.timer"
+
+bash -n "$INSTALLER"
+grep -F -- 'systemd-analyze verify "$rendered_service" "$rendered_timer"' "$INSTALLER" >/dev/null
+grep -F -- "readonly UNIT_DEST='/etc/systemd/system'" "$INSTALLER" >/dev/null
+grep -F -- "readonly DATA_BACKUP_ROOT='/var/backups/skincos/clientes/production-source-sync'" "$INSTALLER" >/dev/null
+grep -F -- 'systemctl enable "$TIMER"' "$INSTALLER" >/dev/null
+grep -F -- 'immediate_run=false' "$INSTALLER" >/dev/null
+grep -F -- 'crm-atendimento-source-sync.service' "$TIMER" >/dev/null
+if grep -Eq 'systemctl (start|restart) (crm\.service|crm-jobs\.service|orb\.service|cloudflare)' "$INSTALLER"; then
+  echo 'source-sync installer must not restart shared services' >&2
+  exit 1
+fi
+if grep -Eq '(^|[[:space:]])(source|\.)[[:space:]].*\.env|eval[[:space:]]|bash[[:space:]]+-c' "$INSTALLER"; then
+  echo 'source-sync installer must not source or eval private environments' >&2
+  exit 1
+fi
+grep -F -- 'DATABASE_URL' "$UNIT" >/dev/null
+grep -F -- 'Environment=CRM_ATENDIMENTO_SOURCE_SYNC_TARGET=production' "$UNIT" >/dev/null
+grep -F -- 'UnsetEnvironment=' "$UNIT" >/dev/null
+grep -F -- 'ProtectSystem=strict' "$UNIT" >/dev/null
+
+echo 'PASS: Atendimento source-sync installer and units are isolated and fail-closed.'


### PR DESCRIPTION
# Summary

Corrige a sincronização do módulo Atendimento sem reativar o runtime HTTP read-only nem o CRM compartilhado.

A causa era operacional: o runtime dedicado estava saudável, mas o espelho de produção nunca tinha recebido um importador autenticado. O refresh legado foi mantido fail-closed e substituído por um sincronizador dedicado com identidade de banco restrita, lock PostgreSQL, fingerprint idempotente e backup privado antes de qualquer escrita.

## Type of change
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Performance
- [x] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [x] Docs updated
- [x] Security review (CodeQL, gitleaks)
- [ ] Performance impact measured

## Links
- Issue: incidente do módulo Atendimento e catálogo online vazio
- Design/ADR: docs/runbooks/atendimento-source-sync.md
- Migration steps: provisionar o ambiente privado de fonte, executar dry-run no mesmo release imutável, aplicar, e só então habilitar o timer.

## Evidence

- Base revalidada: origin/main=f54586d865c0d2c442b4542b163faf67b466b870
- Head exato desta PR: c952ba8edbad86e75faa8e2ca5737cbd5d90e265
- Checks do head atual: CodeQL, Semgrep, CI smoke, lint, arquitetura, segurança, Escala UI E2E e focused validation verdes.
- Testes focados do sincronizador: 64 passed, 0 failed.
- Dry-run nativo de produção concluído sem escrita: 8.967 registros, abas Novo Hamburgo e BarraShoppingSul, banco skincos_clientes_production, usuário migrador dedicado, fingerprint sha256:677a6e24dd453dc4d3f961586d89cf2538b80694d98bbc2ba9738a7f0a4ea8e4.
- Antes do apply, o espelho online ainda está vazio (syncedAt=null, attendances=0); nenhum dado, flag ou timer foi alterado por este dry-run.
- Rollback funcional permanece no release online anterior ce4ff5f6024ee3e321a6968571b7777ec7ba9603.

