### PR TITLE
fix: refine Beauty Movement modal and focus flow

### DIFF
--- a/website/src/components/BeautyMovementExperience.module.css
+++ b/website/src/components/BeautyMovementExperience.module.css
@@ -3944,11 +3944,54 @@
 /* Price cards need the campaign conditions in the editorial flow on desktop,
  * otherwise the link lands on top of the WhatsApp action at compact heights. */
 @media (min-width: 721px) {
+  .specialCardModalDialog {
+    width: min(460px, 100%);
+  }
+
+  .specialCardModalDialog .specialCard {
+    width: min(420px, 100%);
+    min-height: 520px;
+  }
+
   .specialCardModalDialog .specialCardWithPrice {
-    min-height: 456px;
+    min-height: 520px;
+  }
+
+  .specialCardModalDialog .specialCardFrontOffer {
+    gap: 6px;
+    padding: 18px 24px 16px;
+  }
+
+  .specialCardModalDialog .specialCardFrontOffer .specialCardIllustration {
+    width: 92px;
+    height: 92px;
+    margin: 2px auto 0;
+  }
+
+  .specialCardModalDialog .specialCardFrontOffer > strong {
+    max-width: 350px;
+    font-size: clamp(2rem, 3vw, 2.5rem);
+  }
+
+  .specialCardModalDialog .specialCardOfferCopy {
+    max-width: 340px;
+    font-size: 0.86rem;
+    line-height: 1.32;
+  }
+
+  .specialCardModalDialog .specialCardGiftNote {
+    max-width: 340px;
+    font-size: 0.76rem;
+  }
+
+  .specialCardModalDialog .specialCardOfferCondition {
+    max-width: 340px;
+    font-size: 0.7rem;
   }
 
   .specialCardModalDialog .specialCardWithPrice .specialCardWhatsappAction {
+    width: min(100%, 320px);
+    min-height: 48px;
     margin-bottom: 0;
   }
 
@@ -3959,7 +4002,7 @@
   }
 
   .specialCardModalDialog .specialCardWithPrice:has(.specialCardConditions[open]) {
-    min-height: 560px;
+    min-height: 620px;
   }
 }
 

--- a/website/src/components/BeautyMovementExperience.tsx
+++ b/website/src/components/BeautyMovementExperience.tsx
@@ -328,6 +328,7 @@ export default function BeautyMovementExperience({
     const [confirmedOffer, setConfirmedOffer] = useState<BeautyMovementOffer | null>(initialState.offer ?? null);
     const [actionError, setActionError] = useState<string | null>(null);
     const [shareStatus, setShareStatus] = useState<string | null>(null);
+    const [campaignConditionsOpen, setCampaignConditionsOpen] = useState(false);
     const [finaleStage, setFinaleStage] = useState<FinaleStage>(() =>
         initialState.confirmed ? "result" : initialReadingComplete ? "confirmation" : "hidden",
     );
@@ -355,12 +356,14 @@ export default function BeautyMovementExperience({
     const tableSurfaceRef = useRef<HTMLDivElement | null>(null);
     const finaleCountdownRef = useRef<HTMLDivElement | null>(null);
     const progressListRef = useRef<HTMLOListElement | null>(null);
+    const cardButtonRefs = useRef<Array<HTMLButtonElement | null>>([]);
     const progressButtonRefs = useRef<Array<HTMLButtonElement | null>>([]);
     const confirmationActionRef = useRef<HTMLButtonElement | null>(null);
     const specialCardModalCloseRef = useRef<HTMLButtonElement | null>(null);
     const specialCardModalDialogRef = useRef<HTMLElement | null>(null);
     const specialCardReopenActionRef = useRef<HTMLButtonElement | null>(null);
     const specialCardModalTriggerRef = useRef<HTMLElement | null>(null);
+    const shouldFocusNextHandRef = useRef(false);
     const selectionsRef = useRef(selections);
     const displayedActIndexRef = useRef(displayedActIndex);
     const introStageRef = useRef(introStage);
@@ -380,6 +383,7 @@ export default function BeautyMovementExperience({
     const progressMotionKeyRef = useRef(0);
 
     const closeSpecialCardModal = useCallback(() => {
+        setCampaignConditionsOpen(false);
         setIsSpecialCardModalOpen(false);
         window.requestAnimationFrame(() => {
             const focusTarget = specialCardModalTriggerRef.current ?? specialCardReopenActionRef.current;
@@ -1124,15 +1128,20 @@ export default function BeautyMovementExperience({
     function handleDeckKeyDown(event: ReactKeyboardEvent<HTMLButtonElement>) {
         if (event.key !== "Enter" && event.key !== " " && event.key !== "Spacebar") return;
 
+        shouldFocusNextHandRef.current = true;
         // Some embedded browsers focus the native button but do not synthesize its click.
         // Prevent the default activation so physical browsers do not invoke the deal twice.
         event.preventDefault();
         startInitialDeal();
+        window.requestAnimationFrame(() => {
+            progressListRef.current?.focus({ preventScroll: true });
+        });
     }
 
     function beginFinale() {
         if (handStageRef.current !== "held" || finaleStageRef.current !== "hidden" || transitionInFlightRef.current) return;
 
+        shouldFocusNextHandRef.current = false;
         transitionInFlightRef.current = true;
         cancelAutoAdvance();
         const handToken = beginHandTransition();
@@ -1461,7 +1470,17 @@ export default function BeautyMovementExperience({
     ) {
         if (isLocalPreview) {
             return (
-                <button className={className} type="button" onClick={handleWhatsappClick}>
+                <button
+                    className={className}
+                    type="button"
+                    onClick={handleWhatsappClick}
+                    onKeyDown={(event) => {
+                        if ((event.key === "Enter" || event.key === " " || event.key === "Spacebar") && !event.repeat) {
+                            event.preventDefault();
+                            handleWhatsappClick();
+                        }
+                    }}
+                >
                     {label}
                 </button>
             );
@@ -1530,6 +1549,22 @@ export default function BeautyMovementExperience({
         finaleStage === "collecting" ||
         finaleStage === "merging";
 
+    useEffect(() => {
+        if (
+            !shouldFocusNextHandRef.current ||
+            handStage !== "ready" ||
+            finaleStage !== "hidden" ||
+            tableSelected
+        ) return;
+
+        shouldFocusNextHandRef.current = false;
+        const focusFrame = window.requestAnimationFrame(() => {
+            cardButtonRefs.current[0]?.focus({ preventScroll: true });
+        });
+
+        return () => window.cancelAnimationFrame(focusFrame);
+    }, [displayedActIndex, finaleStage, handStage, tableSelected]);
+
     function renderRevealedCardContent(card: BeautyMovementCard, actLabel: string) {
         return (
             <>
@@ -1555,9 +1590,16 @@ export default function BeautyMovementExperience({
                 type="button"
                 className={`${styles.cardButton} ${isPending ? styles.cardButtonPending : ""} ${isSelected ? styles.cardButtonSelected : ""}`.trim()}
                 key={card.id}
+                ref={(node) => {
+                    cardButtonRefs.current[cardIndex] = node;
+                }}
                 onClick={() => void handleReveal(displayedActIndex, card)}
                 onKeyDown={(event) => {
                     if ((event.key === "Enter" || event.key === " ") && !event.repeat) {
+                        shouldFocusNextHandRef.current = true;
+                        window.requestAnimationFrame(() => {
+                            progressListRef.current?.focus({ preventScroll: true });
+                        });
                         event.preventDefault();
                         void handleReveal(displayedActIndex, card);
                     }
@@ -1689,6 +1731,7 @@ export default function BeautyMovementExperience({
         const referencePrice = offerPresentation && offer ? formatBeautyMovementPrice(offer.referencePrice) : null;
         const unlockedPrice = offerPresentation && offer ? formatBeautyMovementPrice(offer.unlockedPrice) : null;
         const campaignConditions = revealed ? initialState.campaign.conditionsText?.trim() : null;
+        const runRevealAction = action === "confirm" ? () => void handleConfirm() : openSpecialCardModal;
 
         return (
             <article
@@ -1719,7 +1762,13 @@ export default function BeautyMovementExperience({
                                         }}
                                         className={styles.primaryButton}
                                         type="button"
-                                        onClick={action === "confirm" ? () => void handleConfirm() : openSpecialCardModal}
+                                        onClick={runRevealAction}
+                                        onKeyDown={(event) => {
+                                            if ((event.key === "Enter" || event.key === " " || event.key === "Spacebar") && !event.repeat) {
+                                                event.preventDefault();
+                                                runRevealAction();
+                                            }
+                                        }}
                                         disabled={action === "confirm" ? isConfirming : undefined}
                                     >
                                         {action === "confirm" && isConfirming ? "Revelando…" : "Clique aqui para revelar sua carta especial"}
@@ -1752,7 +1801,13 @@ export default function BeautyMovementExperience({
                                 <BeautyMovementCardIllustration cardId={iconId} />
                             )}
                         </span>
-                        <strong>{title}</strong>
+                        <strong
+                            id={revealed ? "beauty-movement-special-card-title" : undefined}
+                            role="heading"
+                            aria-level={2}
+                        >
+                            {title}
+                        </strong>
                         {offerPresentation ? (
                             <>
                                 <span className={styles.specialCardOfferDescriptor}>{offerPresentation.descriptor}</span>
@@ -1787,9 +1842,25 @@ export default function BeautyMovementExperience({
                             )
                             : null}
                         {campaignConditions ? (
-                            <details className={styles.specialCardConditions}>
-                                <summary>{initialState.campaign.conditionsLabel?.trim() || "Condições da campanha"}</summary>
-                                <p>{campaignConditions}</p>
+                            <details
+                                className={styles.specialCardConditions}
+                                open={campaignConditionsOpen}
+                                onToggle={(event) => setCampaignConditionsOpen(event.currentTarget.open)}
+                            >
+                                <summary
+                                    role="button"
+                                    aria-expanded={campaignConditionsOpen}
+                                    aria-controls="beauty-movement-special-card-conditions"
+                                    onKeyDown={(event) => {
+                                        if ((event.key === "Enter" || event.key === " " || event.key === "Spacebar") && !event.repeat) {
+                                            event.preventDefault();
+                                            setCampaignConditionsOpen((open) => !open);
+                                        }
+                                    }}
+                                >
+                                    {initialState.campaign.conditionsLabel?.trim() || "Condições da campanha"}
+                                </summary>
+                                <p id="beauty-movement-special-card-conditions">{campaignConditions}</p>
                             </details>
                         ) : null}
                         {revealed && shareStatus ? <span className={styles.specialCardCopy} role="status">{shareStatus}</span> : null}
@@ -1859,6 +1930,7 @@ export default function BeautyMovementExperience({
                                 ref={progressListRef}
                                 className={`${styles.progress} ${progressMotion ? styles.progressMotionActive : ""}`.trim()}
                                 aria-label="Progresso da experiência"
+                                tabIndex={-1}
                             >
                                 {progressMotion ? (
                                     <li
@@ -2068,7 +2140,7 @@ export default function BeautyMovementExperience({
                         className={styles.specialCardModalDialog}
                         role="dialog"
                         aria-modal="true"
-                        aria-label="Carta especial"
+                        aria-labelledby="beauty-movement-special-card-title"
                     >
                         <button
                             ref={specialCardModalCloseRef}
@@ -2076,6 +2148,12 @@ export default function BeautyMovementExperience({
                             type="button"
                             aria-label="Fechar carta especial"
                             onClick={closeSpecialCardModal}
+                            onKeyDown={(event) => {
+                                if ((event.key === "Enter" || event.key === " " || event.key === "Spacebar") && !event.repeat) {
+                                    event.preventDefault();
+                                    closeSpecialCardModal();
+                                }
+                            }}
                         >
                             ×
                         </button>

--- a/website/src/components/BeautyMovementLocalPreview.tsx
+++ b/website/src/components/BeautyMovementLocalPreview.tsx
@@ -54,6 +54,7 @@ function cloneInitialPreviewState(): BeautyMovementExperienceInitialState {
  */
 export default function BeautyMovementLocalPreview() {
     const [state, setState] = useState<BeautyMovementExperienceInitialState>(cloneInitialPreviewState);
+    const [previewRevision, setPreviewRevision] = useState("interactive");
 
     useEffect(() => {
         if (process.env.NODE_ENV === "production") return;
@@ -71,6 +72,10 @@ export default function BeautyMovementLocalPreview() {
             confirmed: true,
             offer: resolved.offer,
         }));
+        // BeautyMovementExperience owns its animation state after mounting.
+        // Remount only for this explicit QA shortcut so the resolved outcome
+        // becomes the initial state without resetting normal interactive reveals.
+        setPreviewRevision(`outcome-${requested}`);
     }, []);
 
     function reveal(actIndex: number, cardId: string) {
@@ -98,6 +103,7 @@ export default function BeautyMovementLocalPreview() {
 
     return (
         <BeautyMovementExperience
+            key={previewRevision}
             initialState={state}
             onReveal={reveal}
             onConfirm={confirm}

--- a/website/tests/beautyMovementContinuous.test.ts
+++ b/website/tests/beautyMovementContinuous.test.ts
@@ -95,6 +95,11 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.doesNotMatch(experience, /inlineFinale|renderResultStage|Leitura completa|O seu presente de celebração/);
     assert.match(experience, /isSpecialCardModalOpen/);
     assert.match(experience, /specialCardReopenActionRef/);
+    assert.match(experience, /const cardButtonRefs = useRef<Array<HTMLButtonElement \| null>>\(\[\]\)/);
+    assert.match(experience, /const shouldFocusNextHandRef = useRef\(false\)/);
+    assert.match(experience, /cardButtonRefs\.current\[0\]\?\.focus\(\{ preventScroll: true \}\)/);
+    assert.match(experience, /progressListRef\.current\?\.focus\(\{ preventScroll: true \}\)/);
+    assert.match(experience, /tabIndex=\{-1\}/);
     assert.match(experience, /automática em \{AUTO_ADVANCE_SECONDS\} segundos/);
     assert.doesNotMatch(experience, /confirmationTriggerRef/);
     assert.match(experience, /className=\{styles\.progressButton\}/);
@@ -168,7 +173,9 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.doesNotMatch(experience, /actsStack|revealedStrip/);
     assert.doesNotMatch(experience, /BeautyMovementModalReading/);
     assert.doesNotMatch(experience, /finaleCardGridSettled/);
-    assert.match(experience, /aria-label="Carta especial"/);
+    assert.match(experience, /aria-labelledby="beauty-movement-special-card-title"/);
+    assert.match(experience, /id=\{revealed \? "beauty-movement-special-card-title" : undefined\}/);
+    assert.match(experience, /role="heading"\s+aria-level=\{2\}/);
     assert.match(experience, /className=\{styles\.cardSparkles\}/);
     assert.match(experience, /className=\{styles\.deckStage\}/);
     assert.match(experience, /className=\{styles\.finaleSpecialCardTransform\}/);
@@ -481,7 +488,12 @@ test("continuous experience reuses the real shell and keeps the special-card fin
     assert.match(experience, /if \(action === "reopen"\) specialCardReopenActionRef\.current = node/);
     assert.match(experience, /confirmationActionRef\.current\?\.focus\(\{ preventScroll: true \}\)/);
     assert.doesNotMatch(experience, /confirmationAction\?\.querySelector<HTMLButtonElement>/);
-    assert.match(experience, /onClick=\{action === "confirm" \? \(\) => void handleConfirm\(\) : openSpecialCardModal\}/);
+    assert.match(experience, /const runRevealAction = action === "confirm" \? \(\) => void handleConfirm\(\) : openSpecialCardModal/);
+    assert.match(experience, /onClick=\{runRevealAction\}/);
+    assert.match(experience, /onKeyDown=\{\(event\) => \{[\s\S]*?runRevealAction\(\);/);
+    assert.match(experience, /aria-expanded=\{campaignConditionsOpen\}/);
+    assert.match(experience, /aria-controls="beauty-movement-special-card-conditions"/);
+    assert.match(experience, /setCampaignConditionsOpen\(\(open\) => !open\)/);
     assert.match(styles, /\.cardFace \{[\s\S]*-webkit-backface-visibility: hidden;[\s\S]*isolation: isolate;/);
     assert.match(styles, /\.cardButtonSelected \.cardFront \{[\s\S]*animation: coveredFaceExit var\(--bm-hand-reveal-ms\)/);
     assert.match(styles, /\.cardButtonSelected \.cardBack \{[\s\S]*animation: revealedFaceEnter var\(--bm-hand-reveal-ms\)/);

--- a/website/tests/beautyMovementLocalPreview.test.ts
+++ b/website/tests/beautyMovementLocalPreview.test.ts
@@ -1,8 +1,20 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { isBeautyMovementLocalPreviewAllowed } from "../src/lib/beautyMovementLocalPreview";
 
 test("local preview stays available only in development and cannot be opened in production", () => {
     assert.equal(isBeautyMovementLocalPreviewAllowed({ isProduction: false }), true);
     assert.equal(isBeautyMovementLocalPreviewAllowed({ isProduction: true }), false);
+});
+
+test("outcome QA shortcut remounts the experience with the resolved initial state", async () => {
+    const source = await readFile(
+        new URL("../src/components/BeautyMovementLocalPreview.tsx", import.meta.url),
+        "utf8",
+    );
+
+    assert.match(source, /const \[previewRevision, setPreviewRevision\] = useState\("interactive"\);/);
+    assert.match(source, /setPreviewRevision\(`outcome-\$\{requested\}`\);/);
+    assert.match(source, /<BeautyMovementExperience\s+key=\{previewRevision\}/);
 });

--- a/website/tests/beautyMovementMobileContract.test.ts
+++ b/website/tests/beautyMovementMobileContract.test.ts
@@ -54,6 +54,9 @@ test("mobile handoff keeps one rhythm, one deck anchor, and a roomier special-ca
     assert.match(experience, /event\.key === "Escape"/);
     assert.match(experience, /specialCardModalDialogRef\.current/);
     assert.match(experience, /textarea:not\(\[disabled\]\), summary, \[tabindex\]/);
+    assert.match(experience, /aria-labelledby="beauty-movement-special-card-title"/);
+    assert.match(experience, /onKeyDown=\{\(event\) => \{[\s\S]*?closeSpecialCardModal\(\);/);
+    assert.match(experience, /role="button"[\s\S]*?aria-expanded=\{campaignConditionsOpen\}/);
 
     const autoAdvanceTimer = experience.slice(
         experience.indexOf("autoAdvanceTimerRef.current = window.setTimeout"),

--- a/website/tests/beautyMovementOfferLayout.test.ts
+++ b/website/tests/beautyMovementOfferLayout.test.ts
@@ -15,10 +15,19 @@ test("desktop price offer keeps campaign conditions in the editorial flow", asyn
     const desktopOfferStyles = styles.slice(desktopOfferBlockStart, desktopOfferBlockEnd + 2);
 
     assert.match(desktopOfferStyles, /@media \(min-width: 721px\)\s*\{/);
-    assert.match(desktopOfferStyles, /\.specialCardModalDialog \.specialCardWithPrice\s*\{\s*min-height: 456px;/);
+    assert.match(desktopOfferStyles, /\.specialCardModalDialog\s*\{\s*width: min\(460px, 100%\);/);
     assert.match(
         desktopOfferStyles,
-        /\.specialCardModalDialog \.specialCardWithPrice \.specialCardWhatsappAction\s*\{\s*margin-bottom: 0;/,
+        /\.specialCardModalDialog \.specialCard\s*\{\s*width: min\(420px, 100%\);\s*min-height: 520px;/,
+    );
+    assert.match(desktopOfferStyles, /\.specialCardModalDialog \.specialCardWithPrice\s*\{\s*min-height: 520px;/);
+    assert.match(
+        desktopOfferStyles,
+        /\.specialCardModalDialog \.specialCardFrontOffer \.specialCardIllustration\s*\{\s*width: 92px;\s*height: 92px;/,
+    );
+    assert.match(
+        desktopOfferStyles,
+        /\.specialCardModalDialog \.specialCardWithPrice \.specialCardWhatsappAction\s*\{[^}]*margin-bottom: 0;/,
     );
     assert.match(
         desktopOfferStyles,
@@ -26,6 +35,6 @@ test("desktop price offer keeps campaign conditions in the editorial flow", asyn
     );
     assert.match(
         desktopOfferStyles,
-        /\.specialCardModalDialog \.specialCardWithPrice:has\(\.specialCardConditions\[open\]\)\s*\{\s*min-height: 560px;/,
+        /\.specialCardModalDialog \.specialCardWithPrice:has\(\.specialCardConditions\[open\]\)\s*\{\s*min-height: 620px;/,
     );
 });


### PR DESCRIPTION
## Objetivo
Refinar a experiência Beauty Movement sem alterar campanha, convidados, ofertas ou persistência: continuidade de foco por teclado, semântica do modal e geometria responsiva da carta especial.

## Superfícies
- `website/src/components/BeautyMovementExperience.tsx`
- `website/src/components/BeautyMovementExperience.module.css`
- `website/src/components/BeautyMovementLocalPreview.tsx`
- contratos de teste Beauty Movement

## Mudanças
- transfere o foco para a primeira carta ao fim de cada distribuição e mantém um alvo estável durante as transições;
- permite revelar, fechar, reabrir e expandir condições da carta especial por teclado em navegadores incorporados;
- nomeia o diálogo pelo título real do prêmio sem IDs duplicados;
- amplia o modal desktop e a arte dos brindes, preservando o layout mobile já aprovado e a rolagem em telas curtas;
- corrige o atalho sintético `?outcome=` da prévia local para testar diretamente todas as ofertas.

## Risco e gates
- risco: médio, restrito a UI/semântica e infraestrutura local de QA;
- flag/coorte: não aplicável; a campanha e a lista ativa não são alteradas;
- migration/dados: não aplicável;
- efeito externo: nenhum antes do fluxo normal de release do site.

## Validação pré-produção — 2026-08-27
- `npm test`: 194/194;
- `npm lint`: verde;
- `npm run typecheck`: build Next.js + TypeScript verdes;
- `git diff --check`: verde;
- Browser nativo: 319×674, 320×568 e 1346×674;
- fluxo completo por teclado entre Beleza → Movimento → Celebração → carta especial;
- modal abre, fecha e reabre com foco restaurado; condições expandem/recolhem;
- ofertas com e sem preço cabem sem sobreposição; tela curta mantém CTA e condições alcançáveis por rolagem;
- sem erros ou avisos no console do fluxo validado.

## Rollback
- versão de retorno: `e98f8420565dcacc8c8a83843e617e586897bf6f`;
- ação: reverter `b8d5a6cf8912008e9b09411f1f7f0f08adf140f6` e publicar novamente pelo workflow canônico do site;
- gatilhos: regressão de foco, conteúdo cortado, falha no modal ou smoke das rotas Beauty Movement;
- dados: nenhuma reversão de dados necessária;
- smoke após rollback: `/beleza-em-movimento`, `/BelezaEmMovimento` e matriz sintética de isolamento de convites.

## Smoke pós-release
- comprovar SHA/deployment publicado;
- validar as duas rotas canônicas e o fluxo sintético autorizado;
- confirmar ausência de regressões mobile/desktop e preservar campanha/links existentes.