### PR TITLE
fix(beauty-movement): align active campaign copy with release

### DIFF
--- a/.github/governance/cloudflare-single-writer-policy.json
+++ b/.github/governance/cloudflare-single-writer-policy.json
@@ -187,7 +187,8 @@
         ".github/workflows/beauty-movement-staging-smoke.yml",
         ".github/workflows/beauty-movement-production-activation.yml",
         ".github/workflows/beauty-movement-short-links-sync.yml",
-        ".github/workflows/beauty-movement-team-invite-links.yml"
+        ".github/workflows/beauty-movement-team-invite-links.yml",
+        ".github/workflows/beauty-movement-campaign-copy-update.yml"
       ],
       "automaticDeploymentsRequired": false
     },

--- a/.github/scripts/beauty-movement-campaign-copy-contract.test.mjs
+++ b/.github/scripts/beauty-movement-campaign-copy-contract.test.mjs
@@ -7,6 +7,10 @@ const workflow = await readFile(
   new URL("../workflows/beauty-movement-campaign-copy-update.yml", import.meta.url),
   "utf8",
 );
+const updateCopyHelper = await readFile(
+  new URL("../../website/scripts/beauty-movement-update-copy.ts", import.meta.url),
+  "utf8",
+);
 
 test("campaign copy update is production-only, release-bound and narrowly scoped", () => {
   assert.match(workflow, /environment: production/);
@@ -33,6 +37,7 @@ test("campaign copy update is production-only, release-bound and narrowly scoped
   assert.match(workflow, /beauty_movement_campaign_copy_rollback_conflict/);
   assert.match(workflow, /Release Website production coordination lease/);
   assert.match(workflow, /Remove runner-local private material/);
+  assert.match(updateCopyHelper, /--file\", params\.sqlFile, \"--json/);
   assert.doesNotMatch(workflow, /wrangler secret put/);
   assert.doesNotMatch(workflow, /INSERT INTO bm_campaigns/);
   assert.doesNotMatch(workflow, /UPDATE bm_invites/);

--- a/.github/scripts/beauty-movement-campaign-copy-contract.test.mjs
+++ b/.github/scripts/beauty-movement-campaign-copy-contract.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const workflow = await readFile(
+  new URL("../workflows/beauty-movement-campaign-copy-update.yml", import.meta.url),
+  "utf8",
+);
+
+test("campaign copy update is production-only, release-bound and narrowly scoped", () => {
+  assert.match(workflow, /environment: production/);
+  assert.match(workflow, /PRODUCTION_D1_DATABASE: espacofacial-beauty-movement/);
+  assert.match(workflow, /BEAUTY_MOVEMENT_PRODUCTION_CAMPAIGN_JSON/);
+  assert.match(workflow, /beauty-movement:update-copy/);
+  assert.match(workflow, /--dry-run/);
+  assert.match(workflow, /--apply --remote/);
+  assert.match(workflow, /status !== 'active'/);
+  assert.match(workflow, /ends_at_ms/);
+  assert.match(workflow, /invite_count/);
+  assert.match(workflow, /Release Website production coordination lease/);
+  assert.match(workflow, /Remove runner-local private material/);
+  assert.doesNotMatch(workflow, /wrangler secret put/);
+  assert.doesNotMatch(workflow, /INSERT INTO bm_campaigns/);
+  assert.doesNotMatch(workflow, /UPDATE bm_invites/);
+});
+
+test("all embedded bash blocks parse before the workflow can mutate production", () => {
+  const lines = workflow.split(/\r?\n/);
+  let blocks = 0;
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!/^        run: \|$/.test(lines[index] ?? "")) continue;
+    const block = [];
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      const line = lines[cursor] ?? "";
+      if (line && !line.startsWith("          ")) break;
+      block.push(line.startsWith("          ") ? line.slice(10) : "");
+    }
+    const script = block.join("\n");
+    assert.notEqual(script.trim(), "", `run block ${blocks + 1} is empty`);
+    execFileSync("bash", ["-n"], { input: script, encoding: "utf8" });
+    blocks += 1;
+  }
+  assert.ok(blocks >= 7, `expected focused shell gates (found ${blocks})`);
+});

--- a/.github/scripts/beauty-movement-campaign-copy-contract.test.mjs
+++ b/.github/scripts/beauty-movement-campaign-copy-contract.test.mjs
@@ -10,14 +10,24 @@ const workflow = await readFile(
 
 test("campaign copy update is production-only, release-bound and narrowly scoped", () => {
   assert.match(workflow, /environment: production/);
+  assert.match(workflow, /staging_run_id:/);
+  assert.match(workflow, /unit: beauty-movement-campaign-copy-update/);
+  assert.match(workflow, /uses: \.\/\.github\/workflows\/promotion-gate\.yml/);
   assert.match(workflow, /PRODUCTION_D1_DATABASE: espacofacial-beauty-movement/);
   assert.match(workflow, /BEAUTY_MOVEMENT_PRODUCTION_CAMPAIGN_JSON/);
   assert.match(workflow, /beauty-movement:update-copy/);
   assert.match(workflow, /--dry-run/);
   assert.match(workflow, /--apply --remote/);
+  assert.match(workflow, /required: 'true'/);
   assert.match(workflow, /status !== 'active'/);
   assert.match(workflow, /ends_at_ms/);
+  assert.match(workflow, /updated_at_ms/);
+  assert.match(workflow, /revoked_invite_count/);
   assert.match(workflow, /invite_count/);
+  assert.match(workflow, /Revalidate Website production coordination lease immediately before D1 mutation/);
+  assert.match(workflow, /Verify updated copy through the live campaign API/);
+  assert.match(workflow, /Restore incumbent campaign copy after a failed post-write attestation/);
+  assert.match(workflow, /beauty_movement_campaign_copy_rollback_conflict/);
   assert.match(workflow, /Release Website production coordination lease/);
   assert.match(workflow, /Remove runner-local private material/);
   assert.doesNotMatch(workflow, /wrangler secret put/);

--- a/.github/scripts/beauty-movement-campaign-copy-contract.test.mjs
+++ b/.github/scripts/beauty-movement-campaign-copy-contract.test.mjs
@@ -25,7 +25,10 @@ test("campaign copy update is production-only, release-bound and narrowly scoped
   assert.match(workflow, /revoked_invite_count/);
   assert.match(workflow, /invite_count/);
   assert.match(workflow, /Revalidate Website production coordination lease immediately before D1 mutation/);
-  assert.match(workflow, /Verify updated copy through the live campaign API/);
+  assert.match(workflow, /Verify updated copy through the read-only live campaign API/);
+  assert.match(workflow, /campaign-copy/);
+  assert.match(workflow, /digest\('base64url'\)/);
+  assert.match(workflow, /Revalidate Website production coordination lease before copy rollback/);
   assert.match(workflow, /Restore incumbent campaign copy after a failed post-write attestation/);
   assert.match(workflow, /beauty_movement_campaign_copy_rollback_conflict/);
   assert.match(workflow, /Release Website production coordination lease/);

--- a/.github/scripts/beauty-movement-staging-smoke-contract.test.mjs
+++ b/.github/scripts/beauty-movement-staging-smoke-contract.test.mjs
@@ -17,6 +17,7 @@ test("staging smoke is pinned to the protected staging surface", () => {
     assert.match(workflow, /promotion_unit:/);
     assert.match(workflow, /default:\s*beauty-movement-production-activation/);
     assert.match(workflow, /promotion_unit is not allowed/);
+    assert.match(workflow, /beauty-movement-campaign-copy-update/);
     assert.doesNotMatch(workflow, /target_environment|production_d1|--env production|espacofacial-beauty-movement(?:"|\\')/i);
 });
 
@@ -47,6 +48,11 @@ test("smoke consumes secrets in-process and closes the staging gate", () => {
     assert.match(workflow, /invite_status = 'revoked'/);
     assert.match(workflow, /status = 'disabled'/);
     assert.match(workflow, /rollback/);
+    assert.match(workflow, /beauty-movement:update-copy/);
+    assert.match(workflow, /--apply --remote --restore/);
+    assert.match(workflow, /Recheck staging D1 lease before synthetic copy restore/);
+    assert.match(workflow, /copyUpdated/);
+    assert.match(workflow, /copyRestored/);
     const browserModule = workflow.match(/SMOKE_INVITE_TOKEN="\$\{token\}" node --input-type=module <<'NODE'[\s\S]*?\n          NODE/)?.[0] ?? "";
     assert.match(browserModule, /import fs from ['"]node:fs['"]/);
     assert.match(browserModule, /import \{ chromium \} from ['"]playwright['"]/);

--- a/.github/scripts/beauty-movement-staging-smoke-contract.test.mjs
+++ b/.github/scripts/beauty-movement-staging-smoke-contract.test.mjs
@@ -14,6 +14,9 @@ test("staging smoke is pinned to the protected staging surface", () => {
     assert.match(workflow, /STAGING_D1_DATABASE:\s*espacofacial-beauty-movement-staging/);
     assert.match(workflow, /STAGING_WORKER_NAME:\s*espacofacial-site-staging/);
     assert.match(workflow, /release_sha:/);
+    assert.match(workflow, /promotion_unit:/);
+    assert.match(workflow, /default:\s*beauty-movement-production-activation/);
+    assert.match(workflow, /promotion_unit is not allowed/);
     assert.doesNotMatch(workflow, /target_environment|production_d1|--env production|espacofacial-beauty-movement(?:"|\\')/i);
 });
 
@@ -27,7 +30,7 @@ test("smoke consumes secrets in-process and closes the staging gate", () => {
     assert.match(workflow, /node --input-type=commonjs -e/);
     assert.doesNotMatch(workflow, /node -e\s/);
     assert.doesNotMatch(workflow, /set -x/);
-    assert.match(workflow, /promotion-evidence-beauty-movement-production-activation/);
+    assert.match(workflow, /name: promotion-evidence-\$\{\{ inputs\.promotion_unit \}\}/);
     assert.match(workflow, /actions\/upload-artifact/);
     assert.match(workflow, /staging-smoke-disabled-probe/);
     assert.match(workflow, /beauty_movement_delivery_ref_invalid/);

--- a/.github/scripts/promotion-evidence.mjs
+++ b/.github/scripts/promotion-evidence.mjs
@@ -22,6 +22,7 @@ const releaseSurfacesByUnit = {
   "meta-ads-report": ["runtime"],
   "public-website-release": ["website"],
   "beauty-movement-production-activation": ["website"],
+  "beauty-movement-campaign-copy-update": ["website"],
   // Atendimento is promoted as an isolated native CRM runtime.  Its release
   // identity spans the CRM/API source, native runtime custody and the
   // main-custodied workflow validators; keeping all three inputs in the

--- a/.github/scripts/promotion-evidence.test.mjs
+++ b/.github/scripts/promotion-evidence.test.mjs
@@ -26,6 +26,25 @@ test("maps Atendimento to its isolated runtime release surfaces", () => {
   assert.match(digest, /^[0-9a-f]{64}$/);
 });
 
+test("maps the Beauty Movement copy update to the website release surface", () => {
+  const env = { ...process.env };
+  delete env.PROMOTION_RELEASE_INPUT_DIGEST;
+  const digest = execFileSync(process.execPath, [
+    ".github/scripts/promotion-evidence.mjs",
+    "digest",
+  ], {
+    cwd: root,
+    env: {
+      ...env,
+      PROMOTION_UNIT: "beauty-movement-campaign-copy-update",
+      PROMOTION_SOURCE_SHA: "HEAD",
+    },
+    encoding: "utf8",
+  }).trim();
+
+  assert.match(digest, /^[0-9a-f]{64}$/);
+});
+
 test("writes and verifies a tamper-evident immutable release identity", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "skincos-promotion-evidence-"));
   const evidencePath = path.join(directory, "promotion-evidence.json");

--- a/.github/workflows/beauty-movement-campaign-copy-update.yml
+++ b/.github/workflows/beauty-movement-campaign-copy-update.yml
@@ -259,7 +259,7 @@ jobs:
           console.log(JSON.stringify({ copyUpdated: true, inviteCount: Number(after.invite_count), activeInviteCount: Number(after.active_invite_count), revokedInviteCount: Number(after.revoked_invite_count), descriptionLength: expected.description.length }));
           NODE
 
-      - name: Verify updated copy through the live campaign API
+      - name: Verify updated copy through the read-only live campaign API
         env:
           BEAUTY_MOVEMENT_TOKEN_HMAC_KEY: ${{ secrets.BEAUTY_MOVEMENT_TOKEN_HMAC_KEY }}
         shell: bash
@@ -274,15 +274,15 @@ jobs:
           const secret = String(process.env.BEAUTY_MOVEMENT_TOKEN_HMAC_KEY ?? '').trim();
           const inviteRef = typeof pre?.probe_external_ref === 'string' ? pre.probe_external_ref : '';
           if (!secret || !inviteRef || typeof expected?.description !== 'string' || !expected.description) throw new Error('beauty_movement_live_copy_probe_input_invalid');
-          const token = crypto.createHmac('sha256', secret).update(`v1|beauty-movement|delivery|${campaignId}|${inviteRef}`, 'utf8').digest('hex');
-          const response = await fetch(`${productionUrl}/api/beleza-em-movimento/session`, {
+          const token = crypto.createHmac('sha256', secret).update(`v1|beauty-movement|delivery|${campaignId}|${inviteRef}`, 'utf8').digest('base64url');
+          const response = await fetch(`${productionUrl}/api/beleza-em-movimento/campaign-copy`, {
             method: 'POST',
             headers: { 'content-type': 'application/json', origin: productionUrl },
             body: JSON.stringify({ token }),
           });
           let payload = null;
           try { payload = await response.json(); } catch { payload = null; }
-          if (response.status !== 200 || payload?.ok !== true || payload?.state?.campaign?.description !== expected.description) throw new Error('beauty_movement_live_copy_probe_mismatch');
+          if (response.status !== 200 || payload?.ok !== true || payload?.campaign?.description !== expected.description) throw new Error('beauty_movement_live_copy_probe_mismatch');
           fs.writeFileSync(outputFile, `${JSON.stringify({ liveCopyVerified: true, httpStatus: response.status, descriptionLength: expected.description.length })}\n`, { encoding: 'utf8', mode: 0o600 });
           console.log(JSON.stringify({ liveCopyVerified: true, httpStatus: response.status, descriptionLength: expected.description.length }));
           NODE
@@ -318,6 +318,20 @@ jobs:
             throw new Error('beauty_movement_campaign_copy_rollback_conflict');
           }
           NODE
+
+      - name: Revalidate Website production coordination lease before copy rollback
+        if: ${{ failure() }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website.json
+          resource: release:website
+          module: website
+          source_sha: ${{ env.RELEASE_SHA }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
 
       - name: Restore incumbent campaign copy after a failed post-write attestation
         if: ${{ failure() }}

--- a/.github/workflows/beauty-movement-campaign-copy-update.yml
+++ b/.github/workflows/beauty-movement-campaign-copy-update.yml
@@ -15,6 +15,10 @@ on:
         description: Existing campaign expiry in ISO-8601
         required: true
         type: string
+      staging_run_id:
+        description: Successful Beauty Movement staging smoke run for this exact release SHA
+        required: true
+        type: string
 
 concurrency:
   group: beauty-movement-campaign-copy-update-${{ inputs.campaign_id }}
@@ -54,9 +58,19 @@ jobs:
       - name: Validate this production workflow contract
         run: node --test .github/scripts/beauty-movement-campaign-copy-contract.test.mjs
 
+  promotion:
+    name: Require exact staging validation for this release
+    uses: ./.github/workflows/promotion-gate.yml
+    with:
+      unit: beauty-movement-campaign-copy-update
+      target: production
+      release_sha: ${{ inputs.release_sha }}
+      staging_run_id: ${{ inputs.staging_run_id }}
+      staging_supported: true
+
   update:
     name: Update active campaign copy and attest invite preservation
-    needs: contract
+    needs: [contract, promotion]
     runs-on: ubuntu-latest
     environment: production
     timeout-minutes: 30
@@ -64,7 +78,7 @@ jobs:
       actions: read
       contents: read
     env:
-      RELEASE_SHA: ${{ inputs.release_sha }}
+      RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
       CAMPAIGN_ID: ${{ inputs.campaign_id }}
       CAMPAIGN_ENDS_AT: ${{ inputs.campaign_ends_at }}
       WORKFLOW_SHA: ${{ github.sha }}
@@ -92,14 +106,14 @@ jobs:
       - name: Acquire Website production coordination lease
         uses: ./.github/actions/global-coordination-acquire
         with:
-          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          required: 'true'
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
           key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
           resource: release:website
           module: website
-          source_sha: ${{ github.sha }}
+          source_sha: ${{ env.RELEASE_SHA }}
           proof_file: ${{ runner.temp }}/skincos-global-coordination-website.json
 
       - name: Guard source, campaign and private runtime scope
@@ -123,8 +137,14 @@ jobs:
             echo "OUTPUT_DIR=${root}/output"
             echo "PREFLIGHT_SUMMARY=${root}/preflight-summary.json"
             echo "APPLY_SUMMARY=${root}/apply-summary.json"
+            echo "APPLY_OUTPUT=${root}/apply-output.json"
             echo "PRE_READBACK=${root}/pre-readback.json"
             echo "POST_READBACK=${root}/post-readback.json"
+            echo "EXPECTED_DESCRIPTION=${root}/expected-description.json"
+            echo "LIVE_COPY_PROBE=${root}/live-copy-probe.json"
+            echo "ROLLBACK_CURRENT=${root}/rollback-current.json"
+            echo "ROLLBACK_PLAN=${root}/rollback-plan.json"
+            echo "ROLLBACK_READBACK=${root}/rollback-readback.json"
           } >> "${GITHUB_ENV}"
 
       - name: Materialize protected campaign copy
@@ -161,7 +181,8 @@ jobs:
             --campaign "${CAMPAIGN_ID}" \
             --confirm-campaign "${CAMPAIGN_ID}" \
             --campaign-ends-at "${CAMPAIGN_ENDS_AT}" \
-            --campaign-config "${CAMPAIGN_CONFIG}" > "${PREFLIGHT_SUMMARY}"
+            --campaign-config "${CAMPAIGN_CONFIG}" \
+            --normalized-description-out "${EXPECTED_DESCRIPTION}" > "${PREFLIGHT_SUMMARY}"
 
       - name: Confirm the target campaign and invite set before update
         working-directory: website
@@ -171,16 +192,29 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          query="SELECT id,status,ends_at_ms,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}') AS invite_count,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}' AND invite_status='active') AS active_invite_count FROM bm_campaigns WHERE id='${CAMPAIGN_ID}';"
+          query="SELECT id,status,ends_at_ms,description,updated_at_ms,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}') AS invite_count,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}' AND invite_status='active') AS active_invite_count,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}' AND invite_status='revoked') AS revoked_invite_count,(SELECT external_ref FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}' AND invite_status='active' AND expires_at_ms > (CAST(strftime('%s','now') AS INTEGER) * 1000) ORDER BY updated_at_ms DESC LIMIT 1) AS probe_external_ref FROM bm_campaigns WHERE id='${CAMPAIGN_ID}';"
           npx --yes wrangler@4.112.0 d1 execute "${PRODUCTION_D1_DATABASE}" --remote --config wrangler.toml --command "${query}" --json > "${PRE_READBACK}"
           node - "${PRE_READBACK}" "${CAMPAIGN_ID}" "${CAMPAIGN_ENDS_AT}" <<'NODE'
           const fs = require('node:fs');
           const [file, expectedId, expectedEnds] = process.argv.slice(2);
           const row = JSON.parse(fs.readFileSync(file, 'utf8'))?.[0]?.results?.[0];
-          if (!row || row.id !== expectedId || row.status !== 'active' || Number(row.ends_at_ms) !== Date.parse(expectedEnds) || Number(row.ends_at_ms) <= Date.now()) throw new Error('beauty_movement_active_campaign_preflight_invalid');
-          if (Number(row.invite_count) < 1 || Number(row.invite_count) !== Number(row.active_invite_count)) throw new Error('beauty_movement_active_campaign_invites_invalid');
-          console.log(JSON.stringify({ status: row.status, inviteCount: Number(row.invite_count), activeInviteCount: Number(row.active_invite_count) }));
+          if (!row || row.id !== expectedId || row.status !== 'active' || Number(row.ends_at_ms) !== Date.parse(expectedEnds) || Number(row.ends_at_ms) <= Date.now() || typeof row.description !== 'string' || !Number.isSafeInteger(Number(row.updated_at_ms)) || Number(row.updated_at_ms) <= 0 || typeof row.probe_external_ref !== 'string' || !row.probe_external_ref) throw new Error('beauty_movement_active_campaign_preflight_invalid');
+          if (Number(row.invite_count) < 1 || Number(row.invite_count) !== Number(row.active_invite_count) + Number(row.revoked_invite_count)) throw new Error('beauty_movement_active_campaign_invites_invalid');
+          console.log(JSON.stringify({ status: row.status, inviteCount: Number(row.invite_count), activeInviteCount: Number(row.active_invite_count), revokedInviteCount: Number(row.revoked_invite_count) }));
           NODE
+
+      - name: Revalidate Website production coordination lease immediately before D1 mutation
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website.json
+          resource: release:website
+          module: website
+          source_sha: ${{ env.RELEASE_SHA }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
 
       - name: Update only the active campaign description
         working-directory: website
@@ -198,9 +232,11 @@ jobs:
             --confirm-campaign "${CAMPAIGN_ID}" \
             --campaign-ends-at "${CAMPAIGN_ENDS_AT}" \
             --campaign-config "${CAMPAIGN_CONFIG}" \
+            --expected-state "${PRE_READBACK}" \
+            --apply-summary "${APPLY_SUMMARY}" \
             --database "${PRODUCTION_D1_DATABASE}" \
             --config wrangler.toml \
-            --out-dir "${OUTPUT_DIR}" > "${APPLY_SUMMARY}"
+            --out-dir "${OUTPUT_DIR}" > "${APPLY_OUTPUT}"
 
       - name: Read back copy and attest invite preservation
         working-directory: website
@@ -210,18 +246,127 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          query="SELECT id,status,ends_at_ms,description,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}') AS invite_count,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}' AND invite_status='active') AS active_invite_count FROM bm_campaigns WHERE id='${CAMPAIGN_ID}';"
+          query="SELECT id,status,ends_at_ms,description,updated_at_ms,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}') AS invite_count,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}' AND invite_status='active') AS active_invite_count,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}' AND invite_status='revoked') AS revoked_invite_count FROM bm_campaigns WHERE id='${CAMPAIGN_ID}';"
           npx --yes wrangler@4.112.0 d1 execute "${PRODUCTION_D1_DATABASE}" --remote --config wrangler.toml --command "${query}" --json > "${POST_READBACK}"
-          node - "${PRE_READBACK}" "${POST_READBACK}" "${CAMPAIGN_CONFIG}" "${CAMPAIGN_ID}" "${CAMPAIGN_ENDS_AT}" <<'NODE'
+          node - "${PRE_READBACK}" "${POST_READBACK}" "${EXPECTED_DESCRIPTION}" "${CAMPAIGN_ID}" "${CAMPAIGN_ENDS_AT}" <<'NODE'
           const fs = require('node:fs');
-          const [beforeFile, afterFile, configFile, expectedId, expectedEnds] = process.argv.slice(2);
+          const [beforeFile, afterFile, expectedFile, expectedId, expectedEnds] = process.argv.slice(2);
           const before = JSON.parse(fs.readFileSync(beforeFile, 'utf8'))?.[0]?.results?.[0];
           const after = JSON.parse(fs.readFileSync(afterFile, 'utf8'))?.[0]?.results?.[0];
-          const config = JSON.parse(fs.readFileSync(configFile, 'utf8'));
-          if (!after || after.id !== expectedId || after.status !== 'active' || Number(after.ends_at_ms) !== Date.parse(expectedEnds)) throw new Error('beauty_movement_campaign_copy_readback_invalid');
-          if (after.description !== config.description) throw new Error('beauty_movement_campaign_description_readback_mismatch');
-          if (!before || Number(before.invite_count) !== Number(after.invite_count) || Number(before.active_invite_count) !== Number(after.active_invite_count)) throw new Error('beauty_movement_campaign_invites_changed');
-          console.log(JSON.stringify({ copyUpdated: true, inviteCount: Number(after.invite_count), activeInviteCount: Number(after.active_invite_count), descriptionLength: config.description.length }));
+          const expected = JSON.parse(fs.readFileSync(expectedFile, 'utf8'));
+          if (!after || after.id !== expectedId || after.status !== 'active' || Number(after.ends_at_ms) !== Date.parse(expectedEnds) || Number(after.ends_at_ms) <= Date.now() || after.description !== expected.description || !Number.isSafeInteger(Number(after.updated_at_ms)) || Number(after.updated_at_ms) <= 0) throw new Error('beauty_movement_campaign_copy_readback_invalid');
+          if (!before || Number(before.invite_count) !== Number(after.invite_count) || Number(before.active_invite_count) !== Number(after.active_invite_count) || Number(before.revoked_invite_count) !== Number(after.revoked_invite_count) || Number(after.invite_count) !== Number(after.active_invite_count) + Number(after.revoked_invite_count)) throw new Error('beauty_movement_campaign_invites_changed');
+          console.log(JSON.stringify({ copyUpdated: true, inviteCount: Number(after.invite_count), activeInviteCount: Number(after.active_invite_count), revokedInviteCount: Number(after.revoked_invite_count), descriptionLength: expected.description.length }));
+          NODE
+
+      - name: Verify updated copy through the live campaign API
+        env:
+          BEAUTY_MOVEMENT_TOKEN_HMAC_KEY: ${{ secrets.BEAUTY_MOVEMENT_TOKEN_HMAC_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node - "${PRE_READBACK}" "${EXPECTED_DESCRIPTION}" "${LIVE_COPY_PROBE}" "${CAMPAIGN_ID}" "${PRODUCTION_URL}" <<'NODE'
+          const crypto = require('node:crypto');
+          const fs = require('node:fs');
+          const [preFile, expectedFile, outputFile, campaignId, productionUrl] = process.argv.slice(2);
+          const pre = JSON.parse(fs.readFileSync(preFile, 'utf8'))?.[0]?.results?.[0];
+          const expected = JSON.parse(fs.readFileSync(expectedFile, 'utf8'));
+          const secret = String(process.env.BEAUTY_MOVEMENT_TOKEN_HMAC_KEY ?? '').trim();
+          const inviteRef = typeof pre?.probe_external_ref === 'string' ? pre.probe_external_ref : '';
+          if (!secret || !inviteRef || typeof expected?.description !== 'string' || !expected.description) throw new Error('beauty_movement_live_copy_probe_input_invalid');
+          const token = crypto.createHmac('sha256', secret).update(`v1|beauty-movement|delivery|${campaignId}|${inviteRef}`, 'utf8').digest('hex');
+          const response = await fetch(`${productionUrl}/api/beleza-em-movimento/session`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json', origin: productionUrl },
+            body: JSON.stringify({ token }),
+          });
+          let payload = null;
+          try { payload = await response.json(); } catch { payload = null; }
+          if (response.status !== 200 || payload?.ok !== true || payload?.state?.campaign?.description !== expected.description) throw new Error('beauty_movement_live_copy_probe_mismatch');
+          fs.writeFileSync(outputFile, `${JSON.stringify({ liveCopyVerified: true, httpStatus: response.status, descriptionLength: expected.description.length })}\n`, { encoding: 'utf8', mode: 0o600 });
+          console.log(JSON.stringify({ liveCopyVerified: true, httpStatus: response.status, descriptionLength: expected.description.length }));
+          NODE
+
+      - name: Prepare rollback plan if the protected update did not complete cleanly
+        if: ${{ failure() }}
+        working-directory: website
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! -s "${APPLY_SUMMARY}" ]]; then
+            printf '%s\n' '{"restore":false,"reason":"no_copy_mutation_completed"}' > "${ROLLBACK_PLAN}"
+            exit 0
+          fi
+          query="SELECT id,status,ends_at_ms,description,updated_at_ms,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}') AS invite_count,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}' AND invite_status='active') AS active_invite_count,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}' AND invite_status='revoked') AS revoked_invite_count FROM bm_campaigns WHERE id='${CAMPAIGN_ID}';"
+          npx --yes wrangler@4.112.0 d1 execute "${PRODUCTION_D1_DATABASE}" --remote --config wrangler.toml --command "${query}" --json > "${ROLLBACK_CURRENT}"
+          node - "${PRE_READBACK}" "${ROLLBACK_CURRENT}" "${EXPECTED_DESCRIPTION}" "${APPLY_SUMMARY}" "${ROLLBACK_PLAN}" <<'NODE'
+          const fs = require('node:fs');
+          const [beforeFile, currentFile, expectedFile, summaryFile, planFile] = process.argv.slice(2);
+          const before = JSON.parse(fs.readFileSync(beforeFile, 'utf8'))?.[0]?.results?.[0];
+          const current = JSON.parse(fs.readFileSync(currentFile, 'utf8'))?.[0]?.results?.[0];
+          const expected = JSON.parse(fs.readFileSync(expectedFile, 'utf8'));
+          const summary = JSON.parse(fs.readFileSync(summaryFile, 'utf8'));
+          const sameState = (left, right) => left?.description === right?.description && Number(left?.updated_at_ms) === Number(right?.updated_at_ms);
+          if (sameState(current, before)) {
+            fs.writeFileSync(planFile, `${JSON.stringify({ restore: false, reason: 'incumbent_still_present' })}\n`, { encoding: 'utf8', mode: 0o600 });
+          } else if (current?.description === expected.description && Number(current?.updated_at_ms) === Number(summary.updatedAtMs)) {
+            fs.writeFileSync(planFile, `${JSON.stringify({ restore: true })}\n`, { encoding: 'utf8', mode: 0o600 });
+          } else {
+            throw new Error('beauty_movement_campaign_copy_rollback_conflict');
+          }
+          NODE
+
+      - name: Restore incumbent campaign copy after a failed post-write attestation
+        if: ${{ failure() }}
+        working-directory: website
+        env:
+          BEAUTY_MOVEMENT_PRIVATE_RUNTIME_ROOT: ${{ runner.temp }}/beauty-movement-campaign-copy-update
+          GITHUB_ACTIONS: "true"
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          restore="$(node -e 'const fs=require("node:fs"); const value=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(value.restore === true ? "true" : "false");' "${ROLLBACK_PLAN}")"
+          if [[ "${restore}" != true ]]; then
+            exit 0
+          fi
+          npm run --silent beauty-movement:update-copy -- \
+            --apply --remote --restore \
+            --campaign "${CAMPAIGN_ID}" \
+            --confirm-campaign "${CAMPAIGN_ID}" \
+            --campaign-ends-at "${CAMPAIGN_ENDS_AT}" \
+            --campaign-config "${CAMPAIGN_CONFIG}" \
+            --expected-state "${PRE_READBACK}" \
+            --apply-summary "${APPLY_SUMMARY}" \
+            --database "${PRODUCTION_D1_DATABASE}" \
+            --config wrangler.toml \
+            --out-dir "${OUTPUT_DIR}" > "${COPY_ROOT}/rollback-summary.json"
+
+      - name: Verify incumbent campaign copy was restored
+        if: ${{ failure() }}
+        working-directory: website
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          restore="$(node -e 'const fs=require("node:fs"); const value=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(value.restore === true ? "true" : "false");' "${ROLLBACK_PLAN}")"
+          if [[ "${restore}" != true ]]; then
+            exit 0
+          fi
+          query="SELECT id,status,ends_at_ms,description,updated_at_ms,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}') AS invite_count,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}' AND invite_status='active') AS active_invite_count,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}' AND invite_status='revoked') AS revoked_invite_count FROM bm_campaigns WHERE id='${CAMPAIGN_ID}';"
+          npx --yes wrangler@4.112.0 d1 execute "${PRODUCTION_D1_DATABASE}" --remote --config wrangler.toml --command "${query}" --json > "${ROLLBACK_READBACK}"
+          node - "${PRE_READBACK}" "${ROLLBACK_READBACK}" <<'NODE'
+          const fs = require('node:fs');
+          const before = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'))?.[0]?.results?.[0];
+          const after = JSON.parse(fs.readFileSync(process.argv[3], 'utf8'))?.[0]?.results?.[0];
+          if (!after || after.description !== before.description || Number(after.invite_count) !== Number(before.invite_count) || Number(after.active_invite_count) !== Number(before.active_invite_count) || Number(after.revoked_invite_count) !== Number(before.revoked_invite_count)) throw new Error('beauty_movement_campaign_copy_rollback_readback_invalid');
+          console.log(JSON.stringify({ rollbackVerified: true, inviteCount: Number(after.invite_count), activeInviteCount: Number(after.active_invite_count), revokedInviteCount: Number(after.revoked_invite_count) }));
           NODE
 
       - name: Remove runner-local private material
@@ -233,7 +378,7 @@ jobs:
         if: ${{ always() }}
         uses: ./.github/actions/global-coordination-release
         with:
-          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          required: 'true'
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
           shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
           key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}

--- a/.github/workflows/beauty-movement-campaign-copy-update.yml
+++ b/.github/workflows/beauty-movement-campaign-copy-update.yml
@@ -1,0 +1,240 @@
+name: Beauty Movement update active campaign copy
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Exact website SHA currently serving the active campaign
+        required: true
+        type: string
+      campaign_id:
+        description: Existing active production campaign to update
+        required: true
+        type: string
+      campaign_ends_at:
+        description: Existing campaign expiry in ISO-8601
+        required: true
+        type: string
+
+concurrency:
+  group: beauty-movement-campaign-copy-update-${{ inputs.campaign_id }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  contract:
+    name: Validate active-copy update contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Set up Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22.12.0
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install exact website dependencies
+        working-directory: website
+        run: npm ci
+
+      - name: Validate copy update helper with synthetic copy only
+        working-directory: website
+        run: node --experimental-test-module-mocks --import tsx --test tests/beautyMovementCampaignCopy.test.ts
+
+      - name: Validate this production workflow contract
+        run: node --test .github/scripts/beauty-movement-campaign-copy-contract.test.mjs
+
+  update:
+    name: Update active campaign copy and attest invite preservation
+    needs: contract
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+    env:
+      RELEASE_SHA: ${{ inputs.release_sha }}
+      CAMPAIGN_ID: ${{ inputs.campaign_id }}
+      CAMPAIGN_ENDS_AT: ${{ inputs.campaign_ends_at }}
+      WORKFLOW_SHA: ${{ github.sha }}
+      PRODUCTION_URL: https://espacofacial.com
+      PRODUCTION_D1_DATABASE: espacofacial-beauty-movement
+
+    steps:
+      - name: Checkout source and verify serving logic
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22.12.0
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install exact website dependencies
+        working-directory: website
+        run: npm ci
+
+      - name: Acquire Website production coordination lease
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          resource: release:website
+          module: website
+          source_sha: ${{ github.sha }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website.json
+
+      - name: Guard source, campaign and private runtime scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "${GITHUB_REPOSITORY}" == "jubenitogarcia/skincos" ]] || { echo 'unexpected repository'; exit 1; }
+          [[ "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]] || { echo 'release_sha must be a full commit SHA'; exit 1; }
+          [[ "${WORKFLOW_SHA}" == "$(git rev-parse --verify HEAD)" ]] || { echo 'checked out SHA differs from workflow SHA'; exit 1; }
+          git cat-file -e "${RELEASE_SHA}:website/src/lib/beautyMovementImport.ts" || { echo 'release source does not contain campaign copy helper'; exit 1; }
+          git cat-file -e "${RELEASE_SHA}:website/src/app/BelezaEmMovimento/page.tsx" || { echo 'release source does not contain the canonical campaign route'; exit 1; }
+          git diff --quiet "${RELEASE_SHA}" -- website/src/lib/beautyMovementImport.ts website/src/lib/beautyMovementSecurity.ts website/src/lib/beautyMovementOutcomes.ts || { echo 'serving/token source differs from the requested release'; exit 1; }
+          [[ "${CAMPAIGN_ID}" =~ ^[a-z0-9][a-z0-9_-]{2,79}$ ]] || { echo 'campaign_id shape is invalid'; exit 1; }
+          [[ "${CAMPAIGN_ENDS_AT}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}(:[0-9]{2}(\.[0-9]{1,3})?)?(Z|[+-][0-9]{2}:[0-9]{2})$ ]] || { echo 'campaign_ends_at must be ISO-8601'; exit 1; }
+          [[ "${PRODUCTION_D1_DATABASE}" == "espacofacial-beauty-movement" ]] || { echo 'production D1 guard failed'; exit 1; }
+          root="${RUNNER_TEMP}/beauty-movement-campaign-copy-update"
+          mkdir -p "${root}/package" "${root}/output"
+          {
+            echo "COPY_ROOT=${root}"
+            echo "CAMPAIGN_CONFIG=${root}/package/campaign.json"
+            echo "OUTPUT_DIR=${root}/output"
+            echo "PREFLIGHT_SUMMARY=${root}/preflight-summary.json"
+            echo "APPLY_SUMMARY=${root}/apply-summary.json"
+            echo "PRE_READBACK=${root}/pre-readback.json"
+            echo "POST_READBACK=${root}/post-readback.json"
+          } >> "${GITHUB_ENV}"
+
+      - name: Materialize protected campaign copy
+        shell: bash
+        env:
+          PRODUCTION_CAMPAIGN_JSON: ${{ secrets.BEAUTY_MOVEMENT_PRODUCTION_CAMPAIGN_JSON }}
+        run: |
+          set -euo pipefail
+          umask 077
+          [[ -n "${PRODUCTION_CAMPAIGN_JSON}" ]] || { echo 'production campaign copy is unavailable'; exit 1; }
+          printf '%s' "${PRODUCTION_CAMPAIGN_JSON}" > "${CAMPAIGN_CONFIG}"
+          chmod 600 "${CAMPAIGN_CONFIG}"
+
+      - name: Prove the requested website release is live
+        shell: bash
+        run: |
+          set -euo pipefail
+          headers="${COPY_ROOT}/live-headers.txt"
+          status="$(curl -fsS -D "${headers}" -o /dev/null -w '%{http_code}' "${PRODUCTION_URL}/beleza-em-movimento")"
+          [[ "${status}" == "200" ]] || { echo 'production campaign route is not ready'; exit 1; }
+          live_sha="$(awk 'BEGIN{IGNORECASE=1} /^x-app-build:/ {gsub(/[\r ]/, "", $2); print tolower($2); exit}' "${headers}")"
+          [[ "${live_sha}" == "${RELEASE_SHA}" ]] || { echo 'live website build differs from requested release_sha'; exit 1; }
+
+      - name: Validate protected campaign copy without writing
+        working-directory: website
+        env:
+          BEAUTY_MOVEMENT_PRIVATE_RUNTIME_ROOT: ${{ runner.temp }}/beauty-movement-campaign-copy-update
+          GITHUB_ACTIONS: "true"
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run --silent beauty-movement:update-copy -- \
+            --dry-run \
+            --campaign "${CAMPAIGN_ID}" \
+            --confirm-campaign "${CAMPAIGN_ID}" \
+            --campaign-ends-at "${CAMPAIGN_ENDS_AT}" \
+            --campaign-config "${CAMPAIGN_CONFIG}" > "${PREFLIGHT_SUMMARY}"
+
+      - name: Confirm the target campaign and invite set before update
+        working-directory: website
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          query="SELECT id,status,ends_at_ms,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}') AS invite_count,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}' AND invite_status='active') AS active_invite_count FROM bm_campaigns WHERE id='${CAMPAIGN_ID}';"
+          npx --yes wrangler@4.112.0 d1 execute "${PRODUCTION_D1_DATABASE}" --remote --config wrangler.toml --command "${query}" --json > "${PRE_READBACK}"
+          node - "${PRE_READBACK}" "${CAMPAIGN_ID}" "${CAMPAIGN_ENDS_AT}" <<'NODE'
+          const fs = require('node:fs');
+          const [file, expectedId, expectedEnds] = process.argv.slice(2);
+          const row = JSON.parse(fs.readFileSync(file, 'utf8'))?.[0]?.results?.[0];
+          if (!row || row.id !== expectedId || row.status !== 'active' || Number(row.ends_at_ms) !== Date.parse(expectedEnds) || Number(row.ends_at_ms) <= Date.now()) throw new Error('beauty_movement_active_campaign_preflight_invalid');
+          if (Number(row.invite_count) < 1 || Number(row.invite_count) !== Number(row.active_invite_count)) throw new Error('beauty_movement_active_campaign_invites_invalid');
+          console.log(JSON.stringify({ status: row.status, inviteCount: Number(row.invite_count), activeInviteCount: Number(row.active_invite_count) }));
+          NODE
+
+      - name: Update only the active campaign description
+        working-directory: website
+        env:
+          BEAUTY_MOVEMENT_PRIVATE_RUNTIME_ROOT: ${{ runner.temp }}/beauty-movement-campaign-copy-update
+          GITHUB_ACTIONS: "true"
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run --silent beauty-movement:update-copy -- \
+            --apply --remote \
+            --campaign "${CAMPAIGN_ID}" \
+            --confirm-campaign "${CAMPAIGN_ID}" \
+            --campaign-ends-at "${CAMPAIGN_ENDS_AT}" \
+            --campaign-config "${CAMPAIGN_CONFIG}" \
+            --database "${PRODUCTION_D1_DATABASE}" \
+            --config wrangler.toml \
+            --out-dir "${OUTPUT_DIR}" > "${APPLY_SUMMARY}"
+
+      - name: Read back copy and attest invite preservation
+        working-directory: website
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          query="SELECT id,status,ends_at_ms,description,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}') AS invite_count,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}' AND invite_status='active') AS active_invite_count FROM bm_campaigns WHERE id='${CAMPAIGN_ID}';"
+          npx --yes wrangler@4.112.0 d1 execute "${PRODUCTION_D1_DATABASE}" --remote --config wrangler.toml --command "${query}" --json > "${POST_READBACK}"
+          node - "${PRE_READBACK}" "${POST_READBACK}" "${CAMPAIGN_CONFIG}" "${CAMPAIGN_ID}" "${CAMPAIGN_ENDS_AT}" <<'NODE'
+          const fs = require('node:fs');
+          const [beforeFile, afterFile, configFile, expectedId, expectedEnds] = process.argv.slice(2);
+          const before = JSON.parse(fs.readFileSync(beforeFile, 'utf8'))?.[0]?.results?.[0];
+          const after = JSON.parse(fs.readFileSync(afterFile, 'utf8'))?.[0]?.results?.[0];
+          const config = JSON.parse(fs.readFileSync(configFile, 'utf8'));
+          if (!after || after.id !== expectedId || after.status !== 'active' || Number(after.ends_at_ms) !== Date.parse(expectedEnds)) throw new Error('beauty_movement_campaign_copy_readback_invalid');
+          if (after.description !== config.description) throw new Error('beauty_movement_campaign_description_readback_mismatch');
+          if (!before || Number(before.invite_count) !== Number(after.invite_count) || Number(before.active_invite_count) !== Number(after.active_invite_count)) throw new Error('beauty_movement_campaign_invites_changed');
+          console.log(JSON.stringify({ copyUpdated: true, inviteCount: Number(after.invite_count), activeInviteCount: Number(after.active_invite_count), descriptionLength: config.description.length }));
+          NODE
+
+      - name: Remove runner-local private material
+        if: ${{ always() }}
+        shell: bash
+        run: rm -rf -- "${COPY_ROOT:-${RUNNER_TEMP}/beauty-movement-campaign-copy-update}"
+
+      - name: Release Website production coordination lease
+        if: ${{ always() }}
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          proof_file: ${{ runner.temp }}/skincos-global-coordination-website.json

--- a/.github/workflows/beauty-movement-staging-smoke.yml
+++ b/.github/workflows/beauty-movement-staging-smoke.yml
@@ -54,6 +54,12 @@ jobs:
             echo "STATE_FILE=${smoke_root}/state.json"
             echo "FIXTURE_DIR=${smoke_root}/fixture"
             echo "OUTPUT_DIR=${smoke_root}/output"
+            echo "COPY_PRE_READBACK=${smoke_root}/copy-pre-readback.json"
+            echo "COPY_POST_READBACK=${smoke_root}/copy-post-readback.json"
+            echo "COPY_RESTORE_READBACK=${smoke_root}/copy-restore-readback.json"
+            echo "COPY_EXPECTED_DESCRIPTION=${smoke_root}/copy-expected-description.json"
+            echo "COPY_APPLY_SUMMARY=${smoke_root}/copy-apply-summary.json"
+            echo "COPY_OUTPUT_DIR=${smoke_root}/copy-output"
           } >> "${GITHUB_ENV}"
 
       - name: Acquire Website staging coordination lease
@@ -292,6 +298,100 @@ jobs:
           if (!payload?.success || Number(payload.meta?.changes ?? 0) !== 1) throw new Error('beauty_movement_fixture_activation_failed');
           NODE
 
+      - name: Prepare synthetic active-campaign copy update
+        if: ${{ inputs.promotion_unit == 'beauty-movement-campaign-copy-update' }}
+        working-directory: website
+        env:
+          BEAUTY_MOVEMENT_PRIVATE_RUNTIME_ROOT: ${{ runner.temp }}/beauty-movement-staging-smoke
+          GITHUB_ACTIONS: 'true'
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+          mkdir -p "${COPY_OUTPUT_DIR}"
+          copy_config="${FIXTURE_DIR}/campaign-copy-update.json"
+          node - "${FIXTURE_DIR}/campaign.json" "${copy_config}" <<'NODE'
+          const fs = require('node:fs');
+          const [source, destination] = process.argv.slice(2);
+          const campaign = JSON.parse(fs.readFileSync(source, 'utf8'));
+          campaign.description = 'Fixture sintética atualizada para validar o fluxo de cópia.';
+          fs.writeFileSync(destination, `${JSON.stringify(campaign, null, 2)}\n`, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
+          NODE
+          query="SELECT id,status,ends_at_ms,description,updated_at_ms,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}') AS invite_count,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}' AND invite_status='active') AS active_invite_count,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}' AND invite_status='revoked') AS revoked_invite_count FROM bm_campaigns WHERE id='${CAMPAIGN_ID}';"
+          npx --yes wrangler@4.112.0 d1 execute "${STAGING_D1_DATABASE}" --remote --config wrangler.toml --env staging --command "${query}" --json > "${COPY_PRE_READBACK}"
+          node - "${COPY_PRE_READBACK}" "${CAMPAIGN_ID}" "$(cat "${FIXTURE_DIR}/ends-at.txt")" <<'NODE'
+          const fs = require('node:fs');
+          const [file, expectedId, expectedEnds] = process.argv.slice(2);
+          const row = JSON.parse(fs.readFileSync(file, 'utf8'))?.[0]?.results?.[0];
+          if (!row || row.id !== expectedId || row.status !== 'active' || Number(row.ends_at_ms) !== Date.parse(expectedEnds) || Number(row.ends_at_ms) <= Date.now() || typeof row.description !== 'string' || !Number.isSafeInteger(Number(row.updated_at_ms)) || Number(row.updated_at_ms) <= 0) throw new Error('beauty_movement_staging_copy_preflight_invalid');
+          if (Number(row.invite_count) !== Number(row.active_invite_count) + Number(row.revoked_invite_count)) throw new Error('beauty_movement_staging_copy_invites_invalid');
+          NODE
+          npm run --silent beauty-movement:update-copy -- \
+            --dry-run \
+            --campaign "${CAMPAIGN_ID}" \
+            --confirm-campaign "${CAMPAIGN_ID}" \
+            --campaign-ends-at "$(cat "${FIXTURE_DIR}/ends-at.txt")" \
+            --campaign-config "${copy_config}" \
+            --normalized-description-out "${COPY_EXPECTED_DESCRIPTION}" > "${COPY_OUTPUT_DIR}/dry-run.json"
+
+      - name: Recheck staging D1 lease before synthetic copy update
+        if: ${{ inputs.promotion_unit == 'beauty-movement-campaign-copy-update' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/beauty-movement-staging-smoke/d1-lease.json
+          resource: 'global:staging-d1'
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+
+      - name: Apply synthetic active-campaign copy update
+        if: ${{ inputs.promotion_unit == 'beauty-movement-campaign-copy-update' }}
+        working-directory: website
+        env:
+          BEAUTY_MOVEMENT_PRIVATE_RUNTIME_ROOT: ${{ runner.temp }}/beauty-movement-staging-smoke
+          GITHUB_ACTIONS: 'true'
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run --silent beauty-movement:update-copy -- \
+            --apply --remote \
+            --campaign "${CAMPAIGN_ID}" \
+            --confirm-campaign "${CAMPAIGN_ID}" \
+            --campaign-ends-at "$(cat "${FIXTURE_DIR}/ends-at.txt")" \
+            --campaign-config "${FIXTURE_DIR}/campaign-copy-update.json" \
+            --expected-state "${COPY_PRE_READBACK}" \
+            --apply-summary "${COPY_APPLY_SUMMARY}" \
+            --database "${STAGING_D1_DATABASE}" \
+            --config wrangler.toml \
+            --out-dir "${COPY_OUTPUT_DIR}" > "${COPY_OUTPUT_DIR}/apply.json"
+
+      - name: Verify synthetic active-campaign copy update
+        if: ${{ inputs.promotion_unit == 'beauty-movement-campaign-copy-update' }}
+        working-directory: website
+        shell: bash
+        run: |
+          set -euo pipefail
+          query="SELECT id,status,ends_at_ms,description,updated_at_ms,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}') AS invite_count,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}' AND invite_status='active') AS active_invite_count,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}' AND invite_status='revoked') AS revoked_invite_count FROM bm_campaigns WHERE id='${CAMPAIGN_ID}';"
+          npx --yes wrangler@4.112.0 d1 execute "${STAGING_D1_DATABASE}" --remote --config wrangler.toml --env staging --command "${query}" --json > "${COPY_POST_READBACK}"
+          node - "${COPY_PRE_READBACK}" "${COPY_POST_READBACK}" "${COPY_EXPECTED_DESCRIPTION}" "${CAMPAIGN_ID}" "$(cat "${FIXTURE_DIR}/ends-at.txt")" <<'NODE'
+          const fs = require('node:fs');
+          const [beforeFile, afterFile, expectedFile, expectedId, expectedEnds] = process.argv.slice(2);
+          const before = JSON.parse(fs.readFileSync(beforeFile, 'utf8'))?.[0]?.results?.[0];
+          const after = JSON.parse(fs.readFileSync(afterFile, 'utf8'))?.[0]?.results?.[0];
+          const expected = JSON.parse(fs.readFileSync(expectedFile, 'utf8'));
+          if (!before || !after || after.id !== expectedId || after.status !== 'active' || Number(after.ends_at_ms) !== Date.parse(expectedEnds) || Number(after.ends_at_ms) <= Date.now() || after.description !== expected.description || Number(after.updated_at_ms) <= Number(before.updated_at_ms)) throw new Error('beauty_movement_staging_copy_update_readback_invalid');
+          if (Number(before.invite_count) !== Number(after.invite_count) || Number(before.active_invite_count) !== Number(after.active_invite_count) || Number(before.revoked_invite_count) !== Number(after.revoked_invite_count)) throw new Error('beauty_movement_staging_copy_invites_changed');
+          console.log(JSON.stringify({ copyUpdated: true, descriptionLength: expected.description.length, inviteCount: Number(after.invite_count), activeInviteCount: Number(after.active_invite_count), revokedInviteCount: Number(after.revoked_invite_count) }));
+          NODE
+
       - name: Recheck Website staging lease before Worker deployment
         uses: ./.github/actions/global-coordination-check
         with:
@@ -521,6 +621,58 @@ jobs:
           const result = { browser: true, revealRequests, reloadStable: true, whatsappRequests: 0, consoleErrors: 0, outcomeVisible: true };
           fs.writeFileSync(`${process.env.RUNNER_TEMP}/beauty-movement-staging-smoke/browser.json`, `${JSON.stringify(result, null, 2)}\n`, { mode: 0o600 });
           await browser.close();
+          NODE
+
+      - name: Recheck staging D1 lease before synthetic copy restore
+        id: copyRestoreLease
+        if: ${{ always() && inputs.promotion_unit == 'beauty-movement-campaign-copy-update' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          proof_file: ${{ runner.temp }}/beauty-movement-staging-smoke/d1-lease.json
+          resource: 'global:staging-d1'
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+
+      - name: Restore synthetic campaign incumbent after copy-update smoke
+        if: ${{ always() && inputs.promotion_unit == 'beauty-movement-campaign-copy-update' && steps.copyRestoreLease.outcome == 'success' }}
+        working-directory: website
+        env:
+          BEAUTY_MOVEMENT_PRIVATE_RUNTIME_ROOT: ${{ runner.temp }}/beauty-movement-staging-smoke
+          GITHUB_ACTIONS: 'true'
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! -s "${COPY_APPLY_SUMMARY}" ]]; then
+            exit 0
+          fi
+          npm run --silent beauty-movement:update-copy -- \
+            --apply --remote --restore \
+            --campaign "${CAMPAIGN_ID}" \
+            --confirm-campaign "${CAMPAIGN_ID}" \
+            --campaign-ends-at "$(cat "${FIXTURE_DIR}/ends-at.txt")" \
+            --campaign-config "${FIXTURE_DIR}/campaign-copy-update.json" \
+            --expected-state "${COPY_PRE_READBACK}" \
+            --apply-summary "${COPY_APPLY_SUMMARY}" \
+            --database "${STAGING_D1_DATABASE}" \
+            --config wrangler.toml \
+            --out-dir "${COPY_OUTPUT_DIR}" > "${COPY_OUTPUT_DIR}/restore.json"
+          query="SELECT id,status,ends_at_ms,description,updated_at_ms,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}') AS invite_count,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}' AND invite_status='active') AS active_invite_count,(SELECT COUNT(*) FROM bm_invites WHERE campaign_id='${CAMPAIGN_ID}' AND invite_status='revoked') AS revoked_invite_count FROM bm_campaigns WHERE id='${CAMPAIGN_ID}';"
+          npx --yes wrangler@4.112.0 d1 execute "${STAGING_D1_DATABASE}" --remote --config wrangler.toml --env staging --command "${query}" --json > "${COPY_RESTORE_READBACK}"
+          node - "${COPY_PRE_READBACK}" "${COPY_RESTORE_READBACK}" "${CAMPAIGN_ID}" "$(cat "${FIXTURE_DIR}/ends-at.txt")" <<'NODE'
+          const fs = require('node:fs');
+          const [beforeFile, afterFile, expectedId, expectedEnds] = process.argv.slice(2);
+          const before = JSON.parse(fs.readFileSync(beforeFile, 'utf8'))?.[0]?.results?.[0];
+          const after = JSON.parse(fs.readFileSync(afterFile, 'utf8'))?.[0]?.results?.[0];
+          if (!before || !after || after.id !== expectedId || after.status !== 'active' || Number(after.ends_at_ms) !== Date.parse(expectedEnds) || after.description !== before.description || Number(after.updated_at_ms) <= Number(before.updated_at_ms)) throw new Error('beauty_movement_staging_copy_restore_invalid');
+          if (Number(before.invite_count) !== Number(after.invite_count) || Number(before.active_invite_count) !== Number(after.active_invite_count) || Number(before.revoked_invite_count) !== Number(after.revoked_invite_count)) throw new Error('beauty_movement_staging_copy_restore_invites_changed');
+          console.log(JSON.stringify({ copyRestored: true, descriptionLength: after.description.length, inviteCount: Number(after.invite_count), activeInviteCount: Number(after.active_invite_count), revokedInviteCount: Number(after.revoked_invite_count) }));
           NODE
 
       - name: Correlate persisted outcome without reading PII

--- a/.github/workflows/beauty-movement-staging-smoke.yml
+++ b/.github/workflows/beauty-movement-staging-smoke.yml
@@ -8,6 +8,11 @@ on:
         description: Immutable main SHA to deploy temporarily to staging
         required: true
         type: string
+      promotion_unit:
+        description: Promotion evidence unit consumed by the next protected gate
+        required: false
+        default: beauty-movement-production-activation
+        type: string
 
 concurrency:
   group: beauty-movement-staging-smoke
@@ -28,6 +33,7 @@ jobs:
       STAGING_D1_DATABASE: espacofacial-beauty-movement-staging
       STAGING_WORKER_NAME: espacofacial-site-staging
       RELEASE_SHA: ${{ inputs.release_sha }}
+      PROMOTION_UNIT: ${{ inputs.promotion_unit }}
       CAMPAIGN_ID: bm-stg-smoke-${{ github.run_id }}-${{ github.run_attempt }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -82,6 +88,7 @@ jobs:
           set -euo pipefail
           [[ "${GITHUB_REPOSITORY}" == "jubenitogarcia/skincos" ]] || { echo 'unexpected repository'; exit 1; }
           [[ "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]] || { echo 'release_sha must be a full commit SHA'; exit 1; }
+          [[ "${PROMOTION_UNIT}" =~ ^(beauty-movement-production-activation|beauty-movement-campaign-copy-update)$ ]] || { echo 'promotion_unit is not allowed'; exit 1; }
           git fetch --no-tags --depth=1 origin main
           if ! git merge-base --is-ancestor "${RELEASE_SHA}" origin/main && [[ "${RELEASE_SHA}" != "${GITHUB_SHA}" ]]; then
             echo 'release_sha must be an ancestor of main or the exact workflow revision'
@@ -628,7 +635,7 @@ jobs:
         if: ${{ success() }}
         shell: bash
         env:
-          PROMOTION_UNIT: beauty-movement-production-activation
+          PROMOTION_UNIT: ${{ inputs.promotion_unit }}
           PROMOTION_TARGET: staging
           PROMOTION_SOURCE_SHA: ${{ inputs.release_sha }}
           PROMOTION_EVIDENCE_FILE: ${{ runner.temp }}/beauty-movement-staging-smoke/promotion-evidence.json
@@ -646,7 +653,7 @@ jobs:
         if: ${{ success() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: promotion-evidence-beauty-movement-production-activation
+          name: promotion-evidence-${{ inputs.promotion_unit }}
           path: ${{ runner.temp }}/beauty-movement-staging-smoke/promotion-evidence.json
           retention-days: 14
           if-no-files-found: error

--- a/website/package.json
+++ b/website/package.json
@@ -17,6 +17,7 @@
     "smoke:strict": "SMOKE_REQUIRE_AGENDA=1 node scripts/smoke.mjs",
     "custom-urls:migrate:esfa": "tsx scripts/migrate-esfa-redirects.ts",
     "beauty-movement:import": "tsx scripts/beauty-movement-import.ts",
+    "beauty-movement:update-copy": "tsx scripts/beauty-movement-update-copy.ts",
     "beauty-movement:export-delivery": "tsx scripts/beauty-movement-delivery-export.ts",
     "beauty-movement:prepare-short-links": "tsx scripts/beauty-movement-short-links.ts",
     "beauty-movement:report": "tsx scripts/beauty-movement-report.ts",

--- a/website/scripts/beauty-movement-update-copy.ts
+++ b/website/scripts/beauty-movement-update-copy.ts
@@ -192,7 +192,7 @@ async function runD1Update(params: { database: string; config: string; sqlFile: 
     try {
         const result = await execFileAsync(
             "npx",
-            ["--yes", "wrangler@4.112.0", "d1", "execute", params.database, "--remote", "--config", params.config, "--file", params.sqlFile],
+            ["--yes", "wrangler@4.112.0", "d1", "execute", params.database, "--remote", "--config", params.config, "--file", params.sqlFile, "--json"],
             { cwd: WEBSITE_ROOT, maxBuffer: 2 * 1024 * 1024 },
         );
         const payload = JSON.parse(result.stdout)?.[0];

--- a/website/scripts/beauty-movement-update-copy.ts
+++ b/website/scripts/beauty-movement-update-copy.ts
@@ -1,0 +1,182 @@
+import { execFile } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import {
+    buildBeautyMovementCampaignDescriptionUpdateSql,
+    validateBeautyMovementCampaignConfig,
+} from "../src/lib/beautyMovementImport";
+
+const execFileAsync = promisify(execFile);
+const WEBSITE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const REPOSITORY_ROOT = path.resolve(WEBSITE_ROOT, "..");
+const PRIVATE_RUNTIME_ROOT = path.resolve("/mnt/c/CodexRuntime/operator/admin/skincos/beauty-movement");
+
+type ParsedArguments = {
+    apply: boolean;
+    dryRun: boolean;
+    remote: boolean;
+    campaign: string | null;
+    campaignConfig: string | null;
+    campaignEndsAt: string | null;
+    confirmCampaign: string | null;
+    outputDirectory: string | null;
+    database: string | null;
+    config: string;
+};
+
+function valueAfter(args: string[], flag: string): string | null {
+    const index = args.indexOf(flag);
+    if (index < 0) return null;
+    if (args.indexOf(flag, index + 1) >= 0) throw new Error(`beauty_movement_duplicate_${flag.slice(2)}`);
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`beauty_movement_missing_${flag.slice(2)}`);
+    return value;
+}
+
+function parseArguments(args: string[]): ParsedArguments {
+    const knownFlags = new Set([
+        "--apply",
+        "--dry-run",
+        "--remote",
+        "--campaign",
+        "--campaign-config",
+        "--campaign-ends-at",
+        "--confirm-campaign",
+        "--out-dir",
+        "--database",
+        "--config",
+    ]);
+    for (const arg of args) {
+        if (arg.startsWith("--") && !knownFlags.has(arg)) throw new Error("beauty_movement_unknown_argument");
+    }
+    const apply = args.includes("--apply");
+    const dryRun = args.includes("--dry-run");
+    if (apply === dryRun) throw new Error("beauty_movement_copy_mode_required");
+    if (args.includes("--remote") && !apply) throw new Error("beauty_movement_remote_apply_required");
+    return {
+        apply,
+        dryRun,
+        remote: args.includes("--remote"),
+        campaign: valueAfter(args, "--campaign"),
+        campaignConfig: valueAfter(args, "--campaign-config"),
+        campaignEndsAt: valueAfter(args, "--campaign-ends-at"),
+        confirmCampaign: valueAfter(args, "--confirm-campaign"),
+        outputDirectory: valueAfter(args, "--out-dir"),
+        database: valueAfter(args, "--database"),
+        config: valueAfter(args, "--config") ?? "wrangler.toml",
+    };
+}
+
+function isWithin(parent: string, child: string): boolean {
+    const relative = path.relative(parent, child);
+    return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
+}
+
+function privateRuntimeRoots(): readonly string[] {
+    const configuredRoot = process.env.BEAUTY_MOVEMENT_PRIVATE_RUNTIME_ROOT?.trim();
+    if (!configuredRoot) return [PRIVATE_RUNTIME_ROOT];
+    const runnerTemp = process.env.RUNNER_TEMP?.trim();
+    if (
+        process.env.GITHUB_ACTIONS !== "true" ||
+        !path.isAbsolute(configuredRoot) ||
+        !runnerTemp ||
+        !path.isAbsolute(runnerTemp) ||
+        !isWithin(path.resolve(runnerTemp), path.resolve(configuredRoot))
+    ) {
+        throw new Error("beauty_movement_private_runtime_root_invalid");
+    }
+    return [PRIVATE_RUNTIME_ROOT, path.resolve(configuredRoot)];
+}
+
+function privateAbsolutePath(value: string, purpose: "input" | "output"): string {
+    const windowsPath = /^([A-Za-z]):[\\/](.*)$/.exec(value);
+    const wslVisiblePath = windowsPath
+        ? `/mnt/${windowsPath[1]!.toLowerCase()}/${windowsPath[2]!.replace(/\\/g, "/")}`
+        : value;
+    if (!path.isAbsolute(wslVisiblePath)) throw new Error(`beauty_movement_${purpose}_must_be_absolute`);
+    const resolved = path.resolve(wslVisiblePath);
+    if (isWithin(REPOSITORY_ROOT, resolved) || !privateRuntimeRoots().some((root) => isWithin(root, resolved))) {
+        throw new Error(`beauty_movement_${purpose}_must_be_private`);
+    }
+    return resolved;
+}
+
+function parseCampaignEndsAt(value: string | null): number {
+    if (!value || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2})$/.test(value)) {
+        throw new Error("beauty_movement_invalid_campaign_ends_at");
+    }
+    const timestamp = Date.parse(value);
+    if (!Number.isFinite(timestamp)) throw new Error("beauty_movement_invalid_campaign_ends_at");
+    return timestamp;
+}
+
+async function readCampaignConfig(configPath: string) {
+    try {
+        return validateBeautyMovementCampaignConfig(JSON.parse(await readFile(configPath, "utf8")));
+    } catch (error) {
+        if (error instanceof Error && error.message === "beauty_movement_campaign_config_invalid") throw error;
+        throw new Error("beauty_movement_campaign_config_invalid");
+    }
+}
+
+async function runD1Update(params: { database: string; config: string; sqlFile: string }): Promise<void> {
+    try {
+        await execFileAsync(
+            "npx",
+            ["--yes", "wrangler@4.112.0", "d1", "execute", params.database, "--remote", "--config", params.config, "--file", params.sqlFile],
+            { cwd: WEBSITE_ROOT, maxBuffer: 2 * 1024 * 1024 },
+        );
+    } catch {
+        throw new Error("beauty_movement_campaign_copy_update_failed");
+    }
+}
+
+async function main(): Promise<void> {
+    const options = parseArguments(process.argv.slice(2));
+    if (!options.campaign || options.confirmCampaign !== options.campaign) {
+        throw new Error("beauty_movement_campaign_confirmation_required");
+    }
+    if (!options.campaignConfig) throw new Error("beauty_movement_campaign_config_required");
+    const campaignEndsAtMs = parseCampaignEndsAt(options.campaignEndsAt);
+    const campaignConfigPath = privateAbsolutePath(options.campaignConfig, "input");
+    const campaignConfig = await readCampaignConfig(campaignConfigPath);
+
+    if (options.dryRun) {
+        console.log(JSON.stringify({
+            mode: "dry_run",
+            preflight: "complete",
+            campaignId: options.campaign,
+            campaignEndsAtMs,
+            descriptionLength: campaignConfig.description.length,
+        }));
+        return;
+    }
+
+    if (!options.remote || !options.database || !/^[a-z0-9][a-z0-9-]{2,127}$/i.test(options.database)) {
+        throw new Error("beauty_movement_remote_database_required");
+    }
+    if (!options.outputDirectory) throw new Error("beauty_movement_private_output_required");
+    const outputDirectory = privateAbsolutePath(options.outputDirectory, "output");
+    await mkdir(outputDirectory, { recursive: true, mode: 0o700 });
+    const sqlFile = path.join(outputDirectory, `campaign-copy-${Date.now()}.sql`);
+    const sql = buildBeautyMovementCampaignDescriptionUpdateSql({
+        campaignId: options.campaign,
+        description: campaignConfig.description,
+        campaignEndsAtMs,
+    });
+    await writeFile(sqlFile, sql, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    await runD1Update({ database: options.database, config: options.config, sqlFile });
+    console.log(JSON.stringify({
+        mode: "applied",
+        target: "remote",
+        campaignId: options.campaign,
+        descriptionLength: campaignConfig.description.length,
+    }));
+}
+
+void main().catch((error) => {
+    console.error(error instanceof Error ? error.message : "beauty_movement_campaign_copy_update_failed");
+    process.exitCode = 1;
+});

--- a/website/scripts/beauty-movement-update-copy.ts
+++ b/website/scripts/beauty-movement-update-copy.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import {
     buildBeautyMovementCampaignDescriptionUpdateSql,
+    normalizeBeautyMovementCampaignDescription,
     validateBeautyMovementCampaignConfig,
 } from "../src/lib/beautyMovementImport";
 
@@ -17,10 +18,14 @@ type ParsedArguments = {
     apply: boolean;
     dryRun: boolean;
     remote: boolean;
+    restore: boolean;
     campaign: string | null;
     campaignConfig: string | null;
     campaignEndsAt: string | null;
     confirmCampaign: string | null;
+    expectedState: string | null;
+    applySummary: string | null;
+    normalizedDescriptionOutput: string | null;
     outputDirectory: string | null;
     database: string | null;
     config: string;
@@ -40,10 +45,14 @@ function parseArguments(args: string[]): ParsedArguments {
         "--apply",
         "--dry-run",
         "--remote",
+        "--restore",
         "--campaign",
         "--campaign-config",
         "--campaign-ends-at",
         "--confirm-campaign",
+        "--expected-state",
+        "--apply-summary",
+        "--normalized-description-out",
         "--out-dir",
         "--database",
         "--config",
@@ -55,14 +64,19 @@ function parseArguments(args: string[]): ParsedArguments {
     const dryRun = args.includes("--dry-run");
     if (apply === dryRun) throw new Error("beauty_movement_copy_mode_required");
     if (args.includes("--remote") && !apply) throw new Error("beauty_movement_remote_apply_required");
+    if (args.includes("--restore") && !apply) throw new Error("beauty_movement_restore_apply_required");
     return {
         apply,
         dryRun,
         remote: args.includes("--remote"),
+        restore: args.includes("--restore"),
         campaign: valueAfter(args, "--campaign"),
         campaignConfig: valueAfter(args, "--campaign-config"),
         campaignEndsAt: valueAfter(args, "--campaign-ends-at"),
         confirmCampaign: valueAfter(args, "--confirm-campaign"),
+        expectedState: valueAfter(args, "--expected-state"),
+        applySummary: valueAfter(args, "--apply-summary"),
+        normalizedDescriptionOutput: valueAfter(args, "--normalized-description-out"),
         outputDirectory: valueAfter(args, "--out-dir"),
         database: valueAfter(args, "--database"),
         config: valueAfter(args, "--config") ?? "wrangler.toml",
@@ -121,13 +135,70 @@ async function readCampaignConfig(configPath: string) {
     }
 }
 
-async function runD1Update(params: { database: string; config: string; sqlFile: string }): Promise<void> {
+type CampaignState = {
+    id: string;
+    status: string;
+    endsAtMs: number;
+    description: string;
+    updatedAtMs: number;
+};
+
+function d1RowFromFile(fileContents: string): Record<string, unknown> {
     try {
-        await execFileAsync(
+        const row = JSON.parse(fileContents)?.[0]?.results?.[0];
+        if (!row || typeof row !== "object" || Array.isArray(row)) throw new Error();
+        return row as Record<string, unknown>;
+    } catch {
+        throw new Error("beauty_movement_campaign_state_invalid");
+    }
+}
+
+async function readCampaignState(statePath: string, expectedCampaignId: string, expectedEndsAtMs: number): Promise<CampaignState> {
+    const row = d1RowFromFile(await readFile(statePath, "utf8"));
+    const description = normalizeBeautyMovementCampaignDescription(typeof row.description === "string" ? row.description : undefined);
+    const endsAtMs = Number(row.ends_at_ms);
+    const updatedAtMs = Number(row.updated_at_ms);
+    if (
+        row.id !== expectedCampaignId ||
+        row.status !== "active" ||
+        endsAtMs !== expectedEndsAtMs ||
+        endsAtMs <= Date.now() ||
+        !description ||
+        row.description !== description ||
+        !Number.isSafeInteger(updatedAtMs) ||
+        updatedAtMs <= 0
+    ) {
+        throw new Error("beauty_movement_campaign_state_invalid");
+    }
+    return { id: expectedCampaignId, status: "active", endsAtMs, description, updatedAtMs };
+}
+
+async function readApplySummary(summaryPath: string): Promise<{ mode: "pending" | "applied"; updatedAtMs: number }> {
+    try {
+        const value = JSON.parse(await readFile(summaryPath, "utf8"));
+        const updatedAtMs = Number(value?.updatedAtMs);
+        if (!["pending", "applied"].includes(value?.mode) || !Number.isSafeInteger(updatedAtMs) || updatedAtMs <= 0) throw new Error();
+        return { mode: value.mode, updatedAtMs };
+    } catch {
+        throw new Error("beauty_movement_campaign_apply_summary_invalid");
+    }
+}
+
+async function writePrivateJson(filePath: string, value: unknown): Promise<void> {
+    await writeFile(filePath, `${JSON.stringify(value)}\n`, { encoding: "utf8", mode: 0o600, flag: "w" });
+}
+
+async function runD1Update(params: { database: string; config: string; sqlFile: string }): Promise<number> {
+    try {
+        const result = await execFileAsync(
             "npx",
             ["--yes", "wrangler@4.112.0", "d1", "execute", params.database, "--remote", "--config", params.config, "--file", params.sqlFile],
             { cwd: WEBSITE_ROOT, maxBuffer: 2 * 1024 * 1024 },
         );
+        const payload = JSON.parse(result.stdout)?.[0];
+        const changes = Number(payload?.meta?.changes);
+        if (payload?.success !== true || changes !== 1) throw new Error();
+        return changes;
     } catch {
         throw new Error("beauty_movement_campaign_copy_update_failed");
     }
@@ -144,6 +215,11 @@ async function main(): Promise<void> {
     const campaignConfig = await readCampaignConfig(campaignConfigPath);
 
     if (options.dryRun) {
+        if (options.restore || options.expectedState || options.applySummary) throw new Error("beauty_movement_dry_run_state_arguments_invalid");
+        if (options.normalizedDescriptionOutput) {
+            const normalizedPath = privateAbsolutePath(options.normalizedDescriptionOutput, "output");
+            await writePrivateJson(normalizedPath, { description: campaignConfig.description });
+        }
         console.log(JSON.stringify({
             mode: "dry_run",
             preflight: "complete",
@@ -158,21 +234,44 @@ async function main(): Promise<void> {
         throw new Error("beauty_movement_remote_database_required");
     }
     if (!options.outputDirectory) throw new Error("beauty_movement_private_output_required");
+    if (!options.expectedState) throw new Error("beauty_movement_campaign_expected_state_required");
+    if (options.normalizedDescriptionOutput) throw new Error("beauty_movement_apply_normalized_output_invalid");
     const outputDirectory = privateAbsolutePath(options.outputDirectory, "output");
+    const expectedStatePath = privateAbsolutePath(options.expectedState, "input");
+    const expectedState = await readCampaignState(expectedStatePath, options.campaign, campaignEndsAtMs);
+    const applySummaryPath = options.applySummary ? privateAbsolutePath(options.applySummary, "output") : null;
+    if (!options.restore && !applySummaryPath) throw new Error("beauty_movement_apply_summary_required");
+    if (options.restore && !applySummaryPath) throw new Error("beauty_movement_restore_summary_required");
+    const applySummary = options.restore ? await readApplySummary(applySummaryPath!) : null;
     await mkdir(outputDirectory, { recursive: true, mode: 0o700 });
     const sqlFile = path.join(outputDirectory, `campaign-copy-${Date.now()}.sql`);
+    const updatedAtMs = Date.now();
+    const description = options.restore ? expectedState.description : campaignConfig.description;
+    const expectedDescription = options.restore ? campaignConfig.description : expectedState.description;
+    const expectedUpdatedAtMs = options.restore ? applySummary!.updatedAtMs : expectedState.updatedAtMs;
     const sql = buildBeautyMovementCampaignDescriptionUpdateSql({
         campaignId: options.campaign,
-        description: campaignConfig.description,
+        description,
         campaignEndsAtMs,
+        expectedDescription,
+        expectedUpdatedAtMs,
+        updatedAtMs,
     });
     await writeFile(sqlFile, sql, { encoding: "utf8", mode: 0o600, flag: "wx" });
-    await runD1Update({ database: options.database, config: options.config, sqlFile });
+    if (applySummaryPath) {
+        await writePrivateJson(applySummaryPath, { mode: "pending", updatedAtMs });
+    }
+    const changedRows = await runD1Update({ database: options.database, config: options.config, sqlFile });
+    if (applySummaryPath) {
+        await writePrivateJson(applySummaryPath, { mode: "applied", updatedAtMs, changedRows });
+    }
     console.log(JSON.stringify({
-        mode: "applied",
+        mode: options.restore ? "restored" : "applied",
         target: "remote",
         campaignId: options.campaign,
-        descriptionLength: campaignConfig.description.length,
+        descriptionLength: description.length,
+        updatedAtMs,
+        changedRows,
     }));
 }
 

--- a/website/src/app/api/beleza-em-movimento/campaign-copy/route.ts
+++ b/website/src/app/api/beleza-em-movimento/campaign-copy/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest } from "next/server";
+import { probeBeautyMovementCampaignCopy } from "@/lib/beautyMovementDb";
+import {
+  beautyMovementInvalidResponse,
+  beautyMovementJson,
+  beautyMovementUnavailableResponse,
+  hasBeautyMovementAllowedOrigin,
+  readBeautyMovementJson,
+  stringField,
+} from "@/lib/beautyMovementRoute";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Read-only authenticated probe for release attestation. Unlike the invite
+ * exchange route, this never creates an HttpOnly session or mutates D1 state.
+ */
+export async function POST(request: NextRequest) {
+  if (!(await hasBeautyMovementAllowedOrigin(request))) return beautyMovementInvalidResponse();
+  const body = await readBeautyMovementJson(request);
+  const token = stringField(body?.token, 256);
+  if (!token) return beautyMovementInvalidResponse();
+
+  const result = await probeBeautyMovementCampaignCopy({
+    token,
+    origin: request.headers.get("origin"),
+  });
+  if (!result.ok) {
+    return result.error === "campaign_unavailable"
+      ? beautyMovementUnavailableResponse()
+      : beautyMovementInvalidResponse();
+  }
+
+  return beautyMovementJson({ ok: true, campaign: result.campaign });
+}

--- a/website/src/lib/beautyMovementDb.ts
+++ b/website/src/lib/beautyMovementDb.ts
@@ -238,6 +238,15 @@ export type BeautyMovementExchangeResult =
     }
     | { ok: false; error: BeautyMovementError };
 
+/**
+ * Read-only production attestation used by the protected copy-update workflow.
+ * It deliberately returns campaign copy only and never creates a session or
+ * touches invite/session/rate-limit state.
+ */
+export type BeautyMovementCampaignCopyProbeResult =
+    | { ok: true; campaign: { description: string } }
+    | { ok: false; error: BeautyMovementError };
+
 export type BeautyMovementOperationOptions = {
     db?: BeautyMovementD1;
     /** Test-only / controlled server override. Runtime defaults fail closed. */
@@ -865,6 +874,29 @@ export async function exchangeBeautyMovementInvite(params: {
         return { ok: true, sessionToken, sessionExpiresAtMs, state };
     } catch {
         return failExchange("campaign_unavailable");
+    }
+}
+
+export async function probeBeautyMovementCampaignCopy(params: {
+    token: string;
+    origin: string | null | undefined;
+    nowMs?: number;
+}, options: BeautyMovementOperationOptions = {}): Promise<BeautyMovementCampaignCopyProbeResult> {
+    if (!(await isBeautyMovementEnabled(options))) return { ok: false, error: "campaign_unavailable" };
+    if (!(await assertOrigin(params.origin, options))) return { ok: false, error: "origin_not_allowed" };
+    if (!isBeautyMovementOpaqueToken(params.token)) return { ok: false, error: "invite_unavailable" };
+    const nowMs = Number.isFinite(params.nowMs) ? Number(params.nowMs) : now(options);
+
+    try {
+        const [db, tokenKey] = await Promise.all([resolveDb(options), resolveTokenHmacKey(options)]);
+        const inviteTokenHash = await hashBeautyMovementInviteToken({ secret: tokenKey, token: params.token });
+        const row = await findInviteByTokenHash(db, inviteTokenHash);
+        if (!row || !inviteIsAvailable(row, nowMs)) return { ok: false, error: "invite_unavailable" };
+        const campaign = renderCampaign(row);
+        if (!campaign) return { ok: false, error: "campaign_unavailable" };
+        return { ok: true, campaign: { description: campaign.description } };
+    } catch {
+        return { ok: false, error: "campaign_unavailable" };
     }
 }
 

--- a/website/src/lib/beautyMovementImport.ts
+++ b/website/src/lib/beautyMovementImport.ts
@@ -695,6 +695,35 @@ function escapeSql(value: string): string {
     return `'${value.replace(/'/g, "''")}'`;
 }
 
+/**
+ * Produces the narrowly-scoped SQL used by the protected active-campaign copy
+ * update workflow. Active campaigns intentionally reject the normal import
+ * upsert; this helper changes only the description after the workflow has
+ * independently attested the exact campaign id, status and expiry.
+ */
+export function buildBeautyMovementCampaignDescriptionUpdateSql(params: {
+    campaignId: string;
+    description: string;
+    campaignEndsAtMs: number;
+    updatedAtMs?: number;
+}): string {
+    const campaignId = validateCampaignId(params.campaignId);
+    const description = cleanText(params.description, 500);
+    if (!description) throw new Error("beauty_movement_campaign_description_invalid");
+    if (!Number.isSafeInteger(params.campaignEndsAtMs) || params.campaignEndsAtMs <= 0) {
+        throw new Error("beauty_movement_invalid_campaign_ends_at");
+    }
+    const updatedAtMs = params.updatedAtMs ?? Date.now();
+    if (!Number.isSafeInteger(updatedAtMs) || updatedAtMs <= 0) {
+        throw new Error("beauty_movement_invalid_campaign_updated_at");
+    }
+    return [
+        `UPDATE bm_campaigns SET description = ${escapeSql(description)}, updated_at_ms = ${updatedAtMs}`,
+        `WHERE id = ${escapeSql(campaignId)} AND status = 'active' AND ends_at_ms = ${params.campaignEndsAtMs};`,
+        "",
+    ].join(" ");
+}
+
 function sha256Hex(value: string): Promise<string> {
     return crypto.subtle.digest("SHA-256", new TextEncoder().encode(value)).then((buffer) =>
         Array.from(new Uint8Array(buffer)).map((byte) => byte.toString(16).padStart(2, "0")).join(""),

--- a/website/src/lib/beautyMovementImport.ts
+++ b/website/src/lib/beautyMovementImport.ts
@@ -241,6 +241,10 @@ function cleanText(value: string | undefined, maxLength: number): string {
     return text;
 }
 
+export function normalizeBeautyMovementCampaignDescription(value: string | undefined): string {
+    return cleanText(value, 500);
+}
+
 function isValidCpfDigits(value: string): boolean {
     if (!/^\d{11}$/.test(value) || /^(\d)\1{10}$/.test(value)) return false;
     const checkDigit = (length: number) => {
@@ -705,13 +709,20 @@ export function buildBeautyMovementCampaignDescriptionUpdateSql(params: {
     campaignId: string;
     description: string;
     campaignEndsAtMs: number;
+    expectedDescription: string;
+    expectedUpdatedAtMs: number;
     updatedAtMs?: number;
 }): string {
     const campaignId = validateCampaignId(params.campaignId);
     const description = cleanText(params.description, 500);
     if (!description) throw new Error("beauty_movement_campaign_description_invalid");
+    const expectedDescription = cleanText(params.expectedDescription, 500);
+    if (!expectedDescription) throw new Error("beauty_movement_campaign_expected_description_invalid");
     if (!Number.isSafeInteger(params.campaignEndsAtMs) || params.campaignEndsAtMs <= 0) {
         throw new Error("beauty_movement_invalid_campaign_ends_at");
+    }
+    if (!Number.isSafeInteger(params.expectedUpdatedAtMs) || params.expectedUpdatedAtMs <= 0) {
+        throw new Error("beauty_movement_campaign_expected_updated_at_invalid");
     }
     const updatedAtMs = params.updatedAtMs ?? Date.now();
     if (!Number.isSafeInteger(updatedAtMs) || updatedAtMs <= 0) {
@@ -719,7 +730,9 @@ export function buildBeautyMovementCampaignDescriptionUpdateSql(params: {
     }
     return [
         `UPDATE bm_campaigns SET description = ${escapeSql(description)}, updated_at_ms = ${updatedAtMs}`,
-        `WHERE id = ${escapeSql(campaignId)} AND status = 'active' AND ends_at_ms = ${params.campaignEndsAtMs};`,
+        `WHERE id = ${escapeSql(campaignId)} AND status = 'active' AND ends_at_ms = ${params.campaignEndsAtMs}`,
+        `AND ends_at_ms > (CAST(strftime('%s','now') AS INTEGER) * 1000)`,
+        `AND description = ${escapeSql(expectedDescription)} AND updated_at_ms = ${params.expectedUpdatedAtMs};`,
         "",
     ].join(" ");
 }

--- a/website/tests/beautyMovementCampaignCopy.test.ts
+++ b/website/tests/beautyMovementCampaignCopy.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
     buildBeautyMovementCampaignDescriptionUpdateSql,
+    normalizeBeautyMovementCampaignDescription,
     validateBeautyMovementCampaignConfig,
 } from "@/lib/beautyMovementImport";
 
@@ -24,6 +25,7 @@ test("campaign copy update validates the private copy contract", () => {
     const config = validateBeautyMovementCampaignConfig(campaignConfig);
     assert.equal(config.description, campaignConfig.description);
     assert.equal(config.startsAtMs, null);
+    assert.equal(normalizeBeautyMovementCampaignDescription("  copy\nwith   spacing  "), "copy with spacing");
 });
 
 test("campaign copy update is restricted to the active campaign description", () => {
@@ -31,6 +33,8 @@ test("campaign copy update is restricted to the active campaign description", ()
         campaignId: "beauty-movement-20260822-live-4",
         description: "O'novo movimento",
         campaignEndsAtMs: Date.parse("2026-12-31T23:59:59Z"),
+        expectedDescription: "Descrição anterior",
+        expectedUpdatedAtMs: 1_754_000_000_000,
         updatedAtMs: 1_756_000_000_000,
     });
 
@@ -39,5 +43,8 @@ test("campaign copy update is restricted to the active campaign description", ()
     assert.match(sql, /WHERE id = 'beauty-movement-20260822-live-4'/);
     assert.match(sql, /status = 'active'/);
     assert.match(sql, /ends_at_ms = 1798761599000/);
+    assert.match(sql, /ends_at_ms > \(CAST\(strftime\('%s','now'\) AS INTEGER\) \* 1000\)/);
+    assert.match(sql, /description = 'Descrição anterior'/);
+    assert.match(sql, /updated_at_ms = 1754000000000/);
     assert.doesNotMatch(sql, /title\s*=|invitation_title|partner_name|bm_invites/);
 });

--- a/website/tests/beautyMovementCampaignCopy.test.ts
+++ b/website/tests/beautyMovementCampaignCopy.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    buildBeautyMovementCampaignDescriptionUpdateSql,
+    validateBeautyMovementCampaignConfig,
+} from "@/lib/beautyMovementImport";
+
+const campaignConfig = {
+    title: "Beleza que se move com você",
+    description: "3 anos. 3 cartas. Um novo movimento para celebrar tudo o que ainda vem pela frente.",
+    invitationTitle: "Seu convite para celebrar",
+    invitationText: "Uma leitura especial para este encontro.",
+    partnerName: "Velocity",
+    whatsappMessageCourtesy: "Olá!",
+    whatsappMessageCommercial: "Olá!",
+    whatsappLabel: "Falar com a equipe no WhatsApp",
+    conditionsLabel: "Ler condições da campanha",
+    conditionsText: "Condições da campanha.",
+    velocityBenefitLabel: "Benefício",
+    velocityBenefitText: "Um benefício especial.",
+};
+
+test("campaign copy update validates the private copy contract", () => {
+    const config = validateBeautyMovementCampaignConfig(campaignConfig);
+    assert.equal(config.description, campaignConfig.description);
+    assert.equal(config.startsAtMs, null);
+});
+
+test("campaign copy update is restricted to the active campaign description", () => {
+    const sql = buildBeautyMovementCampaignDescriptionUpdateSql({
+        campaignId: "beauty-movement-20260822-live-4",
+        description: "O'novo movimento",
+        campaignEndsAtMs: Date.parse("2026-12-31T23:59:59Z"),
+        updatedAtMs: 1_756_000_000_000,
+    });
+
+    assert.match(sql, /UPDATE bm_campaigns SET description = 'O''novo movimento'/);
+    assert.match(sql, /updated_at_ms = 1756000000000/);
+    assert.match(sql, /WHERE id = 'beauty-movement-20260822-live-4'/);
+    assert.match(sql, /status = 'active'/);
+    assert.match(sql, /ends_at_ms = 1798761599000/);
+    assert.doesNotMatch(sql, /title\s*=|invitation_title|partner_name|bm_invites/);
+});

--- a/website/tests/beautyMovementDb.test.ts
+++ b/website/tests/beautyMovementDb.test.ts
@@ -4,6 +4,7 @@ import {
     confirmBeautyMovementInvite,
     exchangeBeautyMovementInvite,
     getBeautyMovementSession,
+    probeBeautyMovementCampaignCopy,
     revealBeautyMovementCard,
     type BeautyMovementD1,
     type BeautyMovementPreparedStatement,
@@ -276,6 +277,17 @@ test("beauty movement exchanges an opaque invite into a private session without 
     assert.equal(restored.ok, true);
     const rejected = await exchangeBeautyMovementInvite({ token: fixture.token, origin: "https://evil.example", ip: "203.0.113.10", nowMs: NOW }, options(fixture.db));
     assert.deepEqual(rejected, { ok: false, error: "origin_not_allowed" });
+});
+
+test("beauty movement campaign copy probe reads the active campaign without creating a session", async () => {
+    const fixture = await makeFixture();
+    const result = await probeBeautyMovementCampaignCopy(
+        { token: fixture.token, origin: ORIGIN, nowMs: NOW },
+        options(fixture.db),
+    );
+    assert.deepEqual(result, { ok: true, campaign: { description: "Beleza que se move com você." } });
+    assert.equal(fixture.db.sessions.size, 0);
+    assert.equal(fixture.db.rateLimits.size, 0);
 });
 
 test("beauty movement applies exchange limits atomically to both the invite token and IP subject", async () => {

--- a/website/tests/beautyMovementRoutes.test.ts
+++ b/website/tests/beautyMovementRoutes.test.ts
@@ -35,6 +35,7 @@ const publicState: PublicState = {
 };
 
 let exchangeCalls = 0;
+let campaignCopyProbeCalls = 0;
 let revealCalls = 0;
 let confirmCalls = 0;
 type RevealOptions = {
@@ -58,6 +59,10 @@ mock.module(moduleUrl("lib/beautyMovementDb"), {
                 state: publicState,
             };
         },
+        probeBeautyMovementCampaignCopy: async () => {
+            campaignCopyProbeCalls += 1;
+            return { ok: true, campaign: { description: publicState.campaign.description } };
+        },
         getBeautyMovementSession: async () => ({ ok: true, state: publicState }),
         revealBeautyMovementCard: async (_input: unknown, options: unknown) => {
             revealCalls += 1;
@@ -73,8 +78,9 @@ mock.module(moduleUrl("lib/beautyMovementDb"), {
 
 process.env.NEXT_PUBLIC_SITE_URL = "https://espacofacial.com";
 
-const [{ POST: exchange }, { GET: getState }, { POST: reveal }, { POST: confirm }] = await Promise.all([
+const [{ POST: exchange }, { POST: campaignCopyProbe }, { GET: getState }, { POST: reveal }, { POST: confirm }] = await Promise.all([
     import("../src/app/api/beleza-em-movimento/session/route"),
+    import("../src/app/api/beleza-em-movimento/campaign-copy/route"),
     import("../src/app/api/beleza-em-movimento/state/route"),
     import("../src/app/api/beleza-em-movimento/reveal/route"),
     import("../src/app/api/beleza-em-movimento/confirm/route"),
@@ -110,6 +116,15 @@ test("invite exchange rejects an untrusted Origin without calling campaign stora
     const response = await exchange(request("/api/beleza-em-movimento/session", { token: "i".repeat(43) }, undefined, "https://evil.example"));
     assert.equal(response.status, 404);
     assert.equal(exchangeCalls, 0);
+});
+
+test("campaign copy probe is read-only and never sets a session cookie", async () => {
+    campaignCopyProbeCalls = 0;
+    const response = await campaignCopyProbe(request("/api/beleza-em-movimento/campaign-copy", { token: "i".repeat(43) }));
+    assert.equal(response.status, 200);
+    assert.equal(campaignCopyProbeCalls, 1);
+    assert.equal(response.headers.get("set-cookie"), null);
+    assert.deepEqual(await response.json(), { ok: true, campaign: { description: publicState.campaign.description } });
 });
 
 test("invite exchange bounds JSON bodies even when Content-Length is absent", async () => {


### PR DESCRIPTION
## Summary
- include the pending desktop price-card layout fix in the release branch
- add a production-gated, active-campaign-only copy update workflow
- update only the campaign description and attest invite preservation

## Validation
- npm test
- npm lint
- npm run typecheck
- git diff --check
- workflow contract and active-copy helper tests

The production campaign and existing invite links remain the same; the protected workflow is dispatched separately after the serving SHA is live.