### PR TITLE
feat(beauty-movement): export private invite delivery links

### DIFF
--- a/.github/governance/cloudflare-single-writer-policy.json
+++ b/.github/governance/cloudflare-single-writer-policy.json
@@ -43,7 +43,8 @@
       "reason": "Reads the active Beauty Movement campaign from D1 and derives a private delivery artifact; it has no Cloudflare mutation or deploy authority.",
       "requiredMarkers": [
         "beauty-movement:export-delivery",
-        "SELECT status, ends_at_ms",
+        "SELECT c.status, c.ends_at_ms",
+        "invite_token_hmac",
         "Upload private delivery artifact"
       ]
     }

--- a/.github/governance/cloudflare-single-writer-policy.json
+++ b/.github/governance/cloudflare-single-writer-policy.json
@@ -37,6 +37,15 @@
         "SELECT",
         "PILOT_COHORT_IDENTITY_INVALID"
       ]
+    },
+    {
+      "workflow": ".github/workflows/beauty-movement-delivery-export.yml",
+      "reason": "Reads the active Beauty Movement campaign from D1 and derives a private delivery artifact; it has no Cloudflare mutation or deploy authority.",
+      "requiredMarkers": [
+        "beauty-movement:export-delivery",
+        "SELECT status, ends_at_ms",
+        "Upload private delivery artifact"
+      ]
     }
   ],
   "coordinationGroups": [

--- a/.github/scripts/beauty-movement-delivery-export-contract.test.mjs
+++ b/.github/scripts/beauty-movement-delivery-export-contract.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const workflow = await readFile(new URL("../workflows/beauty-movement-delivery-export.yml", import.meta.url), "utf8");
+const script = await readFile(new URL("../../website/scripts/beauty-movement-delivery-export.ts", import.meta.url), "utf8");
+
+test("delivery export is an explicit production-environment dispatch", () => {
+  assert.match(workflow, /name: Beauty Movement private delivery export/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /environment: production/);
+  assert.match(workflow, /release_sha:/);
+  assert.match(workflow, /campaign_id:/);
+  assert.match(workflow, /campaign_ends_at:/);
+  assert.match(workflow, /expected_input_sha256:/);
+  assert.match(workflow, /ref: \$\{\{ github\.sha \}\}/);
+  assert.match(workflow, /WORKFLOW_SHA: \$\{\{ github\.sha \}\}/);
+  assert.match(workflow, /git diff --quiet "\$\{RELEASE_SHA\}" -- website\/src\/lib\/beautyMovementImport\.ts/);
+});
+
+test("export derives from protected custody and does not mutate D1 or deploy", () => {
+  for (const name of [
+    "BEAUTY_MOVEMENT_TOKEN_HMAC_KEY",
+    "BEAUTY_MOVEMENT_PII_KEY",
+    "PRODUCTION_INVITES_CSV",
+    "PRODUCTION_CAMPAIGN_JSON",
+  ]) assert.match(workflow, new RegExp(name));
+  assert.match(workflow, /beauty-movement:export-delivery/);
+  assert.match(workflow, /d1 execute .*--remote/);
+  assert.match(workflow, /SELECT status, ends_at_ms/);
+  assert.doesNotMatch(workflow, /--apply/);
+  assert.doesNotMatch(workflow, /d1 migrations apply/);
+  assert.doesNotMatch(workflow, /wrangler deploy/);
+  assert.match(workflow, /x-app-build/);
+  assert.match(workflow, /active_invite_count/);
+  assert.match(workflow, /actions\/upload-artifact/);
+  assert.match(workflow, /retention-days: 1/);
+  assert.match(workflow, /delivery\.csv/);
+  assert.match(workflow, /export-summary\.json/);
+});
+
+test("script stdout is aggregate-only and the output is private", () => {
+  assert.match(script, /flag: "wx"/);
+  assert.match(script, /mode: "delivery_export"/);
+  assert.match(script, /inputSha256/);
+  assert.match(script, /outputSha256/);
+  assert.match(script, /outputBytes/);
+  assert.doesNotMatch(script, /console\.log\([^\n]*(inviteUrl|whatsapp|tokenHmacKey|deliveryRows)/i);
+  assert.doesNotMatch(script, /console\.log\([^\n]*\bname\b/i);
+});
+
+test("all embedded workflow shell blocks parse", () => {
+  const lines = workflow.split(/\r?\n/);
+  let blocks = 0;
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!/^        run: \|$/.test(lines[index] ?? "")) continue;
+    const block = [];
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      const line = lines[cursor] ?? "";
+      if (line && !line.startsWith("          ")) break;
+      block.push(line.startsWith("          ") ? line.slice(10) : "");
+    }
+    execFileSync("bash", ["-n"], { input: block.join("\n"), encoding: "utf8" });
+    blocks += 1;
+  }
+  assert.equal(blocks, 6);
+});

--- a/.github/scripts/beauty-movement-delivery-export-contract.test.mjs
+++ b/.github/scripts/beauty-movement-delivery-export-contract.test.mjs
@@ -25,15 +25,22 @@ test("export derives from protected custody and does not mutate D1 or deploy", (
     "BEAUTY_MOVEMENT_PII_KEY",
     "PRODUCTION_INVITES_CSV",
     "PRODUCTION_CAMPAIGN_JSON",
+    "PRODUCTION_REWARDS_JSON",
+    "PRODUCTION_PROCEDURES_JSON",
   ]) assert.match(workflow, new RegExp(name));
   assert.match(workflow, /beauty-movement:export-delivery/);
   assert.match(workflow, /d1 execute .*--remote/);
-  assert.match(workflow, /SELECT status, ends_at_ms/);
+  assert.match(workflow, /SELECT c\.status, c\.ends_at_ms/);
   assert.doesNotMatch(workflow, /--apply/);
   assert.doesNotMatch(workflow, /d1 migrations apply/);
   assert.doesNotMatch(workflow, /wrangler deploy/);
   assert.match(workflow, /x-app-build/);
   assert.match(workflow, /active_invite_count/);
+  assert.match(workflow, /import_input_sha256/);
+  assert.match(workflow, /token_hmac_attestation/);
+  assert.match(workflow, /secret list --name/);
+  assert.match(workflow, /workerSecretNamesAttested/);
+  assert.doesNotMatch(workflow, /env:\n\s+CLOUDFLARE_API_TOKEN: \$\{\{ secrets\.CLOUDFLARE_API_TOKEN \}\}[\s\S]*?Install exact website dependencies/);
   assert.match(workflow, /actions\/upload-artifact/);
   assert.match(workflow, /retention-days: 1/);
   assert.match(workflow, /delivery\.csv/);
@@ -46,6 +53,8 @@ test("script stdout is aggregate-only and the output is private", () => {
   assert.match(script, /inputSha256/);
   assert.match(script, /outputSha256/);
   assert.match(script, /outputBytes/);
+  assert.match(script, /--attestation/);
+  assert.match(script, /inviteTokenHmacs/);
   assert.doesNotMatch(script, /console\.log\([^\n]*(inviteUrl|whatsapp|tokenHmacKey|deliveryRows)/i);
   assert.doesNotMatch(script, /console\.log\([^\n]*\bname\b/i);
 });

--- a/.github/workflows/beauty-movement-delivery-export.yml
+++ b/.github/workflows/beauty-movement-delivery-export.yml
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node
-        uses: actions/setup-node@249970729cb0ef3589644e289664e5dc5ba9c38 # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22.12.0
           cache: npm

--- a/.github/workflows/beauty-movement-delivery-export.yml
+++ b/.github/workflows/beauty-movement-delivery-export.yml
@@ -1,0 +1,187 @@
+name: Beauty Movement private delivery export
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Exact website SHA currently serving the active campaign
+        required: true
+        type: string
+      campaign_id:
+        description: Active production campaign whose invite links are being handed off
+        required: true
+        type: string
+      campaign_ends_at:
+        description: Campaign expiry used to validate the private source package
+        required: true
+        type: string
+      expected_input_sha256:
+        description: SHA-256 of the approved private invites CSV (prevents wrong-package export)
+        required: true
+        type: string
+
+concurrency:
+  group: beauty-movement-delivery-export-${{ inputs.campaign_id }}
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  export:
+    name: Derive and attest private invite links
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 25
+    permissions:
+      actions: write
+      contents: read
+    env:
+      RELEASE_SHA: ${{ inputs.release_sha }}
+      CAMPAIGN_ID: ${{ inputs.campaign_id }}
+      CAMPAIGN_ENDS_AT: ${{ inputs.campaign_ends_at }}
+      EXPECTED_INPUT_SHA256: ${{ inputs.expected_input_sha256 }}
+      WORKFLOW_SHA: ${{ github.sha }}
+      PRODUCTION_URL: https://espacofacial.com
+      PRODUCTION_D1_DATABASE: espacofacial-beauty-movement
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      BEAUTY_MOVEMENT_TOKEN_HMAC_KEY: ${{ secrets.BEAUTY_MOVEMENT_TOKEN_HMAC_KEY }}
+      BEAUTY_MOVEMENT_PII_KEY: ${{ secrets.BEAUTY_MOVEMENT_PII_KEY }}
+      PRODUCTION_INVITES_CSV: ${{ secrets.BEAUTY_MOVEMENT_PRODUCTION_INVITES_CSV }}
+      PRODUCTION_CAMPAIGN_JSON: ${{ secrets.BEAUTY_MOVEMENT_PRODUCTION_CAMPAIGN_JSON }}
+
+    steps:
+      - name: Checkout the exporter source and verify serving logic is unchanged
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@249970729cb0ef3589644e289664e5dc5ba9c38 # v6
+        with:
+          node-version: 22.12.0
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install exact website dependencies
+        working-directory: website
+        run: npm ci
+
+      - name: Guard source, custody and immutable read-only scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "${GITHUB_REPOSITORY}" == "jubenitogarcia/skincos" ]] || { echo 'unexpected repository'; exit 1; }
+          [[ "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]] || { echo 'release_sha must be a full commit SHA'; exit 1; }
+          [[ "${WORKFLOW_SHA}" == "$(git rev-parse --verify HEAD)" ]] || { echo 'checked out SHA differs from workflow SHA'; exit 1; }
+          git cat-file -e "${RELEASE_SHA}:website/src/lib/beautyMovementImport.ts" || { echo 'release source does not contain the importer'; exit 1; }
+          git diff --quiet "${RELEASE_SHA}" -- website/src/lib/beautyMovementImport.ts website/src/lib/beautyMovementSecurity.ts website/src/lib/beautyMovementOutcomes.ts || { echo 'token derivation source differs from the serving release'; exit 1; }
+          [[ "${CAMPAIGN_ID}" =~ ^[a-z0-9][a-z0-9_-]{2,79}$ ]] || { echo 'campaign_id shape is invalid'; exit 1; }
+          [[ "${CAMPAIGN_ENDS_AT}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}(:[0-9]{2}(\.[0-9]{1,3})?)?(Z|[+-][0-9]{2}:[0-9]{2})$ ]] || { echo 'campaign_ends_at must be ISO-8601'; exit 1; }
+          [[ "${EXPECTED_INPUT_SHA256}" =~ ^[0-9a-f]{64}$ ]] || { echo 'expected_input_sha256 must be a lowercase SHA-256'; exit 1; }
+          [[ "${PRODUCTION_URL}" == "https://espacofacial.com" ]] || { echo 'production URL guard failed'; exit 1; }
+          [[ "${PRODUCTION_D1_DATABASE}" == "espacofacial-beauty-movement" ]] || { echo 'production D1 guard failed'; exit 1; }
+          for required in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID BEAUTY_MOVEMENT_TOKEN_HMAC_KEY BEAUTY_MOVEMENT_PII_KEY PRODUCTION_INVITES_CSV PRODUCTION_CAMPAIGN_JSON; do
+            [[ -n "${!required:-}" ]] || { echo "required production custody is unavailable: ${required}"; exit 1; }
+          done
+          mkdir -p "${RUNNER_TEMP}/beauty-movement-delivery-export"
+          export DELIVERY_EXPORT_ROOT="${RUNNER_TEMP}/beauty-movement-delivery-export"
+          {
+            echo "DELIVERY_EXPORT_ROOT=${DELIVERY_EXPORT_ROOT}"
+            echo "DELIVERY_INPUT=${DELIVERY_EXPORT_ROOT}/invites.csv"
+            echo "DELIVERY_CAMPAIGN=${DELIVERY_EXPORT_ROOT}/campaign.json"
+            echo "DELIVERY_OUTPUT=${DELIVERY_EXPORT_ROOT}/delivery.csv"
+            echo "DELIVERY_SUMMARY=${DELIVERY_EXPORT_ROOT}/export-summary.json"
+            echo "LIVE_HEADERS=${DELIVERY_EXPORT_ROOT}/live-headers.txt"
+            echo "D1_READBACK=${DELIVERY_EXPORT_ROOT}/d1-readback.json"
+          } >> "${GITHUB_ENV}"
+
+      - name: Materialize private source package in runner-only storage
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+          printf '%s' "${PRODUCTION_INVITES_CSV}" > "${DELIVERY_INPUT}"
+          printf '%s' "${PRODUCTION_CAMPAIGN_JSON}" > "${DELIVERY_CAMPAIGN}"
+          chmod 600 "${DELIVERY_INPUT}" "${DELIVERY_CAMPAIGN}"
+          unset PRODUCTION_INVITES_CSV PRODUCTION_CAMPAIGN_JSON
+          echo 'Private source package materialized in runner-only storage.'
+
+      - name: Prove live build identity before deriving links
+        shell: bash
+        run: |
+          set -euo pipefail
+          status="$(curl -fsS -D "${LIVE_HEADERS}" -o /dev/null -w '%{http_code}' "${PRODUCTION_URL}/beleza-em-movimento")"
+          [[ "${status}" == "200" ]] || { echo "production campaign route is not ready (HTTP ${status})"; exit 1; }
+          live_sha="$(awk 'BEGIN{IGNORECASE=1} /^x-app-build:/ {gsub(/[\r ]/, "", $2); print tolower($2); exit}' "${LIVE_HEADERS}")"
+          [[ "${live_sha}" == "${RELEASE_SHA}" ]] || { echo 'live website build differs from requested release_sha'; exit 1; }
+
+      - name: Derive delivery CSV without changing D1
+        id: derive
+        working-directory: website
+        env:
+          BEAUTY_MOVEMENT_PRIVATE_RUNTIME_ROOT: ${{ runner.temp }}/beauty-movement-delivery-export
+          GITHUB_ACTIONS: 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run --silent beauty-movement:export-delivery -- \
+            --input "${DELIVERY_INPUT}" \
+            --campaign "${CAMPAIGN_ID}" \
+            --campaign-config "${DELIVERY_CAMPAIGN}" \
+            --campaign-ends-at "${CAMPAIGN_ENDS_AT}" \
+            --out "${DELIVERY_OUTPUT}" > "${DELIVERY_SUMMARY}"
+          chmod 600 "${DELIVERY_OUTPUT}" "${DELIVERY_SUMMARY}"
+          node - "${DELIVERY_SUMMARY}" "${EXPECTED_INPUT_SHA256}" <<'NODE'
+          const fs = require('node:fs');
+          const [summaryPath, expectedSha] = process.argv.slice(2);
+          const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+          if (summary.mode !== 'delivery_export' || summary.inputSha256 !== expectedSha) {
+            throw new Error('beauty_movement_delivery_export_attestation_invalid');
+          }
+          if (!Number.isInteger(summary.acceptedRows) || summary.acceptedRows < 1 || summary.sourceRows !== summary.acceptedRows) {
+            throw new Error('beauty_movement_delivery_export_row_count_invalid');
+          }
+          if (!/^[0-9a-f]{64}$/.test(summary.outputSha256)) throw new Error('beauty_movement_delivery_export_hash_invalid');
+          NODE
+
+      - name: Read back active campaign from production D1
+        working-directory: website
+        shell: bash
+        run: |
+          set -euo pipefail
+          query="SELECT status, ends_at_ms, (SELECT COUNT(*) FROM bm_invites WHERE campaign_id = '${CAMPAIGN_ID}') AS invite_count, (SELECT COUNT(*) FROM bm_invites WHERE campaign_id = '${CAMPAIGN_ID}' AND invite_status = 'active') AS active_invite_count FROM bm_campaigns WHERE id = '${CAMPAIGN_ID}';"
+          npx --yes wrangler@4.112.0 d1 execute "${PRODUCTION_D1_DATABASE}" --remote --config wrangler.toml --command "${query}" --json > "${D1_READBACK}"
+          node - "${D1_READBACK}" "${DELIVERY_SUMMARY}" "${CAMPAIGN_ID}" <<'NODE'
+          const fs = require('node:fs');
+          const [readbackPath, summaryPath, campaignId] = process.argv.slice(2);
+          const row = JSON.parse(fs.readFileSync(readbackPath, 'utf8'))?.[0]?.results?.[0];
+          const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+          if (!row || row.status !== 'active' || Number(row.ends_at_ms) <= Date.now()) throw new Error('beauty_movement_campaign_not_active');
+          if (Number(row.invite_count) !== summary.acceptedRows || Number(row.active_invite_count) !== summary.acceptedRows) throw new Error('beauty_movement_campaign_invite_count_mismatch');
+          const result = { campaignId, status: row.status, endsAtMs: Number(row.ends_at_ms), inviteCount: Number(row.invite_count), activeInviteCount: Number(row.active_invite_count) };
+          fs.writeFileSync(summaryPath, `${JSON.stringify({ ...summary, d1: result }, null, 2)}\n`, { mode: 0o600 });
+          NODE
+
+      - name: Upload private delivery artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: beauty-movement-delivery-${{ inputs.campaign_id }}-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/beauty-movement-delivery-export/delivery.csv
+            ${{ runner.temp }}/beauty-movement-delivery-export/export-summary.json
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Remove runner-local private material
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          for private_file in "${DELIVERY_INPUT:-}" "${DELIVERY_CAMPAIGN:-}" "${DELIVERY_OUTPUT:-}" "${DELIVERY_SUMMARY:-}" "${LIVE_HEADERS:-}" "${D1_READBACK:-}"; do
+            [[ -n "${private_file}" ]] && rm -f -- "${private_file}"
+          done
+          rmdir "${DELIVERY_EXPORT_ROOT:-}" 2>/dev/null || true

--- a/.github/workflows/beauty-movement-delivery-export.yml
+++ b/.github/workflows/beauty-movement-delivery-export.yml
@@ -45,12 +45,7 @@ jobs:
       WORKFLOW_SHA: ${{ github.sha }}
       PRODUCTION_URL: https://espacofacial.com
       PRODUCTION_D1_DATABASE: espacofacial-beauty-movement
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      BEAUTY_MOVEMENT_TOKEN_HMAC_KEY: ${{ secrets.BEAUTY_MOVEMENT_TOKEN_HMAC_KEY }}
-      BEAUTY_MOVEMENT_PII_KEY: ${{ secrets.BEAUTY_MOVEMENT_PII_KEY }}
-      PRODUCTION_INVITES_CSV: ${{ secrets.BEAUTY_MOVEMENT_PRODUCTION_INVITES_CSV }}
-      PRODUCTION_CAMPAIGN_JSON: ${{ secrets.BEAUTY_MOVEMENT_PRODUCTION_CAMPAIGN_JSON }}
+      PRODUCTION_WORKER_NAME: espacofacial-site
 
     steps:
       - name: Checkout the exporter source and verify serving logic is unchanged
@@ -84,9 +79,6 @@ jobs:
           [[ "${EXPECTED_INPUT_SHA256}" =~ ^[0-9a-f]{64}$ ]] || { echo 'expected_input_sha256 must be a lowercase SHA-256'; exit 1; }
           [[ "${PRODUCTION_URL}" == "https://espacofacial.com" ]] || { echo 'production URL guard failed'; exit 1; }
           [[ "${PRODUCTION_D1_DATABASE}" == "espacofacial-beauty-movement" ]] || { echo 'production D1 guard failed'; exit 1; }
-          for required in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID BEAUTY_MOVEMENT_TOKEN_HMAC_KEY BEAUTY_MOVEMENT_PII_KEY PRODUCTION_INVITES_CSV PRODUCTION_CAMPAIGN_JSON; do
-            [[ -n "${!required:-}" ]] || { echo "required production custody is unavailable: ${required}"; exit 1; }
-          done
           mkdir -p "${RUNNER_TEMP}/beauty-movement-delivery-export"
           export DELIVERY_EXPORT_ROOT="${RUNNER_TEMP}/beauty-movement-delivery-export"
           {
@@ -95,19 +87,42 @@ jobs:
             echo "DELIVERY_CAMPAIGN=${DELIVERY_EXPORT_ROOT}/campaign.json"
             echo "DELIVERY_OUTPUT=${DELIVERY_EXPORT_ROOT}/delivery.csv"
             echo "DELIVERY_SUMMARY=${DELIVERY_EXPORT_ROOT}/export-summary.json"
+            echo "DELIVERY_ATTESTATION=${DELIVERY_EXPORT_ROOT}/token-attestation.json"
             echo "LIVE_HEADERS=${DELIVERY_EXPORT_ROOT}/live-headers.txt"
             echo "D1_READBACK=${DELIVERY_EXPORT_ROOT}/d1-readback.json"
+            echo "SECRET_READBACK=${DELIVERY_EXPORT_ROOT}/worker-secret-names.json"
           } >> "${GITHUB_ENV}"
 
       - name: Materialize private source package in runner-only storage
         shell: bash
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          BEAUTY_MOVEMENT_TOKEN_HMAC_KEY: ${{ secrets.BEAUTY_MOVEMENT_TOKEN_HMAC_KEY }}
+          BEAUTY_MOVEMENT_PII_KEY: ${{ secrets.BEAUTY_MOVEMENT_PII_KEY }}
+          PRODUCTION_INVITES_CSV: ${{ secrets.BEAUTY_MOVEMENT_PRODUCTION_INVITES_CSV }}
+          PRODUCTION_CAMPAIGN_JSON: ${{ secrets.BEAUTY_MOVEMENT_PRODUCTION_CAMPAIGN_JSON }}
+          PRODUCTION_REWARDS_JSON: ${{ secrets.BEAUTY_MOVEMENT_PRODUCTION_REWARDS_JSON }}
+          PRODUCTION_PROCEDURES_JSON: ${{ secrets.BEAUTY_MOVEMENT_PRODUCTION_PROCEDURES_JSON }}
         run: |
           set -euo pipefail
           umask 077
+          for required in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID BEAUTY_MOVEMENT_TOKEN_HMAC_KEY BEAUTY_MOVEMENT_PII_KEY PRODUCTION_INVITES_CSV PRODUCTION_CAMPAIGN_JSON; do
+            [[ -n "${!required:-}" ]] || { echo "required production custody is unavailable: ${required}"; exit 1; }
+          done
+          if [[ -n "${PRODUCTION_REWARDS_JSON:-}" ]] || [[ -n "${PRODUCTION_PROCEDURES_JSON:-}" ]]; then
+            [[ -n "${PRODUCTION_REWARDS_JSON:-}" && -n "${PRODUCTION_PROCEDURES_JSON:-}" ]] || { echo 'reward and procedure custody must be supplied together'; exit 1; }
+          fi
           printf '%s' "${PRODUCTION_INVITES_CSV}" > "${DELIVERY_INPUT}"
           printf '%s' "${PRODUCTION_CAMPAIGN_JSON}" > "${DELIVERY_CAMPAIGN}"
+          if [[ -n "${PRODUCTION_REWARDS_JSON:-}" ]]; then
+            printf '%s' "${PRODUCTION_REWARDS_JSON}" > "${DELIVERY_EXPORT_ROOT}/rewards.json"
+            printf '%s' "${PRODUCTION_PROCEDURES_JSON}" > "${DELIVERY_EXPORT_ROOT}/procedures.json"
+            echo "DELIVERY_REWARDS=${DELIVERY_EXPORT_ROOT}/rewards.json" >> "${GITHUB_ENV}"
+            echo "DELIVERY_PROCEDURES=${DELIVERY_EXPORT_ROOT}/procedures.json" >> "${GITHUB_ENV}"
+          fi
           chmod 600 "${DELIVERY_INPUT}" "${DELIVERY_CAMPAIGN}"
-          unset PRODUCTION_INVITES_CSV PRODUCTION_CAMPAIGN_JSON
+          chmod 600 "${DELIVERY_EXPORT_ROOT}"/*.json 2>/dev/null || true
           echo 'Private source package materialized in runner-only storage.'
 
       - name: Prove live build identity before deriving links
@@ -124,16 +139,25 @@ jobs:
         working-directory: website
         env:
           BEAUTY_MOVEMENT_PRIVATE_RUNTIME_ROOT: ${{ runner.temp }}/beauty-movement-delivery-export
+          BEAUTY_MOVEMENT_TOKEN_HMAC_KEY: ${{ secrets.BEAUTY_MOVEMENT_TOKEN_HMAC_KEY }}
+          BEAUTY_MOVEMENT_PII_KEY: ${{ secrets.BEAUTY_MOVEMENT_PII_KEY }}
           GITHUB_ACTIONS: 'true'
         shell: bash
         run: |
           set -euo pipefail
-          npm run --silent beauty-movement:export-delivery -- \
+          args=( \
             --input "${DELIVERY_INPUT}" \
             --campaign "${CAMPAIGN_ID}" \
             --campaign-config "${DELIVERY_CAMPAIGN}" \
             --campaign-ends-at "${CAMPAIGN_ENDS_AT}" \
-            --out "${DELIVERY_OUTPUT}" > "${DELIVERY_SUMMARY}"
+            --out "${DELIVERY_OUTPUT}" \
+            --attestation "${DELIVERY_ATTESTATION}" \
+          )
+          if [[ -n "${DELIVERY_REWARDS:-}" ]]; then
+            args+=(--reward-catalog "${DELIVERY_REWARDS}" --procedure-catalog "${DELIVERY_PROCEDURES}")
+          fi
+          npm run --silent beauty-movement:export-delivery -- "${args[@]}" \
+            > "${DELIVERY_SUMMARY}"
           chmod 600 "${DELIVERY_OUTPUT}" "${DELIVERY_SUMMARY}"
           node - "${DELIVERY_SUMMARY}" "${EXPECTED_INPUT_SHA256}" <<'NODE'
           const fs = require('node:fs');
@@ -148,21 +172,43 @@ jobs:
           if (!/^[0-9a-f]{64}$/.test(summary.outputSha256)) throw new Error('beauty_movement_delivery_export_hash_invalid');
           NODE
 
-      - name: Read back active campaign from production D1
+      - name: Read back active campaign and attest token custody from production
         working-directory: website
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         shell: bash
         run: |
           set -euo pipefail
-          query="SELECT status, ends_at_ms, (SELECT COUNT(*) FROM bm_invites WHERE campaign_id = '${CAMPAIGN_ID}') AS invite_count, (SELECT COUNT(*) FROM bm_invites WHERE campaign_id = '${CAMPAIGN_ID}' AND invite_status = 'active') AS active_invite_count FROM bm_campaigns WHERE id = '${CAMPAIGN_ID}';"
-          npx --yes wrangler@4.112.0 d1 execute "${PRODUCTION_D1_DATABASE}" --remote --config wrangler.toml --command "${query}" --json > "${D1_READBACK}"
-          node - "${D1_READBACK}" "${DELIVERY_SUMMARY}" "${CAMPAIGN_ID}" <<'NODE'
+          npx --yes wrangler@4.112.0 secret list --name "${PRODUCTION_WORKER_NAME}" --config wrangler.toml --format json > "${SECRET_READBACK}"
+          input_sha="$(node - "${DELIVERY_SUMMARY}" <<'NODE'
           const fs = require('node:fs');
-          const [readbackPath, summaryPath, campaignId] = process.argv.slice(2);
-          const row = JSON.parse(fs.readFileSync(readbackPath, 'utf8'))?.[0]?.results?.[0];
+          const summary = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          if (!/^[0-9a-f]{64}$/.test(summary.inputSha256)) throw new Error('beauty_movement_input_hash_invalid');
+          process.stdout.write(summary.inputSha256);
+          NODE
+          )"
+          query="SELECT c.status, c.ends_at_ms, (SELECT COUNT(*) FROM bm_invites WHERE campaign_id = c.id) AS invite_count, (SELECT COUNT(*) FROM bm_invites WHERE campaign_id = c.id AND invite_status = 'active') AS active_invite_count, (SELECT input_sha256 FROM bm_import_runs WHERE campaign_id = c.id AND input_sha256 = '${input_sha}' AND status = 'applied' ORDER BY applied_at_ms DESC LIMIT 1) AS import_input_sha256, (SELECT accepted_row_count FROM bm_import_runs WHERE campaign_id = c.id AND input_sha256 = '${input_sha}' AND status = 'applied' ORDER BY applied_at_ms DESC LIMIT 1) AS import_accepted_row_count, i.invite_token_hmac FROM bm_campaigns c LEFT JOIN bm_invites i ON i.campaign_id = c.id AND i.invite_status = 'active' WHERE c.id = '${CAMPAIGN_ID}' ORDER BY i.invite_token_hmac;"
+          npx --yes wrangler@4.112.0 d1 execute "${PRODUCTION_D1_DATABASE}" --remote --config wrangler.toml --command "${query}" --json > "${D1_READBACK}"
+          node - "${D1_READBACK}" "${DELIVERY_SUMMARY}" "${DELIVERY_ATTESTATION}" "${SECRET_READBACK}" "${CAMPAIGN_ID}" <<'NODE'
+          const fs = require('node:fs');
+          const [readbackPath, summaryPath, attestationPath, secretPath, campaignId] = process.argv.slice(2);
+          const rows = JSON.parse(fs.readFileSync(readbackPath, 'utf8'))?.[0]?.results ?? [];
           const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+          const attestation = JSON.parse(fs.readFileSync(attestationPath, 'utf8'));
+          const secretEntries = JSON.parse(fs.readFileSync(secretPath, 'utf8'));
+          const row = rows[0];
+          const expectedHashes = Array.isArray(attestation.inviteTokenHmacs) ? [...attestation.inviteTokenHmacs].sort() : [];
+          const actualHashes = rows.map((entry) => entry.invite_token_hmac).filter((value) => typeof value === 'string').sort();
+          const requiredSecrets = new Set(['BEAUTY_MOVEMENT_TOKEN_HMAC_KEY', 'BEAUTY_MOVEMENT_PII_KEY']);
+          const actualSecrets = new Set((Array.isArray(secretEntries) ? secretEntries : []).map((entry) => entry?.name).filter((value) => typeof value === 'string'));
           if (!row || row.status !== 'active' || Number(row.ends_at_ms) <= Date.now()) throw new Error('beauty_movement_campaign_not_active');
           if (Number(row.invite_count) !== summary.acceptedRows || Number(row.active_invite_count) !== summary.acceptedRows) throw new Error('beauty_movement_campaign_invite_count_mismatch');
-          const result = { campaignId, status: row.status, endsAtMs: Number(row.ends_at_ms), inviteCount: Number(row.invite_count), activeInviteCount: Number(row.active_invite_count) };
+          if (row.import_input_sha256 !== summary.inputSha256 || Number(row.import_accepted_row_count) !== summary.acceptedRows) throw new Error('beauty_movement_import_hash_mismatch');
+          if (attestation.campaignId !== campaignId || attestation.inputSha256 !== summary.inputSha256) throw new Error('beauty_movement_token_attestation_scope_invalid');
+          if (expectedHashes.length !== summary.acceptedRows || actualHashes.length !== summary.acceptedRows || JSON.stringify(expectedHashes) !== JSON.stringify(actualHashes)) throw new Error('beauty_movement_token_hmac_attestation_mismatch');
+          for (const required of requiredSecrets) if (!actualSecrets.has(required)) throw new Error(`beauty_movement_worker_secret_missing:${required}`);
+          const result = { campaignId, status: row.status, endsAtMs: Number(row.ends_at_ms), inviteCount: Number(row.invite_count), activeInviteCount: Number(row.active_invite_count), inputSha256: row.import_input_sha256, tokenHashCount: actualHashes.length, tokenHashSetMatch: true, workerSecretNamesAttested: true };
           fs.writeFileSync(summaryPath, `${JSON.stringify({ ...summary, d1: result }, null, 2)}\n`, { mode: 0o600 });
           NODE
 
@@ -181,7 +227,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          for private_file in "${DELIVERY_INPUT:-}" "${DELIVERY_CAMPAIGN:-}" "${DELIVERY_OUTPUT:-}" "${DELIVERY_SUMMARY:-}" "${LIVE_HEADERS:-}" "${D1_READBACK:-}"; do
+          for private_file in "${DELIVERY_INPUT:-}" "${DELIVERY_CAMPAIGN:-}" "${DELIVERY_REWARDS:-}" "${DELIVERY_PROCEDURES:-}" "${DELIVERY_OUTPUT:-}" "${DELIVERY_SUMMARY:-}" "${DELIVERY_ATTESTATION:-}" "${LIVE_HEADERS:-}" "${D1_READBACK:-}" "${SECRET_READBACK:-}"; do
             [[ -n "${private_file}" ]] && rm -f -- "${private_file}"
           done
           rmdir "${DELIVERY_EXPORT_ROOT:-}" 2>/dev/null || true

--- a/website/package.json
+++ b/website/package.json
@@ -17,6 +17,7 @@
     "smoke:strict": "SMOKE_REQUIRE_AGENDA=1 node scripts/smoke.mjs",
     "custom-urls:migrate:esfa": "tsx scripts/migrate-esfa-redirects.ts",
     "beauty-movement:import": "tsx scripts/beauty-movement-import.ts",
+    "beauty-movement:export-delivery": "tsx scripts/beauty-movement-delivery-export.ts",
     "beauty-movement:report": "tsx scripts/beauty-movement-report.ts",
     "beauty-movement:migrate:local": "tsx scripts/beauty-movement-migrate-local.ts",
     "tracking:governance": "node scripts/audit-tracking-governance.mjs",

--- a/website/scripts/beauty-movement-delivery-export.ts
+++ b/website/scripts/beauty-movement-delivery-export.ts
@@ -7,6 +7,10 @@ import {
     serializeBeautyMovementDeliveryCsv,
     validateBeautyMovementCampaignConfig,
 } from "../src/lib/beautyMovementImport";
+import type {
+    BeautyMovementCanonicalProcedure,
+    BeautyMovementRewardCatalogEntry,
+} from "../src/lib/beautyMovementRewards";
 
 const WEBSITE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const REPOSITORY_ROOT = path.resolve(WEBSITE_ROOT, "..");
@@ -17,6 +21,9 @@ type ParsedArguments = {
     campaignConfig: string;
     campaignEndsAt: string;
     output: string;
+    attestation: string;
+    rewardCatalog: string | null;
+    procedureCatalog: string | null;
 };
 
 function valueAfter(args: string[], flag: string): string {
@@ -29,7 +36,16 @@ function valueAfter(args: string[], flag: string): string {
 }
 
 function parseArguments(args: string[]): ParsedArguments {
-    const known = new Set(["--input", "--campaign", "--campaign-config", "--campaign-ends-at", "--out"]);
+    const known = new Set([
+        "--input",
+        "--campaign",
+        "--campaign-config",
+        "--campaign-ends-at",
+        "--out",
+        "--attestation",
+        "--reward-catalog",
+        "--procedure-catalog",
+    ]);
     for (const arg of args) {
         if (arg.startsWith("--") && !known.has(arg)) throw new Error("beauty_movement_unknown_argument");
     }
@@ -39,6 +55,9 @@ function parseArguments(args: string[]): ParsedArguments {
         campaignConfig: valueAfter(args, "--campaign-config"),
         campaignEndsAt: valueAfter(args, "--campaign-ends-at"),
         output: valueAfter(args, "--out"),
+        attestation: valueAfter(args, "--attestation"),
+        rewardCatalog: args.includes("--reward-catalog") ? valueAfter(args, "--reward-catalog") : null,
+        procedureCatalog: args.includes("--procedure-catalog") ? valueAfter(args, "--procedure-catalog") : null,
     };
 }
 
@@ -95,15 +114,30 @@ async function readJson(filePath: string): Promise<unknown> {
     }
 }
 
+async function readOptionalJson<T>(filePath: string | null, unavailableCode: string): Promise<T[] | undefined> {
+    if (!filePath) return undefined;
+    const value = await readJson(filePath);
+    if (!Array.isArray(value)) throw new Error(unavailableCode);
+    return value as T[];
+}
+
 async function main(): Promise<void> {
     const options = parseArguments(process.argv.slice(2));
     const inputPath = privatePath(options.input, "input");
     const campaignConfigPath = privatePath(options.campaignConfig, "input");
     const outputPath = privatePath(options.output, "output");
+    const attestationPath = privatePath(options.attestation, "output");
+    if ((options.rewardCatalog && !options.procedureCatalog) || (!options.rewardCatalog && options.procedureCatalog)) {
+        throw new Error("beauty_movement_reward_catalog_pair_required");
+    }
+    const rewardCatalogPath = options.rewardCatalog ? privatePath(options.rewardCatalog, "input") : null;
+    const procedureCatalogPath = options.procedureCatalog ? privatePath(options.procedureCatalog, "input") : null;
     const csv = await readFile(inputPath, "utf8").catch(() => {
         throw new Error("beauty_movement_input_unavailable");
     });
     const campaignConfig = validateBeautyMovementCampaignConfig(await readJson(campaignConfigPath));
+    const rewardCatalog = await readOptionalJson<BeautyMovementRewardCatalogEntry>(rewardCatalogPath, "beauty_movement_reward_catalog_unavailable");
+    const procedureCatalog = await readOptionalJson<BeautyMovementCanonicalProcedure>(procedureCatalogPath, "beauty_movement_procedure_catalog_unavailable");
     const tokenHmacKey = (process.env.BEAUTY_MOVEMENT_TOKEN_HMAC_KEY ?? "").trim();
     const piiKey = (process.env.BEAUTY_MOVEMENT_PII_KEY ?? "").trim();
     if (!tokenHmacKey || !piiKey) throw new Error("beauty_movement_export_keys_unavailable");
@@ -114,8 +148,8 @@ async function main(): Promise<void> {
         campaignId: options.campaign,
         campaignConfig,
         campaignEndsAtMs,
-        rewardCatalog: [],
-        procedureCatalog: [],
+        rewardCatalog,
+        procedureCatalog,
         tokenHmacKey,
         piiKey,
     });
@@ -132,6 +166,18 @@ async function main(): Promise<void> {
         await writeFile(outputPath, deliveryCsv, { encoding: "utf8", mode: 0o600, flag: "wx" });
     } catch {
         throw new Error("beauty_movement_delivery_output_unavailable");
+    }
+    try {
+        // The attestation is runner-private and is consumed only by the
+        // read-only D1 comparison. It contains hashes, never raw token values.
+        await writeFile(attestationPath, `${JSON.stringify({
+            version: 1,
+            campaignId: plan.campaignId,
+            inputSha256: plan.inputSha256,
+            inviteTokenHmacs: plan.invites.map((invite) => invite.inviteTokenHmac).sort(),
+        })}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    } catch {
+        throw new Error("beauty_movement_delivery_attestation_unavailable");
     }
 
     // This is the only stdout contract. It is intentionally aggregate-only:

--- a/website/scripts/beauty-movement-delivery-export.ts
+++ b/website/scripts/beauty-movement-delivery-export.ts
@@ -1,0 +1,154 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+    prepareBeautyMovementImport,
+    serializeBeautyMovementDeliveryCsv,
+    validateBeautyMovementCampaignConfig,
+} from "../src/lib/beautyMovementImport";
+
+const WEBSITE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const REPOSITORY_ROOT = path.resolve(WEBSITE_ROOT, "..");
+
+type ParsedArguments = {
+    input: string;
+    campaign: string;
+    campaignConfig: string;
+    campaignEndsAt: string;
+    output: string;
+};
+
+function valueAfter(args: string[], flag: string): string {
+    const index = args.indexOf(flag);
+    if (index < 0) throw new Error(`beauty_movement_missing_${flag.slice(2)}`);
+    if (args.indexOf(flag, index + 1) >= 0) throw new Error(`beauty_movement_duplicate_${flag.slice(2)}`);
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`beauty_movement_missing_${flag.slice(2)}`);
+    return value;
+}
+
+function parseArguments(args: string[]): ParsedArguments {
+    const known = new Set(["--input", "--campaign", "--campaign-config", "--campaign-ends-at", "--out"]);
+    for (const arg of args) {
+        if (arg.startsWith("--") && !known.has(arg)) throw new Error("beauty_movement_unknown_argument");
+    }
+    return {
+        input: valueAfter(args, "--input"),
+        campaign: valueAfter(args, "--campaign"),
+        campaignConfig: valueAfter(args, "--campaign-config"),
+        campaignEndsAt: valueAfter(args, "--campaign-ends-at"),
+        output: valueAfter(args, "--out"),
+    };
+}
+
+function toWslPath(value: string): string {
+    const windowsPath = /^([A-Za-z]):[\\/](.*)$/.exec(value);
+    return windowsPath
+        ? `/mnt/${windowsPath[1]!.toLowerCase()}/${windowsPath[2]!.replace(/\\/g, "/")}`
+        : value;
+}
+
+function isWithin(parent: string, child: string): boolean {
+    const relative = path.relative(parent, child);
+    return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
+}
+
+function privatePath(value: string, purpose: "input" | "output"): string {
+    const converted = toWslPath(value);
+    if (!path.isAbsolute(converted)) throw new Error(`beauty_movement_${purpose}_must_be_absolute`);
+    const resolved = path.resolve(converted);
+    if (isWithin(REPOSITORY_ROOT, resolved)) throw new Error(`beauty_movement_${purpose}_must_be_private`);
+
+    const configuredRoot = process.env.BEAUTY_MOVEMENT_PRIVATE_RUNTIME_ROOT?.trim();
+    if (configuredRoot) {
+        const runnerTemp = process.env.RUNNER_TEMP?.trim();
+        if (process.env.GITHUB_ACTIONS !== "true" || !runnerTemp || !path.isAbsolute(toWslPath(runnerTemp))) {
+            throw new Error("beauty_movement_private_runtime_root_invalid");
+        }
+        const runnerRoot = path.resolve(toWslPath(runnerTemp));
+        const root = path.resolve(toWslPath(configuredRoot));
+        if (!isWithin(runnerRoot, root)) throw new Error("beauty_movement_private_runtime_root_invalid");
+        if (!isWithin(root, resolved)) throw new Error(`beauty_movement_${purpose}_outside_private_runtime`);
+    }
+    return resolved;
+}
+
+function parseCampaignEndsAt(value: string): number {
+    if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2})$/.test(value)) {
+        throw new Error("beauty_movement_invalid_campaign_ends_at");
+    }
+    const parsed = Date.parse(value);
+    if (!Number.isFinite(parsed)) throw new Error("beauty_movement_invalid_campaign_ends_at");
+    return parsed;
+}
+
+function sha256(value: string): string {
+    return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+async function readJson(filePath: string): Promise<unknown> {
+    try {
+        return JSON.parse(await readFile(filePath, "utf8")) as unknown;
+    } catch {
+        throw new Error("beauty_movement_campaign_config_unavailable");
+    }
+}
+
+async function main(): Promise<void> {
+    const options = parseArguments(process.argv.slice(2));
+    const inputPath = privatePath(options.input, "input");
+    const campaignConfigPath = privatePath(options.campaignConfig, "input");
+    const outputPath = privatePath(options.output, "output");
+    const csv = await readFile(inputPath, "utf8").catch(() => {
+        throw new Error("beauty_movement_input_unavailable");
+    });
+    const campaignConfig = validateBeautyMovementCampaignConfig(await readJson(campaignConfigPath));
+    const tokenHmacKey = (process.env.BEAUTY_MOVEMENT_TOKEN_HMAC_KEY ?? "").trim();
+    const piiKey = (process.env.BEAUTY_MOVEMENT_PII_KEY ?? "").trim();
+    if (!tokenHmacKey || !piiKey) throw new Error("beauty_movement_export_keys_unavailable");
+
+    const campaignEndsAtMs = parseCampaignEndsAt(options.campaignEndsAt);
+    const plan = await prepareBeautyMovementImport({
+        csv,
+        campaignId: options.campaign,
+        campaignConfig,
+        campaignEndsAtMs,
+        rewardCatalog: [],
+        procedureCatalog: [],
+        tokenHmacKey,
+        piiKey,
+    });
+    if (plan.deliveryRows.length !== plan.invites.length || plan.deliveryRows.length < 1) {
+        throw new Error("beauty_movement_delivery_row_count_invalid");
+    }
+
+    const deliveryCsv = serializeBeautyMovementDeliveryCsv(plan.deliveryRows);
+    await mkdir(path.dirname(outputPath), { recursive: true, mode: 0o700 });
+    try {
+        // wx prevents a rerun from silently replacing a previously handed-off
+        // list. The file contains personal data and invite tokens, so keep it
+        // private even on a runner with a shared filesystem.
+        await writeFile(outputPath, deliveryCsv, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    } catch {
+        throw new Error("beauty_movement_delivery_output_unavailable");
+    }
+
+    // This is the only stdout contract. It is intentionally aggregate-only:
+    // never print names, phone numbers, invite URLs, or token material.
+    console.log(JSON.stringify({
+        mode: "delivery_export",
+        campaignId: plan.campaignId,
+        sourceRows: plan.sourceRowCount,
+        acceptedRows: plan.invites.length,
+        inputSha256: plan.inputSha256,
+        outputSha256: sha256(deliveryCsv),
+        outputBytes: Buffer.byteLength(deliveryCsv, "utf8"),
+    }));
+}
+
+void main().catch((error) => {
+    // Error codes are deliberately generic and contain no input values.
+    console.error(error instanceof Error ? error.message : "beauty_movement_delivery_export_failed");
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Objetivo\n\nDeriva a lista privada de links personalizados da campanha ativa sem gravar no D1, sem deploy e sem expor PII/tokens em logs.\n\n## Contrato\n\n- usa o mesmo HMAC/PII custody do Environment production;\n- verifica que o source de token/segurança/outcomes não divergiu do SHA que está servindo;\n- valida build live, campanha ativa e contagem de convites via readback D1;\n- gera somente 
ame,invite_ref,whatsapp,invite_url em artifact privado de retenção 1 dia;\n- não executa migration, import, UPDATE/INSERT/DELETE ou deploy.\n\n## Validação\n\n- contract test focado aprovado;\n- blocos bash do workflow validados;\n- execução final será disparada após merge com o SHA live cf80c064410a3f08fdc5c3373469953d07f0ddc, campanha eauty-movement-20260822-live-4 e hash privado já conferido.\n\nNão inclui CSV, nomes, telefones ou tokens no GitHub/repositório.