### PR TITLE
fix(meta-ads): classify seed resource write failures

### DIFF
--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -248,6 +248,13 @@ const STAGING_SYNTHETIC_SEED_ATTESTATION_FAILURES = Object.freeze({
   datasetAmbiguous: 'meta_ads_publish_staging_seed_graph_dataset_ambiguous',
   landingOrMediaUnavailable: 'meta_ads_publish_staging_seed_landing_or_media_unavailable',
 });
+const STAGING_SYNTHETIC_SEED_GRAPH_CREATE_STAGES = Object.freeze({
+  campaign: 'campaign',
+  source_adset: 'source_adset',
+  target_adset: 'target_adset',
+  source_creative: 'source_creative',
+  source_ad: 'source_ad',
+});
 const STAGING_SYNTHETIC_SEED_ADSET_FIELDS = [
   'id',
   'name',
@@ -1784,6 +1791,17 @@ function stagingSyntheticSeedFailureResponse(error, requestId) {
     'meta_ads_publish_staging_seed_graph_campaign_name_mismatch',
     'meta_ads_publish_staging_seed_graph_campaign_status_mismatch',
     'meta_ads_publish_staging_seed_graph_campaign_objective_mismatch',
+    'meta_ads_publish_staging_seed_graph_campaign_create_access_denied',
+    'meta_ads_publish_staging_seed_graph_campaign_create_contract_invalid',
+    'meta_ads_publish_staging_seed_graph_source_adset_create_access_denied',
+    'meta_ads_publish_staging_seed_graph_source_adset_create_contract_invalid',
+    'meta_ads_publish_staging_seed_graph_target_adset_create_access_denied',
+    'meta_ads_publish_staging_seed_graph_target_adset_create_contract_invalid',
+    'meta_ads_publish_staging_seed_graph_source_creative_create_access_denied',
+    'meta_ads_publish_staging_seed_graph_source_creative_create_contract_invalid',
+    'meta_ads_publish_staging_seed_graph_source_ad_create_access_denied',
+    'meta_ads_publish_staging_seed_graph_source_ad_create_contract_invalid',
+    'meta_ads_publish_staging_seed_graph_resource_contract_invalid',
     'meta_ads_publish_staging_seed_graph_contract_invalid',
     'meta_ads_publish_staging_seed_failed',
   ]);
@@ -2779,7 +2797,10 @@ async function createStagingSyntheticSeedGraphResource({ key, name, operation, s
     }
     state.resources[key].pending = false;
     await persistStagingSyntheticSeedState({ env: context.env, operation, state, status: 'creating', encryptToken, context });
-    throw error;
+    throw stagingSyntheticSeedFailure(
+      stagingSyntheticSeedGraphCreateFailureCode(key, normalized),
+      409,
+    );
   }
   const id = normalizeStagingSyntheticSeedCreatedId(created, key);
   state.resources[key] = { id, name, pending: false, owned_by_operation: true };
@@ -2789,6 +2810,13 @@ async function createStagingSyntheticSeedGraphResource({ key, name, operation, s
   await persistStagingSyntheticSeedState({ env: context.env, operation, state, status: 'creating', encryptToken, context });
   const value = await read(id);
   return { id, value };
+}
+
+function stagingSyntheticSeedGraphCreateFailureCode(key, normalized) {
+  const stage = STAGING_SYNTHETIC_SEED_GRAPH_CREATE_STAGES[key];
+  if (!stage) return 'meta_ads_publish_staging_seed_graph_resource_contract_invalid';
+  const suffix = normalized?.classification === 'auth' ? 'access_denied' : 'contract_invalid';
+  return `meta_ads_publish_staging_seed_graph_${stage}_create_${suffix}`;
 }
 
 async function seedGraphCreate(auth, path, body, context) {

--- a/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
@@ -315,10 +315,11 @@ class SeedDb {
 }
 
 class FakeGraph {
-  constructor({ ambiguousCreatePath = '', readFailures = {}, readResponses = {} } = {}) {
+  constructor({ ambiguousCreatePath = '', readFailures = {}, readResponses = {}, writeFailures = {} } = {}) {
     this.ambiguousCreatePath = ambiguousCreatePath;
     this.readFailures = new Map(Object.entries(readFailures));
     this.readResponses = new Map(Object.entries(readResponses));
+    this.writeFailures = new Map(Object.entries(writeFailures));
     this.calls = [];
     this.postCalls = [];
     this.resources = new Map();
@@ -350,6 +351,13 @@ class FakeGraph {
 
     this.postCalls.push(path);
     const body = JSON.parse(init.body || '{}');
+    const writeFailure = this.writeFailures.get(path);
+    if (writeFailure) {
+      return graphResponse(
+        { error: { message: 'synthetic write rejected', code: writeFailure.code || 100 } },
+        writeFailure.status ?? 400,
+      );
+    }
     if (this.resources.has(path) && body.status === 'ARCHIVED') {
       const resource = this.resources.get(path);
       resource.body = { ...resource.body, status: 'ARCHIVED' };
@@ -1814,6 +1822,39 @@ test('an ambiguous synthetic POST is never retried and leaves the operation fail
   assert.equal(db.operations.get(operationKey).status, 'reconciliation_required');
   assert.equal(JSON.stringify(body).includes(SOURCE_ACCESS_TOKEN), false);
   assert.equal(JSON.stringify(body).includes(ACCOUNT_ID), false);
+});
+
+test('staging seed classifies permanent Graph resource writes by fixed stage without exposing the Graph error', async () => {
+  const cases = [
+    {
+      name: 'contract',
+      failure: { status: 400, code: 100 },
+      error: 'meta_ads_publish_staging_seed_graph_source_adset_create_contract_invalid',
+    },
+    {
+      name: 'auth',
+      failure: { status: 403, code: 10 },
+      error: 'meta_ads_publish_staging_seed_graph_source_adset_create_access_denied',
+    },
+  ];
+
+  for (const scenario of cases) {
+    const db = new SeedDb();
+    const graph = new FakeGraph({
+      writeFailures: { [`act_${ACCOUNT_ID}/adsets`]: scenario.failure },
+    });
+    const operationKey = `meta-ads-staging-seed:resource-write-${scenario.name}-001`;
+    const response = await seed({ db, graph, operationKey });
+    const body = await response.json();
+
+    assert.equal(response.status, 409, scenario.name);
+    assert.equal(body.error, scenario.error, scenario.name);
+    assert.equal(db.tokens.length, 0, scenario.name);
+    assert.equal(db.operations.get(operationKey).status, 'rolled_back', scenario.name);
+    assert.equal(JSON.stringify(body).includes(SOURCE_ACCESS_TOKEN), false, scenario.name);
+    assert.equal(JSON.stringify(body).includes(ACCOUNT_ID), false, scenario.name);
+    assert.equal(JSON.stringify(body).includes('synthetic write rejected'), false, scenario.name);
+  }
 });
 
 test('candidate reconciliation resolves one exact pending ad set and archives only the owned lineage', async () => {


### PR DESCRIPTION
## Summary
- classify permanent staging synthetic-seed Graph resource-write failures by the fixed resource stage
- distinguish sanitized access-denied versus contract-invalid outcomes without returning Graph bodies, IDs, or bearer material
- preserve ambiguous-write reconciliation and existing cleanup behavior

## Type
Bug fix / diagnostic hardening for Meta Ads staging synthetic seed.

## Scope and risk
- Token Vault staging seed only; no Ponto or CRM changes.
- No new route, migration, traffic activation, production change, or Orb action.
- Ambiguous or retryable Graph writes remain reconciliation-required; only permanent failures receive a fixed stage/class code.

## Validation
- Token Vault suite: 189/189
- focused staging synthetic-seed suite: 34/34
- architecture validation and diff check
- Codex Security diff scan: no findings

## Migration
None.

## Rollback
Revert this commit; the prior generic sanitized failure remains fail-closed.