### PR TITLE
fix(meta-ads): redact delivery diagnostic account id

### DIFF
--- a/.github/workflows/diagnose-meta-ads-source-adset-delivery.yml
+++ b/.github/workflows/diagnose-meta-ads-source-adset-delivery.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -22,11 +23,12 @@ jobs:
         env:
           META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
           META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
-          META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
           META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
+          export META_ADS_ACCOUNT_ID="$(gh api "repos/${GITHUB_REPOSITORY}/actions/variables/META_ADS_ACCOUNT_ID" --jq '.value')"
           node --input-type=module <<'NODE'
           const token = String(process.env.META_ADS_ACCESS_TOKEN || '');
           const pixelId = String(process.env.META_PIXEL_ID || '').trim();

--- a/platform/security/token-vault/tests/meta-ads-source-adset-delivery-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-adset-delivery-workflow.test.js
@@ -120,10 +120,13 @@ test("source ad-set delivery diagnostic is manual, staging-read-only, and no-mut
   assert.match(workflow, /^\s+workflow_dispatch:\s*$/m);
   assert.match(workflow, /if: github\.ref == 'refs\/heads\/main'/);
   assert.match(workflow, /environment: staging/);
+  assert.match(workflow, /actions: read/);
+  assert.match(workflow, /GH_TOKEN/);
   assert.match(workflow, /META_ADS_ACCESS_TOKEN: \$\{\{ secrets\.META_ADS_ACCESS_TOKEN \}\}/);
   assert.match(workflow, /META_PIXEL_ID: \$\{\{ secrets\.META_PIXEL_ID \}\}/);
-  assert.match(workflow, /META_ADS_ACCOUNT_ID: \$\{\{ vars\.META_ADS_ACCOUNT_ID \}\}/);
   assert.match(workflow, /META_ADS_API_VERSION: \$\{\{ vars\.META_ADS_API_VERSION \}\}/);
+  assert.match(workflow, /actions\/variables\/META_ADS_ACCOUNT_ID/);
+  assert.doesNotMatch(workflow, /META_ADS_ACCOUNT_ID:\s*\$\{\{\s*vars\.META_ADS_ACCOUNT_ID/);
   assert.match(workflow, /delivery_estimate/);
   assert.match(workflow, /optimization_goal/);
   assert.match(workflow, /promoted_object/);


### PR DESCRIPTION
## Summary
- Prevent the read-only delivery-estimate diagnostic from exposing the staging ad-account identifier in the Actions automatic env block.
- Resolve the repository variable in memory through the read-only GitHub Actions variables API; keep Graph probing GET-only and staging-scoped.
- Keep the fixed sanitized result codes and regression coverage.

## Operational change contract
- Surface: Meta Ads / Token Vault diagnostic workflow and its focused test only.
- Runtime effect: no Meta mutation, no Cloudflare/D1/Orb/traffic operation, no artifact or output containing source inputs.
- Feature flag: n/a (manual workflow_dispatch, main-only, staging environment).
- Migration: n/a.
- Rollback: revert this commit/PR; the prior diagnostic remains read-only but must not be reused if log redaction is required.
- Security: account variable is no longer in the step env map; only fixed status codes are emitted.

## Validation
- Token Vault suite: 193/193.
- Focused delivery diagnostic: 4/4.
- Deploy topology, Cloudflare single-writer, and dependency-closure validators: passed.