### PR TITLE
perf(ci): eliminate full-history checkouts from routine PR validation

### DIFF
--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -51,23 +51,27 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          fetch-depth: 0
-      - id: scope
+          fetch-depth: 2
+      - id: bounded-diff
+        name: Prepare bounded immutable diff
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: node scripts/codex-bounded-diff.mjs --base "${PR_BASE_SHA:-$BEFORE_SHA}" --head "${PR_HEAD_SHA:-$HEAD_SHA}" --output "$GITHUB_OUTPUT"
+      - id: scope
+        env:
+          BOUNDED_BASE_SHA: ${{ steps.bounded-diff.outputs.base }}
+          BOUNDED_HEAD_SHA: ${{ steps.bounded-diff.outputs.head }}
         run: |
           set -euo pipefail
-          zero_sha='0000000000000000000000000000000000000000'
-          base="${PR_BASE_SHA:-}"
-          if [[ ! "$base" =~ ^[0-9a-f]{40}$ ]]; then base=""; fi
-          if [[ -z "$base" && "${BEFORE_SHA:-}" =~ ^[0-9a-f]{40}$ && "$BEFORE_SHA" != "$zero_sha" ]]; then
-            base="$BEFORE_SHA"
-          fi
-          if [[ -z "$base" ]]; then base="$(git rev-parse HEAD^)"; fi
+          base="$BOUNDED_BASE_SHA"
+          head="$BOUNDED_HEAD_SHA"
           git cat-file -e "$base^{commit}"
+          git cat-file -e "$head^{commit}"
           changed() {
-            if git diff --quiet "$base...$GITHUB_SHA" -- "$@"; then printf false; else printf true; fi
+            if git diff --quiet "$base...$head" -- "$@"; then printf false; else printf true; fi
           }
           website="$(changed website booking package.json package-lock.json)"
           crm_api="$(changed crm/api)"
@@ -102,7 +106,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           token: ${{ secrets.GH_TOKEN != '' && secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Initialize submodules (if configured)
         if: ${{ hashFiles('.gitmodules') != '' }}

--- a/.github/workflows/codex-autonomy-gate.yml
+++ b/.github/workflows/codex-autonomy-gate.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          fetch-depth: 0
+          fetch-depth: 2
       - id: base
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          fetch-depth: 0
+          fetch-depth: 2
       - name: Proportional diff check
         run: git diff --check
       - name: Baseline contract tests

--- a/.github/workflows/lint-format-static.yml
+++ b/.github/workflows/lint-format-static.yml
@@ -50,23 +50,27 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          fetch-depth: 0
-      - id: scope
+          fetch-depth: 2
+      - id: bounded-diff
+        name: Prepare bounded immutable diff
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: node scripts/codex-bounded-diff.mjs --base "${PR_BASE_SHA:-$BEFORE_SHA}" --head "${PR_HEAD_SHA:-$HEAD_SHA}" --output "$GITHUB_OUTPUT"
+      - id: scope
+        env:
+          BOUNDED_BASE_SHA: ${{ steps.bounded-diff.outputs.base }}
+          BOUNDED_HEAD_SHA: ${{ steps.bounded-diff.outputs.head }}
         run: |
           set -euo pipefail
-          zero_sha='0000000000000000000000000000000000000000'
-          base="${PR_BASE_SHA:-}"
-          if [[ ! "$base" =~ ^[0-9a-f]{40}$ ]]; then base=""; fi
-          if [[ -z "$base" && "${BEFORE_SHA:-}" =~ ^[0-9a-f]{40}$ && "$BEFORE_SHA" != "$zero_sha" ]]; then
-            base="$BEFORE_SHA"
-          fi
-          if [[ -z "$base" ]]; then base="$(git rev-parse HEAD^)"; fi
+          base="$BOUNDED_BASE_SHA"
+          head="$BOUNDED_HEAD_SHA"
           git cat-file -e "$base^{commit}"
+          git cat-file -e "$head^{commit}"
           changed() {
-            if git diff --quiet "$base...$GITHUB_SHA" -- "$@"; then printf false; else printf true; fi
+            if git diff --quiet "$base...$head" -- "$@"; then printf false; else printf true; fi
           }
           frontend="$(changed crm/console package.json package-lock.json)"
           website="$(changed website booking package.json package-lock.json)"

--- a/.github/workflows/test-coverage-quality.yml
+++ b/.github/workflows/test-coverage-quality.yml
@@ -34,23 +34,27 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          fetch-depth: 0
-      - id: scope
+          fetch-depth: 2
+      - id: bounded-diff
+        name: Prepare bounded immutable diff
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: node scripts/codex-bounded-diff.mjs --base "${PR_BASE_SHA:-$BEFORE_SHA}" --head "${PR_HEAD_SHA:-$HEAD_SHA}" --output "$GITHUB_OUTPUT"
+      - id: scope
+        env:
+          BOUNDED_BASE_SHA: ${{ steps.bounded-diff.outputs.base }}
+          BOUNDED_HEAD_SHA: ${{ steps.bounded-diff.outputs.head }}
         run: |
           set -euo pipefail
-          zero_sha='0000000000000000000000000000000000000000'
-          base="${PR_BASE_SHA:-}"
-          if [[ ! "$base" =~ ^[0-9a-f]{40}$ ]]; then base=""; fi
-          if [[ -z "$base" && "${BEFORE_SHA:-}" =~ ^[0-9a-f]{40}$ && "$BEFORE_SHA" != "$zero_sha" ]]; then
-            base="$BEFORE_SHA"
-          fi
-          if [[ -z "$base" ]]; then base="$(git rev-parse HEAD^)"; fi
+          base="$BOUNDED_BASE_SHA"
+          head="$BOUNDED_HEAD_SHA"
           git cat-file -e "$base^{commit}"
+          git cat-file -e "$head^{commit}"
           changed() {
-            if git diff --quiet "$base...$GITHUB_SHA" -- "$@"; then printf false; else printf true; fi
+            if git diff --quiet "$base...$head" -- "$@"; then printf false; else printf true; fi
           }
           echo "frontend=$(changed crm/console website booking package.json package-lock.json)" >> "$GITHUB_OUTPUT"
           echo "python=$(changed backend)" >> "$GITHUB_OUTPUT"

--- a/scripts/codex-bounded-diff.mjs
+++ b/scripts/codex-bounded-diff.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+
+const SHA = /^[0-9a-f]{40}$/i;
+const DIFF_FILTER = "ACDMRTUXB";
+
+function argument(name, fallback = "") {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] ?? fallback : fallback;
+}
+
+function git(...args) {
+  return execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
+
+function commitExists(value) {
+  if (!SHA.test(value)) return false;
+  try {
+    git("cat-file", "-e", `${value}^{commit}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function fetchCommit(value, label) {
+  if (!SHA.test(value)) throw new Error(`${label} is not a full immutable commit SHA`);
+  if (commitExists(value)) return;
+  try {
+    git("fetch", "--no-tags", "--depth=2", "origin", value);
+  } catch {
+    throw new Error(`unable to fetch immutable ${label} ${value}`);
+  }
+  if (!commitExists(value)) throw new Error(`fetched ${label} is not available as a commit`);
+}
+
+function fallbackBase() {
+  try {
+    const value = git("rev-parse", "HEAD^");
+    return SHA.test(value) ? value : "";
+  } catch {
+    return "";
+  }
+}
+
+const requestedBase = argument("--base");
+const head = argument("--head", process.env.GITHUB_SHA ?? "");
+let base = "";
+let usedFallback = false;
+
+if (SHA.test(requestedBase)) {
+  try {
+    fetchCommit(requestedBase, "base");
+    base = requestedBase;
+  } catch {
+    usedFallback = true;
+  }
+} else {
+  usedFallback = true;
+}
+if (!base) base = fallbackBase();
+if (!base) throw new Error("no valid immutable base SHA and no local parent fallback is available");
+
+if (usedFallback) fetchCommit(base, "fallback base");
+fetchCommit(head, "head");
+try {
+  git("diff", "--check", base, head);
+} catch {
+  throw new Error(`bounded diff check failed for ${base}..${head}`);
+}
+
+const output = argument("--output", process.env.GITHUB_OUTPUT ?? "");
+const filesOutput = argument("--files-output");
+// Disable rename detection so a rename contributes both its old and new path.
+// This keeps sensitive-path classification conservative without fetching full history.
+const changedFiles = git("-c", "diff.renames=false", "diff", "--name-only", `--diff-filter=${DIFF_FILTER}`, base, head)
+  .split(/\r?\n/).filter(Boolean);
+if (filesOutput) fs.writeFileSync(filesOutput, changedFiles.length ? `${changedFiles.join("\n")}\n` : "");
+const lines = [`base=${base}`, `head=${head}`, `used_fallback=${usedFallback}`];
+if (filesOutput) lines.push(`files_file=${filesOutput}`);
+if (output) fs.appendFileSync(output, `${lines.join("\n")}\n`);
+else process.stdout.write(`${lines.join("\n")}\n`);
+
+if (usedFallback) process.stderr.write(`::warning::bounded diff used local parent ${base} because the requested base was missing or invalid\n`);

--- a/scripts/tests/codex-bounded-diff.test.mjs
+++ b/scripts/tests/codex-bounded-diff.test.mjs
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const root = path.resolve(import.meta.dirname, "../..");
+const script = path.join(root, "scripts/codex-bounded-diff.mjs");
+const isolatedGitEnvironment = { ...process.env };
+delete isolatedGitEnvironment.GIT_DIR;
+delete isolatedGitEnvironment.GIT_WORK_TREE;
+delete isolatedGitEnvironment.GIT_INDEX_FILE;
+
+function git(cwd, ...args) {
+  return execFileSync("git", args, { cwd, env: isolatedGitEnvironment, encoding: "utf8" }).trim();
+}
+
+function fixture() {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "skincos-bounded-diff-"));
+  git(cwd, "init", "-q");
+  git(cwd, "config", "user.email", "test@example.invalid");
+  git(cwd, "config", "user.name", "bounded-diff-test");
+  fs.writeFileSync(path.join(cwd, "file.txt"), "base\n");
+  git(cwd, "add", ".");
+  git(cwd, "commit", "-qm", "base");
+  const base = git(cwd, "rev-parse", "HEAD");
+  fs.writeFileSync(path.join(cwd, "file.txt"), "head\n");
+  git(cwd, "commit", "-qam", "head");
+  const head = git(cwd, "rev-parse", "HEAD");
+  return { cwd, base, head };
+}
+
+function shallowRemoteFixture() {
+  const source = fixture();
+  git(source.cwd, "branch", "-M", "main");
+  const remote = fs.mkdtempSync(path.join(os.tmpdir(), "skincos-bounded-origin-"));
+  git(source.cwd, "init", "--bare", remote);
+  git(source.cwd, "remote", "add", "origin", remote);
+  git(source.cwd, "push", "-q", "origin", "main");
+  const clone = fs.mkdtempSync(path.join(os.tmpdir(), "skincos-bounded-clone-"));
+  execFileSync("git", ["clone", "-q", "--depth=2", "--branch", "main", `file://${remote}`, clone], {
+    env: isolatedGitEnvironment,
+  });
+  return { cwd: clone, base: source.base, head: source.head, source: source.cwd };
+}
+
+function run(fixtureData, ...args) {
+  return execFileSync(process.execPath, [script, ...args], {
+    cwd: fixtureData.cwd,
+    env: isolatedGitEnvironment,
+    encoding: "utf8",
+  });
+}
+
+test("resolves explicit immutable base and head", () => {
+  const data = fixture();
+  const output = run(data, "--base", data.base, "--head", data.head);
+  assert.match(output, new RegExp(`base=${data.base}`));
+  assert.match(output, new RegExp(`head=${data.head}`));
+  assert.match(output, /used_fallback=false/);
+});
+
+test("fetches a missing base from origin in a shallow checkout", () => {
+  const data = shallowRemoteFixture();
+  const output = run(data, "--base", data.base, "--head", data.head);
+  assert.match(output, new RegExp(`base=${data.base}`));
+  assert.match(output, /used_fallback=false/);
+});
+
+test("accepts a synchronized force-pushed head by immutable SHA", () => {
+  const data = shallowRemoteFixture();
+  fs.writeFileSync(path.join(data.source, "file.txt"), "force-pushed-head\n");
+  git(data.source, "commit", "-qam", "force-pushed head");
+  git(data.source, "push", "-q", "origin", "main", "--force");
+  const forcePushedHead = git(data.source, "rev-parse", "HEAD");
+  const output = run(data, "--base", data.base, "--head", forcePushedHead);
+  assert.match(output, new RegExp(`head=${forcePushedHead}`));
+});
+
+test("falls back to the checked-out parent for missing or invalid base", () => {
+  const data = fixture();
+  const output = run(data, "--base", "not-a-sha", "--head", data.head);
+  assert.match(output, new RegExp(`base=${data.base}`));
+  assert.match(output, /used_fallback=true/);
+});
+
+test("rejects an invalid head instead of widening history", () => {
+  const data = fixture();
+  assert.throws(() => run(data, "--base", data.base, "--head", "bad-head"), /head is not a full immutable commit SHA/);
+});
+
+test("includes deleted and both sides of a rename in the bounded file list", () => {
+  const data = fixture();
+  fs.rmSync(path.join(data.cwd, "file.txt"));
+  fs.writeFileSync(path.join(data.cwd, "renamed.txt"), "head\n");
+  git(data.cwd, "add", "-A");
+  git(data.cwd, "commit", "-qm", "rename and delete");
+  const head = git(data.cwd, "rev-parse", "HEAD");
+  const filesPath = path.join(data.cwd, "files.txt");
+  run(data, "--base", data.base, "--head", head, "--files-output", filesPath);
+  const files = fs.readFileSync(filesPath, "utf8").trim().split(/\r?\n/);
+  assert.ok(files.includes("file.txt"));
+  assert.ok(files.includes("renamed.txt"));
+});
+
+test("prevents routine workflows from regressing to full-history checkout", () => {
+  const routineWorkflows = [
+    ".github/workflows/ci-smoke.yml",
+    ".github/workflows/lint-format-static.yml",
+    ".github/workflows/test-coverage-quality.yml",
+  ];
+  for (const workflow of routineWorkflows) {
+    const source = fs.readFileSync(path.join(root, workflow), "utf8");
+    assert.doesNotMatch(source, /fetch-depth:\s*0/);
+    assert.match(source, /scripts\/codex-bounded-diff\.mjs/);
+  }
+  const autonomy = fs.readFileSync(path.join(root, ".github/workflows/codex-autonomy-gate.yml"), "utf8");
+  assert.doesNotMatch(autonomy, /fetch-depth:\s*0/);
+  assert.match(autonomy, /resolve-codex-autonomy-base\.mjs/);
+});


### PR DESCRIPTION
# Summary

Implements #1531 by replacing routine `fetch-depth: 0` checkouts in CI smoke, lint/static, coverage, and the autonomy gate with shallow checkouts. Routine classifiers now resolve an explicit immutable base/head pair through one bounded-diff helper, fetching only the required commit objects and failing closed when the head is invalid. The autonomy gate keeps its existing mainline resolver for force-push/manual recovery semantics.

## Type of change
- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [x] Performance
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] Conventional Commits applied
- [x] Tests added/updated and passing
- [ ] Docs updated (README, API refs, diagrams)
- [ ] Security review (CodeQL, gitleaks)
- [ ] Performance impact measured

## Links
- Issue: #1531
- Design/ADR: Follow-up in #1532/#1535 coordination
- Migration steps: None; workflows consume the helper on the same SHA.

## Screenshots / Evidence
- `node --test scripts/tests/codex-bounded-diff.test.mjs`: 7/7 passing
- `node --test .github/scripts/codex-autonomy-gate-workflow.test.mjs`: 5/5 passing
- `git diff --check`: passing on the focused workflow/test scope
- Fixture tests cover missing base fetch, force-pushed head, invalid head rejection, deletion, and rename path coverage.
