### PR TITLE
fix(beauty-movement): validate staging smoke shell

### DIFF
--- a/.github/scripts/beauty-movement-staging-smoke-contract.test.mjs
+++ b/.github/scripts/beauty-movement-staging-smoke-contract.test.mjs
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
@@ -41,4 +42,17 @@ test("importer only widens private runtime custody inside GitHub Actions", () =>
     assert.match(importer, /RUNNER_TEMP/);
     assert.match(importer, /BEAUTY_MOVEMENT_PRIVATE_RUNTIME_ROOT/);
     assert.match(importer, /isWithin\(REPOSITORY_ROOT, resolved\)/);
+});
+
+test("deployment and browser journey shell remains syntactically valid", () => {
+    const step = workflow.match(
+        /      - name: Deploy temporary staging candidate and run authenticated browser journey[\s\S]*?(?=\n      - name:)/,
+    )?.[0] ?? "";
+    const runBlock = step.match(/\n        run: \|\n([\s\S]*)/)?.[1] ?? "";
+    assert.notEqual(runBlock, "", "deployment step must contain a run block");
+    const script = runBlock
+        .split("\n")
+        .map((line) => (line.startsWith("          ") ? line.slice(10) : line))
+        .join("\n");
+    execFileSync("bash", ["-n"], { input: script, encoding: "utf8" });
 });

--- a/.github/workflows/beauty-movement-staging-smoke.yml
+++ b/.github/workflows/beauty-movement-staging-smoke.yml
@@ -331,17 +331,16 @@ jobs:
           candidate_version=''
           for attempt in $(seq 1 12); do
             npx --yes wrangler@4.112.0 deployments list --config wrangler.toml --env staging --json >"${deployments}"
-            candidate_version="$(node - "${deployments}" "${candidate_message}" <<'NODE'
-          const fs = require('node:fs');
-          const [deploymentsPath, expectedMessage] = process.argv.slice(2);
-          const deployments = JSON.parse(fs.readFileSync(deploymentsPath, 'utf8'));
+            candidate_version="$(node -e '
+          const fs = require("node:fs");
+          const [deploymentsPath, expectedMessage] = process.argv.slice(1);
+          const deployments = JSON.parse(fs.readFileSync(deploymentsPath, "utf8"));
           const found = deployments
-            .filter((deployment) => deployment.annotations?.['workers/message'] === expectedMessage)
+            .filter((deployment) => deployment.annotations?.["workers/message"] === expectedMessage)
             .flatMap((deployment) => deployment.versions ?? [])
             .find((version) => Number(version.percentage) === 100 && /^[0-9a-f-]{36}$/i.test(version.version_id));
-          process.stdout.write(found?.version_id ?? '');
-          NODE
-            )"
+          process.stdout.write(found?.version_id ?? "");
+          ' "${deployments}" "${candidate_message}")"
             if [[ "${candidate_version}" =~ ^[0-9a-f-]{36}$ ]]; then break; fi
             sleep 5
           done
@@ -356,24 +355,23 @@ jobs:
           fs.writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
           NODE
           for attempt in $(seq 1 12); do
-            code="$(curl -sS -o /dev/null -w '%{http_code}' "${SMOKE_URL}/beleza-em-movimento || true)"
+            code="$(curl -sS -o /dev/null -w '%{http_code}' "${SMOKE_URL}/beleza-em-movimento" || true)"
             [[ "${code}" == "200" ]] && break
             sleep 5
           done
           [[ "${code}" == "200" ]] || { echo "temporary staging candidate is not serving the campaign (HTTP ${code})"; exit 1; }
-          invite_url="$(node - "${OUTPUT_DIR}" <<'NODE'
-          const fs = require('node:fs');
-          const path = require('node:path');
-          const directory = process.argv[2];
-          const file = fs.readdirSync(directory).find((name) => name.endsWith('-delivery.csv'));
-          if (!file) throw new Error('beauty_movement_delivery_missing');
-          const row = fs.readFileSync(path.join(directory, file), 'utf8').trim().split(/\r?\n/)[1];
-          const cells = row.match(/("(?:[^"]|"")*"|[^,]*)/g)?.filter((cell) => cell !== '') ?? [];
-          const value = cells.at(-1)?.replace(/^"|"$/g, '').replace(/""/g, '"');
-          if (!value) throw new Error('beauty_movement_delivery_invalid');
+          invite_url="$(node -e '
+          const fs = require("node:fs");
+          const path = require("node:path");
+          const directory = process.argv[1];
+          const file = fs.readdirSync(directory).find((name) => name.endsWith("-delivery.csv"));
+          if (!file) throw new Error("beauty_movement_delivery_missing");
+          const row = fs.readFileSync(path.join(directory, file), "utf8").trim().split(/\r?\n/)[1];
+          const cells = row.match(/("(?:[^"]|"")*"|[^,]*)/g)?.filter((cell) => cell !== "") ?? [];
+          const value = cells.at(-1)?.replace(/^"|"$/g, "").replace(/""/g, "\"");
+          if (!value) throw new Error("beauty_movement_delivery_invalid");
           process.stdout.write(value);
-          NODE
-          )"
+          ' "${OUTPUT_DIR}")"
           token="${invite_url##*#c=}"
           [[ "${token}" =~ ^[A-Za-z0-9_-]{40,180}$ ]] || { echo 'synthetic invite token shape invalid'; exit 1; }
           SMOKE_INVITE_TOKEN="${token}" node --input-type=module <<'NODE'


### PR DESCRIPTION
## Objetivo\nCorrige o smoke autenticado de staging após a primeira execução chegar à implantação e falhar no parse do Bash.\n\n## Alterações\n- corrige a aspa ausente na URL de readiness;\n- remove command substitutions com heredoc no atestado do deployment e na leitura da fixture;\n- adiciona teste focado que extrai o bloco real do workflow e executa bash -n.\n\n## Segurança\n- staging only;\n- nenhum secret é impresso ou persistido;\n- produção não é tocada.\n\n## Validação\n- contrato do smoke: 4/4;\n- git diff --check.