### PR TITLE
fix(orb): guard executor startup on auth material

### DIFF
--- a/ops/runtime/units/orb-ccg-executor.service
+++ b/ops/runtime/units/orb-ccg-executor.service
@@ -17,6 +17,7 @@ EnvironmentFile=-__CONFIG_ROOT__/orb.env
 EnvironmentFile=-__CONFIG_ROOT__/orb-business.env
 EnvironmentFile=-__CONFIG_ROOT__/orb-runtime-paths.env
 EnvironmentFile=-__CONFIG_ROOT__/orb-ccg-executor.env
+ExecStartPre=/usr/bin/grep -Eq ^CCG_EXECUTOR_AUTH_TOKEN=.{32,}$ __CONFIG_ROOT__/orb-ccg-executor.env
 ExecStart=/usr/bin/node campaign-creative-executor/server.js
 Restart=always
 RestartSec=10


### PR DESCRIPTION
## Scope\nAdd a systemd ExecStartPre guard to the CCG executor unit. The service refuses to start unless the dedicated CCG_EXECUTOR_AUTH_TOKEN file contains non-empty auth material, closing the fail-open window while older immutable bundles are still running.\n\n## Validation\n- lifecycle unit templates: systemd-analyze verify passed\n- runtime drop-in updated with the same guard\n- orb-ccg-executor restarted successfully\n- healthz green with live_enabled=false\n- credential remains root:skincos 0640 and outside Git\n\nThis is the follow-up hardening for merged PR #1587. No OpenAI, Meta Ads, or other credential family changed.