### PR TITLE
fix(ci): scan current tree for broad gitleaks

### DIFF
--- a/.github/scripts/security-secrets-audit-workflow.test.mjs
+++ b/.github/scripts/security-secrets-audit-workflow.test.mjs
@@ -27,6 +27,9 @@ test("workflow keeps PR Gitleaks mandatory and reserves full current-tree scans 
   assert.match(workflow, /gitleaks\/gitleaks-action@/);
   assert.match(workflow, /gitleaks dir --redact --exit-code=2 --config \.gitleaks\.toml \./);
   assert.doesNotMatch(workflow, /--log-opts="--all"/);
+  const gitleaksJob = workflow.split("\n  gitleaks:", 2)[1]?.split("\n  npm-audit:", 1)[0] || "";
+  assert.match(gitleaksJob, /git fetch --no-tags --unshallow origin/);
+  assert.ok(gitleaksJob.indexOf("git fetch --no-tags --unshallow origin") < gitleaksJob.indexOf("gitleaks/gitleaks-action@"));
   const fullTreeGitleaks = workflow.split("Run full current-tree Gitleaks scan for broad-risk PRs and main", 2)[1] || "";
   assert.match(fullTreeGitleaks, /if:\s+\$\{\{\s*needs\.scope\.outputs\.full_scan\s*==\s*'true'\s*\}\}/);
   assert.doesNotMatch(fullTreeGitleaks, /github\.event_name/);

--- a/.github/scripts/security-secrets-audit-workflow.test.mjs
+++ b/.github/scripts/security-secrets-audit-workflow.test.mjs
@@ -21,15 +21,15 @@ function scopeFor(files, { eventName = "pull_request", riskReport = null } = {})
   });
 }
 
-test("workflow keeps PR Gitleaks mandatory and reserves full scans for main, schedule, dispatch, or broad risk", () => {
+test("workflow keeps PR Gitleaks mandatory and reserves full current-tree scans for main, schedule, dispatch, or broad risk", () => {
   assert.match(workflow, /pull_request:\n\s+branches:\s+\[main\]/);
   assert.match(workflow, /schedule:/);
   assert.match(workflow, /gitleaks\/gitleaks-action@/);
-  assert.match(workflow, /gitleaks git --redact --exit-code=2/);
-  assert.match(workflow, /--log-opts="--all"/);
-  const fullHistoryGitleaks = workflow.split("Run full Gitleaks history scan for broad-risk PRs and main", 2)[1] || "";
-  assert.match(fullHistoryGitleaks, /if:\s+\$\{\{\s*needs\.scope\.outputs\.full_scan\s*==\s*'true'\s*\}\}/);
-  assert.doesNotMatch(fullHistoryGitleaks, /github\.event_name/);
+  assert.match(workflow, /gitleaks dir --redact --exit-code=2 --config \.gitleaks\.toml \./);
+  assert.doesNotMatch(workflow, /--log-opts="--all"/);
+  const fullTreeGitleaks = workflow.split("Run full current-tree Gitleaks scan for broad-risk PRs and main", 2)[1] || "";
+  assert.match(fullTreeGitleaks, /if:\s+\$\{\{\s*needs\.scope\.outputs\.full_scan\s*==\s*'true'\s*\}\}/);
+  assert.doesNotMatch(fullTreeGitleaks, /github\.event_name/);
   assert.match(workflow, /fetch-depth:\s+2/);
   assert.match(workflow, /codex-bounded-diff\.mjs/);
   assert.match(workflow, /git fetch --no-tags --unshallow origin/);

--- a/.github/workflows/security-secrets-audit.yml
+++ b/.github/workflows/security-secrets-audit.yml
@@ -97,18 +97,19 @@ jobs:
             --base "${PR_BASE_SHA:-$BEFORE_SHA}" \
             --head "${PR_HEAD_SHA:-$HEAD_SHA}" \
             --files-output "$RUNNER_TEMP/security-changed-files.txt"
-      - name: Fetch full history for required full scan
-        if: ${{ needs.scope.outputs.full_scan == 'true' }}
-        run: git fetch --no-tags --unshallow origin
       - name: Run Gitleaks (PR diff-aware; full elsewhere)
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE || '' }}
           GITLEAKS_CONFIG: .gitleaks.toml
-      - name: Run full Gitleaks history scan for broad-risk PRs and main
+      - name: Run full current-tree Gitleaks scan for broad-risk PRs and main
         if: ${{ needs.scope.outputs.full_scan == 'true' }}
-        run: gitleaks git --redact --exit-code=2 --config .gitleaks.toml --log-opts="--all" .
+        # The mandatory action above checks the immutable PR/push range. This
+        # second pass covers every file that exists at the candidate revision
+        # without making already-removed historical findings block all future
+        # high-risk changes.
+        run: gitleaks dir --redact --exit-code=2 --config .gitleaks.toml .
 
   npm-audit:
     name: Dependency Audit (JS/TS)

--- a/.github/workflows/security-secrets-audit.yml
+++ b/.github/workflows/security-secrets-audit.yml
@@ -97,6 +97,12 @@ jobs:
             --base "${PR_BASE_SHA:-$BEFORE_SHA}" \
             --head "${PR_HEAD_SHA:-$HEAD_SHA}" \
             --files-output "$RUNNER_TEMP/security-changed-files.txt"
+      - name: Fetch full history for required full scan
+        if: ${{ needs.scope.outputs.full_scan == 'true' }}
+        # The action below needs the candidate parent to build its immutable
+        # PR/push range. Fetching history here does not make the separate
+        # current-tree pass scan deleted historical content.
+        run: git fetch --no-tags --unshallow origin
       - name: Run Gitleaks (PR diff-aware; full elsewhere)
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:


### PR DESCRIPTION
## Objetivo
Restaurar o gate de Gitleaks para PRs de alto risco após o novo escaneamento de todo o histórico bloquear mudanças por ocorrências antigas já removidas.

## Superfícies e risco
- Superfície: workflow de Security & Secrets Audit e seu teste de contrato.
- Risco: alto por alterar CI de segurança; nenhuma flag, migration, dado, campanha ou segredo é alterado.
- O action obrigatório continua validando o intervalo imutável do PR/push.
- O segundo passe continua bloqueante e cobre integralmente a árvore atual do candidato.

## Validação
- Reproduzido no PR #1663: diff atual sem vazamentos; passe histórico encontrou 136 ocorrências antigas.
- Teste de contrato do workflow: 9/9 aprovado.
- git diff --check aprovado.
- CI deste PR deve provar o passe Gitleaks no próprio workflow corrigido.

## Rollback
Reverter o commit deste PR restaura o workflow anterior. O gatilho é qualquer regressão na cobertura do diff atual ou falha do passe completo da árvore candidata.