### PR TITLE
perf(ci): stop reconciling draft codex PRs

### DIFF
--- a/.github/workflows/codex-keep-prs-mergeable.yml
+++ b/.github/workflows/codex-keep-prs-mergeable.yml
@@ -44,6 +44,7 @@ jobs:
             const candidates = pulls.filter((pr) => {
               if (pr.head?.repo?.full_name !== `${owner}/${repo}`) return false;
               if (!String(pr.head?.ref || "").startsWith("codex/")) return false;
+              if (pr.draft !== false) return false;
               return String(pr.user?.login || "") === "jubenitogarcia";
             });
             let needsMaintenance = false;
@@ -217,7 +218,7 @@ jobs:
             async function dispatchMergeAuthorityIfEligible(pr) {
               const labels = new Set((pr.labels || []).map((label) => String(label?.name || '')));
               const authorityOnlyBlock = pr.mergeable_state === 'blocked' && await authoritySignalIsOnlyBlock(pr);
-              if (pr.draft === true || !['clean', 'blocked'].includes(String(pr.mergeable_state || '')) || (pr.mergeable_state === 'blocked' && !authorityOnlyBlock) || !labels.has(LABELS.enabled.name)) return;
+              if (pr.draft !== false || !['clean', 'blocked'].includes(String(pr.mergeable_state || '')) || (pr.mergeable_state === 'blocked' && !authorityOnlyBlock) || !labels.has(LABELS.enabled.name)) return;
               const activeStatuses = new Set(['queued', 'in_progress', 'waiting', 'requested']);
               let runs = [];
               try {
@@ -294,10 +295,11 @@ jobs:
               if (pr.head?.repo?.full_name !== `${owner}/${repo}`) return false;
               if (!String(pr.head?.ref || "").startsWith("codex/")) return false;
               if (String(pr.user?.login || "") !== "jubenitogarcia") return false;
+              if (pr.draft !== false) return false;
               return true;
             }).slice(0, 50);
 
-            core.info(`Found ${candidates.length} open codex PR(s) to evaluate.`);
+            core.info(`Found ${candidates.length} ready open codex PR(s) to evaluate.`);
 
             for (const pr of candidates) {
               const prNumber = pr.number;

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -84,3 +84,7 @@ for instalada e lida de volta.
   desativado e use somente `global-merge-authority.yml`; a manutenção de PR
   pode atualizar uma branch quando possui `merge:main`, mas não pode integrar
   a PR.
+- `codex-keep-prs-mergeable` admite somente PRs explicitamente prontas
+  (`draft: false`) para lease, `updateBranch` e dispatch da autoridade. Drafts
+  ou estado de prontidão desconhecido não consomem `merge:main` nem provocam
+  reexecução de checks; PRs prontas continuam sujeitas ao strict/up-to-date.

--- a/scripts/tests/codex-keep-prs-mergeable.test.mjs
+++ b/scripts/tests/codex-keep-prs-mergeable.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const root = path.resolve(import.meta.dirname, "../..");
+const workflow = fs.readFileSync(
+  path.join(root, ".github/workflows/codex-keep-prs-mergeable.yml"),
+  "utf8",
+);
+
+test("branch maintenance admits only explicitly ready PRs", () => {
+  assert.equal((workflow.match(/if \(pr\.draft !== false\) return false;/g) || []).length, 2);
+  assert.match(workflow, /Found \$\{candidates\.length\} ready open codex PR\(s\) to evaluate/);
+});
+
+test("authority dispatch remains ready-only and strict freshness remains enabled", () => {
+  assert.match(workflow, /if \(pr\.draft !== false \|\| !\['clean', 'blocked'\]/);
+  assert.match(workflow, /await github\.rest\.pulls\.updateBranch\(\{/);
+  assert.match(workflow, /expected_head_sha: headSha \|\| undefined/);
+});
+
+test("the scheduler and required-check contract remain unchanged", () => {
+  assert.match(workflow, /cron: "\*\/10 \* \* \* \*"/);
+  assert.match(workflow, /workflow_dispatch: \{\}/);
+  assert.doesNotMatch(workflow, /merge_group/);
+  assert.doesNotMatch(workflow, /required_status_checks|branch_protection|ruleset/);
+});


### PR DESCRIPTION
## Summary

- stop `codex-keep-prs-mergeable` from reconciling draft or readiness-unknown Codex PRs;
- preserve strict freshness, required checks, merge authority, ruleset, and concurrency for explicitly ready PRs;
- add focused contract coverage and document the boundary.

Related: #1533

## Validation

- `node scripts/tests/codex-keep-prs-mergeable.test.mjs` (3/3)
- worker focal suite: 26/26
- `git diff --check`
- no production, secret, branch-protection, ruleset, or merge-authority mutation.

## Risk

This removes artificial updateBranch/lease/reconciliation from drafts and unknown readiness states only. A ready PR remains subject to strict up-to-date checks and exact-head merge authority.