### PR TITLE
Fix Beauty Movement Velocity HMAC validation

### DIFF
--- a/.github/scripts/beauty-movement-velocity-invite-links.mjs
+++ b/.github/scripts/beauty-movement-velocity-invite-links.mjs
@@ -18,6 +18,7 @@ export const VELOCITY_APPEND_EXPECTATIONS = Object.freeze({
 const INPUT_HEADER = ["name", "whatsapp", "prize"];
 const DELIVERY_HEADER = ["name", "invite_ref", "whatsapp", "invite_url"];
 const CAMPAIGN_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{2,79}$/;
+const INVITE_TOKEN_HMAC_PATTERN = /^[A-Za-z0-9_-]{43}$/;
 const VELOCITY_BENEFIT = "aula_cortesia_evento";
 const ASSIGNMENT_PROTOCOL_VERSION = "beauty-movement-invite-assignments-v1";
 
@@ -366,7 +367,13 @@ export function verifyPromotionTokenHmacs({ targets, d1Payload, deliveryAttestat
   for (const ref of targets.refs) {
     const expected = expectedByRef[ref];
     const actual = byRef.get(ref)?.invite_token_hmac;
-    if (typeof expected !== "string" || !/^[a-f0-9]{64}$/.test(expected) || actual !== expected) fail("promotion_token_hmac_mismatch");
+    if (
+      typeof expected !== "string" ||
+      typeof actual !== "string" ||
+      !INVITE_TOKEN_HMAC_PATTERN.test(expected) ||
+      !INVITE_TOKEN_HMAC_PATTERN.test(actual) ||
+      actual !== expected
+    ) fail("promotion_token_hmac_mismatch");
   }
   return { targetCount: rows.length, tokenHmacMatch: true };
 }

--- a/.github/scripts/beauty-movement-velocity-invite-links.test.mjs
+++ b/.github/scripts/beauty-movement-velocity-invite-links.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { createHash, createHmac } from "node:crypto";
+import { createHash, createHmac, randomBytes } from "node:crypto";
 import test from "node:test";
 
 import {
@@ -19,7 +19,8 @@ import {
 } from "./beauty-movement-velocity-invite-links.mjs";
 
 const hash = (value) => createHash("sha256").update(value, "utf8").digest("hex");
-const tokenHmac = (value) => createHmac("sha256", "velocity-test-token-key").update(value, "utf8").digest("base64url");
+const tokenHmacKey = randomBytes(32);
+const tokenHmac = (value) => createHmac("sha256", tokenHmacKey).update(value, "utf8").digest("base64url");
 const phone = (value) => `51${String(900000000 + value).slice(-9)}`;
 const csv = (rows) => serializeCsv(["name", "whatsapp", "prize"], rows);
 

--- a/.github/scripts/beauty-movement-velocity-invite-links.test.mjs
+++ b/.github/scripts/beauty-movement-velocity-invite-links.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { createHash } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 import test from "node:test";
 
 import {
@@ -19,6 +19,7 @@ import {
 } from "./beauty-movement-velocity-invite-links.mjs";
 
 const hash = (value) => createHash("sha256").update(value, "utf8").digest("hex");
+const tokenHmac = (value) => createHmac("sha256", "velocity-test-token-key").update(value, "utf8").digest("base64url");
 const phone = (value) => `51${String(900000000 + value).slice(-9)}`;
 const csv = (rows) => serializeCsv(["name", "whatsapp", "prize"], rows);
 
@@ -164,7 +165,8 @@ test("plans and verifies the guarded additive Velocity grant for existing commer
     verifyPromotionApply({ targets, plan, d1Payload: JSON.stringify([{ results: finalRows }]) }),
     { operation: "apply", targetCount: 8, promotionCount: 3 },
   );
-  const tokenRows = preRows.map((row, index) => ({ ...row, invite_token_hmac: `${index.toString(16)}${"a".repeat(63)}` }));
+  const tokenRows = preRows.map((row) => ({ ...row, invite_token_hmac: tokenHmac(row.external_ref) }));
+  assert.match(tokenRows[0].invite_token_hmac, /^[A-Za-z0-9_-]{43}$/);
   const attestation = {
     campaignId: targets.campaignId,
     inviteTokenHmacByRef: Object.fromEntries(tokenRows.map((row) => [row.external_ref, row.invite_token_hmac])),
@@ -173,9 +175,21 @@ test("plans and verifies the guarded additive Velocity grant for existing commer
     verifyPromotionTokenHmacs({ targets, d1Payload: JSON.stringify([{ results: tokenRows }]), deliveryAttestation: attestation }),
     { targetCount: 8, tokenHmacMatch: true },
   );
-  tokenRows[0].invite_token_hmac = "b".repeat(64);
+  tokenRows[0].invite_token_hmac = `${tokenRows[0].invite_token_hmac.slice(0, -1)}${tokenRows[0].invite_token_hmac.endsWith("A") ? "B" : "A"}`;
   assert.throws(
     () => verifyPromotionTokenHmacs({ targets, d1Payload: JSON.stringify([{ results: tokenRows }]), deliveryAttestation: attestation }),
+    /promotion_token_hmac_mismatch/,
+  );
+  tokenRows[0].invite_token_hmac = attestation.inviteTokenHmacByRef[tokenRows[0].external_ref];
+  const malformedAttestation = {
+    ...attestation,
+    inviteTokenHmacByRef: {
+      ...attestation.inviteTokenHmacByRef,
+      [tokenRows[0].external_ref]: "a".repeat(42),
+    },
+  };
+  assert.throws(
+    () => verifyPromotionTokenHmacs({ targets, d1Payload: JSON.stringify([{ results: tokenRows }]), deliveryAttestation: malformedAttestation }),
     /promotion_token_hmac_mismatch/,
   );
   const fullTargets = { ...targets, refs: Array.from({ length: 52 }, (_, index) => `velocity-target-${index + 1}`) };


### PR DESCRIPTION
## Summary
- validate invitation HMACs using the canonical 43-character Base64URL SHA-256 representation
- retain strict format and equality checks for the delivery attestation and production D1 records
- cover a valid Base64URL HMAC, a valid-format mismatch, and malformed expected input

## Validation
- 
ode --test .github/scripts/beauty-movement-team-invite-links-contract.test.mjs .github/scripts/beauty-movement-velocity-invite-links.test.mjs (10 passing)
- git diff --check

The prior production run stopped before any write because the guard incorrectly required a 64-character hexadecimal HMAC. This change retains fail-closed behavior; a real mismatch will still stop the workflow before mutations.