### PR TITLE
fix(ponto): accept canonical production worker output

### DIFF
--- a/.github/scripts/ponto-wrangler-output.mjs
+++ b/.github/scripts/ponto-wrangler-output.mjs
@@ -1,5 +1,11 @@
 import fs from "node:fs";
 
+const TOP_LEVEL_PRODUCTION_WORKERS = new Set([
+  "skincos-insumos",
+  "skincos-ponto-core",
+  "skincos-timekeeping",
+]);
+
 const [file, expectedType, expectedName] = process.argv.slice(2);
 if (!file || !expectedType || !expectedName) {
   throw new Error("usage: ponto-wrangler-output.mjs <ndjson-file> <entry-type> <worker-or-project>");
@@ -25,7 +31,7 @@ const missingEnvironmentAllowed = !actualEnvironment && (
   || (
     expectedType === "version-upload"
     && expectedEnvironment === "production"
-    && expectedName === "skincos-timekeeping"
+    && TOP_LEVEL_PRODUCTION_WORKERS.has(expectedName)
   )
 );
 if (expectedEnvironment && actualEnvironment !== expectedEnvironment && !missingEnvironmentAllowed) {

--- a/.github/scripts/ponto-wrangler-output.test.mjs
+++ b/.github/scripts/ponto-wrangler-output.test.mjs
@@ -8,19 +8,21 @@ import test from "node:test";
 const script = path.resolve(import.meta.dirname, "ponto-wrangler-output.mjs");
 const uuid = "11111111-1111-4111-8111-111111111111";
 
-test("accepts a top-level production version upload without a repeated Wrangler environment", () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wrangler-output-"));
-  const file = path.join(dir, "output.ndjson");
-  fs.writeFileSync(file, [
-    JSON.stringify({ type: "wrangler-session", version: 1 }),
-    JSON.stringify({ type: "version-upload", version: 1, worker_name: "skincos-timekeeping", version_id: uuid }),
-    "",
-  ].join("\n"));
-  const result = spawnSync(process.execPath, [script, file, "version-upload", "skincos-timekeeping"], {
-    encoding: "utf8",
-    env: { ...process.env, PONTO_EXPECTED_WRANGLER_ENV: "production" },
-  });
-  assert.equal(result.status, 0, result.stderr);
+test("accepts top-level production version uploads for every canonical Ponto Worker", () => {
+  for (const workerName of ["skincos-insumos", "skincos-ponto-core", "skincos-timekeeping"]) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wrangler-output-"));
+    const file = path.join(dir, "output.ndjson");
+    fs.writeFileSync(file, [
+      JSON.stringify({ type: "wrangler-session", version: 1 }),
+      JSON.stringify({ type: "version-upload", version: 1, worker_name: workerName, version_id: uuid }),
+      "",
+    ].join("\n"));
+    const result = spawnSync(process.execPath, [script, file, "version-upload", workerName], {
+      encoding: "utf8",
+      env: { ...process.env, PONTO_EXPECTED_WRANGLER_ENV: "production" },
+    });
+    assert.equal(result.status, 0, `${workerName}: ${result.stderr}`);
+  }
 });
 
 test("rejects a staging version upload without its Wrangler environment", () => {


### PR DESCRIPTION
## Objetivo
Corrigir a validação do artefato NDJSON dos Workers Ponto publicados no ambiente produtivo top-level.

## Causa observada
O piloto produtivo 32555293562 publicou a versão de Identity/Workforce sem tráfego, mas o verificador rejeitou skincos-insumos porque o registro version-upload não repetiu wrangler_environment. O rollback automático concluiu com sucesso; nenhum tráfego produtivo foi transferido e a promoção foi interrompida antes de Core API/CRM Pages.

## Mudança
- Mantém a validação fail-closed para ambientes nomeados, especialmente staging.
- Permite ausência de wrangler_environment somente para os três Workers Ponto canônicos top-level de produção: skincos-insumos, skincos-ponto-core e skincos-timekeeping.
- Adiciona cobertura unitária para os três destinos.

## Validação
- node --test .github/scripts/ponto-wrangler-output.test.mjs .github/scripts/ponto-dispatch-workflow.test.mjs
- npm run codex:deploy-topology:test
- git diff --check

## Rollback
Reverter este commit/PR; não há migration, flag, grant ou mudança de dado. O rollback operacional do piloto anterior foi executado e terminou com sucesso.