### PR TITLE
fix(ponto): pass coordination outputs to CRM Pages release

### DIFF
--- a/.github/scripts/ponto-live-deployment-precondition.test.mjs
+++ b/.github/scripts/ponto-live-deployment-precondition.test.mjs
@@ -210,3 +210,14 @@ test("Timekeeping release receives the coordinator proof before global mutation"
   assert.match(release, /needs\.coordination\.outputs\.global_coordinator_url/);
   assert.match(release, /needs\.coordination\.outputs\.global_proof_b64/);
 });
+
+test("CRM Pages production mutation declares and consumes its coordination dependency", () => {
+  const workflow = fs.readFileSync(new URL("../workflows/deploy-crm-pages.yml", import.meta.url), "utf8");
+  const releaseStart = workflow.indexOf("\n  ponto-progressive-release:");
+  const coordinationReleaseStart = workflow.indexOf("\n  global-coordination-release:", releaseStart);
+  assert.ok(releaseStart >= 0 && coordinationReleaseStart > releaseStart);
+  const release = workflow.slice(releaseStart, coordinationReleaseStart);
+  assert.match(release, /needs: \[coordination, progressive\]/);
+  assert.match(release, /needs\.coordination\.outputs\.global_coordinator_url/);
+  assert.match(release, /needs\.coordination\.outputs\.global_proof_b64/);
+});

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -1068,7 +1068,7 @@ jobs:
           if-no-files-found: error
 
   ponto-progressive-release:
-    needs: progressive
+    needs: [coordination, progressive]
     if: ${{ github.run_attempt == 1 && inputs.release_scope == 'ponto' && contains(fromJSON('["pilot","canary","production","rollback"]'), inputs.target) }}
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
## Problema\nO job governado ponto-progressive-release do CRM Pages consumia 
eeds.coordination.outputs.*, mas declarava apenas 
eeds: progressive. O job iniciava sem a URL/prova de coordenação e falhava antes de qualquer mutação com Global coordination custody is unavailable.\n\n## Correção\n- declara 
eeds: [coordination, progressive];\n- adiciona teste estático que exige a dependência e os dois outputs usados pelo gate.\n\n## Validação\n- 
ode --test .github/scripts/ponto-live-deployment-precondition.test.mjs .github/scripts/ponto-orchestrator-lease.test.mjs .github/scripts/ponto-dispatch-workflow.test.mjs (63 testes);\n- 
ode .github/scripts/validate-deploy-topology.mjs.\n\nA correção não contorna os gates: restaura a prova de coordenação que o job já exige.