### PR TITLE
fix(orb): align Livia manifest entrypoint contract

### DIFF
--- a/orb/engine/scripts/apply-livia-runtime-isolation.js
+++ b/orb/engine/scripts/apply-livia-runtime-isolation.js
@@ -37,7 +37,7 @@ function assertPrecreatedManifest(manifestPath, candidate) {
   if (manifest.workflowSha256 !== stableHash({ nodes: candidate.nodes, connections: candidate.connections })) {
     fail('Precreated workflow runtime manifest does not match the candidate workflow hash.');
   }
-  if (!Array.isArray(manifest.entrypoints) || manifest.entrypoints.length !== 6 || manifest.entrypoints.some((entry) => !/^[a-f0-9]{64}$/.test(String(entry?.sha256 || '')))) {
+  if (!Array.isArray(manifest.entrypoints) || manifest.entrypoints.length !== 8 || manifest.entrypoints.some((entry) => !/^[a-f0-9]{64}$/.test(String(entry?.sha256 || '')))) {
     fail('Precreated workflow runtime manifest has an invalid entrypoint hash contract.');
   }
 }

--- a/orb/engine/tests/livia-runtime-isolation.test.js
+++ b/orb/engine/tests/livia-runtime-isolation.test.js
@@ -60,3 +60,9 @@ test('runtime isolation reconciles a stale publish-history identity under a writ
   assert.match(source, /pg_get_serial_sequence\('n8n_runtime\.workflow_publish_history', 'id'\)::regclass/);
   assert.match(source, /COALESCE\(MAX\(id\), 0\)/);
 });
+
+test('runtime isolation accepts every pinned Livia manifest entrypoint', () => {
+  const source = fs.readFileSync(APPLIER, 'utf8');
+  assert.match(source, /entrypoints\.length !== 8/);
+  assert.doesNotMatch(source, /entrypoints\.length !== 6/);
+});


### PR DESCRIPTION
## Objetivo\nCorrigir a guarda do aplicador de runtime descoberta durante a promoção de #1592.\n\n## Causa\nO construtor de manifesto passou a registrar 8 entrypoints após incluir os helpers do lease; o aplicador ainda exigia 6 e recusava o manifesto antes da transação.\n\n## Mudança\n- aceitar e validar os 8 hashes de entrypoint atualmente gerados;\n- adicionar teste de contrato para impedir regressão.\n\n## Validação\n- node --test orb/engine/tests/livia-*.test.js (48 verdes);\n- git diff --check.\n\n## Rollback\nReverter esta alteração mantendo a versão histórica anterior; nenhuma mudança de produção ocorreu neste follow-up.