### PR TITLE
fix(website): attest staging candidate readiness

### DIFF
--- a/.github/workflows/beauty-movement-staging-smoke.yml
+++ b/.github/workflows/beauty-movement-staging-smoke.yml
@@ -494,12 +494,19 @@ jobs:
           state.candidateVersion = candidateVersion;
           fs.writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
           NODE
-          for attempt in $(seq 1 12); do
-            code="$(curl -sS -o /dev/null -w '%{http_code}' "${SMOKE_URL}/beleza-em-movimento" || true)"
-            [[ "${code}" == "200" ]] && break
+          candidate_headers="$RUNNER_TEMP/beauty-movement-staging-smoke/candidate-headers.txt"
+          candidate_build=''
+          code=''
+          for attempt in $(seq 1 24); do
+            code="$(curl -sS -D "${candidate_headers}" -o /dev/null -w '%{http_code}' "${SMOKE_URL}/beleza-em-movimento" || true)"
+            candidate_build="$(awk 'tolower($1) == "x-app-build:" { value=$0; sub(/^[^:]+:[[:space:]]*/, "", value); gsub(/\r/, "", value); print value }' "${candidate_headers}" | tail -n 1)"
+            [[ "${code}" == "200" && "${candidate_build}" == "${RELEASE_SHA}" ]] && break
             sleep 5
           done
-          [[ "${code}" == "200" ]] || { echo "temporary staging candidate is not serving the campaign (HTTP ${code})"; exit 1; }
+          [[ "${code}" == "200" && "${candidate_build}" == "${RELEASE_SHA}" ]] || {
+            echo "temporary staging candidate is not serving the attested release (HTTP ${code}; exact build: false)"
+            exit 1
+          }
           invite_url="$(node --input-type=commonjs -e '
           const fs = require("node:fs");
           const path = require("node:path");
@@ -514,6 +521,19 @@ jobs:
           ' "${OUTPUT_DIR}")"
           token="${invite_url##*#c=}"
           [[ "${token}" =~ ^[A-Za-z0-9_-]{40,180}$ ]] || { echo 'synthetic invite token shape invalid'; exit 1; }
+          campaign_probe_code=''
+          for attempt in $(seq 1 24); do
+            campaign_probe_code="$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+              -H "origin: ${SMOKE_URL}" -H 'content-type: application/json' \
+              --data "{\"token\":\"${token}\"}" \
+              "${SMOKE_URL}/api/beleza-em-movimento/campaign-copy" || true)"
+            [[ "${campaign_probe_code}" == "200" ]] && break
+            sleep 5
+          done
+          [[ "${campaign_probe_code}" == "200" ]] || {
+            echo "temporary staging campaign did not settle before the browser journey (HTTP ${campaign_probe_code})"
+            exit 1
+          }
           invite_ref="$(node --input-type=commonjs -e '
           const fs = require("node:fs");
           const path = require("node:path");

--- a/website/tests/beautyMovementContextIsolation.test.ts
+++ b/website/tests/beautyMovementContextIsolation.test.ts
@@ -250,6 +250,11 @@ test("governed staging and production smokes execute the same four-invite isolat
         assert.match(workflow, /beauty-movement-context-isolation-smoke\.mjs/);
         assert.match(workflow, /context-isolation-readback\.json/);
     }
+    assert.match(staging, /candidate_build=.*x-app-build/);
+    assert.match(staging, /"\$\{candidate_build\}" == "\$\{RELEASE_SHA\}"/);
+    assert.match(staging, /api\/beleza-em-movimento\/campaign-copy/);
+    assert.match(staging, /campaign_probe_code/);
+    assert.match(staging, /temporary staging campaign did not settle before the browser journey/);
     assert.match(smoke, /sameTabStartsFresh: true/);
     assert.match(smoke, /twoPagesSameContextIndependent: true/);
     assert.match(smoke, /simultaneousReloadStable: true/);


### PR DESCRIPTION
## Objetivo
Impedir que o smoke de staging inicie contra o Worker incumbente durante a propagacao de um candidato novo.

## Causa comprovada
O gate anterior aceitava apenas HTTP 200 da rota publica. O Worker incumbente, com a campanha desativada, tambem responde 200 nessa rota. A jornada podia portanto carregar o bundle anterior e enviar uma unica troca de sessao antes da propagacao do candidato, recebendo 503.

## Alteracoes
- aguarda `x-app-build` corresponder ao SHA imutavel solicitado;
- amplia a janela de propagacao sem relaxar o fail-closed;
- executa probe autenticado e somente leitura de `campaign-copy` antes do navegador;
- nunca imprime o token sintetico;
- adiciona contratos de YAML/Bash e readiness.

## Superficie e risco
Somente workflow governado de staging e teste de contrato. Sem mudanca no produto, na campanha real, nos convites ou no progresso existente.

## Validacao
- npm test: 192/192
- npm lint
- npm run typecheck, incluindo build de producao
- git diff --check
- staging anterior restaurado automaticamente apos a falha

## Rollback
Reverter este commit restaura o gate anterior. Producao permanece no ultimo SHA seguro ate um staging integralmente verde.