### PR TITLE
fix(meta-ads): reconcile campaign status drift safely

### DIFF
--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -2180,7 +2180,7 @@ async function resolveStagingSyntheticSeedPendingResources({ env, operation, sta
   if (!/^\d{5,30}$/.test(campaignId) || !campaignName) {
     throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
   }
-  await readStagingSyntheticSeedCampaign(auth, campaignId, campaignName, context);
+  await readStagingSyntheticSeedReconciliationCampaign(auth, campaignId, campaignName, context);
 
   const pendingKeys = ['source_adset', 'target_adset'].filter((key) => (
     asObject(resources[key]).pending === true
@@ -2857,6 +2857,24 @@ async function readStagingSyntheticSeedCampaign(auth, campaignId, expectedName, 
   }
   if (clean(campaign.objective).toUpperCase() !== 'OUTCOME_LEADS') {
     throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_campaign_objective_mismatch', 409);
+  }
+  return campaign;
+}
+
+async function readStagingSyntheticSeedReconciliationCampaign(auth, campaignId, expectedName, context) {
+  const result = await graphRequest(
+    graphUrl(auth.apiVersion, campaignId, { fields: 'id,name,status' }),
+    { method: 'GET' }, auth, context,
+  );
+  const campaign = asObject(result.body);
+  let actualId;
+  try {
+    actualId = normalizeStagingSyntheticSeedGraphId(campaign.id, 'reconcile_campaign_id');
+  } catch {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
+  }
+  if (actualId !== campaignId || clean(campaign.name) !== expectedName || !clean(campaign.status)) {
+    throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_reconciliation_required', 409);
   }
   return campaign;
 }

--- a/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
@@ -1949,7 +1949,7 @@ test('candidate reconciliation refuses duplicate pending ad-set matches without 
   assert.equal(db.operations.get(operationKey).status, 'reconciliation_required');
 });
 
-test('candidate reconciliation closes a campaign-only ambiguous seed when no ad set was accepted', async () => {
+test('candidate reconciliation closes a campaign-only ambiguous seed when no ad set was accepted despite campaign status drift', async () => {
   const db = new SeedDb();
   const graph = new FakeGraph();
   const operationKey = 'meta-ads-staging-seed:reconcile-campaign-only-001';
@@ -1990,7 +1990,7 @@ test('candidate reconciliation closes a campaign-only ambiguous seed when no ad 
       buying_type: 'AUCTION',
       special_ad_categories: [],
       is_adset_budget_sharing_enabled: false,
-      status: 'PAUSED',
+      status: 'ACTIVE',
     },
   });
 
@@ -2003,32 +2003,22 @@ test('candidate reconciliation closes a campaign-only ambiguous seed when no ad 
   assert.equal(JSON.stringify(body).includes(campaignId), false);
 });
 
-test('candidate reconciliation classifies campaign readback drift without Graph writes or sensitive output', async () => {
+test('candidate reconciliation requires exact campaign identity and name without Graph writes or sensitive output', async () => {
   const cases = [
     {
       name: 'malformed',
       campaignResponse: { name: 'opaque', status: 'PAUSED', objective: 'OUTCOME_LEADS' },
-      error: 'meta_ads_publish_staging_seed_graph_campaign_contract_malformed',
+      error: 'meta_ads_publish_staging_seed_reconciliation_required',
     },
     {
       name: 'identity',
       campaignResponse: { id: 'not-numeric', name: 'opaque', status: 'PAUSED', objective: 'OUTCOME_LEADS' },
-      error: 'meta_ads_publish_staging_seed_graph_campaign_contract_malformed',
+      error: 'meta_ads_publish_staging_seed_reconciliation_required',
     },
     {
       name: 'name',
       campaignPatch: { name: '[unexpected-campaign-name]' },
-      error: 'meta_ads_publish_staging_seed_graph_campaign_name_mismatch',
-    },
-    {
-      name: 'status',
-      campaignPatch: { status: 'ACTIVE' },
-      error: 'meta_ads_publish_staging_seed_graph_campaign_status_mismatch',
-    },
-    {
-      name: 'objective',
-      campaignPatch: { objective: 'OUTCOME_SALES' },
-      error: 'meta_ads_publish_staging_seed_graph_campaign_objective_mismatch',
+      error: 'meta_ads_publish_staging_seed_reconciliation_required',
     },
   ];
 


### PR DESCRIPTION
## Summary
- make the recovery readback prove only the journaled campaign identity and exact name before cleanup
- tolerate non-empty campaign status drift so the existing archive helper can safely normalize it
- keep ordinary seed creation readback strict and preserve fixed sanitized failure responses

## Type
Bug fix: staging synthetic-seed reconciliation safety.

## Scope and risk
- Token Vault staging reconciliation only; no Ponto or CRM changes.
- No migration, no new route, no new Graph write, and no traffic or production behavior.
- Reconciliation still requires the exact encrypted journal campaign ID and name; malformed or missing ownership facts remain fail-closed.

## Validation
- `node --test platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js`
- `npm --prefix platform/security/token-vault test`
- architecture validation
- `git diff --check`
- Codex Security diff scan: no findings

## Rollback
Revert this commit. The previous strict reconciliation path remains fail-closed and leaves the operation for manual recovery.

## Migration
None.