### PR TITLE
fix: close nested D1 diagnostic heredoc

### DIFF
--- a/.github/workflows/beauty-movement-short-links-sync.yml
+++ b/.github/workflows/beauty-movement-short-links-sync.yml
@@ -321,7 +321,7 @@ jobs:
               errorKeys: diagnosticErrors.slice(0, 3).map((error) => Object.keys(error ?? {}).sort()),
               errorMessages: diagnosticErrors.slice(0, 3).map((error) => scrub(error?.message ?? error?.text ?? error?.error ?? 'unknown')),
             }));
-            NODE
+          NODE
             exit 1
           fi
 


### PR DESCRIPTION
## Objetivo\nCorrige o fechamento do heredoc Node no bloco fail-closed de aplicação D1 do sincronizador de links Beauty Movement.\n\n## Evidência\nA execução oficial 32616575346 atingiu a etapa de aplicação, mas falhou antes do Wrangler por warning: here-document ... wanted NODE e syntax error: unexpected end of file. O delimitador agora fica na coluna correta após renderização do YAML.\n\n## Escopo\nUma linha no workflow; nenhum segredo, dado ou mapping alterado.