### PR TITLE
fix(beauty-movement): expand mobile prize modal

### DIFF
--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -4669,7 +4669,7 @@
   }
 
   .specialCardModalDialog .specialCardWithPrice {
-    min-height: clamp(454px, 147vw, 480px);
+    min-height: clamp(568px, 178vw, 592px);
   }
 
   /* Conditions are part of the dialog's keyboard path. When expanded, give
@@ -4679,7 +4679,7 @@
   }
 
   .specialCardModalDialog .specialCardWithPrice:has(.specialCardConditions[open]) {
-    min-height: clamp(560px, 176vw, 600px);
+    min-height: clamp(636px, 199vw, 660px);
   }
 
   .specialCardModalDialog .specialCardFrontOffer .specialCardConditions {

--- a/website/tests/beautyMovementLayout.test.ts
+++ b/website/tests/beautyMovementLayout.test.ts
@@ -108,7 +108,7 @@ test("the table handoff follows the deck and keeps the title in the compact view
     assert.match(experience, /className=\{`\$\{styles\.finaleCardFace\} \$\{styles\.cardBack\}`\}/);
     assert.match(experience, /Você também leva o squeeze e a ecobag da Espaço Facial, além de mais mimos da celebração\./);
     assert.match(experience, /styles\.specialCardGiftNote/);
-    assert.match(styles, /\.specialCardModalDialog \.specialCardWithPrice \{[\s\S]*min-height: clamp\(454px, 147vw, 480px\)/);
+    assert.match(styles, /\.specialCardModalDialog \.specialCardWithPrice \{[\s\S]*min-height: clamp\(568px, 178vw, 592px\)/);
     assert.match(styles, /\.specialCardModalDialog \.specialCardFrontOffer \.specialCardConditions \{[\s\S]*position: static[\s\S]*width: 100%/);
     assert.match(styles, /\.specialCardModalDialog \.specialCardWithPrice \.specialCardConditions \{[\s\S]*position: static[\s\S]*width: 100%/);
     assert.match(experience, /renderSpecialCard\(false, "reopen", true\)/);

--- a/website/tests/beautyMovementMobileContract.test.ts
+++ b/website/tests/beautyMovementMobileContract.test.ts
@@ -35,14 +35,14 @@ test("mobile handoff keeps one rhythm, one deck anchor, and a roomier special-ca
         styles,
         /\.specialCardModalDialog \.specialCardFrontOffer \.specialCardIllustration\s*\{\s*width: clamp\(160px, 52vw, 188px\);\s*height: clamp\(148px, 48vw, 174px\);/,
     );
-    assert.match(styles, /\.specialCardModalDialog \.specialCardWithPrice\s*\{\s*min-height: clamp\(454px, 147vw, 480px\);/);
+    assert.match(styles, /\.specialCardModalDialog \.specialCardWithPrice\s*\{\s*min-height: clamp\(568px, 178vw, 592px\);/);
     assert.match(
         styles,
         /\.specialCardModalDialog \.specialCard:has\(\.specialCardConditions\[open\]\)\s*\{\s*min-height: clamp\(548px, 172vw, 584px\);/,
     );
     assert.match(
         styles,
-        /\.specialCardModalDialog \.specialCardWithPrice:has\(\.specialCardConditions\[open\]\)\s*\{\s*min-height: clamp\(560px, 176vw, 600px\);/,
+        /\.specialCardModalDialog \.specialCardWithPrice:has\(\.specialCardConditions\[open\]\)\s*\{\s*min-height: clamp\(636px, 199vw, 660px\);/,
     );
     assert.match(styles, /\.specialCardModalClose\s*\{[\s\S]*?width: 44px;[\s\S]*?height: 44px;/);
 


### PR DESCRIPTION
## Summary
- expand the mobile price-bearing special-card envelope so the reward content, price, WhatsApp CTA, and conditions link are never clipped at 319×674;
- contract the closed and conditions-open mobile heights with the existing visual tests;
- keep desktop geometry and campaign, invitation, reward, and short-link data unchanged.

## Validation
- 
pm test — 163 passed
- 
pm lint
- 
pm run typecheck
- git diff --check
- in-app browser QA at 319×674: closed/open conditions and close/reopen have zero vertical overflow; desktop 1280×800 retains existing geometry.

## Release controls
- Risk: reversible, CSS-only mobile presentation refinement.
- Flag/migration/data change: none.
- Rollback: redeploy the prior validated release 90ab7d8781bd3e94e74434d0718dc73961b0d1f through the standard promotion workflow if the production smoke fails.