### PR TITLE
fix(beauty-movement): accept D1 file mutation responses

### DIFF
--- a/.github/scripts/beauty-movement-campaign-copy-contract.test.mjs
+++ b/.github/scripts/beauty-movement-campaign-copy-contract.test.mjs
@@ -38,7 +38,9 @@ test("campaign copy update is production-only, release-bound and narrowly scoped
   assert.match(workflow, /Release Website production coordination lease/);
   assert.match(workflow, /Remove runner-local private material/);
   assert.match(updateCopyHelper, /--file\", params\.sqlFile, \"--json/);
-  assert.match(updateCopyHelper, /reportedChanges === undefined \? 1 : Number\(reportedChanges\)/);
+  assert.match(updateCopyHelper, /const payload = Array\.isArray\(parsed\) \? parsed\[0\] : parsed/);
+  assert.match(updateCopyHelper, /payload\?\.success !== true/);
+  assert.match(updateCopyHelper, /post-write readback prove the single/);
   assert.doesNotMatch(workflow, /wrangler secret put/);
   assert.doesNotMatch(workflow, /INSERT INTO bm_campaigns/);
   assert.doesNotMatch(workflow, /UPDATE bm_invites/);

--- a/website/scripts/beauty-movement-update-copy.ts
+++ b/website/scripts/beauty-movement-update-copy.ts
@@ -195,11 +195,13 @@ async function runD1Update(params: { database: string; config: string; sqlFile: 
             ["--yes", "wrangler@4.112.0", "d1", "execute", params.database, "--remote", "--config", params.config, "--file", params.sqlFile, "--json"],
             { cwd: WEBSITE_ROOT, maxBuffer: 2 * 1024 * 1024 },
         );
-        const payload = JSON.parse(result.stdout)?.[0];
-        const reportedChanges = payload?.meta?.changes;
-        const changes = reportedChanges === undefined ? 1 : Number(reportedChanges);
-        if (payload?.success !== true || !Number.isSafeInteger(changes) || changes !== 1) throw new Error();
-        return changes;
+        const parsed = JSON.parse(result.stdout);
+        const payload = Array.isArray(parsed) ? parsed[0] : parsed;
+        if (payload?.success !== true) throw new Error();
+        // Wrangler's --file JSON does not expose a stable affected-row count.
+        // The SQL CAS predicate plus the post-write readback prove the single
+        // logical update; metadata is intentionally treated as advisory.
+        return 1;
     } catch {
         throw new Error("beauty_movement_campaign_copy_update_failed");
     }


### PR DESCRIPTION
## Resumo\n\n- aceita respostas JSON de d1 execute --file em formato de objeto ou lista\n- trata metadados de affected rows como advisory, pois o Wrangler não os estabiliza para --file\n- mantém CAS SQL e readback pós-escrita como prova do update\n\n## Validação\n\n- website tests: 169 passed\n- website lint: passed\n- website typecheck/build: passed\n- contratos de campanha, staging e promotion evidence: 9 passed\n- git diff --check: passed\n\n## Contexto\n\nO staging smoke anterior identificou a divergência no contrato JSON do Wrangler; nenhuma alteração de produção foi feita por esse smoke.