### PR TITLE
Beauty Movement: canonical short invite links

### DIFF
--- a/.github/governance/cloudflare-single-writer-policy.json
+++ b/.github/governance/cloudflare-single-writer-policy.json
@@ -185,7 +185,8 @@
         ".github/workflows/sync-website-cloudflare-security.yml",
         ".github/workflows/website-instagram-sync.yml",
         ".github/workflows/beauty-movement-staging-smoke.yml",
-        ".github/workflows/beauty-movement-production-activation.yml"
+        ".github/workflows/beauty-movement-production-activation.yml",
+        ".github/workflows/beauty-movement-short-links-sync.yml"
       ],
       "automaticDeploymentsRequired": false
     },

--- a/.github/workflows/beauty-movement-short-links-sync.yml
+++ b/.github/workflows/beauty-movement-short-links-sync.yml
@@ -1,0 +1,280 @@
+name: Beauty Movement short-link sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Exact website SHA currently serving the active campaign
+        required: true
+        type: string
+      campaign_id:
+        description: Active production campaign whose links are being handed off
+        required: true
+        type: string
+      campaign_ends_at:
+        description: Campaign expiry used to validate the private source package
+        required: true
+        type: string
+      expected_input_sha256:
+        description: SHA-256 of the approved private invites CSV
+        required: true
+        type: string
+
+concurrency:
+  group: beauty-movement-short-links-${{ inputs.campaign_id }}
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  staging-contract:
+    name: Staging-equivalent short-link contract gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Set up Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22.12.0
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install exact website dependencies
+        working-directory: website
+        run: npm ci
+
+      - name: Validate short-link contract with synthetic rows only
+        working-directory: website
+        run: node --experimental-test-module-mocks --import tsx --test tests/beautyMovementShortLinks.test.ts
+
+  production-sync:
+    name: Apply private redirects and attest live resolution
+    needs: staging-contract
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 30
+    permissions:
+      actions: write
+      contents: read
+    env:
+      RELEASE_SHA: ${{ inputs.release_sha }}
+      CAMPAIGN_ID: ${{ inputs.campaign_id }}
+      CAMPAIGN_ENDS_AT: ${{ inputs.campaign_ends_at }}
+      EXPECTED_INPUT_SHA256: ${{ inputs.expected_input_sha256 }}
+      WORKFLOW_SHA: ${{ github.sha }}
+      PRODUCTION_URL: https://espacofacial.com
+      PRODUCTION_D1_DATABASE: espacofacial-beauty-movement
+      BOOKING_D1_DATABASE: espacofacial-booking
+      PRODUCTION_WORKER_NAME: espacofacial-site
+      BOOKING_WORKER_CONFIG: wrangler.toml
+
+    steps:
+      - name: Checkout source and verify serving logic
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22.12.0
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install exact website dependencies
+        working-directory: website
+        run: npm ci
+
+      - name: Guard release, route and private runtime scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "${GITHUB_REPOSITORY}" == "jubenitogarcia/skincos" ]] || { echo 'unexpected repository'; exit 1; }
+          [[ "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]] || { echo 'release_sha must be a full commit SHA'; exit 1; }
+          [[ "${WORKFLOW_SHA}" == "$(git rev-parse --verify HEAD)" ]] || { echo 'checked out SHA differs from workflow SHA'; exit 1; }
+          git cat-file -e "${RELEASE_SHA}:website/src/lib/beautyMovementImport.ts" || { echo 'release source does not contain the importer'; exit 1; }
+          git cat-file -e "${RELEASE_SHA}:website/src/app/BelezaEmMovimento/page.tsx" || { echo 'release source does not contain the canonical campaign route'; exit 1; }
+          git diff --quiet "${RELEASE_SHA}" -- website/src/lib/beautyMovementImport.ts website/src/lib/beautyMovementSecurity.ts website/src/lib/beautyMovementOutcomes.ts || { echo 'token derivation source differs from the serving release'; exit 1; }
+          [[ "${CAMPAIGN_ID}" =~ ^[a-z0-9][a-z0-9_-]{2,79}$ ]] || { echo 'campaign_id shape is invalid'; exit 1; }
+          [[ "${CAMPAIGN_ENDS_AT}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}(:[0-9]{2}(\.[0-9]{1,3})?)?(Z|[+-][0-9]{2}:[0-9]{2})$ ]] || { echo 'campaign_ends_at must be ISO-8601'; exit 1; }
+          [[ "${EXPECTED_INPUT_SHA256}" =~ ^[0-9a-f]{64}$ ]] || { echo 'expected_input_sha256 must be a lowercase SHA-256'; exit 1; }
+          [[ "${PRODUCTION_URL}" == "https://espacofacial.com" ]] || { echo 'production URL guard failed'; exit 1; }
+          [[ "${BOOKING_D1_DATABASE}" == "espacofacial-booking" ]] || { echo 'booking D1 guard failed'; exit 1; }
+          export SHORT_LINK_ROOT="${RUNNER_TEMP}/beauty-movement-short-links"
+          mkdir -p "${SHORT_LINK_ROOT}"
+          {
+            echo "SHORT_LINK_ROOT=${SHORT_LINK_ROOT}"
+            echo "DELIVERY_INPUT=${SHORT_LINK_ROOT}/invites.csv"
+            echo "DELIVERY_CAMPAIGN=${SHORT_LINK_ROOT}/campaign.json"
+            echo "DELIVERY_OUTPUT=${SHORT_LINK_ROOT}/delivery.csv"
+            echo "DELIVERY_SUMMARY=${SHORT_LINK_ROOT}/delivery-summary.json"
+            echo "DELIVERY_ATTESTATION=${SHORT_LINK_ROOT}/delivery-attestation.json"
+            echo "SHORT_OUTPUT=${SHORT_LINK_ROOT}/short-delivery.csv"
+            echo "SHORT_SQL=${SHORT_LINK_ROOT}/short-links.sql"
+            echo "SHORT_CONFLICTS=${SHORT_LINK_ROOT}/short-links-conflicts.sql"
+            echo "SHORT_READBACK=${SHORT_LINK_ROOT}/short-links-readback.sql"
+            echo "SHORT_ATTESTATION=${SHORT_LINK_ROOT}/short-links-attestation.json"
+            echo "SHORT_SUMMARY=${SHORT_LINK_ROOT}/short-links-summary.json"
+            echo "D1_CONFLICT_READBACK=${SHORT_LINK_ROOT}/d1-conflict-readback.json"
+            echo "D1_APPLY_READBACK=${SHORT_LINK_ROOT}/d1-apply-readback.json"
+            echo "D1_FINAL_READBACK=${SHORT_LINK_ROOT}/d1-final-readback.json"
+            echo "LIVE_HEADERS=${SHORT_LINK_ROOT}/live-headers.txt"
+            echo "SHORT_PROBE_HEADERS=${SHORT_LINK_ROOT}/short-probe-headers.txt"
+          } >> "${GITHUB_ENV}"
+
+      - name: Materialize private source package in runner-only storage
+        shell: bash
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          BEAUTY_MOVEMENT_TOKEN_HMAC_KEY: ${{ secrets.BEAUTY_MOVEMENT_TOKEN_HMAC_KEY }}
+          BEAUTY_MOVEMENT_PII_KEY: ${{ secrets.BEAUTY_MOVEMENT_PII_KEY }}
+          PRODUCTION_INVITES_CSV: ${{ secrets.BEAUTY_MOVEMENT_PRODUCTION_INVITES_CSV }}
+          PRODUCTION_CAMPAIGN_JSON: ${{ secrets.BEAUTY_MOVEMENT_PRODUCTION_CAMPAIGN_JSON }}
+        run: |
+          set -euo pipefail
+          umask 077
+          for required in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID BEAUTY_MOVEMENT_TOKEN_HMAC_KEY BEAUTY_MOVEMENT_PII_KEY PRODUCTION_INVITES_CSV PRODUCTION_CAMPAIGN_JSON; do
+            [[ -n "${!required:-}" ]] || { echo "required production custody is unavailable: ${required}"; exit 1; }
+          done
+          printf '%s' "${PRODUCTION_INVITES_CSV}" > "${DELIVERY_INPUT}"
+          printf '%s' "${PRODUCTION_CAMPAIGN_JSON}" > "${DELIVERY_CAMPAIGN}"
+          chmod 600 "${DELIVERY_INPUT}" "${DELIVERY_CAMPAIGN}"
+          echo 'Private source package materialized in runner-only storage.'
+
+      - name: Prove the requested website release is live
+        shell: bash
+        run: |
+          set -euo pipefail
+          status="$(curl -fsS -D "${LIVE_HEADERS}" -o /dev/null -w '%{http_code}' "${PRODUCTION_URL}/BelezaEmMovimento")"
+          [[ "${status}" == "200" ]] || { echo "canonical campaign route is not ready (HTTP ${status})"; exit 1; }
+          live_sha="$(awk 'BEGIN{IGNORECASE=1} /^x-app-build:/ {gsub(/[\r ]/, "", $2); print tolower($2); exit}' "${LIVE_HEADERS}")"
+          [[ "${live_sha}" == "${RELEASE_SHA}" ]] || { echo 'live website build differs from requested release_sha'; exit 1; }
+
+      - name: Derive canonical delivery and private short-link plan
+        working-directory: website
+        env:
+          BEAUTY_MOVEMENT_PRIVATE_RUNTIME_ROOT: ${{ runner.temp }}/beauty-movement-short-links
+          BEAUTY_MOVEMENT_TOKEN_HMAC_KEY: ${{ secrets.BEAUTY_MOVEMENT_TOKEN_HMAC_KEY }}
+          BEAUTY_MOVEMENT_PII_KEY: ${{ secrets.BEAUTY_MOVEMENT_PII_KEY }}
+          GITHUB_ACTIONS: 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run --silent beauty-movement:export-delivery -- \
+            --input "${DELIVERY_INPUT}" \
+            --campaign "${CAMPAIGN_ID}" \
+            --campaign-config "${DELIVERY_CAMPAIGN}" \
+            --campaign-ends-at "${CAMPAIGN_ENDS_AT}" \
+            --out "${DELIVERY_OUTPUT}" \
+            --attestation "${DELIVERY_ATTESTATION}" \
+            > "${DELIVERY_SUMMARY}"
+          node - "${DELIVERY_SUMMARY}" "${EXPECTED_INPUT_SHA256}" <<'NODE'
+          const fs = require('node:fs');
+          const [summaryPath, expectedSha] = process.argv.slice(2);
+          const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+          if (summary.mode !== 'delivery_export' || summary.inputSha256 !== expectedSha || summary.sourceRows !== summary.acceptedRows || summary.acceptedRows < 1) throw new Error('beauty_movement_delivery_export_attestation_invalid');
+          NODE
+          npm run --silent beauty-movement:prepare-short-links -- \
+            --input "${DELIVERY_OUTPUT}" \
+            --out "${SHORT_OUTPUT}" \
+            --sql "${SHORT_SQL}" \
+            --conflicts "${SHORT_CONFLICTS}" \
+            --readback "${SHORT_READBACK}" \
+            --attestation "${SHORT_ATTESTATION}" \
+            --campaign "${CAMPAIGN_ID}" \
+            > "${SHORT_SUMMARY}"
+          chmod 600 "${DELIVERY_OUTPUT}" "${DELIVERY_SUMMARY}" "${DELIVERY_ATTESTATION}" "${SHORT_OUTPUT}" "${SHORT_SQL}" "${SHORT_CONFLICTS}" "${SHORT_READBACK}" "${SHORT_ATTESTATION}" "${SHORT_SUMMARY}"
+
+      - name: Fail closed on existing manual or divergent mappings
+        working-directory: website
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4.112.0 d1 execute "${BOOKING_D1_DATABASE}" --remote --config "${BOOKING_WORKER_CONFIG}" --file "${SHORT_CONFLICTS}" --json > "${D1_CONFLICT_READBACK}"
+          node - "${D1_CONFLICT_READBACK}" "${SHORT_ATTESTATION}" <<'NODE'
+          const crypto = require('node:crypto');
+          const fs = require('node:fs');
+          const [readbackPath, attestationPath] = process.argv.slice(2);
+          const payload = JSON.parse(fs.readFileSync(readbackPath, 'utf8'));
+          const rows = payload.flatMap((entry) => Array.isArray(entry?.results) ? entry.results : []);
+          const attestation = JSON.parse(fs.readFileSync(attestationPath, 'utf8'));
+          const expected = attestation.mappingHashes ?? {};
+          for (const row of rows) {
+            const expectedHash = expected[row.slug_path];
+            const actualHash = crypto.createHash('sha256').update(String(row.destination_url), 'utf8').digest('hex');
+            if (!expectedHash || row.site_host !== 'esfa.co' || row.source !== 'beauty_movement_short_links_v1' || Number(row.active) !== 1 || actualHash !== expectedHash) throw new Error('beauty_movement_short_links_existing_mapping_conflict');
+          }
+          NODE
+
+      - name: Apply private short-link mappings to the booking D1
+        working-directory: website
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: npx --yes wrangler@4.112.0 d1 execute "${BOOKING_D1_DATABASE}" --remote --config "${BOOKING_WORKER_CONFIG}" --file "${SHORT_SQL}" --json > "${D1_APPLY_READBACK}"
+
+      - name: Verify every mapping and one live redirect
+        working-directory: website
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4.112.0 d1 execute "${BOOKING_D1_DATABASE}" --remote --config "${BOOKING_WORKER_CONFIG}" --file "${SHORT_READBACK}" --json > "${D1_FINAL_READBACK}"
+          node - "${D1_FINAL_READBACK}" "${SHORT_ATTESTATION}" <<'NODE'
+          const crypto = require('node:crypto');
+          const fs = require('node:fs');
+          const [readbackPath, attestationPath] = process.argv.slice(2);
+          const payload = JSON.parse(fs.readFileSync(readbackPath, 'utf8'));
+          const rows = payload.flatMap((entry) => Array.isArray(entry?.results) ? entry.results : []);
+          const attestation = JSON.parse(fs.readFileSync(attestationPath, 'utf8'));
+          const expected = attestation.mappingHashes ?? {};
+          if (rows.length !== Number(attestation.count)) throw new Error('beauty_movement_short_links_count_mismatch');
+          for (const row of rows) {
+            const expectedHash = expected[row.slug_path];
+            const actualHash = crypto.createHash('sha256').update(String(row.destination_url), 'utf8').digest('hex');
+            if (!expectedHash || row.site_host !== 'esfa.co' || row.source !== 'beauty_movement_short_links_v1' || Number(row.active) !== 1 || actualHash !== expectedHash) throw new Error('beauty_movement_short_links_readback_mismatch');
+          }
+          NODE
+          probe_url="$(node - "${SHORT_OUTPUT}" <<'NODE'
+          const fs = require('node:fs');
+          const lines = fs.readFileSync(process.argv[2], 'utf8').trim().split(/\r?\n/);
+          const match = lines[1]?.match(/"(https:\/\/esfa\.co\/[^"\r\n]+)"$/);
+          if (!match) throw new Error('beauty_movement_short_links_probe_unavailable');
+          process.stdout.write(match[1]);
+          NODE
+          )"
+          status="$(curl -fsS -D "${SHORT_PROBE_HEADERS}" -o /dev/null -w '%{http_code}' "${probe_url}")"
+          [[ "${status}" == "301" ]] || { echo 'short-link Worker did not return HTTP 301'; exit 1; }
+          location="$(awk 'BEGIN{IGNORECASE=1} /^location:/ {sub(/^[^:]*:[ ]*/, ""); gsub(/[\r]/, ""); print; exit}' "${SHORT_PROBE_HEADERS}")"
+          [[ "${location}" == https://espacofacial.com/BelezaEmMovimento#c=* ]] || { echo 'short-link destination is not the canonical campaign route'; exit 1; }
+
+      - name: Upload the private corrected delivery list
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: beauty-movement-short-delivery-${{ inputs.campaign_id }}-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/beauty-movement-short-links/short-delivery.csv
+            ${{ runner.temp }}/beauty-movement-short-links/short-links-summary.json
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Remove runner-local private material
+        if: ${{ always() }}
+        shell: bash
+        run: rm -rf -- "${SHORT_LINK_ROOT:-${RUNNER_TEMP}/beauty-movement-short-links}"

--- a/.github/workflows/beauty-movement-short-links-sync.yml
+++ b/.github/workflows/beauty-movement-short-links-sync.yml
@@ -51,6 +51,19 @@ jobs:
         working-directory: website
         run: npm ci
 
+      - name: Acquire Website production coordination lease
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          resource: release:website
+          module: website
+          source_sha: ${{ github.sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website.json
+
       - name: Validate short-link contract with synthetic rows only
         working-directory: website
         run: node --experimental-test-module-mocks --import tsx --test tests/beautyMovementShortLinks.test.ts
@@ -203,6 +216,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          test -f "${RUNNER_TEMP}/skincos-global-coordination-website.json"
           npx --yes wrangler@4.112.0 d1 execute "${BOOKING_D1_DATABASE}" --remote --config "${BOOKING_WORKER_CONFIG}" --file "${SHORT_CONFLICTS}" --json > "${D1_CONFLICT_READBACK}"
           node - "${D1_CONFLICT_READBACK}" "${SHORT_ATTESTATION}" <<'NODE'
           const crypto = require('node:crypto');
@@ -218,6 +232,19 @@ jobs:
             if (!expectedHash || row.site_host !== 'esfa.co' || row.source !== 'beauty_movement_short_links_v1' || Number(row.active) !== 1 || actualHash !== expectedHash) throw new Error('beauty_movement_short_links_existing_mapping_conflict');
           }
           NODE
+
+      - name: Recheck Website production coordination lease before D1 mutation
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website.json
+          resource: release:website
+          module: website
+          source_sha: ${{ github.sha }}
 
       - name: Apply private short-link mappings to the booking D1
         working-directory: website
@@ -277,4 +304,22 @@ jobs:
       - name: Remove runner-local private material
         if: ${{ always() }}
         shell: bash
-        run: rm -rf -- "${SHORT_LINK_ROOT:-${RUNNER_TEMP}/beauty-movement-short-links}"
+        run: |
+          if [ -f "${RUNNER_TEMP}/skincos-global-coordination-website.json" ]; then
+            echo 'coordination lease release is handled by the final action step'
+          fi
+          rm -rf -- "${SHORT_LINK_ROOT:-${RUNNER_TEMP}/beauty-movement-short-links}"
+
+      - name: Release Website production coordination lease
+        if: ${{ always() }}
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website.json
+          resource: release:website
+          module: website
+          source_sha: ${{ github.sha }}

--- a/website/README.md
+++ b/website/README.md
@@ -122,6 +122,11 @@ Observação operacional:
 - Quando mudar short links já migrados, rode/siga o workflow oficial de deploy do site para aplicar `npm run custom-urls:migrate:esfa -- --apply --remote`.
 - Validar só `espacofacial.com` não cobre `esfa.co`; cheque os dois domínios.
 
+Links personalizados da campanha Beauty Movement:
+- A rota canônica é `https://espacofacial.com/BelezaEmMovimento`; a rota minúscula anterior continua compatível para convites já distribuídos.
+- O workflow `.github/workflows/beauty-movement-short-links-sync.yml` deriva o atalho `https://esfa.co/<últimos-5>/BelezaEmMovimento` a partir do CSV privado, verifica colisões e grava somente redirects gerenciados no D1.
+- O workflow falha fechado diante de slug manual/divergente, publica a lista curta como artefato privado de retenção curta e valida um redirect real antes de concluir.
+
 ## Checklist de release
 
 Antes do PR:

--- a/website/package.json
+++ b/website/package.json
@@ -18,6 +18,7 @@
     "custom-urls:migrate:esfa": "tsx scripts/migrate-esfa-redirects.ts",
     "beauty-movement:import": "tsx scripts/beauty-movement-import.ts",
     "beauty-movement:export-delivery": "tsx scripts/beauty-movement-delivery-export.ts",
+    "beauty-movement:prepare-short-links": "tsx scripts/beauty-movement-short-links.ts",
     "beauty-movement:report": "tsx scripts/beauty-movement-report.ts",
     "beauty-movement:migrate:local": "tsx scripts/beauty-movement-migrate-local.ts",
     "tracking:governance": "node scripts/audit-tracking-governance.mjs",

--- a/website/scripts/beauty-movement-short-links.ts
+++ b/website/scripts/beauty-movement-short-links.ts
@@ -1,0 +1,131 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+    prepareBeautyMovementShortLinks,
+    renderBeautyMovementShortLinkConflictSql,
+    renderBeautyMovementShortLinkReadbackSql,
+    renderBeautyMovementShortLinkSql,
+    serializeBeautyMovementShortLinkCsv,
+} from "../src/lib/beautyMovementShortLinks";
+import type { BeautyMovementDeliveryRow } from "../src/lib/beautyMovementImport";
+
+const WEBSITE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const REPOSITORY_ROOT = path.resolve(WEBSITE_ROOT, "..");
+
+type ParsedArguments = {
+    input: string;
+    output: string;
+    sql: string;
+    conflicts: string;
+    readback: string;
+    attestation: string;
+    campaign: string;
+};
+
+function valueAfter(args: string[], flag: string): string {
+    const index = args.indexOf(flag);
+    if (index < 0 || args.indexOf(flag, index + 1) >= 0) throw new Error(`beauty_movement_short_links_missing_${flag.slice(2)}`);
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`beauty_movement_short_links_missing_${flag.slice(2)}`);
+    return value;
+}
+
+function parseArguments(args: string[]): ParsedArguments {
+    const known = new Set(["--input", "--out", "--sql", "--conflicts", "--readback", "--attestation", "--campaign"]);
+    for (const arg of args) if (arg.startsWith("--") && !known.has(arg)) throw new Error("beauty_movement_short_links_unknown_argument");
+    return {
+        input: valueAfter(args, "--input"),
+        output: valueAfter(args, "--out"),
+        sql: valueAfter(args, "--sql"),
+        conflicts: valueAfter(args, "--conflicts"),
+        readback: valueAfter(args, "--readback"),
+        attestation: valueAfter(args, "--attestation"),
+        campaign: valueAfter(args, "--campaign"),
+    };
+}
+
+function toWslPath(value: string): string {
+    const windowsPath = /^([A-Za-z]):[\\/](.*)$/.exec(value);
+    return windowsPath ? `/mnt/${windowsPath[1]!.toLowerCase()}/${windowsPath[2]!.replace(/\\/g, "/")}` : value;
+}
+
+function isWithin(parent: string, child: string): boolean {
+    const relative = path.relative(parent, child);
+    return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
+}
+
+function privatePath(value: string): string {
+    const converted = toWslPath(value);
+    if (!path.isAbsolute(converted)) throw new Error("beauty_movement_short_links_path_must_be_absolute");
+    const resolved = path.resolve(converted);
+    if (isWithin(REPOSITORY_ROOT, resolved)) throw new Error("beauty_movement_short_links_path_must_be_private");
+    const configuredRoot = process.env.BEAUTY_MOVEMENT_PRIVATE_RUNTIME_ROOT?.trim();
+    if (configuredRoot) {
+        const runnerTemp = process.env.RUNNER_TEMP?.trim();
+        if (process.env.GITHUB_ACTIONS !== "true" || !runnerTemp || !path.isAbsolute(toWslPath(runnerTemp))) throw new Error("beauty_movement_short_links_private_runtime_invalid");
+        const runnerRoot = path.resolve(toWslPath(runnerTemp));
+        const root = path.resolve(toWslPath(configuredRoot));
+        if (!isWithin(runnerRoot, root) || !isWithin(root, resolved)) throw new Error("beauty_movement_short_links_path_outside_private_runtime");
+    }
+    return resolved;
+}
+
+function parseCsv(input: string): string[][] {
+    const rows: string[][] = [];
+    let row: string[] = [];
+    let cell = "";
+    let quoted = false;
+    for (let index = 0; index < input.length; index += 1) {
+        const char = input[index]!;
+        if (quoted) {
+            if (char === '"' && input[index + 1] === '"') { cell += '"'; index += 1; }
+            else if (char === '"') quoted = false;
+            else cell += char;
+        } else if (char === '"' && cell.length === 0) quoted = true;
+        else if (char === ",") { row.push(cell); cell = ""; }
+        else if (char === "\n") { row.push(cell.replace(/\r$/, "")); rows.push(row); row = []; cell = ""; }
+        else cell += char;
+    }
+    if (quoted) throw new Error("beauty_movement_short_links_invalid_csv");
+    if (cell.length > 0 || row.length > 0) { row.push(cell); rows.push(row); }
+    return rows.filter((entry) => entry.some((value) => value.length > 0));
+}
+
+function readDeliveryRows(input: string): BeautyMovementDeliveryRow[] {
+    const rows = parseCsv(input);
+    const header = rows.shift()?.join(",");
+    if (header !== "name,invite_ref,whatsapp,invite_url") throw new Error("beauty_movement_short_links_invalid_delivery_header");
+    return rows.map((row) => {
+        if (row.length !== 4 || row.some((value) => !value.trim())) throw new Error("beauty_movement_short_links_invalid_delivery_row");
+        return { name: row[0]!, inviteRef: row[1]!, whatsapp: row[2]!, inviteUrl: row[3]! };
+    });
+}
+
+async function writePrivate(filePath: string, content: string): Promise<void> {
+    await mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
+    await writeFile(filePath, content, { encoding: "utf8", mode: 0o600, flag: "wx" });
+}
+
+async function main(): Promise<void> {
+    const options = parseArguments(process.argv.slice(2));
+    const inputPath = privatePath(options.input);
+    const outputPath = privatePath(options.output);
+    const sqlPath = privatePath(options.sql);
+    const conflictsPath = privatePath(options.conflicts);
+    const readbackPath = privatePath(options.readback);
+    const attestationPath = privatePath(options.attestation);
+    const rows = readDeliveryRows(await readFile(inputPath, "utf8").catch(() => { throw new Error("beauty_movement_short_links_input_unavailable"); }));
+    const plan = prepareBeautyMovementShortLinks({ rows, campaignId: options.campaign });
+    await writePrivate(outputPath, serializeBeautyMovementShortLinkCsv(plan));
+    await writePrivate(sqlPath, renderBeautyMovementShortLinkSql(plan));
+    await writePrivate(conflictsPath, renderBeautyMovementShortLinkConflictSql(plan));
+    await writePrivate(readbackPath, renderBeautyMovementShortLinkReadbackSql(plan));
+    await writePrivate(attestationPath, `${JSON.stringify({ version: 1, campaignId: plan.campaignId, count: plan.links.length, mappingHash: plan.mappingHash, mappingHashes: plan.mappingHashes })}\n`);
+    console.log(JSON.stringify({ mode: "beauty_movement_short_links", campaignId: plan.campaignId, count: plan.links.length, mappingHash: plan.mappingHash }));
+}
+
+void main().catch((error) => {
+    console.error(error instanceof Error ? error.message : "beauty_movement_short_links_failed");
+    process.exitCode = 1;
+});

--- a/website/src/app/BelezaEmMovimento/page.tsx
+++ b/website/src/app/BelezaEmMovimento/page.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
   },
 };
 
-export default function BeautyMovementPage() {
+export default function BeautyMovementCanonicalPage() {
   return (
     <>
       <Header preferredUnitSlug="novo-hamburgo" fixedUnitSlug="novo-hamburgo" scrollAware />

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -146,7 +146,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   var shouldScrub = false;
   try {
     var pathname = window.location.pathname.replace(/\\/+$/, "") || "/";
-    if (pathname !== "/beleza-em-movimento") return;
+    var normalizedPathname = pathname.toLowerCase();
+    if (normalizedPathname !== "/beleza-em-movimento" && normalizedPathname !== "/belezaemmovimento") return;
     var fragment = window.location.hash.slice(1);
     if (!fragment) return;
     var params = new URLSearchParams(fragment);

--- a/website/src/lib/beautyMovementImport.ts
+++ b/website/src/lib/beautyMovementImport.ts
@@ -756,7 +756,7 @@ export async function prepareBeautyMovementImport(params: {
     }
 
     const inputSha256 = await sha256Hex(params.csv);
-    const inviteUrlBase = params.inviteUrlBase ?? "https://espacofacial.com/beleza-em-movimento";
+    const inviteUrlBase = params.inviteUrlBase ?? "https://espacofacial.com/BelezaEmMovimento";
     const invites: BeautyMovementPreparedInvite[] = [];
     const deliveryRows: BeautyMovementDeliveryRow[] = [];
 

--- a/website/src/lib/beautyMovementShortLinks.ts
+++ b/website/src/lib/beautyMovementShortLinks.ts
@@ -1,0 +1,172 @@
+import { createHash } from "node:crypto";
+
+import type { BeautyMovementDeliveryRow } from "./beautyMovementImport";
+
+export const BEAUTY_MOVEMENT_SHORT_LINK_SOURCE = "beauty_movement_short_links_v1" as const;
+export const BEAUTY_MOVEMENT_CANONICAL_PATH = "/BelezaEmMovimento" as const;
+export const BEAUTY_MOVEMENT_SHORT_LINK_HOST = "esfa.co" as const;
+
+export type BeautyMovementShortLink = {
+    id: string;
+    name: string;
+    inviteRef: string;
+    whatsapp: string;
+    token: string;
+    shortUrl: string;
+    slugPath: string;
+    normalizedSlugPath: string;
+    destinationUrl: string;
+    destinationHost: string;
+    destinationPath: string;
+    description: string;
+    source: typeof BEAUTY_MOVEMENT_SHORT_LINK_SOURCE;
+    placement: string;
+    active: true;
+};
+
+export type BeautyMovementShortLinkPlan = {
+    campaignId: string;
+    createdAtMs: number;
+    links: BeautyMovementShortLink[];
+    mappingHash: string;
+    mappingHashes: Record<string, string>;
+};
+
+function sqlString(value: string | null): string {
+    return value === null ? "NULL" : `'${value.replace(/'/g, "''")}'`;
+}
+
+function csvCell(value: string): string {
+    const formulaSafe = /^[=+\-@]/.test(value) ? `'${value}` : value;
+    return `"${formulaSafe.replace(/"/g, '""')}"`;
+}
+
+function assertCampaignId(value: string): string {
+    const campaignId = value.trim();
+    if (!/^[a-z0-9][a-z0-9_-]{2,79}$/i.test(campaignId)) throw new Error("beauty_movement_short_links_invalid_campaign_id");
+    return campaignId;
+}
+
+function readInviteToken(inviteUrl: string): string {
+    let parsed: URL;
+    try {
+        parsed = new URL(inviteUrl);
+    } catch {
+        throw new Error("beauty_movement_short_links_invalid_invite_url");
+    }
+    const pathname = parsed.pathname.toLowerCase();
+    if (parsed.protocol !== "https:" || parsed.hostname.toLowerCase() !== "espacofacial.com" || (pathname !== BEAUTY_MOVEMENT_CANONICAL_PATH.toLowerCase() && pathname !== "/beleza-em-movimento") || parsed.search) {
+        throw new Error("beauty_movement_short_links_noncanonical_invite_url");
+    }
+    const token = parsed.hash.startsWith("#c=") ? parsed.hash.slice(3) : "";
+    if (!/^[A-Za-z0-9_-]{40,180}$/.test(token)) throw new Error("beauty_movement_short_links_invalid_token");
+    return token;
+}
+
+function mappingDigest(entries: readonly BeautyMovementShortLink[]): string {
+    const material = entries
+        .map((entry) => `${entry.normalizedSlugPath}\t${entry.destinationUrl}`)
+        .sort()
+        .join("\n");
+    return createHash("sha256").update(material, "utf8").digest("hex");
+}
+
+function destinationHash(value: string): string {
+    return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+export function prepareBeautyMovementShortLinks(params: {
+    rows: readonly BeautyMovementDeliveryRow[];
+    campaignId: string;
+    createdAtMs?: number;
+}): BeautyMovementShortLinkPlan {
+    const campaignId = assertCampaignId(params.campaignId);
+    const createdAtMs = params.createdAtMs ?? Date.now();
+    if (!Number.isSafeInteger(createdAtMs) || createdAtMs < 0) throw new Error("beauty_movement_short_links_invalid_timestamp");
+    if (params.rows.length < 1) throw new Error("beauty_movement_short_links_empty_delivery");
+
+    const links: BeautyMovementShortLink[] = [];
+    const suffixes = new Map<string, number>();
+    for (const row of params.rows) {
+        const token = readInviteToken(row.inviteUrl);
+        const suffix = token.slice(-5);
+        const normalizedSuffix = suffix.toLowerCase();
+        const previous = suffixes.get(normalizedSuffix);
+        if (previous !== undefined) throw new Error(`beauty_movement_short_links_suffix_collision_${previous}`);
+        suffixes.set(normalizedSuffix, links.length + 1);
+
+        const slugPath = `/${suffix}${BEAUTY_MOVEMENT_CANONICAL_PATH}`;
+        const normalizedSlugPath = `/${normalizedSuffix}${BEAUTY_MOVEMENT_CANONICAL_PATH.toLowerCase()}`;
+        const destinationUrl = `https://espacofacial.com${BEAUTY_MOVEMENT_CANONICAL_PATH}#c=${token}`;
+        links.push({
+            id: `beauty-movement-short-v1-${campaignId}-${normalizedSuffix}`,
+            name: `Cartas da Beleza - ${suffix}`,
+            inviteRef: row.inviteRef,
+            whatsapp: row.whatsapp,
+            token,
+            shortUrl: `https://${BEAUTY_MOVEMENT_SHORT_LINK_HOST}${slugPath}`,
+            slugPath,
+            normalizedSlugPath,
+            destinationUrl,
+            destinationHost: "espacofacial.com",
+            destinationPath: `${BEAUTY_MOVEMENT_CANONICAL_PATH}#c=${token}`,
+            description: "Atalho personalizado da campanha Cartas da Beleza em Movimento.",
+            source: BEAUTY_MOVEMENT_SHORT_LINK_SOURCE,
+            placement: "beauty-movement",
+            active: true,
+        });
+    }
+
+    return {
+        campaignId,
+        createdAtMs,
+        links,
+        mappingHash: mappingDigest(links),
+        mappingHashes: Object.fromEntries(links.map((link) => [link.normalizedSlugPath, destinationHash(link.destinationUrl)])),
+    };
+}
+
+export function serializeBeautyMovementShortLinkCsv(plan: BeautyMovementShortLinkPlan): string {
+    const output = ["name,invite_ref,whatsapp,invite_url"];
+    for (const link of plan.links) output.push([link.name, link.inviteRef, link.whatsapp, link.shortUrl].map(csvCell).join(","));
+    return `${output.join("\n")}\n`;
+}
+
+export function renderBeautyMovementShortLinkSql(plan: BeautyMovementShortLinkPlan): string {
+    const statements = ["BEGIN TRANSACTION;"];
+    for (const link of plan.links) {
+        statements.push(`INSERT INTO site_custom_urls (
+id, site_host, name, slug_path, destination_url, destination_host, destination_path,
+description, source, placement, unit_slug, service_id,
+utm_source, utm_medium, utm_campaign, utm_content, utm_term,
+active, created_at_ms, updated_at_ms
+) VALUES (
+${sqlString(link.id)}, ${sqlString(BEAUTY_MOVEMENT_SHORT_LINK_HOST)}, ${sqlString(link.name)}, ${sqlString(link.normalizedSlugPath)}, ${sqlString(link.destinationUrl)}, ${sqlString(link.destinationHost)}, ${sqlString(link.destinationPath)},
+${sqlString(link.description)}, ${sqlString(link.source)}, ${sqlString(link.placement)}, NULL, NULL,
+NULL, NULL, ${sqlString(plan.campaignId)}, NULL, NULL,
+1, ${plan.createdAtMs}, ${plan.createdAtMs}
+) ON CONFLICT(id) DO NOTHING;`);
+    }
+    statements.push("COMMIT;");
+    return `${statements.join("\n\n")}\n`;
+}
+
+export function renderBeautyMovementShortLinkConflictSql(plan: BeautyMovementShortLinkPlan): string {
+    const ids = plan.links.map((link) => sqlString(link.id)).join(", ");
+    const slugs = plan.links.map((link) => sqlString(link.normalizedSlugPath)).join(", ");
+    return `SELECT id, site_host, slug_path, destination_url, source, active
+FROM site_custom_urls
+WHERE id IN (${ids}) OR (site_host = ${sqlString(BEAUTY_MOVEMENT_SHORT_LINK_HOST)} AND slug_path IN (${slugs}));\n`;
+}
+
+export function renderBeautyMovementShortLinkReadbackSql(plan: BeautyMovementShortLinkPlan): string {
+    const ids = plan.links.map((link) => sqlString(link.id)).join(", ");
+    return `SELECT id, site_host, slug_path, destination_url, source, active
+FROM site_custom_urls
+WHERE id IN (${ids});\n`;
+}
+
+export function shortLinkMappingHash(entries: readonly Pick<BeautyMovementShortLink, "normalizedSlugPath" | "destinationUrl">[]): string {
+    const material = entries.map((entry) => `${entry.normalizedSlugPath}\t${entry.destinationUrl}`).sort().join("\n");
+    return createHash("sha256").update(material, "utf8").digest("hex");
+}

--- a/website/tests/beautyMovementImport.test.ts
+++ b/website/tests/beautyMovementImport.test.ts
@@ -155,7 +155,7 @@ test("compact Velocity sheet rows accept the sheet columns and optional duplicat
     assert.equal(plan.deliveryRows.length, 2);
     assert.equal(plan.invites.every((invite) => invite.velocityBenefit === "aula_cortesia_evento"), true);
     assert.equal(plan.invites.every((invite) => invite.rewardId === null), true);
-    assert.equal(plan.deliveryRows.every((row) => row.inviteUrl.startsWith("https://espacofacial.com/beleza-em-movimento#c=")), true);
+    assert.equal(plan.deliveryRows.every((row) => row.inviteUrl.startsWith("https://espacofacial.com/BelezaEmMovimento#c=")), true);
 });
 
 test("compact Velocity imports also accept only name and WhatsApp", () => {
@@ -341,7 +341,7 @@ test("beauty movement import writes encrypted D1 rows and reserves raw delivery 
     const token = inviteUrl.slice(inviteUrl.indexOf("#c=") + 3);
     const sql = buildBeautyMovementImportSql(plan);
 
-    assert.equal(inviteUrl.startsWith("https://espacofacial.com/beleza-em-movimento#c="), true);
+    assert.equal(inviteUrl.startsWith("https://espacofacial.com/BelezaEmMovimento#c="), true);
     assert.equal(sql.includes("Ana Silva"), false);
     assert.equal(sql.includes("ana@example.com"), false);
     assert.equal(sql.includes("+5551999991234"), false);

--- a/website/tests/beautyMovementShortLinks.test.ts
+++ b/website/tests/beautyMovementShortLinks.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    prepareBeautyMovementShortLinks,
+    renderBeautyMovementShortLinkSql,
+    serializeBeautyMovementShortLinkCsv,
+} from "../src/lib/beautyMovementShortLinks";
+
+const row = (token: string, name = "Ana Silva") => ({
+    name,
+    inviteRef: `invite-${token.slice(-5)}`,
+    whatsapp: "+5551999991234",
+    inviteUrl: `https://espacofacial.com/BelezaEmMovimento#c=${token}`,
+});
+
+test("short links use the final five token characters and preserve the canonical destination", () => {
+    const plan = prepareBeautyMovementShortLinks({
+        rows: [row("abcdefghijklmnopqrstuvwxyzABCDEFGHijklmno123")],
+        campaignId: "beauty-movement-test-1",
+        createdAtMs: 1700000000000,
+    });
+    assert.equal(plan.links[0]?.shortUrl, "https://esfa.co/no123/BelezaEmMovimento");
+    assert.equal(plan.links[0]?.normalizedSlugPath, "/no123/belezaemmovimento");
+    assert.equal(plan.links[0]?.destinationUrl, "https://espacofacial.com/BelezaEmMovimento#c=abcdefghijklmnopqrstuvwxyzABCDEFGHijklmno123");
+    assert.equal(plan.links[0]?.source, "beauty_movement_short_links_v1");
+    assert.match(renderBeautyMovementShortLinkSql(plan), /ON CONFLICT\(id\) DO NOTHING/);
+});
+
+test("short-link suffix collisions are detected case-insensitively", () => {
+    assert.throws(
+        () => prepareBeautyMovementShortLinks({ rows: [row("a".repeat(35) + "O1aBc"), row("b".repeat(35) + "o1AbC")], campaignId: "beauty-movement-test-2" }),
+        /suffix_collision/,
+    );
+});
+
+test("delivery export contains no canonical token after shortening", () => {
+    const plan = prepareBeautyMovementShortLinks({ rows: [row("abcdefghijklmnopqrstuvwxyzABCDEFGHijklmno123")], campaignId: "beauty-movement-test-3" });
+    const csv = serializeBeautyMovementShortLinkCsv(plan);
+    assert.match(csv, /https:\/\/esfa\.co\/no123\/BelezaEmMovimento/);
+    assert.equal(csv.includes("#c="), false);
+});
+
+test("short-link preparation upgrades the legacy lowercase delivery path", () => {
+    const legacy = row("abcdefghijklmnopqrstuvwxyzABCDEFGHijklmno123");
+    legacy.inviteUrl = legacy.inviteUrl.replace("/BelezaEmMovimento", "/beleza-em-movimento");
+    const plan = prepareBeautyMovementShortLinks({ rows: [legacy], campaignId: "beauty-movement-test-4" });
+    assert.equal(plan.links[0]?.destinationUrl.startsWith("https://espacofacial.com/BelezaEmMovimento#c="), true);
+});

--- a/website/tests/esfaRedirectWorker.test.ts
+++ b/website/tests/esfaRedirectWorker.test.ts
@@ -23,3 +23,13 @@ test("esfa redirect target retains destination defaults without an incoming quer
         "https://espacofacial.com/agendamento?unit=novo-hamburgo&utm_campaign=aniver7anos",
     );
 });
+
+test("esfa redirect target preserves the private invite fragment while merging attribution", () => {
+    assert.equal(
+        resolveEsfaRedirectTarget(
+            "https://espacofacial.com/BelezaEmMovimento#c=opaque_token_123456789012345678901234567890123456",
+            "?utm_source=whatsapp&utm_campaign=beauty-movement",
+        ),
+        "https://espacofacial.com/BelezaEmMovimento?utm_source=whatsapp&utm_campaign=beauty-movement#c=opaque_token_123456789012345678901234567890123456",
+    );
+});


### PR DESCRIPTION
## Objetivo

Estabelecer o contrato final dos convites personalizados da campanha Beauty Movement:

- rota canônica `https://espacofacial.com/BelezaEmMovimento`;
- atalho `https://esfa.co/<últimos-5>/BelezaEmMovimento`;
- sincronização privada e fail-closed no D1 `espacofacial-booking`;
- lista curta entregue somente como artefato privado.

## Segurança e operação

- o fragmento completo continua apenas no destino privado e é removido no navegador antes do tracking;
- colisões de sufixo são rejeitadas case-insensitivamente;
- slug manual ou destino divergente nunca é sobrescrito;
- o workflow exige release servido, valida staging-equivalent e confirma um redirect 301 real.

## Validação focada

- `npm run lint`
- testes focados de importação, short-links e Worker de redirects
- `npm run build` / `npm run typecheck`
- lista privada atual derivada: 200 linhas, sem colisões.