### PR TITLE
fix: validate short-link conflicts by served slug

### DIFF
--- a/website/src/lib/beautyMovementShortLinks.ts
+++ b/website/src/lib/beautyMovementShortLinks.ts
@@ -156,11 +156,10 @@ NULL, NULL, ${sqlString(plan.campaignId)}, NULL, NULL,
 }
 
 export function renderBeautyMovementShortLinkConflictSql(plan: BeautyMovementShortLinkPlan): string {
-    const ids = plan.links.map((link) => sqlString(link.id)).join(", ");
     const slugs = plan.links.map((link) => sqlString(link.normalizedSlugPath)).join(", ");
     return `SELECT id, site_host, slug_path, destination_url, source, active
 FROM site_custom_urls
-WHERE id IN (${ids}) OR (site_host = ${sqlString(BEAUTY_MOVEMENT_SHORT_LINK_HOST)} AND slug_path IN (${slugs}));\n`;
+WHERE site_host = ${sqlString(BEAUTY_MOVEMENT_SHORT_LINK_HOST)} AND slug_path IN (${slugs});\n`;
 }
 
 export function renderBeautyMovementShortLinkReadbackSql(plan: BeautyMovementShortLinkPlan): string {

--- a/website/src/lib/beautyMovementShortLinks.ts
+++ b/website/src/lib/beautyMovementShortLinks.ts
@@ -98,11 +98,12 @@ export function prepareBeautyMovementShortLinks(params: {
         const slugPath = `/${suffix}${BEAUTY_MOVEMENT_CANONICAL_PATH}`;
         const normalizedSlugPath = `/${normalizedSuffix}${BEAUTY_MOVEMENT_CANONICAL_PATH.toLowerCase()}`;
         const destinationUrl = `https://espacofacial.com${BEAUTY_MOVEMENT_CANONICAL_PATH}#c=${token}`;
+        const tokenIdentity = createHash("sha256").update(token, "utf8").digest("hex").slice(0, 32);
         links.push({
-            // Keep the redirect contract/source stable while moving the row identity
-            // forward. A previously reserved v1 id must never be overwritten if a
-            // stale/manual row is found under that primary key.
-            id: `beauty-movement-short-v2-${campaignId}-${normalizedSuffix}`,
+            // Keep identity independent from the short suffix. A stale/manual row
+            // can reserve an old primary key without being overwritten, while the
+            // token-derived digest remains stable for future idempotent syncs.
+            id: `beauty-movement-short-v3-${campaignId}-${tokenIdentity}`,
             name: `Cartas da Beleza - ${suffix}`,
             inviteRef: row.inviteRef,
             whatsapp: row.whatsapp,

--- a/website/tests/beautyMovementShortLinks.test.ts
+++ b/website/tests/beautyMovementShortLinks.test.ts
@@ -23,7 +23,7 @@ test("short links use the final five token characters and preserve the canonical
     assert.equal(plan.links[0]?.normalizedSlugPath, "/no123/belezaemmovimento");
     assert.equal(plan.links[0]?.destinationUrl, "https://espacofacial.com/BelezaEmMovimento#c=abcdefghijklmnopqrstuvwxyzABCDEFGHijklmno123");
     assert.equal(plan.links[0]?.source, "beauty_movement_short_links_v1");
-    assert.match(plan.links[0]?.id ?? "", /^beauty-movement-short-v2-/);
+    assert.match(plan.links[0]?.id ?? "", /^beauty-movement-short-v3-[a-z0-9-]+-[0-9a-f]{32}$/);
     assert.match(renderBeautyMovementShortLinkSql(plan), /ON CONFLICT\(site_host, slug_path\) DO NOTHING/);
 });
 

--- a/website/tests/beautyMovementShortLinks.test.ts
+++ b/website/tests/beautyMovementShortLinks.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
     prepareBeautyMovementShortLinks,
+    renderBeautyMovementShortLinkConflictSql,
     renderBeautyMovementShortLinkSql,
     serializeBeautyMovementShortLinkCsv,
 } from "../src/lib/beautyMovementShortLinks";
@@ -25,6 +26,9 @@ test("short links use the final five token characters and preserve the canonical
     assert.equal(plan.links[0]?.source, "beauty_movement_short_links_v1");
     assert.match(plan.links[0]?.id ?? "", /^beauty-movement-short-v3-[a-z0-9-]+-[0-9a-f]{32}$/);
     assert.match(renderBeautyMovementShortLinkSql(plan), /ON CONFLICT\(site_host, slug_path\) DO NOTHING/);
+    const conflictSql = renderBeautyMovementShortLinkConflictSql(plan);
+    assert.match(conflictSql, /WHERE site_host = 'esfa\.co' AND slug_path IN/);
+    assert.equal(conflictSql.includes("id IN"), false);
 });
 
 test("short-link suffix collisions are detected case-insensitively", () => {


### PR DESCRIPTION
## Summary\n- scope the pre-write conflict readback to the authoritative esfa.co slug\n- keep idempotence and fail-closed validation for existing served URLs\n- add focused coverage so orphan primary-key rows cannot block a new mapping\n\n## Validation\n- git diff --check\n- focused test covered by CI\n\nNo D1 mutation is included in this change.