### PR TITLE
fix(website): resume Beauty Movement after reload

### DIFF
--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -313,14 +313,15 @@ export default function BeautyMovementExperience({
         () => getSelectionsFromReveals(initialState.palette, initialState.reveals),
         [initialState.palette, initialState.reveals],
     );
-    const initialReadingComplete = getCurrentActIndex(incomingSelections) >= BEAUTY_MOVEMENT_ACTS.length;
+    const initialActIndex = getCurrentActIndex(incomingSelections);
+    const initialReadingComplete = initialActIndex >= BEAUTY_MOVEMENT_ACTS.length;
     const [selections, setSelections] = useState<BeautyMovementSelections>(incomingSelections);
     const [displayedActIndex, setDisplayedActIndex] = useState(() =>
-        Math.min(getCurrentActIndex(incomingSelections), BEAUTY_MOVEMENT_ACTS.length - 1),
+        Math.min(initialActIndex, BEAUTY_MOVEMENT_ACTS.length - 1),
     );
     const [introStage, setIntroStage] = useState<IntroStage>("hidden");
     const [handStage, setHandStage] = useState<HandStage>(() =>
-        initialState.confirmed || initialReadingComplete ? "ready" : "waiting",
+        initialState.confirmed || initialActIndex > 0 ? "ready" : "waiting",
     );
     const [confirmed, setConfirmed] = useState(initialState.confirmed);
     const [operationalConsent, setOperationalConsent] = useState(false);

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -181,6 +181,8 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.match(experience, /<strong>\{card\.title\}<\/strong>/);
     assert.match(experience, /<span>\{card\.shortMessage\}<\/span>/);
     assert.match(experience, /type HandStage =\s*\|\s*"waiting"/);
+    assert.match(experience, /const initialActIndex = getCurrentActIndex\(incomingSelections\)/);
+    assert.match(experience, /initialState\.confirmed \|\| initialActIndex > 0 \? "ready" : "waiting"/);
     assert.match(experience, /"expand"\s*\|\s*"deal"/);
     assert.match(experience, /function scheduleDealSequence\(token: number, onReady: \(\) => void\)/);
     assert.match(experience, /tableSurfaceRef/);


### PR DESCRIPTION
## Causa raiz
Ao restaurar uma leitura parcial, o D1 e `/state` retornavam a etapa correta, mas o estado visual `handStage` era inicializado como `waiting`. Assim, uma sessão já em Movimento parecia carregar a versão antiga, embora o build e o progresso estivessem corretos.

## Correção
- calcula uma única vez o índice restaurado da etapa;
- inicia a mesa em `ready` quando já existe ao menos uma escolha persistida;
- mantém sessões novas em `waiting` e leituras concluídas no fluxo final existente;
- adiciona contrato de regressão para a inicialização restaurada.

## Validação local
- `npm test`: 192/192
- `npm run lint`: aprovado
- `npm run typecheck`: aprovado, incluindo build de produção
- `git diff --check`: aprovado

## Segurança e dados
Nenhuma campanha, convite, token, cookie, migration ou dado de progresso é alterado. A correção é somente de hidratação visual.

## Rollback
Reverter este commit restaura exatamente o comportamento anterior.