### PR TITLE
chore(ci): remove obsolete frontend Dependabot target

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,6 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
   - package-ecosystem: "npm"
-    directory: "/frontend"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-  - package-ecosystem: "npm"
     directory: "/backend"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary

- remove the obsolete npm Dependabot target for `/frontend`;
- keep root npm, backend npm/pip, and GitHub Actions update coverage unchanged.

Related: #1535

## Evidence

- `frontend/` is absent from `origin/main`;
- active manifests remain at `/` and `/backend`;
- independent safety review passed;
- no workflows, required checks, secrets, rulesets, or production surfaces changed.

## Validation

- `git diff --check`
- targeted path/manifests audit