### PR TITLE
fix: make all staging smoke node snippets ESM-safe

### DIFF
--- a/.github/scripts/beauty-movement-staging-smoke-contract.test.mjs
+++ b/.github/scripts/beauty-movement-staging-smoke-contract.test.mjs
@@ -25,6 +25,7 @@ test("smoke consumes secrets in-process and closes the staging gate", () => {
     assert.match(workflow, /smoke_root="\$\{RUNNER_TEMP\}\/beauty-movement-staging-smoke"/);
     assert.match(workflow, /set -euo pipefail/);
     assert.match(workflow, /node --input-type=commonjs -e/);
+    assert.doesNotMatch(workflow, /node -e\s/);
     assert.doesNotMatch(workflow, /set -x/);
     assert.doesNotMatch(workflow, /upload-artifact/);
     assert.match(workflow, /staging-smoke-disabled-probe/);

--- a/.github/workflows/beauty-movement-staging-smoke.yml
+++ b/.github/workflows/beauty-movement-staging-smoke.yml
@@ -278,7 +278,7 @@ jobs:
             --procedure-catalog "${FIXTURE_DIR}/procedures.json" \
             --campaign "${CAMPAIGN_ID}" \
             --confirm-campaign "${CAMPAIGN_ID}" \
-            --campaign-ends-at "$(node -e "const fs=require('fs'); const csv=fs.readFileSync(process.argv[1],'utf8').trim().split(/\\r?\\n/).at(-1).split(','); process.stdout.write(csv[7])" "${FIXTURE_DIR}/invites.csv")" \
+            --campaign-ends-at "$(node --input-type=commonjs -e "const fs=require('fs'); const csv=fs.readFileSync(process.argv[1],'utf8').trim().split(/\\r?\\n/).at(-1).split(','); process.stdout.write(csv[7])" "${FIXTURE_DIR}/invites.csv")" \
             --campaign-config "${FIXTURE_DIR}/campaign.json" \
             --database "${STAGING_D1_DATABASE}" \
             --config wrangler.toml \
@@ -313,7 +313,7 @@ jobs:
         run: |
           set -euo pipefail
           state="${STATE_FILE}"
-          candidate_message="$(node -e "const s=require('fs').readFileSync(process.argv[1],'utf8'); process.stdout.write(JSON.parse(s).candidateMessage)" "${state}")"
+          candidate_message="$(node --input-type=commonjs -e "const s=require('fs').readFileSync(process.argv[1],'utf8'); process.stdout.write(JSON.parse(s).candidateMessage)" "${state}")"
           node - "${state}" <<'NODE'
           const fs = require('node:fs');
           const statePath = process.argv[2];
@@ -345,7 +345,7 @@ jobs:
             sleep 5
           done
           [[ "${candidate_version}" =~ ^[0-9a-f-]{36}$ ]] || { echo 'temporary staging candidate identity was not attested'; exit 1; }
-          incumbent_version="$(node -e "const s=require('fs').readFileSync(process.argv[1],'utf8'); process.stdout.write(JSON.parse(s).incumbentVersion)" "${state}")"
+          incumbent_version="$(node --input-type=commonjs -e "const s=require('fs').readFileSync(process.argv[1],'utf8'); process.stdout.write(JSON.parse(s).incumbentVersion)" "${state}")"
           [[ "${candidate_version}" != "${incumbent_version}" ]] || { echo 'temporary candidate equals incumbent'; exit 1; }
           node - "${state}" "${candidate_version}" <<'NODE'
           const fs = require('node:fs');
@@ -472,7 +472,7 @@ jobs:
             cleanup_failed=1
           fi
           if [[ -f "${STATE_FILE}" ]]; then
-            incumbent_version="$(node -e "const s=require('fs').readFileSync(process.argv[1],'utf8'); process.stdout.write(JSON.parse(s).incumbentVersion || '')" "${STATE_FILE}")"
+            incumbent_version="$(node --input-type=commonjs -e "const s=require('fs').readFileSync(process.argv[1],'utf8'); process.stdout.write(JSON.parse(s).incumbentVersion || '')" "${STATE_FILE}")"
             if [[ "${incumbent_version}" =~ ^[0-9a-f-]{36}$ ]]; then
               current_json="$RUNNER_TEMP/beauty-movement-staging-smoke/current.json"
               npx --yes wrangler@4.112.0 deployments list --config wrangler.toml --env staging --json >"${current_json}" || cleanup_failed=1


### PR DESCRIPTION
## Summary\n- use explicit CommonJS mode for every workflow one-liner that reads JSON/CSV with require\n- fail contract test if a bare 
ode -e regresses\n\n## Validation\n- focused staging smoke contract: 4/4\n- embedded bash syntax check: passed\n- git diff --check: passed\n\nThis follows run 32313282274, where deploy completed but post-deploy attestation failed on the remaining bare node -e; cleanup restored staging and disabled the synthetic fixture.