### PR TITLE
fix: apply resolved offer before opening result card

### DIFF
--- a/website/src/components/BeautyMovementCampaign.tsx
+++ b/website/src/components/BeautyMovementCampaign.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import BeautyMovementExperience, {
   type BeautyMovementConfirmationInput,
+  type BeautyMovementConfirmationCommit,
   type BeautyMovementExperienceInitialState,
   type BeautyMovementReveal,
 } from "@/components/BeautyMovementExperience";
@@ -103,12 +104,13 @@ export default function BeautyMovementCampaign() {
     return { reveals: nextState.reveals };
   }
 
-  async function confirmInvite(input: BeautyMovementConfirmationInput): Promise<void> {
+  async function confirmInvite(input: BeautyMovementConfirmationInput): Promise<BeautyMovementConfirmationCommit> {
     const nextState = await requestCampaignState("/api/beleza-em-movimento/confirm", {
       method: "POST",
       body: JSON.stringify(input),
     });
     setState(nextState);
+    return { confirmed: nextState.confirmed, offer: nextState.offer ?? null };
   }
 
   if (!state) {

--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -103,6 +103,12 @@ export type BeautyMovementConfirmationCommit =
     | void
     | {
           confirmed?: boolean;
+          /**
+           * The server/local resolver's result is returned with the commit so
+           * the result modal never renders from the pre-confirmation props
+           * while the parent state update is still being scheduled.
+           */
+          offer?: BeautyMovementOffer | null;
       };
 
 export type BeautyMovementTrackingParams = Record<string, string | number | boolean | null | undefined> &
@@ -319,6 +325,7 @@ export default function BeautyMovementExperience({
     const [confirmationAttempted, setConfirmationAttempted] = useState(false);
     const [revealPendingCardId, setRevealPendingCardId] = useState<string | null>(null);
     const [isConfirming, setIsConfirming] = useState(false);
+    const [confirmedOffer, setConfirmedOffer] = useState<BeautyMovementOffer | null>(initialState.offer ?? null);
     const [actionError, setActionError] = useState<string | null>(null);
     const [shareStatus, setShareStatus] = useState<string | null>(null);
     const [finaleStage, setFinaleStage] = useState<FinaleStage>(() =>
@@ -442,6 +449,10 @@ export default function BeautyMovementExperience({
             setIsSpecialCardModalOpen(true);
         }
     }, [initialState.confirmed]);
+
+    useEffect(() => {
+        if (initialState.offer) setConfirmedOffer(initialState.offer);
+    }, [initialState.offer]);
 
     useEffect(() => {
         if (openedRef.current) return;
@@ -1339,11 +1350,12 @@ export default function BeautyMovementExperience({
         confirmInFlightRef.current = true;
         setIsConfirming(true);
         try {
-            await onConfirm?.({
+            const commit = await onConfirm?.({
                 email: null,
                 operationalConsent: true,
             });
             if (!mountedRef.current) return;
+            if (commit && "offer" in commit) setConfirmedOffer(commit.offer ?? null);
             setConfirmed(true);
             setCurrentFinaleStage("result");
             setIsSpecialCardModalOpen(true);
@@ -1514,7 +1526,7 @@ export default function BeautyMovementExperience({
         deferRevealContent = false,
     ) {
         const showRevealAction = action !== "none";
-        const offer = initialState.offer ?? null;
+        const offer = initialState.offer ?? confirmedOffer;
         const kind: SpecialCardKind = revealed
             ? hasCourtesyClass
                 ? "velocity"

--- a/website/src/components/BeautyMovementLocalPreview.tsx
+++ b/website/src/components/BeautyMovementLocalPreview.tsx
@@ -83,18 +83,17 @@ export default function BeautyMovementLocalPreview() {
     }
 
     function confirm() {
-        setState((current) => {
-            const selections = current.reveals.reduce<Record<string, string>>((result, reveal) => {
-                const act = ["beleza", "movimento", "celebracao"][reveal.actIndex - 1];
-                if (act) result[act] = reveal.cardId;
-                return result;
-            }, {});
-            const resolved = current.reveals.length === 3
-                ? resolveBeautyMovementOutcome({ palette: current.palette, selections })
-                : null;
-            return { ...current, confirmed: true, offer: resolved?.offer ?? current.offer ?? null };
-        });
-        return { confirmed: true };
+        const selections = state.reveals.reduce<Record<string, string>>((result, reveal) => {
+            const act = ["beleza", "movimento", "celebracao"][reveal.actIndex - 1];
+            if (act) result[act] = reveal.cardId;
+            return result;
+        }, {});
+        const resolved = state.reveals.length === 3
+            ? resolveBeautyMovementOutcome({ palette: state.palette, selections })
+            : null;
+        const offer = resolved?.offer ?? state.offer ?? null;
+        setState((current) => ({ ...current, confirmed: true, offer }));
+        return { confirmed: true, offer };
     }
 
     return (

--- a/website/tests/beautyMovementLocalPreview.test.ts
+++ b/website/tests/beautyMovementLocalPreview.test.ts
@@ -25,6 +25,9 @@ test("local preview is synthetic, blocks production, and cannot open the real Wh
     assert.match(experience, /Prévia local: a abertura do WhatsApp foi simulada\./);
     assert.match(experience, /BEAUTY_MOVEMENT_OFFER_PRESENTATIONS/);
     assert.match(experience, /Suas três escolhas/);
+    assert.match(experience, /const \[confirmedOffer, setConfirmedOffer\]/);
+    assert.match(experience, /if \(commit && "offer" in commit\) setConfirmedOffer\(commit\.offer \?\? null\)/);
+    assert.match(experience, /const offer = initialState\.offer \?\? confirmedOffer/);
     assert.match(experience, /Bioestimulação potencializada/);
     assert.match(experience, /Adquira 2 mL e receba 4 mL\./);
     assert.match(experience, /Adquira 1 mL de Restylane Classic e desbloqueie Sculptra por R\$ 1\.699\./);
@@ -33,4 +36,5 @@ test("local preview is synthetic, blocks production, and cannot open the real Wh
     assert.match(styles, /\.specialCardFrontOffer \{/);
     assert.match(styles, /\.specialCardPriceBlock \{/);
     assert.match(styles, /\.specialCardConditions\[open\] \{/);
+    assert.match(preview, /return \{ confirmed: true, offer \}/);
 });


### PR DESCRIPTION
## Summary
- return the resolved commercial offer from the live and local confirmation adapters
- apply that offer in the experience before opening the result modal, avoiding the pre-confirmation reserved card during the state handoff
- cover the handoff contract in the focused local-preview test

## Validation
- `node --import tsx --test tests/beautyMovementLocalPreview.test.ts`
- `npm run typecheck`
- `node --test .github/scripts/beauty-movement-staging-smoke-contract.test.mjs`