### PR TITLE
fix(website): normalize Beauty Movement release asset attestation

### DIFF
--- a/website/scripts/beauty-movement-production-release-smoke.d.mts
+++ b/website/scripts/beauty-movement-production-release-smoke.d.mts
@@ -1,2 +1,3 @@
 export function parseWranglerJson(output: string): unknown;
+export function extractStaticAssetPaths(html: string): string[];
 export function buildBeautyMovementReleaseValidationMarker(releaseSha: string, releaseOwner: string): string;

--- a/website/scripts/beauty-movement-production-release-smoke.mjs
+++ b/website/scripts/beauty-movement-production-release-smoke.mjs
@@ -187,6 +187,10 @@ function sha256(value) {
   return crypto.createHash("sha256").update(value).digest("hex");
 }
 
+export function extractStaticAssetPaths(html) {
+  return [...new Set(html.match(/\/_next\/static\/[^"'<>\\\s]+/g) ?? [])].sort();
+}
+
 async function attestRouteOnce(baseUrl, route, releaseSha) {
   const response = await fetch(`${baseUrl}${route}`, {
     redirect: "manual",
@@ -207,7 +211,7 @@ async function attestRouteOnce(baseUrl, route, releaseSha) {
       noStore: /no-store/i.test(cacheControl),
     });
   }
-  const assets = [...new Set(html.match(/\/_next\/static\/[^"'<>\s]+/g) ?? [])].sort();
+  const assets = extractStaticAssetPaths(html);
   if (assets.length < 2) fail("beauty_movement_release_smoke_assets_missing", { count: assets.length });
   const hashes = [];
   for (const asset of assets) {

--- a/website/tests/beautyMovementContextIsolation.test.ts
+++ b/website/tests/beautyMovementContextIsolation.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../src/lib/beautyMovementSecurity";
 import {
     buildBeautyMovementReleaseValidationMarker,
+    extractStaticAssetPaths,
     parseWranglerJson,
 } from "../scripts/beauty-movement-production-release-smoke.mjs";
 import {
@@ -185,6 +186,20 @@ test("context references are opaque, domain-separated, and map to one cookie nam
     assert.notEqual(contextRef, sessionHash);
     assert.equal(getBeautyMovementSessionCookieName(contextRef), `ef_bm_ctx_${contextRef}`);
     assert.equal(getBeautyMovementSessionCookieName("invalid"), null);
+});
+
+test("production route attestation ignores serialized trailing escapes in static asset paths", () => {
+    const html = [
+        '<link rel="stylesheet" href="/_next/static/css/layout.css">',
+        "/_next/static/css/layout.css\\",
+        '<script src="/_next/static/chunks/app/page.js"></script>',
+        "/_next/static/chunks/app/page.js\\\\",
+    ].join("\n");
+
+    assert.deepEqual(extractStaticAssetPaths(html), [
+        "/_next/static/chunks/app/page.js",
+        "/_next/static/css/layout.css",
+    ]);
 });
 
 test("governed staging and production smokes execute the same four-invite isolation matrix", async () => {


### PR DESCRIPTION
## Resumo
- normaliza URLs de assets extraídas do HTML da campanha antes do smoke de produção
- ignora barras invertidas de cópias serializadas do payload RSC sem deixar de validar os assets reais
- adiciona cobertura de regressão para o falso negativo que acionava rollback

## Validação
- website: 191/191 testes
- lint
- build + typecheck
- git diff --check
- Gitleaks staged: nenhum vazamento

## Risco e rollback
- alteração restrita ao atestado pós-deploy; não muda UI, campanha, convites ou progresso
- o reconciliador de produção continua restaurando o Worker anterior se o smoke real falhar