### PR TITLE
fix(meta-ads): reconcile ambiguous staging seed lineage

### DIFF
--- a/.github/workflows/deploy-token-vault.yml
+++ b/.github/workflows/deploy-token-vault.yml
@@ -1404,13 +1404,64 @@ jobs:
           if (!valid) throw new Error(`staging synthetic-seed source attestation failed: ${response.status} ${error}`);
           NODE
 
+      - name: Reconcile any durably ambiguous staging synthetic seed before a new write
+        # A prior candidate may have been accepted by Graph after the runner
+        # lost its response. The recovery route proves the exact pending ad-set
+        # under the same candidate bearer and archives only that owned lineage.
+        # It never creates a seed, activates traffic, or emits resource IDs.
+        id: staging_synthetic_seed_reconciliation
+        if: inputs.operation == 'deploy' && inputs.target == 'staging' && steps.candidate_staging_synthetic_seed_attestation.outcome == 'success'
+        env:
+          META_ADS_ACCESS_TOKEN: ${{ inputs.target == 'staging' && secrets.META_ADS_ACCESS_TOKEN || '' }}
+          META_ADS_ACCOUNT_ID: ${{ inputs.target == 'staging' && vars.META_ADS_ACCOUNT_ID || '' }}
+          META_ADS_API_VERSION: ${{ inputs.target == 'staging' && vars.META_ADS_API_VERSION || '' }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs';
+
+          const preview = String(process.env.TOKEN_VAULT_CANDIDATE_PREVIEW_URL || '').replace(/\/$/, '');
+          const seedFile = String(process.env.TOKEN_VAULT_STAGING_SYNTHETIC_SEED_FILE || '');
+          const accessToken = String(process.env.META_ADS_ACCESS_TOKEN || '');
+          const accountId = String(process.env.META_ADS_ACCOUNT_ID || '').trim().replace(/^act_/, '');
+          const apiVersion = String(process.env.META_ADS_API_VERSION || '').trim();
+          if (!/^https:\/\/(?:[a-z0-9-]+\.)+workers\.dev$/.test(preview) || !seedFile || !accessToken || !/^\d{5,30}$/.test(accountId) || !/^v(?:2[5-9]|[3-9][0-9])\.0$/.test(apiVersion)) {
+            throw new Error('staging synthetic-seed reconciliation custody is invalid');
+          }
+          const seedToken = fs.readFileSync(seedFile, 'utf8').trim();
+          if (!/^[A-Za-z0-9_-]{64,}$/.test(seedToken)) throw new Error('staging synthetic-seed reconciliation bearer is unavailable');
+          const response = await fetch(`${preview}/internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/reconcile`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${seedToken}`,
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify({ access_token: accessToken, account_id: accountId, api_version: apiVersion }),
+            cache: 'no-store',
+            redirect: 'error',
+            signal: AbortSignal.timeout(30_000),
+          });
+          let payload = null;
+          try { payload = await response.json(); } catch {}
+          const error = /^[a-z0-9_:-]{1,120}$/i.test(String(payload?.error || '')) ? String(payload.error) : 'unknown';
+          const status = String(payload?.operation_status || '');
+          const valid = response.ok && payload?.ok === true &&
+            Object.keys(payload).every((key) => new Set(['ok', 'reconciled', 'operation_status', 'contract_version', 'requestId']).has(key)) &&
+            (status === 'not_required' || status === 'rolled_back') &&
+            typeof payload?.reconciled === 'boolean' &&
+            String(payload?.contract_version || '') === 'meta-ads-tracking-v20/staging-synthetic-seed/v2' &&
+            typeof payload?.requestId === 'string';
+          if (!valid) throw new Error(`staging synthetic-seed reconciliation failed: ${response.status} ${error}`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `reconciliation_status=${status}\n`);
+          NODE
+
       - name: Seal the isolated staging Meta Ads synthetic seed on the immutable candidate
         # This is deliberately before candidate config authentication and plan
         # derivation: an empty legacy authority has no prior target from which
         # to derive. The generated bearer has no role outside these two seed
         # endpoints and the Meta source inputs never enter a Worker binding.
         id: candidate_staging_synthetic_seed
-        if: inputs.operation == 'deploy' && inputs.target == 'staging' && steps.candidate_staging_synthetic_seed_attestation.outcome == 'success'
+        if: inputs.operation == 'deploy' && inputs.target == 'staging' && steps.candidate_staging_synthetic_seed_attestation.outcome == 'success' && steps.staging_synthetic_seed_reconciliation.outcome == 'success'
         env:
           META_ADS_ACCESS_TOKEN: ${{ inputs.target == 'staging' && secrets.META_ADS_ACCESS_TOKEN || '' }}
           META_PIXEL_ID: ${{ inputs.target == 'staging' && secrets.META_PIXEL_ID || '' }}

--- a/platform/security/token-vault/README.md
+++ b/platform/security/token-vault/README.md
@@ -17,6 +17,7 @@ Worker interno para substituir a aba `Credencial` do Google Sheets usada pelo wo
 - `POST /internal/token-vault/v1/meta-ads-publish/config/bootstrap/rollback`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/attest`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/attest-appsecret-proof`
+- `POST /internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/reconcile`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/rollback`
 - `POST /internal/token-vault/v1/meta-ads-publish/config/staging-exercise`
@@ -28,7 +29,7 @@ O bearer restrito `TOKEN_VAULT_META_ADS_CONFIG_TOKEN` só pode consultar
 bootstrap governados, o rollback desse bootstrap e o exercício de staging. Ele
 não lista/altera tokens, não cria runs e não publica anúncios.
 O bearer efêmero distinto `TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN` só alcança
-os quatro endpoints de atestação, prova de `appsecret_proof`, seed e rollback sintéticos, exclusivamente no
+os cinco endpoints de atestação, prova de `appsecret_proof`, reconciliação, seed e rollback sintéticos, exclusivamente no
 Worker staging; ele não ganha as permissões do bearer de configuração,
 operacional ou administrativo.
 O endpoint de analytics exige o secret separado
@@ -172,9 +173,11 @@ delimitadas, não toca D1 nem tráfego, e devolve apenas
 `appsecret_proof_verified` ou um código sanitizado. Ele não cria, copia nem
 revela `META_APP_SECRET`.
 
-O endpoint responde apenas `sealed` ou `not_required` e uma identidade opaca
-de operação. Se qualquer passo subsequente falhar antes do tráfego, ou se a
-compensação de staging for acionada, `POST .../staging-synthetic-seed/rollback`
+As rotas de seed respondem apenas `sealed` ou `not_required` e uma identidade
+opaca de operação; a rota separada de reconciliação responde somente
+`not_required` ou `rolled_back`, sem identidade de operação. Se qualquer passo
+subsequente falhar antes do tráfego, ou se a compensação de staging for acionada,
+`POST .../staging-synthetic-seed/rollback`
 usa a mesma capacidade efêmera para arquivar exclusivamente os objetos de
 entrega marcados e desativar as credenciais seladas. Um `AdCreative` já
 desanexado não possui estado de arquivamento documentado: ele fica inerte,

--- a/platform/security/token-vault/src/index.js
+++ b/platform/security/token-vault/src/index.js
@@ -18,6 +18,7 @@ const META_ADS_PUBLISH_CONFIG_STAGING_EXERCISE_PATH = `${META_ADS_PUBLISH_CONFIG
 const META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH = `${META_ADS_PUBLISH_CONFIG_PATH}/staging-synthetic-seed`;
 const META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ATTEST_PATH = `${META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH}/attest`;
 const META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ATTEST_APPSECRET_PROOF_PATH = `${META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH}/attest-appsecret-proof`;
+const META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_RECONCILE_PATH = `${META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH}/reconcile`;
 const META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ROLLBACK_PATH = `${META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH}/rollback`;
 const JSON_HEADERS = {
   'content-type': 'application/json; charset=utf-8',
@@ -69,6 +70,7 @@ export async function handleRequest(request, env) {
         request.method !== 'POST' || ![
           META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ATTEST_PATH,
           META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ATTEST_APPSECRET_PROOF_PATH,
+          META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_RECONCILE_PATH,
           META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH,
           META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ROLLBACK_PATH,
         ].includes(pathname)
@@ -92,6 +94,7 @@ export async function handleRequest(request, env) {
     if ([
       META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ATTEST_PATH,
       META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ATTEST_APPSECRET_PROOF_PATH,
+      META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_RECONCILE_PATH,
       META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_PATH,
       META_ADS_PUBLISH_CONFIG_STAGING_SYNTHETIC_SEED_ROLLBACK_PATH,
     ].includes(pathname)) {
@@ -654,7 +657,7 @@ function contract(requestId) {
       meta_ads_config_secret: 'TOKEN_VAULT_META_ADS_CONFIG_TOKEN',
       meta_ads_config_scope: 'health|contract|meta-ads-config-read|meta-ads-config-bootstrap|meta-ads-config-bootstrap-rollback|meta-ads-config-bootstrap-derive-plan|meta-ads-config-bootstrap-derive|meta-ads-config-staging-exercise',
       meta_ads_staging_seed_secret: 'TOKEN_VAULT_META_ADS_STAGING_SEED_TOKEN',
-      meta_ads_staging_seed_scope: 'meta-ads-config-staging-synthetic-seed-attest|meta-ads-config-staging-synthetic-seed-attest-appsecret-proof|meta-ads-config-staging-synthetic-seed|meta-ads-config-staging-synthetic-seed-rollback',
+      meta_ads_staging_seed_scope: 'meta-ads-config-staging-synthetic-seed-attest|meta-ads-config-staging-synthetic-seed-attest-appsecret-proof|meta-ads-config-staging-synthetic-seed-reconcile|meta-ads-config-staging-synthetic-seed|meta-ads-config-staging-synthetic-seed-rollback',
     },
     storage: {
       d1_binding: 'TOKEN_VAULT_DB',

--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -422,6 +422,10 @@ export async function handleMetaAdsPublishRequest(input) {
     return attestStagingSyntheticMetaAdsTrackingAppSecretProof({ request, env, requestId });
   }
 
+  if (request.method === 'POST' && pathname === `${PREFIX}/config/staging-synthetic-seed/reconcile`) {
+    return reconcileStagingSyntheticMetaAdsTracking({ request, env, requestId, decryptToken, encryptToken, writeAudit });
+  }
+
   if (request.method === 'POST' && pathname === `${PREFIX}/config/staging-synthetic-seed`) {
     return seedStagingSyntheticMetaAdsTracking({ request, env, requestId, encryptToken, writeAudit });
   }
@@ -1524,6 +1528,77 @@ export async function rollbackStagingSyntheticMetaAdsTracking({ request, env, re
   }
 }
 
+// A previous seed request can be accepted by Graph and then lose the runner
+// before its response is journaled.  The ordinary seed and rollback routes must
+// remain fail-closed for that state.  This separate, candidate-only route is the
+// only recovery path: it proves the exact pending ad-set by campaign/name/account
+// before issuing any archive POST, and never guesses from list order.
+export async function reconcileStagingSyntheticMetaAdsTracking({ request, env, requestId, decryptToken, encryptToken, writeAudit }) {
+  let operation;
+  let state;
+  let context;
+  let lockOwner = '';
+  try {
+    assertStagingSyntheticSeedEnvironment(env);
+    const input = await readStagingSyntheticSeedReconciliationInput(request);
+    if (typeof decryptToken !== 'function' || typeof encryptToken !== 'function') {
+      throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_unavailable', 503);
+    }
+    lockOwner = `staging-seed-reconcile:${crypto.randomUUID()}`;
+    await acquireConfigWriterLock(env, lockOwner, { ttlMs: STAGING_SYNTHETIC_SEED_LOCK_TTL_MS });
+    context = createStagingSyntheticSeedContext(env, lockOwner, requestId, 'reconcile_staging_synthetic_meta_ads_tracking');
+
+    const candidates = await loadReconciliationStagingSyntheticSeedOperations(env);
+    if (!candidates.length) {
+      return stagingSyntheticSeedReconciliationSuccess({ requestId, status: 'not_required' });
+    }
+    if (candidates.length !== 1) {
+      throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+    }
+    operation = candidates[0];
+    context.operationKey = clean(operation.operation_key);
+    Object.assign(context, stagingSyntheticSeedMutationLockIdentity(operation.operation_key));
+    state = await decryptStagingSyntheticSeedState(operation, decryptToken, env);
+    if (clean(operation.status) !== 'reconciliation_required' || state.reconciliation_required !== true) {
+      throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+    }
+    assertStagingSyntheticSeedReconciliationInput(state, input);
+    const auth = await buildStagingSyntheticSeedGraphAuth(input, env);
+    await resolveStagingSyntheticSeedPendingResources({ env, operation, state, auth, encryptToken, context });
+    await acquireStagingSyntheticSeedMutationLocks(context, state);
+    const rollback = await compensateStagingSyntheticSeed({
+      env,
+      operation,
+      state,
+      auth,
+      encryptToken,
+      context,
+      deactivateCredentials: true,
+      allowReconciliation: true,
+    });
+    if (!rollback.ok) {
+      throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+    }
+    await writeStagingSyntheticSeedAudit(writeAudit, env, requestId, 'rolled_back', { phase: 'reconciled' }).catch(() => undefined);
+    return stagingSyntheticSeedReconciliationSuccess({ requestId, status: 'rolled_back' });
+  } catch (error) {
+    const normalized = normalizeStagingSyntheticSeedError(error);
+    await writeStagingSyntheticSeedAudit(writeAudit, env, requestId, normalized.code, {
+      phase: clean(state?.phase) || 'reconciliation',
+    }).catch(() => undefined);
+    return stagingSyntheticSeedFailureResponse(normalized, requestId);
+  } finally {
+    if (context?.stagingSyntheticSeedMutationLocksHeld === true) {
+      await releaseOperationLocks(
+        env,
+        context.stagingSyntheticSeedMutationRunId,
+        context.stagingSyntheticSeedMutationOperationKey,
+      ).catch(() => undefined);
+    }
+    if (lockOwner) await releaseConfigWriterLock(env, lockOwner);
+  }
+}
+
 function assertStagingSyntheticSeedEnvironment(env) {
   assertStagingSyntheticSeedAttestationEnvironment(env);
   if (!env?.TOKEN_VAULT_DB || typeof env.TOKEN_VAULT_DB.prepare !== 'function' || typeof env.TOKEN_VAULT_DB.batch !== 'function') {
@@ -1566,6 +1641,17 @@ async function readStagingSyntheticSeedRollbackInput(request) {
   }
   return {
     operationKey,
+    accessToken: normalizeStagingSyntheticSeedAccessToken(body.access_token),
+    accountId: normalizeStagingSyntheticSeedNumericId(body.account_id, 'account_id'),
+    apiVersion: normalizeStagingSyntheticSeedApiVersion(body.api_version),
+  };
+}
+
+async function readStagingSyntheticSeedReconciliationInput(request) {
+  const body = await readStagingSyntheticSeedBody(request, new Set([
+    'access_token', 'account_id', 'api_version',
+  ]));
+  return {
     accessToken: normalizeStagingSyntheticSeedAccessToken(body.access_token),
     accountId: normalizeStagingSyntheticSeedNumericId(body.account_id, 'account_id'),
     apiVersion: normalizeStagingSyntheticSeedApiVersion(body.api_version),
@@ -1717,6 +1803,16 @@ function stagingSyntheticSeedSuccess({ requestId, operationKey, status, replayed
     contract_version: STAGING_SYNTHETIC_SEED_CONTRACT,
     requestId,
   }, status === 'sealed' && !replayed ? 201 : 200);
+}
+
+function stagingSyntheticSeedReconciliationSuccess({ requestId, status }) {
+  return response({
+    ok: true,
+    reconciled: status === 'rolled_back',
+    operation_status: status,
+    contract_version: STAGING_SYNTHETIC_SEED_CONTRACT,
+    requestId,
+  });
 }
 
 function stagingSyntheticSeedRollbackSuccess({ requestId, operationKey, replayed }) {
@@ -1905,6 +2001,19 @@ async function loadOutstandingStagingSyntheticSeedOperation(env) {
   }
 }
 
+async function loadReconciliationStagingSyntheticSeedOperations(env) {
+  try {
+    return await dbAll(env, [
+      'SELECT id, operation_key, request_hash, status, state_ciphertext, summary_json',
+      'FROM meta_ads_publish_staging_seed_operations',
+      "WHERE status = 'reconciliation_required'",
+      'ORDER BY updated_at DESC LIMIT 2',
+    ].join(' '));
+  } catch {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_unavailable', 503);
+  }
+}
+
 async function createStagingSyntheticSeedOperation({ env, input, state, encryptToken }) {
   const requestHash = await stagingSyntheticSeedRequestHash(input);
   const stateCiphertext = await encryptStagingSyntheticSeedState(state, encryptToken, env);
@@ -2036,6 +2145,16 @@ function assertStagingSyntheticSeedStateMatchesInput(state, input) {
   }
 }
 
+function assertStagingSyntheticSeedReconciliationInput(state, input) {
+  const saved = asObject(state?.input);
+  if (
+    clean(saved.account_id) !== input.accountId ||
+    clean(saved.api_version) !== input.apiVersion
+  ) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_operation_conflict', 409);
+  }
+}
+
 function stagingSyntheticSeedStateHasNoGraphMutation(state) {
   const resources = asObject(state?.resources);
   return (
@@ -2046,6 +2165,102 @@ function stagingSyntheticSeedStateHasNoGraphMutation(state) {
       return !value.pending && !clean(value.id);
     })
   );
+}
+
+async function resolveStagingSyntheticSeedPendingResources({ env, operation, state, auth, encryptToken, context }) {
+  const resources = asObject(state.resources);
+  const campaignResource = asObject(resources.campaign);
+  const campaignId = clean(campaignResource.id);
+  const campaignName = clean(campaignResource.name);
+  if (!/^\d{5,30}$/.test(campaignId) || !campaignName) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+  await readStagingSyntheticSeedCampaign(auth, campaignId, campaignName, context);
+
+  const pendingKeys = ['source_adset', 'target_adset'].filter((key) => (
+    asObject(resources[key]).pending === true
+  ));
+  if (!pendingKeys.length) {
+    if (stagingSyntheticSeedStateHasAmbiguousMutation(state)) {
+      throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+    }
+    return;
+  }
+  if (pendingKeys.length > 2) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+
+  let listing;
+  try {
+    listing = await seedGraphRead(
+      auth,
+      `${campaignId}/adsets`,
+      'id,name,campaign_id,account_id,status,destination_type',
+      context,
+      { limit: '100' },
+      { maxAttempts: 1, failureCode: 'meta_ads_publish_staging_seed_reconciliation_required', authFailureCode: 'meta_ads_publish_staging_seed_reconciliation_required', malformedFailureCode: 'meta_ads_publish_staging_seed_reconciliation_required', contractFailureCode: 'meta_ads_publish_staging_seed_reconciliation_required' },
+    );
+  } catch {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+  if (!Array.isArray(listing.data) || clean(asObject(listing.paging).next)) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+  if (listing.data.length === 0) {
+    for (const key of pendingKeys) {
+      state.resources[key] = {
+        name: clean(asObject(resources[key]).name),
+        pending: false,
+        owned_by_operation: false,
+      };
+    }
+    state.phase = 'reconciling';
+    await persistStagingSyntheticSeedState({ env, operation, state, status: 'reconciliation_required', encryptToken, context });
+    return;
+  }
+
+  const normalized = listing.data.map((entry) => {
+    const value = asObject(entry);
+    let id;
+    let accountId;
+    let entryCampaignId;
+    try {
+      id = normalizeStagingSyntheticSeedGraphId(value.id, 'reconcile_adset_id');
+      accountId = normalizeStagingSyntheticSeedGraphId(value.account_id, 'reconcile_adset_account_id');
+      entryCampaignId = normalizeStagingSyntheticSeedGraphId(value.campaign_id, 'reconcile_adset_campaign_id');
+    } catch {
+      throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+    }
+    return {
+      id,
+      name: clean(value.name),
+      accountId,
+      campaignId: entryCampaignId,
+      status: clean(value.status).toUpperCase(),
+      destinationType: clean(value.destination_type).toUpperCase(),
+    };
+  });
+  const accountId = clean(asObject(state.input).account_id);
+  for (const key of pendingKeys) {
+    const expectedName = clean(asObject(resources[key]).name);
+    const matches = normalized.filter((entry) => (
+      entry.name === expectedName &&
+      entry.campaignId === campaignId &&
+      entry.accountId === accountId
+    ));
+    if (matches.length !== 1) {
+      throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+    }
+    const match = matches[0];
+    state.resources[key] = {
+      id: match.id,
+      name: expectedName,
+      pending: false,
+      owned_by_operation: true,
+    };
+  }
+  state.phase = 'reconciling';
+  await persistStagingSyntheticSeedState({ env, operation, state, status: 'reconciliation_required', encryptToken, context });
 }
 
 function stagingSyntheticSeedStateHasAmbiguousMutation(state) {
@@ -2853,8 +3068,8 @@ function buildStagingSyntheticSeedCredentialMetadata({ input, state }) {
   };
 }
 
-async function compensateStagingSyntheticSeed({ env, operation, state, auth, encryptToken, context, deactivateCredentials }) {
-  if (state.reconciliation_required === true) return { ok: false };
+async function compensateStagingSyntheticSeed({ env, operation, state, auth, encryptToken, context, deactivateCredentials, allowReconciliation = false }) {
+  if (state.reconciliation_required === true && allowReconciliation !== true) return { ok: false };
   const resources = asObject(state.resources);
   if (Object.values(resources).some((value) => asObject(value).pending === true)) {
     state.reconciliation_required = true;
@@ -2879,6 +3094,7 @@ async function compensateStagingSyntheticSeed({ env, operation, state, auth, enc
     // inert creative under the encrypted operation journal rather than let an
     // otherwise complete rollback strand the candidate Worker forever.
     state.detached_creative_retained = Boolean(clean(asObject(resources.source_creative).id));
+    state.reconciliation_required = false;
     if (deactivateCredentials || state.credentials_sealing_started === true) {
       await deactivateStagingSyntheticSeedCredentials({ env, operation, state, encryptToken, context });
     } else {

--- a/platform/security/token-vault/tests/deploy-token-vault-staging-synthetic-seed-workflow.test.js
+++ b/platform/security/token-vault/tests/deploy-token-vault-staging-synthetic-seed-workflow.test.js
@@ -25,6 +25,10 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
   );
   const attestation = section(
     "      - name: Attest the isolated staging Meta Ads synthetic source on the immutable candidate",
+    "      - name: Reconcile any durably ambiguous staging synthetic seed before a new write",
+  );
+  const reconciliation = section(
+    "      - name: Reconcile any durably ambiguous staging synthetic seed before a new write",
     "      - name: Seal the isolated staging Meta Ads synthetic seed on the immutable candidate",
   );
   const seed = section(
@@ -147,9 +151,18 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
   assert.match(attestation, /AbortSignal\.timeout\(30_000\)/);
   assert.doesNotMatch(attestation, /GITHUB_OUTPUT|console\.log|process\.stdout\.write/);
 
+  assert.match(reconciliation, /id: staging_synthetic_seed_reconciliation/);
+  assert.match(reconciliation, /staging-synthetic-seed\/reconcile/);
+  assert.match(reconciliation, /body: JSON\.stringify\(\{ access_token: accessToken, account_id: accountId, api_version: apiVersion \}\)/);
+  assert.match(reconciliation, /operation_status/);
+  assert.match(reconciliation, /status === 'not_required' \|\| status === 'rolled_back'/);
+  assert.match(reconciliation, /appendFileSync\(process\.env\.GITHUB_OUTPUT, `reconciliation_status=/);
+  assert.doesNotMatch(reconciliation, /META_PIXEL_ID|destination_page_ids|META_ADS_NOVOHAMBURGO_PAGE_ID|META_ADS_BARRASHOPPPINGSUL_PAGE_ID/);
+  assert.doesNotMatch(reconciliation, /console\.log|process\.stdout\.write/);
+
   assert.match(
     seed,
-    /if: inputs\.operation == 'deploy' && inputs\.target == 'staging' && steps\.candidate_staging_synthetic_seed_attestation\.outcome == 'success'/,
+    /if: inputs\.operation == 'deploy' && inputs\.target == 'staging' && steps\.candidate_staging_synthetic_seed_attestation\.outcome == 'success' && steps\.staging_synthetic_seed_reconciliation\.outcome == 'success'/,
   );
   assert.match(
     seed,
@@ -227,6 +240,9 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
   const seedAt = workflow.indexOf(
     "      - name: Seal the isolated staging Meta Ads synthetic seed on the immutable candidate",
   );
+  const reconciliationAt = workflow.indexOf(
+    "      - name: Reconcile any durably ambiguous staging synthetic seed before a new write",
+  );
   const configAt = workflow.indexOf(
     "      - name: Verify immutable Token Vault candidate config bearer before traffic",
   );
@@ -239,6 +255,8 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
   assert.ok(
     uploadAt < attestationAt &&
       attestationAt < seedAt &&
+      attestationAt < reconciliationAt &&
+      reconciliationAt < seedAt &&
       seedAt < configAt &&
       configAt < planAt &&
       planAt < trafficAt,
@@ -282,6 +300,7 @@ test("staging synthetic seed is candidate-scoped, ordered before derivation, and
   assert.doesNotMatch(compensationRollback, /TOKEN_VAULT_STAGING_BASE_URL/);
   const sourceScopes = [
     attestation,
+    reconciliation,
     seed,
     pretrafficRollback,
     activationLeaseRollback,

--- a/platform/security/token-vault/tests/index.test.js
+++ b/platform/security/token-vault/tests/index.test.js
@@ -230,7 +230,7 @@ test('configured worker secrets must remain pairwise distinct', async () => {
   assert.equal((await response.json()).error, 'invalid_worker_secret_configuration');
 });
 
-test('Meta Ads staging seed bearer is staging-only, pairwise distinct, and exclusive to its four POST routes', async () => {
+test('Meta Ads staging seed bearer is staging-only, pairwise distinct, and exclusive to its five POST routes', async () => {
   const disabledDb = new FakeDb();
   const disabledEnvironment = env(disabledDb);
   disabledEnvironment.ENVIRONMENT = 'production';
@@ -276,6 +276,9 @@ test('Meta Ads staging seed bearer is staging-only, pairwise distinct, and exclu
     new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/attest-appsecret-proof', {
       headers: metaAdsStagingSeedAuthHeaders(),
     }),
+    new Request('https://api.skincos.com.br/internal/token-vault/v1/meta-ads-publish/config/staging-synthetic-seed/reconcile', {
+      headers: metaAdsStagingSeedAuthHeaders(),
+    }),
   ]) {
     const response = await handleRequest(request, environment);
     assert.equal(response.status, 403);
@@ -285,6 +288,7 @@ test('Meta Ads staging seed bearer is staging-only, pairwise distinct, and exclu
   for (const pathname of [
     '/v1/meta-ads-publish/config/staging-synthetic-seed/attest',
     '/v1/meta-ads-publish/config/staging-synthetic-seed/attest-appsecret-proof',
+    '/v1/meta-ads-publish/config/staging-synthetic-seed/reconcile',
     '/v1/meta-ads-publish/config/staging-synthetic-seed',
     '/v1/meta-ads-publish/config/staging-synthetic-seed/rollback',
   ]) {
@@ -303,6 +307,7 @@ test('Meta Ads staging seed bearer is staging-only, pairwise distinct, and exclu
   for (const pathname of [
     '/v1/meta-ads-publish/config/staging-synthetic-seed/attest',
     '/v1/meta-ads-publish/config/staging-synthetic-seed/attest-appsecret-proof',
+    '/v1/meta-ads-publish/config/staging-synthetic-seed/reconcile',
     '/v1/meta-ads-publish/config/staging-synthetic-seed',
     '/v1/meta-ads-publish/config/staging-synthetic-seed/rollback',
   ]) {

--- a/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
@@ -3,6 +3,7 @@ import test from 'node:test';
 import {
   attestStagingSyntheticMetaAdsTracking,
   attestStagingSyntheticMetaAdsTrackingAppSecretProof,
+  reconcileStagingSyntheticMetaAdsTracking,
   rollbackStagingSyntheticMetaAdsTracking,
   seedStagingSyntheticMetaAdsTracking,
 } from '../src/meta-ads-publish.js';
@@ -112,6 +113,14 @@ class SeedDb {
 
   async all(sql) {
     const normalized = compactSql(sql);
+    if (normalized.includes('from meta_ads_publish_staging_seed_operations') && normalized.includes("status = 'reconciliation_required'")) {
+      return {
+        results: [...this.operations.values()]
+          .filter((operation) => operation.status === 'reconciliation_required')
+          .sort((left, right) => String(right.updated_at).localeCompare(String(left.updated_at)))
+          .slice(0, 2),
+      };
+    }
     if (normalized.includes('from credential_tokens') && normalized.includes("where provider = 'facebook' and active = 1")) {
       return {
         results: this.tokens
@@ -382,6 +391,22 @@ class FakeGraph {
         ],
       });
     }
+    const campaignAdsets = path.match(/^(\d{5,30})\/adsets$/);
+    if (campaignAdsets) {
+      const campaignId = campaignAdsets[1];
+      return graphResponse({
+        data: [...this.resources.values()]
+          .filter((resource) => resource.kind === 'adset' && resource.body?.campaign_id === campaignId)
+          .map((resource) => ({
+            id: resource.id,
+            name: resource.body.name,
+            campaign_id: resource.body.campaign_id,
+            account_id: ACCOUNT_ID,
+            status: resource.body.status,
+            destination_type: resource.body.destination_type,
+          })),
+      });
+    }
     if (path === 'me/accounts') {
       return graphResponse({ data: [{ id: PAGE_ID, tasks: ['ADVERTISE'], instagram_business_account: { id: INSTAGRAM_ID } }] });
     }
@@ -596,6 +621,30 @@ async function rollback({ db, graph, operationKey, env = {} }) {
     request: rollbackRequest(operationKey),
     env: environment(db, graph, env),
     requestId: 'seed-rollback-test-request-id',
+    decryptToken: decrypt,
+    encryptToken: encrypt,
+    writeAudit: async () => {},
+  });
+}
+
+function reconcileRequest(overrides = {}) {
+  return new Request('https://token-vault.invalid/v1/meta-ads-publish/config/staging-synthetic-seed/reconcile', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      access_token: SOURCE_ACCESS_TOKEN,
+      account_id: ACCOUNT_ID,
+      api_version: 'v25.0',
+      ...overrides,
+    }),
+  });
+}
+
+async function reconcile({ db, graph, env = {}, requestOverrides = {} }) {
+  return reconcileStagingSyntheticMetaAdsTracking({
+    request: reconcileRequest(requestOverrides),
+    env: environment(db, graph, env),
+    requestId: 'seed-reconcile-test-request-id',
     decryptToken: decrypt,
     encryptToken: encrypt,
     writeAudit: async () => {},
@@ -1713,6 +1762,193 @@ test('an ambiguous synthetic POST is never retried and leaves the operation fail
   assert.equal(db.operations.get(operationKey).status, 'reconciliation_required');
   assert.equal(JSON.stringify(body).includes(SOURCE_ACCESS_TOKEN), false);
   assert.equal(JSON.stringify(body).includes(ACCOUNT_ID), false);
+});
+
+test('candidate reconciliation resolves one exact pending ad set and archives only the owned lineage', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph();
+  const operationKey = 'meta-ads-staging-seed:reconcile-pending-001';
+  const campaignId = '23800000000000021';
+  const adsetId = '23800000000000022';
+  const marker = 'b'.repeat(64);
+  const campaignName = `[SKINCOS-STAGING-V20:${marker.slice(0, 24)}] Campaign`;
+  const adsetName = `[SKINCOS-STAGING-V20:${marker.slice(0, 24)}] Source Ad Set`;
+  const state = {
+    contract: 'meta-ads-tracking-v20/staging-synthetic-seed/v2',
+    phase: 'reconciliation_required',
+    reconciliation_required: true,
+    input: { operation_key: operationKey, account_id: ACCOUNT_ID, pixel_id: PIXEL_ID, api_version: 'v25.0' },
+    marker,
+    url_tags: 'skincos_staging_v20=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    credential_ids: {
+      source: `staging.meta-ads.source.${marker.slice(0, 32)}`,
+      target: `staging.meta-ads.target.${marker.slice(0, 32)}`,
+    },
+    credentials_sealed: false,
+    facts: {},
+    resources: {
+      campaign: { id: campaignId, name: campaignName, pending: false, owned_by_operation: true },
+      source_adset: { name: adsetName, pending: true, owned_by_operation: false },
+    },
+  };
+  db.operations.set(operationKey, {
+    id: 'reconcile-operation-id',
+    operation_key: operationKey,
+    request_hash: 'reconcile-request-hash',
+    status: 'reconciliation_required',
+    state_ciphertext: await encrypt(JSON.stringify(state)),
+    summary_json: JSON.stringify({ phase: 'reconciliation_required', reconciliation_required: true }),
+    updated_at: new Date().toISOString(),
+  });
+  graph.resources.set(campaignId, {
+    id: campaignId,
+    kind: 'campaign',
+    body: {
+      name: campaignName,
+      objective: 'OUTCOME_LEADS',
+      buying_type: 'AUCTION',
+      special_ad_categories: [],
+      is_adset_budget_sharing_enabled: false,
+      status: 'PAUSED',
+    },
+  });
+  graph.resources.set(adsetId, {
+    id: adsetId,
+    kind: 'adset',
+    body: {
+      name: adsetName,
+      campaign_id: campaignId,
+      account_id: ACCOUNT_ID,
+      status: 'PAUSED',
+      destination_type: 'WEBSITE',
+      billing_event: 'IMPRESSIONS',
+      optimization_goal: 'OFFSITE_CONVERSIONS',
+      attribution_spec: [],
+      promoted_object: {},
+    },
+  });
+
+  const response = await reconcile({ db, graph });
+  const body = await response.json();
+  assert.equal(response.status, 200);
+  assert.deepEqual(body, {
+    ok: true,
+    reconciled: true,
+    operation_status: 'rolled_back',
+    contract_version: 'meta-ads-tracking-v20/staging-synthetic-seed/v2',
+    requestId: 'seed-reconcile-test-request-id',
+  });
+  assert.deepEqual(graph.postCalls, [adsetId, campaignId]);
+  assert.equal(db.operations.get(operationKey).status, 'rolled_back');
+  assert.equal(db.tokens.length, 0);
+  assert.equal(JSON.stringify(body).includes(ACCOUNT_ID), false);
+  assert.equal(JSON.stringify(body).includes(campaignId), false);
+});
+
+test('candidate reconciliation refuses duplicate pending ad-set matches without Graph POST or state closure', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph();
+  const operationKey = 'meta-ads-staging-seed:reconcile-duplicate-001';
+  const campaignId = '23800000000000031';
+  const marker = 'c'.repeat(64);
+  const campaignName = `[SKINCOS-STAGING-V20:${marker.slice(0, 24)}] Campaign`;
+  const adsetName = `[SKINCOS-STAGING-V20:${marker.slice(0, 24)}] Source Ad Set`;
+  const state = {
+    contract: 'meta-ads-tracking-v20/staging-synthetic-seed/v2',
+    phase: 'reconciliation_required',
+    reconciliation_required: true,
+    input: { operation_key: operationKey, account_id: ACCOUNT_ID, pixel_id: PIXEL_ID, api_version: 'v25.0' },
+    marker,
+    url_tags: 'skincos_staging_v20=cccccccccccccccccccccccccccccccc',
+    credential_ids: { source: `staging.meta-ads.source.${marker.slice(0, 32)}`, target: `staging.meta-ads.target.${marker.slice(0, 32)}` },
+    credentials_sealed: false,
+    facts: {},
+    resources: {
+      campaign: { id: campaignId, name: campaignName, pending: false, owned_by_operation: true },
+      source_adset: { name: adsetName, pending: true, owned_by_operation: false },
+    },
+  };
+  db.operations.set(operationKey, {
+    id: 'reconcile-operation-id-duplicate',
+    operation_key: operationKey,
+    request_hash: 'reconcile-request-hash-duplicate',
+    status: 'reconciliation_required',
+    state_ciphertext: await encrypt(JSON.stringify(state)),
+    summary_json: JSON.stringify({ phase: 'reconciliation_required', reconciliation_required: true }),
+    updated_at: new Date().toISOString(),
+  });
+  graph.resources.set(campaignId, {
+    id: campaignId,
+    kind: 'campaign',
+    body: { name: campaignName, objective: 'OUTCOME_LEADS', buying_type: 'AUCTION', special_ad_categories: [], is_adset_budget_sharing_enabled: false, status: 'PAUSED' },
+  });
+  for (const adsetId of ['23800000000000032', '23800000000000033']) {
+    graph.resources.set(adsetId, {
+      id: adsetId,
+      kind: 'adset',
+      body: { name: adsetName, campaign_id: campaignId, account_id: ACCOUNT_ID, status: 'PAUSED', destination_type: 'WEBSITE' },
+    });
+  }
+  const response = await reconcile({ db, graph });
+  const body = await response.json();
+  assert.equal(response.status, 409);
+  assert.equal(body.error, 'meta_ads_publish_staging_seed_reconciliation_required');
+  assert.equal(graph.postCalls.length, 0);
+  assert.equal(db.operations.get(operationKey).status, 'reconciliation_required');
+});
+
+test('candidate reconciliation closes a campaign-only ambiguous seed when no ad set was accepted', async () => {
+  const db = new SeedDb();
+  const graph = new FakeGraph();
+  const operationKey = 'meta-ads-staging-seed:reconcile-campaign-only-001';
+  const campaignId = '23800000000000041';
+  const marker = 'd'.repeat(64);
+  const campaignName = `[SKINCOS-STAGING-V20:${marker.slice(0, 24)}] Campaign`;
+  const state = {
+    contract: 'meta-ads-tracking-v20/staging-synthetic-seed/v2',
+    phase: 'reconciliation_required',
+    reconciliation_required: true,
+    input: { operation_key: operationKey, account_id: ACCOUNT_ID, pixel_id: PIXEL_ID, api_version: 'v25.0' },
+    marker,
+    url_tags: 'skincos_staging_v20=dddddddddddddddddddddddddddddddd',
+    credential_ids: { source: `staging.meta-ads.source.${marker.slice(0, 32)}`, target: `staging.meta-ads.target.${marker.slice(0, 32)}` },
+    credentials_sealed: false,
+    facts: {},
+    resources: {
+      campaign: { id: campaignId, name: campaignName, pending: false, owned_by_operation: true },
+      source_adset: { name: `${marker} Source Ad Set`, pending: true, owned_by_operation: false },
+      target_adset: { name: `${marker} Target Ad Set`, pending: true, owned_by_operation: false },
+    },
+  };
+  db.operations.set(operationKey, {
+    id: 'reconcile-operation-id-campaign-only',
+    operation_key: operationKey,
+    request_hash: 'reconcile-request-hash-campaign-only',
+    status: 'reconciliation_required',
+    state_ciphertext: await encrypt(JSON.stringify(state)),
+    summary_json: JSON.stringify({ phase: 'reconciliation_required', reconciliation_required: true }),
+    updated_at: new Date().toISOString(),
+  });
+  graph.resources.set(campaignId, {
+    id: campaignId,
+    kind: 'campaign',
+    body: {
+      name: campaignName,
+      objective: 'OUTCOME_LEADS',
+      buying_type: 'AUCTION',
+      special_ad_categories: [],
+      is_adset_budget_sharing_enabled: false,
+      status: 'PAUSED',
+    },
+  });
+
+  const response = await reconcile({ db, graph });
+  const body = await response.json();
+  assert.equal(response.status, 200);
+  assert.equal(body.operation_status, 'rolled_back');
+  assert.deepEqual(graph.postCalls, [campaignId]);
+  assert.equal(db.operations.get(operationKey).status, 'rolled_back');
+  assert.equal(JSON.stringify(body).includes(campaignId), false);
 });
 
 test('rollback rejects a drifted seeded authority before it mutates Graph delivery or D1 credentials', async () => {


### PR DESCRIPTION
## Objetivo
Adicionar a reconciliação durável e fail-closed do seed sintético Meta Ads de staging quando o Graph aceita uma mutação, mas o runner perde a resposta antes do journal fechar.

## Superfícies
- Token Vault Worker: rota POST exclusiva do bearer `meta-ads-staging-seed`.
- Deploy Token Vault: etapa candidate-only antes de qualquer novo seed.
- Testes e README do Token Vault.

## Segurança e risco
- A rota exige staging, D1 journal válido, exatamente uma operação `reconciliation_required` e input account/API compatível.
- Lê a campanha nomeada e lista ad sets com campos fechados; só aceita ad set exatamente correspondente por nome, campanha e conta. Lista vazia sem paginação fecha o caso campaign-only sem inventar IDs.
- Locks de configuração e de ad set são mantidos até a compensação; duplicidade, paginação, shape inválido e drift permanecem em `reconciliation_required`.
- Respostas, outputs e auditoria permanecem sanitizados; tokens e IDs não são emitidos.
- Não altera Ponto/CRM, produção, Orb, fixture ou tráfego neste PR.

## Migrations / flags
- Nenhuma migration, flag ou alteração de custody.

## Rollback
Reverter o commit/PR. A rota nova é isolada; o seed normal continua fail-closed quando a reconciliação não pode provar a linhagem.

## Validação
- Token Vault completo: 187/187.
- Teste focal de seed/reconciliação: 32/32.
- Index auth: 19/19.
- Deploy topology, Cloudflare single-writer, architecture e governance estática verdes.
- Security diff scan: 0 achados no snapshot revisado; pequenos endurecimentos pós-snapshot têm cobertura focal e entram nos gates CI.