### PR TITLE
fix(beauty-movement): bind staging secrets to validation

### DIFF
--- a/.github/scripts/beauty-movement-staging-smoke-contract.test.mjs
+++ b/.github/scripts/beauty-movement-staging-smoke-contract.test.mjs
@@ -31,6 +31,9 @@ test("smoke consumes secrets in-process and closes the staging gate", () => {
     assert.match(workflow, /invite_status = 'revoked'/);
     assert.match(workflow, /status = 'disabled'/);
     assert.match(workflow, /rollback/);
+    const validationStep = workflow.match(/      - name: Validate staging-only source and credentials[\s\S]*?(?=\n      - name:)/)?.[0] ?? "";
+    assert.match(validationStep, /BEAUTY_MOVEMENT_TOKEN_HMAC_KEY:\s*\$\{\{ secrets\.BEAUTY_MOVEMENT_TOKEN_HMAC_KEY \}\}/);
+    assert.match(validationStep, /BEAUTY_MOVEMENT_PII_KEY:\s*\$\{\{ secrets\.BEAUTY_MOVEMENT_PII_KEY \}\}/);
 });
 
 test("importer only widens private runtime custody inside GitHub Actions", () => {

--- a/.github/workflows/beauty-movement-staging-smoke.yml
+++ b/.github/workflows/beauty-movement-staging-smoke.yml
@@ -97,6 +97,9 @@ jobs:
           # The target is fixed by this workflow: there is no environment or
           # database input that could redirect the run to production.
           grep -q 'database_name = "espacofacial-beauty-movement-staging"' website/wrangler.toml || { echo 'staging D1 binding is missing'; exit 1; }
+        env:
+          BEAUTY_MOVEMENT_TOKEN_HMAC_KEY: ${{ secrets.BEAUTY_MOVEMENT_TOKEN_HMAC_KEY }}
+          BEAUTY_MOVEMENT_PII_KEY: ${{ secrets.BEAUTY_MOVEMENT_PII_KEY }}
 
       - name: Check coordination leases before staging D1 inspection
         uses: ./.github/actions/global-coordination-check
@@ -123,9 +126,6 @@ jobs:
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
           key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
-        env:
-          BEAUTY_MOVEMENT_TOKEN_HMAC_KEY: ${{ secrets.BEAUTY_MOVEMENT_TOKEN_HMAC_KEY }}
-          BEAUTY_MOVEMENT_PII_KEY: ${{ secrets.BEAUTY_MOVEMENT_PII_KEY }}
 
       - name: Setup Node
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6

--- a/.github/workflows/beauty-movement-staging-smoke.yml
+++ b/.github/workflows/beauty-movement-staging-smoke.yml
@@ -59,7 +59,7 @@ jobs:
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
           key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
           resource: 'release:website'
-          module: beauty-movement
+          module: website
           source_sha: ${{ inputs.release_sha }}
           proof_file: ${{ runner.temp }}/beauty-movement-staging-smoke/website-lease.json
 
@@ -72,7 +72,7 @@ jobs:
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
           key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
           resource: 'global:staging-d1'
-          module: beauty-movement
+          module: core
           source_sha: ${{ inputs.release_sha }}
           proof_file: ${{ runner.temp }}/beauty-movement-staging-smoke/d1-lease.json
 
@@ -104,7 +104,7 @@ jobs:
           required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           proof_file: ${{ runner.temp }}/beauty-movement-staging-smoke/website-lease.json
           resource: 'release:website'
-          module: beauty-movement
+          module: website
           source_sha: ${{ inputs.release_sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
@@ -117,7 +117,7 @@ jobs:
           required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           proof_file: ${{ runner.temp }}/beauty-movement-staging-smoke/d1-lease.json
           resource: 'global:staging-d1'
-          module: beauty-movement
+          module: core
           source_sha: ${{ inputs.release_sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
@@ -241,7 +241,7 @@ jobs:
           required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           proof_file: ${{ runner.temp }}/beauty-movement-staging-smoke/website-lease.json
           resource: 'release:website'
-          module: beauty-movement
+          module: website
           source_sha: ${{ inputs.release_sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
@@ -254,7 +254,7 @@ jobs:
           required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           proof_file: ${{ runner.temp }}/beauty-movement-staging-smoke/d1-lease.json
           resource: 'global:staging-d1'
-          module: beauty-movement
+          module: core
           source_sha: ${{ inputs.release_sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
@@ -298,7 +298,7 @@ jobs:
           required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           proof_file: ${{ runner.temp }}/beauty-movement-staging-smoke/website-lease.json
           resource: 'release:website'
-          module: beauty-movement
+          module: website
           source_sha: ${{ inputs.release_sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}


### PR DESCRIPTION
## Summary
- bind the existing staging HMAC/PII Environment secrets to the validation step that consumes them;
- add a focused contract assertion so a future lease-step insertion cannot move that env block again.

## Validation
- workflow YAML parse;
- focused staging smoke contract tests (3/3).

The prior official run failed closed before import because the secrets env block was attached to a coordination-check step.