### PR TITLE
fix: use ESM imports in staging browser smoke

### DIFF
--- a/.github/scripts/beauty-movement-staging-smoke-contract.test.mjs
+++ b/.github/scripts/beauty-movement-staging-smoke-contract.test.mjs
@@ -34,6 +34,10 @@ test("smoke consumes secrets in-process and closes the staging gate", () => {
     assert.match(workflow, /invite_status = 'revoked'/);
     assert.match(workflow, /status = 'disabled'/);
     assert.match(workflow, /rollback/);
+    const browserModule = workflow.match(/SMOKE_INVITE_TOKEN="\$\{token\}" node --input-type=module <<'NODE'[\s\S]*?\n          NODE/)?.[0] ?? "";
+    assert.match(browserModule, /import fs from ['"]node:fs['"]/);
+    assert.match(browserModule, /import \{ chromium \} from ['"]playwright['"]/);
+    assert.doesNotMatch(browserModule, /require\(/);
     const validationStep = workflow.match(/      - name: Validate staging-only source and credentials[\s\S]*?(?=\n      - name:)/)?.[0] ?? "";
     assert.match(validationStep, /BEAUTY_MOVEMENT_TOKEN_HMAC_KEY:\s*\$\{\{ secrets\.BEAUTY_MOVEMENT_TOKEN_HMAC_KEY \}\}/);
     assert.match(validationStep, /BEAUTY_MOVEMENT_PII_KEY:\s*\$\{\{ secrets\.BEAUTY_MOVEMENT_PII_KEY \}\}/);

--- a/.github/workflows/beauty-movement-staging-smoke.yml
+++ b/.github/workflows/beauty-movement-staging-smoke.yml
@@ -375,8 +375,8 @@ jobs:
           token="${invite_url##*#c=}"
           [[ "${token}" =~ ^[A-Za-z0-9_-]{40,180}$ ]] || { echo 'synthetic invite token shape invalid'; exit 1; }
           SMOKE_INVITE_TOKEN="${token}" node --input-type=module <<'NODE'
-          const fs = require('node:fs');
-          const { chromium } = require('playwright');
+          import fs from 'node:fs';
+          import { chromium } from 'playwright';
           const base = process.env.SMOKE_URL;
           const token = process.env.SMOKE_INVITE_TOKEN;
           const browser = await chromium.launch({ headless: true });


### PR DESCRIPTION
## Summary\n- fix the authenticated Playwright heredoc, which runs as ESM, to use native imports instead of require\n- extend the staging smoke contract test to reject CommonJS usage inside that ESM block\n\n## Validation\n- focused staging smoke contract: 4/4\n- embedded bash syntax check: passed\n- git diff --check: passed\n\nRun 32314911294 deployed the candidate and reached this browser block; cleanup completed successfully after the ESM require error.