### PR TITLE
fix(beauty-movement): publish canonical website promotion evidence

### DIFF
--- a/.github/scripts/beauty-movement-staging-smoke-contract.test.mjs
+++ b/.github/scripts/beauty-movement-staging-smoke-contract.test.mjs
@@ -28,6 +28,8 @@ test("smoke consumes secrets in-process and closes the staging gate", () => {
     assert.doesNotMatch(workflow, /node -e\s/);
     assert.doesNotMatch(workflow, /set -x/);
     assert.match(workflow, /promotion-evidence-beauty-movement-production-activation/);
+    assert.match(workflow, /PROMOTION_UNIT: public-website-release/);
+    assert.match(workflow, /promotion-evidence-public-website-release/);
     assert.match(workflow, /actions\/upload-artifact/);
     assert.match(workflow, /staging-smoke-disabled-probe/);
     assert.match(workflow, /beauty_movement_delivery_ref_invalid/);

--- a/.github/workflows/beauty-movement-staging-smoke.yml
+++ b/.github/workflows/beauty-movement-staging-smoke.yml
@@ -650,3 +650,35 @@ jobs:
           path: ${{ runner.temp }}/beauty-movement-staging-smoke/promotion-evidence.json
           retention-days: 14
           if-no-files-found: error
+
+      # The Beauty Movement smoke is also the immutable website validation for
+      # the generic website promotion workflow. Keep that evidence under the
+      # canonical unit name expected by promotion-gate.yml while preserving
+      # the campaign-specific artifact above for the controlled activation
+      # workflow.
+      - name: Write public website staging promotion evidence
+        if: ${{ success() }}
+        shell: bash
+        env:
+          PROMOTION_UNIT: public-website-release
+          PROMOTION_TARGET: staging
+          PROMOTION_SOURCE_SHA: ${{ inputs.release_sha }}
+          PROMOTION_EVIDENCE_FILE: ${{ runner.temp }}/beauty-movement-staging-smoke/promotion-evidence-public-website-release.json
+        run: |
+          set -euo pipefail
+          tree="$(git rev-parse "${PROMOTION_SOURCE_SHA}^{tree}")"
+          digest="$(PROMOTION_UNIT="${PROMOTION_UNIT}" PROMOTION_SOURCE_SHA="${PROMOTION_SOURCE_SHA}" node .github/scripts/promotion-evidence.mjs digest)"
+          PROMOTION_SOURCE_TREE="${tree}" \
+          PROMOTION_RELEASE_INPUT_DIGEST="${digest}" \
+          PROMOTION_DEPENDENCY_CLOSURE_DIGEST="${digest}" \
+          node .github/scripts/promotion-evidence.mjs write "${PROMOTION_EVIDENCE_FILE}" >/dev/null
+          test -s "${PROMOTION_EVIDENCE_FILE}"
+
+      - name: Upload public website staging promotion evidence
+        if: ${{ success() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: promotion-evidence-public-website-release
+          path: ${{ runner.temp }}/beauty-movement-staging-smoke/promotion-evidence-public-website-release.json
+          retention-days: 14
+          if-no-files-found: error


### PR DESCRIPTION
## Summary\n- preserve the Beauty Movement-specific staging promotion artifact\n- also publish the canonical public-website-release evidence expected by the generic website promotion gate\n- extend the focused workflow contract test\n\n## Validation\n- node --test .github/scripts/beauty-movement-staging-smoke-contract.test.mjs\n- git diff --check\n\nThis closes the artifact-name/unit mismatch that blocked the production promotion gate; no production mutation was performed by the failed attempt.