### PR TITLE
fix(beauty-movement): apply remote invite migration before smoke

### DIFF
--- a/.github/workflows/beauty-movement-production-activation.yml
+++ b/.github/workflows/beauty-movement-production-activation.yml
@@ -203,6 +203,13 @@ jobs:
             "${PRODUCTION_URL}/api/beleza-em-movimento/session" || true)"
           [[ "${status}" == "503" ]] || { echo "production campaign is not disabled before activation (HTTP ${status})"; exit 1; }
 
+      - name: Apply pending Beauty Movement migrations in production
+        working-directory: website
+        shell: bash
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4.112.0 d1 migrations apply "${PRODUCTION_D1_DATABASE}" --remote --config wrangler.toml
+
       - name: Validate production invite-assignment schema before mutation
         working-directory: website
         shell: bash

--- a/.github/workflows/beauty-movement-staging-smoke.yml
+++ b/.github/workflows/beauty-movement-staging-smoke.yml
@@ -127,6 +127,13 @@ jobs:
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
           key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
 
+      - name: Apply pending Beauty Movement migrations in staging
+        working-directory: website
+        shell: bash
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4.112.0 d1 migrations apply "${STAGING_D1_DATABASE}" --remote --config wrangler.toml --env staging
+
       - name: Setup Node
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:


### PR DESCRIPTION
O smoke descobriu que 0005_invite_assignments.sql ainda estava pendente no D1 de staging. Este PR adiciona a aplicação idempotente das migrations pendentes pelo Wrangler oficial, depois dos leases e antes da validação do schema, em staging e no gate de produção. Nenhum dado é apagado; os workflows continuam fail-closed e com restauração.