### PR TITLE
fix: normalize short-link D1 readback fields

### DIFF
--- a/.github/workflows/beauty-movement-short-links-sync.yml
+++ b/.github/workflows/beauty-movement-short-links-sync.yml
@@ -232,6 +232,7 @@ jobs:
           const rows = payload.flatMap((entry) => Array.isArray(entry?.results) ? entry.results : []);
           const attestation = JSON.parse(fs.readFileSync(attestationPath, 'utf8'));
           const expected = attestation.mappingHashes ?? {};
+          const column = (row, snake, camel) => row?.[snake] ?? row?.[camel];
           const stats = {
             rows: rows.length,
             missingExpected: 0,
@@ -242,19 +243,30 @@ jobs:
             valid: 0,
           };
           for (const row of rows) {
-            const expectedHash = expected[row.slug_path];
-            const actualHash = crypto.createHash('sha256').update(String(row.destination_url), 'utf8').digest('hex');
+            const slugPath = column(row, 'slug_path', 'slugPath');
+            const siteHost = column(row, 'site_host', 'siteHost');
+            const destinationUrl = column(row, 'destination_url', 'destinationUrl');
+            const source = column(row, 'source', 'source');
+            const active = column(row, 'active', 'active');
+            const normalizedSlugPath = typeof slugPath === 'string' ? slugPath.trim().toLowerCase() : '';
+            const expectedHash = expected[slugPath] ?? expected[normalizedSlugPath];
+            const actualHash = crypto.createHash('sha256').update(String(destinationUrl), 'utf8').digest('hex');
             let invalid = false;
             if (!expectedHash) { stats.missingExpected += 1; invalid = true; }
-            if (row.site_host !== 'esfa.co') { stats.wrongHost += 1; invalid = true; }
-            if (row.source !== 'beauty_movement_short_links_v1') { stats.wrongSource += 1; invalid = true; }
-            if (Number(row.active) !== 1) { stats.inactive += 1; invalid = true; }
+            if (siteHost !== 'esfa.co') { stats.wrongHost += 1; invalid = true; }
+            if (source !== 'beauty_movement_short_links_v1') { stats.wrongSource += 1; invalid = true; }
+            if (Number(active) !== 1) { stats.inactive += 1; invalid = true; }
             if (expectedHash && actualHash !== expectedHash) { stats.destinationMismatch += 1; invalid = true; }
             if (invalid) continue;
             stats.valid += 1;
           }
           if (stats.rows !== stats.valid) {
-            console.error(JSON.stringify({ code: 'beauty_movement_short_links_existing_mapping_conflict', ...stats }));
+            const first = rows[0];
+            console.error(JSON.stringify({
+              code: 'beauty_movement_short_links_existing_mapping_conflict',
+              ...stats,
+              rowShape: first ? Object.fromEntries(Object.keys(first).sort().map((key) => [key, typeof first[key]])) : null,
+            }));
             throw new Error('beauty_movement_short_links_existing_mapping_conflict');
           }
           NODE
@@ -300,11 +312,18 @@ jobs:
           const rows = payload.flatMap((entry) => Array.isArray(entry?.results) ? entry.results : []);
           const attestation = JSON.parse(fs.readFileSync(attestationPath, 'utf8'));
           const expected = attestation.mappingHashes ?? {};
+          const column = (row, snake, camel) => row?.[snake] ?? row?.[camel];
           if (rows.length !== Number(attestation.count)) throw new Error('beauty_movement_short_links_count_mismatch');
           for (const row of rows) {
-            const expectedHash = expected[row.slug_path];
-            const actualHash = crypto.createHash('sha256').update(String(row.destination_url), 'utf8').digest('hex');
-            if (!expectedHash || row.site_host !== 'esfa.co' || row.source !== 'beauty_movement_short_links_v1' || Number(row.active) !== 1 || actualHash !== expectedHash) throw new Error('beauty_movement_short_links_readback_mismatch');
+            const slugPath = column(row, 'slug_path', 'slugPath');
+            const siteHost = column(row, 'site_host', 'siteHost');
+            const destinationUrl = column(row, 'destination_url', 'destinationUrl');
+            const source = column(row, 'source', 'source');
+            const active = column(row, 'active', 'active');
+            const normalizedSlugPath = typeof slugPath === 'string' ? slugPath.trim().toLowerCase() : '';
+            const expectedHash = expected[slugPath] ?? expected[normalizedSlugPath];
+            const actualHash = crypto.createHash('sha256').update(String(destinationUrl), 'utf8').digest('hex');
+            if (!expectedHash || siteHost !== 'esfa.co' || source !== 'beauty_movement_short_links_v1' || Number(active) !== 1 || actualHash !== expectedHash) throw new Error('beauty_movement_short_links_readback_mismatch');
           }
           NODE
           probe_url="$(node - "${SHORT_OUTPUT}" <<'NODE'


### PR DESCRIPTION
## Summary\n- accept snake_case or equivalent camelCase fields from Wrangler D1 JSON readbacks\n- normalize slug keys before matching the private attestation\n- include only field-shape metadata in conflict diagnostics, never row values\n\n## Safety\nThe conflict gate remains fail-closed and still rejects any unknown, inactive, wrong-source, wrong-host, or divergent mapping. No D1 mutation is included.\n\n## Validation\n- git diff --check\n- focused validation via CI