### PR TITLE
feat(beauty-movement): compact Velocity invite import

### DIFF
--- a/website/docs/beauty-movement-operations.md
+++ b/website/docs/beauty-movement-operations.md
@@ -10,9 +10,12 @@ gates abaixo estejam concluídos.
   `C:\CodexRuntime\operator\admin\skincos\beauty-movement\` (ou equivalente
   privado no ambiente de release). Não copie CSV, URLs de entrega, CPF, histórico
   ou relatórios para este repositório.
-- O importador aceita exclusivamente a lista sanitizada documentada no próprio
-  comando. CPF, procedimentos, histórico clínico e colunas não reconhecidas são
-  rejeitados antes de qualquer escrita.
+- Para a lista de aula-cortesia Velocity, o importador aceita o formato mínimo
+  `NOME,TELEFONE`; `EMAIL` e `PRÊMIO` são opcionais (`PRÊMIO`, quando presente,
+  deve ser `Velocity`). Ele deriva os campos técnicos do convite a partir da
+  campanha aprovada; não é necessário pré-preencher identificador, paleta,
+  expiração ou status. CPF, procedimentos, histórico clínico e colunas não
+  reconhecidas são rejeitados antes de qualquer escrita.
 - A paleta apenas escolhe o deck editorial; ela não escolhe nem pré-reserva a
   oferta. Nenhum dado pessoal, procedimento ou histórico clínico é enviado ao
   D1 ou ao navegador para decidir o resultado.
@@ -131,9 +134,12 @@ repita a carga sem inspecionar o resumo privado.
       comerciais aprovados para a planilha sanitizada.
 - [ ] Catálogo privado de recompensas aprovado por família, com procedimento
       canônico, tipo de desconto e `approvedAt`.
-- [ ] CSV sanitizado pode omitir `reward_id`; quando presente, ele é tratado
-      apenas como compatibilidade. Nenhum procedimento, CPF ou histórico clínico
-      foi incluído.
+- [ ] CSV Velocity contém somente nome e WhatsApp, com e-mail/prêmio opcionais;
+      quando presente, o prêmio é `Velocity`. `reward_id` e demais campos
+      técnicos são derivados pelo importador. Nenhum procedimento, CPF ou
+      histórico clínico foi incluído.
+- [ ] O CSV privado de entrega gerado contém nome, telefone e URL opaca para o
+      envio manual no WhatsApp; ele permanece fora do repositório.
 - [ ] Gate de privacidade concluído para qualquer origem de paleta baseada em
       dados pré-existentes.
 - [ ] Migration e smoke com convites sintéticos concluídos em staging.

--- a/website/docs/beauty-movement-phase1-input-template.md
+++ b/website/docs/beauty-movement-phase1-input-template.md
@@ -92,19 +92,37 @@ aleatório, concurso ou sorteio.
   de privacidade: `[PENDENTE]`.
 - CPF e histórico de procedimentos: fora do D1, frontend, URL, relatório e
   analytics; nenhum dado bruto deve ser carregado (**consolidado no plano**).
-- Campos do convite: `invite_ref`, nome, WhatsApp, e-mail já vinculado na lista,
-  paleta, `velocity_benefit`, expiração e status do convite. `reward_id` é
-  opcional e legado; o procedimento, desconto e condições vêm da oferta
-  resolvida pelas cartas.
+- Para a lista da aula-cortesia Velocity, a fonte operacional pode conter apenas
+  nome e WhatsApp. E-mail e prêmio são opcionais; quando o prêmio vier, deve ser
+  `Velocity`. O importador gera o identificador opaco do convite, usa a validade
+  da campanha, marca o convite como ativo e mantém uma paleta técnica somente
+  para montar o baralho. A paleta não decide o prêmio. `reward_id` permanece nulo
+  até uma lista comercial posterior.
 - Consentimento: aceite operacional separado de qualquer marketing futuro;
   redação jurídica final: `[PENDENTE]`.
 - Retenção após encerramento + 90 dias: `[PENDENTE — eliminação / anonimização]`.
 
 ## 8. Pacote privado de importação
 
-O CSV sanitizado deve permanecer fora do repositório e conter somente os
-seguintes cabeçalhos permitidos (**contrato técnico consolidado; arquivo real
-continua pendente**):
+O CSV sanitizado deve permanecer fora do repositório. Para a lista Velocity, o
+formato mínimo aceito é:
+
+```text
+NOME,TELEFONE
+```
+
+`EMAIL` e `PRÊMIO` podem ser omitidos ou ficar vazios; o WhatsApp é o canal de
+contato e a chave operacional do convite. Quando informado, o valor de
+`PRÊMIO` deve ser `Velocity` (ou `aula_cortesia_evento`). O importador deriva internamente `invite_ref`,
+`expires_at`, `invite_status=active`, `palette=radiancia` e
+`velocity_benefit=aula_cortesia_evento` a partir da campanha aprovada. E-mails
+repetidos não bloqueiam a carga porque não identificam o convite.
+
+O arquivo privado de entrega gerado pelo importador contém `name`, `invite_ref`,
+`whatsapp` e `invite_url`, para permitir o envio manual da mensagem pelo
+WhatsApp. Ele continua fora do repositório e não é exposto ao navegador.
+
+Para listas comerciais futuras, o formato técnico completo continua disponível:
 
 ```text
 invite_ref,name,whatsapp,email,palette,velocity_benefit,expires_at,invite_status

--- a/website/src/lib/beautyMovementImport.ts
+++ b/website/src/lib/beautyMovementImport.ts
@@ -23,6 +23,12 @@ export type {
 
 export const BEAUTY_MOVEMENT_PALETTES = ["radiancia", "ritmo", "conexao"] as const;
 /**
+ * The compact Velocity source only describes the audience and its approved
+ * prize. The palette is an internal deck-selection detail in that mode; it
+ * must not become a second commercial decision made by the spreadsheet.
+ */
+export const BEAUTY_MOVEMENT_COMPACT_VELOCITY_PALETTE = "radiancia" as const;
+/**
  * These values are retained for the legacy invitation columns. Modern
  * invitations leave the commercial outcome empty until the three cards are
  * persisted and resolved by the server-side combination engine.
@@ -43,8 +49,16 @@ const REQUIRED_HEADERS = [
     "expires_at",
 ] as const;
 
-const OPTIONAL_HEADERS = ["email", "invite_status", "reward_id"] as const;
+const COMPACT_VELOCITY_REQUIRED_HEADERS = ["name", "whatsapp"] as const;
+const OPTIONAL_HEADERS = ["email", "invite_status", "reward_id", "prize"] as const;
 const ALLOWED_HEADERS = new Set<string>([...REQUIRED_HEADERS, ...OPTIONAL_HEADERS]);
+const HEADER_ALIASES: Readonly<Record<string, string>> = {
+    nome: "name",
+    telefone: "whatsapp",
+    telefone_whatsapp: "whatsapp",
+    premio: "prize",
+    recompensa: "prize",
+};
 const FORBIDDEN_HEADERS = new Set([
     "cpf",
     "cpf_cnpj",
@@ -90,12 +104,14 @@ export type BeautyMovementImportIssueCode =
     | "reward_not_found"
     | "reward_family_mismatch"
     | "invalid_velocity_benefit"
+    | "unsupported_prize"
     | "invalid_invite_status"
     | "invalid_text"
     | "invalid_expiry"
     | "expired_invite"
     | "campaign_expiry_before_invite"
     | "missing_reward_catalog"
+    | "compact_expiry_unavailable"
     | "prohibited_sensitive_value";
 
 export type BeautyMovementImportIssue = {
@@ -106,6 +122,7 @@ export type BeautyMovementImportIssue = {
 
 export type BeautyMovementImportRow = {
     inviteRef: string;
+    sourceFormat: "full" | "compact_velocity";
     name: string;
     whatsapp: string;
     email: string | null;
@@ -176,6 +193,7 @@ export type BeautyMovementPreparedInvite = {
 };
 
 export type BeautyMovementDeliveryRow = {
+    name: string;
     inviteRef: string;
     whatsapp: string;
     inviteUrl: string;
@@ -398,6 +416,8 @@ export function validateBeautyMovementImport(params: {
     csv: string;
     rewardCatalog?: readonly BeautyMovementRewardCatalogEntry[];
     nowMs?: number;
+    /** Required when the compact Velocity source omits its derived expiry. */
+    defaultExpiresAtMs?: number;
 }): BeautyMovementImportValidation {
     const delimiter = detectDelimiter(params.csv);
     const parsed = parseDelimited(params.csv, delimiter);
@@ -412,7 +432,10 @@ export function validateBeautyMovementImport(params: {
     }
 
     const rawHeaders = parsed.rows[0];
-    const headers = rawHeaders.map(normalizedHeader);
+    const headers = rawHeaders.map((header) => {
+        const normalized = normalizedHeader(header);
+        return HEADER_ALIASES[normalized] ?? normalized;
+    });
     const issues: BeautyMovementImportIssue[] = [];
     const headerIndex = new Map<string, number>();
     for (const [index, header] of headers.entries()) {
@@ -435,7 +458,15 @@ export function validateBeautyMovementImport(params: {
         headerIndex.set(header, index);
     }
 
-    for (const header of REQUIRED_HEADERS) {
+    const isCompactVelocity = COMPACT_VELOCITY_REQUIRED_HEADERS.every((header) => headerIndex.has(header)) &&
+        !headerIndex.has("invite_ref") &&
+        !headerIndex.has("palette") &&
+        !headerIndex.has("velocity_benefit") &&
+        !headerIndex.has("expires_at") &&
+        !headerIndex.has("invite_status") &&
+        !headerIndex.has("reward_id");
+    const requiredHeaders = isCompactVelocity ? COMPACT_VELOCITY_REQUIRED_HEADERS : REQUIRED_HEADERS;
+    for (const header of requiredHeaders) {
         if (!headerIndex.has(header)) issues.push(issue(1, header, "missing_header"));
     }
     if (issues.length) {
@@ -459,7 +490,6 @@ export function validateBeautyMovementImport(params: {
     const importRows: BeautyMovementImportRow[] = [];
     const inviteRefs = new Set<string>();
     const phones = new Set<string>();
-    const emails = new Set<string>();
     let sourceRowCount = 0;
 
     for (let index = 1; index < parsed.rows.length; index += 1) {
@@ -471,9 +501,14 @@ export function validateBeautyMovementImport(params: {
             issues.push(issue(rowNumber, null, "column_count_mismatch"));
             continue;
         }
-        const value = (header: string) => sourceRow[headerIndex.get(header)!] ?? "";
+        const value = (header: string) => {
+            const columnIndex = headerIndex.get(header);
+            return columnIndex === undefined ? "" : sourceRow[columnIndex] ?? "";
+        };
 
-        const inviteRef = cleanText(value("invite_ref"), 120);
+        const inviteRef = isCompactVelocity
+            ? `velocity-${String(rowNumber).padStart(4, "0")}`
+            : cleanText(value("invite_ref"), 120);
         if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{2,119}$/.test(inviteRef)) {
             issues.push(issue(rowNumber, "invite_ref", inviteRef ? "invalid_invite_ref" : "required_value_missing"));
         } else if (containsProhibitedSensitiveValue(inviteRef)) {
@@ -507,13 +542,11 @@ export function validateBeautyMovementImport(params: {
         const email = normalizeEmail(rawEmail);
         if (rawEmail.trim() && !email) {
             issues.push(issue(rowNumber, "email", "invalid_email"));
-        } else if (email && emails.has(email)) {
-            issues.push(issue(rowNumber, "email", "duplicate_email"));
-        } else if (email) {
-            emails.add(email);
         }
 
-        const palette = asAllowed(cleanText(value("palette"), 40).toLowerCase(), BEAUTY_MOVEMENT_PALETTES);
+        const palette = isCompactVelocity
+            ? BEAUTY_MOVEMENT_COMPACT_VELOCITY_PALETTE
+            : asAllowed(cleanText(value("palette"), 40).toLowerCase(), BEAUTY_MOVEMENT_PALETTES);
         if (!palette) issues.push(issue(rowNumber, "palette", value("palette").trim() ? "invalid_palette" : "required_value_missing"));
 
         const rawRewardId = value("reward_id").trim();
@@ -527,27 +560,53 @@ export function validateBeautyMovementImport(params: {
             issues.push(issue(rowNumber, "reward_id", "reward_family_mismatch"));
         }
 
-        const velocityBenefit = asAllowed(
-            cleanText(value("velocity_benefit"), 40).toLowerCase(),
-            ["none", "aula_cortesia_evento"] as const,
-        );
-        if (!velocityBenefit) {
-            issues.push(issue(
-                rowNumber,
-                "velocity_benefit",
-                value("velocity_benefit").trim() ? "invalid_velocity_benefit" : "required_value_missing",
-            ));
+        let velocityBenefit: BeautyMovementVelocityBenefit | null;
+        if (isCompactVelocity) {
+            const prize = cleanText(value("prize"), 80)
+                .toLowerCase()
+                .normalize("NFD")
+                .replace(/[\u0300-\u036f]/g, "")
+                .replace(/[^a-z0-9]+/g, "_")
+                .replace(/^_+|_+$/g, "");
+            if (!prize || ["velocity", "aula_cortesia_velocity", "aula_cortesia_de_velocity", "aula_cortesia_evento"].includes(prize)) {
+                velocityBenefit = "aula_cortesia_evento";
+            } else {
+                velocityBenefit = null;
+                issues.push(issue(rowNumber, "prize", "unsupported_prize"));
+            }
+        } else {
+            velocityBenefit = asAllowed(
+                cleanText(value("velocity_benefit"), 40).toLowerCase(),
+                ["none", "aula_cortesia_evento"] as const,
+            );
+            if (!velocityBenefit) {
+                issues.push(issue(
+                    rowNumber,
+                    "velocity_benefit",
+                    value("velocity_benefit").trim() ? "invalid_velocity_benefit" : "required_value_missing",
+                ));
+            }
         }
 
-        const inviteStatus = asAllowed(
-            cleanText(value("invite_status"), 32).toLowerCase() || "active",
-            BEAUTY_MOVEMENT_INVITE_STATUSES,
-        );
+        const inviteStatus = isCompactVelocity
+            ? "active" as const
+            : asAllowed(
+                cleanText(value("invite_status"), 32).toLowerCase() || "active",
+                BEAUTY_MOVEMENT_INVITE_STATUSES,
+            );
         if (!inviteStatus) issues.push(issue(rowNumber, "invite_status", "invalid_invite_status"));
 
-        const expiresAtMs = parseStrictIsoDate(value("expires_at"));
+        const expiresAtMs = isCompactVelocity
+            ? Number.isFinite(params.defaultExpiresAtMs) ? params.defaultExpiresAtMs! : null
+            : parseStrictIsoDate(value("expires_at"));
         if (expiresAtMs === null) {
-            issues.push(issue(rowNumber, "expires_at", value("expires_at").trim() ? "invalid_expiry" : "required_value_missing"));
+            issues.push(issue(
+                rowNumber,
+                "expires_at",
+                isCompactVelocity
+                    ? "compact_expiry_unavailable"
+                    : value("expires_at").trim() ? "invalid_expiry" : "required_value_missing",
+            ));
         } else if (inviteStatus === "active" && expiresAtMs <= nowMs) {
             issues.push(issue(rowNumber, "expires_at", "expired_invite"));
         }
@@ -565,6 +624,7 @@ export function validateBeautyMovementImport(params: {
         ) {
             importRows.push({
                 inviteRef,
+                sourceFormat: isCompactVelocity ? "compact_velocity" : "full",
                 name,
                 whatsapp,
                 email,
@@ -632,7 +692,12 @@ export async function prepareBeautyMovementImport(params: {
         ? validateBeautyMovementRewardCatalog({ catalog: params.rewardCatalog, procedureCatalog: params.procedureCatalog ?? [] })
         : [];
     const rewardById = new Map(rewards.map((reward) => [reward.rewardId, reward]));
-    const validation = validateBeautyMovementImport({ csv: params.csv, rewardCatalog: rewards, nowMs });
+    const validation = validateBeautyMovementImport({
+        csv: params.csv,
+        rewardCatalog: rewards,
+        nowMs,
+        defaultExpiresAtMs: params.campaignEndsAtMs,
+    });
     if (!validation.ok) {
         throw new Error(`beauty_movement_import_invalid:${validation.issues.map((entry) => entry.code).join(",")}`);
     }
@@ -646,12 +711,18 @@ export async function prepareBeautyMovementImport(params: {
     const deliveryRows: BeautyMovementDeliveryRow[] = [];
 
     for (const row of validation.rows) {
+        const inviteRef = row.sourceFormat === "compact_velocity"
+            ? `velocity-${await hashBeautyMovementInviteToken({
+                secret: params.tokenHmacKey,
+                token: `velocity-${campaignId}-${row.whatsapp.replace(/\D/g, "")}`,
+            })}`
+            : row.inviteRef;
         const reward = row.rewardId ? rewardById.get(row.rewardId) ?? null : null;
         if (row.rewardId && !reward) throw new Error("beauty_movement_reward_not_found");
         const token = await deriveBeautyMovementInviteToken({
             secret: params.tokenHmacKey,
             campaignId,
-            inviteRef: row.inviteRef,
+            inviteRef,
         });
         const inviteTokenHmac = await hashBeautyMovementInviteToken({ secret: params.tokenHmacKey, token });
         const encrypted = await encryptBeautyMovementPersonalData({
@@ -661,7 +732,7 @@ export async function prepareBeautyMovementImport(params: {
         }, params.piiKey);
         invites.push({
             id: crypto.randomUUID(),
-            inviteRef: row.inviteRef,
+            inviteRef,
             inviteTokenHmac,
             personalDataCiphertext: encrypted.ciphertext,
             personalDataIv: encrypted.iv,
@@ -681,7 +752,8 @@ export async function prepareBeautyMovementImport(params: {
             inviteStatus: row.inviteStatus,
         });
         deliveryRows.push({
-            inviteRef: row.inviteRef,
+            name: row.name,
+            inviteRef,
             whatsapp: row.whatsapp,
             inviteUrl: buildInviteUrl(inviteUrlBase, token),
         });
@@ -830,9 +902,9 @@ function csvCell(value: string): string {
 }
 
 export function serializeBeautyMovementDeliveryCsv(rows: readonly BeautyMovementDeliveryRow[]): string {
-    const output = ["invite_ref,whatsapp,invite_url"];
+    const output = ["name,invite_ref,whatsapp,invite_url"];
     for (const row of rows) {
-        output.push([row.inviteRef, row.whatsapp, row.inviteUrl].map(csvCell).join(","));
+        output.push([row.name, row.inviteRef, row.whatsapp, row.inviteUrl].map(csvCell).join(","));
     }
     return `${output.join("\n")}\n`;
 }

--- a/website/tests/beautyMovementImport.test.ts
+++ b/website/tests/beautyMovementImport.test.ts
@@ -14,6 +14,7 @@ const TOKEN_KEY = `test-token-hmac-${"0".repeat(16)}`;
 const PII_KEY = "0".repeat(64);
 const NOW = Date.parse("2026-08-01T12:00:00Z");
 const EXPIRES = "2026-08-31T23:59:00Z";
+const EXPIRES_MS = Date.parse(EXPIRES);
 
 const PROCEDURES = [
     { procedureId: "lavieen", procedureName: "Lavieen" },
@@ -117,6 +118,73 @@ test("beauty movement import validates only the sanitised private-list schema", 
     if (!duplicate.ok) assert.equal(duplicate.issues.some((entry) => entry.code === "duplicate_whatsapp"), true);
 });
 
+test("compact Velocity sheet rows accept the sheet columns and optional duplicate email", async () => {
+    const csv = [
+        "NOME,TELEFONE,EMAIL,PRÊMIO",
+        "Ana Silva,51999991234,shared@example.com,Velocity",
+        "Bea Souza,51999991235,shared@example.com,Velocity",
+    ].join("\n");
+    const validation = validateBeautyMovementImport({
+        csv,
+        nowMs: NOW,
+        defaultExpiresAtMs: EXPIRES_MS,
+    });
+    assert.equal(validation.ok, true);
+    if (!validation.ok) return;
+    assert.deepEqual(validation.rows.map((row) => row.inviteRef), ["velocity-0002", "velocity-0003"]);
+    assert.equal(validation.rows.every((row) => row.palette === "radiancia"), true);
+    assert.equal(validation.rows.every((row) => row.velocityBenefit === "aula_cortesia_evento"), true);
+    assert.equal(validation.rows.every((row) => row.expiresAtMs === EXPIRES_MS), true);
+    assert.equal(validation.rows.every((row) => row.inviteStatus === "active"), true);
+    assert.equal(validation.rows.every((row) => row.rewardId === null), true);
+
+    const plan = await prepareBeautyMovementImport({
+        csv,
+        campaignId: "nh-velocity",
+        campaignConfig: validCampaignConfig(),
+        campaignEndsAtMs: EXPIRES_MS,
+        tokenHmacKey: TOKEN_KEY,
+        piiKey: PII_KEY,
+        nowMs: NOW,
+    });
+    assert.equal(plan.invites.length, 2);
+    assert.equal(plan.deliveryRows.length, 2);
+    assert.equal(plan.invites.every((invite) => invite.velocityBenefit === "aula_cortesia_evento"), true);
+    assert.equal(plan.invites.every((invite) => invite.rewardId === null), true);
+    assert.equal(plan.deliveryRows.every((row) => row.inviteUrl.startsWith("https://espacofacial.com/beleza-em-movimento#c=")), true);
+});
+
+test("compact Velocity imports also accept only name and WhatsApp", () => {
+    const validation = validateBeautyMovementImport({
+        csv: [
+            "NOME,TELEFONE",
+            "Ana Silva,51999991234",
+        ].join("\n"),
+        nowMs: NOW,
+        defaultExpiresAtMs: EXPIRES_MS,
+    });
+    assert.equal(validation.ok, true);
+    if (validation.ok) assert.equal(validation.rows[0]?.velocityBenefit, "aula_cortesia_evento");
+});
+
+test("compact Velocity imports fail closed without campaign expiry or with another prize", () => {
+    const csv = [
+        "nome,telefone,premio",
+        "Ana Silva,51999991234,Velocity",
+    ].join("\n");
+    const withoutExpiry = validateBeautyMovementImport({ csv, nowMs: NOW });
+    assert.equal(withoutExpiry.ok, false);
+    if (!withoutExpiry.ok) assert.equal(withoutExpiry.issues.some((entry) => entry.code === "compact_expiry_unavailable"), true);
+
+    const unsupported = validateBeautyMovementImport({
+        csv: csv.replace("Velocity", "Preenchimento"),
+        nowMs: NOW,
+        defaultExpiresAtMs: EXPIRES_MS,
+    });
+    assert.equal(unsupported.ok, false);
+    if (!unsupported.ok) assert.equal(unsupported.issues.some((entry) => entry.code === "unsupported_prize"), true);
+});
+
 test("modern imports may omit reward_id and defer the commercial outcome to the card resolver", async () => {
     const csv = [
         "invite_ref,name,whatsapp,email,palette,velocity_benefit,expires_at",
@@ -178,6 +246,8 @@ test("beauty movement import writes encrypted D1 rows and reserves raw delivery 
     assert.match(sql, /SELECT status FROM bm_campaigns WHERE id = excluded\.campaign_id\) = 'draft'/);
 
     const deliveryCsv = serializeBeautyMovementDeliveryCsv(plan.deliveryRows);
+    assert.match(deliveryCsv, /^name,invite_ref,whatsapp,invite_url\n/);
+    assert.equal(deliveryCsv.includes("Ana Silva"), true);
     assert.equal(deliveryCsv.includes("+5551999991234"), true);
     assert.equal(deliveryCsv.includes(inviteUrl), true);
 });


### PR DESCRIPTION
# Summary\n\nAccept the compact Velocity invite sheet without requiring technical columns. The source may contain only NOME and TELEFONE; EMAIL and PRÊMIO are optional. The importer derives technical invite fields, uses an opaque invite reference, and defaults this explicitly scoped source to the Velocity courtesy-class benefit.\n\n## Type of change\n- [x] Feature\n- [ ] Fix\n- [ ] Refactor\n- [x] Docs\n- [ ] Performance\n- [ ] Security\n- [ ] Breaking change\n\n## Checklist\n- [x] Conventional Commits applied\n- [x] Tests added/updated and passing\n- [x] Docs updated\n- [ ] Security review (GitHub checks running)\n- [ ] Performance impact measured\n\n## Links\n- Issue: not applicable\n- Design/ADR: existing Beauty Movement import contract\n- Migration steps: none; campaign activation remains separately gated\n\n## Screenshots / Evidence\n- Focused import test: 147/147 passed\n- Website typecheck/build: passed\n- Current production landing: HTTP 200, X-App-Build e677ef768b2553a38d4345434ec187dcfe99821c\n- Campaign API remains disabled by design\n- No customer data is committed or exposed\n\nProduction activation still requires the private campaign package; this PR does not enable BEAUTY_MOVEMENT_ENABLED.