### PR TITLE
feat(beauty-movement): personalize special-card WhatsApp CTA

### DIFF
--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -25,6 +25,7 @@ import {
 import BeautyMovementWhatsappLink from "@/components/BeautyMovementWhatsappLink";
 import BeautyMovementCardIllustration from "@/components/BeautyMovementCardIllustration";
 import BrandMark from "@/components/BrandMark";
+import { buildBeautyMovementWhatsappMessage } from "@/lib/beautyMovementWhatsapp";
 import type {
     BeautyMovementDiscountKind,
     BeautyMovementRewardType,
@@ -1377,7 +1378,11 @@ export default function BeautyMovementExperience({
         }
     }
 
-    function renderWhatsappAction(className: string, label = primaryWhatsappLabel) {
+    function renderWhatsappAction(
+        className: string,
+        label = primaryWhatsappLabel,
+        message = initialState.campaign.whatsappMessage?.trim() || "",
+    ) {
         if (isLocalPreview) {
             return (
                 <button className={className} type="button" onClick={handleWhatsappClick}>
@@ -1386,11 +1391,11 @@ export default function BeautyMovementExperience({
             );
         }
 
-        if (initialState.campaign.whatsappMessage?.trim()) {
+        if (message) {
             return (
                 <BeautyMovementWhatsappLink
                     className={className}
-                    message={initialState.campaign.whatsappMessage.trim()}
+                    message={message}
                     placement="result"
                     onClick={handleWhatsappClick}
                 >
@@ -1581,10 +1586,25 @@ export default function BeautyMovementExperience({
             : `${primaryWhatsappLabel} no WhatsApp`;
         const revealContentClass = deferRevealContent || showRevealAction ? styles.specialCardRevealContent : undefined;
         const offerPresentation = kind === "offer" && offer ? BEAUTY_MOVEMENT_OFFER_PRESENTATIONS[offer.outcomeKey] : null;
-        const selectedConcepts = revealed && (kind === "offer" || (kind === "velocity" && offer !== null))
+        const selectedConcepts = revealed
             ? reading.map((line) => line.title)
             : [];
         const selectedConceptsLabel = selectedConcepts.join(" · ");
+        const prizeLabel =
+            kind === "velocity"
+                ? velocity?.label?.trim() || "Aula-cortesia de Velocity"
+                : kind === "offer" && offer
+                  ? `${offer.title} — ${offer.commercialText}`
+                  : kind === "discount" || kind === "free_procedure"
+                    ? benefit?.displayText?.trim() || benefit?.procedureName?.trim() || "Condição especial"
+                    : "Presente reservado da campanha";
+        const specialCardWhatsappMessage = revealed
+            ? buildBeautyMovementWhatsappMessage({
+                displayName: initialState.invite.displayName,
+                selectedConcepts: selectedConceptsLabel,
+                prize: prizeLabel,
+            })
+            : null;
         const referencePrice = offerPresentation && offer ? formatBeautyMovementPrice(offer.referencePrice) : null;
         const unlockedPrice = offerPresentation && offer ? formatBeautyMovementPrice(offer.unlockedPrice) : null;
         const campaignConditions = revealed ? initialState.campaign.conditionsText?.trim() : null;
@@ -1677,6 +1697,7 @@ export default function BeautyMovementExperience({
                             ? renderWhatsappAction(
                                 `${styles.primaryButton} ${styles.specialCardWhatsappAction}`,
                                 specialCardWhatsappLabel,
+                                specialCardWhatsappMessage ?? undefined,
                             )
                             : null}
                         {campaignConditions ? (

--- a/website/src/components/BeautyMovementWhatsappLink.tsx
+++ b/website/src/components/BeautyMovementWhatsappLink.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { type AnchorHTMLAttributes, type ReactNode, useMemo } from "react";
-import { buildWhatsappRedirectHref } from "@/lib/whatsappTracking";
+import { buildBeautyMovementWhatsappHref, type BeautyMovementWhatsappPlacement } from "@/lib/beautyMovementWhatsapp";
 
 type BeautyMovementWhatsappLinkProps = Omit<
   AnchorHTMLAttributes<HTMLAnchorElement>,
@@ -9,27 +9,8 @@ type BeautyMovementWhatsappLinkProps = Omit<
 > & {
   children: ReactNode;
   message: string;
-  placement: "result" | "conditions";
+  placement: BeautyMovementWhatsappPlacement;
 };
-
-function buildHref(params: {
-  message: string;
-  placement: BeautyMovementWhatsappLinkProps["placement"];
-}): string {
-  return (
-    buildWhatsappRedirectHref({
-      phone: "5551995811008",
-      text: params.message,
-      tracking: {
-        placement: `beauty_movement_${params.placement}`,
-        unitSlug: "novo-hamburgo",
-        source: "beauty-movement",
-        // The redirect identifies the campaign but never receives a location,
-        // attribution context, event id, or personal campaign state.
-      },
-    }) ?? "#"
-  );
-}
 
 /**
  * Uses the existing first-party WhatsApp redirect without invoking the generic
@@ -45,7 +26,7 @@ export default function BeautyMovementWhatsappLink({
   ...rest
 }: BeautyMovementWhatsappLinkProps) {
   const href = useMemo(
-    () => buildHref({ message, placement }),
+    () => buildBeautyMovementWhatsappHref({ message, placement }) ?? "#",
     [message, placement],
   );
 

--- a/website/src/lib/beautyMovementWhatsapp.ts
+++ b/website/src/lib/beautyMovementWhatsapp.ts
@@ -1,0 +1,63 @@
+import { buildWhatsappRedirectHref } from "@/lib/whatsappTracking";
+
+/**
+ * WhatsApp destination for the Beauty Movement campaign.
+ *
+ * This campaign destination is intentionally kept separate from the site's
+ * legacy phone aliasing rules. The invite CTA must open the number supplied by
+ * the campaign owner exactly as configured.
+ */
+export const BEAUTY_MOVEMENT_WHATSAPP_PHONE = "5551998493563" as const;
+
+export type BeautyMovementWhatsappPlacement = "result" | "conditions";
+
+function cleanMessagePart(value: string | null | undefined, maxLength: number): string {
+    return (value ?? "")
+        .replace(/[\u0000-\u001F\u007F]/g, " ")
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, maxLength);
+}
+
+/**
+ * Creates the only personalized text sent to WhatsApp by this campaign.
+ * Values come from the private invite session and the three cards rendered in
+ * the result; no token, contact detail, or clinical inference is included.
+ */
+export function buildBeautyMovementWhatsappMessage(params: {
+    displayName?: string | null;
+    selectedConcepts?: string | null;
+    prize?: string | null;
+}): string {
+    const name = cleanMessagePart(params.displayName, 120) || "convidado(a)";
+    const concepts = cleanMessagePart(params.selectedConcepts, 240) || "as minhas três cartas";
+    const prize = cleanMessagePart(params.prize, 600) || "o meu prêmio da campanha";
+
+    return `Olá! Eu sou ${name}. Minha sorte em Beleza em Movimento reuniu ${concepts} e revelou o prêmio: ${prize}. Vim falar com a Espaço Facial para saber como resgatar.`;
+}
+
+/**
+ * Builds a direct wa.me destination without passing the campaign number
+ * through the site's legacy-phone compatibility mapping.
+ */
+export function buildBeautyMovementWhatsappDestination(message: string): string {
+    const url = new URL(`https://wa.me/${BEAUTY_MOVEMENT_WHATSAPP_PHONE}`);
+    url.searchParams.set("text", message);
+    return url.toString();
+}
+
+export function buildBeautyMovementWhatsappHref(params: {
+    message: string;
+    placement: BeautyMovementWhatsappPlacement;
+}): string | null {
+    return buildWhatsappRedirectHref({
+        rawUrl: buildBeautyMovementWhatsappDestination(params.message),
+        tracking: {
+            placement: `beauty_movement_${params.placement}`,
+            unitSlug: "novo-hamburgo",
+            source: "beauty-movement",
+            // The redirect identifies the campaign but never receives a
+            // location, attribution context, event id, or personal state.
+        },
+    });
+}

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -449,7 +449,7 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.match(experience, /type SpecialCardAction = "none" \| "confirm" \| "reopen"/);
     assert.match(experience, /function renderSpecialCard\(\s*revealed: boolean,\s*action: SpecialCardAction = "none",\s*settled = false,\s*deferRevealContent = false,/);
     assert.match(experience, /const kind: SpecialCardKind = revealed\s*\? hasCourtesyClass\s*\? "velocity"\s*:\s*offer\s*\? "offer"/);
-    assert.match(experience, /kind === "velocity" && offer !== null/);
+    assert.match(experience, /const selectedConcepts = revealed/);
     assert.match(experience, /className=\{styles\.specialCardRevealAction\}/);
     assert.match(experience, /Garantir presente e confirmar presença/);
     assert.match(experience, /if \(!operationalConsent && !isLocalPreview\) return;/);

--- a/website/tests/beautyMovementWhatsapp.test.ts
+++ b/website/tests/beautyMovementWhatsapp.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    BEAUTY_MOVEMENT_WHATSAPP_PHONE,
+    buildBeautyMovementWhatsappDestination,
+    buildBeautyMovementWhatsappHref,
+    buildBeautyMovementWhatsappMessage,
+} from "../src/lib/beautyMovementWhatsapp";
+import { decodeWhatsappRedirectQueryValue, parseWhatsappDestination } from "../src/lib/whatsappTracking";
+
+test("builds a personalized campaign message from the invite name, reading and prize", () => {
+    const message = buildBeautyMovementWhatsappMessage({
+        displayName: "Ana",
+        selectedConcepts: "Presença · Potência · Renovação",
+        prize: "Firmeza & Renovação — Elleva 210 mg pelo valor do Elleva 150 mg",
+    });
+
+    assert.equal(
+        message,
+        "Olá! Eu sou Ana. Minha sorte em Beleza em Movimento reuniu Presença · Potência · Renovação e revelou o prêmio: Firmeza & Renovação — Elleva 210 mg pelo valor do Elleva 150 mg. Vim falar com a Espaço Facial para saber como resgatar.",
+    );
+    assert.equal(message.includes("invite"), false);
+    assert.equal(message.includes("whatsapp"), false);
+});
+
+test("uses a safe fallback when an invite has no display name", () => {
+    const message = buildBeautyMovementWhatsappMessage({
+        selectedConcepts: "Autocuidado · Leveza · Brilho",
+        prize: "Aula-cortesia de Velocity",
+    });
+
+    assert.match(message, /^Olá! Eu sou convidado\(a\)\./);
+    assert.match(message, /Aula-cortesia de Velocity/);
+});
+
+test("campaign CTA targets the configured clinic number and preserves the message", () => {
+    const message = buildBeautyMovementWhatsappMessage({
+        displayName: "Lia",
+        selectedConcepts: "Harmonia · Sintonia · Encontro",
+        prize: "Harmonia & Definição — 2 mL e receba 4 mL",
+    });
+    const destination = buildBeautyMovementWhatsappDestination(message);
+    const parsedDestination = parseWhatsappDestination(destination);
+    assert.deepEqual(parsedDestination && {
+        phone: parsedDestination.phone,
+        text: parsedDestination.text,
+    }, {
+        phone: BEAUTY_MOVEMENT_WHATSAPP_PHONE,
+        text: message,
+    });
+
+    const href = buildBeautyMovementWhatsappHref({ message, placement: "result" });
+    assert.ok(href);
+    const redirectUrl = new URL(href!, "https://espacofacial.com");
+    const protectedDestination = redirectUrl.searchParams.get("dest");
+    assert.ok(protectedDestination);
+    assert.equal(
+        decodeWhatsappRedirectQueryValue(protectedDestination!),
+        destination,
+    );
+});


### PR DESCRIPTION
Personaliza o CTA da carta especial com nome seguro da sessão, as três cartas escolhidas e o prêmio resolvido, abrindo o WhatsApp da clínica com mensagem pronta. Usa o número exato +55 51 99849-3563 sem o alias legado, preserva o redirect first-party e não envia token, telefone ou e-mail da pessoa. Validação: 62 testes beautyMovement, npm run typecheck, npm run lint e prévia local desktop/mobile. Sem migration, D1 write ou mudança de secrets. Rollback: reverter af31acb9c.