### PR TITLE
fix: validate short-link input hash portably

### DIFF
--- a/.github/workflows/beauty-movement-short-links-sync.yml
+++ b/.github/workflows/beauty-movement-short-links-sync.yml
@@ -120,7 +120,10 @@ jobs:
           [[ "${CAMPAIGN_ID}" =~ ^[a-z0-9][a-z0-9_-]{2,79}$ ]] || { echo 'campaign_id shape is invalid'; exit 1; }
           [[ "${CAMPAIGN_ENDS_AT}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}(:[0-9]{2}(\.[0-9]{1,3})?)?(Z|[+-][0-9]{2}:[0-9]{2})$ ]] || { echo 'campaign_ends_at must be ISO-8601'; exit 1; }
           EXPECTED_INPUT_SHA256="$(printf '%s' "${EXPECTED_INPUT_SHA256}" | tr -d '[:space:]')"
-          [[ "${EXPECTED_INPUT_SHA256}" =~ ^[0-9a-f]{64}$ ]] || { echo 'expected_input_sha256 must be a lowercase SHA-256'; exit 1; }
+          if [[ "${#EXPECTED_INPUT_SHA256}" -ne 64 || "${EXPECTED_INPUT_SHA256}" == *[!0123456789abcdef]* ]]; then
+            echo 'expected_input_sha256 must be a lowercase SHA-256'
+            exit 1
+          fi
           echo "EXPECTED_INPUT_SHA256=${EXPECTED_INPUT_SHA256}" >> "${GITHUB_ENV}"
           [[ "${PRODUCTION_URL}" == "https://espacofacial.com" ]] || { echo 'production URL guard failed'; exit 1; }
           [[ "${BOOKING_D1_DATABASE}" == "espacofacial-booking" ]] || { echo 'booking D1 guard failed'; exit 1; }


### PR DESCRIPTION
## Summary\n- replace bash interval-regex validation for the input SHA with length and lowercase-hex checks\n- keep the short-link workflow fail-closed without exposing invite material\n\n## Validation\n- focused diff check\n- required repository checks and official merge authority before rerunning production sync