### PR TITLE
fix(ponto): match production inventory recovery child

### DIFF
--- a/.github/scripts/ponto-watchdog-journal.mjs
+++ b/.github/scripts/ponto-watchdog-journal.mjs
@@ -36,7 +36,7 @@ const SURFACES = Object.freeze({
   identityWorkforce: {
     workflowPath: ".github/workflows/deploy-core-workers.yml",
     titlePrefix: (stage, sha, runId) =>
-      `Core inventory ${stage} team=true ${sha} orchestrator=${runId}`,
+      `Core inventory ${stage} team=${stage === "staging" ? "true" : "false"} ${sha} orchestrator=${runId}`,
     runFile: "runs/identity.json",
     artifacts: (stage, sha) => [
       [`ponto-surface-identity-workforce-${stage}-${sha}`, "surfaces/identity"],

--- a/.github/scripts/ponto-watchdog-journal.test.mjs
+++ b/.github/scripts/ponto-watchdog-journal.test.mjs
@@ -136,6 +136,40 @@ test("watchdog reconstructs exact surface run files and a bounded artifact manif
   assert.equal(JSON.parse(fs.readFileSync(path.join(root, "runs/core.json"), "utf8")).runId, "12");
 });
 
+test("watchdog matches the production inventory child with unified team disabled", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ponto-watchdog-production-identity-"));
+  const child = run(
+    10,
+    "deploy-core-workers.yml",
+    `Core inventory pilot team=false ${sha} orchestrator=99 nonce=${"1".repeat(32)}`,
+  );
+  anchor(root, "identity.json", "deploy-core-workers.yml", 502, 10);
+  const report = await reconstructWatchdogJournal({
+    repository,
+    coordinatorRunId: "99",
+    releaseSha: sha,
+    stage: "pilot",
+    artifactRoot: root,
+    request: scopedRequest([child]),
+  });
+  assert.equal(report.passed, true);
+  assert.deepEqual(report.unresolved, []);
+  assert.deepEqual(report.downloads, [
+    {
+      surface: "identityWorkforce",
+      runId: "10",
+      artifact: `ponto-surface-identity-workforce-pilot-${sha}`,
+      destination: "surfaces/identity",
+    },
+    {
+      surface: "identityWorkforce",
+      runId: "10",
+      artifact: `ponto-mutation-identity-workforce-pilot-${sha}`,
+      destination: "mutations/identity",
+    },
+  ]);
+});
+
 test("watchdog fails closed on an exact-title child that lacks journal or signed capability", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "ponto-watchdog-spoof-"));
   const title = `Timekeeping production ${sha} orchestrator=99 nonce=${"1".repeat(32)}`;


### PR DESCRIPTION
## Context\nThe manual watchdog correctly reconstructed the failed production coordinator and Timekeeping journal, but rollback stopped fail-closed because the production Identity/Workforce child was titled Core inventory pilot team=false. The recovery matcher only recognized the staging 	eam=true form.\n\n## Change\n- derive the inventory team marker from the release stage\n- preserve staging 	eam=true and recognize production live stages as 	eam=false\n- add a production pilot reconstruction regression test\n\n## Validation\n- WSL: node --test .github/scripts/ponto-watchdog-context.test.mjs .github/scripts/ponto-watchdog-journal.test.mjs\n- 21 assertions passed\n- git diff --check\n\nThis change only widens matching to the exact title emitted by the canonical production workflow; rollback targets remain derived from immutable journals and capability custody.