### PR TITLE
fix(beauty-movement): resolve activation overlay from website root

### DIFF
--- a/.github/scripts/beauty-movement-production-activation-contract.test.mjs
+++ b/.github/scripts/beauty-movement-production-activation-contract.test.mjs
@@ -47,7 +47,7 @@ test("private package and remote secret custody are fail-closed without logging 
 
 test("schema, draft readback, build attestation, browser journey and persisted outcome are required", () => {
   assert.match(workflow, /0004_card_outcomes\.sql/);
-  assert.match(workflow, /beauty_movement_production_0004_schema_invalid/);
+  assert.match(workflow, /beauty_movement_production_invite_assignment_schema_invalid/);
   assert.match(workflow, /status !== 'draft'/);
   assert.match(workflow, /beauty_movement_active_readback_invalid/);
   assert.match(workflow, /beauty_movement_active_campaign_already_present/);

--- a/.github/workflows/beauty-movement-production-activation.yml
+++ b/.github/workflows/beauty-movement-production-activation.yml
@@ -315,7 +315,10 @@ jobs:
           test -f "${RUNNER_TEMP}/beauty-movement-production-activation/website-lease.json"
           NEXT_PUBLIC_BUILD_SHA="${RELEASE_SHA}" NEXT_PUBLIC_BUILD_TIME="${GITHUB_RUN_ID}" node scripts/assert-production-snapshot.mjs
           NEXT_PUBLIC_BUILD_SHA="${RELEASE_SHA}" NEXT_PUBLIC_BUILD_TIME="${GITHUB_RUN_ID}" npx opennextjs-cloudflare build
-          activation_config="${ACTIVATION_ROOT}/wrangler-enabled.toml"
+          # Keep the private overlay beside the checked-out website so Wrangler
+          # resolves the relative OpenNext entrypoint from the website root.
+          activation_config="${PWD}/.beauty-movement-wrangler-enabled.toml"
+          trap 'rm -f "${activation_config}"' EXIT
           node - "${activation_config}" <<'NODE'
           const fs = require('node:fs');
           const output = process.argv[2];

--- a/.github/workflows/beauty-movement-production-activation.yml
+++ b/.github/workflows/beauty-movement-production-activation.yml
@@ -315,6 +315,26 @@ jobs:
           test -f "${RUNNER_TEMP}/beauty-movement-production-activation/website-lease.json"
           NEXT_PUBLIC_BUILD_SHA="${RELEASE_SHA}" NEXT_PUBLIC_BUILD_TIME="${GITHUB_RUN_ID}" node scripts/assert-production-snapshot.mjs
           NEXT_PUBLIC_BUILD_SHA="${RELEASE_SHA}" NEXT_PUBLIC_BUILD_TIME="${GITHUB_RUN_ID}" npx opennextjs-cloudflare build
+          activation_config="${ACTIVATION_ROOT}/wrangler-enabled.toml"
+          node - "${activation_config}" <<'NODE'
+          const fs = require('node:fs');
+          const output = process.argv[2];
+          const input = fs.readFileSync('wrangler.toml', 'utf8');
+          const marker = '[vars]';
+          const start = input.indexOf(marker);
+          if (start < 0) throw new Error('beauty_movement_production_vars_section_missing');
+          const nextSection = input.indexOf('\n[', start + marker.length);
+          const end = nextSection < 0 ? input.length : nextSection;
+          const section = input.slice(start, end);
+          if (!/^BEAUTY_MOVEMENT_ENABLED\s*=\s*"false"\s*$/m.test(section)) {
+            throw new Error('beauty_movement_production_default_flag_changed');
+          }
+          const enabled = section.replace(
+            /^(BEAUTY_MOVEMENT_ENABLED\s*=\s*)"false"\s*$/m,
+            '$1"true"',
+          );
+          fs.writeFileSync(output, `${input.slice(0, start)}${enabled}${input.slice(end)}`, { mode: 0o600 });
+          NODE
           node - "${STATE_FILE}" <<'NODE'
           const fs = require('node:fs');
           const path = process.argv[2];
@@ -323,8 +343,8 @@ jobs:
           fs.writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
           NODE
           NEXT_PUBLIC_BUILD_SHA="${RELEASE_SHA}" NEXT_PUBLIC_BUILD_TIME="${GITHUB_RUN_ID}" \
-            npx --yes wrangler@4.112.0 deploy --config wrangler.toml --keep-vars \
-            --var 'BEAUTY_MOVEMENT_ENABLED:true' --message "beauty-movement-production-activation:${RELEASE_SHA}:${GITHUB_RUN_ID}"
+            npx --yes wrangler@4.112.0 deploy --config "${activation_config}" --keep-vars \
+            --message "beauty-movement-production-activation:${RELEASE_SHA}:${GITHUB_RUN_ID}"
           deployments="${ACTIVATION_ROOT}/candidate.json"
           npx --yes wrangler@4.112.0 deployments list --config wrangler.toml --json > "${deployments}"
           node - "${deployments}" "${STATE_FILE}" "${RELEASE_SHA}" <<'NODE'

--- a/.github/workflows/beauty-movement-production-activation.yml
+++ b/.github/workflows/beauty-movement-production-activation.yml
@@ -344,7 +344,7 @@ jobs:
           NODE
           NEXT_PUBLIC_BUILD_SHA="${RELEASE_SHA}" NEXT_PUBLIC_BUILD_TIME="${GITHUB_RUN_ID}" \
             npx --yes wrangler@4.112.0 deploy --config "${activation_config}" --keep-vars \
-            --message "beauty-movement-production-activation:${RELEASE_SHA}:${GITHUB_RUN_ID}"
+            --var 'BEAUTY_MOVEMENT_ENABLED:true' --message "beauty-movement-production-activation:${RELEASE_SHA}:${GITHUB_RUN_ID}"
           deployments="${ACTIVATION_ROOT}/candidate.json"
           npx --yes wrangler@4.112.0 deployments list --config wrangler.toml --json > "${deployments}"
           node - "${deployments}" "${STATE_FILE}" "${RELEASE_SHA}" <<'NODE'

--- a/.github/workflows/beauty-movement-staging-smoke.yml
+++ b/.github/workflows/beauty-movement-staging-smoke.yml
@@ -317,7 +317,10 @@ jobs:
 
           NEXT_PUBLIC_BUILD_SHA="${RELEASE_SHA}" NEXT_PUBLIC_BUILD_TIME="${GITHUB_RUN_ID}" node scripts/assert-production-snapshot.mjs
           NEXT_PUBLIC_BUILD_SHA="${RELEASE_SHA}" NEXT_PUBLIC_BUILD_TIME="${GITHUB_RUN_ID}" npx opennextjs-cloudflare build
-          activation_config="${RUNNER_TEMP}/beauty-movement-staging-smoke/wrangler-enabled.toml"
+          # Keep the private overlay beside the checked-out website so Wrangler
+          # resolves the relative OpenNext entrypoint from the website root.
+          activation_config="${PWD}/.beauty-movement-wrangler-enabled.toml"
+          trap 'rm -f "${activation_config}"' EXIT
           node - "${activation_config}" <<'NODE'
           const fs = require('node:fs');
           const output = process.argv[2];

--- a/.github/workflows/beauty-movement-staging-smoke.yml
+++ b/.github/workflows/beauty-movement-staging-smoke.yml
@@ -317,9 +317,29 @@ jobs:
 
           NEXT_PUBLIC_BUILD_SHA="${RELEASE_SHA}" NEXT_PUBLIC_BUILD_TIME="${GITHUB_RUN_ID}" node scripts/assert-production-snapshot.mjs
           NEXT_PUBLIC_BUILD_SHA="${RELEASE_SHA}" NEXT_PUBLIC_BUILD_TIME="${GITHUB_RUN_ID}" npx opennextjs-cloudflare build
+          activation_config="${RUNNER_TEMP}/beauty-movement-staging-smoke/wrangler-enabled.toml"
+          node - "${activation_config}" <<'NODE'
+          const fs = require('node:fs');
+          const output = process.argv[2];
+          const input = fs.readFileSync('wrangler.toml', 'utf8');
+          const marker = '[env.staging.vars]';
+          const start = input.indexOf(marker);
+          if (start < 0) throw new Error('beauty_movement_staging_vars_section_missing');
+          const nextSection = input.indexOf('\n[', start + marker.length);
+          const end = nextSection < 0 ? input.length : nextSection;
+          const section = input.slice(start, end);
+          if (!/^BEAUTY_MOVEMENT_ENABLED\s*=\s*"false"\s*$/m.test(section)) {
+            throw new Error('beauty_movement_staging_default_flag_changed');
+          }
+          const enabled = section.replace(
+            /^(BEAUTY_MOVEMENT_ENABLED\s*=\s*)"false"\s*$/m,
+            '$1"true"',
+          );
+          fs.writeFileSync(output, `${input.slice(0, start)}${enabled}${input.slice(end)}`, { mode: 0o600 });
+          NODE
           NEXT_PUBLIC_BUILD_SHA="${RELEASE_SHA}" NEXT_PUBLIC_BUILD_TIME="${GITHUB_RUN_ID}" \
-            npx --yes wrangler@4.112.0 deploy --config wrangler.toml --env staging --keep-vars \
-            --var 'BEAUTY_MOVEMENT_ENABLED:true' --message "${candidate_message}"
+            npx --yes wrangler@4.112.0 deploy --config "${activation_config}" --env staging --keep-vars \
+            --message "${candidate_message}"
           deployments="$RUNNER_TEMP/beauty-movement-staging-smoke/candidate.json"
           candidate_version=''
           for attempt in $(seq 1 12); do

--- a/.github/workflows/beauty-movement-staging-smoke.yml
+++ b/.github/workflows/beauty-movement-staging-smoke.yml
@@ -339,7 +339,7 @@ jobs:
           NODE
           NEXT_PUBLIC_BUILD_SHA="${RELEASE_SHA}" NEXT_PUBLIC_BUILD_TIME="${GITHUB_RUN_ID}" \
             npx --yes wrangler@4.112.0 deploy --config "${activation_config}" --env staging --keep-vars \
-            --message "${candidate_message}"
+            --var 'BEAUTY_MOVEMENT_ENABLED:true' --message "${candidate_message}"
           deployments="$RUNNER_TEMP/beauty-movement-staging-smoke/candidate.json"
           candidate_version=''
           for attempt in $(seq 1 12); do


### PR DESCRIPTION
## Summary
- keep the temporary Wrangler activation overlay beside the checked-out `website` root;
- preserve the versioned default flag as false and remove the overlay after the deploy step;
- keep the existing private overlay and topology marker contract unchanged.

## Root cause
The prior overlay was written under `RUNNER_TEMP`. Wrangler resolves the relative OpenNext `main` entrypoint from the config file directory, so deploy failed with an entrypoint-not-found error even though the build had succeeded.

## Validation
- `codex:deploy-topology:test`
- `.github/scripts/beauty-movement-production-activation-contract.test.mjs`
- `git diff --check`
