### PR TITLE
fix(ponto): allow governed bridge from legacy maintenance proxy

### DIFF
--- a/.github/scripts/ponto-production-baseline.mjs
+++ b/.github/scripts/ponto-production-baseline.mjs
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { evaluateProductionHealth } from "./ponto-production-health.mjs";
 
 const [mode, file] = process.argv.slice(2);
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -76,6 +77,7 @@ const validate = (baseline) => {
     baseline.health?.ready === (initialState === "active"),
     "baseline initial readiness is inconsistent with module state",
   );
+  assert(typeof baseline.health?.gatewayAffinityBridge === "boolean", "baseline gateway affinity bridge attestation is missing");
   assert(baseline.credentialsIncluded === false && baseline.piiIncluded === false, "baseline privacy attestation is invalid");
   const { sha256, ...unsigned } = baseline;
   assert(/^[0-9a-f]{64}$/.test(String(sha256 || "")) && digest(unsigned) === sha256, "baseline digest differs");
@@ -172,27 +174,9 @@ if (mode === "capture") {
     headers: { accept: "application/json", ...accessHeaders },
   });
   const health = await healthResponse.json().catch(() => null);
-  const dependencies = health?.dependencies && typeof health.dependencies === "object" ? Object.entries(health.dependencies) : [];
-  const hasDependencyContract = dependencies.length > 0;
-  const dependencyContractSafe = !hasDependencyContract || (
-    health?.ok === false
-    && health?.ready === false
-    && health?.dependencies?.module_control?.state === "unavailable"
-    && health?.dependencies?.module_control?.reason === "MODULE_MAINTENANCE"
-    && dependencies.every(([name, dependency]) => name === "module_control" || dependency?.required !== true || dependency?.state === "healthy")
-  );
-  const activeReady = healthResponse.status === 200
-    && health?.availability?.state === "active"
-    && health?.ok === true
-    && health?.ready === true
-    && hasDependencyContract
-    && health?.dependencies?.module_control?.state === "healthy"
-    && dependencies.every(([, dependency]) => dependency?.required !== true || dependency?.state === "healthy");
-  const maintenanceOnly = healthResponse.status === 200
-    && health?.availability?.state === "maintenance"
-    && dependencyContractSafe;
-  assert(activeReady || maintenanceOnly, "external Ponto initial health is not valid active or maintenance");
-  const initialState = activeReady ? "active" : "maintenance";
+  const healthAssessment = evaluateProductionHealth(healthResponse.status, health);
+  assert(healthAssessment.passed, "external Ponto initial health is not valid active or maintenance");
+  const initialState = healthAssessment.state;
   const identityResponse = await fetch("https://api.skincos.com.br/insumos/health", {
     redirect: "manual",
     signal: AbortSignal.timeout(15_000),
@@ -257,7 +241,8 @@ if (mode === "capture") {
     health: {
       passed: true,
       state: initialState,
-      ready: activeReady,
+      ready: healthAssessment.ready,
+      gatewayAffinityBridge: healthAssessment.gatewayAffinityBridge,
       changedAt: String(health?.availability?.changedAt || ""),
       crmStatus: healthResponse.status,
       identityStatus: identityResponse.status,

--- a/.github/scripts/ponto-production-baseline.test.mjs
+++ b/.github/scripts/ponto-production-baseline.test.mjs
@@ -70,6 +70,7 @@ const unsignedBaseline = (state = "maintenance") => ({
     passed: true,
     state,
     ready: state === "active",
+    gatewayAffinityBridge: false,
     crmStatus: 200,
     identityStatus: 200,
     observation: "external-production",

--- a/.github/scripts/ponto-production-health.mjs
+++ b/.github/scripts/ponto-production-health.mjs
@@ -1,0 +1,53 @@
+const requiredHealthy = (entries) => entries.every(([, dependency]) =>
+  dependency?.required !== true || dependency?.state === "healthy");
+
+const maintenanceWithLegacyGatewayBridge = (health, dependencies) => {
+  const requiredFailures = dependencies.filter(([, dependency]) =>
+    dependency?.required === true && dependency?.state !== "healthy");
+  return health?.availability?.source === "control"
+    && health?.dependencies?.module_control?.state === "unavailable"
+    && health?.dependencies?.module_control?.reason === "MODULE_MAINTENANCE"
+    && requiredFailures.length === 2
+    && requiredFailures.some(([name]) => name === "module_control")
+    && requiredFailures.some(([name, dependency]) =>
+      name === "gateway_affinity"
+      && dependency?.reason === "RELEASE_AFFINITY_MISMATCH");
+};
+
+const maintenanceControlSafe = (health, dependencies) =>
+  health?.dependencies?.module_control?.state === "unavailable"
+  && health?.dependencies?.module_control?.reason === "MODULE_MAINTENANCE"
+  && dependencies.every(([name, dependency]) =>
+    name === "module_control" || dependency?.required !== true || dependency?.state === "healthy");
+
+export function evaluateProductionHealth(status, health) {
+  const dependencies = health?.dependencies && typeof health.dependencies === "object"
+    ? Object.entries(health.dependencies)
+    : [];
+  const hasDependencyContract = dependencies.length > 0;
+  const activeReady = status === 200
+    && health?.availability?.state === "active"
+    && health?.ok === true
+    && health?.ready === true
+    && hasDependencyContract
+    && health?.dependencies?.module_control?.state === "healthy"
+    && requiredHealthy(dependencies);
+  if (activeReady) return { passed: true, state: "active", ready: true, gatewayAffinityBridge: false };
+
+  const maintenanceOnly = status === 200
+    && health?.availability?.state === "maintenance"
+    && health?.ok === false
+    && health?.ready === false
+    && (
+      !hasDependencyContract
+      || maintenanceControlSafe(health, dependencies)
+      || maintenanceWithLegacyGatewayBridge(health, dependencies)
+    );
+  if (!maintenanceOnly) return { passed: false, state: "", ready: false, gatewayAffinityBridge: false };
+  return {
+    passed: true,
+    state: "maintenance",
+    ready: false,
+    gatewayAffinityBridge: maintenanceWithLegacyGatewayBridge(health, dependencies),
+  };
+}

--- a/.github/scripts/ponto-production-health.test.mjs
+++ b/.github/scripts/ponto-production-health.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { evaluateProductionHealth } from "./ponto-production-health.mjs";
+
+const dependency = (state, reason = "", required = true) => ({ state, reason, required });
+
+const health = (overrides = {}) => ({
+  ok: false,
+  ready: false,
+  availability: { state: "maintenance", source: "control" },
+  dependencies: {
+    d1: dependency("healthy"),
+    module_control: dependency("unavailable", "MODULE_MAINTENANCE"),
+    gateway_affinity: dependency("healthy"),
+  },
+  ...overrides,
+});
+
+test("accepts a normal maintenance health response", () => {
+  const result = evaluateProductionHealth(200, health());
+  assert.deepEqual(result, { passed: true, state: "maintenance", ready: false, gatewayAffinityBridge: false });
+});
+
+test("accepts the legacy gateway mismatch only while control is in maintenance", () => {
+  const result = evaluateProductionHealth(200, health({
+    dependencies: {
+      d1: dependency("healthy"),
+      module_control: dependency("unavailable", "MODULE_MAINTENANCE"),
+      gateway_affinity: dependency("unavailable", "RELEASE_AFFINITY_MISMATCH"),
+    },
+  }));
+  assert.deepEqual(result, { passed: true, state: "maintenance", ready: false, gatewayAffinityBridge: true });
+});
+
+test("rejects the gateway mismatch when maintenance is not controlled or another dependency is unhealthy", () => {
+  const emergency = evaluateProductionHealth(200, health({
+    availability: { state: "maintenance", source: "emergency-latch-active" },
+    dependencies: {
+      d1: dependency("healthy"),
+      module_control: dependency("unavailable", "MODULE_MAINTENANCE"),
+      gateway_affinity: dependency("unavailable", "RELEASE_AFFINITY_MISMATCH"),
+    },
+  }));
+  assert.equal(emergency.passed, false);
+
+  const dependencyFailure = evaluateProductionHealth(200, health({
+    dependencies: {
+      d1: dependency("unavailable", "DATABASE_UNAVAILABLE"),
+      module_control: dependency("unavailable", "MODULE_MAINTENANCE"),
+      gateway_affinity: dependency("unavailable", "RELEASE_AFFINITY_MISMATCH"),
+    },
+  }));
+  assert.equal(dependencyFailure.passed, false);
+});
+
+test("rejects an affinity mismatch outside maintenance", () => {
+  const result = evaluateProductionHealth(200, health({
+    ok: true,
+    ready: true,
+    availability: { state: "active", source: "control" },
+    dependencies: {
+      d1: dependency("healthy"),
+      module_control: dependency("healthy", ""),
+      gateway_affinity: dependency("unavailable", "RELEASE_AFFINITY_MISMATCH"),
+    },
+  }));
+  assert.equal(result.passed, false);
+});


### PR DESCRIPTION
## Context\nProduction is fail-closed in controlled maintenance while the legacy CRM/Ponto proxy reports gateway_affinity=RELEASE_AFFINITY_MISMATCH. The pilot baseline stopped before any candidate mutation, so the Users invite path remained unavailable.\n\n## Change\n- centralize production health classification;\n- allow the legacy affinity bridge only with HTTP 200, controlled maintenance, MODULE_MAINTENANCE, and exactly the gateway affinity mismatch as the remaining required failure;\n- reject the same mismatch outside controlled maintenance or alongside any other dependency failure;\n- record the bridge attestation in the immutable baseline.\n\n## Validation\n- 
ode --test .github/scripts/ponto-production-health.test.mjs .github/scripts/ponto-production-baseline.test.mjs .github/scripts/ponto-production-baseline-publisher.test.mjs\n- 
ode .github/scripts/validate-dependency-closures.mjs\n- git diff --check\n\nNo production mutation is performed by this PR.