### PR TITLE
Fix short-link D1 readback rows

### DIFF
--- a/.github/scripts/beauty-movement-short-links-sync-contract.test.mjs
+++ b/.github/scripts/beauty-movement-short-links-sync-contract.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const workflow = await readFile(
+  new URL("../workflows/beauty-movement-short-links-sync.yml", import.meta.url),
+  "utf8",
+);
+
+test("short-link readbacks use command mode so SELECT rows are returned", () => {
+  assert.ok(workflow.includes('conflict_sql="$(<"${SHORT_CONFLICTS}")"'));
+  assert.match(workflow, /--command "\$\{conflict_sql\}" .*--json > "\$\{D1_CONFLICT_READBACK\}"/);
+  assert.ok(workflow.includes('readback_sql="$(<"${SHORT_READBACK}")"'));
+  assert.match(workflow, /--command "\$\{readback_sql\}" .*--json > "\$\{D1_FINAL_READBACK\}"/);
+  assert.doesNotMatch(
+    workflow,
+    /d1 execute .*--file "\$\{SHORT_CONFLICTS\}"|d1 execute .*--file "\$\{SHORT_READBACK\}"/s,
+  );
+  assert.match(workflow, /d1 execute .*--file "\$\{SHORT_SQL\}" .*--json/);
+});

--- a/.github/workflows/beauty-movement-short-links-sync.yml
+++ b/.github/workflows/beauty-movement-short-links-sync.yml
@@ -220,7 +220,8 @@ jobs:
         run: |
           set -euo pipefail
           test -f "${RUNNER_TEMP}/skincos-global-coordination-website.json"
-          npx --yes wrangler@4.112.0 d1 execute "${BOOKING_D1_DATABASE}" --remote --config "${BOOKING_WORKER_CONFIG}" --file "${SHORT_CONFLICTS}" --json > "${D1_CONFLICT_READBACK}"
+          conflict_sql="$(<"${SHORT_CONFLICTS}")"
+          npx --yes wrangler@4.112.0 d1 execute "${BOOKING_D1_DATABASE}" --remote --config "${BOOKING_WORKER_CONFIG}" --command "${conflict_sql}" --json > "${D1_CONFLICT_READBACK}"
           node - "${D1_CONFLICT_READBACK}" "${SHORT_ATTESTATION}" <<'NODE'
           const crypto = require('node:crypto');
           const fs = require('node:fs');
@@ -300,7 +301,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          npx --yes wrangler@4.112.0 d1 execute "${BOOKING_D1_DATABASE}" --remote --config "${BOOKING_WORKER_CONFIG}" --file "${SHORT_READBACK}" --json > "${D1_FINAL_READBACK}"
+          readback_sql="$(<"${SHORT_READBACK}")"
+          npx --yes wrangler@4.112.0 d1 execute "${BOOKING_D1_DATABASE}" --remote --config "${BOOKING_WORKER_CONFIG}" --command "${readback_sql}" --json > "${D1_FINAL_READBACK}"
           node - "${D1_FINAL_READBACK}" "${SHORT_ATTESTATION}" <<'NODE'
           const crypto = require('node:crypto');
           const fs = require('node:fs');


### PR DESCRIPTION
## Summary\n- execute conflict and final SELECTs with Wrangler --command so D1 returns actual rows\n- keep mutation SQL on --file for atomic writes\n- add a focused workflow contract test\n\n## Validation\n- node --test .github/scripts/beauty-movement-short-links-sync-contract.test.mjs\n- git diff --check\n\nThis closes the false one-row conflict caused by Wrangler file-execution metadata being parsed as a redirect row.