### PR TITLE
test(beauty-movement): attest production mutation responses

### DIFF
--- a/.github/scripts/beauty-movement-production-activation-contract.test.mjs
+++ b/.github/scripts/beauty-movement-production-activation-contract.test.mjs
@@ -55,6 +55,13 @@ test("schema, draft readback, build attestation, browser journey and persisted o
   assert.match(workflow, /beauty_movement_production_build_attestation_failed/);
   assert.match(workflow, /chromium/);
   assert.match(workflow, /revealRequests/);
+  assert.match(workflow, /mutationResponses/);
+  assert.match(workflow, /failedRequests/);
+  assert.match(workflow, /beauty_movement_production_browser_reveal_missing/);
+  assert.match(workflow, /beauty_movement_production_reveal_response_invalid/);
+  assert.match(workflow, /beauty_movement_production_confirm_response_invalid/);
+  assert.match(workflow, /timeout: 60000/);
+  assert.match(workflow, /timeout: 30000/);
   assert.match(workflow, /reloadStable/);
   assert.match(workflow, /whatsappRequests/);
   assert.match(workflow, /outcome_protocol_version/);

--- a/.github/workflows/beauty-movement-production-activation.yml
+++ b/.github/workflows/beauty-movement-production-activation.yml
@@ -515,29 +515,75 @@ jobs:
           const browser = await chromium.launch({ headless: true });
           const context = await browser.newContext();
           const page = await context.newPage();
-          const errors = []; const whatsapp = []; let reveals = 0;
+          const errors = []; const whatsapp = []; const apiResponses = []; const mutationResponses = []; const failedRequests = []; let reveals = 0;
           page.on('console', (message) => { if (message.type() === 'error') errors.push(message.text()); });
           page.on('pageerror', (error) => errors.push(error.message));
+          page.on('requestfailed', (request) => {
+            const url = new URL(request.url());
+            if (url.pathname.startsWith('/api/beleza-em-movimento/')) failedRequests.push(`${request.method()} ${url.pathname}`);
+          });
+          page.on('response', async (response) => {
+            const url = new URL(response.url());
+            if (!url.pathname.startsWith('/api/beleza-em-movimento/')) return;
+            const entry = { method: response.request().method(), path: url.pathname, status: response.status() };
+            let payload = null;
+            try { payload = await response.json(); } catch { /* non-JSON responses are represented by status only */ }
+            const safe = { ...entry, ok: payload?.ok === true, error: typeof payload?.error === 'string' ? payload.error : null };
+            apiResponses.push(safe);
+            if (entry.method === 'POST' && /\/reveal$|\/confirm$/.test(entry.path)) mutationResponses.push(safe);
+          });
           page.on('request', (request) => {
             if (request.url().includes('/api/beleza-em-movimento/reveal') && request.method() === 'POST') reveals += 1;
             if (/^https:\/\/(?:wa\.me|api\.whatsapp\.com|web\.whatsapp\.com)\//i.test(request.url())) whatsapp.push(request.url());
           });
           await page.goto(`${base}/beleza-em-movimento#c=${encodeURIComponent(token)}`, { waitUntil: 'domcontentloaded' });
+          const bootstrapReady = await page.waitForFunction(() => (
+            document.querySelector('button[aria-label*="Clique no baralho"]') !== null ||
+            window.location.pathname !== '/beleza-em-movimento'
+          ), { timeout: 60000 }).then(() => true).catch(() => false);
+          if (await page.getByRole('button', { name: /Clique no baralho para começar a sua leitura/i }).count() === 0) {
+            const diagnostics = await page.evaluate(() => ({
+              readyState: document.readyState,
+              pathname: window.location.pathname,
+              statusPageCount: document.querySelectorAll('[aria-busy="true"]').length,
+              deckButtonCount: document.querySelectorAll('button[aria-label*="Clique no baralho"]').length,
+            }));
+            throw new Error(`beauty_movement_production_browser_bootstrap_missing:${JSON.stringify({ ...diagnostics, bootstrapReady, apiResponses: apiResponses.slice(-20), failedRequests: failedRequests.slice(-12), consoleErrorCount: errors.length })}`);
+          }
           const reveal = async (act) => {
             const card = page.getByRole('button', { name: new RegExp(`Revelar carta 1 de ${act}`, 'i') });
             await card.waitFor({ state: 'visible', timeout: 30000 }); await card.click();
-            await page.locator('button[aria-pressed="true"]').waitFor({ state: 'visible', timeout: 10000 }); await page.waitForTimeout(5600);
+            try {
+              await page.locator('button[aria-pressed="true"]').waitFor({ state: 'visible', timeout: 30000 });
+            } catch {
+              const diagnostics = await page.evaluate(() => ({
+                pathname: window.location.pathname,
+                statusPageCount: document.querySelectorAll('[aria-busy="true"]').length,
+                actionErrorCount: document.querySelectorAll('[role="alert"]').length,
+                selectedCardCount: document.querySelectorAll('button[aria-pressed="true"]').length,
+              }));
+              throw new Error(`beauty_movement_production_browser_reveal_missing:${JSON.stringify({ act, ...diagnostics, mutationResponses: mutationResponses.slice(-12), failedRequests: failedRequests.slice(-12), consoleErrorCount: errors.length })}`);
+            }
+            const mutation = mutationResponses.at(-1);
+            if (!mutation || mutation.path !== '/api/beleza-em-movimento/reveal' || mutation.status < 200 || mutation.status >= 300 || mutation.ok !== true) {
+              throw new Error(`beauty_movement_production_reveal_response_invalid:${JSON.stringify({ act, mutationResponses: mutationResponses.slice(-12), failedRequests: failedRequests.slice(-12) })}`);
+            }
+            await page.waitForTimeout(5600);
           };
           await page.getByRole('button', { name: /Clique no baralho para começar a sua leitura/i }).click();
           await reveal('Beleza'); await reveal('Movimento'); await reveal('Celebração');
           await page.getByRole('heading', { name: /Garanta seu presente e confirme presença/i }).waitFor({ state: 'visible', timeout: 30000 });
           await page.getByRole('checkbox').check(); await page.getByRole('button', { name: /Garantir presente e confirmar presença/i }).click();
+          const confirmation = mutationResponses.at(-1);
+          if (!confirmation || confirmation.path !== '/api/beleza-em-movimento/confirm' || confirmation.status < 200 || confirmation.status >= 300 || confirmation.ok !== true) {
+            throw new Error(`beauty_movement_production_confirm_response_invalid:${JSON.stringify({ mutationResponses: mutationResponses.slice(-12), failedRequests: failedRequests.slice(-12) })}`);
+          }
           const special = page.locator('article[aria-label^="Carta especial:"]'); await special.waitFor({ state: 'visible', timeout: 30000 });
           const first = await special.innerText();
           if (!/combinação|Elleva|Preenchimento|Restylane|Skinbooster|Diamond|Sculptra/i.test(first)) throw new Error('beauty_movement_production_offer_missing');
           const beforeReload = reveals; await page.reload({ waitUntil: 'domcontentloaded' }); await special.waitFor({ state: 'visible', timeout: 30000 });
           const second = await special.innerText();
-          if (first !== second || beforeReload !== 3 || reveals !== 3 || whatsapp.length !== 0 || errors.length !== 0) throw new Error('beauty_movement_production_browser_evidence_invalid');
+          if (first !== second || beforeReload !== 3 || reveals !== 3 || whatsapp.length !== 0 || errors.length !== 0) throw new Error(`beauty_movement_production_browser_evidence_invalid:${JSON.stringify({ beforeReload, reveals, whatsappRequests: whatsapp.length, consoleErrors: errors.length, apiResponses: apiResponses.slice(-20), failedRequests: failedRequests.slice(-12) })}`);
           fs.writeFileSync(`${process.env.RUNNER_TEMP}/beauty-movement-production-activation/browser.json`, `${JSON.stringify({ browser: true, revealRequests: reveals, reloadStable: true, whatsappRequests: 0, consoleErrors: 0, outcomeVisible: true }, null, 2)}\n`, { mode: 0o600 });
           await browser.close();
           NODE


### PR DESCRIPTION
## Summary\n- add sanitized API response and failed-request diagnostics to the controlled production browser smoke\n- require successful reveal and confirmation responses before D1 readback\n- extend the production workflow contract tests\n\n## Validation\n- focused production activation contract test\n- bash syntax validation for every embedded workflow block\n- git diff --check\n\nThis is a fail-closed smoke gate change; it does not enable production by itself.