### PR TITLE
fix(ponto): provide Core selection credentials

### DIFF
--- a/.github/scripts/ponto-dispatch-workflow.test.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.test.mjs
@@ -290,6 +290,20 @@ test("private signing custody is never persisted or inherited by direct rollback
   assert.doesNotMatch(drillScript, /createCapabilityCheck|capabilityExternalId/);
 });
 
+test("Core production candidate selection has Cloudflare custody before querying deployments", () => {
+  const core = fs.readFileSync(
+    new URL("../workflows/deploy-core-workers.yml", import.meta.url),
+    "utf8",
+  );
+  const start = core.indexOf("- name: Test and select the route-isolated Ponto Core candidate");
+  const end = core.indexOf("\n      - name: Resolve incumbent Core version", start);
+  assert.ok(start >= 0 && end > start, "Ponto Core candidate selection step must remain present");
+  const step = core.slice(start, end);
+  assert.match(step, /env:\s*\n\s+CLOUDFLARE_API_TOKEN:\s+\$\{\{\s*secrets\.CLOUDFLARE_API_TOKEN\s*\}\}/);
+  assert.match(step, /CLOUDFLARE_ACCOUNT_ID:\s+\$\{\{\s*secrets\.CLOUDFLARE_ACCOUNT_ID\s*\}\}/);
+  assert.match(step, /wrangler deployments status --name skincos-api --json/);
+});
+
 test("current Pages and Ponto mutators are fenced from legacy repository controls", () => {
   const readWorkflow = (name) => fs.readFileSync(
     new URL(`../workflows/${name}`, import.meta.url),

--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -1147,6 +1147,9 @@ jobs:
           cache: npm
           cache-dependency-path: api/package-lock.json
       - name: Test and select the route-isolated Ponto Core candidate
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail
           npm --prefix api ci --ignore-scripts


### PR DESCRIPTION
## Objetivo
Corrigir a custódia de credenciais no passo produtivo que seleciona o candidato do Ponto Core.

## Causa observada
No piloto `32558594337`, Timekeeping e Identity/Workforce passaram. O filho de Core (`32559114616`) executou os 33 testes e o dry-run, mas falhou ao consultar `wrangler deployments status --name skincos-api --json` sem `CLOUDFLARE_API_TOKEN`; a promoção parou antes da seleção do candidato. O recovery/rollback governado terminou com sucesso.

## Mudança
- Expõe `CLOUDFLARE_API_TOKEN` e `CLOUDFLARE_ACCOUNT_ID` somente no passo `Test and select the route-isolated Ponto Core candidate`.
- Adiciona teste estático que exige a custódia antes da consulta ao estado do Worker.

## Validação
- `node --test .github/scripts/ponto-dispatch-workflow.test.mjs .github/scripts/ponto-wrangler-output.test.mjs` (18 testes)
- `npm run codex:deploy-topology:test`
- `git diff --check`

## Rollback
Reverter este commit/PR; não há migration, flag, grant ou mudança de dado. O piloto anterior foi automaticamente reconciliado e revertido.