### PR TITLE
test(beauty-movement): diagnose staging smoke mutations

### DIFF
--- a/.github/scripts/beauty-movement-staging-smoke-contract.test.mjs
+++ b/.github/scripts/beauty-movement-staging-smoke-contract.test.mjs
@@ -33,6 +33,12 @@ test("smoke consumes secrets in-process and closes the staging gate", () => {
     assert.match(workflow, /beauty_movement_delivery_ref_invalid/);
     assert.match(workflow, /i\.external_ref = '\$\{invite_ref\}'/);
     assert.doesNotMatch(workflow, /i\.external_ref = 'velocity-0002'/);
+    assert.match(workflow, /bootstrapReady/);
+    assert.match(workflow, /mutationResponses/);
+    assert.match(workflow, /failedRequests/);
+    assert.match(workflow, /beauty_movement_browser_reveal_missing/);
+    assert.match(workflow, /timeout: 60000/);
+    assert.match(workflow, /timeout: 30000/);
     assert.match(workflow, /inactive_code.*503/s);
     assert.match(workflow, /if:\s*\$\{\{ always\(\) \}\}/);
     assert.match(workflow, /invite_status = 'revoked'/);

--- a/.github/workflows/beauty-movement-staging-smoke.yml
+++ b/.github/workflows/beauty-movement-staging-smoke.yml
@@ -421,14 +421,26 @@ jobs:
           const consoleErrors = [];
           const whatsappRequests = [];
           const bootstrapResponses = [];
+          const mutationResponses = [];
+          const failedRequests = [];
           let revealRequests = 0;
           let staticFailures = 0;
           const staticResponses = [];
           page.on('console', (message) => { if (message.type() === 'error') consoleErrors.push(message.text()); });
           page.on('pageerror', (error) => consoleErrors.push(error.message));
+          page.on('requestfailed', (request) => {
+            const url = new URL(request.url());
+            if (url.pathname.startsWith('/api/beleza-em-movimento/')) {
+              failedRequests.push(`${request.method()} ${url.pathname}`);
+            }
+          });
           page.on('response', (response) => {
             const url = new URL(response.url());
-            if (url.pathname.startsWith('/api/beleza-em-movimento/')) bootstrapResponses.push(`${response.request().method()} ${url.pathname} ${response.status()}`);
+            if (url.pathname.startsWith('/api/beleza-em-movimento/')) {
+              const entry = `${response.request().method()} ${url.pathname} ${response.status()}`;
+              bootstrapResponses.push(entry);
+              if (response.request().method() === 'POST' && /\/reveal$|\/confirm$/.test(url.pathname)) mutationResponses.push(entry);
+            }
             if (url.pathname.startsWith('/_next/static/')) {
               const status = response.status();
               if (status >= 400) staticFailures += 1;
@@ -440,10 +452,10 @@ jobs:
             if (/^https:\/\/(?:wa\.me|api\.whatsapp\.com|web\.whatsapp\.com)\//i.test(request.url())) whatsappRequests.push(request.url());
           });
           await page.goto(`${base}/beleza-em-movimento#c=${encodeURIComponent(token)}`, { waitUntil: 'domcontentloaded' });
-          await page.waitForFunction(() => (
+          const bootstrapReady = await page.waitForFunction(() => (
             document.querySelector('button[aria-label*="Clique no baralho"]') !== null ||
             window.location.pathname !== '/beleza-em-movimento'
-          ), { timeout: 30000 });
+          ), { timeout: 60000 }).then(() => true).catch(() => false);
           if (await page.getByRole('button', { name: /Clique no baralho para começar a sua leitura/i }).count() === 0) {
             const diagnostics = await page.evaluate(() => {
               let inviteStorage = { present: false, length: 0 };
@@ -461,13 +473,23 @@ jobs:
                 deckButtonCount: document.querySelectorAll('button[aria-label*="Clique no baralho"]').length,
               };
             });
-            throw new Error(`beauty_movement_browser_bootstrap_missing:${JSON.stringify({ ...diagnostics, responses: bootstrapResponses, staticFailures, staticResponses: staticResponses.slice(-12), consoleErrorCount: consoleErrors.length })}`);
+            throw new Error(`beauty_movement_browser_bootstrap_missing:${JSON.stringify({ ...diagnostics, bootstrapReady, responses: bootstrapResponses.slice(-20), failedRequests: failedRequests.slice(-12), staticFailures, staticResponses: staticResponses.slice(-12), consoleErrorCount: consoleErrors.length })}`);
           }
           const reveal = async (actLabel) => {
             const card = page.getByRole('button', { name: new RegExp(`Revelar carta 1 de ${actLabel}`, 'i') });
             await card.waitFor({ state: 'visible', timeout: 30000 });
             await card.click();
-            await page.locator('button[aria-pressed="true"]').waitFor({ state: 'visible', timeout: 10000 });
+            try {
+              await page.locator('button[aria-pressed="true"]').waitFor({ state: 'visible', timeout: 30000 });
+            } catch {
+              const diagnostics = await page.evaluate(() => ({
+                pathname: window.location.pathname,
+                statusPageCount: document.querySelectorAll('[aria-busy="true"]').length,
+                actionErrorCount: document.querySelectorAll('[role="alert"]').length,
+                selectedCardCount: document.querySelectorAll('button[aria-pressed="true"]').length,
+              }));
+              throw new Error(`beauty_movement_browser_reveal_missing:${JSON.stringify({ actLabel, ...diagnostics, mutationResponses: mutationResponses.slice(-12), failedRequests: failedRequests.slice(-12), consoleErrorCount: consoleErrors.length })}`);
+            }
             await page.waitForTimeout(5600);
           };
           await page.getByRole('button', { name: /Clique no baralho para começar a sua leitura/i }).click();


### PR DESCRIPTION
## What changed\n- keep staging browser readiness bounded but allow slower propagation\n- capture redacted API mutation and failed-request evidence when a reveal does not settle\n- extend the staging smoke contract test for the diagnostics\n\nNo secrets, invite tokens, PII, or production surfaces are touched.