### PR TITLE
fix(website): stabilize Beauty Movement journey evidence

### DIFF
--- a/.github/workflows/beauty-movement-production-activation.yml
+++ b/.github/workflows/beauty-movement-production-activation.yml
@@ -621,10 +621,11 @@ jobs:
             throw new Error(`beauty_movement_production_confirm_response_invalid:${JSON.stringify({ mutationResponses: mutationResponses.slice(-12), failedRequests: failedRequests.slice(-12) })}`);
           }
           const special = page.locator('article[aria-label^="Carta especial:"]'); await special.waitFor({ state: 'visible', timeout: 30000 });
-          const first = await special.innerText();
+          const revealedFace = special.locator('div[class*="specialCardFront"]'); await revealedFace.waitFor({ state: 'visible', timeout: 30000 });
+          const first = (await revealedFace.innerText()).replace(/\s+/g, ' ').trim();
           if (!/combinação|Elleva|Preenchimento|Restylane|Skinbooster|Diamond|Sculptra/i.test(first)) throw new Error('beauty_movement_production_offer_missing');
-          const beforeReload = reveals; await page.reload({ waitUntil: 'domcontentloaded' }); await special.waitFor({ state: 'visible', timeout: 30000 });
-          const second = await special.innerText();
+          const beforeReload = reveals; await page.reload({ waitUntil: 'domcontentloaded' }); await special.waitFor({ state: 'visible', timeout: 30000 }); await revealedFace.waitFor({ state: 'visible', timeout: 30000 });
+          const second = (await revealedFace.innerText()).replace(/\s+/g, ' ').trim();
           if (first !== second || beforeReload !== 3 || reveals !== 3 || whatsapp.length !== 0 || errors.length !== 0) throw new Error(`beauty_movement_production_browser_evidence_invalid:${JSON.stringify({ beforeReload, reveals, whatsappRequests: whatsapp.length, consoleErrors: errors.length, apiResponses: apiResponses.slice(-20), failedRequests: failedRequests.slice(-12) })}`);
           fs.writeFileSync(`${process.env.RUNNER_TEMP}/beauty-movement-production-activation/browser.json`, `${JSON.stringify({ browser: true, revealRequests: reveals, reloadStable: true, whatsappRequests: 0, consoleErrors: 0, outcomeVisible: true }, null, 2)}\n`, { mode: 0o600 });
           await browser.close();

--- a/.github/workflows/beauty-movement-staging-smoke.yml
+++ b/.github/workflows/beauty-movement-staging-smoke.yml
@@ -650,12 +650,15 @@ jobs:
           await specialReveal.click();
           const special = page.locator('article[aria-label^="Carta especial:"]');
           await special.waitFor({ state: 'visible', timeout: 30000 });
-          const firstResultText = await special.innerText();
+          const revealedFace = special.locator('div[class*="specialCardFront"]');
+          await revealedFace.waitFor({ state: 'visible', timeout: 30000 });
+          const firstResultText = (await revealedFace.innerText()).replace(/\s+/g, ' ').trim();
           if (!/combinação|Elleva|Preenchimento|Restylane|Skinbooster|Diamond|Sculptra/i.test(firstResultText)) throw new Error('beauty_movement_browser_offer_missing');
           const revealCountBeforeReload = revealRequests;
           await page.reload({ waitUntil: 'domcontentloaded' });
           await special.waitFor({ state: 'visible', timeout: 30000 });
-          const secondResultText = await special.innerText();
+          await revealedFace.waitFor({ state: 'visible', timeout: 30000 });
+          const secondResultText = (await revealedFace.innerText()).replace(/\s+/g, ' ').trim();
           if (firstResultText !== secondResultText) throw new Error('beauty_movement_browser_result_not_persistent');
           if (revealRequests !== revealCountBeforeReload || revealRequests !== 3) throw new Error('beauty_movement_browser_reveal_count_invalid');
           if (whatsappRequests.length !== 0) throw new Error('beauty_movement_external_whatsapp_request');

--- a/website/scripts/beauty-movement-primary-journey-smoke.mjs
+++ b/website/scripts/beauty-movement-primary-journey-smoke.mjs
@@ -172,7 +172,9 @@ async function run() {
 
     const special = page.locator('article[aria-label^="Carta especial:"]');
     await special.waitFor({ state: "visible", timeout: 30_000 });
-    const beforeReload = await special.innerText();
+    const revealedFace = special.locator('div[class*="specialCardFront"]');
+    await revealedFace.waitFor({ state: "visible", timeout: 30_000 });
+    const beforeReload = (await revealedFace.innerText()).replace(/\s+/g, " ").trim();
     if (!/combinação|Elleva|Preenchimento|Restylane|Skinbooster|Diamond|Sculptra/i.test(beforeReload)) {
       fail("beauty_movement_primary_smoke_outcome_missing");
     }
@@ -183,7 +185,8 @@ async function run() {
 
     await page.reload({ waitUntil: "domcontentloaded" });
     await special.waitFor({ state: "visible", timeout: 30_000 });
-    const afterReload = await special.innerText();
+    await revealedFace.waitFor({ state: "visible", timeout: 30_000 });
+    const afterReload = (await revealedFace.innerText()).replace(/\s+/g, " ").trim();
     const restoredContext = await page.evaluate(() => history.state?.__efBeautyMovementContextRef ?? null);
     if (
       beforeReload !== afterReload

--- a/website/scripts/beauty-movement-primary-journey-smoke.mjs
+++ b/website/scripts/beauty-movement-primary-journey-smoke.mjs
@@ -3,7 +3,10 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { chromium } from "playwright";
-import { readSyntheticInvites } from "./beauty-movement-context-isolation-smoke.mjs";
+import {
+  readSyntheticInvites,
+  redactBeautyMovementSmokeError,
+} from "./beauty-movement-context-isolation-smoke.mjs";
 
 const CONTEXT_PATTERN = /^[A-Za-z0-9_-]{32,256}$/;
 
@@ -39,12 +42,6 @@ function parseArgs(argv) {
     deliveryDirectory: path.resolve(deliveryDirectory),
     evidenceFile: path.resolve(evidenceFile),
   };
-}
-
-function redact(value) {
-  return String(value)
-    .replace(/#c=[A-Za-z0-9_-]+/g, "#c=[redacted]")
-    .replace(/[A-Za-z0-9_-]{40,180}/g, "[opaque]");
 }
 
 async function run() {
@@ -235,7 +232,9 @@ const isDirectExecution = process.argv[1]
   && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
 if (isDirectExecution) {
   run().catch((error) => {
-    console.error(redact(error instanceof Error ? error.message : "beauty_movement_primary_smoke_failed"));
+    console.error(redactBeautyMovementSmokeError(
+      error instanceof Error ? error.message : "beauty_movement_primary_smoke_failed",
+    ));
     process.exitCode = 1;
   });
 }

--- a/website/scripts/beauty-movement-production-release-smoke.d.mts
+++ b/website/scripts/beauty-movement-production-release-smoke.d.mts
@@ -1,3 +1,4 @@
 export function parseWranglerJson(output: string): unknown;
+export function extractBeautyMovementChildFailureCode(stderr: unknown): string | null;
 export function extractStaticAssetPaths(html: string): string[];
 export function buildBeautyMovementReleaseValidationMarker(releaseSha: string, releaseOwner: string): string;

--- a/website/scripts/beauty-movement-production-release-smoke.mjs
+++ b/website/scripts/beauty-movement-production-release-smoke.mjs
@@ -71,6 +71,11 @@ function parseArgs(argv) {
   };
 }
 
+export function extractBeautyMovementChildFailureCode(stderr) {
+  const matches = String(stderr).match(/\bbeauty_movement_[a-z0-9_]{3,100}\b/g);
+  return matches?.at(-1) ?? null;
+}
+
 function runChild(command, args, options = {}) {
   const result = spawnSync(command, args, {
     cwd: options.cwd ?? process.cwd(),
@@ -80,7 +85,7 @@ function runChild(command, args, options = {}) {
     stdio: ["ignore", "pipe", "pipe"],
   });
   if (result.error || result.status !== 0) {
-    fail("beauty_movement_release_smoke_child_failed", {
+    fail(extractBeautyMovementChildFailureCode(result.stderr) ?? "beauty_movement_release_smoke_child_failed", {
       command,
       status: result.status ?? -1,
       stderrLines: String(result.stderr ?? "").split(/\r?\n/).filter(Boolean).length,

--- a/website/tests/beautyMovementContextIsolation.test.ts
+++ b/website/tests/beautyMovementContextIsolation.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../src/lib/beautyMovementSecurity";
 import {
     buildBeautyMovementReleaseValidationMarker,
+    extractBeautyMovementChildFailureCode,
     extractStaticAssetPaths,
     parseWranglerJson,
 } from "../scripts/beauty-movement-production-release-smoke.mjs";
@@ -292,10 +293,13 @@ test("governed staging and production smokes execute the same four-invite isolat
     assert.match(primarySmoke, /Clique aqui para revelar sua carta especial/);
     assert.match(primarySmoke, /getByRole\("checkbox"\)\.count\(\) !== 0/);
     assert.doesNotMatch(primarySmoke, /getByRole\("checkbox"\)\.check\(\)/);
+    assert.match(primarySmoke, /specialCardFront/);
+    assert.doesNotMatch(primarySmoke, /beforeReload = await special\.innerText/);
     for (const workflow of [staging, production]) {
         assert.match(workflow, /Clique aqui para revelar sua carta especial/);
         assert.match(workflow, /getByRole\('checkbox'\)\.count\(\) !== 0/);
         assert.doesNotMatch(workflow, /getByRole\('checkbox'\)\.check\(\)/);
+        assert.match(workflow, /specialCardFront/);
     }
     assert.match(releaseSmoke, /syntheticFixtureRevoked: true/);
     assert.match(releaseSmoke, /durableValidationRecorded: true/);
@@ -371,6 +375,16 @@ test("production release smoke parses clean and noisy Wrangler JSON without logg
         () => buildBeautyMovementReleaseValidationMarker("invalid", "bm-123456789-2"),
         /beauty_movement_release_smoke_validation_marker_invalid/,
     );
+});
+
+test("production release smoke preserves a safe child failure code without child output", () => {
+    assert.equal(
+        extractBeautyMovementChildFailureCode(
+            "opaque details\nbeauty_movement_primary_smoke_evidence_invalid:{\"opaque\":\"redacted\"}\n",
+        ),
+        "beauty_movement_primary_smoke_evidence_invalid",
+    );
+    assert.equal(extractBeautyMovementChildFailureCode("generic child failure"), null);
 });
 
 test("production reconciliation derives one bounded synthetic fixture identity", () => {

--- a/website/tests/beautyMovementContextIsolation.test.ts
+++ b/website/tests/beautyMovementContextIsolation.test.ts
@@ -295,6 +295,8 @@ test("governed staging and production smokes execute the same four-invite isolat
     assert.doesNotMatch(primarySmoke, /getByRole\("checkbox"\)\.check\(\)/);
     assert.match(primarySmoke, /specialCardFront/);
     assert.doesNotMatch(primarySmoke, /beforeReload = await special\.innerText/);
+    assert.match(primarySmoke, /redactBeautyMovementSmokeError/);
+    assert.doesNotMatch(primarySmoke, /function redact\(/);
     for (const workflow of [staging, production]) {
         assert.match(workflow, /Clique aqui para revelar sua carta especial/);
         assert.match(workflow, /getByRole\('checkbox'\)\.count\(\) !== 0/);
@@ -378,10 +380,15 @@ test("production release smoke parses clean and noisy Wrangler JSON without logg
 });
 
 test("production release smoke preserves a safe child failure code without child output", () => {
+    const childStderr = redactBeautyMovementSmokeError(
+        `beauty_movement_primary_smoke_evidence_invalid:{"opaque":"${"t".repeat(43)}"}`,
+    );
     assert.equal(
-        extractBeautyMovementChildFailureCode(
-            "opaque details\nbeauty_movement_primary_smoke_evidence_invalid:{\"opaque\":\"redacted\"}\n",
-        ),
+        childStderr,
+        'beauty_movement_primary_smoke_evidence_invalid:{"opaque":"[opaque]"}',
+    );
+    assert.equal(
+        extractBeautyMovementChildFailureCode(`opaque details\n${childStderr}\n`),
         "beauty_movement_primary_smoke_evidence_invalid",
     );
     assert.equal(extractBeautyMovementChildFailureCode("generic child failure"), null);


### PR DESCRIPTION
## Resumo
- compara apenas a face revelada da carta especial antes e depois do reload
- elimina falso negativo causado pela face coberta e pelo estado transitório da animação
- preserva códigos sanitizados dos smokes filhos para diagnóstico sem expor dados

## Validação
- teste focal: 14/14
- suite website: 193/193
- lint: aprovado
- git diff --check: aprovado

## Contexto operacional
Este ajuste corrige o contrato de evidência que bloqueou a publicação depois de a jornada real ter concluído. Nenhuma campanha, convite ou link curto é alterado.