### PR TITLE
fix(governance): pin merge authority to trusted main ref

### DIFF
--- a/.github/workflows/global-merge-authority.yml
+++ b/.github/workflows/global-merge-authority.yml
@@ -25,14 +25,15 @@ concurrency:
   group: merge-main-authority
   cancel-in-progress: false
 
-permissions:
-  contents: write
-  pull-requests: write
-  statuses: write
+permissions: {}
 
 jobs:
   authority-signal:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
     steps:
       - name: Mark direct UI merge as unauthorized
         if: ${{ github.event_name == 'pull_request_target' }}
@@ -48,17 +49,28 @@ jobs:
             -f description='Merge must be issued by global-merge-authority after lease revalidation.' \
             -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/workflows/global-merge-authority.yml" \
             >/dev/null
+      - name: Reject untrusted manual dispatch refs
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main' }}
+        run: |
+          set -euo pipefail
+          echo 'global-merge-authority accepts workflow_dispatch only from refs/heads/main' >&2
+          exit 1
+
+  merge-authority:
+    if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
+    needs: authority-signal
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      statuses: write
+    steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
-        if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
-          # Execute the authority implementation from the explicitly selected
-          # dispatch ref. Normal production dispatches use main; this also
-          # makes the first governed migration run the candidate's corrected
-          # status-publication code before that correction is merged.
-          ref: ${{ github.ref }}
+          # The privileged implementation is always read from the trusted main ref.
+          ref: refs/heads/main
           fetch-depth: 0
       - name: Fetch the exact base tree used by the merge intent
-        if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
           GH_TOKEN: ${{ github.token }}
           PULL_NUMBER: ${{ inputs.pull_number }}
@@ -69,7 +81,6 @@ jobs:
           [[ "$base_sha" =~ ^[0-9a-f]{40}$ ]] || { echo 'pull request base SHA is invalid'; exit 1; }
           git fetch --no-tags origin "$base_sha"
       - name: Acquire merge:main, revalidate base/head, and merge exactly once
-        if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
           # The ruleset's update restriction admits only the GitHub Actions
           # integration. A user PAT is intentionally not accepted here.

--- a/docs/decisions/global-concurrency-release-governance.md
+++ b/docs/decisions/global-concurrency-release-governance.md
@@ -95,6 +95,16 @@ permanece pending em conflito compatível com espera; a segunda adquire
 Actions `concurrency` é apenas scheduler. A prova remota, o status obrigatório e
 a revalidação imediatamente antes da mutação são a autoridade técnica.
 
+O `workflow_dispatch` da autoridade de merge é admitido somente em
+`refs/heads/main`. O guard inicial não recebe `contents:write` nem secrets de
+coordenação; qualquer outra ref falha fechada. O job privilegiado depende desse
+guard, faz checkout explícito de `refs/heads/main` e só então recebe o token de
+escrita e a custódia de coordenação. Assim, o dispatcher não executa a
+implementação de uma ref arbitrária antes da injeção de autoridade; lease,
+`expected_head_sha`, checks obrigatórios e readback continuam no mesmo script
+canônico. O job privilegiado, portanto, não faz checkout nem executa a
+implementação de uma ref arbitrária antes da injeção de autoridade.
+
 O ruleset versionado acrescenta a regra `update`, limita o merge a `squash` e
 declara o GitHub Actions integration actor como único bypass técnico do update
 rule. O validador rejeita qualquer workflow adicional que contenha uma mutação

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -607,7 +607,22 @@ test("merge:main is a fail-closed GitHub mutation authority", () => {
   assert.match(read("scripts/codex-global-coordination-workflow.mjs"), /admission paths are not bound/);
   assert.match(script, /\/pulls\/\$\{pullNumber\}\/merge/);
   assert.match(workflow, /pull_request_target/);
-  assert.match(workflow, /ref: \$\{\{ github\.ref \}\}/);
+  assert.match(workflow, /permissions: \{\}/);
+  assert.match(workflow, /Reject untrusted manual dispatch refs/);
+  assert.match(workflow, /github\.ref != 'refs\/heads\/main'/);
+  assert.match(workflow, /merge-authority:\n    if: \$\{\{ github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/main' \}\}/);
+  assert.match(workflow, /ref: refs\/heads\/main/);
+  assert.doesNotMatch(workflow, /ref: \$\{\{ github\.ref \}\}/);
+  const signalJob = jobBlock(workflow, "authority-signal");
+  const mergeJob = jobBlock(workflow, "merge-authority");
+  assert.doesNotMatch(signalJob, /contents: write|secrets\./);
+  assert.match(mergeJob, /needs: authority-signal/);
+  assert.match(mergeJob, /contents: write/);
+  assert.match(mergeJob, /SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET/);
+  assert.ok(
+    workflow.indexOf("ref: refs/heads/main") < workflow.indexOf("SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET:"),
+    "trusted main checkout must precede coordination secret injection",
+  );
   assert.match(workflow, /state=failure/);
   assert.match(workflow, /run-name: Merge PR #\$\{\{ inputs\.pull_number \}\} through merge:main/);
   assert.match(workflow, /GH_TOKEN: \$\{\{ github\.token \}\}/);


### PR DESCRIPTION
## Summary

- reject manual authority dispatches from non-main refs;
- keep the signal job read-only and free of coordination secrets;
- run the privileged merge job only after the main-ref guard succeeds;
- checkout `refs/heads/main` before injecting write permissions and coordination custody.

## Preserved invariants

- `merge:main` lease and fencing;
- exact `expected_head_sha`;
- required-check and base/head revalidation;
- single merge mutation and post-merge readback;
- no admin/bypass path.

## Validation

- `node scripts/tests/global-concurrency-governance-static.test.mjs` (19/19)
- `git diff --check`
- no remote ruleset/branch-protection/production/secret mutation.