### PR TITLE
fix(beauty-movement): execute live copy probe in ESM

### DIFF
--- a/.github/scripts/beauty-movement-campaign-copy-contract.test.mjs
+++ b/.github/scripts/beauty-movement-campaign-copy-contract.test.mjs
@@ -32,6 +32,9 @@ test("campaign copy update is production-only, release-bound and narrowly scoped
   assert.match(workflow, /Verify updated copy through the read-only live campaign API/);
   assert.match(workflow, /campaign-copy/);
   assert.match(workflow, /digest\('base64url'\)/);
+  assert.match(workflow, /node --input-type=module - "\$\{PRE_READBACK\}"/);
+  assert.match(workflow, /import \{ createHmac \} from 'node:crypto';/);
+  assert.match(workflow, /import \{ readFileSync, writeFileSync \} from 'node:fs';/);
   assert.match(workflow, /Revalidate Website production coordination lease before copy rollback/);
   assert.match(workflow, /Restore incumbent campaign copy after a failed post-write attestation/);
   assert.match(workflow, /beauty_movement_campaign_copy_rollback_conflict/);

--- a/.github/workflows/beauty-movement-campaign-copy-update.yml
+++ b/.github/workflows/beauty-movement-campaign-copy-update.yml
@@ -265,16 +265,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          node - "${PRE_READBACK}" "${EXPECTED_DESCRIPTION}" "${LIVE_COPY_PROBE}" "${CAMPAIGN_ID}" "${PRODUCTION_URL}" <<'NODE'
-          const crypto = require('node:crypto');
-          const fs = require('node:fs');
+          node --input-type=module - "${PRE_READBACK}" "${EXPECTED_DESCRIPTION}" "${LIVE_COPY_PROBE}" "${CAMPAIGN_ID}" "${PRODUCTION_URL}" <<'NODE'
+          import { createHmac } from 'node:crypto';
+          import { readFileSync, writeFileSync } from 'node:fs';
           const [preFile, expectedFile, outputFile, campaignId, productionUrl] = process.argv.slice(2);
-          const pre = JSON.parse(fs.readFileSync(preFile, 'utf8'))?.[0]?.results?.[0];
-          const expected = JSON.parse(fs.readFileSync(expectedFile, 'utf8'));
+          const pre = JSON.parse(readFileSync(preFile, 'utf8'))?.[0]?.results?.[0];
+          const expected = JSON.parse(readFileSync(expectedFile, 'utf8'));
           const secret = String(process.env.BEAUTY_MOVEMENT_TOKEN_HMAC_KEY ?? '').trim();
           const inviteRef = typeof pre?.probe_external_ref === 'string' ? pre.probe_external_ref : '';
           if (!secret || !inviteRef || typeof expected?.description !== 'string' || !expected.description) throw new Error('beauty_movement_live_copy_probe_input_invalid');
-          const token = crypto.createHmac('sha256', secret).update(`v1|beauty-movement|delivery|${campaignId}|${inviteRef}`, 'utf8').digest('base64url');
+          const token = createHmac('sha256', secret).update(`v1|beauty-movement|delivery|${campaignId}|${inviteRef}`, 'utf8').digest('base64url');
           const response = await fetch(`${productionUrl}/api/beleza-em-movimento/campaign-copy`, {
             method: 'POST',
             headers: { 'content-type': 'application/json', origin: productionUrl },
@@ -283,7 +283,7 @@ jobs:
           let payload = null;
           try { payload = await response.json(); } catch { payload = null; }
           if (response.status !== 200 || payload?.ok !== true || payload?.campaign?.description !== expected.description) throw new Error('beauty_movement_live_copy_probe_mismatch');
-          fs.writeFileSync(outputFile, `${JSON.stringify({ liveCopyVerified: true, httpStatus: response.status, descriptionLength: expected.description.length })}\n`, { encoding: 'utf8', mode: 0o600 });
+          writeFileSync(outputFile, `${JSON.stringify({ liveCopyVerified: true, httpStatus: response.status, descriptionLength: expected.description.length })}\n`, { encoding: 'utf8', mode: 0o600 });
           console.log(JSON.stringify({ liveCopyVerified: true, httpStatus: response.status, descriptionLength: expected.description.length }));
           NODE
 


### PR DESCRIPTION
## Objetivo
Corrigir a etapa de atestação da atualização protegida da cópia da campanha Beleza em Movimento.

## Causa comprovada
O probe executava `node -` no diretório raiz do repositório, que é tratado como ES module, mas usava `require(...)`. A atualização D1 concluía o readback e a preservação dos convites, porém o probe falhava antes da chamada HTTP; o rollback automático restaurou a cópia incumbente.

## Alteração
- executar o probe com `node --input-type=module -`;
- usar imports nativos de `node:crypto` e `node:fs`;
- proteger o contrato com asserções estáticas do modo ESM/imports.

## Validação
- contrato do workflow: 2 testes verdes;
- `git diff --check` verde;
- sem mudança de schema, campanha, convites, rota pública ou segredo.

## Rollback
Reverter este commit/PR. A atualização de campanha permanece protegida por readback, atestação pública e rollback automático.