### PR TITLE
test(website): settle fail-closed navigation

### DIFF
--- a/website/scripts/beauty-movement-context-isolation-smoke.mjs
+++ b/website/scripts/beauty-movement-context-isolation-smoke.mjs
@@ -398,13 +398,18 @@ async function reloadAt(page, act, checkpoint) {
   await waitAct(page, act, checkpoint);
 }
 
-async function expectFailClosed(page, target, checkpoint) {
+async function expectFailClosed(page, target, checkpoint, expectedApiStatus = 0) {
   await navigateAtCheckpoint(page, checkpoint, () => page.goto(target, { waitUntil: "domcontentloaded" }));
   try {
     await page.waitForFunction(() => {
       const normalized = window.location.pathname.replace(/\/+$/, "") || "/";
-      return normalized !== "/beleza-em-movimento" && normalized.toLowerCase() !== "/belezaemmovimento";
-    }, { timeout: 60_000 });
+      const campaignSettled = document.querySelectorAll('[aria-busy="true"]').length === 0
+        && document.querySelectorAll('button[aria-label*="Clique no baralho"]').length === 0;
+      return normalized !== "/beleza-em-movimento"
+        && normalized.toLowerCase() !== "/belezaemmovimento"
+        && window.location.hash === ""
+        && campaignSettled;
+    }, undefined, { timeout: 60_000 });
   } catch {
     failAtCheckpoint(page, "beauty_movement_isolation_smoke_fail_closed_invalid", checkpoint, {
       phase: "redirect",
@@ -421,12 +426,20 @@ async function expectFailClosed(page, target, checkpoint) {
       ...result,
     });
   }
+  const diagnostics = checkpointDiagnosticsSnapshot(page);
+  if (diagnostics.lastApiStatus !== expectedApiStatus) {
+    failAtCheckpoint(page, "beauty_movement_isolation_smoke_fail_closed_invalid", checkpoint, {
+      phase: "api-status",
+      expectedApiStatus,
+    });
+  }
 }
 
 function assertDiagnostics(label, diagnostics, options = {}) {
   const allowApiFailures = options.allowApiFailures === true;
+  const expectedConsoleErrors = options.expectedConsoleErrors ?? 0;
   if (
-    diagnostics.consoleErrors !== 0
+    diagnostics.consoleErrors !== expectedConsoleErrors
     || diagnostics.pageErrors !== 0
     || diagnostics.whatsappRequests !== 0
     || (!allowApiFailures && diagnostics.apiFailures !== 0)
@@ -567,6 +580,7 @@ async function run() {
       expiredPage,
       `${baseUrl}${ROUTES[0]}#c=${encodeURIComponent(invites.expired.token)}`,
       "expired-invite",
+      404,
     );
     const legacyAfterExpired = (await shared.cookies(baseUrl)).some((cookie) => cookie.name === LEGACY_COOKIE);
     if (legacyAfterExpired) fail("beauty_movement_isolation_smoke_legacy_cookie_not_cleared");
@@ -627,11 +641,11 @@ async function run() {
       ["reopened-b", diagnosticsReopenedB],
       ["private", diagnosticsPrivate],
       ["storage", diagnosticsStorage],
-      ["expired", diagnosticsExpired],
+      ["expired", diagnosticsExpired, { expectedConsoleErrors: 1 }],
       ["invalid", diagnosticsInvalid],
       ["direct", diagnosticsDirect],
     ];
-    for (const [label, value] of diagnostics) assertDiagnostics(label, value);
+    for (const [label, value, options] of diagnostics) assertDiagnostics(label, value, options);
     assertDiagnostics("race", diagnosticsRace, { allowApiFailures: true });
 
     const evidence = {

--- a/website/tests/beautyMovementContextIsolation.test.ts
+++ b/website/tests/beautyMovementContextIsolation.test.ts
@@ -275,6 +275,10 @@ test("governed staging and production smokes execute the same four-invite isolat
     assert.match(smoke, /"simultaneous-reload-a"/);
     assert.match(smoke, /"simultaneous-reload-b"/);
     assert.match(smoke, /"expired-invite"/);
+    assert.match(smoke, /campaignSettled/);
+    assert.match(smoke, /waitForFunction\([\s\S]*undefined, \{ timeout: 60_000 \}\)/);
+    assert.match(smoke, /"expired-invite",\s*404,/);
+    assert.match(smoke, /\["expired", diagnosticsExpired, \{ expectedConsoleErrors: 1 \}\]/);
     assert.match(smoke, /navigateAtCheckpoint/);
     assert.match(smoke, /checkpointLastApiTransportFailure = true/);
     assert.doesNotMatch(smoke, /console\.log\(.*token/i);


### PR DESCRIPTION
## Objetivo
Tornar deterministico o checkpoint fail-closed do smoke governado de isolamento da campanha, aguardando a navegacao terminar antes de avaliar o DOM.

## Causa
O smoke considerava suficiente o pathname sair da rota da campanha. Em navegacao por `location.replace`, isso permitia ler por alguns milissegundos o DOM anterior ainda ocupado e produzir falso negativo. O timeout do Playwright tambem estava no argumento incorreto.

## Alteracoes
- aguarda URL, fragmento e DOM da campanha assentarem;
- valida explicitamente o status esperado da API para convite expirado;
- permite exatamente o erro de console de recurso 404 esperado nesse caso;
- adiciona contratos para impedir regressao do harness.

## Superficie e risco
Somente harness e testes de release. Nenhum codigo de produto, campanha, convite, token ou progresso e alterado.

## Validacao local
- npm test: 192/192
- npm lint
- npm run typecheck, incluindo build de producao
- git diff --check

## Rollback
Reverter este commit restaura o comportamento anterior do smoke; producao permanece no ultimo SHA seguro ate staging ficar verde.