### PR TITLE
fix(security): sanitize Evolution API documentation examples

### DIFF
--- a/messaging/channels/whatsapp/engine/GUIA-RAPIDO.md
+++ b/messaging/channels/whatsapp/engine/GUIA-RAPIDO.md
@@ -22,14 +22,14 @@ A instância **whatsapp-final** que estava conectada foi perdida quando o banco 
 
 ### Opção 1: Conectar via QR Code no Manager
 1. Acesse: http://localhost:8080/manager
-2. Use a API Key: `429683C4C977415CAAFCCE10F7D57E11`
+2. Use a API Key: `YOUR_EVOLUTION_API_KEY`
 3. Clique na instância **whatsapp-final**
 4. Escaneie o QR Code com seu WhatsApp
 
 ### Opção 2: Obter QR Code via API
 ```bash
 curl -X GET "http://localhost:8080/instance/connect/whatsapp-final" \
-  -H "apikey: 429683C4C977415CAAFCCE10F7D57E11"
+  -H "apikey: YOUR_EVOLUTION_API_KEY"
 ```
 
 ---
@@ -78,7 +78,7 @@ curl http://localhost:8080
 
 ```bash
 curl -X GET "http://localhost:8080/instance/fetchInstances" \
-  -H "apikey: 429683C4C977415CAAFCCE10F7D57E11"
+  -H "apikey: YOUR_EVOLUTION_API_KEY"
 ```
 
 ---
@@ -89,7 +89,7 @@ curl -X GET "http://localhost:8080/instance/fetchInstances" \
 
 ```bash
 curl -X GET "http://localhost:8080/instance/connectionState/whatsapp-final" \
-  -H "apikey: 429683C4C977415CAAFCCE10F7D57E11"
+  -H "apikey: YOUR_EVOLUTION_API_KEY"
 ```
 
 ### Enviar mensagem de teste
@@ -97,7 +97,7 @@ curl -X GET "http://localhost:8080/instance/connectionState/whatsapp-final" \
 ```bash
 curl -X POST "http://localhost:8080/message/sendText/whatsapp-final" \
   -H "Content-Type: application/json" \
-  -H "apikey: 429683C4C977415CAAFCCE10F7D57E11" \
+  -H "apikey: YOUR_EVOLUTION_API_KEY" \
   -d '{
     "number": "5551995103563",
     "text": "Mensagem de teste!"
@@ -108,21 +108,21 @@ curl -X POST "http://localhost:8080/message/sendText/whatsapp-final" \
 
 ```bash
 curl -X DELETE "http://localhost:8080/instance/logout/whatsapp-final" \
-  -H "apikey: 429683C4C977415CAAFCCE10F7D57E11"
+  -H "apikey: YOUR_EVOLUTION_API_KEY"
 ```
 
 ### Deletar instância
 
 ```bash
 curl -X DELETE "http://localhost:8080/instance/delete/whatsapp-final" \
-  -H "apikey: 429683C4C977415CAAFCCE10F7D57E11"
+  -H "apikey: YOUR_EVOLUTION_API_KEY"
 ```
 
 ---
 
 ## 🔑 Credenciais
 
-- **API Key**: `429683C4C977415CAAFCCE10F7D57E11`
+- **API Key**: `YOUR_EVOLUTION_API_KEY`
 - **URL Base**: `http://localhost:8080`
 - **Instância WhatsApp**: `whatsapp-final`
 - **Número**: `5551995103563`
@@ -155,7 +155,7 @@ UPDATE "Instance" SET name = 'novo-nome' WHERE name = 'whatsapp-final';
 ```bash
 curl -X POST "http://localhost:8080/instance/create" \
   -H "Content-Type: application/json" \
-  -H "apikey: 429683C4C977415CAAFCCE10F7D57E11" \
+  -H "apikey: YOUR_EVOLUTION_API_KEY" \
   -d '{
     "instanceName": "novo-nome",
     "qrcode": true,
@@ -186,7 +186,7 @@ node dist/main
 ```bash
 # Reconecte gerando novo QR Code
 curl -X GET "http://localhost:8080/instance/connect/whatsapp-final" \
-  -H "apikey: 429683C4C977415CAAFCCE10F7D57E11"
+  -H "apikey: YOUR_EVOLUTION_API_KEY"
 ```
 
 ### Atualizar Evolution API

--- a/messaging/channels/whatsapp/engine/MIGRATION.md
+++ b/messaging/channels/whatsapp/engine/MIGRATION.md
@@ -116,7 +116,7 @@ npm run dev:server
 ```bash
 # Verificar instâncias
 curl -X GET http://localhost:8080/instance/fetchInstances \
-  -H "apikey: 429683C4C977415CAAFCCE10F7D57E11"
+  -H "apikey: YOUR_EVOLUTION_API_KEY"
 
 # Resultado: 3 instâncias conectadas (state: open)
 ```

--- a/messaging/channels/whatsapp/engine/SUCESSO-INSTALACAO.md
+++ b/messaging/channels/whatsapp/engine/SUCESSO-INSTALACAO.md
@@ -12,7 +12,7 @@ A Evolution API foi instalada localmente e está **FUNCIONANDO PERFEITAMENTE**!
 - **Porta**: 8080
 - **URL**: http://localhost:8080
 - **Versão**: 2.3.4
-- **API Key**: `429683C4C977415CAAFCCE10F7D57E11`
+- **API Key**: `YOUR_EVOLUTION_API_KEY`
 
 ## 🚀 Como Iniciar
 
@@ -45,7 +45,7 @@ O QR Code aparece automaticamente nos logs quando você inicia a API!
 # Criar nova instância
 curl -X POST http://localhost:8080/instance/create \
   -H "Content-Type: application/json" \
-  -H "apikey: 429683C4C977415CAAFCCE10F7D57E11" \
+  -H "apikey: YOUR_EVOLUTION_API_KEY" \
   -d '{
     "instanceName": "seu-numero",
     "qrcode": true,
@@ -54,14 +54,14 @@ curl -X POST http://localhost:8080/instance/create \
 
 # Obter QR Code
 curl -X GET "http://localhost:8080/instance/connect/seu-numero" \
-  -H "apikey: 429683C4C977415CAAFCCE10F7D57E11"
+  -H "apikey: YOUR_EVOLUTION_API_KEY"
 ```
 
 ### Opção 3: Manager Web
 
 Acesse: http://localhost:8080/manager
 
-- API Key: `429683C4C977415CAAFCCE10F7D57E11`
+- API Key: `YOUR_EVOLUTION_API_KEY`
 
 ## 📋 Instância Atual
 
@@ -77,7 +77,7 @@ curl -s http://localhost:8080/ | jq '.'
 ### Listar Instâncias
 ```bash
 curl -s -X GET "http://localhost:8080/instance/fetchInstances" \
-  -H "apikey: 429683C4C977415CAAFCCE10F7D57E11" | jq '.'
+  -H "apikey: YOUR_EVOLUTION_API_KEY" | jq '.'
 ```
 
 ### Parar API

--- a/scripts/tests/evolution-whatsapp-docs-secret-regression.test.mjs
+++ b/scripts/tests/evolution-whatsapp-docs-secret-regression.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "../..");
+const documentationFiles = [
+  "messaging/channels/whatsapp/engine/.env.example",
+  "messaging/channels/whatsapp/engine/GUIA-RAPIDO.md",
+  "messaging/channels/whatsapp/engine/MIGRATION.md",
+  "messaging/channels/whatsapp/engine/SUCESSO-INSTALACAO.md",
+];
+
+const credentialContext = /(AUTHENTICATION_API_KEY|API_AUDIO_CONVERTER_KEY|apikey|authorization)\b/i;
+const hexCredential = /\b[0-9a-f]{32,}\b/gi;
+
+test("WhatsApp documentation contains no long hexadecimal credential in auth context", () => {
+  const offenders = [];
+
+  for (const relativeFile of documentationFiles) {
+    const absoluteFile = path.join(repositoryRoot, relativeFile);
+    if (!existsSync(absoluteFile)) continue;
+
+    const lines = readFileSync(absoluteFile, "utf8").split(/\r?\n/);
+    lines.forEach((line, index) => {
+      if (!credentialContext.test(line)) return;
+      if (hexCredential.test(line)) {
+        offenders.push({ file: relativeFile, line: index + 1 });
+      }
+      hexCredential.lastIndex = 0;
+    });
+  }
+
+  assert.deepEqual(offenders, []);
+});


### PR DESCRIPTION
## Summary
- replace credential-like literals in Evolution API / WhatsApp documentation with an explicit synthetic placeholder
- add a regression test that rejects long hexadecimal credentials in authentication examples

## Validation
- `node --test scripts/tests/evolution-whatsapp-docs-secret-regression.test.mjs`
- `git diff --check`
- `verify:changed` reached architecture validation and deterministic delta secret scan; its quality-critical phase was not runnable in the isolated worktree because `crm/console/node_modules` is absent (`eslint: not found`)

This PR does not change runtime credentials, services, production, or branch protection.