### PR TITLE
fix(beauty-movement): contain desktop prize artwork

### DIFF
--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -1107,6 +1107,17 @@
   animation: specialCardIconFloat 4.8s ease-in-out 820ms infinite alternate;
 }
 
+/* Prize artwork is supplied at a larger transparent source size. Constrain it
+ * to the illustration slot in every layout so the desktop card never paints
+ * over its editorial copy. Mobile can still enlarge the slot itself below. */
+.specialCardIllustration :global(.beautyMovementPrizeArt) {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  filter: drop-shadow(0 8px 10px rgba(23, 54, 46, 0.12));
+}
+
 .specialCardCopy {
   max-width: 275px;
   color: var(--bm-muted);
@@ -4256,13 +4267,6 @@
     margin: 2px auto 0;
   }
 
-  .specialCardIllustration :global(.beautyMovementPrizeArt) {
-    display: block;
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-    filter: drop-shadow(0 8px 10px rgba(23, 54, 46, 0.12));
-  }
 }
 
 @keyframes mobilePromptSurfaceIn {

--- a/website/tests/beautyMovementPrizeArt.test.ts
+++ b/website/tests/beautyMovementPrizeArt.test.ts
@@ -38,3 +38,22 @@ test("prize art ships four compact branded illustrations instead of eager source
     assert.doesNotMatch(component, /-v[23]\.png/);
     assert.doesNotMatch(component, /rewards\/(?:elleva-upgrade|filler-double|sculptra-classic-unlock|skinbooster-diamond-unlock)\.webp/);
 });
+
+test("prize art is constrained by the special-card illustration box on every viewport", async () => {
+    const styles = await readFile(sourceUrl("src/components/BeautyMovementExperience.module.css"), "utf8");
+    const artworkRule = ".specialCardIllustration :global(.beautyMovementPrizeArt)";
+    const mobileHandContract = "/* On a portrait phone the hand is a readable strip";
+    const ruleIndex = styles.indexOf(artworkRule);
+
+    assert.ok(ruleIndex >= 0, "the shared prize-art sizing rule is present");
+    assert.ok(
+        ruleIndex < styles.indexOf(mobileHandContract),
+        "the shared prize-art sizing rule is not confined to the mobile hand breakpoint",
+    );
+
+    const rule = styles.slice(ruleIndex, ruleIndex + 360);
+    assert.match(rule, /display: block;/);
+    assert.match(rule, /width: 100%;/);
+    assert.match(rule, /height: 100%;/);
+    assert.match(rule, /object-fit: contain;/);
+});


### PR DESCRIPTION
## Objetivo
Corrige a carta especial de prêmio em desktop: a arte transparente era limitada apenas pelo breakpoint mobile e assumia 384 px no modal, sobrepondo conteúdo.

## Superfície e risco
- Superfície: modal da carta especial em `/beleza-em-movimento`.
- Risco: baixo/médio de apresentação; sem alteração de campanha, dados, links, flags ou integrações.
- Migração/flag/coorte: não aplicável.

## Validação local
- `npm run website:test` — 164 testes aprovados.
- `npm run module:site-public:website:lint` — aprovado.
- `tsc -p website/tsconfig.json --noEmit --incremental false` — aprovado.
- `git diff --check` — aprovado.
- Navegador nativo, `1346x674`: combinação Radiância / Constância / Renovação, abrir, fechar e reabrir o modal; arte do prêmio permaneceu dentro de 62x62 px e não sobrepôs título, texto ou CTA.

## Pré-produção e rollback
- Pré-produção: preflight do repositório aprovado; CI executará o build completo em ambiente isolado.
- Rollback: reimplantar o SHA de `main` anterior a este PR; não há mutação de dados, campanha, convites ou links.