### PR TITLE
fix(beauty-movement): forward compact import expiry

### DIFF
--- a/website/scripts/beauty-movement-import.ts
+++ b/website/scripts/beauty-movement-import.ts
@@ -272,7 +272,14 @@ async function main(): Promise<void> {
         }
     }
 
-    const validation = validateBeautyMovementImport({ csv, rewardCatalog: validatedRewards });
+    const campaignEndsAtMs = options.campaignEndsAt
+        ? parseCampaignEndsAt(options.campaignEndsAt)
+        : undefined;
+    const validation = validateBeautyMovementImport({
+        csv,
+        rewardCatalog: validatedRewards,
+        defaultExpiresAtMs: campaignEndsAtMs,
+    });
     if (!validation.ok) {
         // This JSON is intentionally aggregate-only: no path, contact, token or row detail.
         console.log(JSON.stringify({ mode: options.dryRun ? "dry_run" : "dry_run_default", ...summarizeBeautyMovementImport(validation) }));

--- a/website/tests/beautyMovementImport.test.ts
+++ b/website/tests/beautyMovementImport.test.ts
@@ -1,5 +1,8 @@
+import { randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
 import test from "node:test";
 import {
     buildBeautyMovementImportSql,
@@ -183,6 +186,55 @@ test("compact Velocity imports fail closed without campaign expiry or with anoth
     });
     assert.equal(unsupported.ok, false);
     if (!unsupported.ok) assert.equal(unsupported.issues.some((entry) => entry.code === "unsupported_prize"), true);
+});
+
+test("CLI dry-run forwards campaign expiry to compact Velocity validation", async () => {
+    const privateRoot = "/mnt/c/CodexRuntime/operator/admin/skincos/beauty-movement";
+    await mkdtemp(path.join(privateRoot, "beauty-movement-cli-test-")).then(async (directory) => {
+        const inputPath = path.join(directory, "invites.csv");
+        const campaignPath = path.join(directory, "campaign.json");
+        const endsAt = "2099-12-31T23:59:00Z";
+        const campaign = {
+            title: "Teste sintético",
+            description: "Fixture sintética do importador.",
+            invitationTitle: "Convite sintético",
+            invitationText: "Texto sintético.",
+            partnerName: "Synthetic QA",
+            whatsappMessageCourtesy: "Mensagem sintética.",
+            whatsappMessageCommercial: "Mensagem comercial sintética.",
+            whatsappLabel: "Falar com a equipe",
+            conditionsLabel: "Condições",
+            conditionsText: "Condições sintéticas.",
+            velocityBenefitLabel: "Aula sintética",
+            velocityBenefitText: "Benefício sintético.",
+        };
+
+        try {
+            await writeFile(inputPath, "NOME,TELEFONE\nSynthetic Guest,5511999990000\n", "utf8");
+            await writeFile(campaignPath, JSON.stringify(campaign), "utf8");
+            const result = spawnSync(
+                process.execPath,
+                [
+                    "--import", "tsx",
+                    "scripts/beauty-movement-import.ts",
+                    "--dry-run",
+                    "--input", inputPath,
+                    "--campaign", `cli-test-${randomUUID().slice(0, 8)}`,
+                    "--campaign-config", campaignPath,
+                    "--campaign-ends-at", endsAt,
+                ],
+                { cwd: path.resolve(import.meta.dirname, ".."), encoding: "utf8" },
+            );
+            assert.equal(result.error, undefined, result.error?.message);
+            assert.equal(result.status, 0, result.stderr);
+            const summary = JSON.parse(result.stdout.trim()) as Record<string, unknown>;
+            assert.equal(summary.mode, "dry_run");
+            assert.equal(summary.preflight, "complete");
+            assert.equal(summary.acceptedRows, 1);
+        } finally {
+            await rm(directory, { recursive: true, force: true });
+        }
+    });
 });
 
 test("modern imports may omit reward_id and defer the commercial outcome to the card resolver", async () => {

--- a/website/tests/beautyMovementImport.test.ts
+++ b/website/tests/beautyMovementImport.test.ts
@@ -190,51 +190,65 @@ test("compact Velocity imports fail closed without campaign expiry or with anoth
 });
 
 test("CLI dry-run forwards campaign expiry to compact Velocity validation", async () => {
-    await mkdtemp(path.join(tmpdir(), "beauty-movement-cli-test-")).then(async (directory) => {
-        const inputPath = path.join(directory, "invites.csv");
-        const campaignPath = path.join(directory, "campaign.json");
-        const endsAt = "2099-12-31T23:59:00Z";
-        const campaign = {
-            title: "Teste sintético",
-            description: "Fixture sintética do importador.",
-            invitationTitle: "Convite sintético",
-            invitationText: "Texto sintético.",
-            partnerName: "Synthetic QA",
-            whatsappMessageCourtesy: "Mensagem sintética.",
-            whatsappMessageCommercial: "Mensagem comercial sintética.",
-            whatsappLabel: "Falar com a equipe",
-            conditionsLabel: "Condições",
-            conditionsText: "Condições sintéticas.",
-            velocityBenefitLabel: "Aula sintética",
-            velocityBenefitText: "Benefício sintético.",
-        };
+    const privateRoot = await mkdtemp(path.join(tmpdir(), "beauty-movement-private-"));
+    try {
+        await mkdtemp(path.join(privateRoot, "beauty-movement-cli-test-")).then(async (directory) => {
+            const inputPath = path.join(directory, "invites.csv");
+            const campaignPath = path.join(directory, "campaign.json");
+            const endsAt = "2099-12-31T23:59:00Z";
+            const campaign = {
+                title: "Teste sintético",
+                description: "Fixture sintética do importador.",
+                invitationTitle: "Convite sintético",
+                invitationText: "Texto sintético.",
+                partnerName: "Synthetic QA",
+                whatsappMessageCourtesy: "Mensagem sintética.",
+                whatsappMessageCommercial: "Mensagem comercial sintética.",
+                whatsappLabel: "Falar com a equipe",
+                conditionsLabel: "Condições",
+                conditionsText: "Condições sintéticas.",
+                velocityBenefitLabel: "Aula sintética",
+                velocityBenefitText: "Benefício sintético.",
+            };
 
-        try {
-            await writeFile(inputPath, "NOME,TELEFONE\nSynthetic Guest,5511999990000\n", "utf8");
-            await writeFile(campaignPath, JSON.stringify(campaign), "utf8");
-            const result = spawnSync(
-                process.execPath,
-                [
-                    "--import", "tsx",
-                    "scripts/beauty-movement-import.ts",
-                    "--dry-run",
-                    "--input", inputPath,
-                    "--campaign", `cli-test-${randomUUID().slice(0, 8)}`,
-                    "--campaign-config", campaignPath,
-                    "--campaign-ends-at", endsAt,
-                ],
-                { cwd: path.resolve(import.meta.dirname, ".."), encoding: "utf8" },
-            );
-            assert.equal(result.error, undefined, result.error?.message);
-            assert.equal(result.status, 0, result.stderr);
-            const summary = JSON.parse(result.stdout.trim()) as Record<string, unknown>;
-            assert.equal(summary.mode, "dry_run");
-            assert.equal(summary.preflight, "complete");
-            assert.equal(summary.acceptedRows, 1);
-        } finally {
-            await rm(directory, { recursive: true, force: true });
-        }
-    });
+            try {
+                await writeFile(inputPath, "NOME,TELEFONE\nSynthetic Guest,5511999990000\n", "utf8");
+                await writeFile(campaignPath, JSON.stringify(campaign), "utf8");
+                const result = spawnSync(
+                    process.execPath,
+                    [
+                        "--import", "tsx",
+                        "scripts/beauty-movement-import.ts",
+                        "--dry-run",
+                        "--input", inputPath,
+                        "--campaign", `cli-test-${randomUUID().slice(0, 8)}`,
+                        "--campaign-config", campaignPath,
+                        "--campaign-ends-at", endsAt,
+                    ],
+                    {
+                        cwd: path.resolve(import.meta.dirname, ".."),
+                        encoding: "utf8",
+                        env: {
+                            ...process.env,
+                            GITHUB_ACTIONS: "true",
+                            RUNNER_TEMP: tmpdir(),
+                            BEAUTY_MOVEMENT_PRIVATE_RUNTIME_ROOT: privateRoot,
+                        },
+                    },
+                );
+                assert.equal(result.error, undefined, result.error?.message);
+                assert.equal(result.status, 0, result.stderr);
+                const summary = JSON.parse(result.stdout.trim()) as Record<string, unknown>;
+                assert.equal(summary.mode, "dry_run");
+                assert.equal(summary.preflight, "complete");
+                assert.equal(summary.acceptedRows, 1);
+            } finally {
+                await rm(directory, { recursive: true, force: true });
+            }
+        });
+    } finally {
+        await rm(privateRoot, { recursive: true, force: true });
+    }
 });
 
 test("modern imports may omit reward_id and defer the commercial outcome to the card resolver", async () => {

--- a/website/tests/beautyMovementImport.test.ts
+++ b/website/tests/beautyMovementImport.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import assert from "node:assert/strict";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import {
@@ -189,8 +190,7 @@ test("compact Velocity imports fail closed without campaign expiry or with anoth
 });
 
 test("CLI dry-run forwards campaign expiry to compact Velocity validation", async () => {
-    const privateRoot = "/mnt/c/CodexRuntime/operator/admin/skincos/beauty-movement";
-    await mkdtemp(path.join(privateRoot, "beauty-movement-cli-test-")).then(async (directory) => {
+    await mkdtemp(path.join(tmpdir(), "beauty-movement-cli-test-")).then(async (directory) => {
         const inputPath = path.join(directory, "invites.csv");
         const campaignPath = path.join(directory, "campaign.json");
         const endsAt = "2099-12-31T23:59:00Z";


### PR DESCRIPTION
## Summary\n- Forward the CLI campaign expiry into compact Velocity validation as defaultExpiresAtMs.\n- Add a synthetic CLI dry-run regression covering name/WhatsApp-only input with an explicit campaign end.\n\n## Validation\n- invoke-skincos-wsl.ps1 with 
pm run test\n- 148 tests passed\n- git diff --check clean\n\nNo resolver, production, secrets, or PII changes.