### PR TITLE
fix(beauty-movement): parse wrapped D1 update output

### DIFF
--- a/website/scripts/beauty-movement-update-copy-json.ts
+++ b/website/scripts/beauty-movement-update-copy-json.ts
@@ -1,0 +1,54 @@
+function extractJsonValue(output: string): unknown {
+    for (let start = 0; start < output.length; start += 1) {
+        const opening = output[start];
+        if (opening !== "[" && opening !== "{") continue;
+        const stack: string[] = [];
+        let inString = false;
+        let escaped = false;
+        for (let index = start; index < output.length; index += 1) {
+            const character = output[index];
+            if (inString) {
+                if (escaped) {
+                    escaped = false;
+                } else if (character === "\\") {
+                    escaped = true;
+                } else if (character === '"') {
+                    inString = false;
+                }
+                continue;
+            }
+            if (character === '"') {
+                inString = true;
+                continue;
+            }
+            if (character === "[" || character === "{") {
+                stack.push(character);
+                continue;
+            }
+            if (character !== "]" && character !== "}") continue;
+            const expected = character === "]" ? "[" : "{";
+            if (stack.at(-1) !== expected) break;
+            stack.pop();
+            if (stack.length !== 0) continue;
+            try {
+                return JSON.parse(output.slice(start, index + 1));
+            } catch {
+                break;
+            }
+        }
+    }
+    throw new Error("beauty_movement_campaign_copy_update_response_invalid");
+}
+
+export function parseD1UpdateResponse(stdout: string): unknown {
+    const output = stdout
+        .replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, "")
+        .replace(/^\uFEFF/, "")
+        .trim();
+    try {
+        return JSON.parse(output);
+    } catch {
+        // Wrangler/npm can prefix the JSON payload with a banner or warning.
+    }
+    return extractJsonValue(output);
+}

--- a/website/scripts/beauty-movement-update-copy.ts
+++ b/website/scripts/beauty-movement-update-copy.ts
@@ -8,6 +8,7 @@ import {
     normalizeBeautyMovementCampaignDescription,
     validateBeautyMovementCampaignConfig,
 } from "../src/lib/beautyMovementImport";
+import { parseD1UpdateResponse } from "./beauty-movement-update-copy-json";
 
 const execFileAsync = promisify(execFile);
 const WEBSITE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -216,7 +217,7 @@ async function runD1Update(params: { database: string; config: string; sqlFile: 
     }
     let parsed: unknown;
     try {
-        parsed = JSON.parse(result.stdout.toString("utf8"));
+        parsed = parseD1UpdateResponse(result.stdout.toString("utf8"));
     } catch {
         return failD1Update("response_invalid");
     }

--- a/website/tests/beautyMovementCopyJson.test.ts
+++ b/website/tests/beautyMovementCopyJson.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseD1UpdateResponse } from "../scripts/beauty-movement-update-copy-json";
+
+test("parses a clean Wrangler D1 JSON response", () => {
+    const response = [{ success: true, meta: { duration: 1 } }];
+    assert.deepEqual(parseD1UpdateResponse(JSON.stringify(response)), response);
+});
+
+test("parses JSON after Wrangler/npm output and ANSI formatting", () => {
+    const response = [{ success: true, meta: { duration: 1 } }];
+    const output = `\u001b[33mwarning before payload\u001b[0m\n${JSON.stringify(response, null, 2)}\ntrailing log`;
+    assert.deepEqual(parseD1UpdateResponse(output), response);
+});
+
+test("rejects output without a complete JSON object or array", () => {
+    assert.throws(
+        () => parseD1UpdateResponse("Wrangler failed before producing a JSON response"),
+        /beauty_movement_campaign_copy_update_response_invalid/,
+    );
+});


### PR DESCRIPTION
## Summary
- tolerate Wrangler/npm banners and ANSI output before/after D1 JSON responses
- retain the success-payload validation and CAS/readback proof
- add focused parser coverage for clean, wrapped, and invalid responses

## Validation
- website tests: 172 passed
- website lint: passed
- website typecheck/build: passed
- Beauty Movement contract tests: 9 passed