### PR TITLE
fix(beauty-movement): stabilize desktop price-card conditions

### DIFF
--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -3801,6 +3801,28 @@
   overflow: auto;
 }
 
+/* Price cards need the campaign conditions in the editorial flow on desktop,
+ * otherwise the link lands on top of the WhatsApp action at compact heights. */
+@media (min-width: 721px) {
+  .specialCardModalDialog .specialCardWithPrice {
+    min-height: 456px;
+  }
+
+  .specialCardModalDialog .specialCardWithPrice .specialCardWhatsappAction {
+    margin-bottom: 0;
+  }
+
+  .specialCardModalDialog .specialCardWithPrice .specialCardConditions {
+    position: static;
+    width: 100%;
+    margin-top: 0;
+  }
+
+  .specialCardModalDialog .specialCardWithPrice:has(.specialCardConditions[open]) {
+    min-height: 560px;
+  }
+}
+
 @media (max-width: 720px) {
   .specialCardFrontOffer {
     gap: 4px;

--- a/website/tests/beautyMovementOfferLayout.test.ts
+++ b/website/tests/beautyMovementOfferLayout.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const sourceUrl = (relativePath: string) => new URL(`../${relativePath}`, import.meta.url);
+
+test("desktop price offer keeps campaign conditions in the editorial flow", async () => {
+    const styles = await readFile(sourceUrl("src/components/BeautyMovementExperience.module.css"), "utf8");
+    const desktopOfferBlockStart = styles.indexOf("/* Price cards need the campaign conditions in the editorial flow on desktop,");
+    const desktopOfferBlockEnd = styles.indexOf("\n}\n\n@media (max-width: 720px) {", desktopOfferBlockStart);
+
+    assert.ok(desktopOfferBlockStart >= 0, "the desktop price-offer block is present");
+    assert.ok(desktopOfferBlockEnd > desktopOfferBlockStart, "the desktop price-offer block closes before mobile overrides");
+
+    const desktopOfferStyles = styles.slice(desktopOfferBlockStart, desktopOfferBlockEnd + 2);
+
+    assert.match(desktopOfferStyles, /@media \(min-width: 721px\)\s*\{/);
+    assert.match(desktopOfferStyles, /\.specialCardModalDialog \.specialCardWithPrice\s*\{\s*min-height: 456px;/);
+    assert.match(
+        desktopOfferStyles,
+        /\.specialCardModalDialog \.specialCardWithPrice \.specialCardWhatsappAction\s*\{\s*margin-bottom: 0;/,
+    );
+    assert.match(
+        desktopOfferStyles,
+        /\.specialCardModalDialog \.specialCardWithPrice \.specialCardConditions\s*\{\s*position: static;\s*width: 100%;\s*margin-top: 0;/,
+    );
+    assert.match(
+        desktopOfferStyles,
+        /\.specialCardModalDialog \.specialCardWithPrice:has\(\.specialCardConditions\[open\]\)\s*\{\s*min-height: 560px;/,
+    );
+});


### PR DESCRIPTION
## Summary
- keeps the price-card campaign conditions in the desktop editorial flow
- reserves the necessary card height when conditions are expanded
- adds a contract test for the desktop price offer layout

## Validation
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `git diff --check`
- Browser QA at 1346x674 and 319x674: full card flow, finale, price modal, conditions, and modal reopen

## Risk and rollback
CSS-only campaign presentation adjustment. No campaign data, invitations, redirects, flags, or APIs change. Revert commit `88514304c9bcebd89e66893604fe9047fa408c10` to return to the current production layout.