### PR TITLE
fix(meta-ads): align website staging ad set contract

### DIFF
--- a/platform/security/token-vault/README.md
+++ b/platform/security/token-vault/README.md
@@ -134,8 +134,10 @@ em fail-closed (`reconciliation_required`).
 
 `POST .../config/staging-exercise` funciona exclusivamente no Worker staging.
 Ele seleciona uma única fixture sintética autorizada, prova a reconciliação
-GET-POST-GET do evento Website/dataset offline e restaura o snapshot antes de
-retornar `reconciled_and_rolled_back`.
+GET-POST-GET do evento Website e restaura o snapshot antes de retornar
+`reconciled_and_rolled_back`. Um perfil explicitamente offline pode exigir
+também `offline_conversion_data_set_id`; isso não é inferido nem acrescentado
+ao fixture Website.
 
 Quando a autoridade legada de staging está vazia, o caminho canônico não
 adivinha nem importa configuração de produção. Antes de derivar o plano, o
@@ -157,10 +159,13 @@ unidade, prova pela relação limitada de Páginas atribuídas ao System User um
 única associação elegível e confirma o mesmo par Página+Instagram por leitura
 direta. Os pares devem ser distintos. Os seletores não são bindings do Worker
 e não entram no `--secrets-file`, artefato, log ou output do workflow. O Vault
-exige então uma conta/pixel, os dois pares Página+Instagram provados e, no
-contrato de convergência atual, usa a identidade do Pixel já provado como
-`offline_conversion_data_set_id`; não enumera edges legados ou o edge Business
-de AdsDataset para inferir outro identificador. Cria somente recursos `PAUSED`
+exige então uma conta/pixel e os dois pares Página+Instagram provados. No
+contrato de convergência atual, a identidade do Pixel já provado é retida como
+fato privado do Dataset convergente, mas o `promoted_object` do fixture Website
+envia somente `pixel_id` e `custom_event_type`; o campo
+`offline_conversion_data_set_id` só é emitido quando o perfil é explicitamente
+offline. O fluxo não enumera edges legados ou o edge Business de AdsDataset
+para inferir outro identificador. Cria somente recursos `PAUSED`
 nomeados para staging e
 sela duas credenciais internas cifradas. Não seleciona campanhas, conjuntos ou
 anúncios comerciais, nem torna o token Meta um binding do Worker.

--- a/platform/security/token-vault/src/meta-ads-publish.js
+++ b/platform/security/token-vault/src/meta-ads-publish.js
@@ -2675,7 +2675,6 @@ async function createStagingSyntheticSeedResources({ input, auth, facts, operati
       promoted_object: {
         pixel_id: input.pixelId,
         custom_event_type: 'LEAD',
-        offline_conversion_data_set_id: facts.dataset_id,
       },
     }, context),
     read: (id) => readStagingSyntheticSeedAdset(auth, id, campaign.id, `${marker} Source Ad Set`, context),
@@ -2930,14 +2929,13 @@ function assertStagingSyntheticSeedAdsetContract({ input, source, target }) {
     const sourcePromoted = asObject(source.promoted_object);
     if (
       normalizeNumericId(sourcePromoted.pixel_id, 'staging_seed_source_pixel_id') !== input.pixelId ||
-      !safeTrackingEnum(sourcePromoted.custom_event_type) ||
-      !normalizeNumericId(sourcePromoted.offline_conversion_data_set_id, 'staging_seed_source_dataset_id')
+      !safeTrackingEnum(sourcePromoted.custom_event_type)
     ) {
       throw new Error('source_tracking_missing');
     }
     assertWebsiteTrackingCompatibility(source, target, {
       website_event_requirement: 'required',
-      offline_event_dataset_requirement: 'required',
+      offline_event_dataset_requirement: 'not_required',
     });
   } catch {
     throw stagingSyntheticSeedFailure('meta_ads_publish_staging_seed_graph_contract_invalid', 409);
@@ -3521,6 +3519,13 @@ async function deriveWebsiteBootstrapEntry({
   staging,
 }) {
   const targetConfig = asObject(targetAuth.config);
+  if (
+    staging &&
+    clean(targetConfig.source_adset_id) &&
+    clean(targetConfig.source_adset_id) === clean(targetConfig.adset_id)
+  ) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_derive_staging_source_row_excluded', 409);
+  }
   // A target-declared tag fragment is an authority fact, not a candidate
   // preference. Validate it before examining any potential source so a bad
   // target value can never make another source look acceptable by fallback.
@@ -3535,6 +3540,12 @@ async function deriveWebsiteBootstrapEntry({
     staging,
     targetCanonicalUrlTags,
   });
+  if (
+    staging &&
+    clean(asObject(source.sourceAuth?.config).adset_id) === clean(asObject(targetAuth.config).adset_id)
+  ) {
+    throw bootstrapFailure('meta_ads_publish_bootstrap_derive_staging_source_row_excluded', 409);
+  }
   const entry = {
     config_token_id: targetAuth.tokenId,
     destination_type: 'website',
@@ -4523,14 +4534,15 @@ export async function exerciseStagingMetaAdsTrackingFixture({ request, env, requ
     };
     const ensured = await ensureAdsetConversionContract(stagingExerciseEnsureBody(fixture), ensureContext);
     snapshotId = clean(ensured?.snapshot_id);
+    const offlineEventDatasetRequired = fixture.offlineEventDatasetRequirement === 'required';
     if (
       ensured?.status !== 'reconciled' ||
       ensured?.graph_mutation !== 'promoted_object_updated' ||
       !snapshotId ||
       ensured?.website_event?.configured !== true ||
       ensured?.website_event?.required !== true ||
-      ensured?.offline_event_dataset?.configured !== true ||
-      ensured?.offline_event_dataset?.required !== true
+      ensured?.offline_event_dataset?.configured !== offlineEventDatasetRequired ||
+      ensured?.offline_event_dataset?.required !== offlineEventDatasetRequired
     ) {
       throw stagingExerciseFailure('staging_tracking_fixture_not_reconciled', 409);
     }
@@ -4624,8 +4636,7 @@ function resolveStagingTrackingFixture(rows) {
       normalizeDestinationKind(config.destination_type) !== 'website' ||
       contract.destination_kind !== 'website' ||
       contract.staging_synthetic_fixture !== true ||
-      contract.website_event_requirement !== 'required' ||
-      contract.offline_event_dataset_requirement !== 'required'
+      contract.website_event_requirement !== 'required'
     ) {
       continue;
     }
@@ -4639,6 +4650,7 @@ function resolveStagingTrackingFixture(rows) {
       apiVersion: normalizeApiVersion(config.api_version || 'v25.0'),
       adsetId: targetAdsetId,
       profileRef: contract.profile_ref,
+      offlineEventDatasetRequirement: contract.offline_event_dataset_requirement,
     });
   }
   if (candidates.length !== 1) {
@@ -5405,6 +5417,7 @@ async function resolveLegacyBootstrapSourceAuth(entry, targetAuth, context) {
   let sourceAdsetId = clean(entry.sourceAdsetId);
   let sourceAccountId = targetAuth.accountId;
   const sourceConfigTokenId = clean(entry.sourceConfigTokenId);
+  let sourceLineageMarker = '';
   if (sourceConfigTokenId) {
     if (!CONFIG_WRITER_TOKEN_ID_PATTERN.test(sourceConfigTokenId)) {
       throw bootstrapFailure('meta_ads_publish_bootstrap_source_invalid', 400);
@@ -5420,6 +5433,7 @@ async function resolveLegacyBootstrapSourceAuth(entry, targetAuth, context) {
     try {
       sourceAdsetId = normalizeNumericId(config.adset_id, 'bootstrap_source_adset_id');
       sourceAccountId = normalizeNumericId(config.account_id, 'bootstrap_source_account_id');
+      if (clean(config.source_adset_id) === sourceAdsetId) sourceLineageMarker = sourceAdsetId;
     } catch {
       throw bootstrapFailure('meta_ads_publish_bootstrap_legacy_config_invalid', 409);
     }
@@ -5432,6 +5446,7 @@ async function resolveLegacyBootstrapSourceAuth(entry, targetAuth, context) {
       ...asObject(targetAuth.config),
       adset_id: sourceAdsetId,
       account_id: sourceAccountId,
+      ...(sourceLineageMarker ? { source_adset_id: sourceLineageMarker } : {}),
     },
   };
 }
@@ -5450,6 +5465,7 @@ function buildBootstrapTrackingProfile({ sourceAuth, sourceAdset, targetAuth, ta
     source.optimization_goal,
   );
   const offlineRequired = Boolean(clean(asObject(source.promoted_object).offline_conversion_data_set_id));
+  const sourceIsSeedSource = clean(asObject(sourceAuth.config).source_adset_id) === clean(asObject(sourceAuth.config).adset_id);
   const profile = {
     profile_ref: bootstrapProfileRef(targetAuth.tokenId),
     source_adset_id: sourceAuth.config.adset_id,
@@ -5461,7 +5477,7 @@ function buildBootstrapTrackingProfile({ sourceAuth, sourceAdset, targetAuth, ta
     if (
       sourceAuth.config.adset_id === targetAuth.config.adset_id ||
       profile.website_event_requirement !== 'required' ||
-      profile.offline_event_dataset_requirement !== 'required'
+      (!offlineRequired && !sourceIsSeedSource)
     ) {
       throw bootstrapFailure('meta_ads_publish_bootstrap_staging_fixture_invalid', 409);
     }
@@ -8881,8 +8897,7 @@ function normalizeTrackingContract(value, profilesValue = {}, targetAdsetId = ''
   const stagingSyntheticFixture = profileConfigured &&
     profile.staging_synthetic_fixture === true &&
     sourceAdsetId !== clean(targetAdsetId) &&
-    websiteRequirement === 'required' &&
-    offlineRequirement === 'required';
+    websiteRequirement === 'required';
   const productionUrlTagsReadbackFixtureConfigured = profileConfigured &&
     hasValidProductionUrlTagsReadbackFixture(source.production_url_tags_readback_fixture);
   return {

--- a/platform/security/token-vault/tests/meta-ads-publish-bootstrap.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-bootstrap.test.js
@@ -567,6 +567,17 @@ function enableDerivedStagingLineage(graph) {
   graph.ads.set('723456791', ad('723456791', TARGET_ADSET_ID, '823456791', RAW_URL_TAGS));
 }
 
+function markSeededStagingLineage(db) {
+  const sourceRow = db.tokens.find((row) => row.id === 'facebook_a_source');
+  const targetRow = db.tokens.find((row) => row.id === 'facebook_b_target');
+  const sourceMetadata = JSON.parse(sourceRow.metadata_json);
+  const targetMetadata = JSON.parse(targetRow.metadata_json);
+  sourceMetadata.meta_ads_publish.source_adset_id = SOURCE_ADSET_ID;
+  targetMetadata.meta_ads_publish.source_config_token_id = 'facebook_a_source';
+  sourceRow.metadata_json = JSON.stringify(sourceMetadata);
+  targetRow.metadata_json = JSON.stringify(targetMetadata);
+}
+
 function json(body, status = 200) {
   return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
 }
@@ -703,6 +714,11 @@ test('autonomous bootstrap derivation keeps the manifest private and applies onl
   const db = new BootstrapDb();
   const graph = new BootstrapGraph();
   enableDerivedStagingLineage(graph);
+  // A modern converged Pixel/Dataset Website fixture must not require the
+  // offline promoted-object field. Keep the Dataset identity as a private
+  // discovery fact, but exercise the actual Website contract independently.
+  delete graph.adsets.get(SOURCE_ADSET_ID).promoted_object.offline_conversion_data_set_id;
+  markSeededStagingLineage(db);
   const state = new Map();
   const { env, decryptToken, encryptToken } = bootstrapContext({ db, graph, state });
   env.ENVIRONMENT = 'staging';
@@ -748,7 +764,9 @@ test('autonomous bootstrap derivation keeps the manifest private and applies onl
   assert.equal(appliedPayload.website_fixture_count, 2);
   const targetConfig = JSON.parse(db.tokens.find((row) => row.id === 'facebook_b_target').metadata_json).meta_ads_publish;
   assert.equal(targetConfig.tracking_contract.url_tags, RAW_URL_TAGS);
-  assert.equal(targetConfig.tracking_profiles[targetConfig.tracking_contract.profile_ref].staging_synthetic_fixture, true);
+  const targetProfile = targetConfig.tracking_profiles[targetConfig.tracking_contract.profile_ref];
+  assert.equal(targetProfile.staging_synthetic_fixture, true);
+  assert.equal(targetProfile.offline_event_dataset_requirement, 'not_required');
   assert.deepEqual(graph.adsets.get(TARGET_ADSET_ID).promoted_object, graph.targetBefore.promoted_object);
 
   const callsBeforeReplay = graph.calls.length;
@@ -775,6 +793,7 @@ test('autonomous bootstrap derivation rejects digest, authority and source ambig
   const db = new BootstrapDb();
   const graph = new BootstrapGraph();
   enableDerivedStagingLineage(graph);
+  markSeededStagingLineage(db);
   const state = new Map();
   const { env, decryptToken, encryptToken } = bootstrapContext({ db, graph, state });
   env.ENVIRONMENT = 'staging';
@@ -809,6 +828,7 @@ test('autonomous bootstrap derivation rejects digest, authority and source ambig
   const contractDb = new BootstrapDb();
   const contractGraph = new BootstrapGraph();
   enableDerivedStagingLineage(contractGraph);
+  markSeededStagingLineage(contractDb);
   const contractState = new Map();
   const contract = bootstrapContext({ db: contractDb, graph: contractGraph, state: contractState });
   contract.env.ENVIRONMENT = 'staging';
@@ -862,6 +882,7 @@ test('autonomous bootstrap derivation rejects digest, authority and source ambig
   const revisionDb = new BootstrapDb();
   const revisionGraph = new BootstrapGraph();
   enableDerivedStagingLineage(revisionGraph);
+  markSeededStagingLineage(revisionDb);
   const revisionState = new Map();
   const revision = bootstrapContext({ db: revisionDb, graph: revisionGraph, state: revisionState });
   revision.env.ENVIRONMENT = 'staging';

--- a/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
+++ b/platform/security/token-vault/tests/meta-ads-publish-staging-synthetic-seed.test.js
@@ -1781,7 +1781,11 @@ test('staging seed seals a configured Page only after the System User assignment
   assert.equal(seededAdsets.length, 2);
   const sourceAdsets = seededAdsets.filter((resource) => resource.body?.promoted_object);
   assert.equal(sourceAdsets.length, 1);
-  assert.equal(sourceAdsets[0].body.promoted_object.offline_conversion_data_set_id, PIXEL_ID);
+  assert.deepEqual(sourceAdsets[0].body.promoted_object, {
+    pixel_id: PIXEL_ID,
+    custom_event_type: 'LEAD',
+  });
+  assert.equal(Object.hasOwn(sourceAdsets[0].body.promoted_object, 'offline_conversion_data_set_id'), false);
   assert.ok(graph.calls.every((call) => call.path !== 'me/accounts'));
   assert.equal(db.tokens.length, 2);
   assert.equal(db.operations.get(operationKey).status, 'sealed');


### PR DESCRIPTION
## Objetivo
Alinhar a criação da ad set sintética Website ao contrato Graph atual: `promoted_object` envia somente `pixel_id` + `custom_event_type`; o fato privado do Dataset convergente continua preservado e o campo offline fica reservado a perfis explicitamente offline.

## Escopo
- Token Vault staging synthetic seed e bootstrap/fixture derivation.
- Testes de seed/bootstrap e documentação do contrato.
- Nenhuma alteração em Ponto, CRM, produção, Orb ou permissões Meta.

## Evidência e causa
A execução staging anterior passou Pixel, conta, Página/Instagram e campanha, mas a criação do ad set Website falhou com código sanitizado permanente de contrato. O payload combinava `pixel_id` e `offline_conversion_data_set_id`; a correção separa o perfil Website do perfil offline, mantendo o Dataset convergente apenas como fato interno.

## Migração/flags
- Migration: none.
- Feature flag/cohort: none; staging-only synthetic path.
- No production behavior change.

## Validação
- Token Vault: 189/189.
- Global coordination/governance: 203/203.
- Architecture/topology, single-writer and dependency-closure validators: passed.
- Security diff scan: 0 findings (scan f1e10b09-b129-4654-91a3-8276c4c199bf).

## Rollback
Revert this commit through the canonical PR/merge-authority flow. The existing staging compensation/rollback remains unchanged; no staging run is dispatched by this PR.