### PR TITLE
perf(ci): add shadow merge freshness admission

### DIFF
--- a/.github/workflows/codex-merge-freshness-shadow.yml
+++ b/.github/workflows/codex-merge-freshness-shadow.yml
@@ -1,0 +1,81 @@
+name: Codex merge freshness shadow
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      previous_main_sha:
+        description: Previously validated main SHA
+        required: true
+        type: string
+      current_main_sha:
+        description: Current main SHA
+        required: true
+        type: string
+
+concurrency:
+  group: codex-merge-freshness-shadow
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  shadow:
+    name: Shadow freshness admission (read-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22
+      - name: Collect open Codex PR heads (read-only)
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          PR_LIST_PATH: ${{ runner.temp }}/merge-freshness-prs.json
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "open",
+              base: "main",
+              per_page: 100,
+            });
+            const candidates = pulls
+              .filter((pr) => pr.head?.repo?.full_name === `${owner}/${repo}`)
+              .filter((pr) => String(pr.head?.ref || "").startsWith("codex/"))
+              .map((pr) => ({
+                number: pr.number,
+                title: pr.title,
+                baseSha: pr.base?.sha,
+                headSha: pr.head?.sha,
+              }));
+            require("fs").writeFileSync(process.env.PR_LIST_PATH, `${JSON.stringify(candidates)}\n`);
+            core.info(`Collected ${candidates.length} open Codex PR(s) for shadow analysis.`);
+      - name: Classify bounded main advance and PR closures
+        env:
+          PREVIOUS_MAIN_SHA: ${{ github.event_name == 'push' && github.event.before || inputs.previous_main_sha }}
+          CURRENT_MAIN_SHA: ${{ github.event_name == 'push' && github.sha || inputs.current_main_sha }}
+        run: |
+          set -euo pipefail
+          node scripts/codex-merge-freshness-shadow.mjs \
+            --previous-main "$PREVIOUS_MAIN_SHA" \
+            --current-main "$CURRENT_MAIN_SHA" \
+            --prs-file "$RUNNER_TEMP/merge-freshness-prs.json" \
+            --output merge-freshness-shadow.json
+          cat merge-freshness-shadow.json
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: merge-freshness-shadow-${{ github.run_id }}
+          path: merge-freshness-shadow.json
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -42,6 +42,31 @@ revalidação do lease. Não adicionar bypass humano para compensar a limitaçã
 Depois de provisionar a autoridade compatível, reaplicar o ruleset completo e
 confirmar o readback antes de remover este blocker.
 
+## Shadow de freshness e dependency closure
+
+O workflow `Codex merge freshness shadow` observa cada avanço de `main` e os PRs
+Codex abertos usando o classificador canônico de impacto. Ele produz um artefato
+com a closure da mudança de `main`, a closure de cada PR e uma decisão de
+`shadow-reuse-candidate` ou `revalidate-required`.
+
+Esse workflow é deliberadamente somente leitura: não atualiza branches, não
+publica status required, não altera rulesets e não faz merge. Mesmo quando duas
+closures são disjuntas, o campo `strict_up_to_date_still_required` permanece
+`true`; o resultado é evidência para uma futura fila nativa/actor compatível, não
+um bypass da regra atual.
+
+Quando a classificação falha, contém `unclassified`, shared contracts,
+dependências, produção ou segurança, o resultado é `revalidate-required`.
+Assim, a medição da reutilização potencial é fail-closed e não transforma uma
+alteração de alto risco em fast lane.
+
+No repositório pessoal atual, o ruleset não aceita a integração GitHub Actions
+como actor de bypass. Por isso não foi alterado `Require branches to be up to
+date`, `merge_group`, `global-merge-authority` ou qualquer check obrigatório.
+Após a migração para uma Organization/App compatível, a evidência desse shadow
+deve ser usada para avaliar merge queue nativa; até lá, a mutação continua
+serializada pela autoridade global.
+
 O endpoint REST de merge recebe um SHA condicional da HEAD da PR, mas não um
 compare-and-swap do SHA-base de `main`. A autoridade agora faz readback do
 commit squash, dos parents, da PR e da ponta de `main` depois da mutação; isso

--- a/scripts/codex-merge-freshness-shadow.mjs
+++ b/scripts/codex-merge-freshness-shadow.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+  buildClassificationFallback,
+  classifyFiles,
+  parseGitNameStatus,
+} from "./codex-autonomy-lib.mjs";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const FULL_SHA = /^[0-9a-f]{40}$/i;
+const DEPTH_STEPS = [32, 128, 512];
+const SENSITIVE_SURFACES = new Set(["unclassified", "codex-baseline", "github-governance"]);
+
+function argument(name, fallback = null) {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? fallback : process.argv[index + 1] ?? fallback;
+}
+
+function git(...args) {
+  return execFileSync("git", args, {
+    cwd: ROOT,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function commitExists(value) {
+  if (!FULL_SHA.test(value)) return false;
+  try {
+    git("cat-file", "-e", `${value}^{commit}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function fetchCommit(value, label) {
+  if (!FULL_SHA.test(value)) throw new Error(`${label} must be a full immutable commit SHA`);
+  if (commitExists(value)) return;
+  try {
+    git("fetch", "--no-tags", "--depth=2", "origin", value);
+  } catch {
+    throw new Error(`unable to fetch immutable ${label} ${value}`);
+  }
+  if (!commitExists(value)) throw new Error(`fetched ${label} is not available as a commit`);
+}
+
+function mergeBase(base, head) {
+  try {
+    return git("merge-base", base, head);
+  } catch {
+    return "";
+  }
+}
+
+function ensureBoundedRange(base, head) {
+  fetchCommit(base, "base");
+  fetchCommit(head, "head");
+  let resolved = mergeBase(base, head);
+  if (resolved) return resolved;
+
+  for (const depth of DEPTH_STEPS) {
+    for (const endpoint of [base, head]) {
+      try {
+        git("fetch", "--no-tags", `--depth=${depth}`, "origin", endpoint);
+      } catch {
+        // Keep trying bounded endpoint/depth combinations; exhaustion fails closed.
+      }
+    }
+    resolved = mergeBase(base, head);
+    if (resolved) return resolved;
+  }
+  throw new Error(`unable to resolve merge base for bounded range ${base}...${head}`);
+}
+
+function closureMaterial(report) {
+  return {
+    risk: report.risk,
+    surfaces: [...new Set(report.surfaces || [])].sort(),
+    languages: [...new Set(report.languages || [])].sort(),
+    dependencies_changed: report.dependencies_changed === true,
+    shared_contracts_changed: report.shared_contracts_changed === true,
+    production_sensitive: report.production_sensitive === true,
+    security_sensitive: report.security_sensitive === true,
+  };
+}
+
+export function dependencyClosureDigest(report) {
+  return crypto.createHash("sha256")
+    .update(JSON.stringify(closureMaterial(report)))
+    .digest("hex");
+}
+
+function hasSensitiveClosure(report) {
+  const surfaces = new Set(report.surfaces || []);
+  return report.risk === "high"
+    || report.risk === "critical"
+    || report.dependencies_changed === true
+    || report.shared_contracts_changed === true
+    || report.production_sensitive === true
+    || report.security_sensitive === true
+    || [...SENSITIVE_SURFACES].some((surface) => surfaces.has(surface));
+}
+
+export function buildShadowDecision({
+  previousMainSha,
+  currentMainSha,
+  pr,
+  mainReport,
+  prReport,
+}) {
+  const reasons = [];
+  const previous = String(previousMainSha || "").trim().toLowerCase();
+  const current = String(currentMainSha || "").trim().toLowerCase();
+  const base = String(pr?.baseSha || "").trim().toLowerCase();
+  const head = String(pr?.headSha || "").trim().toLowerCase();
+  const mainSurfaces = new Set(mainReport.surfaces || []);
+  const prSurfaces = new Set(prReport.surfaces || []);
+  const overlap = [...mainSurfaces].some((surface) => prSurfaces.has(surface));
+  let reusable = true;
+
+  if (!FULL_SHA.test(previous) || !FULL_SHA.test(current) || !FULL_SHA.test(head)) {
+    reusable = false;
+    reasons.push("immutable SHA input is missing or invalid");
+  }
+  if (current === previous) reasons.push("main did not advance");
+  if (base && base !== previous) {
+    reusable = false;
+    reasons.push("PR base is not the previously validated main SHA");
+  }
+  if (current !== previous && hasSensitiveClosure(mainReport)) {
+    reusable = false;
+    reasons.push("main advance has an elevated or shared dependency closure");
+  }
+  if (current !== previous && overlap) {
+    reusable = false;
+    reasons.push("main advance and PR share an affected surface");
+  }
+  if (hasSensitiveClosure(prReport)) {
+    reusable = false;
+    reasons.push("PR itself is elevated or shared; full revalidation remains required");
+  }
+  if (mainReport.classification_status !== "ok" || prReport.classification_status !== "ok") {
+    reusable = false;
+    reasons.push("classification is not sealed; fail closed");
+  }
+  if (!reasons.length) reasons.push("closures are disjoint and both classifications are sealed");
+
+  return {
+    pr_number: pr?.number ?? null,
+    head_sha: head || null,
+    previous_main_sha: previous || null,
+    current_main_sha: current || null,
+    base_sha: base || null,
+    admission: reusable ? "shadow-reuse-candidate" : "revalidate-required",
+    reusable_candidate: reusable,
+    strict_up_to_date_still_required: true,
+    mutates_repository: false,
+    main_closure_digest: dependencyClosureDigest(mainReport),
+    pr_closure_digest: dependencyClosureDigest(prReport),
+    reasons,
+  };
+}
+
+function classifyRange(policy, base, head) {
+  try {
+    ensureBoundedRange(base, head);
+    const entries = parseGitNameStatus(git("diff", "--name-status", "-z", `${base}...${head}`));
+    return classifyFiles(policy, entries);
+  } catch (error) {
+    return buildClassificationFallback({
+      policy,
+      reason: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function readPrs(file) {
+  const value = JSON.parse(fs.readFileSync(path.resolve(ROOT, file), "utf8"));
+  if (!Array.isArray(value)) throw new Error("PR input must be an array");
+  return value;
+}
+
+function main() {
+  const previousMainSha = argument("--previous-main");
+  const currentMainSha = argument("--current-main");
+  const prsFile = argument("--prs-file");
+  const outputPath = argument("--output");
+  if (!FULL_SHA.test(String(previousMainSha)) || !FULL_SHA.test(String(currentMainSha))) {
+    throw new Error("previous and current main SHAs must be full immutable commits");
+  }
+  if (!prsFile) throw new Error("--prs-file is required");
+
+  const policyPath = argument("--policy", "ops/codex/risk-policy.json");
+  const policy = JSON.parse(fs.readFileSync(path.resolve(ROOT, policyPath), "utf8"));
+  const mainReport = classifyRange(policy, previousMainSha, currentMainSha);
+  const results = [];
+  for (const pr of readPrs(prsFile)) {
+    const headSha = String(pr.headSha || "").trim().toLowerCase();
+    const baseSha = FULL_SHA.test(String(pr.baseSha || "")) ? String(pr.baseSha).trim().toLowerCase() : previousMainSha;
+    const prReport = classifyRange(policy, baseSha, headSha);
+    results.push({
+      ...buildShadowDecision({ previousMainSha, currentMainSha, pr, mainReport, prReport }),
+      main_report: closureMaterial(mainReport),
+      pr_report: closureMaterial(prReport),
+    });
+  }
+
+  const result = {
+    schemaVersion: 1,
+    mode: "shadow-only",
+    generated_at: new Date().toISOString(),
+    previous_main_sha: previousMainSha,
+    current_main_sha: currentMainSha,
+    main_report: closureMaterial(mainReport),
+    main_classification_status: mainReport.classification_status,
+    strict_up_to_date_policy: "unchanged",
+    required_checks_policy: "unchanged",
+    mutation_policy: "read-only; no branch, merge, ruleset, or required-check mutation",
+    results,
+  };
+  const serialized = `${JSON.stringify(result, null, 2)}\n`;
+  if (outputPath) fs.writeFileSync(path.resolve(ROOT, outputPath), serialized);
+  else process.stdout.write(serialized);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 2;
+  }
+}

--- a/scripts/tests/codex-merge-freshness-shadow.test.mjs
+++ b/scripts/tests/codex-merge-freshness-shadow.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildShadowDecision,
+  dependencyClosureDigest,
+} from "../codex-merge-freshness-shadow.mjs";
+
+const sha = (letter) => letter.repeat(40);
+
+function report(overrides = {}) {
+  return {
+    risk: "low",
+    surfaces: ["crm"],
+    languages: ["javascript"],
+    dependencies_changed: false,
+    shared_contracts_changed: false,
+    production_sensitive: false,
+    security_sensitive: false,
+    classification_status: "ok",
+    ...overrides,
+  };
+}
+
+test("closure digest is canonical across field ordering", () => {
+  const left = report({ surfaces: ["crm", "website"], languages: ["typescript", "javascript"] });
+  const right = report({ surfaces: ["website", "crm"], languages: ["javascript", "typescript"] });
+  assert.equal(dependencyClosureDigest(left), dependencyClosureDigest(right));
+});
+
+test("disjoint low-risk closures produce a read-only reuse candidate", () => {
+  const decision = buildShadowDecision({
+    previousMainSha: sha("a"),
+    currentMainSha: sha("b"),
+    pr: { number: 42, baseSha: sha("a"), headSha: sha("c") },
+    mainReport: report({ surfaces: ["website"] }),
+    prReport: report({ surfaces: ["crm"] }),
+  });
+  assert.equal(decision.admission, "shadow-reuse-candidate");
+  assert.equal(decision.reusable_candidate, true);
+  assert.equal(decision.strict_up_to_date_still_required, true);
+  assert.equal(decision.mutates_repository, false);
+});
+
+test("shared, elevated, or overlapping closures require revalidation", () => {
+  for (const mainReport of [
+    report({ surfaces: ["crm"] }),
+    report({ risk: "high", surfaces: ["website"] }),
+    report({ shared_contracts_changed: true, surfaces: ["website"] }),
+  ]) {
+    const decision = buildShadowDecision({
+      previousMainSha: sha("a"),
+      currentMainSha: sha("b"),
+      pr: { number: 42, baseSha: sha("a"), headSha: sha("c") },
+      mainReport,
+      prReport: report({ surfaces: ["crm"] }),
+    });
+    assert.equal(decision.admission, "revalidate-required");
+    assert.equal(decision.reusable_candidate, false);
+  }
+});
+
+test("base drift and unsealed fallback remain fail-closed", () => {
+  const decision = buildShadowDecision({
+    previousMainSha: sha("a"),
+    currentMainSha: sha("b"),
+    pr: { number: 42, baseSha: sha("d"), headSha: sha("c") },
+    mainReport: report({ surfaces: ["website"] }),
+    prReport: report({ classification_status: "failed", surfaces: ["unclassified"] }),
+  });
+  assert.equal(decision.admission, "revalidate-required");
+  assert.match(decision.reasons.join("; "), /base|classification|elevated|shared/i);
+});


### PR DESCRIPTION
## Summary

Implements the safe shadow/prototype portion of #1533.

On each main push or manual dispatch, the read-only workflow evaluates the canonical risk classifier for the bounded main advance and open Codex PR closures. It emits a digest and classifies each PR as:

- `shadow-reuse-candidate` when low-risk closures are disjoint and sealed;
- `revalidate-required` for overlap, shared/dependency/production/security impact, base drift, or any classifier failure.

## Safety

- no branch updates;
- no merge mutation;
- no required status publication;
- no ruleset or branch-protection changes;
- strict up-to-date remains required;
- all classifier/fetch failures fail closed.

This deliberately leaves native merge queue/merge-group adoption for a compatible Organization/App ruleset. The current personal-repository limitation is documented in `docs/branch-protection.md`.

## Validation

- shadow closure tests: 4/4
- YAML parse: passing
- `git diff --check`: passing

Issue: #1533