### PR TITLE
feat(beauty-movement): honor per-invite prize assignments

### DIFF
--- a/website/docs/beauty-movement-operations.md
+++ b/website/docs/beauty-movement-operations.md
@@ -10,20 +10,22 @@ gates abaixo estejam concluídos.
   `C:\CodexRuntime\operator\admin\skincos\beauty-movement\` (ou equivalente
   privado no ambiente de release). Não copie CSV, URLs de entrega, CPF, histórico
   ou relatórios para este repositório.
-- Para a lista de aula-cortesia Velocity, o importador aceita o formato mínimo
-  `NOME,TELEFONE`; `EMAIL` e `PRÊMIO` são opcionais (`PRÊMIO`, quando presente,
-  deve ser `Velocity`). Ele deriva os campos técnicos do convite a partir da
-  campanha aprovada; não é necessário pré-preencher identificador, paleta,
-  expiração ou status. CPF, procedimentos, histórico clínico e colunas não
-  reconhecidas são rejeitados antes de qualquer escrita.
+- Para a lista final, o importador aceita o formato mínimo `NOME,TELEFONE` e as
+  colunas opcionais `EMAIL,PRÊMIO`. Quando `PRÊMIO` está presente, ele é a
+  atribuição autoritativa do convite: `Velocity` representa a aula-cortesia e os
+  quatro rótulos comerciais canônicos representam a oferta correspondente.
+  Não é necessário pré-preencher identificador, paleta, expiração ou status.
+  CPF, procedimentos, histórico clínico e colunas não reconhecidas são
+  rejeitados antes de qualquer escrita.
 - A paleta apenas escolhe o deck editorial; ela não escolhe nem pré-reserva a
   oferta. Nenhum dado pessoal, procedimento ou histórico clínico é enviado ao
   D1 ou ao navegador para decidir o resultado.
-- A condição comercial moderna é propriedade do resolver determinístico das
-  três cartas. `reward_id` é opcional na importação e só é lido para manter
-  compatibilidade com convites legados; nunca é aceito do navegador como
-  autoridade. O resultado persistido inclui `outcome_key`, versão do protocolo
-  e snapshot estruturado da oferta.
+- Para convites da lista final, a condição/prêmio é propriedade da atribuição
+  privada do convite. As três cartas são uma leitura simbólica pré-configurada;
+  qualquer clique válido mantém a mesma promessa e o servidor persiste o
+  outcome atribuído. `reward_id` é opcional e só mantém compatibilidade com
+  convites legados. O resultado persistido inclui `outcome_key`, versão do
+  protocolo e snapshot estruturado da oferta.
 
 ## Infraestrutura exigida antes de staging
 
@@ -35,7 +37,8 @@ gates abaixo estejam concluídos.
 3. Configurar `BEAUTY_MOVEMENT_ALLOWED_ORIGINS` com a origem exata do ambiente.
 4. Declarar `migrations_dir = "migrations/beauty-movement"` na binding dedicada
    e aplicar as migrations `0001_initial.sql`, `0002_rewards.sql` e
-   `0003_reward_integrity.sql` e `0004_card_outcomes.sql` pelo mecanismo oficial do Wrangler. O helper
+   `0003_reward_integrity.sql`, `0004_card_outcomes.sql` e
+   `0005_invite_assignments.sql` pelo mecanismo oficial do Wrangler. O helper
    local executa `wrangler d1 migrations apply --local`; nunca aplique os SQLs
    manualmente em sequência, pois a segunda migration possui alterações
    aditivas. Registrar checkpoint/export e validar schema. Rollback operacional

--- a/website/docs/beauty-movement-phase1-input-template.md
+++ b/website/docs/beauty-movement-phase1-input-template.md
@@ -58,10 +58,11 @@ evidência da unidade no site; não fecham os valores específicos da ação.
 
 ## 5. Benefícios e condições
 
-As três cartas definem uma oferta por meio do resolver determinístico
-`beautyMovementOutcomes.ts` (**decisão vigente**). A matriz completa e o
-desempate estão em `docs/beauty-movement-combination-map.md`; o catálogo abaixo
-documenta apenas as quatro ofertas comerciais aprovadas.
+Para convites sem atribuição (legado), as três cartas definem uma oferta por
+meio do resolver determinístico `beautyMovementOutcomes.ts`. Na lista final, o
+campo `PRÊMIO` atribui o resultado antes da leitura: as cartas são simbólicas e
+qualquer triplet válido preserva a oferta atribuída. A matriz completa continua
+documentando o catálogo e fornece as combinações simbólicas auditáveis.
 
 | Resultado | Oferta estruturada | Texto comercial | Preços fornecidos | Regras externas | Estado |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -92,12 +93,11 @@ aleatório, concurso ou sorteio.
   de privacidade: `[PENDENTE]`.
 - CPF e histórico de procedimentos: fora do D1, frontend, URL, relatório e
   analytics; nenhum dado bruto deve ser carregado (**consolidado no plano**).
-- Para a lista da aula-cortesia Velocity, a fonte operacional pode conter apenas
-  nome e WhatsApp. E-mail e prêmio são opcionais; quando o prêmio vier, deve ser
-  `Velocity`. O importador gera o identificador opaco do convite, usa a validade
-  da campanha, marca o convite como ativo e mantém uma paleta técnica somente
-  para montar o baralho. A paleta não decide o prêmio. `reward_id` permanece nulo
-  até uma lista comercial posterior.
+- Para a lista final, a fonte operacional pode conter nome, WhatsApp, e-mail
+  opcional e `PRÊMIO`. Os cinco rótulos canônicos são aceitos; o importador gera
+  o identificador opaco, usa a validade da campanha, marca o convite como ativo
+  e mantém uma paleta técnica somente para montar o baralho. A paleta e os
+  cliques não alteram a atribuição. `reward_id` permanece opcional.
 - Consentimento: aceite operacional separado de qualquer marketing futuro;
   redação jurídica final: `[PENDENTE]`.
 - Retenção após encerramento + 90 dias: `[PENDENTE — eliminação / anonimização]`.
@@ -111,9 +111,9 @@ formato mínimo aceito é:
 NOME,TELEFONE
 ```
 
-`EMAIL` e `PRÊMIO` podem ser omitidos ou ficar vazios; o WhatsApp é o canal de
-contato e a chave operacional do convite. Quando informado, o valor de
-`PRÊMIO` deve ser `Velocity` (ou `aula_cortesia_evento`). O importador deriva internamente `invite_ref`,
+`EMAIL` é opcional; o WhatsApp é o canal de contato e a chave operacional do
+convite. Quando informado, `PRÊMIO` deve ser `Velocity` ou um dos quatro
+rótulos comerciais canônicos. O importador deriva internamente `invite_ref`,
 `expires_at`, `invite_status=active`, `palette=radiancia` e
 `velocity_benefit=aula_cortesia_evento` a partir da campanha aprovada. E-mails
 repetidos não bloqueiam a carga porque não identificam o convite.

--- a/website/migrations/beauty-movement/0005_invite_assignments.sql
+++ b/website/migrations/beauty-movement/0005_invite_assignments.sql
@@ -1,0 +1,14 @@
+-- Invite-level prize authority. The spreadsheet assignment is immutable
+-- campaign input; card reveals remain symbolic/auditable and may not change it.
+-- NULL assigned_outcome_key represents the Velocity courtesy outcome when the
+-- assignment protocol is present. Legacy rows have a NULL protocol and keep
+-- the historical card-derived resolver.
+
+PRAGMA foreign_keys = ON;
+
+ALTER TABLE bm_invites ADD COLUMN assigned_outcome_key TEXT;
+ALTER TABLE bm_invites ADD COLUMN assignment_protocol_version TEXT;
+ALTER TABLE bm_invites ADD COLUMN planned_card_selections_json TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_bm_invites_campaign_assignment
+ON bm_invites(campaign_id, assignment_protocol_version, assigned_outcome_key);

--- a/website/src/lib/beautyMovementDb.ts
+++ b/website/src/lib/beautyMovementDb.ts
@@ -13,7 +13,12 @@ import {
     type BeautyMovementEncryptedPersonalData,
 } from "@/lib/beautyMovementSecurity";
 import { getRuntimeSecret } from "@/lib/runtimeSecrets";
-import type { BeautyMovementBenefitStatus, BeautyMovementInviteStatus, BeautyMovementPalette } from "@/lib/beautyMovementImport";
+import {
+    BEAUTY_MOVEMENT_ASSIGNMENT_PROTOCOL_VERSION,
+    type BeautyMovementBenefitStatus,
+    type BeautyMovementInviteStatus,
+    type BeautyMovementPalette,
+} from "@/lib/beautyMovementImport";
 import type {
     BeautyMovementDiscountKind,
     BeautyMovementRewardType,
@@ -94,6 +99,9 @@ type InviteRow = CampaignRow & {
     contact_mask: string;
     palette: BeautyMovementPalette;
     reward_id: string | null;
+    assigned_outcome_key: BeautyMovementOutcomeKey | null;
+    assignment_protocol_version: string | null;
+    planned_card_selections_json: string | null;
     outcome_key: BeautyMovementOutcomeKey | null;
     outcome_snapshot_json: string | null;
     outcome_protocol_version: string | null;
@@ -447,7 +455,8 @@ async function findInviteByTokenHash(db: BeautyMovementD1, tokenHash: string): P
             `SELECT
                 i.id AS invite_id, i.invite_status, i.expires_at_ms AS invite_expires_at_ms,
                 i.personal_data_version, i.personal_data_ciphertext, i.personal_data_iv, i.contact_mask,
-                i.palette, i.reward_id, i.outcome_key, i.outcome_snapshot_json, i.outcome_protocol_version, i.outcome_resolved_at_ms, i.velocity_benefit,
+                i.palette, i.reward_id, i.assigned_outcome_key, i.assignment_protocol_version, i.planned_card_selections_json,
+                i.outcome_key, i.outcome_snapshot_json, i.outcome_protocol_version, i.outcome_resolved_at_ms, i.velocity_benefit,
                 i.benefit_status, i.benefit_text, i.benefit_validity, i.benefit_rules, i.terms_version,
                 r.reward_type, r.procedure_name AS reward_procedure_name,
                 r.discount_kind AS reward_discount_kind, r.discount_value AS reward_discount_value,
@@ -481,7 +490,8 @@ async function findSessionByTokenHash(db: BeautyMovementD1, tokenHash: string): 
                 s.id AS session_id, s.expires_at_ms AS session_expires_at_ms, s.revoked_at_ms AS session_revoked_at_ms,
                 i.id AS invite_id, i.invite_status, i.expires_at_ms AS invite_expires_at_ms,
                 i.personal_data_version, i.personal_data_ciphertext, i.personal_data_iv, i.contact_mask,
-                i.palette, i.reward_id, i.outcome_key, i.outcome_snapshot_json, i.outcome_protocol_version, i.outcome_resolved_at_ms, i.velocity_benefit,
+                i.palette, i.reward_id, i.assigned_outcome_key, i.assignment_protocol_version, i.planned_card_selections_json,
+                i.outcome_key, i.outcome_snapshot_json, i.outcome_protocol_version, i.outcome_resolved_at_ms, i.velocity_benefit,
                 i.benefit_status, i.benefit_text, i.benefit_validity, i.benefit_rules, i.terms_version,
                 r.reward_type, r.procedure_name AS reward_procedure_name,
                 r.discount_kind AS reward_discount_kind, r.discount_value AS reward_discount_value,
@@ -621,6 +631,48 @@ async function resolveAndPersistOutcome(params: {
     nowMs: number;
 }): Promise<BeautyMovementOffer | null> {
     if (params.reveals.length !== 3) return null;
+    const hasInviteAssignment = params.row.assignment_protocol_version === BEAUTY_MOVEMENT_ASSIGNMENT_PROTOCOL_VERSION;
+    if (hasInviteAssignment) {
+        const assignedOutcomeKey = params.row.assigned_outcome_key;
+        if (assignedOutcomeKey !== null && !BEAUTY_MOVEMENT_OUTCOME_KEYS.includes(assignedOutcomeKey)) {
+            throw new Error("beauty_movement_assigned_outcome_invalid");
+        }
+        // Velocity is a guaranteed courtesy outcome, not a commercial offer.
+        // Never let the symbolic cards manufacture a commercial result for it.
+        if (assignedOutcomeKey === null) {
+            if (params.row.outcome_key !== null) throw new Error("beauty_movement_outcome_mismatch");
+            return null;
+        }
+
+        const assignedOffer = getBeautyMovementOffer(assignedOutcomeKey);
+        const assignedSnapshot = JSON.stringify(assignedOffer);
+        if (params.row.outcome_key !== null) {
+            const stored = renderStoredOffer(params.row);
+            if (!stored || params.row.outcome_key !== assignedOutcomeKey) {
+                throw new Error("beauty_movement_outcome_mismatch");
+            }
+            // Assignment authority is immutable. A previously persisted
+            // snapshot may use an older commercial protocol, but it must still
+            // belong to the assigned outcome and remain structurally valid.
+            return stored;
+        }
+        await params.db
+            .prepare(
+                `UPDATE bm_invites
+                 SET outcome_key = COALESCE(outcome_key, ?),
+                     outcome_snapshot_json = COALESCE(outcome_snapshot_json, ?),
+                     outcome_protocol_version = COALESCE(outcome_protocol_version, ?),
+                     outcome_resolved_at_ms = COALESCE(outcome_resolved_at_ms, ?),
+                     updated_at_ms = ?
+                 WHERE id = ? AND outcome_key IS NULL`,
+            )
+            .bind(assignedOutcomeKey, assignedSnapshot, BEAUTY_MOVEMENT_OUTCOME_PROTOCOL_VERSION, params.nowMs, params.nowMs, params.row.invite_id)
+            .run();
+        return assignedOffer;
+    }
+
+    // Legacy invitations without the assignment protocol retain their
+    // historical card-derived behavior for backwards compatibility.
     const selections = {
         beleza: params.reveals.find((reveal) => reveal.act_index === 1)?.card_id,
         movimento: params.reveals.find((reveal) => reveal.act_index === 2)?.card_id,

--- a/website/src/lib/beautyMovementImport.ts
+++ b/website/src/lib/beautyMovementImport.ts
@@ -11,6 +11,11 @@ import {
     type BeautyMovementValidatedReward,
     type BeautyMovementVelocityBenefit,
 } from "@/lib/beautyMovementRewards";
+import {
+    getBeautyMovementOffer,
+    selectBeautyMovementPlannedSelections,
+} from "@/lib/beautyMovementOutcomes";
+import type { BeautyMovementOutcomeKey } from "@/lib/beautyMovementOutcomes";
 
 export type {
     BeautyMovementCanonicalProcedure,
@@ -23,18 +28,19 @@ export type {
 
 export const BEAUTY_MOVEMENT_PALETTES = ["radiancia", "ritmo", "conexao"] as const;
 /**
- * The compact Velocity source only describes the audience and its approved
- * prize. The palette is an internal deck-selection detail in that mode; it
- * must not become a second commercial decision made by the spreadsheet.
+ * The compact sheet is the audience and its approved prize. The palette is an
+ * internal deck-selection detail; it must never become a second commercial
+ * decision or override the spreadsheet assignment.
  */
 export const BEAUTY_MOVEMENT_COMPACT_VELOCITY_PALETTE = "radiancia" as const;
 /**
- * These values are retained for the legacy invitation columns. Modern
- * invitations leave the commercial outcome empty until the three cards are
- * persisted and resolved by the server-side combination engine.
+ * These values are retained for legacy invitation columns. New sheet
+ * invitations persist an explicit assignment protocol; only unassigned legacy
+ * rows use the card-derived combination engine.
  */
 export const BEAUTY_MOVEMENT_BENEFIT_STATUSES = ["aula_cortesia_evento", "evento_condicao_comercial"] as const;
 export const BEAUTY_MOVEMENT_INVITE_STATUSES = ["active", "revoked"] as const;
+export const BEAUTY_MOVEMENT_ASSIGNMENT_PROTOCOL_VERSION = "beauty-movement-invite-assignments-v1" as const;
 
 export type BeautyMovementPalette = (typeof BEAUTY_MOVEMENT_PALETTES)[number];
 export type BeautyMovementBenefitStatus = (typeof BEAUTY_MOVEMENT_BENEFIT_STATUSES)[number];
@@ -128,6 +134,9 @@ export type BeautyMovementImportRow = {
     email: string | null;
     palette: BeautyMovementPalette;
     rewardId: string | null;
+    /** Spreadsheet prize authority. Null means the invite is the Velocity courtesy outcome. */
+    assignedOutcomeKey: BeautyMovementOutcomeKey | null;
+    prizeAssigned: boolean;
     velocityBenefit: BeautyMovementVelocityBenefit;
     expiresAtMs: number;
     inviteStatus: BeautyMovementInviteStatus;
@@ -182,6 +191,9 @@ export type BeautyMovementPreparedInvite = {
     contactMask: string;
     palette: BeautyMovementPalette;
     rewardId: string | null;
+    assignedOutcomeKey: BeautyMovementOutcomeKey | null;
+    assignmentProtocolVersion: typeof BEAUTY_MOVEMENT_ASSIGNMENT_PROTOCOL_VERSION | null;
+    plannedCardSelectionsJson: string;
     velocityBenefit: BeautyMovementVelocityBenefit;
     benefitStatus: BeautyMovementBenefitStatus;
     benefitText: string;
@@ -329,6 +341,31 @@ export function validateBeautyMovementCampaignConfig(value: unknown): BeautyMove
 
 function asAllowed<T extends readonly string[]>(value: string, allowed: T): T[number] | null {
     return (allowed as readonly string[]).includes(value) ? value as T[number] : null;
+}
+
+const PRIZE_OUTCOME_ALIASES: Readonly<Record<string, BeautyMovementOutcomeKey>> = {
+    firmeza_renovacao: "elleva_upgrade",
+    elleva: "elleva_upgrade",
+    harmonia_definicao: "filler_double",
+    preenchimento: "filler_double",
+    estrutura_estimulo: "sculptra_classic_unlock",
+    restylane_classic_sculptra: "sculptra_classic_unlock",
+    hidratacao_luminosidade: "skinbooster_diamond_unlock",
+    restylane_skinbooster_diamond: "skinbooster_diamond_unlock",
+};
+
+function normalizePrize(value: string): BeautyMovementOutcomeKey | null | undefined {
+    const normalized = value
+        .trim()
+        .toLowerCase()
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .replace(/[^a-z0-9]+/g, "_")
+        .replace(/^_+|_+$/g, "");
+    if (!normalized || ["velocity", "aula_cortesia_velocity", "aula_cortesia_de_velocity", "aula_cortesia_evento"].includes(normalized)) {
+        return null;
+    }
+    return PRIZE_OUTCOME_ALIASES[normalized];
 }
 
 function scanRecordDelimiter(line: string, delimiter: string): number {
@@ -560,25 +597,30 @@ export function validateBeautyMovementImport(params: {
             issues.push(issue(rowNumber, "reward_id", "reward_family_mismatch"));
         }
 
+        const rawPrize = cleanText(value("prize"), 80);
+        const assignedOutcomeKey = rawPrize ? normalizePrize(rawPrize) : null;
+        if (rawPrize && assignedOutcomeKey === undefined) {
+            issues.push(issue(rowNumber, "prize", "unsupported_prize"));
+        }
         let velocityBenefit: BeautyMovementVelocityBenefit | null;
         if (isCompactVelocity) {
-            const prize = cleanText(value("prize"), 80)
-                .toLowerCase()
-                .normalize("NFD")
-                .replace(/[\u0300-\u036f]/g, "")
-                .replace(/[^a-z0-9]+/g, "_")
-                .replace(/^_+|_+$/g, "");
-            if (!prize || ["velocity", "aula_cortesia_velocity", "aula_cortesia_de_velocity", "aula_cortesia_evento"].includes(prize)) {
-                velocityBenefit = "aula_cortesia_evento";
-            } else {
-                velocityBenefit = null;
-                issues.push(issue(rowNumber, "prize", "unsupported_prize"));
-            }
+            // The compact sheet is now the canonical invite source: Velocity
+            // rows receive the courtesy entitlement, while each commercial
+            // prize is an explicit server-side assignment.
+            velocityBenefit = assignedOutcomeKey === null ? "aula_cortesia_evento" : "none";
         } else {
             velocityBenefit = asAllowed(
                 cleanText(value("velocity_benefit"), 40).toLowerCase(),
                 ["none", "aula_cortesia_evento"] as const,
             );
+            if (assignedOutcomeKey !== null && assignedOutcomeKey !== undefined) {
+                // The sheet is authoritative for a prepared invite. A stale
+                // legacy courtesy flag must never turn a commercial prize into
+                // a mixed entitlement.
+                velocityBenefit = "none";
+            } else if (assignedOutcomeKey === null && rawPrize) {
+                velocityBenefit = "aula_cortesia_evento";
+            }
             if (!velocityBenefit) {
                 issues.push(issue(
                     rowNumber,
@@ -618,6 +660,7 @@ export function validateBeautyMovementImport(params: {
             (rawEmail.trim() === "" || email) &&
             palette &&
             (!rewardId || reward) &&
+            assignedOutcomeKey !== undefined &&
             velocityBenefit &&
             inviteStatus &&
             expiresAtMs !== null
@@ -630,6 +673,8 @@ export function validateBeautyMovementImport(params: {
                 email,
                 palette,
                 rewardId,
+                assignedOutcomeKey,
+                prizeAssigned: isCompactVelocity || Boolean(rawPrize),
                 velocityBenefit,
                 expiresAtMs,
                 inviteStatus,
@@ -730,6 +775,10 @@ export async function prepareBeautyMovementImport(params: {
             whatsapp: row.whatsapp,
             email: row.email,
         }, params.piiKey);
+        const plannedCardSelections = selectBeautyMovementPlannedSelections({
+            palette: row.palette,
+            outcomeKey: row.prizeAssigned ? row.assignedOutcomeKey : null,
+        });
         invites.push({
             id: crypto.randomUUID(),
             inviteRef,
@@ -739,12 +788,19 @@ export async function prepareBeautyMovementImport(params: {
             contactMask: maskBeautyMovementContact(row.whatsapp, row.email),
             palette: row.palette,
             rewardId: reward?.rewardId ?? null,
+            assignedOutcomeKey: row.assignedOutcomeKey,
+            assignmentProtocolVersion: row.prizeAssigned ? BEAUTY_MOVEMENT_ASSIGNMENT_PROTOCOL_VERSION : null,
+            plannedCardSelectionsJson: JSON.stringify(plannedCardSelections),
             velocityBenefit: row.velocityBenefit,
             // Legacy columns remain populated during the additive migration so
             // old reports/readers fail closed instead of losing the approved
             // condition while the structured reward join is rolled out.
             benefitStatus: reward ? "evento_condicao_comercial" : row.velocityBenefit === "aula_cortesia_evento" ? "aula_cortesia_evento" : "evento_condicao_comercial",
-            benefitText: reward?.displayText ?? "Sua combinação será determinada pelas três cartas.",
+            benefitText: reward?.displayText ?? (row.prizeAssigned
+                ? row.assignedOutcomeKey
+                    ? getBeautyMovementOffer(row.assignedOutcomeKey).commercialText
+                    : "Sua combinação desbloqueou a aula-cortesia Velocity."
+                : "Sua combinação será determinada pelas três cartas."),
             benefitValidity: reward?.validity ?? "Definida após a confirmação da leitura.",
             benefitRules: reward?.rules ?? "A elegibilidade clínica depende de avaliação profissional.",
             termsVersion: reward?.termsVersion ?? "beauty-movement-outcomes-v1",
@@ -848,12 +904,14 @@ export function buildBeautyMovementImportSql(plan: BeautyMovementPreparedImport)
                 id, campaign_id, external_ref, invite_token_hmac,
                 personal_data_version, personal_data_ciphertext, personal_data_iv, contact_mask,
                 palette, reward_id, velocity_benefit,
+                assigned_outcome_key, assignment_protocol_version, planned_card_selections_json,
                 benefit_status, benefit_text, benefit_validity, benefit_rules, terms_version,
                 invite_status, expires_at_ms, created_at_ms, updated_at_ms
             ) VALUES (
                 ${escapeSql(invite.id)}, ${escapeSql(plan.campaignId)}, ${escapeSql(invite.inviteRef)}, ${escapeSql(invite.inviteTokenHmac)},
                 1, ${escapeSql(invite.personalDataCiphertext)}, ${escapeSql(invite.personalDataIv)}, ${escapeSql(invite.contactMask)},
                 ${escapeSql(invite.palette)}, ${invite.rewardId ? escapeSql(invite.rewardId) : "NULL"}, ${escapeSql(invite.velocityBenefit)},
+                ${invite.assignedOutcomeKey ? escapeSql(invite.assignedOutcomeKey) : "NULL"}, ${invite.assignmentProtocolVersion ? escapeSql(invite.assignmentProtocolVersion) : "NULL"}, ${escapeSql(invite.plannedCardSelectionsJson)},
                 ${escapeSql(invite.benefitStatus)}, ${escapeSql(invite.benefitText)}, ${escapeSql(invite.benefitValidity)}, ${escapeSql(invite.benefitRules)}, ${escapeSql(invite.termsVersion)},
                 ${escapeSql(invite.inviteStatus)}, ${invite.expiresAtMs}, ${plan.createdAtMs}, ${plan.createdAtMs}
             ) ON CONFLICT(campaign_id, external_ref) DO UPDATE SET
@@ -864,6 +922,9 @@ export function buildBeautyMovementImportSql(plan: BeautyMovementPreparedImport)
                 palette = excluded.palette,
                 reward_id = excluded.reward_id,
                 velocity_benefit = excluded.velocity_benefit,
+                assigned_outcome_key = excluded.assigned_outcome_key,
+                assignment_protocol_version = excluded.assignment_protocol_version,
+                planned_card_selections_json = excluded.planned_card_selections_json,
                 benefit_status = excluded.benefit_status,
                 benefit_text = excluded.benefit_text,
                 benefit_validity = excluded.benefit_validity,

--- a/website/src/lib/beautyMovementOutcomes.ts
+++ b/website/src/lib/beautyMovementOutcomes.ts
@@ -315,6 +315,39 @@ export function getBeautyMovementOffer(outcomeKey: BeautyMovementOutcomeKey): Be
     return BEAUTY_MOVEMENT_OFFERS[outcomeKey];
 }
 
+/**
+ * Selects one stable, reviewable card triplet for an invite assignment.
+ *
+ * The triplet is an audit/display aid only: the invite assignment remains the
+ * server-side authority, so a visitor may still click any valid card without
+ * changing the guaranteed prize. Keeping this mapping deterministic lets an
+ * import report show which symbolic reading was prepared for each outcome
+ * without using a person's identity or any random source.
+ */
+export function selectBeautyMovementPlannedSelections(params: {
+    palette: BeautyMovementPalette;
+    outcomeKey: BeautyMovementOutcomeKey | null;
+}): BeautyMovementSelections {
+    const firstCards = BEAUTY_MOVEMENT_ACTS.map((act) => getBeautyMovementCardsForAct(params.palette, act)[0]);
+    if (firstCards.some((card) => !card)) throw new Error("beauty_movement_planned_cards_unavailable");
+    if (params.outcomeKey === null) {
+        return Object.fromEntries(BEAUTY_MOVEMENT_ACTS.map((act, index) => [act, firstCards[index]!.id])) as BeautyMovementSelections;
+    }
+
+    const cardsByAct = BEAUTY_MOVEMENT_ACTS.map((act) => getBeautyMovementCardsForAct(params.palette, act));
+    for (const beleza of cardsByAct[0]!) {
+        for (const movimento of cardsByAct[1]!) {
+            for (const celebracao of cardsByAct[2]!) {
+                const selections = { beleza: beleza.id, movimento: movimento.id, celebracao: celebracao.id } as const;
+                if (resolveBeautyMovementOutcome({ palette: params.palette, selections }).outcomeKey === params.outcomeKey) {
+                    return selections;
+                }
+            }
+        }
+    }
+    throw new Error("beauty_movement_planned_outcome_unreachable");
+}
+
 /** Stable, review-friendly artifact used to audit every reachable combination. */
 export function formatBeautyMovementCombinationMapMarkdown(): string {
     const matrix = enumerateBeautyMovementCombinations();

--- a/website/tests/beautyMovementDb.test.ts
+++ b/website/tests/beautyMovementDb.test.ts
@@ -487,6 +487,12 @@ test("invite assignment is authoritative even when symbolic cards resolve elsewh
 test("assigned Velocity invites never manufacture a commercial outcome", async () => {
     const fixture = await makeFixture();
     fixture.db.invite.reward_id = null;
+    fixture.db.invite.reward_type = null;
+    fixture.db.invite.reward_procedure_name = null;
+    fixture.db.invite.reward_display_text = null;
+    fixture.db.invite.reward_validity = null;
+    fixture.db.invite.reward_rules = null;
+    fixture.db.invite.reward_terms_version = null;
     fixture.db.invite.velocity_benefit = "aula_cortesia_evento";
     fixture.db.invite.assigned_outcome_key = null;
     fixture.db.invite.assignment_protocol_version = "beauty-movement-invite-assignments-v1";

--- a/website/tests/beautyMovementDb.test.ts
+++ b/website/tests/beautyMovementDb.test.ts
@@ -446,6 +446,86 @@ test("beauty movement enforces ordered immutable cards and confirms the configur
     assert.equal(stored.email, "ana+event@example.com");
 });
 
+test("invite assignment is authoritative even when symbolic cards resolve elsewhere", async () => {
+    const fixture = await makeFixture();
+    fixture.db.invite.reward_id = null;
+    fixture.db.invite.velocity_benefit = "none";
+    fixture.db.invite.assigned_outcome_key = "filler_double";
+    fixture.db.invite.assignment_protocol_version = "beauty-movement-invite-assignments-v1";
+    const exchange = await exchangeBeautyMovementInvite({
+        token: fixture.token,
+        origin: ORIGIN,
+        ip: "203.0.113.71",
+        nowMs: NOW,
+    }, options(fixture.db));
+    assert.equal(exchange.ok, true);
+    if (!exchange.ok) return;
+    // This triplet is an Elleva reading under the legacy affinity resolver;
+    // the prepared invite must still reveal its assigned commercial offer.
+    for (const [actIndex, cardId] of [[1, "beleza-presenca"], [2, "movimento-potencia"], [3, "celebracao-renovacao"]] as const) {
+        const reveal = await revealBeautyMovementCard({
+            sessionToken: exchange.sessionToken,
+            actIndex,
+            cardId,
+            origin: ORIGIN,
+            ip: "203.0.113.71",
+        }, options(fixture.db));
+        assert.equal(reveal.ok, true);
+    }
+    const confirmed = await confirmBeautyMovementInvite({
+        sessionToken: exchange.sessionToken,
+        operationalConsent: true,
+        origin: ORIGIN,
+        ip: "203.0.113.71",
+    }, options(fixture.db));
+    assert.equal(confirmed.ok, true);
+    if (!confirmed.ok) return;
+    assert.deepEqual(confirmed.state.offer, getBeautyMovementOffer("filler_double"));
+    assert.equal(fixture.db.invite.outcome_key, "filler_double");
+});
+
+test("assigned Velocity invites never manufacture a commercial outcome", async () => {
+    const fixture = await makeFixture();
+    fixture.db.invite.reward_id = null;
+    fixture.db.invite.velocity_benefit = "aula_cortesia_evento";
+    fixture.db.invite.assigned_outcome_key = null;
+    fixture.db.invite.assignment_protocol_version = "beauty-movement-invite-assignments-v1";
+    const exchange = await exchangeBeautyMovementInvite({
+        token: fixture.token,
+        origin: ORIGIN,
+        ip: "203.0.113.72",
+        nowMs: NOW,
+    }, options(fixture.db));
+    assert.equal(exchange.ok, true);
+    if (!exchange.ok) return;
+    for (const [actIndex, cardId] of [[1, "beleza-presenca"], [2, "movimento-potencia"], [3, "celebracao-renovacao"]] as const) {
+        const reveal = await revealBeautyMovementCard({
+            sessionToken: exchange.sessionToken,
+            actIndex,
+            cardId,
+            origin: ORIGIN,
+            ip: "203.0.113.72",
+        }, options(fixture.db));
+        assert.equal(reveal.ok, true);
+    }
+    const confirmed = await confirmBeautyMovementInvite({
+        sessionToken: exchange.sessionToken,
+        operationalConsent: true,
+        origin: ORIGIN,
+        ip: "203.0.113.72",
+    }, options(fixture.db));
+    assert.equal(confirmed.ok, true);
+    if (!confirmed.ok) return;
+    assert.equal(confirmed.state.offer, null);
+    assert.equal(confirmed.state.benefit, null);
+    assert.deepEqual(confirmed.state.velocity, {
+        enabled: true,
+        label: "Aula-cortesia Velocity",
+        text: "A equipe confirmará a turma e os detalhes operacionais.",
+    });
+    assert.equal(fixture.db.invite.outcome_key, null);
+});
+
 test("beauty movement preserves a prior v1 outcome instead of reinterpreting it with v2 affinities", async () => {
     const fixture = await makeFixture();
     const exchange = await exchangeBeautyMovementInvite({ token: fixture.token, origin: ORIGIN, ip: "203.0.113.12", nowMs: NOW }, options(fixture.db));

--- a/website/tests/beautyMovementImport.test.ts
+++ b/website/tests/beautyMovementImport.test.ts
@@ -216,7 +216,7 @@ test("assigned commercial compact imports persist a deterministic symbolic tripl
     assert.equal(plan.invites[0]?.assignedOutcomeKey, "sculptra_classic_unlock");
     assert.equal(plan.invites[0]?.assignmentProtocolVersion, "beauty-movement-invite-assignments-v1");
     assert.deepEqual(JSON.parse(plan.invites[0]!.plannedCardSelectionsJson), {
-        beleza: "beleza-autoria",
+        beleza: "beleza-autocuidado",
         movimento: "movimento-potencia",
         celebracao: "celebracao-confianca",
     });

--- a/website/tests/beautyMovementImport.test.ts
+++ b/website/tests/beautyMovementImport.test.ts
@@ -171,7 +171,7 @@ test("compact Velocity imports also accept only name and WhatsApp", () => {
     if (validation.ok) assert.equal(validation.rows[0]?.velocityBenefit, "aula_cortesia_evento");
 });
 
-test("compact Velocity imports fail closed without campaign expiry or with another prize", () => {
+test("compact invite imports fail closed without campaign expiry and map canonical prizes", async () => {
     const csv = [
         "nome,telefone,premio",
         "Ana Silva,51999991234,Velocity",
@@ -180,13 +180,50 @@ test("compact Velocity imports fail closed without campaign expiry or with anoth
     assert.equal(withoutExpiry.ok, false);
     if (!withoutExpiry.ok) assert.equal(withoutExpiry.issues.some((entry) => entry.code === "compact_expiry_unavailable"), true);
 
-    const unsupported = validateBeautyMovementImport({
+    const commercial = validateBeautyMovementImport({
         csv: csv.replace("Velocity", "Preenchimento"),
         nowMs: NOW,
         defaultExpiresAtMs: EXPIRES_MS,
     });
-    assert.equal(unsupported.ok, false);
-    if (!unsupported.ok) assert.equal(unsupported.issues.some((entry) => entry.code === "unsupported_prize"), true);
+    assert.equal(commercial.ok, true);
+    if (commercial.ok) {
+        assert.equal(commercial.rows[0]?.assignedOutcomeKey, "filler_double");
+        assert.equal(commercial.rows[0]?.velocityBenefit, "none");
+    }
+
+    const unknown = validateBeautyMovementImport({
+        csv: csv.replace("Velocity", "Premio desconhecido"),
+        nowMs: NOW,
+        defaultExpiresAtMs: EXPIRES_MS,
+    });
+    assert.equal(unknown.ok, false);
+    if (!unknown.ok) assert.equal(unknown.issues.some((entry) => entry.code === "unsupported_prize"), true);
+});
+
+test("assigned commercial compact imports persist a deterministic symbolic triplet", async () => {
+    const plan = await prepareBeautyMovementImport({
+        csv: [
+            "NOME,TELEFONE,PRÊMIO",
+            "Ana Silva,51999991234,Estrutura & Estímulo",
+        ].join("\n"),
+        campaignId: "nh-assigned",
+        campaignConfig: validCampaignConfig(),
+        campaignEndsAtMs: EXPIRES_MS,
+        tokenHmacKey: TOKEN_KEY,
+        piiKey: PII_KEY,
+        nowMs: NOW,
+    });
+    assert.equal(plan.invites[0]?.assignedOutcomeKey, "sculptra_classic_unlock");
+    assert.equal(plan.invites[0]?.assignmentProtocolVersion, "beauty-movement-invite-assignments-v1");
+    assert.deepEqual(JSON.parse(plan.invites[0]!.plannedCardSelectionsJson), {
+        beleza: "beleza-autoria",
+        movimento: "movimento-potencia",
+        celebracao: "celebracao-confianca",
+    });
+    const sql = buildBeautyMovementImportSql(plan);
+    assert.match(sql, /assigned_outcome_key, assignment_protocol_version, planned_card_selections_json/);
+    assert.match(sql, /sculptra_classic_unlock/);
+    assert.match(sql, /beauty-movement-invite-assignments-v1/);
 });
 
 test("CLI dry-run forwards campaign expiry to compact Velocity validation", async () => {
@@ -382,4 +419,8 @@ test("D1 migrations preserve the structured reward-to-palette invariant", async 
     assert.match(outcomeMigration, /outcome_key/);
     assert.match(outcomeMigration, /outcome_snapshot_json/);
     assert.match(outcomeMigration, /outcome_protocol_version/);
+    const assignmentMigration = await readFile(new URL("../migrations/beauty-movement/0005_invite_assignments.sql", import.meta.url), "utf8");
+    assert.match(assignmentMigration, /assigned_outcome_key/);
+    assert.match(assignmentMigration, /assignment_protocol_version/);
+    assert.match(assignmentMigration, /planned_card_selections_json/);
 });


### PR DESCRIPTION
Implements the final invite contract: PRÊMIO is the server-authoritative assignment, Velocity remains a courtesy outcome, and card clicks stay symbolic. Adds additive 0005 invite assignment fields, deterministic planned-card audit data, importer mapping for all five canonical prizes, server persistence/readback enforcement, and focused tests/docs. No PII or secrets included.