### PR TITLE
fix(website): defer invite hash popstate

### DIFF
--- a/website/src/components/BeautyMovementCampaign.tsx
+++ b/website/src/components/BeautyMovementCampaign.tsx
@@ -15,6 +15,7 @@ import {
   clearBeautyMovementContextRef,
   consumeBeautyMovementInviteHandoff,
   isBeautyMovementContextRef,
+  parseBeautyMovementInviteFragment,
   readBeautyMovementContextRef,
   type BeautyMovementInviteHandoff,
 } from "@/lib/beautyMovementBrowserContext";
@@ -145,24 +146,33 @@ export default function BeautyMovementCampaign() {
       }
     }
 
-    const reinitialize = () => {
+    const reinitializeFromHandoff = () => {
+      pendingHandoffRef.current = null;
+      void initialize();
+    };
+    const reinitializeFromHistory = () => {
+      // Chromium emits popstate before hashchange for same-document fragment
+      // navigation. The synchronous layout handler owns invite fragments, so
+      // let it scrub and dispatch the explicit handoff instead of treating the
+      // transient history entry as a tokenless visit.
+      if (parseBeautyMovementInviteFragment(window.location.hash).attempted) return;
       pendingHandoffRef.current = null;
       void initialize();
     };
     const revalidateRestoredPage = (event: PageTransitionEvent) => {
-      if (event.persisted) reinitialize();
+      if (event.persisted) reinitializeFromHistory();
     };
 
-    window.addEventListener(BEAUTY_MOVEMENT_HANDOFF_EVENT, reinitialize);
-    window.addEventListener("popstate", reinitialize);
+    window.addEventListener(BEAUTY_MOVEMENT_HANDOFF_EVENT, reinitializeFromHandoff);
+    window.addEventListener("popstate", reinitializeFromHistory);
     window.addEventListener("pageshow", revalidateRestoredPage);
     void initialize();
 
     return () => {
       mounted = false;
       initializationAbortRef.current?.abort();
-      window.removeEventListener(BEAUTY_MOVEMENT_HANDOFF_EVENT, reinitialize);
-      window.removeEventListener("popstate", reinitialize);
+      window.removeEventListener(BEAUTY_MOVEMENT_HANDOFF_EVENT, reinitializeFromHandoff);
+      window.removeEventListener("popstate", reinitializeFromHistory);
       window.removeEventListener("pageshow", revalidateRestoredPage);
     };
   }, []);

--- a/website/tests/beautyMovementContextIsolation.test.ts
+++ b/website/tests/beautyMovementContextIsolation.test.ts
@@ -70,6 +70,12 @@ test("campaign identity is selected explicitly per history entry instead of by a
     assert.match(campaign, /AbortController/);
     assert.match(
         campaign,
+        /const reinitializeFromHistory = \(\) => \{[\s\S]*parseBeautyMovementInviteFragment\(window\.location\.hash\)\.attempted\) return;/,
+    );
+    assert.match(campaign, /addEventListener\(BEAUTY_MOVEMENT_HANDOFF_EVENT, reinitializeFromHandoff\)/);
+    assert.match(campaign, /addEventListener\("popstate", reinitializeFromHistory\)/);
+    assert.match(
+        campaign,
         /const verified = await requestCampaignState\("\/api\/beleza-em-movimento\/state", \{\s*contextRef: exchange\.contextRef,/,
     );
     assert.match(campaign, /nextState = verified\.state/);


### PR DESCRIPTION
## Causa raiz comprovada
O Chromium emite `popstate` antes de `hashchange` numa navegação de mesmo documento para `#c=...`. O listener genérico de histórico tentava restaurar o novo entry antes que o capturador síncrono consumisse o convite. Como esse entry transitório ainda não possuía contextRef, o fluxo iniciava o redirect fail-closed; o `hashchange` então começava a troca válida, que era abortada pela navegação para `/`.

## Correção
- separa a reinicialização por handoff da reinicialização por histórico;
- quando `popstate` contém tentativa de convite, aguarda o capturador síncrono scrubbar o fragmento e disparar o handoff explícito;
- mantém back/forward e bfcache vinculados ao contextRef do próprio history entry;
- preserva AbortController e last-navigation-wins para A→B→A rápido.

## Evidência
- reprodução Playwright isolada: `popstate` precede `hashchange` em Chromium;
- staging anterior falhou exatamente em `switch-a-to-b` com request `/session` abortado e pathname `/`;
- `npm test`: 192/192;
- `npm run lint`: aprovado;
- `npm run typecheck`: aprovado, incluindo build;
- `git diff --check`: aprovado.

## Segurança e dados
Nenhum convite, cookie, token, campanha, migration ou progresso real é alterado. Convites inválidos continuam falhando fechados.

## Rollback
Reverter este commit restaura os listeners anteriores.