### PR TITLE
fix: avoid reserved short-link identity collisions

### DIFF
--- a/.github/workflows/beauty-movement-short-links-sync.yml
+++ b/.github/workflows/beauty-movement-short-links-sync.yml
@@ -232,10 +232,30 @@ jobs:
           const rows = payload.flatMap((entry) => Array.isArray(entry?.results) ? entry.results : []);
           const attestation = JSON.parse(fs.readFileSync(attestationPath, 'utf8'));
           const expected = attestation.mappingHashes ?? {};
+          const stats = {
+            rows: rows.length,
+            missingExpected: 0,
+            wrongHost: 0,
+            wrongSource: 0,
+            inactive: 0,
+            destinationMismatch: 0,
+            valid: 0,
+          };
           for (const row of rows) {
             const expectedHash = expected[row.slug_path];
             const actualHash = crypto.createHash('sha256').update(String(row.destination_url), 'utf8').digest('hex');
-            if (!expectedHash || row.site_host !== 'esfa.co' || row.source !== 'beauty_movement_short_links_v1' || Number(row.active) !== 1 || actualHash !== expectedHash) throw new Error('beauty_movement_short_links_existing_mapping_conflict');
+            let invalid = false;
+            if (!expectedHash) { stats.missingExpected += 1; invalid = true; }
+            if (row.site_host !== 'esfa.co') { stats.wrongHost += 1; invalid = true; }
+            if (row.source !== 'beauty_movement_short_links_v1') { stats.wrongSource += 1; invalid = true; }
+            if (Number(row.active) !== 1) { stats.inactive += 1; invalid = true; }
+            if (expectedHash && actualHash !== expectedHash) { stats.destinationMismatch += 1; invalid = true; }
+            if (invalid) continue;
+            stats.valid += 1;
+          }
+          if (stats.rows !== stats.valid) {
+            console.error(JSON.stringify({ code: 'beauty_movement_short_links_existing_mapping_conflict', ...stats }));
+            throw new Error('beauty_movement_short_links_existing_mapping_conflict');
           }
           NODE
 

--- a/website/src/lib/beautyMovementShortLinks.ts
+++ b/website/src/lib/beautyMovementShortLinks.ts
@@ -99,7 +99,10 @@ export function prepareBeautyMovementShortLinks(params: {
         const normalizedSlugPath = `/${normalizedSuffix}${BEAUTY_MOVEMENT_CANONICAL_PATH.toLowerCase()}`;
         const destinationUrl = `https://espacofacial.com${BEAUTY_MOVEMENT_CANONICAL_PATH}#c=${token}`;
         links.push({
-            id: `beauty-movement-short-v1-${campaignId}-${normalizedSuffix}`,
+            // Keep the redirect contract/source stable while moving the row identity
+            // forward. A previously reserved v1 id must never be overwritten if a
+            // stale/manual row is found under that primary key.
+            id: `beauty-movement-short-v2-${campaignId}-${normalizedSuffix}`,
             name: `Cartas da Beleza - ${suffix}`,
             inviteRef: row.inviteRef,
             whatsapp: row.whatsapp,

--- a/website/src/lib/beautyMovementShortLinks.ts
+++ b/website/src/lib/beautyMovementShortLinks.ts
@@ -148,7 +148,7 @@ ${sqlString(link.id)}, ${sqlString(BEAUTY_MOVEMENT_SHORT_LINK_HOST)}, ${sqlStrin
 ${sqlString(link.description)}, ${sqlString(link.source)}, ${sqlString(link.placement)}, NULL, NULL,
 NULL, NULL, ${sqlString(plan.campaignId)}, NULL, NULL,
 1, ${plan.createdAtMs}, ${plan.createdAtMs}
-) ON CONFLICT(id) DO NOTHING;`);
+) ON CONFLICT(site_host, slug_path) DO NOTHING;`);
     }
     statements.push("COMMIT;");
     return `${statements.join("\n\n")}\n`;
@@ -163,10 +163,10 @@ WHERE id IN (${ids}) OR (site_host = ${sqlString(BEAUTY_MOVEMENT_SHORT_LINK_HOST
 }
 
 export function renderBeautyMovementShortLinkReadbackSql(plan: BeautyMovementShortLinkPlan): string {
-    const ids = plan.links.map((link) => sqlString(link.id)).join(", ");
+    const slugs = plan.links.map((link) => sqlString(link.normalizedSlugPath)).join(", ");
     return `SELECT id, site_host, slug_path, destination_url, source, active
 FROM site_custom_urls
-WHERE id IN (${ids});\n`;
+WHERE site_host = ${sqlString(BEAUTY_MOVEMENT_SHORT_LINK_HOST)} AND slug_path IN (${slugs});\n`;
 }
 
 export function shortLinkMappingHash(entries: readonly Pick<BeautyMovementShortLink, "normalizedSlugPath" | "destinationUrl">[]): string {

--- a/website/tests/beautyMovementShortLinks.test.ts
+++ b/website/tests/beautyMovementShortLinks.test.ts
@@ -24,7 +24,7 @@ test("short links use the final five token characters and preserve the canonical
     assert.equal(plan.links[0]?.destinationUrl, "https://espacofacial.com/BelezaEmMovimento#c=abcdefghijklmnopqrstuvwxyzABCDEFGHijklmno123");
     assert.equal(plan.links[0]?.source, "beauty_movement_short_links_v1");
     assert.match(plan.links[0]?.id ?? "", /^beauty-movement-short-v2-/);
-    assert.match(renderBeautyMovementShortLinkSql(plan), /ON CONFLICT\(id\) DO NOTHING/);
+    assert.match(renderBeautyMovementShortLinkSql(plan), /ON CONFLICT\(site_host, slug_path\) DO NOTHING/);
 });
 
 test("short-link suffix collisions are detected case-insensitively", () => {

--- a/website/tests/beautyMovementShortLinks.test.ts
+++ b/website/tests/beautyMovementShortLinks.test.ts
@@ -23,6 +23,7 @@ test("short links use the final five token characters and preserve the canonical
     assert.equal(plan.links[0]?.normalizedSlugPath, "/no123/belezaemmovimento");
     assert.equal(plan.links[0]?.destinationUrl, "https://espacofacial.com/BelezaEmMovimento#c=abcdefghijklmnopqrstuvwxyzABCDEFGHijklmno123");
     assert.equal(plan.links[0]?.source, "beauty_movement_short_links_v1");
+    assert.match(plan.links[0]?.id ?? "", /^beauty-movement-short-v2-/);
     assert.match(renderBeautyMovementShortLinkSql(plan), /ON CONFLICT\(id\) DO NOTHING/);
 });
 


### PR DESCRIPTION
Keeps the existing redirect contract and slug format while advancing the primary-key identity. This preserves fail-closed behavior for a stale/manual v1 row without overwriting it, allowing the current private invitation set to be materialized safely. Adds a focused contract assertion.