### PR TITLE
fix(beauty-movement): accept Wrangler D1 success without changes metadata

### DIFF
--- a/.github/scripts/beauty-movement-campaign-copy-contract.test.mjs
+++ b/.github/scripts/beauty-movement-campaign-copy-contract.test.mjs
@@ -38,6 +38,7 @@ test("campaign copy update is production-only, release-bound and narrowly scoped
   assert.match(workflow, /Release Website production coordination lease/);
   assert.match(workflow, /Remove runner-local private material/);
   assert.match(updateCopyHelper, /--file\", params\.sqlFile, \"--json/);
+  assert.match(updateCopyHelper, /reportedChanges === undefined \? 1 : Number\(reportedChanges\)/);
   assert.doesNotMatch(workflow, /wrangler secret put/);
   assert.doesNotMatch(workflow, /INSERT INTO bm_campaigns/);
   assert.doesNotMatch(workflow, /UPDATE bm_invites/);

--- a/website/scripts/beauty-movement-update-copy.ts
+++ b/website/scripts/beauty-movement-update-copy.ts
@@ -196,8 +196,9 @@ async function runD1Update(params: { database: string; config: string; sqlFile: 
             { cwd: WEBSITE_ROOT, maxBuffer: 2 * 1024 * 1024 },
         );
         const payload = JSON.parse(result.stdout)?.[0];
-        const changes = Number(payload?.meta?.changes);
-        if (payload?.success !== true || changes !== 1) throw new Error();
+        const reportedChanges = payload?.meta?.changes;
+        const changes = reportedChanges === undefined ? 1 : Number(reportedChanges);
+        if (payload?.success !== true || !Number.isSafeInteger(changes) || changes !== 1) throw new Error();
         return changes;
     } catch {
         throw new Error("beauty_movement_campaign_copy_update_failed");


### PR DESCRIPTION
## Objetivo
Corrigir o utilitário de atualização de copy para aceitar a resposta JSON válida do Wrangler quando `meta.changes` não é retornado.

## Segurança
- Valores explícitos de `meta.changes` diferentes de 1 continuam falhando.
- O CAS e o readback posterior continuam confirmando a descrição, `updated_at_ms` e a preservação dos convites.
- Baseado no release integrado do PR #1646 (`e7327ed8ef0709c4b8a7e4a14f0e2c9e42da0985`).

## Validação
- `npm test` (169/169)
- `npm lint`
- `npm run typecheck`
- contratos de staging/promotion e `git diff --check`