### PR TITLE
fix: normalize short-link input hash with node

### DIFF
--- a/.github/workflows/beauty-movement-short-links-sync.yml
+++ b/.github/workflows/beauty-movement-short-links-sync.yml
@@ -119,11 +119,15 @@ jobs:
           git diff --quiet "${RELEASE_SHA}" -- website/src/lib/beautyMovementImport.ts website/src/lib/beautyMovementSecurity.ts website/src/lib/beautyMovementOutcomes.ts || { echo 'token derivation source differs from the serving release'; exit 1; }
           [[ "${CAMPAIGN_ID}" =~ ^[a-z0-9][a-z0-9_-]{2,79}$ ]] || { echo 'campaign_id shape is invalid'; exit 1; }
           [[ "${CAMPAIGN_ENDS_AT}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}(:[0-9]{2}(\.[0-9]{1,3})?)?(Z|[+-][0-9]{2}:[0-9]{2})$ ]] || { echo 'campaign_ends_at must be ISO-8601'; exit 1; }
-          EXPECTED_INPUT_SHA256="$(printf '%s' "${EXPECTED_INPUT_SHA256}" | tr -d '[:space:]')"
-          if [[ "${#EXPECTED_INPUT_SHA256}" -ne 64 || "${EXPECTED_INPUT_SHA256}" == *[!0123456789abcdef]* ]]; then
-            echo 'expected_input_sha256 must be a lowercase SHA-256'
-            exit 1
-          fi
+          EXPECTED_INPUT_SHA256="$(node -e "process.stdout.write((process.env.EXPECTED_INPUT_SHA256 || '').replace(/\s/g, ''))")"
+          export EXPECTED_INPUT_SHA256
+          node <<'NODE'
+          const value = process.env.EXPECTED_INPUT_SHA256 || '';
+          if (!/^[0-9a-f]{64}$/.test(value)) {
+            console.error('expected_input_sha256 must be a lowercase SHA-256');
+            process.exit(1);
+          }
+          NODE
           echo "EXPECTED_INPUT_SHA256=${EXPECTED_INPUT_SHA256}" >> "${GITHUB_ENV}"
           [[ "${PRODUCTION_URL}" == "https://espacofacial.com" ]] || { echo 'production URL guard failed'; exit 1; }
           [[ "${BOOKING_D1_DATABASE}" == "espacofacial-booking" ]] || { echo 'booking D1 guard failed'; exit 1; }


### PR DESCRIPTION
## Summary\n- normalize the expected invite-input SHA in Node, including Unicode whitespace\n- validate the normalized value without relying on runner-specific Bash parsing\n- keep the workflow fail-closed before any D1 mutation\n\n## Context\nThe previous two runs rejected the exact lowercase SHA before the production mutation step.\n\n## Validation\nRequired repository checks and official merge authority will run before the production sync is retried.