### PR TITLE
fix(beauty-movement): read smoke invite ref from delivery

### DIFF
--- a/.github/scripts/beauty-movement-production-activation-contract.test.mjs
+++ b/.github/scripts/beauty-movement-production-activation-contract.test.mjs
@@ -60,6 +60,9 @@ test("schema, draft readback, build attestation, browser journey and persisted o
   assert.match(workflow, /outcome_protocol_version/);
   assert.match(workflow, /beauty-movement-outcomes-v2/);
   assert.match(workflow, /outcome_snapshot_length/);
+  assert.match(workflow, /delivery-meta\.json/);
+  assert.match(workflow, /i\.external_ref = '\$\{invite_ref\}'/);
+  assert.doesNotMatch(workflow, /i\.external_ref = 'velocity-0002'/);
 });
 
 test("failed or incomplete activation compensates only run-scoped data and restores the attested incumbent", () => {

--- a/.github/workflows/beauty-movement-production-activation.yml
+++ b/.github/workflows/beauty-movement-production-activation.yml
@@ -487,15 +487,24 @@ jobs:
           SMOKE_URL: https://espacofacial.com
         run: |
           set -euo pipefail
-          invite_url="$(node --input-type=commonjs -e '
-          const fs=require("fs"), path=require("path");
-          const dir=process.argv[1]; const file=fs.readdirSync(dir).find((name)=>name.endsWith("-delivery.csv"));
-          if (!file) throw new Error("beauty_movement_smoke_delivery_missing");
-          const row=fs.readFileSync(path.join(dir,file),"utf8").trim().split(/\r?\n/)[1];
-          const cells=row.match(/("(?:[^"]|"")*"|[^,]*)/g)?.filter((cell)=>cell!=="")??[];
-          const value=cells.at(-1)?.replace(/^"|"$/g,"").replace(/""/g,String.fromCharCode(34));
-          if (!value) throw new Error("beauty_movement_smoke_delivery_invalid"); process.stdout.write(value);
-          ' "${OUTPUT_DIR}")"
+          delivery_meta="${SMOKE_ROOT}/delivery-meta.json"
+          node - "${OUTPUT_DIR}" "${delivery_meta}" <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const [dir, output] = process.argv.slice(2);
+          const file = fs.readdirSync(dir).find((name) => name.endsWith('-delivery.csv'));
+          if (!file) throw new Error('beauty_movement_smoke_delivery_missing');
+          const lines = fs.readFileSync(path.join(dir, file), 'utf8').trim().split(/\r?\n/);
+          const row = lines[1];
+          const cells = row?.match(/("(?:[^"]|"")*"|[^,]*)/g)?.filter((cell) => cell !== '') ?? [];
+          const unquote = (value) => value?.replace(/^"|"$/g, '').replace(/""/g, '"') ?? '';
+          const inviteRef = unquote(cells[1]);
+          const inviteUrl = unquote(cells[3]);
+          if (!inviteRef || !inviteUrl) throw new Error('beauty_movement_smoke_delivery_invalid');
+          fs.writeFileSync(output, `${JSON.stringify({ inviteRef, inviteUrl })}\n`, { mode: 0o600 });
+          NODE
+          invite_url="$(node --input-type=commonjs -e 'const fs=require("fs"); process.stdout.write(JSON.parse(fs.readFileSync(process.argv[1],"utf8")).inviteUrl)' "${delivery_meta}")"
+          invite_ref="$(node --input-type=commonjs -e 'const fs=require("fs"); process.stdout.write(JSON.parse(fs.readFileSync(process.argv[1],"utf8")).inviteRef)' "${delivery_meta}")"
           token="${invite_url##*#c=}"
           [[ "${token}" =~ ^[A-Za-z0-9_-]{40,180}$ ]] || { echo 'synthetic invite token shape invalid'; exit 1; }
           SMOKE_INVITE_TOKEN="${token}" SMOKE_CAMPAIGN_ID="${SMOKE_CAMPAIGN_ID}" node --input-type=module <<'NODE'
@@ -532,7 +541,7 @@ jobs:
           fs.writeFileSync(`${process.env.RUNNER_TEMP}/beauty-movement-production-activation/browser.json`, `${JSON.stringify({ browser: true, revealRequests: reveals, reloadStable: true, whatsappRequests: 0, consoleErrors: 0, outcomeVisible: true }, null, 2)}\n`, { mode: 0o600 });
           await browser.close();
           NODE
-          readback_sql="SELECT c.status AS campaign_status, i.invite_status, i.confirmed_at_ms, i.outcome_key, i.outcome_protocol_version, i.outcome_resolved_at_ms, i.assigned_outcome_key, i.assignment_protocol_version, length(i.outcome_snapshot_json) AS outcome_snapshot_length, length(i.planned_card_selections_json) AS planned_card_selections_length, (SELECT COUNT(*) FROM bm_card_reveals r WHERE r.invite_id = i.id) AS reveal_count FROM bm_campaigns c INNER JOIN bm_invites i ON i.campaign_id = c.id WHERE c.id = '${SMOKE_CAMPAIGN_ID}' AND i.external_ref = 'velocity-0002';"
+          readback_sql="SELECT c.status AS campaign_status, i.invite_status, i.confirmed_at_ms, i.outcome_key, i.outcome_protocol_version, i.outcome_resolved_at_ms, i.assigned_outcome_key, i.assignment_protocol_version, length(i.outcome_snapshot_json) AS outcome_snapshot_length, length(i.planned_card_selections_json) AS planned_card_selections_length, (SELECT COUNT(*) FROM bm_card_reveals r WHERE r.invite_id = i.id) AS reveal_count FROM bm_campaigns c INNER JOIN bm_invites i ON i.campaign_id = c.id WHERE c.id = '${SMOKE_CAMPAIGN_ID}' AND i.external_ref = '${invite_ref}';"
           npx --yes wrangler@4.112.0 d1 execute "${PRODUCTION_D1_DATABASE}" --remote --config wrangler.toml --command "${readback_sql}" --json > "${SMOKE_ROOT}/readback.json"
           node - "${SMOKE_ROOT}/readback.json" "${RUNNER_TEMP}/beauty-movement-production-activation/browser.json" <<'NODE'
           const fs = require('node:fs');


### PR DESCRIPTION
## Why\nThe controlled production smoke used compact invite CSVs, whose importer derives a hashed xternal_ref. The workflow hard-coded elocity-0002, so the browser journey succeeded but the persisted readback selected no row and failed closed.\n\n## Change\n- capture the exact synthetic invite_ref and invite URL from the private delivery artifact;\n- use that ref for the D1 readback;\n- add a contract assertion preventing regression to the hard-coded ref.\n\n## Validation\n- 
ode --test .github/scripts/beauty-movement-production-activation-contract.test.mjs (6/6);\n- 
pm run codex:deploy-topology:test.\n\nNo secrets or PII are emitted.