### PR TITLE
fix(meta-ads): use masked account secret for diagnostic

### DIFF
--- a/.github/workflows/diagnose-meta-ads-source-adset-delivery.yml
+++ b/.github/workflows/diagnose-meta-ads-source-adset-delivery.yml
@@ -22,12 +22,11 @@ jobs:
         env:
           META_ADS_ACCESS_TOKEN: ${{ secrets.META_ADS_ACCESS_TOKEN }}
           META_PIXEL_ID: ${{ secrets.META_PIXEL_ID }}
-          META_ADS_ACCOUNT_ID: ${{ vars.META_ADS_ACCOUNT_ID }}
+          META_ADS_ACCOUNT_ID: ${{ secrets.META_ADS_ACCOUNT_ID }}
           META_ADS_API_VERSION: ${{ vars.META_ADS_API_VERSION }}
         shell: bash
         run: |
           set -euo pipefail
-          echo "::add-mask::$META_ADS_ACCOUNT_ID"
           node --input-type=module <<'NODE'
           const token = String(process.env.META_ADS_ACCESS_TOKEN || '');
           const pixelId = String(process.env.META_PIXEL_ID || '').trim();

--- a/platform/deploy/operational-units.json
+++ b/platform/deploy/operational-units.json
@@ -102,7 +102,7 @@
       "concurrencyPrefix": "deploy-token-vault-",
       "publishes": ["Worker:skincos-token-vault", "Worker:skincos-token-vault-staging"],
       "resources": ["Token Vault Worker", "skincos-token-vault D1", "skincos-token-vault-staging D1", "Token Vault route and auth bindings", "Governed Meta Ads staging synthetic source and appsecret-proof attestations, seed, bootstrap derivation, rollback journal and paused creative fixture"],
-      "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "TOKEN_VAULT_API_TOKEN", "TOKEN_VAULT_N8N_API_TOKEN", "TOKEN_VAULT_ANALYTICS_API_TOKEN", "TOKEN_VAULT_ENCRYPTION_KEY", "TOKEN_VAULT_META_ADS_CONFIG_TOKEN", "TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST", "META_ADS_ACCESS_TOKEN", "META_PIXEL_ID", "novohamburgo_page_id", "barrashopppingsul_page_id"],
+      "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "TOKEN_VAULT_API_TOKEN", "TOKEN_VAULT_N8N_API_TOKEN", "TOKEN_VAULT_ANALYTICS_API_TOKEN", "TOKEN_VAULT_ENCRYPTION_KEY", "TOKEN_VAULT_META_ADS_CONFIG_TOKEN", "TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST", "META_ADS_ACCESS_TOKEN", "META_ADS_ACCOUNT_ID", "META_PIXEL_ID", "novohamburgo_page_id", "barrashopppingsul_page_id"],
       "migrationPaths": ["platform/security/token-vault/migrations"],
       "environments": ["preview", "staging", "production"],
       "promotion": {

--- a/platform/security/token-vault/tests/meta-ads-source-adset-delivery-workflow.test.js
+++ b/platform/security/token-vault/tests/meta-ads-source-adset-delivery-workflow.test.js
@@ -122,9 +122,9 @@ test("source ad-set delivery diagnostic is manual, staging-read-only, and no-mut
   assert.match(workflow, /environment: staging/);
   assert.match(workflow, /META_ADS_ACCESS_TOKEN: \$\{\{ secrets\.META_ADS_ACCESS_TOKEN \}\}/);
   assert.match(workflow, /META_PIXEL_ID: \$\{\{ secrets\.META_PIXEL_ID \}\}/);
-  assert.match(workflow, /META_ADS_ACCOUNT_ID: \$\{\{ vars\.META_ADS_ACCOUNT_ID \}\}/);
+  assert.match(workflow, /META_ADS_ACCOUNT_ID: \$\{\{ secrets\.META_ADS_ACCOUNT_ID \}\}/);
   assert.match(workflow, /META_ADS_API_VERSION: \$\{\{ vars\.META_ADS_API_VERSION \}\}/);
-  assert.match(workflow, /add-mask::\$META_ADS_ACCOUNT_ID/);
+  assert.doesNotMatch(workflow, /META_ADS_ACCOUNT_ID: \$\{\{ vars\.META_ADS_ACCOUNT_ID \}\}/);
   assert.match(workflow, /delivery_estimate/);
   assert.match(workflow, /optimization_goal/);
   assert.match(workflow, /promoted_object/);

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -83,6 +83,7 @@ test("Token Vault has one immutable Worker and D1 publisher with explicit tracki
   assert.ok(tokenVaultUnit.secrets.includes("TOKEN_VAULT_META_ADS_CONFIG_TOKEN"));
   assert.ok(tokenVaultUnit.secrets.includes("TOKEN_VAULT_META_ADS_BOOTSTRAP_MANIFEST"));
   assert.ok(tokenVaultUnit.secrets.includes("META_ADS_ACCESS_TOKEN"));
+  assert.ok(tokenVaultUnit.secrets.includes("META_ADS_ACCOUNT_ID"));
   assert.ok(tokenVaultUnit.secrets.includes("META_PIXEL_ID"));
   assert.ok(tokenVaultUnit.secrets.includes("novohamburgo_page_id"));
   assert.ok(tokenVaultUnit.secrets.includes("barrashopppingsul_page_id"));


### PR DESCRIPTION
## Summary
- Keep the delivery-estimate diagnostic account identifier in a masked staging Environment secret instead of an unmasked configuration variable.
- Register the secret in the Token Vault custody catalog and governance regression.
- Preserve the manual main-only GET probe and fixed redacted result codes.

## Operational change contract
- Surface: Meta Ads / Token Vault diagnostic workflow, custody catalog, and focused governance tests only.
- Runtime effect: one bounded Graph GET diagnostic; no Meta POST, D1 write, Cloudflare upload/deploy, Orb, traffic, artifact, or source-input output.
- Feature flag: n/a.
- Migration: n/a.
- Rollback: revert this PR and remove the staging shadow secret if the diagnostic is retired; the existing repository variable remains untouched for governed deploy workflows.
- Security: the diagnostic reads the account identifier through `secrets.META_ADS_ACCOUNT_ID`, so the Actions runner masks it automatically. The secret was provisioned from the existing custody variable via stdin without printing its value.

## Validation
- Focused delivery diagnostic: 4/4.
- Governance catalog/static test: 19/19.
- Deploy topology, Cloudflare single-writer, and dependency-closure validators: passed.