### PR TITLE
fix(ci): preserve staging smoke refs in shell

### DIFF
--- a/.github/scripts/beauty-movement-staging-smoke-contract.test.mjs
+++ b/.github/scripts/beauty-movement-staging-smoke-contract.test.mjs
@@ -37,6 +37,10 @@ test("smoke consumes secrets in-process and closes the staging gate", () => {
     assert.match(workflow, /beauty_movement_delivery_ref_invalid/);
     assert.match(workflow, /i\.external_ref = '\$\{invite_ref\}'/);
     assert.doesNotMatch(workflow, /i\.external_ref = 'velocity-0002'/);
+    const correlationStep = workflow.match(/      - name: Correlate persisted outcome without reading PII[\s\S]*?(?=\n      - name:)/)?.[0] ?? "";
+    assert.match(correlationStep, /const quote = String\.fromCharCode\(39\)/);
+    assert.match(correlationStep, /refs\.map\(\(value\) => quote \+ value \+ quote\)/);
+    assert.doesNotMatch(correlationStep, /\$\{value\}/);
     assert.match(workflow, /bootstrapReady/);
     assert.match(workflow, /mutationResponses/);
     assert.match(workflow, /failedRequests/);

--- a/.github/workflows/beauty-movement-staging-smoke.yml
+++ b/.github/workflows/beauty-movement-staging-smoke.yml
@@ -732,7 +732,8 @@ jobs:
           const evidence = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
           const refs = [evidence.inviteRefs?.a, evidence.inviteRefs?.b, evidence.inviteRefs?.expired];
           if (!refs.every((value) => /^[A-Za-z0-9][A-Za-z0-9._:-]{2,119}$/.test(value ?? "")) || new Set(refs).size !== 3) throw new Error("beauty_movement_isolation_refs_invalid");
-          process.stdout.write(refs.map((value) => `'${value}'`).join(","));
+          const quote = String.fromCharCode(39);
+          process.stdout.write(refs.map((value) => quote + value + quote).join(","));
           ' "${isolation_evidence}")"
           isolation_sql="SELECT i.external_ref, i.invite_status, i.confirmed_at_ms, i.expires_at_ms, (SELECT COUNT(*) FROM bm_card_reveals r WHERE r.invite_id = i.id) AS reveal_count FROM bm_invites i WHERE i.campaign_id = '${CAMPAIGN_ID}' AND i.external_ref IN (${isolation_refs}) ORDER BY i.external_ref;"
           npx --yes wrangler@4.112.0 d1 execute "${STAGING_D1_DATABASE}" --remote --config wrangler.toml --env staging --command "${isolation_sql}" --json >"${isolation_readback}"


### PR DESCRIPTION
## Summary
- prevent Bash from expanding the JavaScript value placeholder under nounset
- add a regression contract for the persisted-outcome correlation step

## Evidence
- failing authenticated staging smoke: run 33000383308
- visual/authenticated journey and staging restoration succeeded; only redacted persistence correlation failed
- targeted contract tests: 4/4 passed
- git diff --check passed

## Rollback
Revert this commit; no production or campaign state is changed by this PR.