### PR TITLE
fix(ci): classify Inventory routes as sensitive

### DIFF
--- a/ops/codex/risk-policy.json
+++ b/ops/codex/risk-policy.json
@@ -111,6 +111,7 @@
     ".github/actions/**",
     "api/**",
     "crm/api/**",
+    "inventory/src/routes/**",
     "workforce/**",
     "website/**",
     "booking/**",
@@ -148,6 +149,7 @@
     ".github/scripts/**",
     "ops/governance/**",
     "platform/security/**",
+    "inventory/src/routes/**",
     "**/migrations/**",
     "**/*credential-exposure*",
     "**/*real-data*",
@@ -162,8 +164,8 @@
     },
     {
       "risk": "high",
-      "reason": "Authentication, sessions, permissions, secrets, migrations, payment, deployment, workflow, Worker, database, tracking, or externally integrated surface changed and needs a focal check plus rollback.",
-      "patterns": ["**/auth/**", "**/*auth*", "**/*session*", "**/*permission*", "**/*secret*", "**/*credential*", "**/*token*", "**/*payment*", "**/*billing*", "**/*root*key*", "**/migrations/**", "**/*migration*", ".github/workflows/**", ".github/scripts/**", "workforce/**", "api/**", "crm/api/**", "platform/**", "ops/runtime/**", "website/**/api/**", "ops/cloudflare/**", "ops/governance/**", "scripts/codex-global-coordination*.mjs", "scripts/tests/codex-global-coordination*.mjs", "**/wrangler*.toml", "**/worker*.{js,mjs,ts}", "**/d1/**", "**/*tracking*", "**/*integration*", "**/*webhook*"]
+      "reason": "Authentication, sessions, permissions, secrets, migrations, payment, deployment, workflow, Worker, database, tracking, externally integrated, or Inventory route surface changed and needs a focal check plus rollback.",
+      "patterns": ["**/auth/**", "**/*auth*", "**/*session*", "**/*permission*", "**/*secret*", "**/*credential*", "**/*token*", "**/*payment*", "**/*billing*", "**/*root*key*", "**/migrations/**", "**/*migration*", ".github/workflows/**", ".github/scripts/**", "workforce/**", "api/**", "crm/api/**", "inventory/src/routes/**", "platform/**", "ops/runtime/**", "website/**/api/**", "ops/cloudflare/**", "ops/governance/**", "scripts/codex-global-coordination*.mjs", "scripts/tests/codex-global-coordination*.mjs", "**/wrangler*.toml", "**/worker*.{js,mjs,ts}", "**/d1/**", "**/*tracking*", "**/*integration*", "**/*webhook*"]
     },
     {
       "risk": "medium",

--- a/scripts/tests/codex-risk-classifier.test.mjs
+++ b/scripts/tests/codex-risk-classifier.test.mjs
@@ -110,6 +110,20 @@ test("dependency, shared-contract, and security signals cannot remain medium", (
   }
 });
 
+test("Inventory routes are high and sensitive while nearby non-route code is not overclassified", () => {
+  const routeReport = classifyFiles(policy, ["inventory/src/routes/admin.js"]);
+  assert.equal(routeReport.risk, "high");
+  assert.equal(routeReport.production_sensitive, true);
+  assert.equal(routeReport.security_sensitive, true);
+  assert.equal(routeReport.pathClassifications[0].risk, "high");
+
+  const nonRouteReport = classifyFiles(policy, ["inventory/src/index.js"]);
+  assert.equal(nonRouteReport.risk, "medium");
+  assert.equal(nonRouteReport.production_sensitive, false);
+  assert.equal(nonRouteReport.security_sensitive, false);
+  assert.equal(nonRouteReport.pathClassifications[0].risk, "medium");
+});
+
 test("the fallback report is complete, conservative, and sanitized", () => {
   const report = buildClassificationFallback({
     policy,


### PR DESCRIPTION
## Summary

- classify `inventory/src/routes/**` as a production-sensitive surface;
- raise those routes to HIGH so auth/D1/admin changes cannot enter MEDIUM/LOW lanes;
- keep nearby non-route Inventory code at its existing classification;
- add a positive and negative classifier contract test.

## Validation

- `node scripts/tests/codex-risk-classifier.test.mjs` (12/12)
- `git diff --check`
- no workflow, required-check, merge-authority, branch-protection, secret, or production mutation.

## Safety

This is a conservative false-negative fix. It only expands validation for Inventory routes and does not create a new classifier or bypass.