### PR TITLE
fix: derive short-link identity from token hash

### DIFF
--- a/website/src/lib/beautyMovementShortLinks.ts
+++ b/website/src/lib/beautyMovementShortLinks.ts
@@ -98,11 +98,12 @@ export function prepareBeautyMovementShortLinks(params: {
         const slugPath = `/${suffix}${BEAUTY_MOVEMENT_CANONICAL_PATH}`;
         const normalizedSlugPath = `/${normalizedSuffix}${BEAUTY_MOVEMENT_CANONICAL_PATH.toLowerCase()}`;
         const destinationUrl = `https://espacofacial.com${BEAUTY_MOVEMENT_CANONICAL_PATH}#c=${token}`;
+        const tokenIdentity = createHash("sha256").update(token, "utf8").digest("hex").slice(0, 32);
         links.push({
-            // Keep the redirect contract/source stable while moving the row identity
-            // forward. A previously reserved v1 id must never be overwritten if a
-            // stale/manual row is found under that primary key.
-            id: `beauty-movement-short-v2-${campaignId}-${normalizedSuffix}`,
+            // Keep identity independent from the short suffix. A stale/manual row
+            // can reserve an old primary key without being overwritten, while the
+            // token-derived digest remains stable for future idempotent syncs.
+            id: `beauty-movement-short-v3-${campaignId}-${tokenIdentity}`,
             name: `Cartas da Beleza - ${suffix}`,
             inviteRef: row.inviteRef,
             whatsapp: row.whatsapp,

--- a/website/tests/beautyMovementShortLinks.test.ts
+++ b/website/tests/beautyMovementShortLinks.test.ts
@@ -23,7 +23,7 @@ test("short links use the final five token characters and preserve the canonical
     assert.equal(plan.links[0]?.normalizedSlugPath, "/no123/belezaemmovimento");
     assert.equal(plan.links[0]?.destinationUrl, "https://espacofacial.com/BelezaEmMovimento#c=abcdefghijklmnopqrstuvwxyzABCDEFGHijklmno123");
     assert.equal(plan.links[0]?.source, "beauty_movement_short_links_v1");
-    assert.match(plan.links[0]?.id ?? "", /^beauty-movement-short-v2-/);
+    assert.match(plan.links[0]?.id ?? "", /^beauty-movement-short-v3-[a-z0-9-]+-[0-9a-f]{32}$/);
     assert.match(renderBeautyMovementShortLinkSql(plan), /ON CONFLICT\(site_host, slug_path\) DO NOTHING/);
 });
 


### PR DESCRIPTION
Replaces versioned suffix-only primary keys with a stable non-reversible token digest. Keeps slug-level idempotence and fail-closed conflict handling while avoiding stale/manual primary-key reservations. No token values are logged or included in delivery URLs.