### PR TITLE
fix(website): align Beauty Movement release smoke

### DIFF
--- a/.github/workflows/beauty-movement-production-activation.yml
+++ b/.github/workflows/beauty-movement-production-activation.yml
@@ -613,9 +613,10 @@ jobs:
           };
           await page.getByRole('button', { name: /Clique no baralho para começar a sua leitura/i }).click();
           await reveal('Beleza'); await reveal('Movimento'); await reveal('Celebração');
-          await page.getByRole('heading', { name: /Garanta seu presente e confirme presença/i }).waitFor({ state: 'visible', timeout: 30000 });
-          await page.getByRole('checkbox').check();
-          const confirmation = await waitForMutationResponse('/api/beleza-em-movimento/confirm', () => page.getByRole('button', { name: /Garantir presente e confirmar presença/i }).click());
+          const specialReveal = page.getByRole('button', { name: /Clique aqui para revelar sua carta especial/i });
+          await specialReveal.waitFor({ state: 'visible', timeout: 30000 });
+          if (await page.getByRole('checkbox').count() !== 0) throw new Error('beauty_movement_production_obsolete_consent_present');
+          const confirmation = await waitForMutationResponse('/api/beleza-em-movimento/confirm', () => specialReveal.click());
           if (!confirmation || confirmation.path !== '/api/beleza-em-movimento/confirm' || confirmation.status < 200 || confirmation.status >= 300 || confirmation.ok !== true) {
             throw new Error(`beauty_movement_production_confirm_response_invalid:${JSON.stringify({ mutationResponses: mutationResponses.slice(-12), failedRequests: failedRequests.slice(-12) })}`);
           }

--- a/.github/workflows/beauty-movement-staging-smoke.yml
+++ b/.github/workflows/beauty-movement-staging-smoke.yml
@@ -644,9 +644,10 @@ jobs:
           await reveal('Beleza');
           await reveal('Movimento');
           await reveal('Celebração');
-          await page.getByRole('heading', { name: /Garanta seu presente e confirme presença/i }).waitFor({ state: 'visible', timeout: 30000 });
-          await page.getByRole('checkbox').check();
-          await page.getByRole('button', { name: /Garantir presente e confirmar presença/i }).click();
+          const specialReveal = page.getByRole('button', { name: /Clique aqui para revelar sua carta especial/i });
+          await specialReveal.waitFor({ state: 'visible', timeout: 30000 });
+          if (await page.getByRole('checkbox').count() !== 0) throw new Error('beauty_movement_staging_obsolete_consent_present');
+          await specialReveal.click();
           const special = page.locator('article[aria-label^="Carta especial:"]');
           await special.waitFor({ state: 'visible', timeout: 30000 });
           const firstResultText = await special.innerText();

--- a/website/scripts/beauty-movement-primary-journey-smoke.mjs
+++ b/website/scripts/beauty-movement-primary-journey-smoke.mjs
@@ -158,12 +158,16 @@ async function run() {
     await reveal("Movimento");
     await reveal("Celebração");
 
-    await page.getByRole("heading", { name: /Garanta seu presente e confirme presença/i })
-      .waitFor({ state: "visible", timeout: 30_000 });
-    await page.getByRole("checkbox").check();
+    const specialReveal = page.getByRole("button", {
+      name: /Clique aqui para revelar sua carta especial/i,
+    });
+    await specialReveal.waitFor({ state: "visible", timeout: 30_000 });
+    if (await page.getByRole("checkbox").count() !== 0) {
+      fail("beauty_movement_primary_smoke_obsolete_consent_present");
+    }
     await mutate(
       "/api/beleza-em-movimento/confirm",
-      () => page.getByRole("button", { name: /Garantir presente e confirmar presença/i }).click(),
+      () => specialReveal.click(),
     );
 
     const special = page.locator('article[aria-label^="Carta especial:"]');

--- a/website/tests/beautyMovementContextIsolation.test.ts
+++ b/website/tests/beautyMovementContextIsolation.test.ts
@@ -289,6 +289,14 @@ test("governed staging and production smokes execute the same four-invite isolat
     assert.doesNotMatch(smoke, /console\.log\(.*token/i);
     assert.match(primarySmoke, /whatsappCtaPresent: true/);
     assert.match(primarySmoke, /contextRestoredAfterReload: true/);
+    assert.match(primarySmoke, /Clique aqui para revelar sua carta especial/);
+    assert.match(primarySmoke, /getByRole\("checkbox"\)\.count\(\) !== 0/);
+    assert.doesNotMatch(primarySmoke, /getByRole\("checkbox"\)\.check\(\)/);
+    for (const workflow of [staging, production]) {
+        assert.match(workflow, /Clique aqui para revelar sua carta especial/);
+        assert.match(workflow, /getByRole\('checkbox'\)\.count\(\) !== 0/);
+        assert.doesNotMatch(workflow, /getByRole\('checkbox'\)\.check\(\)/);
+    }
     assert.match(releaseSmoke, /syntheticFixtureRevoked: true/);
     assert.match(releaseSmoke, /durableValidationRecorded: true/);
     assert.match(releaseSmoke, /persistDurableValidation/);


### PR DESCRIPTION
## Resumo
- atualiza o smoke primário para o fluxo de revelação direta da carta especial
- exige que o checkbox obsoleto permaneça ausente
- mantém os workflows governados de staging e ativação de produção no mesmo contrato

## Contexto operacional
O release `486b3dfc4a08f670e08ca898b8800f785ec53525` foi corretamente rejeitado pelo smoke antigo, que ainda procurava o checkbox removido. A reconciliação restaurou o incumbent `a2d0c97dc7475f2919163c5ba867f230ce02a59f`, preservou a campanha ativa e revogou a fixture sintética.

## Validação
- 13/13 testes focais de isolamento/workflows
- 192/192 testes do website
- lint
- YAML parseado pelos testes de contrato
- `git diff --check`