### PR TITLE
fix(ponto): preserve production Pages secret binding

### DIFF
--- a/.github/scripts/ponto-dispatch-workflow.test.mjs
+++ b/.github/scripts/ponto-dispatch-workflow.test.mjs
@@ -356,10 +356,10 @@ test("current Pages and Ponto mutators are fenced from legacy repository control
     /name: Attest remote Ponto Pages values before Ponto deployment[\s\S]*?if: \$\{\{ inputs\.release_scope == 'ponto'/,
     "Ponto remote values must be gated to governed Ponto releases",
   );
-  assert.match(sharedPages, /if \[\[ "\$RELEASE_SCOPE" == general && "\$DEPLOY_TARGET" == production \]\]; then/);
+  assert.match(sharedPages, /if \[\[ "\$DEPLOY_TARGET" == production \|\| "\$DEPLOY_TARGET" == pilot \|\| "\$DEPLOY_TARGET" == canary \]\]; then/);
   assert.ok(
     sharedPages.includes("sed -i '/^PONTO_API_TARGET[[:space:]]*=/d' wrangler.toml"),
-    "general production Pages releases must preserve the existing Ponto secret binding",
+    "production, pilot, and canary Pages releases must preserve the existing Ponto secret binding",
   );
   for (const name of [
     "CRM_GENERAL_PAGES_PROJECT",

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -570,11 +570,11 @@ jobs:
           NODE
             fi
           fi
-          if [[ "$RELEASE_SCOPE" == general && "$DEPLOY_TARGET" == production ]]; then
-            # Production already owns PONTO_API_TARGET as a Pages secret. Do
-            # not redeclare that binding as a plaintext variable in a general
-            # deployment; leaving the remote secret untouched preserves the
-            # independently fenced Ponto surface.
+          if [[ "$DEPLOY_TARGET" == production || "$DEPLOY_TARGET" == pilot || "$DEPLOY_TARGET" == canary ]]; then
+            # Production Pages already owns PONTO_API_TARGET as a secret. Do
+            # not redeclare that binding as a plaintext variable during a
+            # production, pilot, or canary release; leaving the remote secret
+            # untouched preserves the independently governed Ponto surface.
             sed -i '/^PONTO_API_TARGET[[:space:]]*=/d' wrangler.toml
           fi
           node - wrangler.toml "$MODULE_CONTROL_KV_ID" <<'NODE'


### PR DESCRIPTION
## Summary\n- preserve the existing production PONTO_API_TARGET Pages secret for production, pilot, and canary deployments\n- prevent Wrangler from redeclaring the binding as a plaintext variable\n- update the governed static regression test\n\n## Validation\n- focused Ponto workflow tests: 72 passed\n- deploy topology validation: passed\n\n## Production incident context\n- the exact release SHA is 79362b3bbe2242885c2e7dd52b8d42873970366d\n- the failed pilot reached Pages deployment and was rejected by Cloudflare with Binding name PONTO_API_TARGET already in use\n- no credentials or PII included\n