### PR TITLE
fix: make short-link D1 SQL Wrangler-safe

### DIFF
--- a/website/src/lib/beautyMovementShortLinks.ts
+++ b/website/src/lib/beautyMovementShortLinks.ts
@@ -137,7 +137,10 @@ export function serializeBeautyMovementShortLinkCsv(plan: BeautyMovementShortLin
 }
 
 export function renderBeautyMovementShortLinkSql(plan: BeautyMovementShortLinkPlan): string {
-    const statements = ["BEGIN TRANSACTION;"];
+    // Wrangler's remote D1 command rejects explicit transaction control
+    // statements. Each INSERT remains idempotent through its unique slug
+    // constraint and ON CONFLICT DO NOTHING clause.
+    const statements: string[] = [];
     for (const link of plan.links) {
         statements.push(`INSERT INTO site_custom_urls (
 id, site_host, name, slug_path, destination_url, destination_host, destination_path,
@@ -151,7 +154,6 @@ NULL, NULL, ${sqlString(plan.campaignId)}, NULL, NULL,
 1, ${plan.createdAtMs}, ${plan.createdAtMs}
 ) ON CONFLICT(site_host, slug_path) DO NOTHING;`);
     }
-    statements.push("COMMIT;");
     return `${statements.join("\n\n")}\n`;
 }
 

--- a/website/tests/beautyMovementShortLinks.test.ts
+++ b/website/tests/beautyMovementShortLinks.test.ts
@@ -25,7 +25,9 @@ test("short links use the final five token characters and preserve the canonical
     assert.equal(plan.links[0]?.destinationUrl, "https://espacofacial.com/BelezaEmMovimento#c=abcdefghijklmnopqrstuvwxyzABCDEFGHijklmno123");
     assert.equal(plan.links[0]?.source, "beauty_movement_short_links_v1");
     assert.match(plan.links[0]?.id ?? "", /^beauty-movement-short-v3-[a-z0-9-]+-[0-9a-f]{32}$/);
-    assert.match(renderBeautyMovementShortLinkSql(plan), /ON CONFLICT\(site_host, slug_path\) DO NOTHING/);
+    const sql = renderBeautyMovementShortLinkSql(plan);
+    assert.match(sql, /ON CONFLICT\(site_host, slug_path\) DO NOTHING/);
+    assert.doesNotMatch(sql, /\b(?:BEGIN|COMMIT|SAVEPOINT)\b/i);
     const conflictSql = renderBeautyMovementShortLinkConflictSql(plan);
     assert.match(conflictSql, /WHERE site_host = 'esfa\.co' AND slug_path IN/);
     assert.equal(conflictSql.includes("id IN"), false);


### PR DESCRIPTION
## Objetivo\nRemove BEGIN TRANSACTION/COMMIT do SQL privado de short-links. O Wrangler remoto rejeita controle explícito de transação no D1; os INSERTs permanecem idempotentes por ON CONFLICT(site_host, slug_path) DO NOTHING.\n\n## Evidência\nA execução oficial 32617321082 passou pelos gates e falhou na mutação com a mensagem sanitizada: To execute a transaction, please use the state.storage.transaction() or state.storage.transactionSync() APIs instead of the SQL BEGIN TRANSACTION....\n\n## Validação\nTeste focado agora garante que o SQL não contém BEGIN/COMMIT/SAVEPOINT. Nenhum dado ou segredo foi alterado neste PR.