### PR TITLE
fix(ponto): allow governed manual watchdog recovery

### DIFF
--- a/.github/scripts/ponto-watchdog-context.mjs
+++ b/.github/scripts/ponto-watchdog-context.mjs
@@ -93,6 +93,7 @@ async function findActivePeerCoordinator({
 
 export async function validateWatchdogContext({
   event,
+  manualCoordinatorRunId,
   repository,
   repositoryId,
   token,
@@ -124,11 +125,17 @@ export async function validateWatchdogContext({
     return response.json();
   });
   const eventRun = event?.workflow_run;
-  if (!Number.isInteger(eventRun?.id)) throw new Error("workflow_run event is absent");
+  const manualRunId = String(manualCoordinatorRunId || "").trim();
+  const eventRunId = Number.isInteger(eventRun?.id) ? String(eventRun.id) : "";
+  const coordinatorRunId = manualRunId || eventRunId;
+  const manualRecovery = Boolean(manualRunId);
+  if (!/^[1-9][0-9]*$/.test(coordinatorRunId)) {
+    throw new Error("workflow_run event or manual coordinator run is absent");
+  }
   const [workflow, run, jobs] = await Promise.all([
     request(`/repos/${repository}/actions/workflows/ponto-progressive-release.yml`),
-    request(`/repos/${repository}/actions/runs/${eventRun.id}`),
-    request(`/repos/${repository}/actions/runs/${eventRun.id}/jobs?per_page=100`),
+    request(`/repos/${repository}/actions/runs/${coordinatorRunId}`),
+    request(`/repos/${repository}/actions/runs/${coordinatorRunId}/jobs?per_page=100`),
   ]);
   const match = TITLE.exec(String(run?.display_title || ""));
   const sourceMatchesRelease = sourceMatchesImmutableRelease(
@@ -137,7 +144,7 @@ export async function validateWatchdogContext({
     assertReleaseSource,
   );
   const runAttempt = Number(run?.run_attempt);
-  const eventAttempt = Number(eventRun?.run_attempt);
+  const eventAttempt = manualRecovery ? runAttempt : Number(eventRun?.run_attempt);
   const unauthorizedReplay = Number.isInteger(runAttempt) && runAttempt > 1;
   const validConclusion = unauthorizedReplay
     ? typeof run?.conclusion === "string" && run.conclusion.length > 0
@@ -149,7 +156,7 @@ export async function validateWatchdogContext({
     )
     || workflow?.path !== ".github/workflows/ponto-progressive-release.yml"
     || !Number.isInteger(workflow?.id)
-    || run?.id !== eventRun.id
+    || String(run?.id || "") !== coordinatorRunId
     || run?.workflow_id !== workflow.id
     || ![workflow.path, `${workflow.path}@refs/heads/main`].includes(run?.path)
     || run?.status !== "completed"
@@ -166,11 +173,13 @@ export async function validateWatchdogContext({
     || !match
     || String(run.id) !== match[3]
     || !sourceMatchesRelease
-    || eventRun.workflow_id !== workflow.id
-    || eventRun.path !== run.path
-    || eventRun.head_sha !== run.head_sha
     || eventAttempt !== runAttempt
-    || eventRun.conclusion !== run.conclusion
+    || (!manualRecovery && (
+      eventRun.workflow_id !== workflow.id
+      || eventRun.path !== run.path
+      || eventRun.head_sha !== run.head_sha
+      || eventRun.conclusion !== run.conclusion
+    ))
   ) throw new Error("failed coordinator provenance is invalid");
   const stage = match[1];
   // Only an entered orchestrate job can acquire the composite release lease or
@@ -228,6 +237,7 @@ if (invokedPath === import.meta.url) {
   const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
   const context = await validateWatchdogContext({
     event,
+    manualCoordinatorRunId: process.env.PONTO_WATCHDOG_COORDINATOR_RUN_ID,
     repository: process.env.GITHUB_REPOSITORY,
     repositoryId: process.env.GITHUB_REPOSITORY_ID,
     token: process.env.GH_TOKEN,

--- a/.github/scripts/ponto-watchdog-context.test.mjs
+++ b/.github/scripts/ponto-watchdog-context.test.mjs
@@ -62,6 +62,17 @@ test("watchdog accepts only an exact failed first-attempt coordinator from main"
   assert.equal(context.releaseSha, sha);
 });
 
+test("watchdog accepts an explicit manual recovery target without a workflow_run event", async () => {
+  const context = await validateWatchdogContext(input({
+    event: {},
+    manualCoordinatorRunId: "99",
+  }));
+  assert.equal(context.coordinatorRunId, "99");
+  assert.equal(context.stage, "staging");
+  assert.equal(context.target, "staging");
+  assert.equal(context.requiresClose, true);
+});
+
 test("watchdog maps a failed bootstrap coordinator to the production fail-close target", async () => {
   const bootstrapRun = {
     ...run,

--- a/.github/workflows/ponto-release-watchdog.yml
+++ b/.github/workflows/ponto-release-watchdog.yml
@@ -1,7 +1,13 @@
 name: Ponto progressive release watchdog
-run-name: Ponto watchdog source=${{ github.event.workflow_run.id }}
+run-name: Ponto watchdog source=${{ inputs.coordinator_run_id || github.event.workflow_run.id }}
 
 on:
+  workflow_dispatch:
+    inputs:
+      coordinator_run_id:
+        description: Exact completed Ponto coordinator run that requires recovery
+        required: true
+        type: string
   workflow_run:
     workflows: ["Ponto progressive release"]
     types: [completed]
@@ -31,6 +37,7 @@ jobs:
         id: context
         env:
           GH_TOKEN: ${{ github.token }}
+          PONTO_WATCHDOG_COORDINATOR_RUN_ID: ${{ inputs.coordinator_run_id || '' }}
           PONTO_WATCHDOG_CONTEXT_FILE: ${{ runner.temp }}/ponto-watchdog/context.json
         run: |
           set -euo pipefail
@@ -39,7 +46,7 @@ jobs:
       - name: Upload sanitized watchdog context
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: ponto-watchdog-context-${{ github.event.workflow_run.id }}-${{ github.run_id }}
+          name: ponto-watchdog-context-${{ inputs.coordinator_run_id || github.event.workflow_run.id }}-${{ github.run_id }}
           path: ${{ runner.temp }}/ponto-watchdog/context.json
           retention-days: 90
           if-no-files-found: error


### PR DESCRIPTION
## Context\nA failed Ponto coordinator can leave a child mutation behind while the automatic watchdog is blocked by a transient broker close error. A later watchdog run may have no child journal and safely no-op, leaving the surface in a mixed deployment state.\n\n## Change\n- add a governed workflow_dispatch entry point to the existing watchdog\n- validate an explicitly supplied coordinator run through the same canonical provenance, SHA, terminal-state, and custody checks\n- cover the manual event path with a regression test\n\n## Validation\n- WSL: node --test .github/scripts/ponto-watchdog-context.test.mjs .github/scripts/ponto-watchdog-journal.test.mjs\n- 20 assertions passed\n- git diff --check\n\nThe manual input accepts only the completed coordinator run ID; rollback targets remain derived from immutable child evidence.