### PR TITLE
fix: align Beauty Movement short-link release gate

### DIFF
--- a/.github/workflows/beauty-movement-short-links-sync.yml
+++ b/.github/workflows/beauty-movement-short-links-sync.yml
@@ -315,11 +315,7 @@ jobs:
         uses: ./.github/actions/global-coordination-release
         with:
           required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
-          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
           key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
           proof_file: ${{ runner.temp }}/skincos-global-coordination-website.json
-          resource: release:website
-          module: website
-          source_sha: ${{ github.sha }}


### PR DESCRIPTION
## Summary\n- remove unsupported inputs from the global coordination release action call\n- keep the production short-link sync fail-closed before D1 mutation\n\n## Validation\n- prior sync run 32600953712 stopped before D1 mutation on this invalid action contract\n- workflow-only diff passes git diff --check