### PR TITLE
fix(website): stabilize Beauty Movement journey smoke

### DIFF
--- a/website/scripts/beauty-movement-context-isolation-smoke.d.mts
+++ b/website/scripts/beauty-movement-context-isolation-smoke.d.mts
@@ -1,0 +1,1 @@
+export function redactBeautyMovementSmokeError(message: string): string;

--- a/website/scripts/beauty-movement-context-isolation-smoke.mjs
+++ b/website/scripts/beauty-movement-context-isolation-smoke.mjs
@@ -9,7 +9,6 @@ const CONTEXT_PATTERN = /^[A-Za-z0-9_-]{32,256}$/;
 const INVITE_REF_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{2,119}$/;
 const ROUTES = ["/beleza-em-movimento", "/BelezaEmMovimento"];
 const LEGACY_COOKIE = "ef_beauty_movement_session";
-const JOURNEY_CONTEXT_OPTIONS = { reducedMotion: "no-preference" };
 
 function fail(code, details = {}) {
   const safe = Object.fromEntries(
@@ -295,10 +294,7 @@ async function run() {
 
   const browser = await chromium.launch({ headless: true });
   try {
-    // This isolation smoke validates the campaign's automatic animated path.
-    // Pin the media profile so the runner host cannot silently select the
-    // manual reduced-motion path and make the journey wait for user input.
-    const shared = await browser.newContext(JOURNEY_CONTEXT_OPTIONS);
+    const shared = await browser.newContext();
     const pageA = await shared.newPage();
     const diagnosticsA = attachDiagnostics(pageA);
 
@@ -344,7 +340,7 @@ async function run() {
     const diagnosticsReopenedB = attachDiagnostics(reopenedB);
     await openInvite(reopenedB, baseUrl, invites.b, ROUTES[1], "Movimento");
 
-    const privateContext = await browser.newContext(JOURNEY_CONTEXT_OPTIONS);
+    const privateContext = await browser.newContext();
     const privatePage = await privateContext.newPage();
     const diagnosticsPrivate = attachDiagnostics(privatePage);
     await openInvite(privatePage, baseUrl, invites.primary, ROUTES[0]);
@@ -357,7 +353,7 @@ async function run() {
     // a bypass that production users would not have.
     await pageA.waitForTimeout(61_000);
 
-    const storageUnavailable = await browser.newContext(JOURNEY_CONTEXT_OPTIONS);
+    const storageUnavailable = await browser.newContext();
     await storageUnavailable.addInitScript(() => {
       Object.defineProperty(window, "sessionStorage", {
         configurable: true,
@@ -408,7 +404,7 @@ async function run() {
     const sharedCookies = await shared.cookies(`${baseUrl}/api/beleza-em-movimento/state`);
     const cookieA = sharedCookies.find((cookie) => cookie.name === `ef_bm_ctx_${firstContextA}`);
     if (!cookieA || !cookieA.httpOnly) fail("beauty_movement_isolation_smoke_http_only_cookie_missing");
-    const mismatchContext = await browser.newContext(JOURNEY_CONTEXT_OPTIONS);
+    const mismatchContext = await browser.newContext();
     await mismatchContext.addCookies([{
       name: cookieA.name,
       value: cookieA.value,

--- a/website/scripts/beauty-movement-context-isolation-smoke.mjs
+++ b/website/scripts/beauty-movement-context-isolation-smoke.mjs
@@ -9,6 +9,7 @@ const CONTEXT_PATTERN = /^[A-Za-z0-9_-]{32,256}$/;
 const INVITE_REF_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{2,119}$/;
 const ROUTES = ["/beleza-em-movimento", "/BelezaEmMovimento"];
 const LEGACY_COOKIE = "ef_beauty_movement_session";
+const JOURNEY_CONTEXT_OPTIONS = { reducedMotion: "no-preference" };
 
 function fail(code, details = {}) {
   const safe = Object.fromEntries(
@@ -186,9 +187,31 @@ async function waitFresh(page) {
   await assertScrubbed(page);
 }
 
+async function readJourneyState(page) {
+  return page.evaluate(() => {
+    const table = document.querySelector("[data-hand-stage]");
+    return {
+      motionNoPreference: !window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+      documentVisible: document.visibilityState === "visible",
+      handStage: table?.getAttribute("data-hand-stage") ?? "missing",
+      actIndex: Number(table?.getAttribute("data-act-index") ?? -1),
+      finaleStage: table?.getAttribute("data-finale-stage") ?? "missing",
+      revealButtonCount: Array.from(document.querySelectorAll("button[aria-label]"))
+        .filter((button) => button.getAttribute("aria-label")?.startsWith("Revelar carta ")).length,
+      selectedCardCount: document.querySelectorAll('button[aria-pressed="true"]').length,
+      busyRegionCount: document.querySelectorAll('[aria-busy="true"]').length,
+    };
+  });
+}
+
 async function waitAct(page, act) {
-  await page.getByRole("button", { name: `Revelar carta 1 de ${act}`, exact: true })
-    .waitFor({ state: "visible", timeout: 60_000 });
+  try {
+    await page.getByRole("button", { name: `Revelar carta 1 de ${act}`, exact: true })
+      .waitFor({ state: "visible", timeout: 60_000 });
+  } catch {
+    const state = await readJourneyState(page).catch(() => ({ stateUnavailable: true }));
+    fail("beauty_movement_isolation_smoke_act_timeout", { expectedAct: act, ...state });
+  }
   await assertScrubbed(page);
 }
 
@@ -272,7 +295,10 @@ async function run() {
 
   const browser = await chromium.launch({ headless: true });
   try {
-    const shared = await browser.newContext();
+    // This isolation smoke validates the campaign's automatic animated path.
+    // Pin the media profile so the runner host cannot silently select the
+    // manual reduced-motion path and make the journey wait for user input.
+    const shared = await browser.newContext(JOURNEY_CONTEXT_OPTIONS);
     const pageA = await shared.newPage();
     const diagnosticsA = attachDiagnostics(pageA);
 
@@ -318,7 +344,7 @@ async function run() {
     const diagnosticsReopenedB = attachDiagnostics(reopenedB);
     await openInvite(reopenedB, baseUrl, invites.b, ROUTES[1], "Movimento");
 
-    const privateContext = await browser.newContext();
+    const privateContext = await browser.newContext(JOURNEY_CONTEXT_OPTIONS);
     const privatePage = await privateContext.newPage();
     const diagnosticsPrivate = attachDiagnostics(privatePage);
     await openInvite(privatePage, baseUrl, invites.primary, ROUTES[0]);
@@ -331,7 +357,7 @@ async function run() {
     // a bypass that production users would not have.
     await pageA.waitForTimeout(61_000);
 
-    const storageUnavailable = await browser.newContext();
+    const storageUnavailable = await browser.newContext(JOURNEY_CONTEXT_OPTIONS);
     await storageUnavailable.addInitScript(() => {
       Object.defineProperty(window, "sessionStorage", {
         configurable: true,
@@ -382,7 +408,7 @@ async function run() {
     const sharedCookies = await shared.cookies(`${baseUrl}/api/beleza-em-movimento/state`);
     const cookieA = sharedCookies.find((cookie) => cookie.name === `ef_bm_ctx_${firstContextA}`);
     if (!cookieA || !cookieA.httpOnly) fail("beauty_movement_isolation_smoke_http_only_cookie_missing");
-    const mismatchContext = await browser.newContext();
+    const mismatchContext = await browser.newContext(JOURNEY_CONTEXT_OPTIONS);
     await mismatchContext.addCookies([{
       name: cookieA.name,
       value: cookieA.value,
@@ -479,13 +505,23 @@ async function run() {
 }
 
 const isDirectExecution = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+export function redactBeautyMovementSmokeError(message) {
+  const redactDetails = (value) => value
+    .replace(/#c=[A-Za-z0-9_-]+/g, "#c=[redacted]")
+    .replace(/[A-Za-z0-9_-]{40,180}/g, "[opaque]");
+  if (/^beauty_movement_[a-z0-9_]+$/i.test(message)) return message;
+  const separator = message.indexOf(":");
+  const code = separator >= 0 ? message.slice(0, separator) : "";
+  if (/^beauty_movement_[a-z0-9_]+$/i.test(code)) {
+    return `${code}:${redactDetails(message.slice(separator + 1))}`;
+  }
+  return redactDetails(message);
+}
+
 if (isDirectExecution) {
   run().catch((error) => {
     const message = error instanceof Error ? error.message : "beauty_movement_isolation_smoke_failed";
-    const redacted = message
-      .replace(/#c=[A-Za-z0-9_-]+/g, "#c=[redacted]")
-      .replace(/[A-Za-z0-9_-]{40,180}/g, "[opaque]");
-    console.error(redacted);
+    console.error(redactBeautyMovementSmokeError(message));
     process.exitCode = 1;
   });
 }

--- a/website/tests/beautyMovementContextIsolation.test.ts
+++ b/website/tests/beautyMovementContextIsolation.test.ts
@@ -251,7 +251,6 @@ test("governed staging and production smokes execute the same four-invite isolat
     assert.match(smoke, /crossCookieCredentialRejected: true/);
     assert.match(smoke, /name: `ef_bm_ctx_\$\{secondContextB\}`/);
     assert.match(smoke, /rawTokensPersistedInEvidence: false/);
-    assert.match(smoke, /reducedMotion: "no-preference"/);
     assert.match(smoke, /beauty_movement_isolation_smoke_act_timeout/);
     assert.doesNotMatch(smoke, /console\.log\(.*token/i);
     assert.match(primarySmoke, /whatsappCtaPresent: true/);

--- a/website/tests/beautyMovementContextIsolation.test.ts
+++ b/website/tests/beautyMovementContextIsolation.test.ts
@@ -22,6 +22,7 @@ import {
     extractStaticAssetPaths,
     parseWranglerJson,
 } from "../scripts/beauty-movement-production-release-smoke.mjs";
+import { redactBeautyMovementSmokeError } from "../scripts/beauty-movement-context-isolation-smoke.mjs";
 import {
     buildBeautyMovementReleaseOwner,
     buildBeautyMovementSyntheticCampaignId,
@@ -202,6 +203,21 @@ test("production route attestation ignores serialized trailing escapes in static
     ]);
 });
 
+test("browser smoke diagnostics preserve safe failure codes while redacting opaque values", () => {
+    const opaque = "t".repeat(43);
+    const message = `beauty_movement_isolation_smoke_act_timeout:{\"expectedAct\":\"Movimento\",\"opaque\":\"${opaque}\"}`;
+
+    assert.equal(
+        redactBeautyMovementSmokeError(message),
+        'beauty_movement_isolation_smoke_act_timeout:{"expectedAct":"Movimento","opaque":"[opaque]"}',
+    );
+    assert.equal(
+        redactBeautyMovementSmokeError("beauty_movement_isolation_smoke_context_missing"),
+        "beauty_movement_isolation_smoke_context_missing",
+    );
+    assert.equal(redactBeautyMovementSmokeError(`navigation failed at /#c=${opaque}`), "navigation failed at /#c=[redacted]");
+});
+
 test("governed staging and production smokes execute the same four-invite isolation matrix", async () => {
     const [staging, production, deploy, recovery, smoke, primarySmoke, releaseSmoke, deployWorker, reconcile] = await Promise.all([
         readFile(sourceUrl("../.github/workflows/beauty-movement-staging-smoke.yml"), "utf8"),
@@ -235,6 +251,8 @@ test("governed staging and production smokes execute the same four-invite isolat
     assert.match(smoke, /crossCookieCredentialRejected: true/);
     assert.match(smoke, /name: `ef_bm_ctx_\$\{secondContextB\}`/);
     assert.match(smoke, /rawTokensPersistedInEvidence: false/);
+    assert.match(smoke, /reducedMotion: "no-preference"/);
+    assert.match(smoke, /beauty_movement_isolation_smoke_act_timeout/);
     assert.doesNotMatch(smoke, /console\.log\(.*token/i);
     assert.match(primarySmoke, /whatsappCtaPresent: true/);
     assert.match(primarySmoke, /contextRestoredAfterReload: true/);


### PR DESCRIPTION
## Objetivo
Tornar a falha do smoke autenticado do Beleza em Movimento diagnosticável antes de uma nova publicação da versão visual já aprovada.

## Contexto
O staging reproduziu um timeout após a primeira revelação, mas o redator genérico ocultava o código de falha e o estado visual da mesa. A hipótese inicial sobre `prefers-reduced-motion` foi descartada durante a revisão porque o Playwright já usa `no-preference` por padrão; esta versão mantém o perfil do navegador inalterado.

## Alterações
- registra estado sanitizado da mesa quando uma categoria não aparece;
- preserva códigos de falha legíveis sem expor tokens opacos;
- adiciona contrato de regressão para diagnóstico e redação.

## Risco e dados
Risco operacional baixo: mudança restrita à observabilidade de validação sintética. Nenhum convidado, token, telefone, campanha ou dado real é alterado.

## Validação local
- website tests: 192/192
- teste focal após a revisão: 13/13
- lint: aprovado
- build + typecheck: aprovado
- git diff --check: aprovado
- Gitleaks staged: sem vazamentos

## Pré-produção
Após merge, executar o smoke autenticado de staging com quatro convites sintéticos para obter o estado exato da transição. Produção permanece na versão anterior segura até o diagnóstico e o gate final ficarem verdes.

## Rollback
Reverter os commits deste PR restaura o diagnóstico anterior. Nenhuma publicação de produção é feita por este PR.