### PR TITLE
fix(beauty-movement): force temporary activation flag in overlay config

### DIFF
--- a/.github/scripts/beauty-movement-production-activation-contract.test.mjs
+++ b/.github/scripts/beauty-movement-production-activation-contract.test.mjs
@@ -47,7 +47,7 @@ test("private package and remote secret custody are fail-closed without logging 
 
 test("schema, draft readback, build attestation, browser journey and persisted outcome are required", () => {
   assert.match(workflow, /0004_card_outcomes\.sql/);
-  assert.match(workflow, /beauty_movement_production_0004_schema_invalid/);
+  assert.match(workflow, /beauty_movement_production_invite_assignment_schema_invalid/);
   assert.match(workflow, /status !== 'draft'/);
   assert.match(workflow, /beauty_movement_active_readback_invalid/);
   assert.match(workflow, /beauty_movement_active_campaign_already_present/);

--- a/.github/workflows/beauty-movement-production-activation.yml
+++ b/.github/workflows/beauty-movement-production-activation.yml
@@ -315,6 +315,26 @@ jobs:
           test -f "${RUNNER_TEMP}/beauty-movement-production-activation/website-lease.json"
           NEXT_PUBLIC_BUILD_SHA="${RELEASE_SHA}" NEXT_PUBLIC_BUILD_TIME="${GITHUB_RUN_ID}" node scripts/assert-production-snapshot.mjs
           NEXT_PUBLIC_BUILD_SHA="${RELEASE_SHA}" NEXT_PUBLIC_BUILD_TIME="${GITHUB_RUN_ID}" npx opennextjs-cloudflare build
+          activation_config="${ACTIVATION_ROOT}/wrangler-enabled.toml"
+          node - "${activation_config}" <<'NODE'
+          const fs = require('node:fs');
+          const output = process.argv[2];
+          const input = fs.readFileSync('wrangler.toml', 'utf8');
+          const marker = '[vars]';
+          const start = input.indexOf(marker);
+          if (start < 0) throw new Error('beauty_movement_production_vars_section_missing');
+          const nextSection = input.indexOf('\n[', start + marker.length);
+          const end = nextSection < 0 ? input.length : nextSection;
+          const section = input.slice(start, end);
+          if (!/^BEAUTY_MOVEMENT_ENABLED\s*=\s*"false"\s*$/m.test(section)) {
+            throw new Error('beauty_movement_production_default_flag_changed');
+          }
+          const enabled = section.replace(
+            /^(BEAUTY_MOVEMENT_ENABLED\s*=\s*)"false"\s*$/m,
+            '$1"true"',
+          );
+          fs.writeFileSync(output, `${input.slice(0, start)}${enabled}${input.slice(end)}`, { mode: 0o600 });
+          NODE
           node - "${STATE_FILE}" <<'NODE'
           const fs = require('node:fs');
           const path = process.argv[2];
@@ -323,8 +343,8 @@ jobs:
           fs.writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
           NODE
           NEXT_PUBLIC_BUILD_SHA="${RELEASE_SHA}" NEXT_PUBLIC_BUILD_TIME="${GITHUB_RUN_ID}" \
-            npx --yes wrangler@4.112.0 deploy --config wrangler.toml --keep-vars \
-            --var 'BEAUTY_MOVEMENT_ENABLED:true' --message "beauty-movement-production-activation:${RELEASE_SHA}:${GITHUB_RUN_ID}"
+            npx --yes wrangler@4.112.0 deploy --config "${activation_config}" --keep-vars \
+            --message "beauty-movement-production-activation:${RELEASE_SHA}:${GITHUB_RUN_ID}"
           deployments="${ACTIVATION_ROOT}/candidate.json"
           npx --yes wrangler@4.112.0 deployments list --config wrangler.toml --json > "${deployments}"
           node - "${deployments}" "${STATE_FILE}" "${RELEASE_SHA}" <<'NODE'

--- a/.github/workflows/beauty-movement-production-activation.yml
+++ b/.github/workflows/beauty-movement-production-activation.yml
@@ -344,7 +344,7 @@ jobs:
           NODE
           NEXT_PUBLIC_BUILD_SHA="${RELEASE_SHA}" NEXT_PUBLIC_BUILD_TIME="${GITHUB_RUN_ID}" \
             npx --yes wrangler@4.112.0 deploy --config "${activation_config}" --keep-vars \
-            --message "beauty-movement-production-activation:${RELEASE_SHA}:${GITHUB_RUN_ID}"
+            --var 'BEAUTY_MOVEMENT_ENABLED:true' --message "beauty-movement-production-activation:${RELEASE_SHA}:${GITHUB_RUN_ID}"
           deployments="${ACTIVATION_ROOT}/candidate.json"
           npx --yes wrangler@4.112.0 deployments list --config wrangler.toml --json > "${deployments}"
           node - "${deployments}" "${STATE_FILE}" "${RELEASE_SHA}" <<'NODE'

--- a/.github/workflows/beauty-movement-staging-smoke.yml
+++ b/.github/workflows/beauty-movement-staging-smoke.yml
@@ -317,9 +317,29 @@ jobs:
 
           NEXT_PUBLIC_BUILD_SHA="${RELEASE_SHA}" NEXT_PUBLIC_BUILD_TIME="${GITHUB_RUN_ID}" node scripts/assert-production-snapshot.mjs
           NEXT_PUBLIC_BUILD_SHA="${RELEASE_SHA}" NEXT_PUBLIC_BUILD_TIME="${GITHUB_RUN_ID}" npx opennextjs-cloudflare build
+          activation_config="${RUNNER_TEMP}/beauty-movement-staging-smoke/wrangler-enabled.toml"
+          node - "${activation_config}" <<'NODE'
+          const fs = require('node:fs');
+          const output = process.argv[2];
+          const input = fs.readFileSync('wrangler.toml', 'utf8');
+          const marker = '[env.staging.vars]';
+          const start = input.indexOf(marker);
+          if (start < 0) throw new Error('beauty_movement_staging_vars_section_missing');
+          const nextSection = input.indexOf('\n[', start + marker.length);
+          const end = nextSection < 0 ? input.length : nextSection;
+          const section = input.slice(start, end);
+          if (!/^BEAUTY_MOVEMENT_ENABLED\s*=\s*"false"\s*$/m.test(section)) {
+            throw new Error('beauty_movement_staging_default_flag_changed');
+          }
+          const enabled = section.replace(
+            /^(BEAUTY_MOVEMENT_ENABLED\s*=\s*)"false"\s*$/m,
+            '$1"true"',
+          );
+          fs.writeFileSync(output, `${input.slice(0, start)}${enabled}${input.slice(end)}`, { mode: 0o600 });
+          NODE
           NEXT_PUBLIC_BUILD_SHA="${RELEASE_SHA}" NEXT_PUBLIC_BUILD_TIME="${GITHUB_RUN_ID}" \
-            npx --yes wrangler@4.112.0 deploy --config wrangler.toml --env staging --keep-vars \
-            --var 'BEAUTY_MOVEMENT_ENABLED:true' --message "${candidate_message}"
+            npx --yes wrangler@4.112.0 deploy --config "${activation_config}" --env staging --keep-vars \
+            --message "${candidate_message}"
           deployments="$RUNNER_TEMP/beauty-movement-staging-smoke/candidate.json"
           candidate_version=''
           for attempt in $(seq 1 12); do

--- a/.github/workflows/beauty-movement-staging-smoke.yml
+++ b/.github/workflows/beauty-movement-staging-smoke.yml
@@ -339,7 +339,7 @@ jobs:
           NODE
           NEXT_PUBLIC_BUILD_SHA="${RELEASE_SHA}" NEXT_PUBLIC_BUILD_TIME="${GITHUB_RUN_ID}" \
             npx --yes wrangler@4.112.0 deploy --config "${activation_config}" --env staging --keep-vars \
-            --message "${candidate_message}"
+            --var 'BEAUTY_MOVEMENT_ENABLED:true' --message "${candidate_message}"
           deployments="$RUNNER_TEMP/beauty-movement-staging-smoke/candidate.json"
           candidate_version=''
           for attempt in $(seq 1 12); do


### PR DESCRIPTION
## Summary\n- generate a runner-private Wrangler overlay that explicitly enables Beauty Movement for the temporary staging smoke and controlled production activation\n- keep the versioned wrangler.toml default disabled and preserve unrelated remote vars with --keep-vars\n- remove reliance on a CLI --var override that was masked by the incumbent remote false value\n\n## Evidence\nRuns 32520308294 and 32520715518 deployed successfully but browser session bootstrap returned 503 because BEAUTY_MOVEMENT_ENABLED remained false. Both runs restored staging and left production untouched. The overlay is validated against the versioned default before deployment.