### PR TITLE
test(website): start both isolated readings

### DIFF
--- a/website/scripts/beauty-movement-context-isolation-smoke.mjs
+++ b/website/scripts/beauty-movement-context-isolation-smoke.mjs
@@ -322,6 +322,17 @@ async function openInvite(page, baseUrl, invite, route, expectedAct = null, chec
   return contextRef(page, checkpoint);
 }
 
+async function beginReading(page, act, checkpoint) {
+  resetCheckpointDiagnostics(page);
+  const deck = page.getByRole("button", { name: /Clique no baralho para começar a sua leitura/i });
+  try {
+    await deck.click();
+  } catch {
+    failAtCheckpoint(page, "beauty_movement_isolation_smoke_deck_start_failed", checkpoint);
+  }
+  await waitAct(page, act, checkpoint);
+}
+
 async function revealAndAdvance(page, currentAct, nextAct, checkpoint) {
   resetCheckpointDiagnostics(page);
   const card = page.getByRole("button", {
@@ -442,7 +453,7 @@ async function run() {
     const diagnosticsA = attachDiagnostics(pageA);
 
     const firstContextA = await openInvite(pageA, baseUrl, invites.a, ROUTES[0], null, "initial-a");
-    await pageA.getByRole("button", { name: /Clique no baralho para começar a sua leitura/i }).click();
+    await beginReading(pageA, "Beleza", "start-a-reading");
     await revealAndAdvance(pageA, "Beleza", "Movimento", "advance-a-beleza-to-movimento");
     await reloadAt(pageA, "Movimento", "reload-a-movement");
 
@@ -457,6 +468,7 @@ async function run() {
     if (secondContextB === firstContextA || secondContextB === firstContextB) {
       failAtCheckpoint(pageB, "beauty_movement_isolation_smoke_session_context_reused", "parallel-b");
     }
+    await beginReading(pageB, "Beleza", "start-b-reading");
 
     await navigateAtCheckpoint(pageA, "back-a", () => pageA.goBack());
     await waitAct(pageA, "Movimento", "back-a");

--- a/website/tests/beautyMovementContextIsolation.test.ts
+++ b/website/tests/beautyMovementContextIsolation.test.ts
@@ -266,6 +266,8 @@ test("governed staging and production smokes execute the same four-invite isolat
     assert.match(smoke, /waitAct\(page, act, checkpoint = "act-transition"\)/);
     assert.match(smoke, /"forward-b"/);
     assert.match(smoke, /"hash-race-b-to-a"/);
+    assert.match(smoke, /beginReading\(pageA, "Beleza", "start-a-reading"\)/);
+    assert.match(smoke, /beginReading\(pageB, "Beleza", "start-b-reading"\)/);
     assert.match(smoke, /"advance-a-beleza-to-movimento"/);
     assert.match(smoke, /"advance-b-beleza-to-movimento"/);
     assert.match(smoke, /phase: "click"/);


### PR DESCRIPTION
## Objetivo
Corrigir o smoke autenticado para iniciar explicitamente a leitura nas duas abas sintéticas antes de tentar revelar a primeira carta.

## Superfícies e risco
- Apenas o roteiro governado de staging/produção e seu teste de contrato.
- Nenhuma alteração de UI, API, D1, campanha, convite ou dado real.
- Risco baixo e fail-closed: o smoke continua bloqueando a promoção diante de qualquer divergência.

## Flag e migration
- Não aplicável.

## Validação
- npm test: 192/192
- npm run lint
- npm run typecheck (build de produção + TypeScript)
- git diff --check
- Reexecutar o smoke autenticado de staging no SHA de merge exato.

## Rollback
Reverter este commit restaura o roteiro anterior; nenhum estado remoto depende da mudança.