### PR TITLE
fix(beauty-movement): run smoke attestations in commonjs

### DIFF
--- a/.github/scripts/beauty-movement-staging-smoke-contract.test.mjs
+++ b/.github/scripts/beauty-movement-staging-smoke-contract.test.mjs
@@ -24,6 +24,7 @@ test("smoke consumes secrets in-process and closes the staging gate", () => {
     assert.match(workflow, /Initialize private runner paths/);
     assert.match(workflow, /smoke_root="\$\{RUNNER_TEMP\}\/beauty-movement-staging-smoke"/);
     assert.match(workflow, /set -euo pipefail/);
+    assert.match(workflow, /node --input-type=commonjs -e/);
     assert.doesNotMatch(workflow, /set -x/);
     assert.doesNotMatch(workflow, /upload-artifact/);
     assert.match(workflow, /staging-smoke-disabled-probe/);

--- a/.github/workflows/beauty-movement-staging-smoke.yml
+++ b/.github/workflows/beauty-movement-staging-smoke.yml
@@ -331,7 +331,7 @@ jobs:
           candidate_version=''
           for attempt in $(seq 1 12); do
             npx --yes wrangler@4.112.0 deployments list --config wrangler.toml --env staging --json >"${deployments}"
-            candidate_version="$(node -e '
+            candidate_version="$(node --input-type=commonjs -e '
           const fs = require("node:fs");
           const [deploymentsPath, expectedMessage] = process.argv.slice(1);
           const deployments = JSON.parse(fs.readFileSync(deploymentsPath, "utf8"));
@@ -360,7 +360,7 @@ jobs:
             sleep 5
           done
           [[ "${code}" == "200" ]] || { echo "temporary staging candidate is not serving the campaign (HTTP ${code})"; exit 1; }
-          invite_url="$(node -e '
+          invite_url="$(node --input-type=commonjs -e '
           const fs = require("node:fs");
           const path = require("node:path");
           const directory = process.argv[1];


### PR DESCRIPTION
## Objetivo\nCorrige a execução do smoke autenticado após o deploy temporário. O website usa ESM por padrão e os one-liners de atestação usavam require sem declarar CommonJS.\n\n## Alterações\n- executa os atestadores com node --input-type=commonjs;\n- preserva a correção de readiness/shell e o teste bash -n do PR anterior;\n- mantém staging-only, sem secrets em logs e sem produção.\n\n## Validação\n- contrato do smoke: 4/4;\n- node CommonJS verificado no diretório website;\n- git diff --check.