### PR TITLE
fix(meta-ads): bind exact staging page secret names

### DIFF
--- a/.github/workflows/attest-meta-ads-candidate-appsecret.yml
+++ b/.github/workflows/attest-meta-ads-candidate-appsecret.yml
@@ -42,8 +42,8 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
           META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
-          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ secrets.NOVOHAMBURGO_PAGE_ID }}
-          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ secrets.BARRASHOPPINGSUL_PAGE_ID }}
+          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ secrets.novohamburgo_page_id }}
+          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ secrets.barrashopppingsul_page_id }}
           META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
           META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
           ENABLE_TOKEN_VAULT_DEPLOY_STAGING: ${{ vars.ENABLE_TOKEN_VAULT_DEPLOY_STAGING }}
@@ -94,8 +94,8 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
           META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
-          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ secrets.NOVOHAMBURGO_PAGE_ID }}
-          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ secrets.BARRASHOPPINGSUL_PAGE_ID }}
+          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ secrets.novohamburgo_page_id }}
+          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ secrets.barrashopppingsul_page_id }}
           META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
           META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
           SOURCE_SHA: ${{ github.sha }}

--- a/.github/workflows/attest-meta-ads-source-access.yml
+++ b/.github/workflows/attest-meta-ads-source-access.yml
@@ -22,8 +22,8 @@ jobs:
         env:
           META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
           META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
-          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ secrets.NOVOHAMBURGO_PAGE_ID }}
-          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ secrets.BARRASHOPPINGSUL_PAGE_ID }}
+          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ secrets.novohamburgo_page_id }}
+          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ secrets.barrashopppingsul_page_id }}
           META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
           META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
         shell: bash

--- a/.github/workflows/deploy-token-vault.yml
+++ b/.github/workflows/deploy-token-vault.yml
@@ -991,8 +991,8 @@ jobs:
           # never Worker bindings. Each must be proved with its own Instagram
           # pair against the System User before the synthetic seed may create
           # any Meta or D1 resources.
-          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ inputs.target == 'staging' && secrets.NOVOHAMBURGO_PAGE_ID || '' }}
-          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ inputs.target == 'staging' && secrets.BARRASHOPPINGSUL_PAGE_ID || '' }}
+          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ inputs.target == 'staging' && secrets.novohamburgo_page_id || '' }}
+          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ inputs.target == 'staging' && secrets.barrashopppingsul_page_id || '' }}
           META_ADS_API_VERSION: ${{ inputs.target == 'staging' && vars.META_ADS_API_VERSION || '' }}
           TARGET: ${{ inputs.target }}
           OPERATION: ${{ inputs.operation }}
@@ -1338,8 +1338,8 @@ jobs:
         env:
           META_ADS_ACCESS_TOKEN: ${{ inputs.target == 'staging' && secrets.META_ADS_ACCESS_TOKEN || '' }}
           META_PIXEL_ID: ${{ inputs.target == 'staging' && secrets.META_PIXEL_ID || '' }}
-          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ inputs.target == 'staging' && secrets.NOVOHAMBURGO_PAGE_ID || '' }}
-          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ inputs.target == 'staging' && secrets.BARRASHOPPINGSUL_PAGE_ID || '' }}
+          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ inputs.target == 'staging' && secrets.novohamburgo_page_id || '' }}
+          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ inputs.target == 'staging' && secrets.barrashopppingsul_page_id || '' }}
           META_ADS_ACCOUNT_ID: ${{ inputs.target == 'staging' && vars.META_ADS_ACCOUNT_ID || '' }}
           META_ADS_API_VERSION: ${{ inputs.target == 'staging' && vars.META_ADS_API_VERSION || '' }}
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
@@ -1414,8 +1414,8 @@ jobs:
         env:
           META_ADS_ACCESS_TOKEN: ${{ inputs.target == 'staging' && secrets.META_ADS_ACCESS_TOKEN || '' }}
           META_PIXEL_ID: ${{ inputs.target == 'staging' && secrets.META_PIXEL_ID || '' }}
-          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ inputs.target == 'staging' && secrets.NOVOHAMBURGO_PAGE_ID || '' }}
-          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ inputs.target == 'staging' && secrets.BARRASHOPPPINGSUL_PAGE_ID || '' }}
+          META_ADS_NOVOHAMBURGO_PAGE_ID: ${{ inputs.target == 'staging' && secrets.novohamburgo_page_id || '' }}
+          META_ADS_BARRASHOPPPINGSUL_PAGE_ID: ${{ inputs.target == 'staging' && secrets.barrashopppingsul_page_id || '' }}
           META_ADS_ACCOUNT_ID: ${{ inputs.target == 'staging' && vars.META_ADS_ACCOUNT_ID || '' }}
           META_ADS_API_VERSION: ${{ inputs.target == 'staging' && vars.META_ADS_API_VERSION || '' }}
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}

--- a/platform/security/token-vault/tests/deploy-token-vault-staging-synthetic-seed-workflow.test.js
+++ b/platform/security/token-vault/tests/deploy-token-vault-staging-synthetic-seed-workflow.test.js
@@ -79,11 +79,11 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
 
   assert.match(
     authorization,
-    /META_ADS_NOVOHAMBURGO_PAGE_ID: \$\{\{ inputs\.target == 'staging' && secrets\.NOVOHAMBURGO_PAGE_ID \|\| '' \}\}/,
+    /META_ADS_NOVOHAMBURGO_PAGE_ID: \$\{\{ inputs\.target == 'staging' && secrets.novohamburgo_page_id \|\| '' \}\}/,
   );
   assert.match(
     authorization,
-    /META_ADS_BARRASHOPPPINGSUL_PAGE_ID: \$\{\{ inputs\.target == 'staging' && secrets\.BARRASHOPPINGSUL_PAGE_ID \|\| '' \}\}/,
+    /META_ADS_BARRASHOPPPINGSUL_PAGE_ID: \$\{\{ inputs\.target == 'staging' && secrets.barrashopppingsul_page_id \|\| '' \}\}/,
   );
   assert.match(
     authorization,

--- a/platform/security/token-vault/tests/meta-ads-candidate-appsecret-proof-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-candidate-appsecret-proof-workflow.test.js
@@ -105,11 +105,11 @@ test("candidate appsecret-proof request keeps source inputs and bearer private w
   assert.match(workflow, /pixel_id: pixelId/);
   assert.match(
     workflow,
-    /META_ADS_NOVOHAMBURGO_PAGE_ID: \$\{\{ secrets\.NOVOHAMBURGO_PAGE_ID \}\}/,
+    /META_ADS_NOVOHAMBURGO_PAGE_ID: \$\{\{ secrets.novohamburgo_page_id \}\}/,
   );
   assert.match(
     workflow,
-    /META_ADS_BARRASHOPPPINGSUL_PAGE_ID: \$\{\{ secrets\.BARRASHOPPINGSUL_PAGE_ID \}\}/,
+    /META_ADS_BARRASHOPPPINGSUL_PAGE_ID: \$\{\{ secrets.barrashopppingsul_page_id \}\}/,
   );
   assert.match(
     workflow,

--- a/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-access-attestation-workflow.test.js
@@ -173,11 +173,11 @@ test("Meta Ads source-access attestation is manual, GET-only, and bound to two s
   assert.match(workflow, /timeout-minutes: 3/);
   assert.match(
     workflow,
-    /META_ADS_NOVOHAMBURGO_PAGE_ID: \$\{\{ secrets\.NOVOHAMBURGO_PAGE_ID \}\}/,
+    /META_ADS_NOVOHAMBURGO_PAGE_ID: \$\{\{ secrets.novohamburgo_page_id \}\}/,
   );
   assert.match(
     workflow,
-    /META_ADS_BARRASHOPPPINGSUL_PAGE_ID: \$\{\{ secrets\.BARRASHOPPINGSUL_PAGE_ID \}\}/,
+    /META_ADS_BARRASHOPPPINGSUL_PAGE_ID: \$\{\{ secrets.barrashopppingsul_page_id \}\}/,
   );
   assert.match(workflow, /destinationSelectors = \{[\s\S]*novo_hamburgo:[\s\S]*barra_shopping_sul:/);
   assert.match(workflow, /source_destination_page_selector_invalid/);


### PR DESCRIPTION
## What changed
Updated the raw source attestation, candidate appsecret-proof attestation, and governed staging seed to read the exact staging Environment secrets 
ovohamburgo_page_id and arrashopppingsul_page_id. Updated focused workflow contract tests accordingly.

## Root cause
The previous workflow expressions used a legacy/mismatched spelling, so the Barra selector reached the governed seed empty even though the operator had provisioned the requested staging Page secret. The seed failed closed before Meta Graph writes or traffic.

## Scope and safety
This is limited to staging secret-name bindings and tests. No Worker logic, Meta permissions, D1 schema/data, Orb, Ponto, CRM, production route, or traffic behavior changes. Secret values remain confined to the existing private staging request path and are not written to logs, outputs, artifacts, or bindings. Existing legacy secret names are retained for safe rollback compatibility.

## Validation
- Token Vault suite: 184/184
- Focused staging workflow tests: 14/14
- Global concurrency governance: 19/19
- Worktree validation and git diff --check passed

## Rollback
Revert this commit/PR; no migration or external Meta mutation is introduced by the code change.