### PR TITLE
fix(orb): remove auth material from example env

### DIFF
--- a/orb/engine/.env.example
+++ b/orb/engine/.env.example
@@ -50,7 +50,8 @@ META_ADS_REPORT_COMPAT_EXPORT_TARGET=google_sheets_optional
 
 # Campaign Creative Creator executor (keep LIVE disabled unless explicitly governed)
 CCG_EXECUTOR_BASE_URL=http://127.0.0.1:8790
-CCG_EXECUTOR_AUTH_TOKEN= # gitleaks:allow - intentionally empty example value; use a private overlay for governed runs
+# Executor authentication is intentionally omitted from this example.
+# Provide the dedicated token only through a private runtime overlay for governed runs.
 CCG_EXECUTOR_LIVE_ENABLED=0
 CCG_EXECUTOR_LISTEN_ADDRESS=127.0.0.1
 CCG_EXECUTOR_PORT=8790

--- a/orb/engine/tests/campaign-creative-executor.test.js
+++ b/orb/engine/tests/campaign-creative-executor.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 const test = require('node:test');
 const {
   AdapterRegistry,
@@ -31,6 +33,11 @@ function job(jobId, capability, extra = {}) {
     ...extra,
   };
 }
+
+test('example environment never contains CCG executor authentication material', () => {
+  const envExample = fs.readFileSync(path.join(__dirname, '..', '.env.example'), 'utf8');
+  assert.doesNotMatch(envExample, /^CCG_EXECUTOR_AUTH_TOKEN=/m);
+});
 
 function manifest(jobs, extra = {}) {
   const maxJobs = Math.max(1, jobs.length);


### PR DESCRIPTION
## Summary\n- remove the empty CCG executor auth assignment from the committed example environment\n- document private-overlay provisioning without a committed credential-shaped value\n- add a regression test preventing an auth assignment from returning to the example\n\n## Validation\n- orb executor test: 17/17\n- orb lint: passed\n- git diff --check: passed\n\nThis is a sanitized follow-up to the G3 custody remediation. No secret material is included.