### PR TITLE
test(website): pinpoint Beauty Movement staging handoff failures

### DIFF
--- a/website/scripts/beauty-movement-context-isolation-smoke.mjs
+++ b/website/scripts/beauty-movement-context-isolation-smoke.mjs
@@ -199,9 +199,28 @@ function checkpointDiagnosticsSnapshot(page) {
   };
 }
 
-async function contextRef(page) {
-  const value = await page.evaluate(() => history.state?.__efBeautyMovementContextRef ?? null);
-  if (!CONTEXT_PATTERN.test(value ?? "")) fail("beauty_movement_isolation_smoke_context_missing");
+function failAtCheckpoint(page, code, checkpoint, details = {}) {
+  fail(code, {
+    checkpoint,
+    ...details,
+    ...checkpointDiagnosticsSnapshot(page),
+  });
+}
+
+async function contextRef(page, checkpoint = "context-ref") {
+  let value = null;
+  try {
+    value = await page.evaluate(() => history.state?.__efBeautyMovementContextRef ?? null);
+  } catch {
+    failAtCheckpoint(page, "beauty_movement_isolation_smoke_context_missing", checkpoint, {
+      phase: "read",
+    });
+  }
+  if (!CONTEXT_PATTERN.test(value ?? "")) {
+    failAtCheckpoint(page, "beauty_movement_isolation_smoke_context_missing", checkpoint, {
+      phase: "validation",
+    });
+  }
   return value;
 }
 
@@ -300,7 +319,7 @@ async function openInvite(page, baseUrl, invite, route, expectedAct = null, chec
   ));
   if (expectedAct) await waitAct(page, expectedAct, checkpoint);
   else await waitFresh(page, checkpoint);
-  return contextRef(page);
+  return contextRef(page, checkpoint);
 }
 
 async function revealAndAdvance(page, currentAct, nextAct) {
@@ -310,13 +329,29 @@ async function revealAndAdvance(page, currentAct, nextAct) {
     name: `Revelar carta 1 de ${currentAct}`,
     exact: true,
   });
-  await card.waitFor({ state: "visible", timeout: 30_000 });
-  const responsePromise = page.waitForResponse((response) => {
-    const url = new URL(response.url());
-    return response.request().method() === "POST" && url.pathname === "/api/beleza-em-movimento/reveal";
-  }, { timeout: 30_000 });
-  await card.click();
-  const response = await responsePromise;
+  try {
+    await card.waitFor({ state: "visible", timeout: 30_000 });
+  } catch {
+    failAtCheckpoint(page, "beauty_movement_isolation_smoke_reveal_failed", checkpoint, {
+      phase: "button",
+      status: 0,
+    });
+  }
+  let response;
+  try {
+    [response] = await Promise.all([
+      page.waitForResponse((candidate) => {
+        const url = new URL(candidate.url());
+        return candidate.request().method() === "POST" && url.pathname === "/api/beleza-em-movimento/reveal";
+      }, { timeout: 30_000 }),
+      card.click(),
+    ]);
+  } catch {
+    failAtCheckpoint(page, "beauty_movement_isolation_smoke_reveal_failed", checkpoint, {
+      phase: "request",
+      status: 0,
+    });
+  }
   let payload = null;
   try {
     payload = await response.json();
@@ -324,9 +359,19 @@ async function revealAndAdvance(page, currentAct, nextAct) {
     // Status and the public ok flag are both required below.
   }
   if (!response.ok() || payload?.ok !== true) {
-    fail("beauty_movement_isolation_smoke_reveal_failed", { status: response.status() });
+    failAtCheckpoint(page, "beauty_movement_isolation_smoke_reveal_failed", checkpoint, {
+      phase: "response",
+      status: response.status(),
+    });
   }
-  await page.locator('button[aria-pressed="true"]').waitFor({ state: "visible", timeout: 30_000 });
+  try {
+    await page.locator('button[aria-pressed="true"]').waitFor({ state: "visible", timeout: 30_000 });
+  } catch {
+    failAtCheckpoint(page, "beauty_movement_isolation_smoke_reveal_failed", checkpoint, {
+      phase: "selection",
+      status: response.status(),
+    });
+  }
   await page.waitForTimeout(5_600);
   await waitAct(page, nextAct, checkpoint);
 }
@@ -398,10 +443,10 @@ async function run() {
 
     await navigateAtCheckpoint(pageA, "back-a", () => pageA.goBack());
     await waitAct(pageA, "Movimento", "back-a");
-    if (await contextRef(pageA) !== firstContextA) fail("beauty_movement_isolation_smoke_back_restored_wrong_context");
+    if (await contextRef(pageA, "back-a") !== firstContextA) fail("beauty_movement_isolation_smoke_back_restored_wrong_context");
     await navigateAtCheckpoint(pageA, "forward-b", () => pageA.goForward());
     await waitFresh(pageA, "forward-b");
-    if (await contextRef(pageA) !== firstContextB) fail("beauty_movement_isolation_smoke_forward_restored_wrong_context");
+    if (await contextRef(pageA, "forward-b") !== firstContextB) fail("beauty_movement_isolation_smoke_forward_restored_wrong_context");
 
     await navigateAtCheckpoint(pageA, "back-a-final", () => pageA.goBack());
     await waitAct(pageA, "Movimento", "back-a-final");
@@ -412,7 +457,8 @@ async function run() {
       reloadAt(pageA, "Celebração", "simultaneous-reload-a"),
       reloadAt(pageB, "Movimento", "simultaneous-reload-b"),
     ]);
-    if (await contextRef(pageA) !== firstContextA || await contextRef(pageB) !== secondContextB) {
+    if (await contextRef(pageA, "simultaneous-reload-a") !== firstContextA
+      || await contextRef(pageB, "simultaneous-reload-b") !== secondContextB) {
       fail("beauty_movement_isolation_smoke_simultaneous_reload_context_changed");
     }
 

--- a/website/scripts/beauty-movement-context-isolation-smoke.mjs
+++ b/website/scripts/beauty-movement-context-isolation-smoke.mjs
@@ -322,8 +322,7 @@ async function openInvite(page, baseUrl, invite, route, expectedAct = null, chec
   return contextRef(page, checkpoint);
 }
 
-async function revealAndAdvance(page, currentAct, nextAct) {
-  const checkpoint = `advance-${currentAct.toLowerCase()}-to-${nextAct.toLowerCase()}`;
+async function revealAndAdvance(page, currentAct, nextAct, checkpoint) {
   resetCheckpointDiagnostics(page);
   const card = page.getByRole("button", {
     name: `Revelar carta 1 de ${currentAct}`,
@@ -437,7 +436,7 @@ async function run() {
 
     const firstContextA = await openInvite(pageA, baseUrl, invites.a, ROUTES[0], null, "initial-a");
     await pageA.getByRole("button", { name: /Clique no baralho para começar a sua leitura/i }).click();
-    await revealAndAdvance(pageA, "Beleza", "Movimento");
+    await revealAndAdvance(pageA, "Beleza", "Movimento", "advance-a-beleza-to-movimento");
     await reloadAt(pageA, "Movimento", "reload-a-movement");
 
     const firstContextB = await openInvite(pageA, baseUrl, invites.b, ROUTES[0], null, "switch-a-to-b");
@@ -465,8 +464,8 @@ async function run() {
 
     await navigateAtCheckpoint(pageA, "back-a-final", () => pageA.goBack());
     await waitAct(pageA, "Movimento", "back-a-final");
-    await revealAndAdvance(pageA, "Movimento", "Celebração");
-    await revealAndAdvance(pageB, "Beleza", "Movimento");
+    await revealAndAdvance(pageA, "Movimento", "Celebração", "advance-a-movimento-to-celebracao");
+    await revealAndAdvance(pageB, "Beleza", "Movimento", "advance-b-beleza-to-movimento");
 
     await Promise.all([
       reloadAt(pageA, "Celebração", "simultaneous-reload-a"),

--- a/website/scripts/beauty-movement-context-isolation-smoke.mjs
+++ b/website/scripts/beauty-movement-context-isolation-smoke.mjs
@@ -123,8 +123,10 @@ function attachDiagnostics(page) {
     apiResponses: 0,
     revealRequests: 0,
     whatsappRequests: 0,
-    lastApiStatus: 0,
-    lastApiOperation: "none",
+    checkpointApiFailures: 0,
+    checkpointApiResponses: 0,
+    checkpointLastApiStatus: 0,
+    checkpointLastApiOperation: "none",
   };
   page.on("console", (message) => {
     if (message.type() === "error") diagnostics.consoleErrors += 1;
@@ -134,7 +136,10 @@ function attachDiagnostics(page) {
   });
   page.on("requestfailed", (request) => {
     try {
-      if (new URL(request.url()).pathname.startsWith("/api/beleza-em-movimento/")) diagnostics.apiFailures += 1;
+      if (new URL(request.url()).pathname.startsWith("/api/beleza-em-movimento/")) {
+        diagnostics.apiFailures += 1;
+        diagnostics.checkpointApiFailures += 1;
+      }
     } catch {
       // Ignore malformed third-party URLs; no value is retained.
     }
@@ -144,8 +149,9 @@ function attachDiagnostics(page) {
       const pathname = new URL(response.url()).pathname;
       if (pathname.startsWith("/api/beleza-em-movimento/")) {
         diagnostics.apiResponses += 1;
-        diagnostics.lastApiStatus = response.status();
-        diagnostics.lastApiOperation = pathname.split("/").at(-1) ?? "unknown";
+        diagnostics.checkpointApiResponses += 1;
+        diagnostics.checkpointLastApiStatus = response.status();
+        diagnostics.checkpointLastApiOperation = pathname.split("/").at(-1) ?? "unknown";
       }
     } catch {
       // No URL is retained in evidence.
@@ -162,6 +168,15 @@ function attachDiagnostics(page) {
   });
   pageDiagnostics.set(page, diagnostics);
   return diagnostics;
+}
+
+function resetCheckpointDiagnostics(page) {
+  const diagnostics = pageDiagnostics.get(page);
+  if (!diagnostics) return;
+  diagnostics.checkpointApiFailures = 0;
+  diagnostics.checkpointApiResponses = 0;
+  diagnostics.checkpointLastApiStatus = 0;
+  diagnostics.checkpointLastApiOperation = "none";
 }
 
 async function contextRef(page) {
@@ -206,10 +221,10 @@ async function waitFresh(page, checkpoint) {
     fail("beauty_movement_isolation_smoke_fresh_timeout", {
       checkpoint,
       ...state,
-      apiResponses: diagnostics.apiResponses ?? 0,
-      apiFailures: diagnostics.apiFailures ?? 0,
-      lastApiStatus: diagnostics.lastApiStatus ?? 0,
-      lastApiOperation: diagnostics.lastApiOperation ?? "none",
+      apiResponses: diagnostics.checkpointApiResponses ?? 0,
+      apiFailures: diagnostics.checkpointApiFailures ?? 0,
+      lastApiStatus: diagnostics.checkpointLastApiStatus ?? 0,
+      lastApiOperation: diagnostics.checkpointLastApiOperation ?? "none",
       consoleErrors: diagnostics.consoleErrors ?? 0,
       pageErrors: diagnostics.pageErrors ?? 0,
     });
@@ -247,6 +262,7 @@ async function waitAct(page, act) {
 
 async function openInvite(page, baseUrl, invite, route, expectedAct = null, checkpoint = "open-invite") {
   if (!ROUTES.includes(route)) fail("beauty_movement_isolation_smoke_route_invalid");
+  resetCheckpointDiagnostics(page);
   await page.goto(`${baseUrl}${route}#c=${encodeURIComponent(invite.token)}`, { waitUntil: "domcontentloaded" });
   if (expectedAct) await waitAct(page, expectedAct);
   else await waitFresh(page, checkpoint);
@@ -347,6 +363,7 @@ async function run() {
     await pageA.goBack();
     await waitAct(pageA, "Movimento");
     if (await contextRef(pageA) !== firstContextA) fail("beauty_movement_isolation_smoke_back_restored_wrong_context");
+    resetCheckpointDiagnostics(pageA);
     await pageA.goForward();
     await waitFresh(pageA, "forward-b");
     if (await contextRef(pageA) !== firstContextB) fail("beauty_movement_isolation_smoke_forward_restored_wrong_context");
@@ -375,6 +392,7 @@ async function run() {
     const privatePage = await privateContext.newPage();
     const diagnosticsPrivate = attachDiagnostics(privatePage);
     await openInvite(privatePage, baseUrl, invites.primary, ROUTES[0], null, "private-primary");
+    resetCheckpointDiagnostics(privatePage);
     await privatePage.reload({ waitUntil: "domcontentloaded" });
     await waitFresh(privatePage, "private-reload");
 
@@ -396,6 +414,7 @@ async function run() {
     const storagePage = await storageUnavailable.newPage();
     const diagnosticsStorage = attachDiagnostics(storagePage);
     await openInvite(storagePage, baseUrl, invites.primary, ROUTES[1], null, "storage-unavailable");
+    resetCheckpointDiagnostics(storagePage);
     await storagePage.reload({ waitUntil: "domcontentloaded" });
     await waitFresh(storagePage, "storage-reload");
 

--- a/website/scripts/beauty-movement-context-isolation-smoke.mjs
+++ b/website/scripts/beauty-movement-context-isolation-smoke.mjs
@@ -127,6 +127,7 @@ function attachDiagnostics(page) {
     checkpointApiResponses: 0,
     checkpointLastApiStatus: 0,
     checkpointLastApiOperation: "none",
+    checkpointLastApiTransportFailure: false,
   };
   page.on("console", (message) => {
     if (message.type() === "error") diagnostics.consoleErrors += 1;
@@ -136,9 +137,13 @@ function attachDiagnostics(page) {
   });
   page.on("requestfailed", (request) => {
     try {
-      if (new URL(request.url()).pathname.startsWith("/api/beleza-em-movimento/")) {
+      const pathname = new URL(request.url()).pathname;
+      if (pathname.startsWith("/api/beleza-em-movimento/")) {
         diagnostics.apiFailures += 1;
         diagnostics.checkpointApiFailures += 1;
+        diagnostics.checkpointLastApiStatus = 0;
+        diagnostics.checkpointLastApiOperation = pathname.split("/").at(-1) ?? "unknown";
+        diagnostics.checkpointLastApiTransportFailure = true;
       }
     } catch {
       // Ignore malformed third-party URLs; no value is retained.
@@ -152,6 +157,7 @@ function attachDiagnostics(page) {
         diagnostics.checkpointApiResponses += 1;
         diagnostics.checkpointLastApiStatus = response.status();
         diagnostics.checkpointLastApiOperation = pathname.split("/").at(-1) ?? "unknown";
+        diagnostics.checkpointLastApiTransportFailure = false;
       }
     } catch {
       // No URL is retained in evidence.
@@ -177,6 +183,7 @@ function resetCheckpointDiagnostics(page) {
   diagnostics.checkpointApiResponses = 0;
   diagnostics.checkpointLastApiStatus = 0;
   diagnostics.checkpointLastApiOperation = "none";
+  diagnostics.checkpointLastApiTransportFailure = false;
 }
 
 async function contextRef(page) {
@@ -204,30 +211,45 @@ async function assertScrubbed(page) {
   }
 }
 
+async function reportFreshCheckpointFailure(page, checkpoint, phase) {
+  const state = await page.evaluate(() => ({
+    pathname: window.location.pathname,
+    historyLength: window.history.length,
+    hasContextRef: typeof window.history.state?.__efBeautyMovementContextRef === "string",
+    documentVisible: document.visibilityState === "visible",
+    deckButtonCount: document.querySelectorAll('button[aria-label*="Clique no baralho"]').length,
+    busyRegionCount: document.querySelectorAll('[aria-busy="true"]').length,
+  })).catch(() => ({ stateUnavailable: true }));
+  const diagnostics = pageDiagnostics.get(page) ?? {};
+  fail("beauty_movement_isolation_smoke_fresh_checkpoint_failure", {
+    checkpoint,
+    phase,
+    ...state,
+    apiResponses: diagnostics.checkpointApiResponses ?? 0,
+    apiFailures: diagnostics.checkpointApiFailures ?? 0,
+    lastApiStatus: diagnostics.checkpointLastApiStatus ?? 0,
+    lastApiOperation: diagnostics.checkpointLastApiOperation ?? "none",
+    lastApiTransportFailure: diagnostics.checkpointLastApiTransportFailure ?? false,
+    consoleErrors: diagnostics.consoleErrors ?? 0,
+    pageErrors: diagnostics.pageErrors ?? 0,
+  });
+}
+
+async function navigateAtCheckpoint(page, checkpoint, navigate) {
+  resetCheckpointDiagnostics(page);
+  try {
+    await navigate();
+  } catch {
+    await reportFreshCheckpointFailure(page, checkpoint, "navigation");
+  }
+}
+
 async function waitFresh(page, checkpoint) {
   const deck = page.getByRole("button", { name: /Clique no baralho para começar a sua leitura/i });
   try {
     await deck.waitFor({ state: "visible", timeout: 60_000 });
   } catch {
-    const state = await page.evaluate(() => ({
-      pathname: window.location.pathname,
-      historyLength: window.history.length,
-      hasContextRef: typeof window.history.state?.__efBeautyMovementContextRef === "string",
-      documentVisible: document.visibilityState === "visible",
-      deckButtonCount: document.querySelectorAll('button[aria-label*="Clique no baralho"]').length,
-      busyRegionCount: document.querySelectorAll('[aria-busy="true"]').length,
-    })).catch(() => ({ stateUnavailable: true }));
-    const diagnostics = pageDiagnostics.get(page) ?? {};
-    fail("beauty_movement_isolation_smoke_fresh_timeout", {
-      checkpoint,
-      ...state,
-      apiResponses: diagnostics.checkpointApiResponses ?? 0,
-      apiFailures: diagnostics.checkpointApiFailures ?? 0,
-      lastApiStatus: diagnostics.checkpointLastApiStatus ?? 0,
-      lastApiOperation: diagnostics.checkpointLastApiOperation ?? "none",
-      consoleErrors: diagnostics.consoleErrors ?? 0,
-      pageErrors: diagnostics.pageErrors ?? 0,
-    });
+    await reportFreshCheckpointFailure(page, checkpoint, "freshness");
   }
   await assertScrubbed(page);
 }
@@ -262,8 +284,9 @@ async function waitAct(page, act) {
 
 async function openInvite(page, baseUrl, invite, route, expectedAct = null, checkpoint = "open-invite") {
   if (!ROUTES.includes(route)) fail("beauty_movement_isolation_smoke_route_invalid");
-  resetCheckpointDiagnostics(page);
-  await page.goto(`${baseUrl}${route}#c=${encodeURIComponent(invite.token)}`, { waitUntil: "domcontentloaded" });
+  await navigateAtCheckpoint(page, checkpoint, () => (
+    page.goto(`${baseUrl}${route}#c=${encodeURIComponent(invite.token)}`, { waitUntil: "domcontentloaded" })
+  ));
   if (expectedAct) await waitAct(page, expectedAct);
   else await waitFresh(page, checkpoint);
   return contextRef(page);
@@ -295,8 +318,8 @@ async function revealAndAdvance(page, currentAct, nextAct) {
   await waitAct(page, nextAct);
 }
 
-async function reloadAt(page, act) {
-  await page.reload({ waitUntil: "domcontentloaded" });
+async function reloadAt(page, act, checkpoint) {
+  await navigateAtCheckpoint(page, checkpoint, () => page.reload({ waitUntil: "domcontentloaded" }));
   await waitAct(page, act);
 }
 
@@ -348,7 +371,7 @@ async function run() {
     const firstContextA = await openInvite(pageA, baseUrl, invites.a, ROUTES[0], null, "initial-a");
     await pageA.getByRole("button", { name: /Clique no baralho para começar a sua leitura/i }).click();
     await revealAndAdvance(pageA, "Beleza", "Movimento");
-    await reloadAt(pageA, "Movimento");
+    await reloadAt(pageA, "Movimento", "reload-a-movement");
 
     const firstContextB = await openInvite(pageA, baseUrl, invites.b, ROUTES[0], null, "switch-a-to-b");
     if (firstContextA === firstContextB) fail("beauty_movement_isolation_smoke_context_collision");
@@ -360,22 +383,21 @@ async function run() {
       fail("beauty_movement_isolation_smoke_session_context_reused");
     }
 
-    await pageA.goBack();
+    await navigateAtCheckpoint(pageA, "back-a", () => pageA.goBack());
     await waitAct(pageA, "Movimento");
     if (await contextRef(pageA) !== firstContextA) fail("beauty_movement_isolation_smoke_back_restored_wrong_context");
-    resetCheckpointDiagnostics(pageA);
-    await pageA.goForward();
+    await navigateAtCheckpoint(pageA, "forward-b", () => pageA.goForward());
     await waitFresh(pageA, "forward-b");
     if (await contextRef(pageA) !== firstContextB) fail("beauty_movement_isolation_smoke_forward_restored_wrong_context");
 
-    await pageA.goBack();
+    await navigateAtCheckpoint(pageA, "back-a-final", () => pageA.goBack());
     await waitAct(pageA, "Movimento");
     await revealAndAdvance(pageA, "Movimento", "Celebração");
     await revealAndAdvance(pageB, "Beleza", "Movimento");
 
     await Promise.all([
-      reloadAt(pageA, "Celebração"),
-      reloadAt(pageB, "Movimento"),
+      reloadAt(pageA, "Celebração", "simultaneous-reload-a"),
+      reloadAt(pageB, "Movimento", "simultaneous-reload-b"),
     ]);
     if (await contextRef(pageA) !== firstContextA || await contextRef(pageB) !== secondContextB) {
       fail("beauty_movement_isolation_smoke_simultaneous_reload_context_changed");
@@ -383,17 +405,16 @@ async function run() {
 
     const reopenedA = await shared.newPage();
     const diagnosticsReopenedA = attachDiagnostics(reopenedA);
-    await openInvite(reopenedA, baseUrl, invites.a, ROUTES[0], "Celebração");
+    await openInvite(reopenedA, baseUrl, invites.a, ROUTES[0], "Celebração", "reopen-a");
     const reopenedB = await shared.newPage();
     const diagnosticsReopenedB = attachDiagnostics(reopenedB);
-    await openInvite(reopenedB, baseUrl, invites.b, ROUTES[1], "Movimento");
+    await openInvite(reopenedB, baseUrl, invites.b, ROUTES[1], "Movimento", "reopen-b");
 
     const privateContext = await browser.newContext();
     const privatePage = await privateContext.newPage();
     const diagnosticsPrivate = attachDiagnostics(privatePage);
     await openInvite(privatePage, baseUrl, invites.primary, ROUTES[0], null, "private-primary");
-    resetCheckpointDiagnostics(privatePage);
-    await privatePage.reload({ waitUntil: "domcontentloaded" });
+    await navigateAtCheckpoint(privatePage, "private-reload", () => privatePage.reload({ waitUntil: "domcontentloaded" }));
     await waitFresh(privatePage, "private-reload");
 
     // The public exchange limiter allows six attempts per source IP and
@@ -414,13 +435,12 @@ async function run() {
     const storagePage = await storageUnavailable.newPage();
     const diagnosticsStorage = attachDiagnostics(storagePage);
     await openInvite(storagePage, baseUrl, invites.primary, ROUTES[1], null, "storage-unavailable");
-    resetCheckpointDiagnostics(storagePage);
-    await storagePage.reload({ waitUntil: "domcontentloaded" });
+    await navigateAtCheckpoint(storagePage, "storage-reload", () => storagePage.reload({ waitUntil: "domcontentloaded" }));
     await waitFresh(storagePage, "storage-reload");
 
     const racePage = await shared.newPage();
     const diagnosticsRace = attachDiagnostics(racePage);
-    await openInvite(racePage, baseUrl, invites.a, ROUTES[0], "Celebração");
+    await openInvite(racePage, baseUrl, invites.a, ROUTES[0], "Celebração", "race-a");
     await racePage.evaluate(({ tokenB, tokenA }) => {
       window.location.hash = `c=${tokenB}`;
       window.setTimeout(() => {

--- a/website/scripts/beauty-movement-context-isolation-smoke.mjs
+++ b/website/scripts/beauty-movement-context-isolation-smoke.mjs
@@ -9,6 +9,7 @@ const CONTEXT_PATTERN = /^[A-Za-z0-9_-]{32,256}$/;
 const INVITE_REF_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{2,119}$/;
 const ROUTES = ["/beleza-em-movimento", "/BelezaEmMovimento"];
 const LEGACY_COOKIE = "ef_beauty_movement_session";
+const pageDiagnostics = new WeakMap();
 
 function fail(code, details = {}) {
   const safe = Object.fromEntries(
@@ -122,6 +123,8 @@ function attachDiagnostics(page) {
     apiResponses: 0,
     revealRequests: 0,
     whatsappRequests: 0,
+    lastApiStatus: 0,
+    lastApiOperation: "none",
   };
   page.on("console", (message) => {
     if (message.type() === "error") diagnostics.consoleErrors += 1;
@@ -138,7 +141,12 @@ function attachDiagnostics(page) {
   });
   page.on("response", (response) => {
     try {
-      if (new URL(response.url()).pathname.startsWith("/api/beleza-em-movimento/")) diagnostics.apiResponses += 1;
+      const pathname = new URL(response.url()).pathname;
+      if (pathname.startsWith("/api/beleza-em-movimento/")) {
+        diagnostics.apiResponses += 1;
+        diagnostics.lastApiStatus = response.status();
+        diagnostics.lastApiOperation = pathname.split("/").at(-1) ?? "unknown";
+      }
     } catch {
       // No URL is retained in evidence.
     }
@@ -152,6 +160,7 @@ function attachDiagnostics(page) {
       diagnostics.whatsappRequests += 1;
     }
   });
+  pageDiagnostics.set(page, diagnostics);
   return diagnostics;
 }
 
@@ -180,9 +189,31 @@ async function assertScrubbed(page) {
   }
 }
 
-async function waitFresh(page) {
+async function waitFresh(page, checkpoint) {
   const deck = page.getByRole("button", { name: /Clique no baralho para começar a sua leitura/i });
-  await deck.waitFor({ state: "visible", timeout: 60_000 });
+  try {
+    await deck.waitFor({ state: "visible", timeout: 60_000 });
+  } catch {
+    const state = await page.evaluate(() => ({
+      pathname: window.location.pathname,
+      historyLength: window.history.length,
+      hasContextRef: typeof window.history.state?.__efBeautyMovementContextRef === "string",
+      documentVisible: document.visibilityState === "visible",
+      deckButtonCount: document.querySelectorAll('button[aria-label*="Clique no baralho"]').length,
+      busyRegionCount: document.querySelectorAll('[aria-busy="true"]').length,
+    })).catch(() => ({ stateUnavailable: true }));
+    const diagnostics = pageDiagnostics.get(page) ?? {};
+    fail("beauty_movement_isolation_smoke_fresh_timeout", {
+      checkpoint,
+      ...state,
+      apiResponses: diagnostics.apiResponses ?? 0,
+      apiFailures: diagnostics.apiFailures ?? 0,
+      lastApiStatus: diagnostics.lastApiStatus ?? 0,
+      lastApiOperation: diagnostics.lastApiOperation ?? "none",
+      consoleErrors: diagnostics.consoleErrors ?? 0,
+      pageErrors: diagnostics.pageErrors ?? 0,
+    });
+  }
   await assertScrubbed(page);
 }
 
@@ -214,11 +245,11 @@ async function waitAct(page, act) {
   await assertScrubbed(page);
 }
 
-async function openInvite(page, baseUrl, invite, route, expectedAct = null) {
+async function openInvite(page, baseUrl, invite, route, expectedAct = null, checkpoint = "open-invite") {
   if (!ROUTES.includes(route)) fail("beauty_movement_isolation_smoke_route_invalid");
   await page.goto(`${baseUrl}${route}#c=${encodeURIComponent(invite.token)}`, { waitUntil: "domcontentloaded" });
   if (expectedAct) await waitAct(page, expectedAct);
-  else await waitFresh(page);
+  else await waitFresh(page, checkpoint);
   return contextRef(page);
 }
 
@@ -298,17 +329,17 @@ async function run() {
     const pageA = await shared.newPage();
     const diagnosticsA = attachDiagnostics(pageA);
 
-    const firstContextA = await openInvite(pageA, baseUrl, invites.a, ROUTES[0]);
+    const firstContextA = await openInvite(pageA, baseUrl, invites.a, ROUTES[0], null, "initial-a");
     await pageA.getByRole("button", { name: /Clique no baralho para começar a sua leitura/i }).click();
     await revealAndAdvance(pageA, "Beleza", "Movimento");
     await reloadAt(pageA, "Movimento");
 
-    const firstContextB = await openInvite(pageA, baseUrl, invites.b, ROUTES[0]);
+    const firstContextB = await openInvite(pageA, baseUrl, invites.b, ROUTES[0], null, "switch-a-to-b");
     if (firstContextA === firstContextB) fail("beauty_movement_isolation_smoke_context_collision");
 
     const pageB = await shared.newPage();
     const diagnosticsB = attachDiagnostics(pageB);
-    const secondContextB = await openInvite(pageB, baseUrl, invites.b, ROUTES[1]);
+    const secondContextB = await openInvite(pageB, baseUrl, invites.b, ROUTES[1], null, "parallel-b");
     if (secondContextB === firstContextA || secondContextB === firstContextB) {
       fail("beauty_movement_isolation_smoke_session_context_reused");
     }
@@ -317,7 +348,7 @@ async function run() {
     await waitAct(pageA, "Movimento");
     if (await contextRef(pageA) !== firstContextA) fail("beauty_movement_isolation_smoke_back_restored_wrong_context");
     await pageA.goForward();
-    await waitFresh(pageA);
+    await waitFresh(pageA, "forward-b");
     if (await contextRef(pageA) !== firstContextB) fail("beauty_movement_isolation_smoke_forward_restored_wrong_context");
 
     await pageA.goBack();
@@ -343,9 +374,9 @@ async function run() {
     const privateContext = await browser.newContext();
     const privatePage = await privateContext.newPage();
     const diagnosticsPrivate = attachDiagnostics(privatePage);
-    await openInvite(privatePage, baseUrl, invites.primary, ROUTES[0]);
+    await openInvite(privatePage, baseUrl, invites.primary, ROUTES[0], null, "private-primary");
     await privatePage.reload({ waitUntil: "domcontentloaded" });
-    await waitFresh(privatePage);
+    await waitFresh(privatePage, "private-reload");
 
     // The public exchange limiter allows six attempts per source IP and
     // minute. Phase one intentionally consumes exactly six exchanges. Waiting
@@ -364,9 +395,9 @@ async function run() {
     });
     const storagePage = await storageUnavailable.newPage();
     const diagnosticsStorage = attachDiagnostics(storagePage);
-    await openInvite(storagePage, baseUrl, invites.primary, ROUTES[1]);
+    await openInvite(storagePage, baseUrl, invites.primary, ROUTES[1], null, "storage-unavailable");
     await storagePage.reload({ waitUntil: "domcontentloaded" });
-    await waitFresh(storagePage);
+    await waitFresh(storagePage, "storage-reload");
 
     const racePage = await shared.newPage();
     const diagnosticsRace = attachDiagnostics(racePage);

--- a/website/scripts/beauty-movement-context-isolation-smoke.mjs
+++ b/website/scripts/beauty-movement-context-isolation-smoke.mjs
@@ -499,14 +499,15 @@ async function run() {
 
     const racePage = await shared.newPage();
     const diagnosticsRace = attachDiagnostics(racePage);
-    await openInvite(racePage, baseUrl, invites.a, ROUTES[0], "Celebração", "race-a");
+    await openInvite(racePage, baseUrl, invites.a, ROUTES[0], "Celebração", "race-seed-a");
+    resetCheckpointDiagnostics(racePage);
     await racePage.evaluate(({ tokenB, tokenA }) => {
       window.location.hash = `c=${tokenB}`;
       window.setTimeout(() => {
         window.location.hash = `c=${tokenA}`;
       }, 50);
     }, { tokenB: invites.b.token, tokenA: invites.a.token });
-    await waitAct(racePage, "Celebração", "race-a");
+    await waitAct(racePage, "Celebração", "hash-race-b-to-a");
     await assertScrubbed(racePage);
 
     await shared.addCookies([{

--- a/website/scripts/beauty-movement-context-isolation-smoke.mjs
+++ b/website/scripts/beauty-movement-context-isolation-smoke.mjs
@@ -336,15 +336,22 @@ async function revealAndAdvance(page, currentAct, nextAct, checkpoint) {
       status: 0,
     });
   }
+  const responsePromise = page.waitForResponse((candidate) => {
+    const url = new URL(candidate.url());
+    return candidate.request().method() === "POST" && url.pathname === "/api/beleza-em-movimento/reveal";
+  }, { timeout: 30_000 });
+  try {
+    await card.click();
+  } catch {
+    void responsePromise.catch(() => undefined);
+    failAtCheckpoint(page, "beauty_movement_isolation_smoke_reveal_failed", checkpoint, {
+      phase: "click",
+      status: 0,
+    });
+  }
   let response;
   try {
-    [response] = await Promise.all([
-      page.waitForResponse((candidate) => {
-        const url = new URL(candidate.url());
-        return candidate.request().method() === "POST" && url.pathname === "/api/beleza-em-movimento/reveal";
-      }, { timeout: 30_000 }),
-      card.click(),
-    ]);
+    response = await responsePromise;
   } catch {
     failAtCheckpoint(page, "beauty_movement_isolation_smoke_reveal_failed", checkpoint, {
       phase: "request",

--- a/website/scripts/beauty-movement-context-isolation-smoke.mjs
+++ b/website/scripts/beauty-movement-context-isolation-smoke.mjs
@@ -224,7 +224,7 @@ async function contextRef(page, checkpoint = "context-ref") {
   return value;
 }
 
-async function assertScrubbed(page) {
+async function assertScrubbed(page, checkpoint) {
   const result = await page.evaluate(() => {
     let inviteStorage = null;
     try {
@@ -239,7 +239,7 @@ async function assertScrubbed(page) {
     };
   });
   if (!result.hashEmpty || !result.tokenAbsentFromUrl || !result.inviteStorageEmpty) {
-    fail("beauty_movement_isolation_smoke_handoff_not_scrubbed", result);
+    failAtCheckpoint(page, "beauty_movement_isolation_smoke_handoff_not_scrubbed", checkpoint, result);
   }
 }
 
@@ -276,7 +276,7 @@ async function waitFresh(page, checkpoint) {
   } catch {
     await reportFreshCheckpointFailure(page, checkpoint, "freshness");
   }
-  await assertScrubbed(page);
+  await assertScrubbed(page, checkpoint);
 }
 
 async function readJourneyState(page) {
@@ -309,7 +309,7 @@ async function waitAct(page, act, checkpoint = "act-transition") {
       ...checkpointDiagnosticsSnapshot(page),
     });
   }
-  await assertScrubbed(page);
+  await assertScrubbed(page, checkpoint);
 }
 
 async function openInvite(page, baseUrl, invite, route, expectedAct = null, checkpoint = "open-invite") {
@@ -508,7 +508,7 @@ async function run() {
       }, 50);
     }, { tokenB: invites.b.token, tokenA: invites.a.token });
     await waitAct(racePage, "Celebração", "hash-race-b-to-a");
-    await assertScrubbed(racePage);
+    await assertScrubbed(racePage, "hash-race-b-to-a");
 
     await shared.addCookies([{
       name: LEGACY_COOKIE,

--- a/website/scripts/beauty-movement-context-isolation-smoke.mjs
+++ b/website/scripts/beauty-movement-context-isolation-smoke.mjs
@@ -186,6 +186,19 @@ function resetCheckpointDiagnostics(page) {
   diagnostics.checkpointLastApiTransportFailure = false;
 }
 
+function checkpointDiagnosticsSnapshot(page) {
+  const diagnostics = pageDiagnostics.get(page) ?? {};
+  return {
+    apiResponses: diagnostics.checkpointApiResponses ?? 0,
+    apiFailures: diagnostics.checkpointApiFailures ?? 0,
+    lastApiStatus: diagnostics.checkpointLastApiStatus ?? 0,
+    lastApiOperation: diagnostics.checkpointLastApiOperation ?? "none",
+    lastApiTransportFailure: diagnostics.checkpointLastApiTransportFailure ?? false,
+    consoleErrors: diagnostics.consoleErrors ?? 0,
+    pageErrors: diagnostics.pageErrors ?? 0,
+  };
+}
+
 async function contextRef(page) {
   const value = await page.evaluate(() => history.state?.__efBeautyMovementContextRef ?? null);
   if (!CONTEXT_PATTERN.test(value ?? "")) fail("beauty_movement_isolation_smoke_context_missing");
@@ -220,18 +233,11 @@ async function reportFreshCheckpointFailure(page, checkpoint, phase) {
     deckButtonCount: document.querySelectorAll('button[aria-label*="Clique no baralho"]').length,
     busyRegionCount: document.querySelectorAll('[aria-busy="true"]').length,
   })).catch(() => ({ stateUnavailable: true }));
-  const diagnostics = pageDiagnostics.get(page) ?? {};
   fail("beauty_movement_isolation_smoke_fresh_checkpoint_failure", {
     checkpoint,
     phase,
     ...state,
-    apiResponses: diagnostics.checkpointApiResponses ?? 0,
-    apiFailures: diagnostics.checkpointApiFailures ?? 0,
-    lastApiStatus: diagnostics.checkpointLastApiStatus ?? 0,
-    lastApiOperation: diagnostics.checkpointLastApiOperation ?? "none",
-    lastApiTransportFailure: diagnostics.checkpointLastApiTransportFailure ?? false,
-    consoleErrors: diagnostics.consoleErrors ?? 0,
-    pageErrors: diagnostics.pageErrors ?? 0,
+    ...checkpointDiagnosticsSnapshot(page),
   });
 }
 
@@ -271,13 +277,18 @@ async function readJourneyState(page) {
   });
 }
 
-async function waitAct(page, act) {
+async function waitAct(page, act, checkpoint = "act-transition") {
   try {
     await page.getByRole("button", { name: `Revelar carta 1 de ${act}`, exact: true })
       .waitFor({ state: "visible", timeout: 60_000 });
   } catch {
     const state = await readJourneyState(page).catch(() => ({ stateUnavailable: true }));
-    fail("beauty_movement_isolation_smoke_act_timeout", { expectedAct: act, ...state });
+    fail("beauty_movement_isolation_smoke_act_timeout", {
+      checkpoint,
+      expectedAct: act,
+      ...state,
+      ...checkpointDiagnosticsSnapshot(page),
+    });
   }
   await assertScrubbed(page);
 }
@@ -287,12 +298,14 @@ async function openInvite(page, baseUrl, invite, route, expectedAct = null, chec
   await navigateAtCheckpoint(page, checkpoint, () => (
     page.goto(`${baseUrl}${route}#c=${encodeURIComponent(invite.token)}`, { waitUntil: "domcontentloaded" })
   ));
-  if (expectedAct) await waitAct(page, expectedAct);
+  if (expectedAct) await waitAct(page, expectedAct, checkpoint);
   else await waitFresh(page, checkpoint);
   return contextRef(page);
 }
 
 async function revealAndAdvance(page, currentAct, nextAct) {
+  const checkpoint = `advance-${currentAct.toLowerCase()}-to-${nextAct.toLowerCase()}`;
+  resetCheckpointDiagnostics(page);
   const card = page.getByRole("button", {
     name: `Revelar carta 1 de ${currentAct}`,
     exact: true,
@@ -315,12 +328,12 @@ async function revealAndAdvance(page, currentAct, nextAct) {
   }
   await page.locator('button[aria-pressed="true"]').waitFor({ state: "visible", timeout: 30_000 });
   await page.waitForTimeout(5_600);
-  await waitAct(page, nextAct);
+  await waitAct(page, nextAct, checkpoint);
 }
 
 async function reloadAt(page, act, checkpoint) {
   await navigateAtCheckpoint(page, checkpoint, () => page.reload({ waitUntil: "domcontentloaded" }));
-  await waitAct(page, act);
+  await waitAct(page, act, checkpoint);
 }
 
 async function expectFailClosed(page, target) {
@@ -384,14 +397,14 @@ async function run() {
     }
 
     await navigateAtCheckpoint(pageA, "back-a", () => pageA.goBack());
-    await waitAct(pageA, "Movimento");
+    await waitAct(pageA, "Movimento", "back-a");
     if (await contextRef(pageA) !== firstContextA) fail("beauty_movement_isolation_smoke_back_restored_wrong_context");
     await navigateAtCheckpoint(pageA, "forward-b", () => pageA.goForward());
     await waitFresh(pageA, "forward-b");
     if (await contextRef(pageA) !== firstContextB) fail("beauty_movement_isolation_smoke_forward_restored_wrong_context");
 
     await navigateAtCheckpoint(pageA, "back-a-final", () => pageA.goBack());
-    await waitAct(pageA, "Movimento");
+    await waitAct(pageA, "Movimento", "back-a-final");
     await revealAndAdvance(pageA, "Movimento", "Celebração");
     await revealAndAdvance(pageB, "Beleza", "Movimento");
 
@@ -447,7 +460,7 @@ async function run() {
         window.location.hash = `c=${tokenA}`;
       }, 50);
     }, { tokenB: invites.b.token, tokenA: invites.a.token });
-    await waitAct(racePage, "Celebração");
+    await waitAct(racePage, "Celebração", "race-a");
     await assertScrubbed(racePage);
 
     await shared.addCookies([{

--- a/website/scripts/beauty-movement-context-isolation-smoke.mjs
+++ b/website/scripts/beauty-movement-context-isolation-smoke.mjs
@@ -381,19 +381,28 @@ async function reloadAt(page, act, checkpoint) {
   await waitAct(page, act, checkpoint);
 }
 
-async function expectFailClosed(page, target) {
-  await page.goto(target, { waitUntil: "domcontentloaded" });
-  await page.waitForFunction(() => {
-    const normalized = window.location.pathname.replace(/\/+$/, "") || "/";
-    return normalized !== "/beleza-em-movimento" && normalized.toLowerCase() !== "/belezaemmovimento";
-  }, { timeout: 60_000 });
+async function expectFailClosed(page, target, checkpoint) {
+  await navigateAtCheckpoint(page, checkpoint, () => page.goto(target, { waitUntil: "domcontentloaded" }));
+  try {
+    await page.waitForFunction(() => {
+      const normalized = window.location.pathname.replace(/\/+$/, "") || "/";
+      return normalized !== "/beleza-em-movimento" && normalized.toLowerCase() !== "/belezaemmovimento";
+    }, { timeout: 60_000 });
+  } catch {
+    failAtCheckpoint(page, "beauty_movement_isolation_smoke_fail_closed_invalid", checkpoint, {
+      phase: "redirect",
+    });
+  }
   const result = await page.evaluate(() => ({
     hashEmpty: window.location.hash === "",
     campaignBusy: document.querySelectorAll('[aria-busy="true"]').length,
     campaignDeck: document.querySelectorAll('button[aria-label*="Clique no baralho"]').length,
   }));
   if (!result.hashEmpty || result.campaignBusy !== 0 || result.campaignDeck !== 0) {
-    fail("beauty_movement_isolation_smoke_fail_closed_invalid", result);
+    failAtCheckpoint(page, "beauty_movement_isolation_smoke_fail_closed_invalid", checkpoint, {
+      phase: "validation",
+      ...result,
+    });
   }
 }
 
@@ -432,21 +441,27 @@ async function run() {
     await reloadAt(pageA, "Movimento", "reload-a-movement");
 
     const firstContextB = await openInvite(pageA, baseUrl, invites.b, ROUTES[0], null, "switch-a-to-b");
-    if (firstContextA === firstContextB) fail("beauty_movement_isolation_smoke_context_collision");
+    if (firstContextA === firstContextB) {
+      failAtCheckpoint(pageA, "beauty_movement_isolation_smoke_context_collision", "switch-a-to-b");
+    }
 
     const pageB = await shared.newPage();
     const diagnosticsB = attachDiagnostics(pageB);
     const secondContextB = await openInvite(pageB, baseUrl, invites.b, ROUTES[1], null, "parallel-b");
     if (secondContextB === firstContextA || secondContextB === firstContextB) {
-      fail("beauty_movement_isolation_smoke_session_context_reused");
+      failAtCheckpoint(pageB, "beauty_movement_isolation_smoke_session_context_reused", "parallel-b");
     }
 
     await navigateAtCheckpoint(pageA, "back-a", () => pageA.goBack());
     await waitAct(pageA, "Movimento", "back-a");
-    if (await contextRef(pageA, "back-a") !== firstContextA) fail("beauty_movement_isolation_smoke_back_restored_wrong_context");
+    if (await contextRef(pageA, "back-a") !== firstContextA) {
+      failAtCheckpoint(pageA, "beauty_movement_isolation_smoke_back_restored_wrong_context", "back-a");
+    }
     await navigateAtCheckpoint(pageA, "forward-b", () => pageA.goForward());
     await waitFresh(pageA, "forward-b");
-    if (await contextRef(pageA, "forward-b") !== firstContextB) fail("beauty_movement_isolation_smoke_forward_restored_wrong_context");
+    if (await contextRef(pageA, "forward-b") !== firstContextB) {
+      failAtCheckpoint(pageA, "beauty_movement_isolation_smoke_forward_restored_wrong_context", "forward-b");
+    }
 
     await navigateAtCheckpoint(pageA, "back-a-final", () => pageA.goBack());
     await waitAct(pageA, "Movimento", "back-a-final");
@@ -457,9 +472,19 @@ async function run() {
       reloadAt(pageA, "Celebração", "simultaneous-reload-a"),
       reloadAt(pageB, "Movimento", "simultaneous-reload-b"),
     ]);
-    if (await contextRef(pageA, "simultaneous-reload-a") !== firstContextA
-      || await contextRef(pageB, "simultaneous-reload-b") !== secondContextB) {
-      fail("beauty_movement_isolation_smoke_simultaneous_reload_context_changed");
+    if (await contextRef(pageA, "simultaneous-reload-a") !== firstContextA) {
+      failAtCheckpoint(
+        pageA,
+        "beauty_movement_isolation_smoke_simultaneous_reload_context_changed",
+        "simultaneous-reload-a",
+      );
+    }
+    if (await contextRef(pageB, "simultaneous-reload-b") !== secondContextB) {
+      failAtCheckpoint(
+        pageB,
+        "beauty_movement_isolation_smoke_simultaneous_reload_context_changed",
+        "simultaneous-reload-b",
+      );
     }
 
     const reopenedA = await shared.newPage();
@@ -520,16 +545,20 @@ async function run() {
     }]);
     const expiredPage = await shared.newPage();
     const diagnosticsExpired = attachDiagnostics(expiredPage);
-    await expectFailClosed(expiredPage, `${baseUrl}${ROUTES[0]}#c=${encodeURIComponent(invites.expired.token)}`);
+    await expectFailClosed(
+      expiredPage,
+      `${baseUrl}${ROUTES[0]}#c=${encodeURIComponent(invites.expired.token)}`,
+      "expired-invite",
+    );
     const legacyAfterExpired = (await shared.cookies(baseUrl)).some((cookie) => cookie.name === LEGACY_COOKIE);
     if (legacyAfterExpired) fail("beauty_movement_isolation_smoke_legacy_cookie_not_cleared");
 
     const invalidPage = await shared.newPage();
     const diagnosticsInvalid = attachDiagnostics(invalidPage);
-    await expectFailClosed(invalidPage, `${baseUrl}${ROUTES[1]}#c=invalid`);
+    await expectFailClosed(invalidPage, `${baseUrl}${ROUTES[1]}#c=invalid`, "invalid-invite");
     const directPage = await shared.newPage();
     const diagnosticsDirect = attachDiagnostics(directPage);
-    await expectFailClosed(directPage, `${baseUrl}${ROUTES[0]}`);
+    await expectFailClosed(directPage, `${baseUrl}${ROUTES[0]}`, "direct-entry");
 
     const sharedCookies = await shared.cookies(`${baseUrl}/api/beleza-em-movimento/state`);
     const cookieA = sharedCookies.find((cookie) => cookie.name === `ef_bm_ctx_${firstContextA}`);

--- a/website/tests/beautyMovementContextIsolation.test.ts
+++ b/website/tests/beautyMovementContextIsolation.test.ts
@@ -255,6 +255,7 @@ test("governed staging and production smokes execute the same four-invite isolat
     assert.match(smoke, /beauty_movement_isolation_smoke_fresh_checkpoint_failure/);
     assert.match(smoke, /checkpointDiagnosticsSnapshot/);
     assert.match(smoke, /failAtCheckpoint/);
+    assert.match(smoke, /assertScrubbed\(page, checkpoint\)/);
     assert.match(smoke, /contextRef\(page, checkpoint = "context-ref"\)/);
     assert.match(smoke, /waitAct\(page, act, checkpoint = "act-transition"\)/);
     assert.match(smoke, /"forward-b"/);

--- a/website/tests/beautyMovementContextIsolation.test.ts
+++ b/website/tests/beautyMovementContextIsolation.test.ts
@@ -253,6 +253,8 @@ test("governed staging and production smokes execute the same four-invite isolat
     assert.match(smoke, /rawTokensPersistedInEvidence: false/);
     assert.match(smoke, /beauty_movement_isolation_smoke_act_timeout/);
     assert.match(smoke, /beauty_movement_isolation_smoke_fresh_checkpoint_failure/);
+    assert.match(smoke, /checkpointDiagnosticsSnapshot/);
+    assert.match(smoke, /waitAct\(page, act, checkpoint = "act-transition"\)/);
     assert.match(smoke, /"forward-b"/);
     assert.match(smoke, /navigateAtCheckpoint/);
     assert.match(smoke, /checkpointLastApiTransportFailure = true/);

--- a/website/tests/beautyMovementContextIsolation.test.ts
+++ b/website/tests/beautyMovementContextIsolation.test.ts
@@ -254,6 +254,8 @@ test("governed staging and production smokes execute the same four-invite isolat
     assert.match(smoke, /beauty_movement_isolation_smoke_act_timeout/);
     assert.match(smoke, /beauty_movement_isolation_smoke_fresh_checkpoint_failure/);
     assert.match(smoke, /checkpointDiagnosticsSnapshot/);
+    assert.match(smoke, /failAtCheckpoint/);
+    assert.match(smoke, /contextRef\(page, checkpoint = "context-ref"\)/);
     assert.match(smoke, /waitAct\(page, act, checkpoint = "act-transition"\)/);
     assert.match(smoke, /"forward-b"/);
     assert.match(smoke, /navigateAtCheckpoint/);

--- a/website/tests/beautyMovementContextIsolation.test.ts
+++ b/website/tests/beautyMovementContextIsolation.test.ts
@@ -258,6 +258,7 @@ test("governed staging and production smokes execute the same four-invite isolat
     assert.match(smoke, /contextRef\(page, checkpoint = "context-ref"\)/);
     assert.match(smoke, /waitAct\(page, act, checkpoint = "act-transition"\)/);
     assert.match(smoke, /"forward-b"/);
+    assert.match(smoke, /"hash-race-b-to-a"/);
     assert.match(smoke, /navigateAtCheckpoint/);
     assert.match(smoke, /checkpointLastApiTransportFailure = true/);
     assert.doesNotMatch(smoke, /console\.log\(.*token/i);

--- a/website/tests/beautyMovementContextIsolation.test.ts
+++ b/website/tests/beautyMovementContextIsolation.test.ts
@@ -252,8 +252,10 @@ test("governed staging and production smokes execute the same four-invite isolat
     assert.match(smoke, /name: `ef_bm_ctx_\$\{secondContextB\}`/);
     assert.match(smoke, /rawTokensPersistedInEvidence: false/);
     assert.match(smoke, /beauty_movement_isolation_smoke_act_timeout/);
-    assert.match(smoke, /beauty_movement_isolation_smoke_fresh_timeout/);
+    assert.match(smoke, /beauty_movement_isolation_smoke_fresh_checkpoint_failure/);
     assert.match(smoke, /"forward-b"/);
+    assert.match(smoke, /navigateAtCheckpoint/);
+    assert.match(smoke, /checkpointLastApiTransportFailure = true/);
     assert.doesNotMatch(smoke, /console\.log\(.*token/i);
     assert.match(primarySmoke, /whatsappCtaPresent: true/);
     assert.match(primarySmoke, /contextRestoredAfterReload: true/);

--- a/website/tests/beautyMovementContextIsolation.test.ts
+++ b/website/tests/beautyMovementContextIsolation.test.ts
@@ -262,6 +262,8 @@ test("governed staging and production smokes execute the same four-invite isolat
     assert.match(smoke, /"hash-race-b-to-a"/);
     assert.match(smoke, /"advance-a-beleza-to-movimento"/);
     assert.match(smoke, /"advance-b-beleza-to-movimento"/);
+    assert.match(smoke, /phase: "click"/);
+    assert.match(smoke, /phase: "request"/);
     assert.match(smoke, /"simultaneous-reload-a"/);
     assert.match(smoke, /"simultaneous-reload-b"/);
     assert.match(smoke, /"expired-invite"/);

--- a/website/tests/beautyMovementContextIsolation.test.ts
+++ b/website/tests/beautyMovementContextIsolation.test.ts
@@ -252,6 +252,8 @@ test("governed staging and production smokes execute the same four-invite isolat
     assert.match(smoke, /name: `ef_bm_ctx_\$\{secondContextB\}`/);
     assert.match(smoke, /rawTokensPersistedInEvidence: false/);
     assert.match(smoke, /beauty_movement_isolation_smoke_act_timeout/);
+    assert.match(smoke, /beauty_movement_isolation_smoke_fresh_timeout/);
+    assert.match(smoke, /"forward-b"/);
     assert.doesNotMatch(smoke, /console\.log\(.*token/i);
     assert.match(primarySmoke, /whatsappCtaPresent: true/);
     assert.match(primarySmoke, /contextRestoredAfterReload: true/);

--- a/website/tests/beautyMovementContextIsolation.test.ts
+++ b/website/tests/beautyMovementContextIsolation.test.ts
@@ -260,6 +260,8 @@ test("governed staging and production smokes execute the same four-invite isolat
     assert.match(smoke, /waitAct\(page, act, checkpoint = "act-transition"\)/);
     assert.match(smoke, /"forward-b"/);
     assert.match(smoke, /"hash-race-b-to-a"/);
+    assert.match(smoke, /"advance-a-beleza-to-movimento"/);
+    assert.match(smoke, /"advance-b-beleza-to-movimento"/);
     assert.match(smoke, /"simultaneous-reload-a"/);
     assert.match(smoke, /"simultaneous-reload-b"/);
     assert.match(smoke, /"expired-invite"/);

--- a/website/tests/beautyMovementContextIsolation.test.ts
+++ b/website/tests/beautyMovementContextIsolation.test.ts
@@ -260,6 +260,9 @@ test("governed staging and production smokes execute the same four-invite isolat
     assert.match(smoke, /waitAct\(page, act, checkpoint = "act-transition"\)/);
     assert.match(smoke, /"forward-b"/);
     assert.match(smoke, /"hash-race-b-to-a"/);
+    assert.match(smoke, /"simultaneous-reload-a"/);
+    assert.match(smoke, /"simultaneous-reload-b"/);
+    assert.match(smoke, /"expired-invite"/);
     assert.match(smoke, /navigateAtCheckpoint/);
     assert.match(smoke, /checkpointLastApiTransportFailure = true/);
     assert.doesNotMatch(smoke, /console\.log\(.*token/i);


### PR DESCRIPTION
## Summary
- identify the exact fresh-session checkpoint that fails in the governed staging journey
- report only sanitized route, API operation/status, and aggregate browser state
- keep opaque invitation and session values out of logs and evidence

## Validation
- website test suite: 192/192 passing
- website lint: passing
- git diff --check: passing