### PR TITLE
fix(ponto): repair drifted production Pages target binding

### DIFF
--- a/.github/scripts/ponto-secret-custody.test.mjs
+++ b/.github/scripts/ponto-secret-custody.test.mjs
@@ -191,6 +191,23 @@ test("Pages root derivation passes private paths through explicit environment va
   assert.match(step, /unset PONTO_ROOT_ATTESTATION_KEY_SHARED PONTO_IDEMPOTENCY_KEY/);
 });
 
+test("Pages production repair converts drifted Ponto target metadata to a secret binding", () => {
+  const source = workflow("cloudflare-pages-sync-ponto.yml");
+  const repairStart = source.indexOf("- name: Repair production Ponto target binding when metadata drifted");
+  const deriveStart = source.indexOf("- name: Derive and provision environment-scoped Ponto Pages keys");
+  const repair = source.slice(repairStart, deriveStart);
+  assert.ok(repairStart >= 0 && deriveStart > repairStart);
+  assert.match(repair, /if: \$\{\{ inputs\.target == 'production' \}\}/);
+  assert.match(repair, /PONTO_API_TARGET: \$\{\{ secrets\.PONTO_API_TARGET \}\}/);
+  assert.match(repair, /Production Ponto Pages project identity differs from policy/);
+  assert.match(repair, /PONTO_API_TARGET.*pages secret put/);
+  assert.match(repair, /binding\?\.type !== "secret_text"/);
+  assert.match(repair, /targetBindingRepair/);
+  assert.match(repair, /mutationStarted = true/);
+  assert.match(source, /const previousJournal = fs\.existsSync\(process\.argv\[3\]\)/);
+  assert.match(source, /mutationStarted: previousJournal\.mutationStarted === true/);
+});
+
 test("Ponto REST run provenance accepts canonical parent or immutable release path representations", () => {
   for (const name of [
     "cloudflare-pages-sync-ponto.yml",

--- a/.github/workflows/cloudflare-pages-audit.yml
+++ b/.github/workflows/cloudflare-pages-audit.yml
@@ -55,6 +55,10 @@ jobs:
             env_vars=env_cfg.get("env_vars") or {}
             keys=sorted(env_vars.keys())
             print(f"{env} env var keys ({len(keys)}):", ", ".join(keys) if keys else "(none)")
+            for name in ("PONTO_API_TARGET", "PONTO_PROXY_TOKEN", "PONTO_ACTOR_HMAC_KEY"):
+              binding=env_vars.get(name)
+              binding_type=binding.get("type") if isinstance(binding, dict) else None
+              print(f"{env} {name} binding type:", binding_type or "absent")
           PY
 
       - name: Check required env vars (presence only)

--- a/.github/workflows/cloudflare-pages-sync-ponto.yml
+++ b/.github/workflows/cloudflare-pages-sync-ponto.yml
@@ -285,6 +285,100 @@ jobs:
             "$RUNNER_TEMP/repository-secrets.json" \
             "$RUNNER_TEMP/environment-variables.json" \
             "$RUNNER_TEMP/repository-variables.json"
+      - name: Repair production Ponto target binding when metadata drifted
+        if: ${{ inputs.target == 'production' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PONTO_API_TARGET: ${{ secrets.PONTO_API_TARGET }}
+          PROJECT_RAW: ${{ vars.PONTO_CLOUDFLARE_PAGES_PROJECT }}
+          PROBE_EVIDENCE_FILE: ${{ runner.temp }}/pages-release-probe-evidence.json
+        run: |
+          set -euo pipefail
+          PROJECT="$PROJECT_RAW"
+          [[ "$PROJECT" == "skincos" ]] || { echo 'Production Ponto Pages project is not the exact isolated project'; exit 1; }
+          [[ "$PONTO_API_TARGET" == "https://api.skincos.com.br" ]] || { echo 'Production Ponto target secret is not the approved API origin'; exit 1; }
+          [[ -s "$PROBE_EVIDENCE_FILE" ]] || { echo 'Pages mutation journal is missing before target-binding repair'; exit 1; }
+          before_file="$RUNNER_TEMP/ponto-api-target-before.json"
+          after_file="$RUNNER_TEMP/ponto-api-target-after.json"
+          trap 'rm -f "$before_file" "$after_file"' EXIT
+          curl --fail --silent --show-error \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT" \
+            > "$before_file"
+          target_type="$(node - "$before_file" <<'NODE'
+          const fs = require("fs");
+          const payload = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const project = payload?.result;
+          if (
+            payload?.success !== true
+            || project?.name !== "skincos"
+            || project?.production_branch !== "main"
+            || project?.subdomain !== "skincos.pages.dev"
+          ) throw new Error("Production Ponto Pages project identity differs from policy");
+          const binding = project?.deployment_configs?.production?.env_vars?.PONTO_API_TARGET;
+          if (!binding || typeof binding !== "object" || Array.isArray(binding)) {
+            process.stdout.write("absent");
+          } else {
+            process.stdout.write(String(binding.type || "unknown"));
+          }
+          NODE
+          )"
+          node - "$PROBE_EVIDENCE_FILE" "$target_type" <<'NODE'
+          const fs = require("fs");
+          const file = process.argv[2];
+          const beforeType = process.argv[3];
+          const journal = JSON.parse(fs.readFileSync(file, "utf8"));
+          const required = beforeType !== "secret_text";
+          journal.targetBindingRepair = {
+            required,
+            beforeType,
+            mutation: required ? "pages-secret-put" : "none",
+            completed: !required,
+            valuesIncluded: false,
+          };
+          if (required) {
+            journal.mutationStarted = true;
+            journal.mutationRequestStartedAt = new Date().toISOString();
+          }
+          fs.writeFileSync(file, `${JSON.stringify(journal, null, 2)}\n`, { mode: 0o600 });
+          NODE
+          if [[ "$target_type" != "secret_text" ]]; then
+            printf '%s\n' "$PONTO_API_TARGET" | npx --yes wrangler@4.112.0 pages secret put PONTO_API_TARGET \
+              --project-name "$PROJECT" \
+              --env production
+            curl --fail --silent --show-error \
+              -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+              "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT" \
+              > "$after_file"
+            node - "$after_file" <<'NODE'
+          const fs = require("fs");
+          const payload = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const project = payload?.result;
+          const binding = project?.deployment_configs?.production?.env_vars?.PONTO_API_TARGET;
+          if (
+            payload?.success !== true
+            || project?.name !== "skincos"
+            || project?.production_branch !== "main"
+            || project?.subdomain !== "skincos.pages.dev"
+            || binding?.type !== "secret_text"
+          ) throw new Error("Production Ponto target binding did not become secret_text");
+          NODE
+            node - "$PROBE_EVIDENCE_FILE" <<'NODE'
+          const fs = require("fs");
+          const file = process.argv[2];
+          const journal = JSON.parse(fs.readFileSync(file, "utf8"));
+          journal.targetBindingRepair = {
+            ...journal.targetBindingRepair,
+            completed: true,
+            completedAt: new Date().toISOString(),
+          };
+          fs.writeFileSync(file, `${JSON.stringify(journal, null, 2)}\n`, { mode: 0o600 });
+          NODE
+            echo 'Production Ponto target binding repaired and attested as secret_text.'
+          else
+            echo 'Production Ponto target binding already attested as secret_text.'
+          fi
       - name: Derive and provision environment-scoped Ponto Pages keys
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -391,6 +485,9 @@ jobs:
           node - "$before_project_file" "$evidence_file" <<'NODE'
           const fs = require("fs");
           const projectPayload = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const previousJournal = fs.existsSync(process.argv[3])
+            ? JSON.parse(fs.readFileSync(process.argv[3], "utf8"))
+            : {};
           const project = projectPayload?.result;
           const envVars = project?.deployment_configs?.production?.env_vars;
           if (
@@ -422,13 +519,14 @@ jobs:
             throw new Error("production PONTO_API_TARGET secret is absent");
           }
           fs.writeFileSync(process.argv[3], `${JSON.stringify({
+            ...previousJournal,
             schemaVersion: 1,
             surface: "pagesEnvironmentSecrets",
             target: process.env.TARGET,
             project: process.env.PROJECT,
             releaseSha: process.env.RELEASE_SHA,
             orchestratorRunId: process.env.ORCHESTRATOR_RUN_ID,
-            mutationStarted: false,
+            mutationStarted: previousJournal.mutationStarted === true,
             mutationCompleted: false,
             remoteAttestationCompleted: false,
             retentionPolicy: "environment-scoped-deterministic-prerequisite",


### PR DESCRIPTION
## Summary
- expose only Pages binding types in the read-only audit;
- repair production PONTO_API_TARGET with the approved environment secret when the remote binding is not secret_text;
- verify project identity before mutation, verify secret_text after mutation, and preserve the sanitized mutation journal.

## Evidence
- production Pages audit run 32574158488 found PONTO_API_TARGET present as plain_text; preview is secret_text;
- focused ponto-secret-custody.test.mjs passes;
- deployment topology validation passes.

## Safety
- no secret values are printed or persisted;
- repair is production-only, exact-project/branch/subdomain/approved-origin guarded, and uses the existing ponto-surface-mutation / global coordination path;
- staging remains unchanged.