### PR TITLE
docs: make SKINCOS an Orb MCP consumer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,13 +79,6 @@ dist/
 eggs/
 .eggs/
 lib/
-!orb/engine/music-composition-studio/lib/
-!orb/engine/music-composition-studio/lib/**
-!orb/engine/scripts/lib/
-orb/engine/scripts/lib/*
-!orb/engine/scripts/lib/runtime-paths.sh
-!orb/engine/scripts/lib/runtime-paths.js
-!orb/engine/scripts/lib/meta-ads-publish-execution-semantics.js
 lib64/
 parts/
 sdist/

--- a/CODEX_CONTEXT.md
+++ b/CODEX_CONTEXT.md
@@ -33,9 +33,14 @@
   every Windows-published artifact matched its native SHA-256.
 - Orb backup owner, PostgreSQL restore and n8n encryption-key custody belong to
   the independent Orb repository and its private runtime. SKINCOS does not
-  copy, publish or delete `C:\CodexRuntime\n8n` or Orb evidence.
+  copy, publish or delete the retained legacy paths `C:\CodexRuntime\n8n` and
+  `C:\CodexRuntime\operator\admin\skincos\orb`; new Orb operator evidence
+  belongs under `C:\CodexRuntime\operator\admin\orb`.
 - Cutover checkpoint: `C:\CodexRuntime\backups\runtime-cutover\20260715T182203Z`; it preserves the pre-cutover unit/config evidence while the active and prior immutable releases provide operational rollback.
-- Native releases are immutable. Rollback repoints `/opt/skincos/current/*` to the prior release, restores the captured units/config and restarts only the affected services.
+- Native releases are immutable. O rollback do Orb é gerido exclusivamente no
+  repositório Orb e repõe `/opt/orb/current` para a release anterior; qualquer
+  referência a `/opt/skincos/current/*` é histórica e não deve ser usada como
+  runtime, release ou rollback do Orb.
 - Cross-filesystem transfer is Windows-owned. Do not recursively traverse `C:`
   from WSL or launch Windows transfer binaries from a Linux service.
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,5 +1,17 @@
 # DECISIONS
 
+## 2026-08-26 - SKINCOS é consumidor do Orb remoto segmentado
+
+- Decisão: o SKINCOS não hospeda nem replica código, units, workflows, backups
+  ou runtime do Orb. O consumidor preserva `orb.skincos.com.br`, healthchecks e
+  contratos de integração, e referencia os planos MCP remotos `orb_readonly`,
+  `orb_workflows`, `orb_admin` e `orb_ops` apenas por documentação/configuração
+  local do Codex.
+- Compatibilidade: `skincos-n8n` permanece como alias temporário e sem fonte
+  operacional própria. `orb-n8n` no repositório Orb é a instrução canônica.
+- Retenção: worktrees, releases e runtime privados legados permanecem
+  imutáveis; nenhuma exclusão, movimentação ou cópia é feita pelo SKINCOS.
+
 ## 2026-08-24 - Separar Orb/n8n do repositório SKINCOS
 
 - Decisão: o Orb/n8n passa a ser mantido exclusivamente no repositório privado

--- a/docs/architecture/orb-integration-contract.md
+++ b/docs/architecture/orb-integration-contract.md
@@ -24,15 +24,22 @@ submodule, mirror ou cópia sincronizada neste repositório.
   contrato externo de integração e não dá acesso direto ao banco;
 - os schemas, autenticação, idempotência e versionamento dos endpoints do Orb
   são publicados e testados no repositório independente.
+- A configuração MCP do consumidor usa somente os nomes `orb_readonly`,
+  `orb_workflows`, `orb_admin` e `orb_ops`, com hostnames publicados pelo Orb.
+  Headers Access, OAuth e aprovações ficam no computador do Codex, nunca neste
+  repositório consumidor.
 
 ## Gate de corte
 
-O corte de produção só é elegível depois de reconciliar uma exportação
-autenticada do n8n live com o ledger de execuções, restaurar e validar o banco
-PostgreSQL próprio do Orb, testar import/export isolado e executar smoke
-sintético em staging. A release anterior e o banco anterior permanecem
-retidos até o encerramento da observação pós-corte.
+O runtime Orb já foi separado em namespace próprio. A promoção de novas
+releases e dos planos MCP continua elegível somente depois de reconciliar uma
+exportação autenticada do n8n live com o ledger de execuções, restaurar e
+validar o banco PostgreSQL próprio do Orb, testar import/export isolado e
+executar smoke sintético em staging. A release anterior e o banco anterior
+permanecem retidos durante a observação pós-corte.
 
 Os diretórios privados `C:\CodexRuntime\n8n` e
-`C:\CodexRuntime\operator\admin\skincos\orb` não fazem parte do Git e não
-devem ser copiados, apagados ou tratados como fonte de código.
+`C:\CodexRuntime\operator\admin\skincos\orb` são legado retido: não fazem
+parte do Git e não devem ser copiados, apagados ou tratados como fonte de
+código. Cópias futuras verificadas pertencem exclusivamente ao namespace
+`C:\CodexRuntime\operator\admin\orb`.

--- a/docs/architecture/orb-mcp-consumer-config.md
+++ b/docs/architecture/orb-mcp-consumer-config.md
@@ -1,0 +1,17 @@
+# SKINCOS como consumidor do Orb MCP
+
+O SKINCOS não instala, hospeda ou sincroniza o MCP do Orb. O Codex de cada
+operador se conecta diretamente aos quatro servidores remotos do Orb:
+
+| Nome no Codex | URL |
+| --- | --- |
+| `orb_readonly` | `https://mcp-read.orb.skincos.com.br/mcp` |
+| `orb_workflows` | `https://mcp-workflows.orb.skincos.com.br/mcp` |
+| `orb_admin` | `https://mcp-admin.orb.skincos.com.br/mcp` |
+| `orb_ops` | `https://mcp-ops.orb.skincos.com.br/mcp` |
+
+Os headers Cloudflare Access, tokens OAuth e escolhas de aprovação pertencem ao
+cofre/configuração local do Codex. O contrato canônico, o bloco `config.toml`
+e o rollout ficam no repositório Orb. O domínio
+`https://orb.skincos.com.br`, o healthcheck e integrações CRM/compliance não
+são renomeados por esta separação.

--- a/docs/project-state/current-state.md
+++ b/docs/project-state/current-state.md
@@ -2,7 +2,7 @@
 
 ## Checkpoint atual — separação do Orb/n8n — 2026-08-24
 
-- O código de `orb/engine` foi extraído com histórico preservado para o
+- O código histórico de `orb/engine` foi extraído com histórico preservado para o
   repositório privado [jubenitogarcia/orb](https://github.com/jubenitogarcia/orb).
 - Este repositório não contém mais código, workflow JSON, units, backup,
   migration ou publisher do Orb; mantém somente contratos de integração,
@@ -10,9 +10,11 @@
 - `C:\CodexRuntime\n8n` e
   `C:\CodexRuntime\operator\admin\skincos\orb` permanecem privados e
   intocados.
-- O corte de produção não foi executado: falta exportação live autenticada e
-  reconciliação de paridade com o ledger. As seções abaixo são snapshots e
-  evidências históricas; não são fonte atual do Orb.
+- O runtime live já opera no namespace independente do Orb. A promoção da
+  release canônica e a ativação do MCP remoto ainda exigem exportação live
+  autenticada, reconciliação de paridade, staging e rollback comprovado. As
+  seções abaixo são snapshots e evidências históricas; não são fonte atual do
+  Orb.
 
 ## Snapshot terminal do Ponto — `origin/main` `6daa6eaee7c4c49f047e97944e70ea1aa320ca61` — 2026-08-05T01:59:29Z
 

--- a/scripts/sync-skincos-n8n-skill.ps1
+++ b/scripts/sync-skincos-n8n-skill.ps1
@@ -1,11 +1,17 @@
 param(
-    [string]$Destination = "$env:USERPROFILE\.codex\skills\skincos-n8n"
+    [string]$Destination = "$env:USERPROFILE\.codex\skills\skincos-n8n",
+    [string]$OrbRepository = 'C:\CodexShared\Projetos\orb'
 )
 
 $ErrorActionPreference = 'Stop'
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $source = Join-Path $repoRoot 'skills\skincos-n8n\SKILL.md'
-if (-not (Test-Path -LiteralPath $source -PathType Leaf)) { throw "Skill source is missing: $source" }
+if (-not (Test-Path -LiteralPath $source -PathType Leaf)) { throw "Compatibility alias is missing: $source" }
 New-Item -ItemType Directory -Force -Path $Destination | Out-Null
 Copy-Item -LiteralPath $source -Destination (Join-Path $Destination 'SKILL.md') -Force
-Write-Output "Installed skincos-n8n Skill from repository source into $Destination"
+$orbSync = Join-Path $OrbRepository 'scripts\sync-orb-n8n-skill.ps1'
+if (Test-Path -LiteralPath $orbSync -PathType Leaf) {
+    Write-Output "Installed temporary skincos-n8n alias. Install the canonical source with: $orbSync"
+} else {
+    Write-Output 'Installed temporary skincos-n8n alias. Obtain orb-n8n from the independent Orb repository.'
+}

--- a/skills/skincos-n8n/SKILL.md
+++ b/skills/skincos-n8n/SKILL.md
@@ -1,18 +1,13 @@
 ---
 name: skincos-n8n
-description: Inspect SKINCOS Orb/n8n workflows, graphs, dependencies, executions, health, and repository snapshots safely. Use for questions about an Orb workflow, n8n error, automation architecture, workflow status, Meta Ads, Livia, or when live evidence is needed before proposing a workflow change.
+description: Temporary compatibility alias for the Orb n8n skill while SKINCOS is only an integration consumer.
 ---
 
-# Skincos n8n
+# Deprecated compatibility alias
 
-Use `skincos_orb_readonly` as the primary source for the live Orb instance.
+The canonical skill is `orb-n8n` in the independent Orb repository. Install or
+use that skill for live workflows, executions, MCP planes and n8n operations.
 
-1. Start with `list_workflows` or `search_workflows`; do not infer live state from repository files.
-2. Use `get_workflow_summary`, `get_workflow_graph`, and `find_workflow_dependencies` for architecture questions. State that the result is live and sanitized.
-3. For an incident, call `list_recent_executions` first, then `get_execution_error` only for an execution returned by that list. Explain when the gateway reports that error data exceeded a safe inspection limit.
-4. Use `compare_workflow_with_repository` only as a historical comparison. Label its ref/commit as a snapshot, never as live state.
-5. Use `get_orb_status` for runtime health. Treat public health as reachability, not proof of a business journey.
-
-Never call or request a workflow execution, retry, creation, import, edit, activation, publication, credential/user/project/secret management, SQL, or shell command through the MCP gateway. `execute_workflow` is intentionally not available. Do not expose credential values, headers, tokens, payloads, patient data, email addresses, phones, or full execution messages.
-
-Distinguish in every response: **live**, **repository snapshot**, **proposal**, or **unproven**. Cite workflow ID/name, tool consulted, timestamp where available, and the limits of the sanitized result.
+This alias intentionally contains no Orb workflow or runtime instructions. It
+exists only so older SKINCOS invocations can be redirected without recreating a
+second source of truth.


### PR DESCRIPTION
## Summary
- make SKINCOS an integration consumer of independent Orb runtime and MCP planes
- remove obsolete `orb/engine` ignore exceptions without deleting retained history
- redirect `skincos-n8n` to the Orb-owned canonical `orb-n8n` skill
- document the four remote MCP server names while keeping headers, OAuth, and approvals local to each Codex machine
- mark legacy runtime paths as retained evidence, not active Orb sources

## Validation
- `npm run architecture:validate` (passes; reports three pre-existing tracked legacy-import warnings)
- PowerShell parser validation for `scripts/sync-skincos-n8n-skill.ps1`
- `git diff --cached --check`

## Boundary
No workflow, runtime, backup, secret, domain, healthcheck, CRM, or compliance resource is changed. Remote MCP endpoints remain activated only by the Orb rollout gates.