### PR TITLE
feat: establish multi-repository delivery wave zero

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,7 @@
 /scripts/ @jubenitogarcia
 /skills/ @jubenitogarcia
 /shared/ @jubenitogarcia
+/packages/ @jubenitogarcia
 
 # Active domain roots
 /ads/ @jubenitogarcia

--- a/.github/scripts/inventory-legacy-jobs-release-guard.test.mjs
+++ b/.github/scripts/inventory-legacy-jobs-release-guard.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const workflow = fs.readFileSync(new URL('../workflows/deploy-core-workers.yml', import.meta.url), 'utf8');
+const start = workflow.indexOf('          if [[ "$UNIT" == "api" || "$UNIT" == "all" ]]; then');
+const end = workflow.indexOf('            [[ "$TIMEKEEPING_VERSION_ID"', start);
+assert.ok(start >= 0 && end > start, 'API deployment block is missing');
+const guard = workflow.slice(start, end);
+
+test('API deploy waits for a stable Inventory RPC-capable release before cutover', () => {
+  assert.match(guard, /if \[\[ "\$RELEASE_SCOPE" == "general" \]\]; then/);
+  assert.match(guard, /if \[\[ "\$UNIT" == "all" \]\]; then\s+expected_inventory_sha="\$RELEASE_SHA"/);
+  assert.match(guard, /expected_inventory_sha="\$INVENTORY_LEGACY_JOBS_RELEASE_SHA"/);
+  assert.match(guard, /node --input-type=module - "\$expected_inventory_sha" "\$inventory_health_url"/);
+  assert.match(guard, /const propagationDeadline = Date\.now\(\) \+ 75_000/);
+  assert.match(guard, /while \(Date\.now\(\) <= propagationDeadline\)/);
+  assert.match(guard, /AbortSignal\.timeout\(15_000\)/);
+  assert.match(guard, /'cache-control': 'no-cache'/);
+  assert.match(guard, /probe\.searchParams\.set\('legacy_jobs_release_probe'/);
+  assert.match(guard, /health\?\.ready === true/);
+  assert.match(guard, /String\(health\?\.version \|\| ''\)\.toLowerCase\(\) === expectedSha\.toLowerCase\(\)/);
+  assert.match(guard, /health\?\.legacyApiJobsRpc === 'legacy-api-jobs-rpc\/v1'/);
+  assert.match(guard, /if \(consecutiveValidSamples >= 2\)/);
+  assert.match(guard, /Math\.min\(5_000, remainingMs\)/);
+});
+
+test('API rollback remains ordered before Inventory rollback', () => {
+  const manifest = JSON.parse(fs.readFileSync(new URL('../../shared/domain-boundaries.json', import.meta.url), 'utf8'));
+  const binding = manifest.statefulServiceBindings.find((entry) => entry.id === 'api-inventory-legacy-jobs-rpc-v1');
+
+  assert.deepEqual(binding.deployOrder, ['inventory', 'api']);
+  assert.deepEqual(binding.rollbackOrder, ['api', 'inventory']);
+  assert.equal(binding.healthCapability, 'legacy-api-jobs-rpc/v1');
+});

--- a/.github/scripts/promotion-evidence.mjs
+++ b/.github/scripts/promotion-evidence.mjs
@@ -9,6 +9,10 @@ const required = (name) => {
   if (!value) throw new Error(`missing ${name}`);
   return value;
 };
+const optional = (name) => process.env[name] || null;
+const SHA256 = /^[0-9a-f]{64}$/i;
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const SAFE_TEXT = /^[^\u0000-\u001f\u007f]+$/;
 
 const releaseSurfacesByUnit = {
   "timekeeping": ["timekeeping"],
@@ -60,6 +64,102 @@ function requiredSha(value, label) {
   return String(value).toLowerCase();
 }
 
+function requiredSha256(value, label) {
+  if (!SHA256.test(String(value || ""))) throw new Error(`${label} must be a SHA-256 digest`);
+  return String(value).toLowerCase();
+}
+
+function requiredRepository(value, label) {
+  const normalized = String(value || "").trim();
+  if (!REPOSITORY.test(normalized)) throw new Error(`${label} must be an owner/repository identifier`);
+  return normalized.toLowerCase();
+}
+
+function requiredText(value, label) {
+  const normalized = String(value || "").trim();
+  if (!normalized || normalized.length > 512 || !SAFE_TEXT.test(normalized)) throw new Error(`${label} must be a non-empty safe string`);
+  return normalized;
+}
+
+function parseJson(value, label) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    throw new Error(`${label} must be valid JSON`);
+  }
+}
+
+function normalizeIntegrity(value, label) {
+  const normalized = requiredText(value, label);
+  if (SHA256.test(normalized)) return normalized.toLowerCase();
+  if (/^sha256:[0-9a-f]{64}$/i.test(normalized)) return `sha256:${normalized.slice("sha256:".length).toLowerCase()}`;
+  if (/^sha(?:256|384|512)-[A-Za-z0-9+/]+={0,2}$/.test(normalized)) return normalized;
+  throw new Error(`${label} must be a SHA-256 digest or SRI integrity value`);
+}
+
+function normalizeContractVersions(value, label) {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  const normalized = value.map((entry, index) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) throw new Error(`${label}[${index}] must be an object`);
+    return {
+      name: requiredText(entry.name, `${label}[${index}].name`),
+      version: requiredText(entry.version, `${label}[${index}].version`),
+      integrity: normalizeIntegrity(entry.integrity, `${label}[${index}].integrity`),
+    };
+  }).sort((left, right) => left.name.localeCompare(right.name) || left.version.localeCompare(right.version));
+  for (let index = 1; index < normalized.length; index += 1) {
+    if (normalized[index - 1].name === normalized[index].name) throw new Error(`${label} contains duplicate package ${normalized[index].name}`);
+  }
+  return normalized;
+}
+
+function normalizeArtifacts(value, label) {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  const normalized = value.map((entry, index) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) throw new Error(`${label}[${index}] must be an object`);
+    return {
+      id: requiredText(entry.id, `${label}[${index}].id`),
+      digest: normalizeIntegrity(entry.digest, `${label}[${index}].digest`),
+      fileDigest: normalizeIntegrity(entry.fileDigest, `${label}[${index}].fileDigest`),
+    };
+  }).sort((left, right) => left.id.localeCompare(right.id) || left.digest.localeCompare(right.digest));
+  for (let index = 1; index < normalized.length; index += 1) {
+    if (normalized[index - 1].id === normalized[index].id) throw new Error(`${label} contains duplicate artifact ${normalized[index].id}`);
+  }
+  return normalized;
+}
+
+function v4ReleaseIdentity({
+  unit,
+  sourceRepository,
+  sourceCommit,
+  sourceTree,
+  sourceRef,
+  deliveryContractVersion,
+  contractManifestDigest,
+  dependencyClosureDigest,
+  contractVersions,
+  artifacts,
+}) {
+  const identity = {
+    schemaVersion: 2,
+    module: unit,
+    sourceRepository,
+    sourceCommit,
+    sourceTree,
+    sourceRef,
+    deliveryContractVersion,
+    contractManifestDigest,
+    dependencyClosureDigest,
+    contractVersions,
+    artifacts,
+  };
+  return {
+    ...identity,
+    releaseIdentityDigest: sha256(canonicalJson(identity)),
+  };
+}
+
 function buildIdentityFromEnv({ artifacts = [] } = {}) {
   const unit = required("PROMOTION_UNIT");
   const sourceSha = requiredSha(required("PROMOTION_SOURCE_SHA"), "promotion source SHA");
@@ -77,29 +177,325 @@ function buildIdentityFromEnv({ artifacts = [] } = {}) {
   });
 }
 
-if (mode === "write") {
+function requestedEvidenceSchemaVersion() {
+  const value = optional("PROMOTION_EVIDENCE_SCHEMA_VERSION") || "3";
+  if (value !== "3" && value !== "4") throw new Error("PROMOTION_EVIDENCE_SCHEMA_VERSION must be 3 or 4");
+  return Number(value);
+}
+
+function sourceCommitFromEnv() {
+  const sourceCommit = optional("PROMOTION_SOURCE_COMMIT");
+  const sourceSha = optional("PROMOTION_SOURCE_SHA");
+  if (!sourceCommit && !sourceSha) throw new Error("missing PROMOTION_SOURCE_SHA");
+  const normalized = requiredSha(sourceCommit || sourceSha, "promotion source SHA");
+  if (sourceCommit && sourceSha && normalized !== requiredSha(sourceSha, "promotion source SHA")) {
+    throw new Error("PROMOTION_SOURCE_COMMIT and PROMOTION_SOURCE_SHA disagree");
+  }
+  return normalized;
+}
+
+function buildV4IdentityFromEnv() {
   const unit = required("PROMOTION_UNIT");
-  const sourceSha = required("PROMOTION_SOURCE_SHA");
-  const sourceTree = required("PROMOTION_SOURCE_TREE");
-  const artifacts = process.env.PROMOTION_ARTIFACT_DIGESTS_JSON ? JSON.parse(process.env.PROMOTION_ARTIFACT_DIGESTS_JSON) : [];
-  if (!Array.isArray(artifacts)) throw new Error("PROMOTION_ARTIFACT_DIGESTS_JSON must be an array");
-  const identity = buildIdentityFromEnv({ artifacts });
-  const evidence = {
-    schemaVersion: 3,
+  const sourceRepository = requiredRepository(required("PROMOTION_SOURCE_REPOSITORY"), "promotion source repository");
+  const sourceCommit = sourceCommitFromEnv();
+  const sourceTree = requiredSha(required("PROMOTION_SOURCE_TREE"), "promotion source tree");
+  const sourceRef = requiredText(required("PROMOTION_SOURCE_REF"), "promotion source ref");
+  const deliveryContractVersion = requiredText(required("PROMOTION_DELIVERY_CONTRACT_VERSION"), "promotion delivery contract version");
+  const contractManifestDigest = requiredSha256(required("PROMOTION_CONTRACT_MANIFEST_DIGEST"), "promotion contract manifest digest");
+  const releaseInputDigest = requiredSha256(required("PROMOTION_RELEASE_INPUT_DIGEST"), "promotion release-input digest");
+  const dependencyClosureDigest = requiredSha256(
+    process.env.PROMOTION_DEPENDENCY_CLOSURE_DIGEST || process.env.PROMOTION_RELEASE_INPUT_DIGEST,
+    "promotion dependency closure digest",
+  );
+  if (releaseInputDigest !== dependencyClosureDigest) throw new Error("promotion dependency-closure digest differs from release-input digest");
+  const contractVersions = normalizeContractVersions(
+    parseJson(required("PROMOTION_CONTRACT_VERSIONS_JSON"), "PROMOTION_CONTRACT_VERSIONS_JSON"),
+    "promotion contract versions",
+  );
+  const artifacts = normalizeArtifacts(
+    parseJson(required("PROMOTION_ARTIFACT_IDENTITIES_JSON"), "PROMOTION_ARTIFACT_IDENTITIES_JSON"),
+    "promotion artifact identities",
+  );
+  if (!artifacts.length) throw new Error("schema v4 evidence requires at least one immutable artifact identity");
+  return {
     unit,
-    target: required("PROMOTION_TARGET"),
-    sourceSha: identity.sourceCommit,
-    sourceTree: identity.sourceTree,
-    releaseInputDigest: process.env.PROMOTION_RELEASE_INPUT_DIGEST || releaseInputDigest(unit, sourceSha),
-    dependencyClosureDigest: identity.dependencyClosureDigest,
+    sourceRepository,
+    sourceCommit,
+    sourceTree,
+    sourceRef,
+    deliveryContractVersion,
+    contractManifestDigest,
+    releaseInputDigest,
+    dependencyClosureDigest,
+    contractVersions,
     artifacts,
-    releaseIdentity: identity,
-    releaseIdentityDigest: identity.releaseIdentityDigest,
-    promotionStrategy: artifacts.length ? "exact-artifacts" : "immutable-source-identity",
-    runId: required("GITHUB_RUN_ID"),
-    repository: required("GITHUB_REPOSITORY"),
-    createdAt: new Date().toISOString(),
+    identity: v4ReleaseIdentity({
+      unit,
+      sourceRepository,
+      sourceCommit,
+      sourceTree,
+      sourceRef,
+      deliveryContractVersion,
+      contractManifestDigest,
+      dependencyClosureDigest,
+      contractVersions,
+      artifacts,
+    }),
   };
+}
+
+function requiredRunId(value, label) {
+  const normalized = requiredText(value, label);
+  if (!/^[0-9]+$/.test(normalized)) throw new Error(`${label} must be a numeric GitHub Actions run id`);
+  return normalized;
+}
+
+function provenanceFromEnv() {
+  const evidenceRepository = requiredRepository(
+    process.env.PROMOTION_EVIDENCE_REPOSITORY || required("GITHUB_REPOSITORY"),
+    "promotion evidence repository",
+  );
+  const evidenceRunId = requiredRunId(
+    process.env.PROMOTION_EVIDENCE_RUN_ID || required("GITHUB_RUN_ID"),
+    "promotion evidence run id",
+  );
+  const evidenceArtifact = requiredText(required("PROMOTION_EVIDENCE_ARTIFACT"), "promotion evidence artifact");
+  const predecessorRepository = optional("PROMOTION_PREDECESSOR_REPOSITORY");
+  const predecessorRunId = optional("PROMOTION_PREDECESSOR_RUN_ID");
+  const predecessorArtifact = optional("PROMOTION_PREDECESSOR_ARTIFACT");
+  if (!predecessorRepository && !predecessorRunId && !predecessorArtifact) {
+    return { evidenceRepository, evidenceRunId, evidenceArtifact };
+  }
+  if (!predecessorRepository || !predecessorRunId || !predecessorArtifact) {
+    throw new Error("predecessor repository, run id, and artifact must be supplied together");
+  }
+  return {
+    evidenceRepository,
+    evidenceRunId,
+    evidenceArtifact,
+    predecessorRepository: requiredRepository(predecessorRepository, "promotion predecessor repository"),
+    predecessorRunId: requiredRunId(predecessorRunId, "promotion predecessor run id"),
+    predecessorArtifact: requiredText(predecessorArtifact, "promotion predecessor artifact"),
+  };
+}
+
+function expectedSourceCommitFromEnv() {
+  const sourceCommit = optional("PROMOTION_EXPECTED_SOURCE_COMMIT");
+  const sourceSha = optional("PROMOTION_EXPECTED_SHA");
+  if (!sourceCommit && !sourceSha) return null;
+  const normalized = requiredSha(sourceCommit || sourceSha, "expected promotion source SHA");
+  if (sourceCommit && sourceSha && normalized !== requiredSha(sourceSha, "expected promotion source SHA")) {
+    throw new Error("PROMOTION_EXPECTED_SOURCE_COMMIT and PROMOTION_EXPECTED_SHA disagree");
+  }
+  return normalized;
+}
+
+function expectedPredecessorFromEnv() {
+  const repository = optional("PROMOTION_EXPECTED_PREDECESSOR_REPOSITORY");
+  const runId = optional("PROMOTION_EXPECTED_PREDECESSOR_RUN_ID");
+  const artifact = optional("PROMOTION_EXPECTED_PREDECESSOR_ARTIFACT");
+  if (!repository && !runId && !artifact) return null;
+  if (!repository || !runId || !artifact) {
+    throw new Error("expected predecessor repository, run id, and artifact must be supplied together");
+  }
+  return {
+    predecessorRepository: requiredRepository(repository, "expected promotion predecessor repository"),
+    predecessorRunId: requiredRunId(runId, "expected promotion predecessor run id"),
+    predecessorArtifact: requiredText(artifact, "expected promotion predecessor artifact"),
+  };
+}
+
+function assertOptionalEqual(actual, expected, label) {
+  if (expected !== null && actual !== expected) throw new Error(`promotion evidence ${label} differs from the requested candidate`);
+}
+
+function v4FieldsFromEvidence(evidence) {
+  const sourceRepository = requiredRepository(evidence.sourceRepository, "promotion evidence source repository");
+  const sourceCommit = requiredSha(evidence.sourceSha, "promotion evidence source SHA");
+  const sourceTree = requiredSha(evidence.sourceTree, "promotion evidence source tree");
+  const sourceRef = requiredText(evidence.sourceRef, "promotion evidence source ref");
+  const deliveryContractVersion = requiredText(evidence.deliveryContractVersion, "promotion evidence delivery contract version");
+  const contractManifestDigest = requiredSha256(evidence.contractManifestDigest, "promotion evidence contract manifest digest");
+  const releaseInputDigest = requiredSha256(evidence.releaseInputDigest, "promotion evidence release-input digest");
+  const dependencyClosureDigest = requiredSha256(evidence.dependencyClosureDigest, "promotion evidence dependency closure digest");
+  if (releaseInputDigest !== dependencyClosureDigest) throw new Error("promotion evidence dependency-closure digest differs from release-input digest");
+  const contractVersions = normalizeContractVersions(evidence.contractVersions, "promotion evidence contract versions");
+  const artifacts = normalizeArtifacts(evidence.artifacts, "promotion evidence artifact identities");
+  if (!artifacts.length) throw new Error("schema v4 evidence requires at least one immutable artifact identity");
+  const evidenceRepository = requiredRepository(evidence.evidenceRepository, "promotion evidence repository");
+  const evidenceRunId = requiredRunId(evidence.evidenceRunId, "promotion evidence run id");
+  const evidenceArtifact = requiredText(evidence.evidenceArtifact, "promotion evidence artifact");
+  if (evidence.repository !== undefined && requiredRepository(evidence.repository, "promotion evidence repository") !== evidenceRepository) {
+    throw new Error("promotion evidence repository alias does not match its v4 envelope");
+  }
+  if (evidence.runId !== undefined && requiredRunId(evidence.runId, "promotion evidence run id") !== evidenceRunId) {
+    throw new Error("promotion evidence run id alias does not match its v4 envelope");
+  }
+  const predecessor = {
+    predecessorRepository: evidence.predecessorRepository,
+    predecessorRunId: evidence.predecessorRunId,
+    predecessorArtifact: evidence.predecessorArtifact,
+  };
+  const predecessorValues = Object.values(predecessor).filter((value) => value !== undefined && value !== null && String(value).trim() !== "");
+  if (predecessorValues.length && predecessorValues.length !== 3) {
+    throw new Error("promotion evidence predecessor provenance is incomplete");
+  }
+  const normalizedPredecessor = predecessorValues.length
+    ? {
+      predecessorRepository: requiredRepository(predecessor.predecessorRepository, "promotion evidence predecessor repository"),
+      predecessorRunId: requiredRunId(predecessor.predecessorRunId, "promotion evidence predecessor run id"),
+      predecessorArtifact: requiredText(predecessor.predecessorArtifact, "promotion evidence predecessor artifact"),
+    }
+    : null;
+  if (evidence.target !== "preview" && !normalizedPredecessor) {
+    throw new Error("schema v4 evidence after preview requires predecessor provenance");
+  }
+  const identity = v4ReleaseIdentity({
+    unit: evidence.unit,
+    sourceRepository,
+    sourceCommit,
+    sourceTree,
+    sourceRef,
+    deliveryContractVersion,
+    contractManifestDigest,
+    dependencyClosureDigest,
+    contractVersions,
+    artifacts,
+  });
+  if (evidence.releaseIdentityDigest !== identity.releaseIdentityDigest || canonicalJson(evidence.releaseIdentity) !== canonicalJson(identity)) {
+    throw new Error("promotion evidence release identity digest is invalid");
+  }
+  return {
+    sourceRepository,
+    sourceCommit,
+    sourceTree,
+    sourceRef,
+    deliveryContractVersion,
+    contractManifestDigest,
+    releaseInputDigest,
+    dependencyClosureDigest,
+    contractVersions,
+    artifacts,
+    evidenceRepository,
+    evidenceRunId,
+    evidenceArtifact,
+    predecessor: normalizedPredecessor,
+  };
+}
+
+function verifyV4Evidence(evidence) {
+  const fields = v4FieldsFromEvidence(evidence);
+  assertOptionalEqual(fields.sourceRepository, optional("PROMOTION_EXPECTED_SOURCE_REPOSITORY") === null ? null : requiredRepository(optional("PROMOTION_EXPECTED_SOURCE_REPOSITORY"), "expected promotion source repository"), "source repository");
+  assertOptionalEqual(fields.sourceCommit, expectedSourceCommitFromEnv(), "SHA");
+  assertOptionalEqual(fields.sourceTree, optional("PROMOTION_EXPECTED_SOURCE_TREE") === null ? null : requiredSha(optional("PROMOTION_EXPECTED_SOURCE_TREE"), "expected promotion source tree"), "source tree");
+  assertOptionalEqual(fields.sourceRef, optional("PROMOTION_EXPECTED_SOURCE_REF") === null ? null : requiredText(optional("PROMOTION_EXPECTED_SOURCE_REF"), "expected promotion source ref"), "source ref");
+  assertOptionalEqual(fields.releaseInputDigest, optional("PROMOTION_EXPECTED_RELEASE_INPUT_DIGEST") === null ? null : requiredSha256(optional("PROMOTION_EXPECTED_RELEASE_INPUT_DIGEST"), "expected promotion release-input digest"), "release-input digest");
+  assertOptionalEqual(fields.deliveryContractVersion, optional("PROMOTION_EXPECTED_DELIVERY_CONTRACT_VERSION") === null ? null : requiredText(optional("PROMOTION_EXPECTED_DELIVERY_CONTRACT_VERSION"), "expected promotion delivery contract version"), "delivery contract version");
+  assertOptionalEqual(fields.contractManifestDigest, optional("PROMOTION_EXPECTED_CONTRACT_MANIFEST_DIGEST") === null ? null : requiredSha256(optional("PROMOTION_EXPECTED_CONTRACT_MANIFEST_DIGEST"), "expected promotion contract manifest digest"), "contract manifest digest");
+  const expectedVersions = optional("PROMOTION_EXPECTED_CONTRACT_VERSIONS_JSON") === null
+    ? null
+    : normalizeContractVersions(parseJson(optional("PROMOTION_EXPECTED_CONTRACT_VERSIONS_JSON"), "PROMOTION_EXPECTED_CONTRACT_VERSIONS_JSON"), "expected promotion contract versions");
+  if (expectedVersions && canonicalJson(fields.contractVersions) !== canonicalJson(expectedVersions)) {
+    throw new Error("promotion evidence contract versions differ from the requested candidate");
+  }
+  const expectedArtifacts = optional("PROMOTION_EXPECTED_ARTIFACT_IDENTITIES_JSON") === null
+    ? null
+    : normalizeArtifacts(parseJson(optional("PROMOTION_EXPECTED_ARTIFACT_IDENTITIES_JSON"), "PROMOTION_EXPECTED_ARTIFACT_IDENTITIES_JSON"), "expected promotion artifact identities");
+  if (expectedArtifacts && canonicalJson(fields.artifacts) !== canonicalJson(expectedArtifacts)) {
+    throw new Error("promotion evidence artifact identities differ from the requested candidate");
+  }
+  assertOptionalEqual(fields.evidenceRepository, optional("PROMOTION_EXPECTED_EVIDENCE_REPOSITORY") === null ? null : requiredRepository(optional("PROMOTION_EXPECTED_EVIDENCE_REPOSITORY"), "expected promotion evidence repository"), "evidence repository");
+  assertOptionalEqual(fields.evidenceRunId, optional("PROMOTION_EXPECTED_EVIDENCE_RUN_ID") === null ? null : requiredRunId(optional("PROMOTION_EXPECTED_EVIDENCE_RUN_ID"), "expected promotion evidence run id"), "evidence run id");
+  assertOptionalEqual(fields.evidenceArtifact, optional("PROMOTION_EXPECTED_EVIDENCE_ARTIFACT") === null ? null : requiredText(optional("PROMOTION_EXPECTED_EVIDENCE_ARTIFACT"), "expected promotion evidence artifact"), "evidence artifact");
+  const expectedPredecessor = expectedPredecessorFromEnv();
+  if (expectedPredecessor && canonicalJson(fields.predecessor) !== canonicalJson(expectedPredecessor)) {
+    throw new Error("promotion evidence predecessor provenance differs from the requested candidate");
+  }
+  assertOptionalEqual(evidence.releaseIdentityDigest, optional("PROMOTION_EXPECTED_RELEASE_IDENTITY_DIGEST") === null ? null : requiredSha256(optional("PROMOTION_EXPECTED_RELEASE_IDENTITY_DIGEST"), "expected promotion release identity digest"), "release identity");
+  return fields;
+}
+
+function assertLegacyEvidenceIsIntraRepository(evidence) {
+  const expectedPredecessor = expectedPredecessorFromEnv();
+  const repositories = [
+    optional("GITHUB_REPOSITORY") && requiredRepository(optional("GITHUB_REPOSITORY"), "GitHub repository"),
+    optional("PROMOTION_EXPECTED_SOURCE_REPOSITORY") && requiredRepository(optional("PROMOTION_EXPECTED_SOURCE_REPOSITORY"), "expected promotion source repository"),
+    optional("PROMOTION_EXPECTED_EVIDENCE_REPOSITORY") && requiredRepository(optional("PROMOTION_EXPECTED_EVIDENCE_REPOSITORY"), "expected promotion evidence repository"),
+    expectedPredecessor?.predecessorRepository,
+    evidence.repository && requiredRepository(evidence.repository, "promotion evidence repository"),
+  ].filter(Boolean);
+  if (repositories.some((repository) => repository !== repositories[0])) {
+    throw new Error("legacy promotion evidence can only be used intra-repository; schema v4 is required for cross-repository promotion");
+  }
+}
+
+if (mode === "write") {
+  const schemaVersion = requestedEvidenceSchemaVersion();
+  const target = required("PROMOTION_TARGET");
+  let evidence;
+  if (schemaVersion === 4) {
+    const prepared = buildV4IdentityFromEnv();
+    const provenance = provenanceFromEnv();
+    if (target !== "preview" && !provenance.predecessorRepository) {
+      throw new Error("schema v4 evidence after preview requires predecessor provenance");
+    }
+    evidence = {
+      schemaVersion: 4,
+      unit: prepared.unit,
+      target,
+      sourceRepository: prepared.sourceRepository,
+      sourceSha: prepared.sourceCommit,
+      sourceTree: prepared.sourceTree,
+      sourceRef: prepared.sourceRef,
+      deliveryContractVersion: prepared.deliveryContractVersion,
+      contractManifestDigest: prepared.contractManifestDigest,
+      releaseInputDigest: prepared.releaseInputDigest,
+      dependencyClosureDigest: prepared.dependencyClosureDigest,
+      contractVersions: prepared.contractVersions,
+      artifacts: prepared.artifacts,
+      releaseIdentity: prepared.identity,
+      releaseIdentityDigest: prepared.identity.releaseIdentityDigest,
+      promotionStrategy: "exact-artifacts",
+      ...provenance,
+      // Aliases preserve the v1-v3 envelope readers during the transition.
+      runId: provenance.evidenceRunId,
+      repository: provenance.evidenceRepository,
+      createdAt: new Date().toISOString(),
+    };
+  } else {
+    const unit = required("PROMOTION_UNIT");
+    const sourceSha = required("PROMOTION_SOURCE_SHA");
+    const artifacts = process.env.PROMOTION_ARTIFACT_DIGESTS_JSON ? JSON.parse(process.env.PROMOTION_ARTIFACT_DIGESTS_JSON) : [];
+    if (!Array.isArray(artifacts)) throw new Error("PROMOTION_ARTIFACT_DIGESTS_JSON must be an array");
+    const identity = buildIdentityFromEnv({ artifacts });
+    const repository = requiredRepository(required("GITHUB_REPOSITORY"), "promotion evidence repository");
+    const explicitSourceRepository = optional("PROMOTION_SOURCE_REPOSITORY");
+    const explicitEvidenceRepository = optional("PROMOTION_EVIDENCE_REPOSITORY");
+    const explicitPredecessorRepository = optional("PROMOTION_PREDECESSOR_REPOSITORY");
+    if (
+      (explicitSourceRepository && requiredRepository(explicitSourceRepository, "promotion source repository") !== repository)
+      || (explicitEvidenceRepository && requiredRepository(explicitEvidenceRepository, "promotion evidence repository") !== repository)
+      || (explicitPredecessorRepository && requiredRepository(explicitPredecessorRepository, "promotion predecessor repository") !== repository)
+    ) {
+      throw new Error("cross-repository promotion evidence requires schema v4");
+    }
+    evidence = {
+      schemaVersion: 3,
+      unit,
+      target,
+      sourceSha: identity.sourceCommit,
+      sourceTree: identity.sourceTree,
+      releaseInputDigest: process.env.PROMOTION_RELEASE_INPUT_DIGEST || releaseInputDigest(unit, sourceSha),
+      dependencyClosureDigest: identity.dependencyClosureDigest,
+      artifacts,
+      releaseIdentity: identity,
+      releaseIdentityDigest: identity.releaseIdentityDigest,
+      promotionStrategy: artifacts.length ? "exact-artifacts" : "immutable-source-identity",
+      runId: required("GITHUB_RUN_ID"),
+      repository,
+      createdAt: new Date().toISOString(),
+    };
+  }
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, `${JSON.stringify(evidence, null, 2)}\n`);
   process.stdout.write(`${JSON.stringify(evidence)}\n`);
@@ -110,28 +506,41 @@ if (mode === "write") {
   const expectedSha = process.env.PROMOTION_EXPECTED_SHA;
   const expectedReleaseInputDigest = process.env.PROMOTION_EXPECTED_RELEASE_INPUT_DIGEST;
   const expectedReleaseIdentityDigest = process.env.PROMOTION_EXPECTED_RELEASE_IDENTITY_DIGEST;
-  if (![1, 2, 3].includes(evidence.schemaVersion) || evidence.unit !== expectedUnit || evidence.target !== expectedTarget || !/^[0-9a-f]{40}$/i.test(evidence.sourceSha) || !/^[0-9a-f]{40}$/i.test(evidence.sourceTree)) {
+  if (![1, 2, 3, 4].includes(evidence.schemaVersion) || evidence.unit !== expectedUnit || evidence.target !== expectedTarget || !/^[0-9a-f]{40}$/i.test(evidence.sourceSha) || !/^[0-9a-f]{40}$/i.test(evidence.sourceTree)) {
     throw new Error("promotion evidence has an invalid identity or stage");
   }
-  if (expectedSha && evidence.sourceSha !== expectedSha) throw new Error("promotion evidence SHA differs from requested release SHA");
-  if (expectedReleaseInputDigest && evidence.releaseInputDigest !== expectedReleaseInputDigest) throw new Error("promotion evidence release-input digest differs from the requested candidate");
-  if (evidence.dependencyClosureDigest && evidence.dependencyClosureDigest !== evidence.releaseInputDigest) throw new Error("promotion evidence dependency-closure digest differs from release-input digest");
-  if (evidence.schemaVersion >= 3) {
-    const identity = releaseIdentity({
-      unit: evidence.unit,
-      sourceSha: evidence.sourceSha,
-      sourceTree: evidence.sourceTree,
-      releaseInputDigest: evidence.dependencyClosureDigest || evidence.releaseInputDigest,
-      artifacts: evidence.artifacts || [],
-    });
-    if (evidence.releaseIdentityDigest !== identity.releaseIdentityDigest || canonicalJson(evidence.releaseIdentity) !== canonicalJson(identity)) {
-      throw new Error("promotion evidence release identity digest is invalid");
+  let v4Fields = null;
+  if (evidence.schemaVersion === 4) {
+    v4Fields = verifyV4Evidence(evidence);
+  } else {
+    assertLegacyEvidenceIsIntraRepository(evidence);
+    if (expectedSha && evidence.sourceSha !== expectedSha) throw new Error("promotion evidence SHA differs from requested release SHA");
+    if (expectedReleaseInputDigest && evidence.releaseInputDigest !== expectedReleaseInputDigest) throw new Error("promotion evidence release-input digest differs from the requested candidate");
+    if (evidence.dependencyClosureDigest && evidence.dependencyClosureDigest !== evidence.releaseInputDigest) throw new Error("promotion evidence dependency-closure digest differs from release-input digest");
+    if (evidence.schemaVersion >= 3) {
+      const identity = releaseIdentity({
+        unit: evidence.unit,
+        sourceSha: evidence.sourceSha,
+        sourceTree: evidence.sourceTree,
+        releaseInputDigest: evidence.dependencyClosureDigest || evidence.releaseInputDigest,
+        artifacts: evidence.artifacts || [],
+      });
+      if (evidence.releaseIdentityDigest !== identity.releaseIdentityDigest || canonicalJson(evidence.releaseIdentity) !== canonicalJson(identity)) {
+        throw new Error("promotion evidence release identity digest is invalid");
+      }
+      if (expectedReleaseIdentityDigest && evidence.releaseIdentityDigest !== expectedReleaseIdentityDigest) throw new Error("promotion evidence release identity differs from requested candidate");
+    } else if (expectedReleaseIdentityDigest) {
+      throw new Error("legacy promotion evidence has no immutable release identity");
     }
-    if (expectedReleaseIdentityDigest && evidence.releaseIdentityDigest !== expectedReleaseIdentityDigest) throw new Error("promotion evidence release identity differs from requested candidate");
-  } else if (expectedReleaseIdentityDigest) {
-    throw new Error("legacy promotion evidence has no immutable release identity");
   }
-  if (process.env.GITHUB_OUTPUT) fs.appendFileSync(process.env.GITHUB_OUTPUT, `source_sha=${evidence.sourceSha}\nsource_tree=${evidence.sourceTree}\nrelease_input_digest=${evidence.releaseInputDigest || ""}\ndependency_closure_digest=${evidence.dependencyClosureDigest || evidence.releaseInputDigest || ""}\nrelease_identity_digest=${evidence.releaseIdentityDigest || ""}\n`);
+  if (process.env.GITHUB_OUTPUT) {
+    const sourceRepository = v4Fields?.sourceRepository || evidence.repository || "";
+    const sourceRef = v4Fields?.sourceRef || "";
+    const evidenceRepository = v4Fields?.evidenceRepository || evidence.repository || "";
+    const evidenceRunId = v4Fields?.evidenceRunId || evidence.runId || "";
+    const evidenceArtifact = v4Fields?.evidenceArtifact || "";
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `source_repository=${sourceRepository}\nsource_sha=${evidence.sourceSha}\nsource_tree=${evidence.sourceTree}\nsource_ref=${sourceRef}\nrelease_input_digest=${evidence.releaseInputDigest || ""}\ndependency_closure_digest=${evidence.dependencyClosureDigest || evidence.releaseInputDigest || ""}\nrelease_identity_digest=${evidence.releaseIdentityDigest || ""}\nevidence_repository=${evidenceRepository}\nevidence_run_id=${evidenceRunId}\nevidence_artifact=${evidenceArtifact}\n`);
+  }
   process.stdout.write(`Promotion evidence verified for ${evidence.unit} ${evidence.sourceSha} from ${evidence.target}.\n`);
 } else if (mode === "digest") {
   const unit = required("PROMOTION_UNIT");
@@ -140,7 +549,9 @@ if (mode === "write") {
   if (!digest) throw new Error(`no release surface mapping exists for ${unit}; provide PROMOTION_RELEASE_INPUT_DIGEST explicitly`);
   process.stdout.write(`${digest}\n`);
 } else if (mode === "identity") {
-  process.stdout.write(`${JSON.stringify(buildIdentityFromEnv())}\n`);
+  const schemaVersion = requestedEvidenceSchemaVersion();
+  const identity = schemaVersion === 4 ? buildV4IdentityFromEnv().identity : buildIdentityFromEnv();
+  process.stdout.write(`${JSON.stringify(identity)}\n`);
 } else {
   throw new Error("usage: promotion-evidence.mjs write|verify <file> | digest | identity");
 }

--- a/.github/scripts/promotion-evidence.test.mjs
+++ b/.github/scripts/promotion-evidence.test.mjs
@@ -4,7 +4,6 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { test } from "node:test";
-import { createPromotionEvidenceV4, verifyPromotionEvidenceV4 } from "../../packages/skincos-delivery-contract/src/index.js";
 
 const root = path.resolve(import.meta.dirname, "../..");
 const sha256 = (character) => character.repeat(64);
@@ -165,7 +164,7 @@ test("v4 binds repository, contract manifest, package versions, and exact artifa
   assert.notEqual(artifactVariant.releaseIdentityDigest, identity.releaseIdentityDigest);
 });
 
-test("writes evidence accepted by the portable v4 delivery contract", async () => {
+test("writes and verifies cross-repository promotion evidence with a v4 provenance envelope", () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "skincos-promotion-evidence-v4-"));
   const evidencePath = path.join(directory, "promotion-evidence.json");
   const sourceSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
@@ -196,43 +195,6 @@ test("writes evidence accepted by the portable v4 delivery contract", async () =
     PROMOTION_EXPECTED_EVIDENCE_RUN_ID: evidence.evidenceRunId,
     PROMOTION_EXPECTED_EVIDENCE_ARTIFACT: evidence.evidenceArtifact,
     PROMOTION_EXPECTED_RELEASE_IDENTITY_DIGEST: evidence.releaseIdentityDigest,
-  });
-
-  const portable = await verifyPromotionEvidenceV4(evidence, {
-    target: "preview",
-    sourceRepository: evidence.sourceRepository,
-    sourceCommit: sourceSha,
-    releaseIdentityDigest: evidence.releaseIdentityDigest,
-  });
-  assert.equal(portable.evidence.releaseIdentityDigest, evidence.releaseIdentityDigest);
-
-  const packageEvidence = await createPromotionEvidenceV4({
-    target: "preview",
-    createdAt: "2026-08-28T14:23:04.000Z",
-    evidenceRepository: evidence.evidenceRepository,
-    evidenceRunId: evidence.evidenceRunId,
-    evidenceArtifact: evidence.evidenceArtifact,
-    releaseIdentity: evidence.releaseIdentity,
-  });
-  const packageEvidencePath = path.join(directory, "package-promotion-evidence.json");
-  fs.writeFileSync(packageEvidencePath, `${JSON.stringify(packageEvidence)}\n`);
-  runPromotion(["verify", packageEvidencePath], {
-    ...env,
-    GITHUB_REPOSITORY: "jubenitogarcia/skincos-release-controller",
-    PROMOTION_EXPECTED_TARGET: "preview",
-    PROMOTION_EXPECTED_SOURCE_REPOSITORY: packageEvidence.sourceRepository,
-    PROMOTION_EXPECTED_SOURCE_COMMIT: sourceSha,
-    PROMOTION_EXPECTED_SOURCE_TREE: sourceTree,
-    PROMOTION_EXPECTED_SOURCE_REF: "refs/heads/main",
-    PROMOTION_EXPECTED_RELEASE_INPUT_DIGEST: sha256("d"),
-    PROMOTION_EXPECTED_DELIVERY_CONTRACT_VERSION: "1.0.0",
-    PROMOTION_EXPECTED_CONTRACT_MANIFEST_DIGEST: sha256("c"),
-    PROMOTION_EXPECTED_CONTRACT_VERSIONS_JSON: env.PROMOTION_CONTRACT_VERSIONS_JSON,
-    PROMOTION_EXPECTED_ARTIFACT_IDENTITIES_JSON: env.PROMOTION_ARTIFACT_IDENTITIES_JSON,
-    PROMOTION_EXPECTED_EVIDENCE_REPOSITORY: packageEvidence.evidenceRepository,
-    PROMOTION_EXPECTED_EVIDENCE_RUN_ID: packageEvidence.evidenceRunId,
-    PROMOTION_EXPECTED_EVIDENCE_ARTIFACT: packageEvidence.evidenceArtifact,
-    PROMOTION_EXPECTED_RELEASE_IDENTITY_DIGEST: packageEvidence.releaseIdentityDigest,
   });
 
   const tampered = { ...evidence, sourceRepository: "jubenitogarcia/other-source" };

--- a/.github/scripts/promotion-evidence.test.mjs
+++ b/.github/scripts/promotion-evidence.test.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { test } from "node:test";
+import { createPromotionEvidenceV4, verifyPromotionEvidenceV4 } from "../../packages/skincos-delivery-contract/src/index.js";
 
 const root = path.resolve(import.meta.dirname, "../..");
 const sha256 = (character) => character.repeat(64);
@@ -36,7 +37,7 @@ function v4Environment({ sourceSha, sourceTree, ...overrides }) {
     PROMOTION_RELEASE_INPUT_DIGEST: sha256("d"),
     PROMOTION_DEPENDENCY_CLOSURE_DIGEST: sha256("d"),
     PROMOTION_CONTRACT_VERSIONS_JSON: JSON.stringify([
-      { name: "@jubenitogarcia/skincos-contracts", version: "1.0.0", integrity: `sha256:${sha256("e")}` },
+      { name: "@jubenitogarcia/skincos-contracts", version: "1.0.0", integrity: sha256("e") },
     ]),
     PROMOTION_ARTIFACT_IDENTITIES_JSON: JSON.stringify([
       { id: "worker.tgz", digest: sha256("f"), fileDigest: sha256("1") },
@@ -164,7 +165,7 @@ test("v4 binds repository, contract manifest, package versions, and exact artifa
   assert.notEqual(artifactVariant.releaseIdentityDigest, identity.releaseIdentityDigest);
 });
 
-test("writes and verifies cross-repository promotion evidence with a v4 provenance envelope", () => {
+test("writes evidence accepted by the portable v4 delivery contract", async () => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "skincos-promotion-evidence-v4-"));
   const evidencePath = path.join(directory, "promotion-evidence.json");
   const sourceSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
@@ -195,6 +196,43 @@ test("writes and verifies cross-repository promotion evidence with a v4 provenan
     PROMOTION_EXPECTED_EVIDENCE_RUN_ID: evidence.evidenceRunId,
     PROMOTION_EXPECTED_EVIDENCE_ARTIFACT: evidence.evidenceArtifact,
     PROMOTION_EXPECTED_RELEASE_IDENTITY_DIGEST: evidence.releaseIdentityDigest,
+  });
+
+  const portable = await verifyPromotionEvidenceV4(evidence, {
+    target: "preview",
+    sourceRepository: evidence.sourceRepository,
+    sourceCommit: sourceSha,
+    releaseIdentityDigest: evidence.releaseIdentityDigest,
+  });
+  assert.equal(portable.evidence.releaseIdentityDigest, evidence.releaseIdentityDigest);
+
+  const packageEvidence = await createPromotionEvidenceV4({
+    target: "preview",
+    createdAt: "2026-08-28T14:23:04.000Z",
+    evidenceRepository: evidence.evidenceRepository,
+    evidenceRunId: evidence.evidenceRunId,
+    evidenceArtifact: evidence.evidenceArtifact,
+    releaseIdentity: evidence.releaseIdentity,
+  });
+  const packageEvidencePath = path.join(directory, "package-promotion-evidence.json");
+  fs.writeFileSync(packageEvidencePath, `${JSON.stringify(packageEvidence)}\n`);
+  runPromotion(["verify", packageEvidencePath], {
+    ...env,
+    GITHUB_REPOSITORY: "jubenitogarcia/skincos-release-controller",
+    PROMOTION_EXPECTED_TARGET: "preview",
+    PROMOTION_EXPECTED_SOURCE_REPOSITORY: packageEvidence.sourceRepository,
+    PROMOTION_EXPECTED_SOURCE_COMMIT: sourceSha,
+    PROMOTION_EXPECTED_SOURCE_TREE: sourceTree,
+    PROMOTION_EXPECTED_SOURCE_REF: "refs/heads/main",
+    PROMOTION_EXPECTED_RELEASE_INPUT_DIGEST: sha256("d"),
+    PROMOTION_EXPECTED_DELIVERY_CONTRACT_VERSION: "1.0.0",
+    PROMOTION_EXPECTED_CONTRACT_MANIFEST_DIGEST: sha256("c"),
+    PROMOTION_EXPECTED_CONTRACT_VERSIONS_JSON: env.PROMOTION_CONTRACT_VERSIONS_JSON,
+    PROMOTION_EXPECTED_ARTIFACT_IDENTITIES_JSON: env.PROMOTION_ARTIFACT_IDENTITIES_JSON,
+    PROMOTION_EXPECTED_EVIDENCE_REPOSITORY: packageEvidence.evidenceRepository,
+    PROMOTION_EXPECTED_EVIDENCE_RUN_ID: packageEvidence.evidenceRunId,
+    PROMOTION_EXPECTED_EVIDENCE_ARTIFACT: packageEvidence.evidenceArtifact,
+    PROMOTION_EXPECTED_RELEASE_IDENTITY_DIGEST: packageEvidence.releaseIdentityDigest,
   });
 
   const tampered = { ...evidence, sourceRepository: "jubenitogarcia/other-source" };

--- a/.github/scripts/promotion-evidence.test.mjs
+++ b/.github/scripts/promotion-evidence.test.mjs
@@ -6,6 +6,48 @@ import os from "node:os";
 import { test } from "node:test";
 
 const root = path.resolve(import.meta.dirname, "../..");
+const sha256 = (character) => character.repeat(64);
+
+function cleanEnv(overrides = {}) {
+  const env = { ...process.env, ...overrides };
+  delete env.GITHUB_OUTPUT;
+  return env;
+}
+
+function runPromotion(args, env) {
+  return execFileSync(process.execPath, [".github/scripts/promotion-evidence.mjs", ...args], {
+    cwd: root,
+    env: cleanEnv(env),
+    encoding: "utf8",
+  });
+}
+
+function v4Environment({ sourceSha, sourceTree, ...overrides }) {
+  return {
+    PROMOTION_EVIDENCE_SCHEMA_VERSION: "4",
+    PROMOTION_UNIT: "synthetic-unit",
+    PROMOTION_TARGET: "preview",
+    PROMOTION_SOURCE_REPOSITORY: "jubenitogarcia/skincos-meta-ads-reporting",
+    PROMOTION_SOURCE_COMMIT: sourceSha,
+    PROMOTION_SOURCE_TREE: sourceTree,
+    PROMOTION_SOURCE_REF: "refs/heads/main",
+    PROMOTION_DELIVERY_CONTRACT_VERSION: "1.0.0",
+    PROMOTION_CONTRACT_MANIFEST_DIGEST: sha256("c"),
+    PROMOTION_RELEASE_INPUT_DIGEST: sha256("d"),
+    PROMOTION_DEPENDENCY_CLOSURE_DIGEST: sha256("d"),
+    PROMOTION_CONTRACT_VERSIONS_JSON: JSON.stringify([
+      { name: "@jubenitogarcia/skincos-contracts", version: "1.0.0", integrity: `sha256:${sha256("e")}` },
+    ]),
+    PROMOTION_ARTIFACT_IDENTITIES_JSON: JSON.stringify([
+      { id: "worker.tgz", digest: sha256("f"), fileDigest: sha256("1") },
+    ]),
+    GITHUB_REPOSITORY: "jubenitogarcia/skincos-release-evidence",
+    GITHUB_RUN_ID: "33179818924",
+    PROMOTION_EVIDENCE_REPOSITORY: "jubenitogarcia/skincos-release-evidence",
+    PROMOTION_EVIDENCE_ARTIFACT: "promotion-evidence-synthetic-unit",
+    ...overrides,
+  };
+}
 
 test("maps Atendimento to its isolated runtime release surfaces", () => {
   const env = { ...process.env };
@@ -91,4 +133,98 @@ test("writes and verifies a tamper-evident immutable release identity", () => {
     },
     encoding: "utf8",
   }), /release identity digest is invalid/);
+});
+
+test("v4 binds repository, contract manifest, package versions, and exact artifact files into the release identity", () => {
+  const sourceSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+  const sourceTree = execFileSync("git", ["rev-parse", "HEAD^{tree}"], { cwd: root, encoding: "utf8" }).trim();
+  const base = v4Environment({ sourceSha, sourceTree });
+  const identity = JSON.parse(runPromotion(["identity"], base));
+  assert.equal(identity.schemaVersion, 2);
+  assert.equal(identity.sourceRepository, "jubenitogarcia/skincos-meta-ads-reporting");
+  assert.equal(identity.sourceCommit, sourceSha);
+  assert.match(identity.releaseIdentityDigest, /^[0-9a-f]{64}$/);
+
+  const repositoryVariant = JSON.parse(runPromotion(["identity"], {
+    ...base,
+    PROMOTION_SOURCE_REPOSITORY: "jubenitogarcia/skincos-finance",
+  }));
+  const contractVariant = JSON.parse(runPromotion(["identity"], {
+    ...base,
+    PROMOTION_DELIVERY_CONTRACT_VERSION: "1.0.1",
+  }));
+  const artifactVariant = JSON.parse(runPromotion(["identity"], {
+    ...base,
+    PROMOTION_ARTIFACT_IDENTITIES_JSON: JSON.stringify([
+      { id: "worker.tgz", digest: sha256("9"), fileDigest: sha256("1") },
+    ]),
+  }));
+  assert.notEqual(repositoryVariant.releaseIdentityDigest, identity.releaseIdentityDigest);
+  assert.notEqual(contractVariant.releaseIdentityDigest, identity.releaseIdentityDigest);
+  assert.notEqual(artifactVariant.releaseIdentityDigest, identity.releaseIdentityDigest);
+});
+
+test("writes and verifies cross-repository promotion evidence with a v4 provenance envelope", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "skincos-promotion-evidence-v4-"));
+  const evidencePath = path.join(directory, "promotion-evidence.json");
+  const sourceSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+  const sourceTree = execFileSync("git", ["rev-parse", "HEAD^{tree}"], { cwd: root, encoding: "utf8" }).trim();
+  const env = v4Environment({ sourceSha, sourceTree });
+  runPromotion(["write", evidencePath], env);
+  const evidence = JSON.parse(fs.readFileSync(evidencePath, "utf8"));
+  assert.equal(evidence.schemaVersion, 4);
+  assert.equal(evidence.sourceRepository, "jubenitogarcia/skincos-meta-ads-reporting");
+  assert.equal(evidence.evidenceRepository, "jubenitogarcia/skincos-release-evidence");
+  assert.equal(evidence.releaseIdentity.sourceCommit, sourceSha);
+  assert.equal(Object.hasOwn(evidence.releaseIdentity, "evidenceArtifact"), false);
+
+  runPromotion(["verify", evidencePath], {
+    ...env,
+    GITHUB_REPOSITORY: "jubenitogarcia/skincos-release-controller",
+    PROMOTION_EXPECTED_TARGET: "preview",
+    PROMOTION_EXPECTED_SOURCE_REPOSITORY: evidence.sourceRepository,
+    PROMOTION_EXPECTED_SOURCE_COMMIT: sourceSha,
+    PROMOTION_EXPECTED_SOURCE_TREE: sourceTree,
+    PROMOTION_EXPECTED_SOURCE_REF: "refs/heads/main",
+    PROMOTION_EXPECTED_RELEASE_INPUT_DIGEST: sha256("d"),
+    PROMOTION_EXPECTED_DELIVERY_CONTRACT_VERSION: "1.0.0",
+    PROMOTION_EXPECTED_CONTRACT_MANIFEST_DIGEST: sha256("c"),
+    PROMOTION_EXPECTED_CONTRACT_VERSIONS_JSON: env.PROMOTION_CONTRACT_VERSIONS_JSON,
+    PROMOTION_EXPECTED_ARTIFACT_IDENTITIES_JSON: env.PROMOTION_ARTIFACT_IDENTITIES_JSON,
+    PROMOTION_EXPECTED_EVIDENCE_REPOSITORY: evidence.evidenceRepository,
+    PROMOTION_EXPECTED_EVIDENCE_RUN_ID: evidence.evidenceRunId,
+    PROMOTION_EXPECTED_EVIDENCE_ARTIFACT: evidence.evidenceArtifact,
+    PROMOTION_EXPECTED_RELEASE_IDENTITY_DIGEST: evidence.releaseIdentityDigest,
+  });
+
+  const tampered = { ...evidence, sourceRepository: "jubenitogarcia/other-source" };
+  fs.writeFileSync(evidencePath, `${JSON.stringify(tampered)}\n`);
+  assert.throws(() => runPromotion(["verify", evidencePath], {
+    ...env,
+    PROMOTION_EXPECTED_TARGET: "preview",
+  }), /release identity digest is invalid/);
+});
+
+test("legacy evidence is rejected when the requested source is cross-repository", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "skincos-promotion-evidence-v3-cross-"));
+  const evidencePath = path.join(directory, "promotion-evidence.json");
+  const sourceSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+  const sourceTree = execFileSync("git", ["rev-parse", "HEAD^{tree}"], { cwd: root, encoding: "utf8" }).trim();
+  const closure = "a".repeat(64);
+  const env = {
+    PROMOTION_UNIT: "synthetic-unit",
+    PROMOTION_TARGET: "preview",
+    PROMOTION_SOURCE_SHA: sourceSha,
+    PROMOTION_SOURCE_TREE: sourceTree,
+    PROMOTION_RELEASE_INPUT_DIGEST: closure,
+    PROMOTION_DEPENDENCY_CLOSURE_DIGEST: closure,
+    GITHUB_RUN_ID: "123",
+    GITHUB_REPOSITORY: "jubenitogarcia/skincos",
+  };
+  runPromotion(["write", evidencePath], env);
+  assert.throws(() => runPromotion(["verify", evidencePath], {
+    ...env,
+    PROMOTION_EXPECTED_TARGET: "preview",
+    PROMOTION_EXPECTED_SOURCE_REPOSITORY: "jubenitogarcia/skincos-meta-ads-reporting",
+  }), /schema v4 is required/);
 });

--- a/.github/scripts/validate-dependency-closures.test.mjs
+++ b/.github/scripts/validate-dependency-closures.test.mjs
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { validateDependencyClosures } from "./validate-dependency-closures.mjs";
 
 function fixture(overrides = {}) {
@@ -118,4 +119,9 @@ test("dependency closure resolves npm scripts to their package helpers", () => {
   });
   assert.deepEqual(result.errors, []);
   assert.equal(result.reports[0].reachableFileCount, 4);
+});
+
+test("promotion source-ref validation remains in every shared release closure", () => {
+  const policy = JSON.parse(readFileSync(new URL("../../ops/governance/global-concurrency-policy.json", import.meta.url), "utf8"));
+  assert.ok(policy.sharedInputs.includes(".github/scripts/validate-promotion-source-ref.mjs"));
 });

--- a/.github/scripts/validate-domain-boundaries.mjs
+++ b/.github/scripts/validate-domain-boundaries.mjs
@@ -83,8 +83,8 @@ try {
   process.exit(1);
 }
 
-if (policy.schemaVersion !== 1 || !Array.isArray(policy.contracts) || !Array.isArray(policy.recommendedContracts) || !Array.isArray(policy.legacyDirectImports)) {
-  fail("shared/domain-boundaries.json must declare schemaVersion 1, contracts, recommendedContracts and legacyDirectImports");
+if (policy.schemaVersion !== 1 || !Array.isArray(policy.contracts) || !Array.isArray(policy.recommendedContracts) || !Array.isArray(policy.legacyDirectImports) || !Array.isArray(policy.statefulServiceBindings)) {
+  fail("shared/domain-boundaries.json must declare schemaVersion 1, contracts, recommendedContracts, legacyDirectImports and statefulServiceBindings");
 }
 
 const contractsById = new Map();
@@ -130,6 +130,60 @@ for (const legacy of policy.legacyDirectImports ?? []) {
   const key = `${legacy.from}:${legacy.specifier}`;
   if (legacyImports.has(key)) fail(`duplicate legacy direct import ${key}`);
   legacyImports.set(key, legacy);
+}
+
+const statefulServiceBindings = new Map();
+for (const binding of policy.statefulServiceBindings ?? []) {
+  const orderedPair = (value, first, second) => Array.isArray(value)
+    && value.length === 2
+    && value[0] === first
+    && value[1] === second;
+  const validVerification = Array.isArray(binding?.verification)
+    && binding.verification.length > 0
+    && binding.verification.every((check) =>
+      nonEmptyString(check?.path)
+      && !path.isAbsolute(check.path)
+      && !check.path.split(/[\\/]/).includes("..")
+      && Array.isArray(check?.mustContain)
+      && check.mustContain.length > 0
+      && check.mustContain.every(nonEmptyString),
+    );
+  const validService = binding?.service
+    && nonEmptyString(binding.service.production)
+    && nonEmptyString(binding.service.staging);
+  if (!binding || !nonEmptyString(binding.id) || !governedRoots.has(binding.consumer) || !governedRoots.has(binding.producer)
+    || binding.consumer === binding.producer || !nonEmptyString(binding.serviceBinding) || !validService
+    || !nonEmptyString(binding.entrypoint) || !nonEmptyString(binding.rpcMethod) || !nonEmptyString(binding.dtoContract)
+    || !nonEmptyString(binding.healthCapability) || !/^\d{4}-\d{2}-\d{2}$/.test(binding.reviewBy ?? "")
+    || !nonEmptyString(binding.reviewTrigger) || !nonEmptyString(binding.retirementCondition)
+    || !orderedPair(binding.deployOrder, binding.producer, binding.consumer)
+    || !orderedPair(binding.rollbackOrder, binding.consumer, binding.producer)
+    || !validVerification) {
+    fail("each stateful service binding must declare consumer/producer, service, binding, entrypoint, RPC DTO/capability, inverse deploy/rollback order, review date/retirement conditions and source verification");
+    continue;
+  }
+  if (statefulServiceBindings.has(binding.id)) {
+    fail(`duplicate stateful service binding id ${binding.id}`);
+    continue;
+  }
+  statefulServiceBindings.set(binding.id, binding);
+  const today = new Date().toISOString().slice(0, 10);
+  if (today > binding.reviewBy) {
+    fail(`stateful service binding ${binding.id} review expired on ${binding.reviewBy}; renew or retire the bridge with a proven state migration plan`);
+  }
+  for (const check of binding.verification) {
+    const verificationPath = path.join(root, check.path);
+    if (!fs.existsSync(verificationPath)) {
+      fail(`stateful service binding ${binding.id} points to missing verification path ${check.path}`);
+      continue;
+    }
+    const source = fs.readFileSync(verificationPath, "utf8");
+    for (const fragment of check.mustContain) {
+      if (!source.includes(fragment)) {
+        fail(`stateful service binding ${binding.id} verification path ${check.path} is missing required fragment ${JSON.stringify(fragment)}`);
+      }
+    }
+  }
 }
 
 const usedLegacyImports = new Set();

--- a/.github/scripts/validate-progressive-release.mjs
+++ b/.github/scripts/validate-progressive-release.mjs
@@ -69,7 +69,7 @@ for (const required of ["workflow_run:", "workflows: [Global merge authority]", 
 }
 const gate = read(".github/workflows/promotion-gate.yml");
 if (!gate.includes("fetch-depth: 0")) fail("promotion gate must fetch complete main history before validating an immutable rollback SHA");
-for (const required of ["release_sha", "Verify predecessor evidence", "promotion-evidence.mjs verify", "source_sha"]) if (!gate.includes(required)) fail(`immutable promotion gate is missing ${required}`);
+for (const required of ["release_sha", "Verify predecessor evidence", "promotion-evidence.mjs verify", "source_sha", "validate-promotion-source-ref.mjs", "remote_default_branch", "remote_branch_protected"]) if (!gate.includes(required)) fail(`immutable promotion gate is missing ${required}`);
 const coordinator = read(".github/workflows/ponto-progressive-release.yml");
 for (const required of ["single-operator Codex governance", "canonical merged PR and required checks", "ponto-environment-protection.mjs"]) if (!coordinator.includes(required)) fail(`Ponto coordinator is missing ${required}`);
 if (coordinator.includes("Require the independent no-review true-only emergency close path")) fail("Ponto coordinator still names the retired independent-review gate");

--- a/.github/scripts/validate-promotion-source-ref.mjs
+++ b/.github/scripts/validate-promotion-source-ref.mjs
@@ -1,0 +1,41 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const SAFE_DEFAULT_BRANCH = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+function required(value, label) {
+  const normalized = String(value ?? '').trim();
+  if (!normalized) throw new Error(`${label} is required`);
+  return normalized;
+}
+
+/**
+ * Cross-repository promotion is permitted only from the source repository's
+ * protected default branch. Callers may attest a commit and tree, but they may
+ * not select a feature branch as the promotion authority.
+ */
+export function assertCanonicalPromotionSourceRef({ sourceRef, defaultBranch, branchProtected }) {
+  const normalizedRef = required(sourceRef, 'source_ref');
+  const normalizedDefaultBranch = required(defaultBranch, 'producer default branch');
+  if (!SAFE_DEFAULT_BRANCH.test(normalizedDefaultBranch)) {
+    throw new Error('producer default branch has an unsupported name');
+  }
+  const canonicalRef = `refs/heads/${normalizedDefaultBranch}`;
+  if (normalizedRef !== canonicalRef) {
+    throw new Error(`cross-repository source_ref must equal the producer protected default branch ${canonicalRef}`);
+  }
+  if (branchProtected !== true) {
+    throw new Error(`producer default branch ${normalizedDefaultBranch} is not protected`);
+  }
+  return Object.freeze({ sourceRef: normalizedRef, defaultBranch: normalizedDefaultBranch, canonicalRef });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  const [sourceRef, defaultBranch, protectedValue] = process.argv.slice(2);
+  assertCanonicalPromotionSourceRef({
+    sourceRef,
+    defaultBranch,
+    branchProtected: protectedValue === 'true',
+  });
+  process.stdout.write(`Canonical protected promotion source: ${sourceRef}\n`);
+}

--- a/.github/scripts/validate-promotion-source-ref.test.mjs
+++ b/.github/scripts/validate-promotion-source-ref.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+import { assertCanonicalPromotionSourceRef } from './validate-promotion-source-ref.mjs';
+
+test('cross-repository promotion accepts only the protected default branch', () => {
+  assert.deepEqual(
+    assertCanonicalPromotionSourceRef({
+      sourceRef: 'refs/heads/main',
+      defaultBranch: 'main',
+      branchProtected: true,
+    }),
+    { sourceRef: 'refs/heads/main', defaultBranch: 'main', canonicalRef: 'refs/heads/main' },
+  );
+});
+
+test('cross-repository promotion rejects a feature branch even with a valid source identity', () => {
+  assert.throws(
+    () => assertCanonicalPromotionSourceRef({
+      sourceRef: 'refs/heads/feature/release-candidate',
+      defaultBranch: 'main',
+      branchProtected: true,
+    }),
+    /must equal the producer protected default branch/,
+  );
+});
+
+test('cross-repository promotion rejects an unprotected default branch', () => {
+  assert.throws(
+    () => assertCanonicalPromotionSourceRef({
+      sourceRef: 'refs/heads/main',
+      defaultBranch: 'main',
+      branchProtected: false,
+    }),
+    /is not protected/,
+  );
+});
+
+test('promotion gate resolves and validates the producer default branch instead of caller branch input', () => {
+  const workflow = fs.readFileSync(new URL('../workflows/promotion-gate.yml', import.meta.url), 'utf8');
+
+  assert.match(workflow, /remote_default_branch="\$\(gh api "repos\/\$\{source_repository\}" --jq '\.default_branch'\)"/);
+  assert.match(workflow, /remote_branch_protected="\$\(gh api "repos\/\$\{source_repository\}\/branches\/\$\{remote_default_branch\}" --jq '\.protected'\)"/);
+  assert.match(workflow, /node \.github\/scripts\/validate-promotion-source-ref\.mjs "\$source_ref" "\$remote_default_branch" "\$remote_branch_protected"/);
+  assert.match(workflow, /compare\/\$\{source_sha\}\.\.\.\$\{remote_default_branch\}/);
+  assert.doesNotMatch(workflow, /source_branch="\$\{source_ref#refs\/heads\/\}"/);
+});

--- a/.github/workflows/architecture-governance.yml
+++ b/.github/workflows/architecture-governance.yml
@@ -96,6 +96,8 @@ jobs:
         run: node .github/scripts/validate-dependency-closures.mjs
       - name: Test dependency closure validator
         run: node --test .github/scripts/validate-dependency-closures.test.mjs
+      - name: Test multi-repository promotion-source policy
+        run: node --test .github/scripts/promotion-evidence.test.mjs .github/scripts/validate-promotion-source-ref.test.mjs
       - run: node .github/scripts/validate-progressive-release.mjs
       - name: Validate module catalog, maturity and dependency graph
         run: node .github/scripts/validate-module-catalog.mjs && node .github/scripts/validate-module-maturity.mjs

--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -50,6 +50,10 @@ on:
         options: [pilot, canary, production]
       timekeeping_candidate_version_id: { description: "Required for Ponto pilot Core upload", required: false, type: string }
       timekeeping_version_id: { description: "Required for every general Core API deploy to prevent stale service affinity", required: false, type: string }
+      inventory_legacy_jobs_release_sha:
+        description: "Required for a general API-only deploy after the InventoryLegacyJobsEntrypoint cutover; attest the active Inventory source SHA and legacy-api-jobs-rpc/v1 capability. Use unit=all for the first paired deployment."
+        required: false
+        type: string
       orchestrator_run_id: { description: "Ponto coordinator correlation ID", required: false, type: string }
       orchestrator_stage: { description: "Exact stage of the issuing Ponto coordinator", required: false, type: string }
       orchestrator_issuer_run_id: { description: "Exact direct issuer run", required: false, type: string }
@@ -774,6 +778,7 @@ jobs:
           RELEASE_SCOPE: ${{ inputs.release_scope }}
           RELEASE_SHA: ${{ needs.promotion.outputs.source_sha }}
           TIMEKEEPING_VERSION_ID: ${{ inputs.timekeeping_version_id }}
+          INVENTORY_LEGACY_JOBS_RELEASE_SHA: ${{ inputs.inventory_legacy_jobs_release_sha }}
         run: |
           set -euo pipefail
           if [[ "$TARGET" == "staging" ]]; then
@@ -841,6 +846,78 @@ jobs:
               --var "UNIFIED_TEAM_ENABLED:$unified_team_var"
           fi
           if [[ "$UNIT" == "api" || "$UNIT" == "all" ]]; then
+            # The API's retained JobQueue Durable Object now calls the
+            # Inventory named RPC entrypoint. The first cutover must deploy
+            # both workers in this order; later API-only releases must attest
+            # the active Inventory version that already exports that entrypoint.
+            if [[ "$RELEASE_SCOPE" == "general" ]]; then
+              if [[ "$UNIT" == "all" ]]; then
+                expected_inventory_sha="$RELEASE_SHA"
+              else
+                expected_inventory_sha="$INVENTORY_LEGACY_JOBS_RELEASE_SHA"
+              fi
+              [[ "$expected_inventory_sha" =~ ^[0-9a-fA-F]{40}$ ]] || {
+                echo 'API-only release requires inventory_legacy_jobs_release_sha; use unit=all for the first paired Inventory -> API cutover.'
+                exit 1
+              }
+              if [[ "$TARGET" == "staging" ]]; then
+                inventory_health_url='https://api-staging.skincos.com.br/insumos/health'
+              else
+                inventory_health_url='https://api.skincos.com.br/insumos/health'
+              fi
+              node --input-type=module - "$expected_inventory_sha" "$inventory_health_url" <<'NODE'
+              const [expectedSha, inventoryHealthUrl] = process.argv.slice(2);
+              const propagationDeadline = Date.now() + 75_000;
+              let consecutiveValidSamples = 0;
+              let lastValidSampleKey = '';
+              let lastObservation = 'no response';
+              let attempt = 0;
+              let passed = false;
+
+              while (Date.now() <= propagationDeadline) {
+                attempt += 1;
+                const probe = new URL(inventoryHealthUrl);
+                probe.searchParams.set('legacy_jobs_release_probe', `${Date.now()}-${attempt}`);
+                try {
+                  const response = await fetch(probe, {
+                    redirect: 'manual',
+                    signal: AbortSignal.timeout(15_000),
+                    headers: { accept: 'application/json', 'cache-control': 'no-cache' },
+                  });
+                  const health = await response.json().catch(() => null);
+                  const workerVersionId = String(health?.workerVersion?.id || '').toLowerCase();
+                  const validSample = response.status === 200
+                    && health?.ready === true
+                    && String(health?.version || '').toLowerCase() === expectedSha.toLowerCase()
+                    && health?.legacyApiJobsRpc === 'legacy-api-jobs-rpc/v1';
+                  const sampleKey = `${health?.version || ''}:${health?.legacyApiJobsRpc || ''}:${workerVersionId}`;
+                  if (validSample && sampleKey === lastValidSampleKey) consecutiveValidSamples += 1;
+                  else if (validSample) {
+                    lastValidSampleKey = sampleKey;
+                    consecutiveValidSamples = 1;
+                  } else {
+                    lastValidSampleKey = '';
+                    consecutiveValidSamples = 0;
+                  }
+                  lastObservation = `HTTP ${response.status}, version=${String(health?.version || '')}, capability=${String(health?.legacyApiJobsRpc || '')}, workerVersionId=${workerVersionId}`;
+                  if (consecutiveValidSamples >= 2) {
+                    passed = true;
+                    break;
+                  }
+                } catch (error) {
+                  lastValidSampleKey = '';
+                  consecutiveValidSamples = 0;
+                  lastObservation = error instanceof Error ? error.message : String(error);
+                }
+                const remainingMs = propagationDeadline - Date.now();
+                if (remainingMs > 0) await new Promise((resolve) => setTimeout(resolve, Math.min(5_000, remainingMs)));
+              }
+
+              if (!passed) {
+                throw new Error(`Inventory health did not attest the required InventoryLegacyJobsEntrypoint release in two consecutive samples within the propagation window; attempts=${attempt}; last=${lastObservation}`);
+              }
+              NODE
+            fi
             [[ "$TIMEKEEPING_VERSION_ID" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo 'Core API deploy requires an explicit Timekeeping version UUID'; exit 1; }
             if [[ "$BOOTSTRAP_FINANCE_CONTEXT" == "true" ]]; then
               [[ "$TARGET" == "staging" ]] || { echo 'Finance context bootstrap is staging-only.'; exit 1; }

--- a/.github/workflows/package-contracts.yml
+++ b/.github/workflows/package-contracts.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - 'packages/**'
       - 'scripts/tests/package-tarball-install.test.mjs'
+      - 'scripts/tests/promotion-evidence-contract-interop.test.mjs'
       - '.github/workflows/package-contracts.yml'
   push:
     branches: [main]
     paths:
       - 'packages/**'
       - 'scripts/tests/package-tarball-install.test.mjs'
+      - 'scripts/tests/promotion-evidence-contract-interop.test.mjs'
       - '.github/workflows/package-contracts.yml'
   workflow_dispatch: {}
 
@@ -33,4 +35,5 @@ jobs:
             packages/skincos-contracts/test/public-exports.test.mjs \
             packages/skincos-edge-adapters/test/public-exports.test.mjs \
             packages/skincos-delivery-contract/test/release-identity-v4.test.mjs \
-            scripts/tests/package-tarball-install.test.mjs
+            scripts/tests/package-tarball-install.test.mjs \
+            scripts/tests/promotion-evidence-contract-interop.test.mjs

--- a/.github/workflows/package-contracts.yml
+++ b/.github/workflows/package-contracts.yml
@@ -1,0 +1,36 @@
+name: Package Contract Artifacts
+
+on:
+  pull_request:
+    paths:
+      - 'packages/**'
+      - 'scripts/tests/package-tarball-install.test.mjs'
+      - '.github/workflows/package-contracts.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/**'
+      - 'scripts/tests/package-tarball-install.test.mjs'
+      - '.github/workflows/package-contracts.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  package-contract-artifacts:
+    name: Pack and install private package contracts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: '22.12.0'
+      - name: Test package contracts and isolated tarball installation
+        run: |
+          set -euo pipefail
+          node --test \
+            packages/skincos-contracts/test/public-exports.test.mjs \
+            packages/skincos-edge-adapters/test/public-exports.test.mjs \
+            packages/skincos-delivery-contract/test/release-identity-v4.test.mjs \
+            scripts/tests/package-tarball-install.test.mjs

--- a/.github/workflows/promotion-gate.yml
+++ b/.github/workflows/promotion-gate.yml
@@ -6,13 +6,34 @@ on:
       unit: { required: true, type: string }
       target: { required: true, type: string }
       release_sha: { required: false, type: string, default: "" }
+      source_repository: { required: false, type: string, default: "" }
+      source_commit: { required: false, type: string, default: "" }
+      source_tree: { required: false, type: string, default: "" }
+      source_ref: { required: false, type: string, default: "" }
+      release_input_digest: { required: false, type: string, default: "" }
+      delivery_contract_version: { required: false, type: string, default: "" }
+      contract_manifest_digest: { required: false, type: string, default: "" }
+      contract_versions_json: { required: false, type: string, default: "" }
+      artifact_identities_json: { required: false, type: string, default: "" }
       preview_run_id: { required: false, type: string, default: "" }
       staging_run_id: { required: false, type: string, default: "" }
+      predecessor_repository: { required: false, type: string, default: "" }
+      predecessor_run_id: { required: false, type: string, default: "" }
+      predecessor_artifact: { required: false, type: string, default: "" }
       staging_supported: { required: false, type: boolean, default: true }
       emit_preview_evidence: { required: false, type: boolean, default: true }
+    secrets:
+      cross_repo_token:
+        required: false
     outputs:
       source_sha:
         value: ${{ jobs.gate.outputs.source_sha }}
+      source_repository:
+        value: ${{ jobs.gate.outputs.source_repository }}
+      source_tree:
+        value: ${{ jobs.gate.outputs.source_tree }}
+      source_ref:
+        value: ${{ jobs.gate.outputs.source_ref }}
       release_input_digest:
         value: ${{ jobs.gate.outputs.release_input_digest }}
       dependency_closure_digest:
@@ -29,6 +50,9 @@ jobs:
       contents: read
     outputs:
       source_sha: ${{ steps.identity.outputs.source_sha }}
+      source_repository: ${{ steps.identity.outputs.source_repository }}
+      source_tree: ${{ steps.identity.outputs.source_tree }}
+      source_ref: ${{ steps.identity.outputs.source_ref }}
       release_input_digest: ${{ steps.identity.outputs.release_input_digest }}
       dependency_closure_digest: ${{ steps.identity.outputs.release_input_digest }}
       release_identity_digest: ${{ steps.identity.outputs.release_identity_digest }}
@@ -43,26 +67,88 @@ jobs:
         env:
           REQUESTED_SHA: ${{ inputs.release_sha }}
           PROMOTION_TARGET: ${{ inputs.target }}
+          PROMOTION_UNIT: ${{ inputs.unit }}
+          INPUT_SOURCE_REPOSITORY: ${{ inputs.source_repository }}
+          INPUT_SOURCE_COMMIT: ${{ inputs.source_commit }}
+          INPUT_SOURCE_TREE: ${{ inputs.source_tree }}
+          INPUT_SOURCE_REF: ${{ inputs.source_ref }}
+          INPUT_RELEASE_INPUT_DIGEST: ${{ inputs.release_input_digest }}
+          INPUT_DELIVERY_CONTRACT_VERSION: ${{ inputs.delivery_contract_version }}
+          INPUT_CONTRACT_MANIFEST_DIGEST: ${{ inputs.contract_manifest_digest }}
+          INPUT_CONTRACT_VERSIONS_JSON: ${{ inputs.contract_versions_json }}
+          INPUT_ARTIFACT_IDENTITIES_JSON: ${{ inputs.artifact_identities_json }}
+          INPUT_PREDECESSOR_REPOSITORY: ${{ inputs.predecessor_repository }}
+          CROSS_REPO_TOKEN: ${{ secrets.cross_repo_token }}
         run: |
           set -euo pipefail
-          if [[ "$PROMOTION_TARGET" != "preview" && -z "${REQUESTED_SHA:-}" ]]; then
+          if [[ "$PROMOTION_TARGET" != "preview" && -z "${REQUESTED_SHA:-}" && -z "${INPUT_SOURCE_COMMIT:-}" ]]; then
             echo "::error::staging and production require the exact release_sha from predecessor evidence."
             exit 1
           fi
-          source_sha="${REQUESTED_SHA:-$GITHUB_SHA}"
-          git fetch --no-tags origin main
-          git fetch --no-tags origin "$source_sha"
-          git cat-file -e "$source_sha^{commit}"
-          git merge-base --is-ancestor "$source_sha" origin/main || {
-            echo "::error::$source_sha is not reachable from origin/main."
+          source_repository="${INPUT_SOURCE_REPOSITORY:-$GITHUB_REPOSITORY}"
+          source_sha="${INPUT_SOURCE_COMMIT:-${REQUESTED_SHA:-$GITHUB_SHA}}"
+          if [[ -n "${INPUT_SOURCE_COMMIT:-}" && -n "${REQUESTED_SHA:-}" && "$INPUT_SOURCE_COMMIT" != "$REQUESTED_SHA" ]]; then
+            echo "::error::source_commit and release_sha must identify the same commit."
             exit 1
-          }
-          release_input_digest="$(PROMOTION_UNIT='${{ inputs.unit }}' PROMOTION_SOURCE_SHA="$source_sha" node .github/scripts/promotion-evidence.mjs digest)"
-          source_tree="$(git rev-parse "${source_sha}^{tree}")"
-          release_identity_digest="$(PROMOTION_UNIT='${{ inputs.unit }}' PROMOTION_SOURCE_SHA="$source_sha" PROMOTION_SOURCE_TREE="$source_tree" PROMOTION_RELEASE_INPUT_DIGEST="$release_input_digest" node .github/scripts/promotion-evidence.mjs identity | node -e 'let data=""; process.stdin.on("data", chunk => data += chunk); process.stdin.on("end", () => process.stdout.write(JSON.parse(data).releaseIdentityDigest));')"
+          fi
+          source_ref="${INPUT_SOURCE_REF:-refs/heads/main}"
+          cross_source=false
+          if [[ "$source_repository" == "$GITHUB_REPOSITORY" ]]; then
+            git fetch --no-tags origin main
+            git fetch --no-tags origin "$source_sha"
+            git cat-file -e "$source_sha^{commit}"
+            git merge-base --is-ancestor "$source_sha" origin/main || {
+              echo "::error::$source_sha is not reachable from origin/main."
+              exit 1
+            }
+            source_tree="$(git rev-parse "${source_sha}^{tree}")"
+            if [[ -n "${INPUT_SOURCE_TREE:-}" && "$INPUT_SOURCE_TREE" != "$source_tree" ]]; then
+              echo "::error::source_tree differs from the checked immutable source commit."
+              exit 1
+            fi
+            release_input_digest="${INPUT_RELEASE_INPUT_DIGEST:-}"
+            if [[ -z "$release_input_digest" ]]; then
+              release_input_digest="$(PROMOTION_UNIT="$PROMOTION_UNIT" PROMOTION_SOURCE_SHA="$source_sha" node .github/scripts/promotion-evidence.mjs digest)"
+            fi
+          else
+            cross_source=true
+            for required_input in INPUT_SOURCE_REPOSITORY INPUT_SOURCE_COMMIT INPUT_SOURCE_TREE INPUT_SOURCE_REF INPUT_RELEASE_INPUT_DIGEST; do
+              [[ -n "${!required_input:-}" ]] || { echo "::error::cross-repository promotion requires explicit ${required_input#INPUT_}."; exit 1; }
+            done
+            [[ -n "${CROSS_REPO_TOKEN:-}" ]] || { echo "::error::cross-repository source verification requires the cross_repo_token secret."; exit 1; }
+            [[ "$source_repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || { echo "::error::source_repository must be an owner/repository identifier."; exit 1; }
+            [[ "$source_sha" =~ ^[0-9a-fA-F]{40}$ && "$INPUT_SOURCE_TREE" =~ ^[0-9a-fA-F]{40}$ ]] || { echo "::error::cross-repository source_commit and source_tree must be full SHAs."; exit 1; }
+            export GH_TOKEN="$CROSS_REPO_TOKEN"
+            remote_default_branch="$(gh api "repos/${source_repository}" --jq '.default_branch')"
+            remote_branch_protected="$(gh api "repos/${source_repository}/branches/${remote_default_branch}" --jq '.protected')"
+            node .github/scripts/validate-promotion-source-ref.mjs "$source_ref" "$remote_default_branch" "$remote_branch_protected"
+            remote_tree="$(gh api "repos/${source_repository}/git/commits/${source_sha}" --jq '.tree.sha')"
+            [[ "$remote_tree" == "$INPUT_SOURCE_TREE" ]] || { echo "::error::source_tree differs from the producer commit tree."; exit 1; }
+            ancestry="$(gh api "repos/${source_repository}/compare/${source_sha}...${remote_default_branch}" --jq '.status')"
+            [[ "$ancestry" == "ahead" || "$ancestry" == "identical" ]] || { echo "::error::$source_sha is not reachable from ${source_repository}/${remote_default_branch}."; exit 1; }
+            source_tree="$INPUT_SOURCE_TREE"
+            release_input_digest="$INPUT_RELEASE_INPUT_DIGEST"
+          fi
+          predecessor_repository="${INPUT_PREDECESSOR_REPOSITORY:-$GITHUB_REPOSITORY}"
+          schema_version=3
+          if [[ "$cross_source" == true || ( "$PROMOTION_TARGET" != "preview" && "$predecessor_repository" != "$GITHUB_REPOSITORY" ) || -n "${INPUT_DELIVERY_CONTRACT_VERSION:-}${INPUT_CONTRACT_MANIFEST_DIGEST:-}${INPUT_CONTRACT_VERSIONS_JSON:-}${INPUT_ARTIFACT_IDENTITIES_JSON:-}" ]]; then
+            schema_version=4
+          fi
+          if [[ "$schema_version" == 4 ]]; then
+            for required_input in INPUT_DELIVERY_CONTRACT_VERSION INPUT_CONTRACT_MANIFEST_DIGEST INPUT_CONTRACT_VERSIONS_JSON INPUT_ARTIFACT_IDENTITIES_JSON; do
+              [[ -n "${!required_input:-}" ]] || { echo "::error::schema v4 promotion requires explicit ${required_input#INPUT_}."; exit 1; }
+            done
+            release_identity_digest="$(PROMOTION_EVIDENCE_SCHEMA_VERSION=4 PROMOTION_UNIT="$PROMOTION_UNIT" PROMOTION_SOURCE_REPOSITORY="$source_repository" PROMOTION_SOURCE_COMMIT="$source_sha" PROMOTION_SOURCE_TREE="$source_tree" PROMOTION_SOURCE_REF="$source_ref" PROMOTION_DELIVERY_CONTRACT_VERSION="$INPUT_DELIVERY_CONTRACT_VERSION" PROMOTION_CONTRACT_MANIFEST_DIGEST="$INPUT_CONTRACT_MANIFEST_DIGEST" PROMOTION_RELEASE_INPUT_DIGEST="$release_input_digest" PROMOTION_CONTRACT_VERSIONS_JSON="$INPUT_CONTRACT_VERSIONS_JSON" PROMOTION_ARTIFACT_IDENTITIES_JSON="$INPUT_ARTIFACT_IDENTITIES_JSON" node .github/scripts/promotion-evidence.mjs identity | node -e 'let data=""; process.stdin.on("data", chunk => data += chunk); process.stdin.on("end", () => process.stdout.write(JSON.parse(data).releaseIdentityDigest));')"
+          else
+            release_identity_digest="$(PROMOTION_UNIT="$PROMOTION_UNIT" PROMOTION_SOURCE_SHA="$source_sha" PROMOTION_SOURCE_TREE="$source_tree" PROMOTION_RELEASE_INPUT_DIGEST="$release_input_digest" node .github/scripts/promotion-evidence.mjs identity | node -e 'let data=""; process.stdin.on("data", chunk => data += chunk); process.stdin.on("end", () => process.stdout.write(JSON.parse(data).releaseIdentityDigest));')"
+          fi
+          echo "source_repository=$source_repository" >> "$GITHUB_OUTPUT"
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+          echo "source_tree=$source_tree" >> "$GITHUB_OUTPUT"
+          echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
           echo "release_input_digest=$release_input_digest" >> "$GITHUB_OUTPUT"
           echo "release_identity_digest=$release_identity_digest" >> "$GITHUB_OUTPUT"
+          echo "evidence_schema_version=$schema_version" >> "$GITHUB_OUTPUT"
       - name: Block unsupported staging target
         if: ${{ inputs.target == 'staging' && !inputs.staging_supported }}
         run: |
@@ -71,33 +157,62 @@ jobs:
       - name: Verify predecessor evidence
         if: ${{ inputs.target != 'preview' }}
         env:
-          GH_TOKEN: ${{ github.token }}
-          PREDECESSOR_RUN_ID: ${{ inputs.target == 'staging' && inputs.preview_run_id || inputs.staging_run_id }}
-          EXPECTED_TARGET: ${{ inputs.target == 'staging' && 'preview' || 'staging' }}
+          GITHUB_TOKEN: ${{ github.token }}
+          CROSS_REPO_TOKEN: ${{ secrets.cross_repo_token }}
+          PREDECESSOR_REPOSITORY: ${{ inputs.predecessor_repository || github.repository }}
+          PREDECESSOR_RUN_ID: ${{ inputs.predecessor_run_id || (inputs.target == 'staging' && inputs.preview_run_id || inputs.staging_run_id) }}
+          PREDECESSOR_ARTIFACT: ${{ inputs.predecessor_artifact || format('promotion-evidence-{0}', inputs.unit) }}
           PROMOTION_UNIT: ${{ inputs.unit }}
           PROMOTION_EXPECTED_TARGET: ${{ inputs.target == 'staging' && 'preview' || 'staging' }}
+          PROMOTION_EXPECTED_SOURCE_REPOSITORY: ${{ steps.identity.outputs.source_repository }}
           PROMOTION_EXPECTED_SHA: ${{ steps.identity.outputs.source_sha }}
+          PROMOTION_EXPECTED_SOURCE_TREE: ${{ steps.identity.outputs.source_tree }}
+          PROMOTION_EXPECTED_SOURCE_REF: ${{ steps.identity.outputs.source_ref }}
           PROMOTION_EXPECTED_RELEASE_INPUT_DIGEST: ${{ steps.identity.outputs.release_input_digest }}
           PROMOTION_EXPECTED_RELEASE_IDENTITY_DIGEST: ${{ steps.identity.outputs.release_identity_digest }}
+          PROMOTION_EXPECTED_DELIVERY_CONTRACT_VERSION: ${{ inputs.delivery_contract_version }}
+          PROMOTION_EXPECTED_CONTRACT_MANIFEST_DIGEST: ${{ inputs.contract_manifest_digest }}
+          PROMOTION_EXPECTED_CONTRACT_VERSIONS_JSON: ${{ inputs.contract_versions_json }}
+          PROMOTION_EXPECTED_ARTIFACT_IDENTITIES_JSON: ${{ inputs.artifact_identities_json }}
         run: |
           set -euo pipefail
           [[ "$PREDECESSOR_RUN_ID" =~ ^[0-9]+$ ]] || { echo "::error::A numeric predecessor run id is required."; exit 1; }
+          [[ -n "${PREDECESSOR_ARTIFACT:-}" ]] || { echo "::error::A predecessor evidence artifact name is required."; exit 1; }
+          if [[ "$PREDECESSOR_REPOSITORY" == "$GITHUB_REPOSITORY" ]]; then
+            export GH_TOKEN="$GITHUB_TOKEN"
+          else
+            [[ -n "${CROSS_REPO_TOKEN:-}" ]] || { echo "::error::cross-repository predecessor evidence requires the cross_repo_token secret."; exit 1; }
+            export GH_TOKEN="$CROSS_REPO_TOKEN"
+          fi
           mkdir -p "$RUNNER_TEMP/promotion-evidence"
-          gh run download "$PREDECESSOR_RUN_ID" --repo "$GITHUB_REPOSITORY" --name "promotion-evidence-${PROMOTION_UNIT}" --dir "$RUNNER_TEMP/promotion-evidence"
+          gh run download "$PREDECESSOR_RUN_ID" --repo "$PREDECESSOR_REPOSITORY" --name "$PREDECESSOR_ARTIFACT" --dir "$RUNNER_TEMP/promotion-evidence"
+          export PROMOTION_EXPECTED_EVIDENCE_REPOSITORY="$PREDECESSOR_REPOSITORY"
+          export PROMOTION_EXPECTED_EVIDENCE_RUN_ID="$PREDECESSOR_RUN_ID"
+          export PROMOTION_EXPECTED_EVIDENCE_ARTIFACT="$PREDECESSOR_ARTIFACT"
           node .github/scripts/promotion-evidence.mjs verify "$RUNNER_TEMP/promotion-evidence/promotion-evidence.json"
       - name: Write preview evidence
         if: ${{ inputs.target == 'preview' && inputs.emit_preview_evidence }}
         env:
+          PROMOTION_EVIDENCE_SCHEMA_VERSION: ${{ steps.identity.outputs.evidence_schema_version }}
           PROMOTION_UNIT: ${{ inputs.unit }}
           PROMOTION_TARGET: preview
+          PROMOTION_SOURCE_REPOSITORY: ${{ steps.identity.outputs.source_repository }}
+          PROMOTION_SOURCE_COMMIT: ${{ steps.identity.outputs.source_sha }}
           PROMOTION_SOURCE_SHA: ${{ steps.identity.outputs.source_sha }}
-          PROMOTION_SOURCE_TREE: ${{ github.sha }}
+          PROMOTION_SOURCE_TREE: ${{ steps.identity.outputs.source_tree }}
+          PROMOTION_SOURCE_REF: ${{ steps.identity.outputs.source_ref }}
           PROMOTION_RELEASE_INPUT_DIGEST: ${{ steps.identity.outputs.release_input_digest }}
           PROMOTION_DEPENDENCY_CLOSURE_DIGEST: ${{ steps.identity.outputs.release_input_digest }}
+          PROMOTION_DELIVERY_CONTRACT_VERSION: ${{ inputs.delivery_contract_version }}
+          PROMOTION_CONTRACT_MANIFEST_DIGEST: ${{ inputs.contract_manifest_digest }}
+          PROMOTION_CONTRACT_VERSIONS_JSON: ${{ inputs.contract_versions_json }}
+          PROMOTION_ARTIFACT_IDENTITIES_JSON: ${{ inputs.artifact_identities_json }}
+          PROMOTION_EVIDENCE_REPOSITORY: ${{ github.repository }}
+          PROMOTION_EVIDENCE_RUN_ID: ${{ github.run_id }}
+          PROMOTION_EVIDENCE_ARTIFACT: promotion-evidence-${{ inputs.unit }}
         run: |
           set -euo pipefail
-          tree="$(git rev-parse "${PROMOTION_SOURCE_SHA}^{tree}")"
-          PROMOTION_SOURCE_TREE="$tree" node .github/scripts/promotion-evidence.mjs write "$RUNNER_TEMP/promotion-evidence/promotion-evidence.json"
+          node .github/scripts/promotion-evidence.mjs write "$RUNNER_TEMP/promotion-evidence/promotion-evidence.json"
       - name: Upload preview evidence
         if: ${{ inputs.target == 'preview' && inputs.emit_preview_evidence }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/timekeeping-ci.yml
+++ b/.github/workflows/timekeeping-ci.yml
@@ -5,8 +5,13 @@ on:
     paths:
       - 'workforce/timekeeping/**'
       - 'api/**'
+      - 'api/workers/legacy-inventory-durable-objects.js'
+      - 'api/wrangler.toml'
       - 'inventory/src/worker.js'
+      - 'inventory/src/legacy-api-jobs.js'
+      - 'inventory/workers/**'
       - 'inventory/tests/releaseHealth.test.mjs'
+      - 'inventory/tests/legacyApiJobsContract.test.mjs'
       - 'inventory/wrangler.toml'
       - 'shared/identity-runtime/**'
       - 'shared/module-availability/**'
@@ -28,11 +33,13 @@ on:
       - '.github/workflows/module-availability.yml'
       - '.github/workflows/ponto-*.yml'
       - '.github/scripts/ponto-*.mjs'
+      - '.github/scripts/inventory-legacy-jobs-release-guard.test.mjs'
       - 'scripts/bootstrap-ponto-jit-runner.ps1'
       - 'scripts/runtime/install-ponto-jit-runner.sh'
       - 'scripts/runtime/ponto-jit-*.mjs'
       - 'scripts/runtime/provision-ponto-jit-custody.sh'
       - 'scripts/tests/ponto-jit-custody-runner.test.mjs'
+      - 'scripts/tests/timekeeping-ci-inventory-rpc.test.mjs'
       - 'ops/runtime/github-actions-runner/ponto-jit-*.sh'
       - 'ops/runtime/github-actions-runner/skincos-native-custody.sudoers'
       - 'ops/runtime/units/skincos-ponto-jit-runner.service'
@@ -47,8 +54,13 @@ on:
     paths:
       - 'workforce/timekeeping/**'
       - 'api/**'
+      - 'api/workers/legacy-inventory-durable-objects.js'
+      - 'api/wrangler.toml'
       - 'inventory/src/worker.js'
+      - 'inventory/src/legacy-api-jobs.js'
+      - 'inventory/workers/**'
       - 'inventory/tests/releaseHealth.test.mjs'
+      - 'inventory/tests/legacyApiJobsContract.test.mjs'
       - 'inventory/wrangler.toml'
       - 'shared/identity-runtime/**'
       - 'shared/module-availability/**'
@@ -70,11 +82,13 @@ on:
       - '.github/workflows/module-availability.yml'
       - '.github/workflows/ponto-*.yml'
       - '.github/scripts/ponto-*.mjs'
+      - '.github/scripts/inventory-legacy-jobs-release-guard.test.mjs'
       - 'scripts/bootstrap-ponto-jit-runner.ps1'
       - 'scripts/runtime/install-ponto-jit-runner.sh'
       - 'scripts/runtime/ponto-jit-*.mjs'
       - 'scripts/runtime/provision-ponto-jit-custody.sh'
       - 'scripts/tests/ponto-jit-custody-runner.test.mjs'
+      - 'scripts/tests/timekeeping-ci-inventory-rpc.test.mjs'
       - 'ops/runtime/github-actions-runner/ponto-jit-*.sh'
       - 'ops/runtime/github-actions-runner/skincos-native-custody.sudoers'
       - 'ops/runtime/units/skincos-ponto-jit-runner.service'
@@ -102,6 +116,8 @@ jobs:
             api/package-lock.json
             inventory/pnpm-lock.yaml
             crm/console/package-lock.json
+      - name: Verify Inventory/API RPC CI coverage
+        run: node --test .github/scripts/inventory-legacy-jobs-release-guard.test.mjs scripts/tests/timekeeping-ci-inventory-rpc.test.mjs
       - name: Install pinned Timekeeping toolchain
         run: npm --prefix workforce/timekeeping ci --ignore-scripts
       - name: Test Timekeeping domain
@@ -132,6 +148,12 @@ jobs:
           npm --prefix api ci --ignore-scripts
           (cd inventory && corepack pnpm install --frozen-lockfile --ignore-scripts)
           npm --prefix api test
+          node --test inventory/tests/legacyApiJobsContract.test.mjs
+          # The inventory default configuration is production; staging is
+          # intentionally validated separately so service-binding compilation
+          # cannot drift between the two environments.
+          inventory/node_modules/.bin/wrangler deploy --dry-run --config inventory/wrangler.toml --outdir "$RUNNER_TEMP/inventory-production-dry-run"
+          inventory/node_modules/.bin/wrangler deploy --dry-run --config inventory/wrangler.toml --env staging --outdir "$RUNNER_TEMP/inventory-staging-dry-run"
           api/node_modules/.bin/wrangler deploy --dry-run --config api/wrangler.toml --env="" --outdir "$RUNNER_TEMP/api-dry-run"
           api/node_modules/.bin/wrangler deploy --dry-run --config api/wrangler.ponto.toml --env="" --outdir "$RUNNER_TEMP/ponto-core-dry-run"
           api/node_modules/.bin/wrangler deploy --dry-run --config api/wrangler.ponto.toml --env staging --outdir "$RUNNER_TEMP/ponto-core-staging-dry-run"

--- a/api/package.json
+++ b/api/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "wrangler dev --config wrangler.toml",
     "deploy": "wrangler deploy --config wrangler.toml --keep-vars",
-    "test": "node --test test/gateway.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "lint": "echo \"(todo)\""
   },
   "devDependencies": {

--- a/api/test/legacy-inventory-job-queue.test.mjs
+++ b/api/test/legacy-inventory-job-queue.test.mjs
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { JobQueue } from '../workers/legacy-inventory-durable-objects.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..', '..');
+
+function createDb(rows = []) {
+    const calls = [];
+    return {
+        calls,
+        prepare(sql) {
+            const result = {
+                all: async () => ({ results: sql.includes('SELECT id, type, unidade, payload_json') ? rows : [] }),
+                first: async () => (sql.includes('COUNT(*)') ? { c: 0 } : null),
+                run: async () => ({ meta: { changes: 1 } }),
+            };
+            return {
+                bind(...bindings) {
+                    calls.push({ sql, bindings });
+                    return result;
+                },
+                first: result.first,
+            };
+        },
+    };
+}
+
+test('legacy API JobQueue rejects every job type except notifications refresh before touching D1', async () => {
+    const db = createDb();
+    const queue = new JobQueue({ storage: { setAlarm: async () => {} } }, { DB: db });
+
+    const result = await queue.enqueue({ type: 'REBUILD_SEARCH_INDEX' });
+
+    assert.deepEqual(result, { enqueued: false, reason: 'UNSUPPORTED_JOB_TYPE' });
+    assert.equal(db.calls.length, 0);
+});
+
+test('legacy API JobQueue rejects an invalid unit before creating a pending row', async () => {
+    const db = createDb();
+    const queue = new JobQueue({ storage: { setAlarm: async () => {} } }, { DB: db });
+
+    const result = await queue.enqueue({ type: 'NOTIFICATIONS_REFRESH', unidade: 'unknown-unit' });
+
+    assert.deepEqual(result, { enqueued: false, reason: 'UNIDADE_INVALID' });
+    assert.equal(db.calls.length, 0);
+});
+
+test('legacy API JobQueue canonicalizes a valid unit before writing the pending row', async () => {
+    const db = createDb();
+    const queue = new JobQueue({ storage: { setAlarm: async () => {} } }, { DB: db });
+
+    const result = await queue.enqueue({ type: 'NOTIFICATIONS_REFRESH', unidade: 'NH' });
+
+    assert.deepEqual(result, { enqueued: true, id: 'NOTIFICATIONS_REFRESH:novo-hamburgo' });
+    assert.equal(db.calls.length >= 2, true);
+    assert.equal(db.calls[0].bindings[2], 'novo-hamburgo');
+});
+
+test('legacy API JobQueue executes notification work through the Inventory RPC binding', async () => {
+    const db = createDb([{
+        id: 'NOTIFICATIONS_REFRESH:novo-hamburgo',
+        type: 'NOTIFICATIONS_REFRESH',
+        unidade: 'novo-hamburgo',
+        payload_json: null,
+    }]);
+    const alarms = [];
+    const rpcCalls = [];
+    const queue = new JobQueue({ storage: { setAlarm: async (at) => alarms.push(at) } }, {
+        DB: db,
+        INVENTORY_LEGACY_JOBS: {
+            async runNotificationsRefresh(input) {
+                rpcCalls.push(input);
+                return { ok: true, type: 'NOTIFICATIONS_REFRESH', unidade: input.unidade };
+            },
+        },
+    });
+
+    const result = await queue.processBatch();
+
+    assert.deepEqual(result, { processed: 1, remaining: 0 });
+    assert.deepEqual(rpcCalls, [{ unidade: 'novo-hamburgo' }]);
+    assert.equal(alarms.length, 0);
+    assert.equal(db.calls.some(({ sql }) => sql.includes("status='RUNNING'")), true);
+    assert.equal(db.calls.some(({ sql }) => sql.includes("status='DONE'")), true);
+    assert.equal(db.calls.some(({ sql }) => sql.includes("WHERE status='PENDING'")), true);
+});
+
+test('legacy API JobQueue marks an inherited unsupported pending row failed without invoking Inventory RPC', async () => {
+    const db = createDb([{
+        id: 'REBUILD_SEARCH_INDEX:ALL',
+        type: 'REBUILD_SEARCH_INDEX',
+        unidade: null,
+        payload_json: null,
+    }]);
+    let rpcCalls = 0;
+    const queue = new JobQueue({ storage: { setAlarm: async () => {} } }, {
+        DB: db,
+        INVENTORY_LEGACY_JOBS: {
+            async runNotificationsRefresh() {
+                rpcCalls += 1;
+                return { ok: true };
+            },
+        },
+    });
+
+    const result = await queue.processBatch();
+
+    assert.deepEqual(result, { processed: 1, remaining: 0 });
+    assert.equal(rpcCalls, 0);
+    assert.equal(db.calls.some(({ sql }) => sql.includes("status='FAILED'")), true);
+});
+
+test('API has no Inventory implementation import and declares an internal named RPC binding', async () => {
+    const [apiEntrypoint, apiConfig] = await Promise.all([
+        readFile(path.join(repoRoot, 'api', 'workers', 'index.js'), 'utf8'),
+        readFile(path.join(repoRoot, 'api', 'wrangler.toml'), 'utf8'),
+    ]);
+
+    assert.doesNotMatch(apiEntrypoint, /inventory\/src\/worker/);
+    assert.match(apiEntrypoint, /legacy-inventory-durable-objects/);
+    assert.match(apiConfig, /binding = "INVENTORY_LEGACY_JOBS"\s+service = "skincos-insumos"\s+entrypoint = "InventoryLegacyJobsEntrypoint"/);
+    assert.match(apiConfig, /binding = "INVENTORY_LEGACY_JOBS"\s+service = "skincos-insumos-staging"\s+entrypoint = "InventoryLegacyJobsEntrypoint"/);
+});
+
+test('API Durable Object migration declarations stay intact while the implementation becomes local', async () => {
+    const apiConfig = await readFile(path.join(repoRoot, 'api', 'wrangler.toml'), 'utf8');
+
+    assert.match(apiConfig, /name = "RATE_LIMITER"\s+class_name = "RateLimiter"/);
+    assert.match(apiConfig, /name = "JOB_QUEUE"\s+class_name = "JobQueue"/);
+    assert.match(apiConfig, /tag = "v1"\s+new_sqlite_classes = \["RateLimiter"\]/);
+    assert.match(apiConfig, /tag = "v2"\s+new_sqlite_classes = \["JobQueue"\]/);
+    assert.doesNotMatch(apiConfig, /deleted_classes/);
+});

--- a/api/workers/index.js
+++ b/api/workers/index.js
@@ -1,4 +1,4 @@
-export { RateLimiter, JobQueue } from '../../inventory/src/worker.js';
+export { RateLimiter, JobQueue } from './legacy-inventory-durable-objects.js';
 import { handleGatewayRequest } from '../src/gateway.js';
 
 export default {

--- a/api/workers/legacy-inventory-durable-objects.js
+++ b/api/workers/legacy-inventory-durable-objects.js
@@ -1,0 +1,257 @@
+import { normalizeUnitScope } from '../../shared/identity-contract/index.js';
+
+const LEGACY_API_NOTIFICATIONS_REFRESH = 'NOTIFICATIONS_REFRESH';
+
+function safeJson(value, maxLen = 45000) {
+    try {
+        const serialized = JSON.stringify(value ?? null);
+        return serialized.length > maxLen ? `${serialized.slice(0, maxLen)}…` : serialized;
+    } catch {
+        return '';
+    }
+}
+
+function normalizeLegacyJob(job) {
+    const type = String(job?.type || '').trim().toUpperCase();
+    if (!type) return { ok: false, reason: 'MISSING_TYPE' };
+    if (type !== LEGACY_API_NOTIFICATIONS_REFRESH) {
+        return { ok: false, reason: 'UNSUPPORTED_JOB_TYPE' };
+    }
+
+    const rawUnidade = job?.unidade;
+    if (rawUnidade === undefined || rawUnidade === null || String(rawUnidade).trim() === '') {
+        return { ok: true, type, unidade: null };
+    }
+    if (typeof rawUnidade !== 'string') {
+        return { ok: false, reason: 'UNIDADE_INVALID' };
+    }
+
+    const unidade = rawUnidade.trim();
+    if (unidade.length > 160) {
+        return { ok: false, reason: 'UNIDADE_TOO_LONG' };
+    }
+    const canonicalUnidade = normalizeUnitScope(unidade);
+    if (!canonicalUnidade) {
+        return { ok: false, reason: 'UNIDADE_INVALID' };
+    }
+
+    return { ok: true, type, unidade: canonicalUnidade };
+}
+
+async function runLegacyInventoryJob(env, job) {
+    const normalized = normalizeLegacyJob(job);
+    if (!normalized.ok) throw new Error(normalized.reason);
+
+    const service = env?.INVENTORY_LEGACY_JOBS;
+    if (!service || typeof service.runNotificationsRefresh !== 'function') {
+        throw new Error('INVENTORY_LEGACY_JOBS_UNAVAILABLE');
+    }
+
+    const result = await service.runNotificationsRefresh({ unidade: normalized.unidade });
+    if (!result || result.ok !== true) {
+        throw new Error('INVENTORY_LEGACY_JOBS_REJECTED');
+    }
+    return result;
+}
+
+// These class names must remain owned by API: Cloudflare associates them with
+// the existing API Durable Object namespaces declared in api/wrangler.toml.
+export class RateLimiter {
+    constructor(state, env) {
+        this.state = state;
+        this.env = env;
+        this._cache = new Map();
+    }
+
+    async fetch(request) {
+        const url = new URL(request.url);
+        const key = url.searchParams.get('key') || 'anon';
+        const limit = Math.max(1, parseInt(url.searchParams.get('limit') || '60', 10) || 60);
+        const windowSec = Math.max(1, parseInt(url.searchParams.get('window') || '60', 10) || 60);
+        const nowSec = Math.floor(Date.now() / 1000);
+        const bucket = Math.floor(nowSec / windowSec);
+        const storageKey = `rl:${key}:${bucket}`;
+
+        const nowMs = Date.now();
+        const bucketExpiresAtMs = (bucket + 2) * windowSec * 1000;
+
+        let entry = this._cache.get(storageKey);
+        if (!entry || entry.expiresAtMs <= nowMs) {
+            const current = (await this.state.storage.get(storageKey)) || 0;
+            entry = {
+                count: Number(current) || 0,
+                lastPersistAtMs: 0,
+                expiresAtMs: bucketExpiresAtMs,
+            };
+            this._cache.set(storageKey, entry);
+        }
+
+        const next = (entry.count += 1);
+        const persistEvery = Math.max(1, Math.floor(limit / 4));
+        const persistIntervalMs = 15_000;
+        const shouldPersist =
+            next === 1 ||
+            next % persistEvery === 0 ||
+            next >= limit ||
+            (entry.lastPersistAtMs && nowMs - entry.lastPersistAtMs >= persistIntervalMs);
+
+        if (shouldPersist) {
+            await this.state.storage.put(storageKey, next, { expirationTtl: windowSec * 2 });
+            entry.lastPersistAtMs = nowMs;
+        }
+
+        if (this._cache.size > 500) {
+            let scanned = 0;
+            for (const [cacheKey, cacheEntry] of this._cache) {
+                if (cacheEntry.expiresAtMs <= nowMs) this._cache.delete(cacheKey);
+                if (++scanned >= 50) break;
+            }
+        }
+
+        const allowed = next <= limit;
+        return new Response(JSON.stringify({ allowed, limit, remaining: Math.max(0, limit - next) }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+        });
+    }
+}
+
+export class JobQueue {
+    constructor(state, env) {
+        this.state = state;
+        this.env = env;
+    }
+
+    async enqueue(job) {
+        if (!this.env?.DB) return { enqueued: false, reason: 'DB_NOT_CONFIGURED' };
+
+        const normalized = normalizeLegacyJob(job);
+        if (!normalized.ok) return { enqueued: false, reason: normalized.reason };
+
+        const now = new Date().toISOString();
+        const payloadJson = job?.payload ? safeJson(job.payload) : null;
+        const id = job?.id ? String(job.id) : `${normalized.type}:${normalized.unidade || 'ALL'}`;
+
+        await this.env.DB.prepare(
+            `INSERT OR IGNORE INTO jobs (id, type, status, unidade, payload_json, created_at)
+             VALUES (?, ?, 'PENDING', ?, ?, ?)`
+        )
+            .bind(id, normalized.type, normalized.unidade, payloadJson, now)
+            .run();
+
+        await this.env.DB.prepare(
+            `UPDATE jobs
+             SET status='PENDING', created_at=?, started_at=NULL, finished_at=NULL, error=NULL, payload_json=?
+             WHERE id=? AND status!='PENDING'`
+        )
+            .bind(now, payloadJson, id)
+            .run();
+
+        await this.state.storage.setAlarm(Date.now() + 1500);
+        return { enqueued: true, id };
+    }
+
+    async processBatch(limit = 10) {
+        if (!this.env?.DB) return { processed: 0, remaining: 0 };
+
+        const rows = await this.env.DB.prepare(
+            `SELECT id, type, unidade, payload_json
+             FROM jobs
+             WHERE status='PENDING'
+             ORDER BY created_at ASC
+             LIMIT ?`
+        )
+            .bind(limit)
+            .all();
+
+        const jobs = rows?.results || [];
+        let processed = 0;
+
+        for (const job of jobs) {
+            const startedAt = new Date().toISOString();
+            const claimed = await this.env.DB.prepare(
+                `UPDATE jobs SET status='RUNNING', started_at=? WHERE id=? AND status='PENDING'`
+            )
+                .bind(startedAt, job.id)
+                .run();
+            if ((claimed?.meta?.changes || 0) === 0) continue;
+
+            try {
+                await runLegacyInventoryJob(this.env, job);
+                const finishedAt = new Date().toISOString();
+                await this.env.DB.prepare(
+                    `UPDATE jobs SET status='DONE', finished_at=?, error=NULL WHERE id=?`
+                )
+                    .bind(finishedAt, job.id)
+                    .run();
+                processed += 1;
+            } catch (err) {
+                const finishedAt = new Date().toISOString();
+                await this.env.DB.prepare(
+                    `UPDATE jobs SET status='FAILED', finished_at=?, error=? WHERE id=?`
+                )
+                    .bind(finishedAt, String(err?.message || err || 'JOB_ERROR'), job.id)
+                    .run();
+                processed += 1;
+            }
+        }
+
+        const remainingRow = await this.env.DB.prepare(
+            `SELECT COUNT(*) as c FROM jobs WHERE status='PENDING'`
+        )
+            .first();
+        const remaining = Number(remainingRow?.c || 0);
+        if (remaining > 0) {
+            await this.state.storage.setAlarm(Date.now() + 2000);
+        }
+        return { processed, remaining };
+    }
+
+    async fetch(request) {
+        const url = new URL(request.url);
+        if (request.method === 'POST' && url.pathname === '/enqueue') {
+            const body = await request.json().catch(() => ({}));
+            const result = await this.enqueue(body);
+            return new Response(JSON.stringify({ success: true, ...result }), {
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+            });
+        }
+        if (request.method === 'POST' && url.pathname === '/run') {
+            const out = await this.processBatch(25);
+            return new Response(JSON.stringify({ success: true, ...out }), {
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+            });
+        }
+        if (request.method === 'GET' && url.pathname === '/status') {
+            if (!this.env?.DB) {
+                return new Response(JSON.stringify({ success: true, db: false }), {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                });
+            }
+            const pending = await this.env.DB.prepare(`SELECT COUNT(*) as c FROM jobs WHERE status='PENDING'`).first();
+            const running = await this.env.DB.prepare(`SELECT COUNT(*) as c FROM jobs WHERE status='RUNNING'`).first();
+            const failed = await this.env.DB.prepare(`SELECT COUNT(*) as c FROM jobs WHERE status='FAILED'`).first();
+            return new Response(
+                JSON.stringify({
+                    success: true,
+                    db: true,
+                    pending: Number(pending?.c || 0),
+                    running: Number(running?.c || 0),
+                    failed: Number(failed?.c || 0),
+                }),
+                { status: 200, headers: { 'content-type': 'application/json' } }
+            );
+        }
+        return new Response('Not Found', { status: 404 });
+    }
+
+    async alarm() {
+        // Preserve the existing API Durable Object alarm serialization contract.
+        await this.state.blockConcurrencyWhile(async () => {
+            await this.processBatch(25);
+        });
+    }
+}

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -45,6 +45,11 @@ binding = "INVENTORY"
 service = "skincos-insumos"
 
 [[services]]
+binding = "INVENTORY_LEGACY_JOBS"
+service = "skincos-insumos"
+entrypoint = "InventoryLegacyJobsEntrypoint"
+
+[[services]]
 binding = "TIMEKEEPING"
 service = "skincos-timekeeping"
 
@@ -89,6 +94,11 @@ database_id = "4bdd7995-ad69-465a-917c-0aab22db5c4e"
 [[env.staging.services]]
 binding = "INVENTORY"
 service = "skincos-insumos-staging"
+
+[[env.staging.services]]
+binding = "INVENTORY_LEGACY_JOBS"
+service = "skincos-insumos-staging"
+entrypoint = "InventoryLegacyJobsEntrypoint"
 
 [[env.staging.services]]
 binding = "TIMEKEEPING"

--- a/docs/architecture/domain-isolation.md
+++ b/docs/architecture/domain-isolation.md
@@ -26,8 +26,12 @@ dívidas com arquivo, specifier, motivo, contrato de substituição e prazo. O C
 emite uma anotação para cada uma e passa a falhar após o prazo; quando a
 migração termina, a entrada precisa ser removida no mesmo PR.
 
-Baseline atual: cinco dívidas históricas estão registradas no manifesto, cada
-uma com arquivo, specifier, contrato alvo e prazo verificável pelo CI. Elas
-cobrem os mounts transitórios API → Inventory/Finance, um teste CRM → Inventory
-e o smoke Finance → dependência local do CRM. A sessão Identity usa o adapter
-registrado `identity-runtime-adapter-v1`, sem exceção permanente para Inventory.
+Baseline atual: não há importações diretas históricas registradas. A
+compatibilidade stateful API -> Inventory fica em `statefulServiceBindings`,
+com consumer/produtor, service binding/entrypoint, DTO, capability de health,
+ordem de deploy/rollback, revisão até 2026-11-30 e condição de aposentadoria
+validados. Ela preserva os
+Durable Objects legados da API enquanto a regra de negócio da fila passa para
+Inventory; não é uma autorização para novos imports diretos. A sessão Identity
+usa o adapter registrado `identity-runtime-adapter-v1`, sem exceção permanente
+para Inventory.

--- a/docs/architecture/multi-repository-extraction-roadmap.md
+++ b/docs/architecture/multi-repository-extraction-roadmap.md
@@ -1,0 +1,98 @@
+# Roteiro para a extração multi-repositório
+
+**Estado:** decisão de arquitetura em execução
+**Data:** 2026-08-28
+**Escopo:** após a extração de Orb e BioEvo, ordenar os próximos produtos que
+podem deixar o monorepo SKINCOS sem copiar código, runtime ou responsabilidade
+de dados.
+
+## Regra de corte
+
+Uma extração só está concluída quando o produto possui repositório privado,
+build, testes, publicação e rollback próprios; consome outros produtos apenas
+por contrato versionado ou API/service binding; e o código, workflow e
+publicador antigos foram removidos do SKINCOS. Espelhos, submódulos, cópias e
+dois publicadores para o mesmo Worker não contam como separação.
+
+O produtor continua dono do seu código, runtime, dados, migrations, release e
+rollback. Consumidores ficam limitados ao contrato, health/observabilidade e
+testes de integração. Este é o padrão já aplicado a Orb.
+
+## O bloqueio comum: Wave 0
+
+Não extrair `shared`, `platform` ou `ops` agora. Eles ainda contêm tanto
+contratos neutros quanto infraestrutura/implementação local. Antes de qualquer
+corte, concluir estas bases:
+
+1. Publicar contratos neutros como pacotes privados versionados, com exports
+    explícitos e SemVer. Os primeiros candidatos são identidade, finance,
+    disponibilidade de módulo, observabilidade e adapters de borda. `crm-auth`
+    e `identity-runtime` ficam locais até que deixem de reexportar
+    implementação. O bootstrap local `skincos-contracts` não deve virar um
+    release plane permanente para donos de cadências diferentes: antes da
+    primeira publicação, separar contratos de Finance, Identity e Platform ou
+    atribuir formalmente um owner neutro, aprovação e calendário de release ao
+    pacote compartilhado.
+2. Fazer a evidência de promoção identificar repositório, SHA, árvore, digest
+   da closure, versão/integridade dos contratos, artefato e predecessor. Um
+   predecessor de outro repositório deve usar identidade explícita, nunca a
+   suposição de `origin/main` ou `$GITHUB_REPOSITORY` do monorepo.
+3. Eliminar as importações diretas sem estado já identificadas e tratar a ponte
+   API -> Inventory como compatibilidade stateful. Os Durable Objects legados
+   da API não devem ser apagados ou migrados nesta etapa; a regra de negócio da
+   fila deve passar para Inventory por service-binding RPC dedicado.
+4. Tornar locks e concorrência repo-aware (`merge:<repo>:main` e
+   `release:<repo>/<unit>`), mantendo globais apenas os recursos físicos que
+   de fato são compartilhados.
+
+## Ordem recomendada
+
+| Onda | Produto privado proposto | Decisão | Motivo e condição de entrada |
+| --- | --- | --- | --- |
+| P1 | `skincos-meta-ads-reporting` | **Preparar, não cortar ainda** | Há duas implementações divergentes entre `ads/meta/apps/report-ingest-worker` e Orb apontando para o mesmo Worker/D1/R2. Primeiro reconciliar owner, fluxo Orb, contrato HTTP/evento e staging; o novo repositório deve herdar os recursos existentes, não recriá-los. |
+| P1 | `skincos-finance` | **Preparar, não cortar ainda** | Worker, D1/KV, migrations e gateway já são próximos de independentes; a UI ainda é compilada pelo CRM e testes ainda tomam runtime/configuração do CRM. Separar UI, testes e pipeline, e registrar um disable/maintenance explícito antes do primeiro rollout. |
+| P1 | `skincos-clientes-readonly` | **Preparar, não cortar ainda** | A operação read-only é isolável, mas o entrypoint importa CRM completo e o perfil `full` expõe mais que Clientes. Definir allowlist de leitura e entrypoint próprio, sem rotas comerciais, antes do corte. |
+| P2 | `skincos-workforce-schedule` | **Depois da Wave 0** | A API de escala já tem Worker/D1/migrations, porém Website lê o D1 de escala diretamente e Ponto depende do contrato HMAC. Publicar API de leitura de agenda e contrato de ator antes de trocar os consumidores. |
+| P2 | `skincos-public-website-booking` | **Depois de Schedule** | `booking/` é só um esqueleto; o booking real (dados pessoais, pedidos, comunicação e tracking) está em `website/`. Extrair Website junto do booking real inicialmente, substituindo a leitura direta da escala por API. |
+| P2 | `skincos-whatsapp-adapter` | **Depois da Wave 0** | O diretório atual inclui um fork/upstream Evolution API e o release nativo copia do checkout mutável. O corte deve possuir o adapter/custódia e uma fonte imutável, sem duplicar o upstream. |
+
+## Domínios deliberadamente adiados
+
+`api`, `inventory` e `identity` continuam juntos até haver um plano stateful
+para Durable Objects, sessão e dados compartilhados. Também ficam no monorepo
+por enquanto: CRM completo, Ponto/timekeeping, EF inteiro, social, backend,
+platform, ops, Token Vault e coordenador global. Esses domínios têm contratos,
+dados ou release ownership ainda cruzados e seriam falsos positivos de
+independência.
+
+## Critérios por corte
+
+Cada PR/repositório de extração deve demonstrar:
+
+1. pacote/contrato publicado e instalação limpa por versão exata;
+2. build, testes e artefato do produtor sem path relativo para SKINCOS;
+3. dados e migrations com owner único, checkpoint e plano de rollback;
+4. preview e staging a partir do mesmo artefato, com health, integração
+   sintética e evidência de versão;
+5. consumidor migrado ao contrato, sem import, workflow ou publicador antigo;
+6. rollback para a versão anterior do novo owner, sem republicar produtos não
+   relacionados;
+7. remoção verificada da fonte, pipeline e runtime duplicados no SKINCOS.
+
+## Próxima decisão executável
+
+Concluir a Wave 0 em PRs pequenos e independentes. Em seguida, iniciar Meta
+Ads Reporting pela reconciliação de ownership (não pela criação do repositório)
+e Finance pela remoção da dependência de UI/testes do CRM. O primeiro corte só
+começa quando um deles satisfizer todos os critérios acima.
+
+## Evidência de código
+
+- A política de imports e o registro da ponte stateful API -> Inventory estão em
+  [`shared/domain-boundaries.json`](../../shared/domain-boundaries.json).
+- A fronteira pretendida de cada root está em
+  [`target-domain-map.md`](target-domain-map.md).
+- O gate atual de promoção fica em
+  [`.github/workflows/promotion-gate.yml`](../../.github/workflows/promotion-gate.yml)
+  e sua identidade em
+  [`.github/scripts/promotion-evidence.mjs`](../../.github/scripts/promotion-evidence.mjs).

--- a/inventory/src/legacy-api-jobs.js
+++ b/inventory/src/legacy-api-jobs.js
@@ -1,0 +1,45 @@
+import { normalizeUnitScope } from '../../shared/identity-contract/index.js';
+
+// Narrow, serializable contract used only by API's retained legacy JobQueue
+// Durable Object.  The Inventory Worker keeps ownership of the business work.
+export const LEGACY_API_NOTIFICATIONS_REFRESH = 'NOTIFICATIONS_REFRESH';
+export const LEGACY_API_JOBS_RPC_CAPABILITY = 'legacy-api-jobs-rpc/v1';
+
+export function normalizeLegacyApiNotificationsRefreshJob(job) {
+    const type = String(job?.type || '').trim().toUpperCase();
+    if (type !== LEGACY_API_NOTIFICATIONS_REFRESH) {
+        throw new Error('LEGACY_API_JOB_TYPE_UNSUPPORTED');
+    }
+
+    const rawUnidade = job?.unidade;
+    if (rawUnidade === undefined || rawUnidade === null || String(rawUnidade).trim() === '') {
+        return { type, unidade: null };
+    }
+
+    if (typeof rawUnidade !== 'string') {
+        throw new TypeError('LEGACY_API_JOB_UNIDADE_INVALID');
+    }
+
+    const unidade = rawUnidade.trim();
+    if (unidade.length > 160) {
+        throw new RangeError('LEGACY_API_JOB_UNIDADE_TOO_LONG');
+    }
+
+    const canonicalUnidade = normalizeUnitScope(unidade);
+    if (!canonicalUnidade) {
+        throw new Error('LEGACY_API_JOB_UNIDADE_INVALID');
+    }
+
+    return { type, unidade: canonicalUnidade };
+}
+
+export function normalizeLegacyApiNotificationsRefreshRequest(input) {
+    if (input === null || Array.isArray(input) || typeof input !== 'object') {
+        throw new TypeError('LEGACY_API_JOB_REQUEST_INVALID');
+    }
+
+    return normalizeLegacyApiNotificationsRefreshJob({
+        type: LEGACY_API_NOTIFICATIONS_REFRESH,
+        unidade: input.unidade,
+    });
+}

--- a/inventory/src/worker.js
+++ b/inventory/src/worker.js
@@ -57,6 +57,7 @@ import {
     d1ListInsumosOptions,
 } from './d1Store.js';
 import { hasUnitScopeAccess, normalizeUnitScope } from '../../shared/identity-contract/index.js';
+import { LEGACY_API_JOBS_RPC_CAPABILITY } from './legacy-api-jobs.js';
 
 const MAX_PROFILE_PHOTO_URL_CHARS = 45000;
 
@@ -228,7 +229,7 @@ export class JobQueue {
             if ((claimed?.meta?.changes || 0) === 0) continue;
 
             try {
-                await runJob({ env: this.env, job });
+                await runInventoryJob({ env: this.env, job });
                 const finishedAt = new Date().toISOString();
                 await this.env.DB.prepare(
                     `UPDATE jobs SET status='DONE', finished_at=?, error=NULL WHERE id=?`
@@ -1040,10 +1041,14 @@ async function refreshNotificationsSnapshotInD1({ env, unidade }) {
     }
 }
 
-async function runJob({ env, job }) {
+export async function runNotificationsRefreshJob({ env, unidade }) {
+    await refreshNotificationsSnapshotInD1({ env, unidade: unidade ? String(unidade) : null });
+}
+
+async function runInventoryJob({ env, job }) {
     const type = String(job?.type || '').toUpperCase();
     if (type === 'NOTIFICATIONS_REFRESH') {
-        await refreshNotificationsSnapshotInD1({ env, unidade: job?.unidade ? String(job.unidade) : null });
+        await runNotificationsRefreshJob({ env, unidade: job?.unidade });
         return;
     }
     throw new Error(`Unknown job type: ${type}`);
@@ -1268,6 +1273,7 @@ export default {
                     runtime: "cloudflare-workers",
                     version: String(env?.APP_VERSION || "unknown"),
                     environment: String(env?.ENVIRONMENT || "unknown"),
+                    legacyApiJobsRpc: LEGACY_API_JOBS_RPC_CAPABILITY,
                     workerVersion: {
                         id: String(env?.CF_VERSION_METADATA?.id || "") || null,
                         tag: String(env?.CF_VERSION_METADATA?.tag || "") || null,

--- a/inventory/tests/legacyApiJobsContract.test.mjs
+++ b/inventory/tests/legacyApiJobsContract.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+    LEGACY_API_JOBS_RPC_CAPABILITY,
+    LEGACY_API_NOTIFICATIONS_REFRESH,
+    normalizeLegacyApiNotificationsRefreshJob,
+    normalizeLegacyApiNotificationsRefreshRequest,
+} from '../src/legacy-api-jobs.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..', '..');
+
+test('the Inventory-owned legacy contract permits only a normalized notifications refresh DTO', () => {
+    assert.deepEqual(
+        normalizeLegacyApiNotificationsRefreshJob({ type: ' notifications_refresh ', unidade: ' novo-hamburgo ' }),
+        { type: LEGACY_API_NOTIFICATIONS_REFRESH, unidade: 'novo-hamburgo' },
+    );
+    assert.deepEqual(
+        normalizeLegacyApiNotificationsRefreshRequest({ unidade: null }),
+        { type: LEGACY_API_NOTIFICATIONS_REFRESH, unidade: null },
+    );
+    assert.deepEqual(
+        normalizeLegacyApiNotificationsRefreshRequest({ unidade: 'NH' }),
+        { type: LEGACY_API_NOTIFICATIONS_REFRESH, unidade: 'novo-hamburgo' },
+    );
+});
+
+test('the Inventory-owned legacy contract rejects a generic job dispatcher payload', () => {
+    assert.throws(
+        () => normalizeLegacyApiNotificationsRefreshJob({ type: 'DELETE_ALL' }),
+        /LEGACY_API_JOB_TYPE_UNSUPPORTED/,
+    );
+    assert.throws(
+        () => normalizeLegacyApiNotificationsRefreshRequest(['novo-hamburgo']),
+        /LEGACY_API_JOB_REQUEST_INVALID/,
+    );
+    assert.throws(
+        () => normalizeLegacyApiNotificationsRefreshRequest({ unidade: 'unknown-unit' }),
+        /LEGACY_API_JOB_UNIDADE_INVALID/,
+    );
+});
+
+test('the RPC entrypoint delegates business work to Inventory and exposes no HTTP route', async () => {
+    const [entrypoint, worker] = await Promise.all([
+        readFile(path.join(repoRoot, 'inventory', 'workers', 'legacy-api-jobs-entrypoint.js'), 'utf8'),
+        readFile(path.join(repoRoot, 'inventory', 'src', 'worker.js'), 'utf8'),
+    ]);
+
+    assert.match(entrypoint, /runNotificationsRefreshJob\(\{ env: this\.env, unidade: job\.unidade \}\)/);
+    assert.doesNotMatch(entrypoint, /(?:^|\n)\s*(?:async\s+)?fetch\s*\(/);
+    assert.match(worker, /export async function runNotificationsRefreshJob/);
+    assert.equal(LEGACY_API_JOBS_RPC_CAPABILITY, 'legacy-api-jobs-rpc/v1');
+    assert.match(worker, /legacyApiJobsRpc: LEGACY_API_JOBS_RPC_CAPABILITY/);
+});

--- a/inventory/workers/index.js
+++ b/inventory/workers/index.js
@@ -2,5 +2,6 @@
 // Keeps Durable Object exports intact while delegating implementation to src/.
 
 export { RateLimiter, JobQueue } from '../src/worker.js';
+export { InventoryLegacyJobsEntrypoint } from './legacy-api-jobs-entrypoint.js';
 import worker from '../src/worker.js';
 export default worker;

--- a/inventory/workers/legacy-api-jobs-entrypoint.js
+++ b/inventory/workers/legacy-api-jobs-entrypoint.js
@@ -1,0 +1,13 @@
+import { WorkerEntrypoint } from 'cloudflare:workers';
+import { normalizeLegacyApiNotificationsRefreshRequest } from '../src/legacy-api-jobs.js';
+import { runNotificationsRefreshJob } from '../src/worker.js';
+
+// This named entrypoint has no public HTTP handler. API can invoke it only
+// through its Inventory service binding, with a small DTO.
+export class InventoryLegacyJobsEntrypoint extends WorkerEntrypoint {
+    async runNotificationsRefresh(input) {
+        const job = normalizeLegacyApiNotificationsRefreshRequest(input);
+        await runNotificationsRefreshJob({ env: this.env, unidade: job.unidade });
+        return { ok: true, type: job.type, unidade: job.unidade };
+    }
+}

--- a/ops/governance/github-repository-transfer-plan.json
+++ b/ops/governance/github-repository-transfer-plan.json
@@ -26,7 +26,7 @@
     {"slug": "skincos-security", "purpose": "Rulesets, secret governance and incident review", "permission": "maintain"}
   ],
   "codeownersBlueprint": [
-    {"paths": ["/.github/", "/.githooks/", "/ops/", "/scripts/", "/docs/", "/db/", "/skills/"], "team": "skincos-platform"},
+    {"paths": ["/.github/", "/.githooks/", "/ops/", "/scripts/", "/docs/", "/db/", "/skills/", "/packages/"], "team": "skincos-platform"},
     {"paths": ["/crm/", "/api/", "/backend/", "/frontend/", "/identity/", "/service/", "/booking/", "/integration/", "/messaging/"], "team": "skincos-crm"},
     {"paths": ["/finance/"], "team": "skincos-finance"},
     {"paths": ["/workforce/"], "team": "skincos-workforce"},

--- a/ops/governance/global-concurrency-policy.json
+++ b/ops/governance/global-concurrency-policy.json
@@ -191,6 +191,7 @@
     "scripts/runtime/ponto-jit-claims.mjs",
     ".github/actions/**",
     ".github/scripts/promotion-*.mjs",
+    ".github/scripts/validate-promotion-source-ref.mjs",
     ".github/workflows/promotion-gate.yml",
     ".github/workflows/global-coordination-release.yml",
     "shared/**",

--- a/packages/skincos-contracts/README.md
+++ b/packages/skincos-contracts/README.md
@@ -1,0 +1,25 @@
+# SKINCOS Contracts
+
+Private, versioned contract package for independent SKINCOS domain repositories.
+
+The public entrypoints intentionally contain only portable, dependency-free
+contracts. They do not import from the SKINCOS monorepo at runtime.
+
+Current public entrypoints:
+
+- @jubenitogarcia/skincos-contracts/identity
+- @jubenitogarcia/skincos-contracts/finance
+- @jubenitogarcia/skincos-contracts/finance/csv
+- @jubenitogarcia/skincos-contracts/finance/moneywiz
+- @jubenitogarcia/skincos-contracts/finance/ef-caixa
+- @jubenitogarcia/skincos-contracts/module-availability
+- @jubenitogarcia/skincos-contracts/observability
+
+Publishing is intentionally separate from this bootstrap. Before a consumer
+depends on a released version, the release plane must attest the package
+version, artifact digest, source repository and source commit, and GitHub
+Packages visibility must remain restricted.
+
+No repository metadata is present intentionally. These packages must first be
+published from their private owning repositories and must never be associated
+with the public SKINCOS monorepo.

--- a/packages/skincos-contracts/package.json
+++ b/packages/skincos-contracts/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@jubenitogarcia/skincos-contracts",
+  "version": "1.0.0",
+  "description": "Versioned portable SKINCOS domain contracts.",
+  "license": "UNLICENSED",
+  "type": "module",
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./identity": "./src/identity-contract.js",
+    "./finance": "./src/finance/index.js",
+    "./finance/csv": "./src/finance/csv.js",
+    "./finance/moneywiz": "./src/finance/moneywiz.js",
+    "./finance/ef-caixa": "./src/finance/ef-caixa.js",
+    "./module-availability": "./src/module-availability.js",
+    "./observability": "./src/observability.js",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  }
+}

--- a/packages/skincos-contracts/src/finance/csv.js
+++ b/packages/skincos-contracts/src/finance/csv.js
@@ -1,0 +1,106 @@
+import { FinanceContractError, asCurrency, asIsoDate, asTrimmedString } from './index.js';
+
+export const FINANCE_IMPORT_FIELDS = Object.freeze(['date', 'description', 'amount', 'income', 'expense', 'type', 'account', 'category', 'payee', 'tags', 'note', 'status', 'currency', 'transferAccount', 'externalId']);
+
+const aliases = Object.freeze({
+  date: ['data', 'date', 'competencia', 'competência', 'vencimento'],
+  description: ['descricao', 'descrição', 'description', 'historico', 'histórico', 'memo'],
+  amount: ['valor', 'amount', 'montante'], income: ['entrada', 'receita', 'credit', 'credito', 'crédito'], expense: ['saida', 'saída', 'despesa', 'debit', 'debito', 'débito'],
+  type: ['tipo', 'type', 'natureza'], account: ['conta', 'account'], category: ['categoria', 'category'], payee: ['favorecido', 'beneficiario', 'beneficiário', 'payee'],
+  tags: ['tags', 'tag', 'etiquetas'], note: ['observacao', 'observação', 'nota', 'note', 'memo'], status: ['status', 'situacao', 'situação'], currency: ['moeda', 'currency'], transferAccount: ['transferencias', 'transferências', 'transfers', 'transfer account', 'conta destino'], externalId: ['id externo', 'identificador externo', 'external id', 'external_id', 'transaction id', 'transaction_id', 'id', 'check #'],
+});
+
+export function importNameKey(value) { return String(value || '').normalize('NFKD').replace(/[\u0300-\u036f]/g, '').trim().toLowerCase().replace(/\s+/g, ' '); }
+
+export function detectCsvDelimiter(content) {
+  const line = String(content || '').split(/\r?\n/).find((value) => value.trim()) || '';
+  const counts = [',', ';', '\t'].map((delimiter) => ({ delimiter, count: parseCsvLine(line, delimiter).length - 1 }));
+  return counts.sort((a, b) => b.count - a.count)[0]?.count > 0 ? counts.sort((a, b) => b.count - a.count)[0].delimiter : ',';
+}
+
+function parseCsvLine(line, delimiter) {
+  const values = []; let field = ''; let quoted = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    if (char === '"') { if (quoted && line[index + 1] === '"') { field += '"'; index += 1; } else quoted = !quoted; }
+    else if (char === delimiter && !quoted) { values.push(field); field = ''; }
+    else field += char;
+  }
+  if (quoted) throw new FinanceContractError('VALIDATION_ERROR', 'CSV possui aspas não fechadas.');
+  values.push(field); return values;
+}
+
+export function parseCsv(content, delimiter = detectCsvDelimiter(content)) {
+  const rows = []; let row = []; let field = ''; let quoted = false; const value = String(content || '').replace(/^\uFEFF/, '');
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (char === '"') { if (quoted && value[index + 1] === '"') { field += '"'; index += 1; } else quoted = !quoted; }
+    else if (char === delimiter && !quoted) { row.push(field); field = ''; }
+    else if ((char === '\n' || char === '\r') && !quoted) { if (char === '\r' && value[index + 1] === '\n') index += 1; row.push(field); if (row.some((cell) => cell.trim())) rows.push(row); row = []; field = ''; }
+    else field += char;
+  }
+  if (quoted) throw new FinanceContractError('VALIDATION_ERROR', 'CSV possui aspas não fechadas.');
+  row.push(field); if (row.some((cell) => cell.trim())) rows.push(row);
+  if (!rows.length) throw new FinanceContractError('VALIDATION_ERROR', 'CSV está vazio.');
+  return rows;
+}
+
+export function inferImportMapping(headers) {
+  const normalized = headers.map(importNameKey); const mapping = {};
+  for (const field of FINANCE_IMPORT_FIELDS) { const found = aliases[field]?.find((alias) => normalized.includes(alias)); if (found) mapping[field] = headers[normalized.indexOf(found)]; }
+  return mapping;
+}
+
+export function detectDateFormat(values) {
+  const samples = values.filter(Boolean).map((value) => String(value).trim()).slice(0, 100);
+  if (samples.some((value) => /^\d{4}-\d{2}-\d{2}$/.test(value))) return 'YYYY-MM-DD';
+  if (samples.some((value) => /^\d{1,2}[/-]\d{1,2}[/-]\d{2,4}$/.test(value))) return 'DD/MM/YYYY';
+  return 'unknown';
+}
+
+export function toIsoImportDate(value, dateFormat = 'unknown') {
+  const raw = String(value || '').trim();
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return asIsoDate(raw, 'data');
+  const match = raw.match(/^(\d{1,2})[/-](\d{1,2})[/-](\d{2,4})$/);
+  if (!match) throw new FinanceContractError('VALIDATION_ERROR', 'data deve usar YYYY-MM-DD ou DD/MM/AAAA.');
+  const year = match[3].length === 2 ? `20${match[3]}` : match[3]; const iso = `${year}-${match[2].padStart(2, '0')}-${match[1].padStart(2, '0')}`;
+  return asIsoDate(iso, 'data');
+}
+
+export function decimalToMinorUnits(value, field = 'valor') {
+  let raw = String(value ?? '').trim().replace(/\s/g, '').replace(/^(R\$|US\$|€)/i, '');
+  if (!raw) throw new FinanceContractError('VALIDATION_ERROR', `${field} é obrigatório.`);
+  const sign = raw.startsWith('-') ? -1 : 1; raw = raw.replace(/^[+-]/, '');
+  const comma = raw.lastIndexOf(','); const dot = raw.lastIndexOf('.'); const decimal = comma > dot ? ',' : dot > comma ? '.' : '';
+  if (decimal) {
+    const fractionLength = raw.length - raw.lastIndexOf(decimal) - 1;
+    if (fractionLength > 2) throw new FinanceContractError('VALIDATION_ERROR', `${field} possui mais de duas casas decimais.`);
+    const parts = raw.split(decimal); raw = `${parts.slice(0, -1).join('').replace(/[.,]/g, '')}.${parts.at(-1)}`;
+  } else raw = raw.replace(/[.,]/g, '');
+  const match = raw.match(/^(\d+)(?:\.(\d{1,2}))?$/);
+  if (!match) throw new FinanceContractError('VALIDATION_ERROR', `${field} não é um valor monetário válido.`);
+  const minor = Number(match[1]) * 100 + Number((match[2] || '').padEnd(2, '0'));
+  if (!Number.isSafeInteger(minor) || minor === 0) throw new FinanceContractError('VALIDATION_ERROR', `${field} deve ser diferente de zero.`);
+  return { sign, amountMinor: minor };
+}
+
+export function analyseCsvImport(content, suppliedMapping = {}, encoding = 'utf-8') {
+  const delimiter = detectCsvDelimiter(content); const matrix = parseCsv(content, delimiter); const headers = matrix[0];
+  if (matrix.length < 2) throw new FinanceContractError('VALIDATION_ERROR', 'CSV precisa de cabeçalho e ao menos uma linha.');
+  const mapping = { ...inferImportMapping(headers), ...(suppliedMapping || {}) };
+  const dateColumn = mapping.date; const dateFormat = detectDateFormat(dateColumn ? matrix.slice(1).map((row) => row[headers.indexOf(dateColumn)]) : []);
+  return { delimiter, encoding, hasHeader: true, headers, mapping, dateFormat, rows: matrix.slice(1).map((values, index) => Object.fromEntries(headers.map((header, column) => [importNameKey(header), values[column] || '']).concat([['__row', index + 2]]))) };
+}
+
+export function normalizeImportRow(raw, mapping = {}, dateFormat = 'unknown') {
+  const pick = (field) => { const mapped = mapping[field]; if (mapped && raw[importNameKey(mapped)] !== undefined) return raw[importNameKey(mapped)]; return aliases[field]?.map((alias) => raw[alias]).find((candidate) => candidate !== undefined); };
+  const description = asTrimmedString(pick('description'), 'descrição'); const competenceDate = toIsoImportDate(pick('date'), dateFormat);
+  const income = pick('income'); const expense = pick('expense'); const amount = pick('amount'); const hasNonZero = (value) => { const raw = String(value || '').trim(); if (!raw || /^[+-]?0(?:[.,]0{1,2})?$/.test(raw)) return false; return decimalToMinorUnits(value).amountMinor > 0; }; const hasIncome = hasNonZero(income); const hasExpense = hasNonZero(expense);
+  let monetary; let type;
+  if (hasIncome || hasExpense) { if (hasIncome && hasExpense) throw new FinanceContractError('VALIDATION_ERROR', 'Linha possui entrada e saída ao mesmo tempo.'); monetary = decimalToMinorUnits(String(hasIncome ? income : expense), hasIncome ? 'entrada' : 'saída'); type = hasIncome ? 'income' : 'expense'; }
+  else { monetary = decimalToMinorUnits(amount); const typeText = importNameKey(pick('type')); type = typeText ? ({ receita: 'income', income: 'income', entrada: 'income', despesa: 'expense', expense: 'expense', saida: 'expense', saída: 'expense' }[typeText]) : (monetary.sign < 0 ? 'expense' : 'income'); }
+  if (!type) throw new FinanceContractError('VALIDATION_ERROR', 'tipo deve ser receita ou despesa.');
+  const currencyValue = pick('currency'); const currency = currencyValue ? asCurrency(currencyValue) : 'BRL';
+  const categoryPath = String(pick('category') || '').trim() || null; const tags = String(pick('tags') || '').split(/[;,|]/).map((tag) => tag.trim()).filter(Boolean);
+  return { description, competenceDate, paidDate: competenceDate, type, amountMinor: monetary.amountMinor, currency, accountName: String(pick('account') || '').trim() || null, categoryName: categoryPath, categoryPath, payeeName: String(pick('payee') || '').trim() || null, tagNames: tags, note: String(pick('note') || '').trim() || null, sourceStatus: String(pick('status') || '').trim() || null, transferAccountName: String(pick('transferAccount') || '').trim() || null, externalId: String(pick('externalId') || '').trim() || null };
+}

--- a/packages/skincos-contracts/src/finance/ef-caixa.js
+++ b/packages/skincos-contracts/src/finance/ef-caixa.js
@@ -1,0 +1,54 @@
+import { FinanceContractError, asCurrency, asIsoDate, asMinorAmount, asNonNegativeMinorAmount, asTrimmedString } from './index.js';
+import { analyseCsvImport } from './csv.js';
+
+// This adapter is deliberately transport-only. It turns the versioned delivery
+// emitted by integration/ef into the same canonical CSV analysed by Finance.
+// It never selects a Finance account, creates a movement, or posts the ledger.
+export const EF_CAIXA_CONTRACT_VERSION = 'ef-caixa/v1';
+const CANONICAL_HEADERS = Object.freeze(['Data', 'Descrição', 'Valor', 'Categoria', 'Favorecido', 'Tags', 'Observação', 'Status', 'Moeda', 'Identificador Externo']);
+const REVIEW_STATUSES = /(?:cancel|estorn|refund|inconsisten|taxa_desconhecida)/i;
+
+const csvCell = (value) => `"${String(value ?? '').replace(/"/g, '""')}"`;
+const displayMinor = (value) => `${Math.floor(value / 100)},${String(value % 100).padStart(2, '0')}`;
+const stableStringify = (value) => JSON.stringify(value, Object.keys(value || {}).sort());
+const unitSlug = (value) => asTrimmedString(value, 'unit.slug', { max: 80 }).normalize('NFKD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
+function recordFingerprint(record) {
+  return stableStringify({ occurredOn: record.occurredOn, occurredAt: record.occurredAt || null, clientName: record.clientName || null, paidAmountMinor: record.paidAmountMinor, paymentMethod: record.paymentMethod || null, status: record.status || null, currency: record.currency || 'BRL' });
+}
+
+function validateRecord(raw, index) {
+  if (!raw || typeof raw !== 'object') throw new FinanceContractError('VALIDATION_ERROR', `records[${index}] deve ser um objeto.`);
+  const occurredOn = asIsoDate(raw.occurredOn, `records[${index}].occurredOn`);
+  const paidAmountMinor = asNonNegativeMinorAmount(raw.paidAmountMinor, `records[${index}].paidAmountMinor`);
+  const grossAmountMinor = raw.grossAmountMinor === undefined || raw.grossAmountMinor === null ? null : asMinorAmount(raw.grossAmountMinor, `records[${index}].grossAmountMinor`);
+  const clientCreditMinor = raw.clientCreditMinor === undefined || raw.clientCreditMinor === null ? 0 : Number(raw.clientCreditMinor);
+  const feeAmountMinor = raw.feeAmountMinor === undefined || raw.feeAmountMinor === null ? 0 : Number(raw.feeAmountMinor);
+  const installmentCount = raw.installmentCount === undefined || raw.installmentCount === null ? 1 : Number(raw.installmentCount);
+  if (!Number.isSafeInteger(clientCreditMinor) || clientCreditMinor < 0 || !Number.isSafeInteger(feeAmountMinor) || feeAmountMinor < 0 || !Number.isSafeInteger(installmentCount) || installmentCount < 1 || installmentCount > 120) throw new FinanceContractError('VALIDATION_ERROR', `records[${index}] possui crédito, taxa ou parcelas inválidos.`);
+  const status = asTrimmedString(raw.status || 'confirmed', `records[${index}].status`, { max: 120 });
+  const paymentMethod = asTrimmedString(raw.paymentMethod || 'Não informado', `records[${index}].paymentMethod`, { max: 120 });
+  const currency = asCurrency(raw.currency || 'BRL');
+  const clientName = asTrimmedString(raw.clientName || 'Cliente não identificado', `records[${index}].clientName`, { max: 240 });
+  const externalId = raw.externalId ? asTrimmedString(raw.externalId, `records[${index}].externalId`, { max: 240 }) : `ef-caixa:${recordFingerprint({ occurredOn, occurredAt: raw.occurredAt, clientName, paidAmountMinor, paymentMethod, status, currency })}`;
+  return { occurredOn, occurredAt: raw.occurredAt ? asTrimmedString(raw.occurredAt, `records[${index}].occurredAt`, { max: 32 }) : null, paidAmountMinor, grossAmountMinor, clientCreditMinor, feeAmountMinor, installmentCount, paymentMethod, paymentMethodRaw: raw.paymentMethodRaw ? asTrimmedString(raw.paymentMethodRaw, `records[${index}].paymentMethodRaw`, { max: 240 }) : null, status, currency, clientName, externalId, refundOfExternalId: raw.refundOfExternalId ? asTrimmedString(raw.refundOfExternalId, `records[${index}].refundOfExternalId`, { max: 240 }) : null };
+}
+
+export function prepareEfCaixaImport(rawDelivery) {
+  if (!rawDelivery || typeof rawDelivery !== 'object') throw new FinanceContractError('VALIDATION_ERROR', 'Entrega Caixa EF deve ser um objeto JSON.');
+  if (rawDelivery.contractVersion !== EF_CAIXA_CONTRACT_VERSION) throw new FinanceContractError('VALIDATION_ERROR', `contractVersion deve ser ${EF_CAIXA_CONTRACT_VERSION}.`);
+  const source = rawDelivery.source || {}; const executionId = asTrimmedString(source.executionId, 'source.executionId', { max: 240 }); const unit = rawDelivery.unit || {}; const normalizedUnitSlug = unitSlug(unit.slug || unit.name);
+  const period = rawDelivery.period || {}; const from = asIsoDate(period.from, 'period.from'); const to = asIsoDate(period.to, 'period.to'); if (to < from) throw new FinanceContractError('VALIDATION_ERROR', 'period.to não pode ser anterior a period.from.');
+  if (!Array.isArray(rawDelivery.records) || !rawDelivery.records.length || rawDelivery.records.length > 20_000) throw new FinanceContractError('VALIDATION_ERROR', 'records deve conter entre 1 e 20000 linhas.');
+  const records = rawDelivery.records.map(validateRecord);
+  const rows = records.map((record) => {
+    const requiresReview = REVIEW_STATUSES.test(record.status) || record.feeAmountMinor > 0 || Boolean(record.refundOfExternalId);
+    const status = requiresReview ? `review:${record.status}` : record.status;
+    const category = `Receitas > Caixa EF > ${record.paymentMethod}`;
+    const note = [`Origem Caixa EF`, `pagamento: ${record.paymentMethodRaw || record.paymentMethod}`, `parcelas informadas: ${record.installmentCount}`, record.grossAmountMinor ? `valor da venda: ${displayMinor(record.grossAmountMinor)}` : null, record.clientCreditMinor ? `crédito cliente: ${displayMinor(record.clientCreditMinor)}` : null, record.feeAmountMinor ? `taxa: ${displayMinor(record.feeAmountMinor)}` : null, record.refundOfExternalId ? `estorno de: ${record.refundOfExternalId}` : null].filter(Boolean).join(' | ');
+    return [record.occurredOn, `Caixa EF · ${record.clientName}`, displayMinor(record.paidAmountMinor), category, record.clientName, `ef-caixa;pagamento:${record.paymentMethod}`, note, status, record.currency, record.externalId];
+  });
+  const csv = [CANONICAL_HEADERS, ...rows].map((row) => row.map(csvCell).join(';')).join('\n'); const mapping = { date: 'Data', description: 'Descrição', amount: 'Valor', category: 'Categoria', payee: 'Favorecido', tags: 'Tags', note: 'Observação', status: 'Status', currency: 'Moeda', externalId: 'Identificador Externo' };
+  const analysis = analyseCsvImport(csv, mapping, 'utf-8'); const sourceIdentity = stableStringify({ contractVersion: rawDelivery.contractVersion, executionId, artifactSha256: source.artifactSha256 || null, unitSlug: normalizedUnitSlug, period: { from, to }, records: records.map((record) => record.externalId) });
+  return { sourceType: 'ef-caixa', sourceAdapter: EF_CAIXA_CONTRACT_VERSION, unitSlug: normalizedUnitSlug, sourceIdentity, sourcePayload: rawDelivery, csv, mapping: analysis.mapping, analysis: { delimiter: analysis.delimiter, encoding: analysis.encoding, hasHeader: analysis.hasHeader, headers: analysis.headers, dateFormat: analysis.dateFormat }, metadata: { executionId, artifactId: source.artifactId || null, artifactSha256: source.artifactSha256 || null, period: { from, to }, unitSlug: normalizedUnitSlug, recordCount: records.length, limitations: ['Sem identificador nativo de venda na origem; externalId pode ser sintético.', 'Taxas e estornos exigem revisão humana.', 'Parcelas descrevem a venda, não um cronograma de liquidação.'] } };
+}

--- a/packages/skincos-contracts/src/finance/index.js
+++ b/packages/skincos-contracts/src/finance/index.js
@@ -1,0 +1,80 @@
+/**
+ * Stable, dependency-free transport contract for the Finance domain. It is
+ * deliberately consumable by both Workers and browser bundles.
+ */
+export const FINANCE_CONTRACT_VERSION = 'finance/v1';
+export const FINANCE_MODULE_KEY = 'finance';
+export const FINANCE_SCOPE_KINDS = Object.freeze(['unit', 'personal']);
+export const FINANCE_ACCOUNT_TYPES = Object.freeze(['cash', 'bank', 'card', 'clearing']);
+export const FINANCE_MOVEMENT_TYPES = Object.freeze(['income', 'expense', 'transfer']);
+// `status` is the immutable ledger lifecycle; `operationalStatus` is the
+// intentionally simpler state exposed by the operational UI.
+export const FINANCE_MOVEMENT_STATUSES = Object.freeze(['draft', 'posted', 'cancelled']);
+export const FINANCE_OPERATIONAL_STATUSES = Object.freeze(['pending', 'confirmed', 'reconciled', 'cancelled']);
+// Obligations are planning/AP-AR records. They never post a second journal:
+// settlement links the obligation to an already-confirmed operational movement.
+export const FINANCE_OBLIGATION_KINDS = Object.freeze(['payable', 'receivable']);
+export const FINANCE_OBLIGATION_STATUSES = Object.freeze(['open', 'partially_settled', 'settled', 'cancelled']);
+// Recurrence rules are planning templates. Materializing one creates AP/AR
+// titles; it never posts a cash movement or a journal entry by itself.
+export const FINANCE_RECURRENCE_FREQUENCIES = Object.freeze(['monthly']);
+// A pending draft is the only mutable operational record.  The client sends
+// its last observed revision so the API can reject a stale save atomically.
+export const FINANCE_DRAFT_REVISION_CONTRACT = Object.freeze({ method: 'PUT', path: '/movements/:id', requiredField: 'expectedRevision' });
+
+export function asTrimmedString(value, field, { required = true, max = 240 } = {}) {
+  const normalized = String(value ?? '').trim();
+  if (required && !normalized) throw new FinanceContractError('VALIDATION_ERROR', `${field} é obrigatório.`);
+  if (normalized.length > max) throw new FinanceContractError('VALIDATION_ERROR', `${field} excede ${max} caracteres.`);
+  return normalized;
+}
+
+export function asMinorAmount(value, field = 'amountMinor') {
+  const amount = Number(value);
+  if (!Number.isSafeInteger(amount) || amount <= 0) {
+    throw new FinanceContractError('VALIDATION_ERROR', `${field} deve ser um inteiro positivo em centavos.`);
+  }
+  return amount;
+}
+
+export function asNonNegativeMinorAmount(value, field = 'amountMinor') {
+  const amount = Number(value);
+  if (!Number.isSafeInteger(amount) || amount < 0) {
+    throw new FinanceContractError('VALIDATION_ERROR', `${field} deve ser um inteiro não negativo em minor units.`);
+  }
+  return amount;
+}
+
+export function asSignedMinorAmount(value, field = 'amountMinor') {
+  const amount = Number(value);
+  if (!Number.isSafeInteger(amount) || amount === 0) {
+    throw new FinanceContractError('VALIDATION_ERROR', `${field} deve ser um inteiro diferente de zero em minor units.`);
+  }
+  return amount;
+}
+
+export function asExchangeRatePpm(value, field = 'exchangeRatePpm') {
+  const rate = Number(value ?? 1_000_000);
+  if (!Number.isSafeInteger(rate) || rate <= 0) {
+    throw new FinanceContractError('VALIDATION_ERROR', `${field} deve ser um inteiro positivo em partes por milhão.`);
+  }
+  return rate;
+}
+
+export function asIsoDate(value, field) {
+  const date = asTrimmedString(value, field, { max: 10 });
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || Number.isNaN(Date.parse(`${date}T00:00:00Z`))) {
+    throw new FinanceContractError('VALIDATION_ERROR', `${field} deve usar YYYY-MM-DD.`);
+  }
+  return date;
+}
+
+export function asCurrency(value) {
+  const currency = asTrimmedString(value || 'BRL', 'currency', { max: 3 }).toUpperCase();
+  if (!/^[A-Z]{3}$/.test(currency)) throw new FinanceContractError('VALIDATION_ERROR', 'currency deve usar ISO-4217.');
+  return currency;
+}
+
+export class FinanceContractError extends Error {
+  constructor(code, message) { super(message); this.code = code; }
+}

--- a/packages/skincos-contracts/src/finance/moneywiz.js
+++ b/packages/skincos-contracts/src/finance/moneywiz.js
@@ -1,0 +1,26 @@
+import { FinanceContractError } from './index.js';
+import { analyseCsvImport, importNameKey } from './csv.js';
+
+// MoneyWiz has configurable CSV exports. This adapter only recognizes the
+// documented transaction/report vocabulary and returns a generic staging
+// contract; it never assigns a ledger account or posts a movement.
+const MONEYWIZ_HEADERS = Object.freeze({
+  date: ['date', 'data'], description: ['description', 'descrição', 'descricao'], amount: ['amount', 'valor'],
+  income: ['credits', 'credit', 'income', 'receitas', 'entrada'], expense: ['debits', 'debit', 'expenses', 'despesas', 'saída', 'saida'],
+  account: ['account', 'conta'], category: ['category', 'categoria'], payee: ['payee', 'favorecido'], tags: ['tags', 'tag'],
+  note: ['memo', 'note', 'observação', 'observacao'], status: ['status'], currency: ['currency', 'moeda'],
+  transferAccount: ['transfers', 'transfer', 'transfer account', 'conta destino'], externalId: ['transaction id', 'transaction_id', 'external id', 'id', 'check #'],
+});
+
+function mappingFor(headers) {
+  const keys = headers.map(importNameKey); const mapping = {};
+  for (const [field, names] of Object.entries(MONEYWIZ_HEADERS)) { const index = names.map(importNameKey).map((name) => keys.indexOf(name)).find((value) => value >= 0); if (index !== undefined && index >= 0) mapping[field] = headers[index]; }
+  return mapping;
+}
+
+export function prepareMoneyWizImport(content, encoding = 'utf-8') {
+  const probe = analyseCsvImport(content, {}, encoding); const mapping = mappingFor(probe.headers);
+  if (!mapping.date || !mapping.description || (!mapping.amount && !mapping.income && !mapping.expense)) throw new FinanceContractError('VALIDATION_ERROR', 'Exportação MoneyWiz requer Date, Description e Amount ou Credits/Debits.');
+  const analysis = analyseCsvImport(content, mapping, encoding);
+  return { sourceType: 'moneywiz', mapping: analysis.mapping, analysis: { delimiter: analysis.delimiter, encoding: analysis.encoding, hasHeader: analysis.hasHeader, headers: analysis.headers, dateFormat: analysis.dateFormat }, capabilities: { accounts: Boolean(mapping.account), categories: Boolean(mapping.category), payees: Boolean(mapping.payee), tags: Boolean(mapping.tags), notes: Boolean(mapping.note), status: Boolean(mapping.status), currencies: Boolean(mapping.currency), transfers: Boolean(mapping.transferAccount), externalIds: Boolean(mapping.externalId) } };
+}

--- a/packages/skincos-contracts/src/identity-contract.js
+++ b/packages/skincos-contracts/src/identity-contract.js
@@ -1,0 +1,91 @@
+export const IDENTITY_ACTOR_CONTRACT_VERSION = 'identity-actor/v1';
+
+// Unit scopes are closed: persisted and RBAC-facing values are only these slugs.
+export const CANONICAL_UNIT_SCOPES = Object.freeze(['novo-hamburgo', 'barra-shopping-sul']);
+const CANONICAL_UNIT_SCOPE_SET = new Set(CANONICAL_UNIT_SCOPES);
+
+function scopeItems(value) {
+  if (Array.isArray(value)) return value.map(String).map((item) => item.trim()).filter(Boolean);
+  if (typeof value !== 'string') return [];
+  const raw = value.trim();
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed.map(String).map((item) => item.trim()).filter(Boolean);
+  } catch {
+    // Legacy delimited rows remain readable until their explicit repair.
+  }
+  return raw.split(/[,;|]/g).map((item) => item.trim()).filter(Boolean);
+}
+
+export function normalizeUnitScope(value) {
+  const key = String(value || '')
+    .trim()
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '');
+  if (key === 'novohamburgo' || key === 'nh') return 'novo-hamburgo';
+  if (key === 'barrashoppingsul' || key === 'bss') return 'barra-shopping-sul';
+  return '';
+}
+
+export function normalizeAllowedUnits(value) {
+  const units = [];
+  for (const item of scopeItems(value)) {
+    const canonical = normalizeUnitScope(item);
+    if (canonical && !units.includes(canonical)) units.push(canonical);
+  }
+  return units;
+}
+
+export function unknownUnitScopes(value) {
+  return scopeItems(value).filter((item) => !normalizeUnitScope(item));
+}
+
+export function isCanonicalUnitScope(value) {
+  return CANONICAL_UNIT_SCOPE_SET.has(String(value || '').trim());
+}
+
+export function hasUnitScopeAccess({ role, allowedUnits }, requestedUnit) {
+  const unit = normalizeUnitScope(requestedUnit);
+  if (!unit) return false;
+  if (String(role || '').trim().toUpperCase() === 'ADMIN') return true;
+  return normalizeAllowedUnits(allowedUnits).includes(unit);
+}
+
+const asList = (value) => Array.isArray(value)
+  ? [...new Set(value.map(String).map((item) => item.trim()).filter(Boolean))]
+  : [];
+
+/**
+ * The only identity shape a product receives. Legacy aliases remain while
+ * callers move to scopes.units/scopes.modules without invalidating sessions.
+ */
+export function toAuthenticatedActor(user) {
+  if (!user?.username) return null;
+  const units = normalizeAllowedUnits(user.allowedUnits);
+  const modules = asList(user.allowedModules);
+  const permissions = asList(user.permissions);
+  return Object.freeze({
+    contractVersion: IDENTITY_ACTOR_CONTRACT_VERSION,
+    subject: String(user.username),
+    username: String(user.username),
+    displayName: String(user.displayName || user.name || user.username),
+    email: String(user.email || ''),
+    role: String(user.role || 'CONSULTOR').toUpperCase(),
+    scopes: Object.freeze({ units, modules, permissions }),
+    // Compatibility aliases. New consumers must use scopes.*.
+    allowedUnits: units,
+    allowedModules: modules,
+    permissions,
+  });
+}
+
+export function csrfErrorFor(request, csrf) {
+  if (!['POST', 'PUT', 'PATCH', 'DELETE'].includes(request.method.toUpperCase())) return null;
+  const received = String(request.headers.get('x-csrf-token') || '').trim();
+  return csrf && received === csrf
+    ? null
+    : new Response(JSON.stringify({ ok: false, error: 'CSRF_INVALID' }), { status: 403, headers: { 'content-type': 'application/json' } });
+}

--- a/packages/skincos-contracts/src/index.js
+++ b/packages/skincos-contracts/src/index.js
@@ -1,0 +1,7 @@
+export * from './identity-contract.js';
+export * from './finance/index.js';
+export * from './finance/csv.js';
+export * from './finance/moneywiz.js';
+export * from './finance/ef-caixa.js';
+export * from './module-availability.js';
+export * from './observability.js';

--- a/packages/skincos-contracts/src/module-availability.js
+++ b/packages/skincos-contracts/src/module-availability.js
@@ -1,0 +1,229 @@
+const CONTROL_KEY_PREFIX = 'module-control:';
+export const TIMEKEEPING_EMERGENCY_LATCH_KEY = 'module-control:timekeeping:emergency-latch';
+const VALID_STATES = new Set(['active', 'canary', 'maintenance', 'disabled']);
+const MAX_CANARY_ACTORS = 100;
+const MAX_CANARY_UNITS = 20;
+const MAX_CANARY_EMPLOYEES = 100;
+const MAX_CANARY_IDENTITIES = 100;
+const MAX_CANARY_NETWORK_CONTEXTS = 20;
+const VERSION_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const TIMEKEEPING_RUNTIME_TARGETS = new Set(['staging', 'production', 'local']);
+
+const list = (value, max) => Array.isArray(value)
+  ? Array.from(new Set(value.map(String).map((item) => item.trim()).filter(Boolean))).slice(0, max)
+  : [];
+const percentage = (value) => Number.isFinite(Number(value)) ? Math.max(0, Math.min(100, Math.floor(Number(value)))) : 0;
+const stateOr = (value, fallback) => VALID_STATES.has(String(value || '').trim().toLowerCase())
+  ? String(value).trim().toLowerCase()
+  : fallback;
+const versionId = (value) => VERSION_ID.test(String(value || '').trim()) ? String(value).trim().toLowerCase() : '';
+
+function normalize(value) {
+  const state = stateOr(value?.state, 'active');
+  return {
+    state,
+    message: String(value?.message || '').trim().slice(0, 240),
+    changedAt: String(value?.changedAt || '').trim(),
+    schemaVersion: Number.isSafeInteger(Number(value?.schemaVersion)) ? Number(value.schemaVersion) : 1,
+    rolloutStage: String(value?.rolloutStage || '').trim().toLowerCase(),
+    // Canary authorization is conjunctive. Older modules keep actor names;
+    // Timekeeping uses opaque employee and network references instead.
+    pilotActors: list(value?.pilotActors, MAX_CANARY_ACTORS),
+    pilotUnits: list(value?.pilotUnits, MAX_CANARY_UNITS),
+    pilotEmployeeRefs: list(value?.pilotEmployeeRefs, MAX_CANARY_EMPLOYEES),
+    pilotIdentityRefs: list(value?.pilotIdentityRefs, MAX_CANARY_IDENTITIES),
+    pilotIdentityLoginRefs: list(value?.pilotIdentityLoginRefs, MAX_CANARY_IDENTITIES),
+    pilotNetworkContexts: list(value?.pilotNetworkContexts, MAX_CANARY_NETWORK_CONTEXTS),
+    percentage: percentage(value?.percentage),
+    releaseSha: String(value?.releaseSha || '').trim().toLowerCase(),
+    versions: {
+      timekeeping: {
+        candidate: versionId(value?.versions?.timekeeping?.candidate),
+        incumbent: versionId(value?.versions?.timekeeping?.incumbent),
+      },
+      coreApi: {
+        candidate: versionId(value?.versions?.coreApi?.candidate),
+        incumbent: versionId(value?.versions?.coreApi?.incumbent),
+      },
+      identityWorkforce: {
+        candidate: versionId(value?.versions?.identityWorkforce?.candidate),
+        incumbent: versionId(value?.versions?.identityWorkforce?.incumbent),
+      },
+    },
+    expiresAt: String(value?.expiresAt || '').trim(),
+    syntheticOnly: value?.syntheticOnly === true,
+  };
+}
+
+function fallbackAvailability(state, source, message, extra = {}) {
+  return {
+    ...normalize({
+      state,
+      message: state === 'active' ? '' : message,
+      ...extra,
+    }),
+    source,
+  };
+}
+
+function validTimekeepingEmergencyLatch(value) {
+  return Boolean(
+    value
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    && value.schemaVersion === 1
+    && value.module === 'timekeeping'
+    && typeof value.latched === 'boolean'
+    && Number.isFinite(Date.parse(String(value.changedAt || '')))
+    && String(value.changedBy || '').trim(),
+  );
+}
+
+async function requireOpenTimekeepingEmergencyLatch(store, runtimeTarget) {
+  const expectedTarget = String(runtimeTarget || '').trim().toLowerCase();
+  if (!TIMEKEEPING_RUNTIME_TARGETS.has(expectedTarget)) {
+    return fallbackAvailability(
+      'maintenance',
+      'emergency-latch-runtime-target-invalid',
+      'Ambiente da parada de emergência inválido.',
+    );
+  }
+  let latch;
+  try {
+    latch = await store.get(TIMEKEEPING_EMERGENCY_LATCH_KEY, 'json');
+  } catch {
+    return fallbackAvailability(
+      'maintenance',
+      'emergency-latch-unavailable',
+      'Parada de emergência temporariamente indisponível.',
+    );
+  }
+  if (latch === null || latch === undefined) {
+    return fallbackAvailability(
+      'maintenance',
+      'emergency-latch-missing',
+      'Parada de emergência não configurada.',
+    );
+  }
+  if (!validTimekeepingEmergencyLatch(latch)) {
+    return fallbackAvailability(
+      'maintenance',
+      'emergency-latch-malformed',
+      'Parada de emergência inválida.',
+    );
+  }
+  const latchTarget = typeof latch.target === 'string'
+    ? latch.target.trim().toLowerCase()
+    : '';
+  if (!TIMEKEEPING_RUNTIME_TARGETS.has(latchTarget)) {
+    return fallbackAvailability(
+      'maintenance',
+      'emergency-latch-target-malformed',
+      'Destino da parada de emergência inválido.',
+    );
+  }
+  if (latchTarget !== expectedTarget) {
+    return fallbackAvailability(
+      'maintenance',
+      'emergency-latch-target-mismatch',
+      'Parada de emergência pertence a outro ambiente.',
+    );
+  }
+  if (latch.latched) {
+    return fallbackAvailability(
+      'maintenance',
+      'emergency-latch-active',
+      'Ponto interrompido por parada de emergência.',
+      { changedAt: latch.changedAt },
+    );
+  }
+  return null;
+}
+
+/**
+ * Runtime control is deliberately external to an artifact. A control change
+ * can put one module in maintenance or disable it without redeploying its
+ * Worker or the CRM shell. Modules that have not migrated to an explicit
+ * control preserve the historical active default. Sensitive modules opt into
+ * a fail-closed missing/malformed state through the options below.
+ */
+export async function readModuleAvailability(env, moduleId, {
+  missingState = 'active',
+  malformedState = 'active',
+  runtimeTarget = env?.ENVIRONMENT,
+} = {}) {
+  const safeMissingState = stateOr(missingState, 'active');
+  const safeMalformedState = stateOr(malformedState, 'maintenance');
+  const store = env?.MODULE_CONTROL;
+  if (!store || typeof store.get !== 'function') {
+    return fallbackAvailability(safeMissingState, 'binding-missing', 'Controle operacional não configurado.');
+  }
+  if (moduleId === 'timekeeping') {
+    const emergencyLatch = await requireOpenTimekeepingEmergencyLatch(store, runtimeTarget);
+    if (emergencyLatch) return emergencyLatch;
+  }
+  try {
+    const raw = await store.get(`${CONTROL_KEY_PREFIX}${moduleId}`, 'json');
+    if (raw === null || raw === undefined) {
+      return fallbackAvailability(safeMissingState, 'key-missing', 'Controle operacional não configurado.');
+    }
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw) || !VALID_STATES.has(String(raw.state || '').trim().toLowerCase())) {
+      return fallbackAvailability(safeMalformedState, 'malformed', 'Controle operacional inválido.');
+    }
+    return { ...normalize(raw), source: 'control' };
+  } catch {
+    return fallbackAvailability('maintenance', 'unavailable', 'Controle operacional temporariamente indisponível.');
+  }
+}
+
+export function publicModuleAvailability(availability) {
+  return {
+    state: stateOr(availability?.state, 'maintenance'),
+    message: String(availability?.message || '').trim().slice(0, 240),
+    changedAt: String(availability?.changedAt || '').trim(),
+    source: String(availability?.source || '').trim(),
+    schemaVersion: Number.isSafeInteger(Number(availability?.schemaVersion)) ? Number(availability.schemaVersion) : 1,
+    rolloutStage: String(availability?.rolloutStage || '').trim().toLowerCase(),
+    releaseSha: String(availability?.releaseSha || '').trim().toLowerCase(),
+    expiresAt: String(availability?.expiresAt || '').trim(),
+    syntheticOnly: availability?.syntheticOnly === true,
+  };
+}
+
+export function moduleUnavailableResponse(moduleId, availability, requestId, { publicOnly = false } = {}) {
+  const error = availability.state === 'disabled' ? 'MODULE_DISABLED' : 'MODULE_MAINTENANCE';
+  const visibleAvailability = publicOnly ? publicModuleAvailability(availability) : availability;
+  return new Response(JSON.stringify({ ok: false, error, module: moduleId, availability: visibleAvailability }), {
+    status: availability.state === 'disabled' ? 423 : 503,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'no-store',
+      'x-skincos-module-state': availability.state,
+      'x-request-id': requestId,
+    },
+  });
+}
+
+export function canaryBucket(actorId) {
+  // FNV-1a is stable across Worker isolates. It is a cohort selector, not a
+  // security primitive; authorization remains the explicit allow-list.
+  let hash = 0x811c9dc5;
+  for (const char of String(actorId || '')) { hash ^= char.codePointAt(0); hash = Math.imul(hash, 0x01000193); }
+  return (hash >>> 0) % 10_000;
+}
+
+export function canUseCanary(availability, actor) {
+  if (availability.state !== 'canary') return true;
+  const username = String(actor?.username || '').trim();
+  const units = Array.isArray(actor?.allowedUnits) ? actor.allowedUnits.map(String).map((unit) => unit.trim()) : [];
+  if (!username || !availability.pilotActors.includes(username)) return false;
+  if (!availability.pilotUnits.length || !availability.pilotUnits.some((unit) => units.includes(unit))) return false;
+  if (!availability.percentage) return false;
+  return canaryBucket(username) < availability.percentage * 100;
+}
+
+export function moduleHealthResponse(moduleId, availability, requestId) {
+  return new Response(JSON.stringify({ ok: true, module: moduleId, availability }), {
+    headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', 'x-skincos-module-state': availability.state, 'x-request-id': requestId },
+  });
+}

--- a/packages/skincos-contracts/src/observability.js
+++ b/packages/skincos-contracts/src/observability.js
@@ -1,0 +1,18 @@
+export const OBSERVABILITY_CONTRACT_VERSION = 'skincos-observability/v1';
+
+export function dependencyState(available, { required = true, reason = '' } = {}) {
+  return { state: available ? 'healthy' : required ? 'unavailable' : 'degraded', required, ...(reason ? { reason } : {}) };
+}
+
+export function operationalStatus({ unit, version, environment, ready, dependencies, requestId }) {
+  return {
+    ok: Boolean(ready), contractVersion: OBSERVABILITY_CONTRACT_VERSION, unit,
+    version: String(version || 'unknown'), environment: String(environment || 'unknown'), ready: Boolean(ready),
+    dependencies: dependencies || {}, request_id: String(requestId || ''),
+  };
+}
+
+/** Metadata only: callers must never include actors, query strings, payloads or secrets. */
+export function operationalLog({ domain, version, environment, requestId, durationMs, status, route }) {
+  return JSON.stringify({ domain, version: String(version || 'unknown'), environment: String(environment || 'unknown'), request_id: String(requestId || ''), duration_ms: Math.max(0, Number(durationMs || 0)), status: Number(status || 0), route: String(route || '/').split('?')[0] });
+}

--- a/packages/skincos-contracts/test/public-exports.test.mjs
+++ b/packages/skincos-contracts/test/public-exports.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import * as contracts from '../src/index.js';
+
+test('aggregate public API exposes the portable contracts', () => {
+  assert.equal(contracts.IDENTITY_ACTOR_CONTRACT_VERSION, 'identity-actor/v1');
+  assert.equal(contracts.FINANCE_CONTRACT_VERSION, 'finance/v1');
+  assert.equal(contracts.OBSERVABILITY_CONTRACT_VERSION, 'skincos-observability/v1');
+  assert.equal(typeof contracts.normalizeAllowedUnits, 'function');
+  assert.equal(typeof contracts.prepareMoneyWizImport, 'function');
+  assert.equal(typeof contracts.readModuleAvailability, 'function');
+});
+
+test('identity and finance contracts retain their dependency-free behavior', () => {
+  assert.deepEqual(
+    contracts.normalizeAllowedUnits(['NH', 'barra shopping sul', 'unknown']),
+    ['novo-hamburgo', 'barra-shopping-sul'],
+  );
+  assert.equal(contracts.asMinorAmount(1_250), 1_250);
+  assert.equal(contracts.canaryBucket('contract-test'), contracts.canaryBucket('contract-test'));
+});
+
+test('every declared contract entrypoint resolves from the package source', async () => {
+  const entries = [
+    '../src/identity-contract.js',
+    '../src/finance/index.js',
+    '../src/finance/csv.js',
+    '../src/finance/moneywiz.js',
+    '../src/finance/ef-caixa.js',
+    '../src/module-availability.js',
+    '../src/observability.js',
+  ];
+
+  for (const entry of entries) {
+    const imported = await import(entry);
+    assert.ok(Object.keys(imported).length > 0, 'entrypoint must export a contract');
+  }
+});

--- a/packages/skincos-delivery-contract/README.md
+++ b/packages/skincos-delivery-contract/README.md
@@ -1,0 +1,26 @@
+# SKINCOS Delivery Contract
+
+Private, portable release-identity contract for independent SKINCOS repositories.
+
+It provides deterministic canonical JSON plus promotion-evidence schema-v4
+helpers. The embedded release identity uses its own schema version 2 and binds
+a candidate to its source repository, commit/ref/tree, contract-manifest and
+dependency-closure digests, contract package versions, and released artifact
+digests.
+
+Evidence and predecessor repository, run and artifact metadata remain outside
+the release identity. The evidence artifact is created after the evidence file
+is written, so including its later identifier or digest in the identity would
+be circular.
+
+The contract is intentionally runtime-neutral: it has no GitHub CLI, filesystem,
+workflow, repository checkout or deployment dependency. A promotion gate can
+depend on this package instead of copying the identity algorithm.
+
+Publishing is intentionally separate from this bootstrap. Before a consumer
+depends on a released version, GitHub Packages visibility must remain restricted
+and the release plane must bind the package version to its artifact digest.
+
+No repository metadata is present intentionally. Publish only from the private
+owning repository; do not associate this package with the public SKINCOS
+monorepo.

--- a/packages/skincos-delivery-contract/package.json
+++ b/packages/skincos-delivery-contract/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@jubenitogarcia/skincos-delivery-contract",
+  "version": "1.0.0",
+  "description": "Portable SKINCOS multi-repository release identity contract.",
+  "license": "UNLICENSED",
+  "type": "module",
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  }
+}

--- a/packages/skincos-delivery-contract/src/index.js
+++ b/packages/skincos-delivery-contract/src/index.js
@@ -40,6 +40,12 @@ function normalizeTimestamp(value, label) {
   return normalized;
 }
 
+function normalizeRunId(value, label) {
+  const normalized = requiredText(value, label, { max: 128 });
+  if (!/^[0-9]+$/.test(normalized)) throw new TypeError(label + ' must be a numeric GitHub Actions run id');
+  return normalized;
+}
+
 function normalizeArtifactDigest(value, label) {
   const normalized = requiredText(value, label, { max: 1024 });
   if (SHA256.test(normalized)) return normalized.toLowerCase();
@@ -50,11 +56,7 @@ function normalizeArtifactDigest(value, label) {
 }
 
 function normalizePackageIntegrity(value, label) {
-  const normalized = requiredText(value, label, { max: 1024 });
-  const integrity = normalized.match(SHA256_INTEGRITY);
-  if (integrity) return 'sha256:' + integrity[1].toLowerCase();
-  if (SRI.test(normalized)) return normalized;
-  throw new TypeError(label + ' must be sha256:<hex> or an SRI integrity value');
+  return normalizeArtifactDigest(value, label);
 }
 
 function freezeArray(entries) {
@@ -103,7 +105,7 @@ function normalizeEvidenceProvenance(value) {
   if (!isPlainObject(value)) throw new TypeError('promotion evidence input must be an object');
   return Object.freeze({
     evidenceRepository: normalizeRepository(value.evidenceRepository, 'evidenceRepository'),
-    evidenceRunId: requiredText(value.evidenceRunId, 'evidenceRunId', { max: 128 }),
+    evidenceRunId: normalizeRunId(value.evidenceRunId, 'evidenceRunId'),
     evidenceArtifact: requiredText(value.evidenceArtifact, 'evidenceArtifact'),
   });
 }
@@ -116,7 +118,7 @@ function normalizeOptionalPredecessor(value) {
   if (supplied.length !== 3) throw new TypeError('predecessor provenance must include repository, run id and artifact together');
   return Object.freeze({
     predecessorRepository: normalizeRepository(value.predecessorRepository, 'predecessorRepository'),
-    predecessorRunId: requiredText(value.predecessorRunId, 'predecessorRunId', { max: 128 }),
+    predecessorRunId: normalizeRunId(value.predecessorRunId, 'predecessorRunId'),
     predecessorArtifact: requiredText(value.predecessorArtifact, 'predecessorArtifact'),
   });
 }
@@ -228,6 +230,12 @@ export async function createPromotionEvidenceV4(value) {
   const predecessor = normalizeOptionalPredecessor(value);
   const target = normalizeTarget(value.target);
   const createdAt = normalizeTimestamp(value.createdAt, 'createdAt');
+  if (!releaseIdentity.artifacts.length) {
+    throw new TypeError('schema v4 promotion evidence requires at least one immutable artifact identity');
+  }
+  if (target !== 'preview' && !predecessor) {
+    throw new TypeError('schema v4 promotion evidence after preview requires predecessor provenance');
+  }
   return Object.freeze({
     schemaVersion: PROMOTION_EVIDENCE_SCHEMA_VERSION,
     unit: releaseIdentity.module,
@@ -246,7 +254,7 @@ export async function createPromotionEvidenceV4(value) {
     ...(predecessor || {}),
     releaseIdentity,
     releaseIdentityDigest: releaseIdentity.releaseIdentityDigest,
-    promotionStrategy: releaseIdentity.artifacts.length ? 'exact-artifacts' : 'immutable-source-identity',
+    promotionStrategy: 'exact-artifacts',
     createdAt,
   });
 }
@@ -259,6 +267,13 @@ export async function verifyPromotionEvidenceV4(value, expected = {}) {
   const identity = await assertReleaseIdentityV4(value.releaseIdentity);
   const provenance = normalizeEvidenceProvenance(value);
   const predecessor = normalizeOptionalPredecessor(value);
+  const target = normalizeTarget(value.target);
+  if (!identity.artifacts.length) {
+    throw new TypeError('schema v4 promotion evidence requires at least one immutable artifact identity');
+  }
+  if (target !== 'preview' && !predecessor) {
+    throw new TypeError('schema v4 promotion evidence after preview requires predecessor provenance');
+  }
   const valid = value.unit === identity.module
     && value.sourceRepository === identity.sourceRepository
     && value.sourceSha === identity.sourceCommit
@@ -275,7 +290,7 @@ export async function verifyPromotionEvidenceV4(value, expected = {}) {
     && value.evidenceRunId === provenance.evidenceRunId
     && value.evidenceArtifact === provenance.evidenceArtifact;
   if (!valid) throw new Error('promotion evidence does not match its release identity');
-  if (normalizedExpected.target && value.target !== normalizeTarget(normalizedExpected.target)) {
+  if (normalizedExpected.target && target !== normalizeTarget(normalizedExpected.target)) {
     throw new Error('promotion evidence target differs from the expected target');
   }
   if (normalizedExpected.sourceRepository && identity.sourceRepository !== normalizeRepository(normalizedExpected.sourceRepository, 'expected.sourceRepository')) {

--- a/packages/skincos-delivery-contract/src/index.js
+++ b/packages/skincos-delivery-contract/src/index.js
@@ -1,0 +1,291 @@
+export const PROMOTION_EVIDENCE_SCHEMA_VERSION = 4;
+export const RELEASE_IDENTITY_SCHEMA_VERSION = 2;
+
+const SHA1 = /^[0-9a-f]{40}$/i;
+const SHA256 = /^[0-9a-f]{64}$/i;
+const SHA256_INTEGRITY = /^sha256:([0-9a-f]{64})$/i;
+const SRI = /^sha(?:256|384|512)-[A-Za-z0-9+/]+={0,2}$/;
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const MODULE = /^[a-z0-9][a-z0-9._-]{0,127}$/;
+const CONTROL = /[\u0000-\u001f\u007f]/;
+
+function isPlainObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function requiredText(value, label, { pattern = null, max = 240 } = {}) {
+  const normalized = String(value ?? '').trim();
+  if (!normalized || normalized.length > max || CONTROL.test(normalized)) {
+    throw new TypeError(label + ' must be a non-empty safe string');
+  }
+  if (pattern && !pattern.test(normalized)) {
+    throw new TypeError(label + ' has an invalid format');
+  }
+  return normalized;
+}
+
+function normalizeRepository(value, label) {
+  return requiredText(value, label, { pattern: REPOSITORY, max: 256 }).toLowerCase();
+}
+
+function normalizeSha(value, label, pattern) {
+  return requiredText(value, label, { pattern, max: pattern === SHA1 ? 40 : 64 }).toLowerCase();
+}
+
+function normalizeTimestamp(value, label) {
+  const normalized = requiredText(value, label, { max: 64 });
+  if (!Number.isFinite(Date.parse(normalized))) throw new TypeError(label + ' must be an ISO timestamp');
+  return normalized;
+}
+
+function normalizeArtifactDigest(value, label) {
+  const normalized = requiredText(value, label, { max: 1024 });
+  if (SHA256.test(normalized)) return normalized.toLowerCase();
+  const integrity = normalized.match(SHA256_INTEGRITY);
+  if (integrity) return 'sha256:' + integrity[1].toLowerCase();
+  if (SRI.test(normalized)) return normalized;
+  throw new TypeError(label + ' must be a SHA-256 digest or SRI integrity value');
+}
+
+function normalizePackageIntegrity(value, label) {
+  const normalized = requiredText(value, label, { max: 1024 });
+  const integrity = normalized.match(SHA256_INTEGRITY);
+  if (integrity) return 'sha256:' + integrity[1].toLowerCase();
+  if (SRI.test(normalized)) return normalized;
+  throw new TypeError(label + ' must be sha256:<hex> or an SRI integrity value');
+}
+
+function freezeArray(entries) {
+  return Object.freeze(entries.map((entry) => Object.freeze(entry)));
+}
+
+function normalizeArtifacts(value) {
+  if (!Array.isArray(value)) throw new TypeError('artifacts must be an array');
+  const artifacts = value.map((item, index) => {
+    if (!isPlainObject(item)) throw new TypeError('artifacts[' + index + '] must be an object');
+    return {
+      id: requiredText(item.id, 'artifacts[' + index + '].id'),
+      digest: normalizeArtifactDigest(item.digest, 'artifacts[' + index + '].digest'),
+      fileDigest: normalizeArtifactDigest(item.fileDigest, 'artifacts[' + index + '].fileDigest'),
+    };
+  });
+  artifacts.sort((left, right) => left.id.localeCompare(right.id) || left.digest.localeCompare(right.digest));
+  for (let index = 1; index < artifacts.length; index += 1) {
+    if (artifacts[index - 1].id === artifacts[index].id) {
+      throw new TypeError('artifacts must not contain duplicate ids');
+    }
+  }
+  return freezeArray(artifacts);
+}
+
+function normalizeContractVersions(value) {
+  if (!Array.isArray(value)) throw new TypeError('contractVersions must be an array');
+  const packages = value.map((item, index) => {
+    if (!isPlainObject(item)) throw new TypeError('contractVersions[' + index + '] must be an object');
+    return {
+      name: requiredText(item.name, 'contractVersions[' + index + '].name'),
+      version: requiredText(item.version, 'contractVersions[' + index + '].version'),
+      integrity: normalizePackageIntegrity(item.integrity, 'contractVersions[' + index + '].integrity'),
+    };
+  });
+  packages.sort((left, right) => left.name.localeCompare(right.name) || left.version.localeCompare(right.version));
+  for (let index = 1; index < packages.length; index += 1) {
+    if (packages[index - 1].name === packages[index].name) {
+      throw new TypeError('contractVersions must not contain duplicate names');
+    }
+  }
+  return freezeArray(packages);
+}
+
+function normalizeEvidenceProvenance(value) {
+  if (!isPlainObject(value)) throw new TypeError('promotion evidence input must be an object');
+  return Object.freeze({
+    evidenceRepository: normalizeRepository(value.evidenceRepository, 'evidenceRepository'),
+    evidenceRunId: requiredText(value.evidenceRunId, 'evidenceRunId', { max: 128 }),
+    evidenceArtifact: requiredText(value.evidenceArtifact, 'evidenceArtifact'),
+  });
+}
+
+function normalizeOptionalPredecessor(value) {
+  if (!isPlainObject(value)) throw new TypeError('promotion evidence input must be an object');
+  const supplied = [value.predecessorRepository, value.predecessorRunId, value.predecessorArtifact]
+    .filter((entry) => entry !== undefined && entry !== null && String(entry).trim() !== '');
+  if (!supplied.length) return null;
+  if (supplied.length !== 3) throw new TypeError('predecessor provenance must include repository, run id and artifact together');
+  return Object.freeze({
+    predecessorRepository: normalizeRepository(value.predecessorRepository, 'predecessorRepository'),
+    predecessorRunId: requiredText(value.predecessorRunId, 'predecessorRunId', { max: 128 }),
+    predecessorArtifact: requiredText(value.predecessorArtifact, 'predecessorArtifact'),
+  });
+}
+
+function normalizeTarget(value) {
+  return requiredText(value, 'target', { max: 128 });
+}
+
+function normalizeExpected(value) {
+  if (value === undefined || value === null) return {};
+  if (!isPlainObject(value)) throw new TypeError('expected identity must be an object');
+  return value;
+}
+
+function requireWebCrypto() {
+  if (!globalThis.crypto?.subtle) {
+    throw new Error('Web Crypto SubtleCrypto is required to calculate release identity digests');
+  }
+  return globalThis.crypto.subtle;
+}
+
+function hex(bytes) {
+  return Array.from(new Uint8Array(bytes), (item) => item.toString(16).padStart(2, '0')).join('');
+}
+
+function canonicalize(value) {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new TypeError('canonical JSON does not support non-finite numbers');
+    return value;
+  }
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (!isPlainObject(value)) throw new TypeError('canonical JSON supports only plain JSON values');
+  return Object.fromEntries(Object.keys(value).sort().map((key) => [key, canonicalize(value[key])]));
+}
+
+export function canonicalJson(value) {
+  return JSON.stringify(canonicalize(value));
+}
+
+export async function sha256Hex(value) {
+  const bytes = new TextEncoder().encode(typeof value === 'string' ? value : canonicalJson(value));
+  return hex(await requireWebCrypto().digest('SHA-256', bytes));
+}
+
+/**
+ * Builds the identity carried by promotion-evidence schema v4. Its own schema
+ * is versioned separately because a release identity is reusable outside one
+ * concrete workflow implementation.
+ *
+ * Evidence-artifact and predecessor provenance deliberately remain outside the
+ * identity. Their identifiers are only available after an evidence artifact is
+ * written or downloaded, so placing them in the digest would be circular.
+ */
+export function createReleaseIdentityV4(value) {
+  if (!isPlainObject(value)) throw new TypeError('release identity must be an object');
+  return Object.freeze({
+    schemaVersion: RELEASE_IDENTITY_SCHEMA_VERSION,
+    module: requiredText(value.module, 'module', { pattern: MODULE, max: 128 }),
+    sourceRepository: normalizeRepository(value.sourceRepository, 'sourceRepository'),
+    sourceCommit: normalizeSha(value.sourceCommit, 'sourceCommit', SHA1),
+    sourceTree: normalizeSha(value.sourceTree, 'sourceTree', SHA1),
+    sourceRef: requiredText(value.sourceRef, 'sourceRef', { max: 512 }),
+    deliveryContractVersion: requiredText(value.deliveryContractVersion, 'deliveryContractVersion', { max: 128 }),
+    contractManifestDigest: normalizeSha(value.contractManifestDigest, 'contractManifestDigest', SHA256),
+    dependencyClosureDigest: normalizeSha(value.dependencyClosureDigest, 'dependencyClosureDigest', SHA256),
+    contractVersions: normalizeContractVersions(value.contractVersions ?? []),
+    artifacts: normalizeArtifacts(value.artifacts ?? []),
+  });
+}
+
+export async function releaseIdentityDigestV4(value) {
+  return sha256Hex(canonicalJson(createReleaseIdentityV4(value)));
+}
+
+export async function createReleaseIdentityV4WithDigest(value) {
+  const identity = createReleaseIdentityV4(value);
+  return Object.freeze({
+    ...identity,
+    releaseIdentityDigest: await releaseIdentityDigestV4(identity),
+  });
+}
+
+export async function verifyReleaseIdentityV4(value) {
+  if (!isPlainObject(value) || value.schemaVersion !== RELEASE_IDENTITY_SCHEMA_VERSION) {
+    throw new TypeError('release identity must use schema version ' + RELEASE_IDENTITY_SCHEMA_VERSION);
+  }
+  const identity = createReleaseIdentityV4(value);
+  const providedDigest = normalizeSha(value.releaseIdentityDigest, 'releaseIdentityDigest', SHA256);
+  const calculatedDigest = await releaseIdentityDigestV4(identity);
+  return Object.freeze({
+    identity,
+    providedDigest,
+    calculatedDigest,
+    valid: providedDigest === calculatedDigest,
+  });
+}
+
+export async function assertReleaseIdentityV4(value) {
+  const verification = await verifyReleaseIdentityV4(value);
+  if (!verification.valid) throw new Error('release identity digest is invalid');
+  return verification.identity;
+}
+
+export async function createPromotionEvidenceV4(value) {
+  if (!isPlainObject(value)) throw new TypeError('promotion evidence input must be an object');
+  const releaseIdentity = await createReleaseIdentityV4WithDigest(value.releaseIdentity);
+  const provenance = normalizeEvidenceProvenance(value);
+  const predecessor = normalizeOptionalPredecessor(value);
+  const target = normalizeTarget(value.target);
+  const createdAt = normalizeTimestamp(value.createdAt, 'createdAt');
+  return Object.freeze({
+    schemaVersion: PROMOTION_EVIDENCE_SCHEMA_VERSION,
+    unit: releaseIdentity.module,
+    target,
+    sourceRepository: releaseIdentity.sourceRepository,
+    sourceSha: releaseIdentity.sourceCommit,
+    sourceTree: releaseIdentity.sourceTree,
+    sourceRef: releaseIdentity.sourceRef,
+    deliveryContractVersion: releaseIdentity.deliveryContractVersion,
+    releaseInputDigest: releaseIdentity.dependencyClosureDigest,
+    dependencyClosureDigest: releaseIdentity.dependencyClosureDigest,
+    contractManifestDigest: releaseIdentity.contractManifestDigest,
+    contractVersions: releaseIdentity.contractVersions,
+    artifacts: releaseIdentity.artifacts,
+    ...provenance,
+    ...(predecessor || {}),
+    releaseIdentity,
+    releaseIdentityDigest: releaseIdentity.releaseIdentityDigest,
+    promotionStrategy: releaseIdentity.artifacts.length ? 'exact-artifacts' : 'immutable-source-identity',
+    createdAt,
+  });
+}
+
+export async function verifyPromotionEvidenceV4(value, expected = {}) {
+  if (!isPlainObject(value) || value.schemaVersion !== PROMOTION_EVIDENCE_SCHEMA_VERSION) {
+    throw new TypeError('promotion evidence must use schema version ' + PROMOTION_EVIDENCE_SCHEMA_VERSION);
+  }
+  const normalizedExpected = normalizeExpected(expected);
+  const identity = await assertReleaseIdentityV4(value.releaseIdentity);
+  const provenance = normalizeEvidenceProvenance(value);
+  const predecessor = normalizeOptionalPredecessor(value);
+  const valid = value.unit === identity.module
+    && value.sourceRepository === identity.sourceRepository
+    && value.sourceSha === identity.sourceCommit
+    && value.sourceTree === identity.sourceTree
+    && value.sourceRef === identity.sourceRef
+    && value.deliveryContractVersion === identity.deliveryContractVersion
+    && value.releaseInputDigest === identity.dependencyClosureDigest
+    && value.dependencyClosureDigest === identity.dependencyClosureDigest
+    && value.contractManifestDigest === identity.contractManifestDigest
+    && canonicalJson(value.contractVersions) === canonicalJson(identity.contractVersions)
+    && canonicalJson(value.artifacts) === canonicalJson(identity.artifacts)
+    && value.releaseIdentityDigest === await releaseIdentityDigestV4(identity)
+    && value.evidenceRepository === provenance.evidenceRepository
+    && value.evidenceRunId === provenance.evidenceRunId
+    && value.evidenceArtifact === provenance.evidenceArtifact;
+  if (!valid) throw new Error('promotion evidence does not match its release identity');
+  if (normalizedExpected.target && value.target !== normalizeTarget(normalizedExpected.target)) {
+    throw new Error('promotion evidence target differs from the expected target');
+  }
+  if (normalizedExpected.sourceRepository && identity.sourceRepository !== normalizeRepository(normalizedExpected.sourceRepository, 'expected.sourceRepository')) {
+    throw new Error('promotion evidence source repository differs from the expected repository');
+  }
+  if (normalizedExpected.sourceCommit && identity.sourceCommit !== normalizeSha(normalizedExpected.sourceCommit, 'expected.sourceCommit', SHA1)) {
+    throw new Error('promotion evidence source commit differs from the expected commit');
+  }
+  if (normalizedExpected.releaseIdentityDigest && value.releaseIdentityDigest !== normalizeSha(normalizedExpected.releaseIdentityDigest, 'expected.releaseIdentityDigest', SHA256)) {
+    throw new Error('promotion evidence release identity differs from the expected identity');
+  }
+  return Object.freeze({ evidence: value, identity, provenance, predecessor });
+}

--- a/packages/skincos-delivery-contract/test/release-identity-v4.test.mjs
+++ b/packages/skincos-delivery-contract/test/release-identity-v4.test.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  canonicalJson,
+  createPromotionEvidenceV4,
+  createReleaseIdentityV4WithDigest,
+  verifyPromotionEvidenceV4,
+  verifyReleaseIdentityV4,
+} from '../src/index.js';
+
+const sha1 = 'a'.repeat(40);
+const tree = 'b'.repeat(40);
+const sha256 = (character) => character.repeat(64);
+
+function releaseInput() {
+  return {
+    module: 'meta-ads-report',
+    sourceRepository: 'JubenitoGarcia/Skincos-Meta-Ads-Reporting',
+    sourceCommit: sha1,
+    sourceTree: tree,
+    sourceRef: 'refs/heads/main',
+    deliveryContractVersion: '1.0.0',
+    contractManifestDigest: sha256('c'),
+    dependencyClosureDigest: sha256('d'),
+    contractVersions: [
+      { name: '@jubenitogarcia/skincos-edge-adapters', version: '1.0.0', integrity: 'sha256:' + sha256('e') },
+      { name: '@jubenitogarcia/skincos-contracts', version: '1.0.0', integrity: 'sha512-ZmFrZS1wYWNrYWdlLWludGVncml0eQ==' },
+    ],
+    artifacts: [
+      { id: 'worker.tgz', digest: sha256('f'), fileDigest: sha256('1') },
+    ],
+  };
+}
+
+test('canonical JSON preserves values while sorting object keys', () => {
+  assert.equal(
+    canonicalJson({ z: [{ b: 2, a: 1 }], a: true }),
+    '{"a":true,"z":[{"a":1,"b":2}]}',
+  );
+});
+
+test('release identity v4 is repository-aware and excludes later evidence artifacts', async () => {
+  const identity = await createReleaseIdentityV4WithDigest(releaseInput());
+  assert.equal(identity.schemaVersion, 2);
+  assert.equal(identity.sourceRepository, 'jubenitogarcia/skincos-meta-ads-reporting');
+  assert.equal(identity.artifacts[0].fileDigest, sha256('1'));
+  assert.equal(Object.hasOwn(identity, 'evidenceArtifact'), false);
+  assert.match(identity.releaseIdentityDigest, /^[0-9a-f]{64}$/);
+  assert.equal((await verifyReleaseIdentityV4(identity)).valid, true);
+
+  const tampered = { ...identity, sourceRepository: 'jubenitogarcia/other-repository' };
+  assert.equal((await verifyReleaseIdentityV4(tampered)).valid, false);
+});
+
+test('promotion evidence v4 keeps evidence and predecessor provenance outside the identity', async () => {
+  const evidence = await createPromotionEvidenceV4({
+    target: 'staging',
+    createdAt: '2026-08-28T14:23:04.000Z',
+    evidenceRepository: 'JubenitoGarcia/Skincos-Release-Evidence',
+    evidenceRunId: '33179818924',
+    evidenceArtifact: 'promotion-evidence.json',
+    predecessorRepository: 'JubenitoGarcia/Skincos-Release-Evidence',
+    predecessorRunId: '33179681322',
+    predecessorArtifact: 'predecessor-evidence.json',
+    releaseIdentity: releaseInput(),
+  });
+  assert.equal(evidence.schemaVersion, 4);
+  assert.equal(evidence.evidenceRepository, 'jubenitogarcia/skincos-release-evidence');
+  assert.equal(evidence.predecessorRunId, '33179681322');
+  assert.equal(Object.hasOwn(evidence.releaseIdentity, 'evidenceArtifact'), false);
+  const verified = await verifyPromotionEvidenceV4(evidence, {
+    target: 'staging',
+    sourceRepository: 'jubenitogarcia/skincos-meta-ads-reporting',
+    sourceCommit: sha1,
+    releaseIdentityDigest: evidence.releaseIdentityDigest,
+  });
+  assert.equal(verified.identity.module, 'meta-ads-report');
+});

--- a/packages/skincos-delivery-contract/test/release-identity-v4.test.mjs
+++ b/packages/skincos-delivery-contract/test/release-identity-v4.test.mjs
@@ -24,7 +24,7 @@ function releaseInput() {
     contractManifestDigest: sha256('c'),
     dependencyClosureDigest: sha256('d'),
     contractVersions: [
-      { name: '@jubenitogarcia/skincos-edge-adapters', version: '1.0.0', integrity: 'sha256:' + sha256('e') },
+      { name: '@jubenitogarcia/skincos-edge-adapters', version: '1.0.0', integrity: sha256('e') },
       { name: '@jubenitogarcia/skincos-contracts', version: '1.0.0', integrity: 'sha512-ZmFrZS1wYWNrYWdlLWludGVncml0eQ==' },
     ],
     artifacts: [
@@ -76,4 +76,44 @@ test('promotion evidence v4 keeps evidence and predecessor provenance outside th
     releaseIdentityDigest: evidence.releaseIdentityDigest,
   });
   assert.equal(verified.identity.module, 'meta-ads-report');
+});
+
+test('promotion evidence v4 requires exact artifacts and a post-preview predecessor', async () => {
+  const withoutArtifacts = releaseInput();
+  withoutArtifacts.artifacts = [];
+  await assert.rejects(
+    createPromotionEvidenceV4({
+      target: 'preview',
+      createdAt: '2026-08-28T14:23:04.000Z',
+      evidenceRepository: 'JubenitoGarcia/Skincos-Release-Evidence',
+      evidenceRunId: '33179818924',
+      evidenceArtifact: 'promotion-evidence.json',
+      releaseIdentity: withoutArtifacts,
+    }),
+    /requires at least one immutable artifact identity/,
+  );
+
+  await assert.rejects(
+    createPromotionEvidenceV4({
+      target: 'staging',
+      createdAt: '2026-08-28T14:23:04.000Z',
+      evidenceRepository: 'JubenitoGarcia/Skincos-Release-Evidence',
+      evidenceRunId: '33179818924',
+      evidenceArtifact: 'promotion-evidence.json',
+      releaseIdentity: releaseInput(),
+    }),
+    /after preview requires predecessor provenance/,
+  );
+
+  await assert.rejects(
+    createPromotionEvidenceV4({
+      target: 'preview',
+      createdAt: '2026-08-28T14:23:04.000Z',
+      evidenceRepository: 'JubenitoGarcia/Skincos-Release-Evidence',
+      evidenceRunId: 'not-a-run-id',
+      evidenceArtifact: 'promotion-evidence.json',
+      releaseIdentity: releaseInput(),
+    }),
+    /must be a numeric GitHub Actions run id/,
+  );
 });

--- a/packages/skincos-edge-adapters/README.md
+++ b/packages/skincos-edge-adapters/README.md
@@ -1,0 +1,21 @@
+# SKINCOS Edge Adapters
+
+Private, versioned adapter package for cross-repository Worker integrations.
+
+The package contains the portable service-binding, signed domain-context and
+resilience contracts. It deliberately excludes Worker configuration, routes,
+bindings, migrations, credentials and product-owned runtime behavior.
+
+Current public entrypoints:
+
+- @jubenitogarcia/skincos-edge-adapters/cloudflare-service-binding
+- @jubenitogarcia/skincos-edge-adapters/signed-domain-context
+- @jubenitogarcia/skincos-edge-adapters/resilience
+
+Publishing is intentionally separate from this bootstrap. The release plane
+must bind a published version to its source repository, commit and artifact
+digest, and GitHub Packages visibility must remain restricted.
+
+No repository metadata is present intentionally. Publish only from the private
+owning repository; do not associate this package with the public SKINCOS
+monorepo.

--- a/packages/skincos-edge-adapters/package.json
+++ b/packages/skincos-edge-adapters/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@jubenitogarcia/skincos-edge-adapters",
+  "version": "1.0.0",
+  "description": "Versioned portable SKINCOS edge service adapters.",
+  "license": "UNLICENSED",
+  "type": "module",
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./cloudflare-service-binding": "./src/cloudflare-service-binding.js",
+    "./signed-domain-context": "./src/signed-domain-context.js",
+    "./resilience": "./src/resilience.js",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  }
+}

--- a/packages/skincos-edge-adapters/src/cloudflare-service-binding.js
+++ b/packages/skincos-edge-adapters/src/cloudflare-service-binding.js
@@ -1,0 +1,30 @@
+import { callOptionalDependency, createDependencyState } from './resilience.js';
+
+const serviceDependencyState = createDependencyState();
+const safeResponseCache = new Map();
+
+function degradedResponse(bindingName, mode) {
+  return new Response(JSON.stringify({ ok: false, error: 'domain_service_degraded', dependency: bindingName, mode, pendingSynchronization: true }), { status: 503, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', 'x-skincos-dependency-status': mode, 'x-skincos-sync-state': 'pending' } });
+}
+
+export async function fetchBoundService(request, env, bindingName, {
+  timeoutMs = 800,
+  failureThreshold = 2,
+  cooldownMs = 15_000,
+  cacheTtlMs = 0,
+  passThroughErrorStatuses = [],
+} = {}) {
+  const binding = env?.[bindingName]; if (!binding || typeof binding.fetch !== 'function') return degradedResponse(bindingName, 'unavailable');
+  const passThroughStatuses = new Set(
+    Array.isArray(passThroughErrorStatuses)
+      ? passThroughErrorStatuses.filter((status) => Number.isInteger(status) && status >= 400 && status <= 599)
+      : [],
+  );
+  const cacheKey = request.method === 'GET' && cacheTtlMs > 0 ? `${bindingName}:${request.url}` : null;
+  const result = await callOptionalDependency({ dependency: bindingName, state: serviceDependencyState, cache: safeResponseCache, cacheKey, cacheTtlMs, timeoutMs, failureThreshold, cooldownMs, invoke: async (signal) => { const response = await binding.fetch(new Request(request, { signal })); if (response.status >= 500 && !passThroughStatuses.has(response.status)) throw new Error(`upstream status ${response.status}`); return cacheKey ? response.clone() : response; }, fallback: ({ mode }) => degradedResponse(bindingName, mode) });
+  const response = result.mode === 'live' ? result.value : result.value.clone ? result.value.clone() : result.value;
+  const headers = new Headers(response.headers); headers.set('x-skincos-dependency-status', result.mode); headers.set('x-skincos-sync-state', result.pendingSynchronization ? 'pending' : 'current');
+  return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
+}
+
+export function resetBoundServiceResilienceForTest() { serviceDependencyState.clear(); safeResponseCache.clear(); }

--- a/packages/skincos-edge-adapters/src/index.js
+++ b/packages/skincos-edge-adapters/src/index.js
@@ -1,0 +1,3 @@
+export * from './resilience.js';
+export * from './cloudflare-service-binding.js';
+export * from './signed-domain-context.js';

--- a/packages/skincos-edge-adapters/src/resilience.js
+++ b/packages/skincos-edge-adapters/src/resilience.js
@@ -1,0 +1,32 @@
+export class DependencyUnavailableError extends Error {
+  constructor(dependency, reason) { super(`${dependency} is unavailable: ${reason}`); this.name = 'DependencyUnavailableError'; this.dependency = dependency; }
+}
+
+export function createDependencyState() { return new Map(); }
+
+function stateFor(state, dependency) {
+  if (!state.has(dependency)) state.set(dependency, { failures: 0, openUntil: 0 });
+  return state.get(dependency);
+}
+
+function withTimeout(invoke, timeoutMs) {
+  const controller = new AbortController(); let timer;
+  const timeout = new Promise((_, reject) => { timer = setTimeout(() => { controller.abort(); reject(new DependencyUnavailableError('upstream', `timeout after ${timeoutMs}ms`)); }, timeoutMs); });
+  return Promise.race([Promise.resolve().then(() => invoke(controller.signal)), timeout]).finally(() => clearTimeout(timer));
+}
+
+/** Isolates optional domain calls with a short timeout, circuit breaker and explicit degraded result. */
+export async function callOptionalDependency({ dependency, invoke, fallback, timeoutMs = 800, failureThreshold = 2, cooldownMs = 15_000, cache, cacheKey, cacheTtlMs = 0, state = createDependencyState(), now = Date.now }) {
+  const clock = now(); const circuit = stateFor(state, dependency); const cached = cacheKey && cache?.get(cacheKey);
+  const usableCache = cached && cached.expiresAt > clock;
+  const degrade = (mode, error) => ({ mode, pendingSynchronization: true, value: usableCache ? cached.value : fallback({ dependency, mode, error }), error });
+  if (circuit.openUntil > clock) return degrade('circuit-open', new DependencyUnavailableError(dependency, 'circuit open'));
+  try {
+    const value = await withTimeout(invoke, timeoutMs); circuit.failures = 0; circuit.openUntil = 0;
+    if (cacheKey && cache && cacheTtlMs > 0) cache.set(cacheKey, { value, expiresAt: clock + cacheTtlMs });
+    return { mode: 'live', pendingSynchronization: false, value, error: null };
+  } catch (error) {
+    circuit.failures += 1; if (circuit.failures >= failureThreshold) circuit.openUntil = clock + cooldownMs;
+    return degrade('degraded', error instanceof DependencyUnavailableError ? error : new DependencyUnavailableError(dependency, error?.message || 'request failed'));
+  }
+}

--- a/packages/skincos-edge-adapters/src/signed-domain-context.js
+++ b/packages/skincos-edge-adapters/src/signed-domain-context.js
@@ -1,0 +1,18 @@
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const toBase64Url = (bytes) => btoa(String.fromCharCode(...bytes)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+const fromBase64Url = (value) => { const normalized = String(value || '').replace(/-/g, '+').replace(/_/g, '/'); const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4); return Uint8Array.from(atob(padded), (item) => item.charCodeAt(0)); };
+const safeEqual = (left, right) => { const a = encoder.encode(left || ''); const b = encoder.encode(right || ''); if (a.length !== b.length) return false; let difference = 0; for (let index = 0; index < a.length; index += 1) difference |= a[index] ^ b[index]; return difference === 0; };
+async function sign(secret, payload) { const key = await crypto.subtle.importKey('raw', encoder.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']); return toBase64Url(new Uint8Array(await crypto.subtle.sign('HMAC', key, encoder.encode(payload)))); }
+
+export async function createSignedDomainContext({ actor, csrf, requestId }, secret, audience, now = Date.now()) {
+  if (!secret || !actor?.username) throw new TypeError('A service identity and authenticated actor are required');
+  const payload = toBase64Url(encoder.encode(JSON.stringify({ v: 1, audience, issuedAt: now, actor, csrf: String(csrf || ''), requestId: String(requestId || '') })));
+  return { 'x-skincos-domain-context': payload, 'x-skincos-domain-signature': await sign(secret, payload) };
+}
+
+export async function verifySignedDomainContext(request, secret, audience, { maxAgeMs = 60_000, now = Date.now() } = {}) {
+  const payload = String(request.headers.get('x-skincos-domain-context') || ''); const received = String(request.headers.get('x-skincos-domain-signature') || '');
+  if (!secret || !payload || !received || !safeEqual(await sign(secret, payload), received)) return null;
+  try { const value = JSON.parse(decoder.decode(fromBase64Url(payload))); if (value?.v !== 1 || value?.audience !== audience || !value?.actor?.username || !Number.isFinite(value?.issuedAt) || Math.abs(now - value.issuedAt) > maxAgeMs) return null; return { actor: value.actor, csrf: String(value.csrf || ''), requestId: String(value.requestId || '') }; } catch { return null; }
+}

--- a/packages/skincos-edge-adapters/test/public-exports.test.mjs
+++ b/packages/skincos-edge-adapters/test/public-exports.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import * as adapters from '../src/index.js';
+
+test('aggregate public API exposes portable edge adapter contracts', () => {
+  assert.equal(typeof adapters.callOptionalDependency, 'function');
+  assert.equal(typeof adapters.fetchBoundService, 'function');
+  assert.equal(typeof adapters.createSignedDomainContext, 'function');
+  assert.equal(typeof adapters.verifySignedDomainContext, 'function');
+  assert.equal(typeof adapters.createDependencyState, 'function');
+});
+
+test('resilience state remains local to the package consumer', () => {
+  const state = adapters.createDependencyState();
+  assert.ok(state instanceof Map);
+  assert.equal(state.size, 0);
+  assert.equal(new adapters.DependencyUnavailableError('service', 'offline').dependency, 'service');
+});
+
+test('every declared edge entrypoint resolves from the package source', async () => {
+  const entries = [
+    '../src/cloudflare-service-binding.js',
+    '../src/signed-domain-context.js',
+    '../src/resilience.js',
+  ];
+
+  for (const entry of entries) {
+    const imported = await import(entry);
+    assert.ok(Object.keys(imported).length > 0, 'entrypoint must export an adapter');
+  }
+});

--- a/scripts/tests/package-tarball-install.test.mjs
+++ b/scripts/tests/package-tarball-install.test.mjs
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(scriptDirectory, '../..');
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const packageDirectories = [
+  'packages/skincos-contracts',
+  'packages/skincos-edge-adapters',
+  'packages/skincos-delivery-contract',
+];
+
+function run(command, arguments_, { cwd }) {
+  const result = spawnSync(command, arguments_, {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      npm_config_audit: 'false',
+      npm_config_fund: 'false',
+    },
+  });
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error([
+      `${command} ${arguments_.join(' ')} exited with ${result.status}`,
+      result.stdout,
+      result.stderr,
+    ].filter(Boolean).join('\n'));
+  }
+  return result.stdout;
+}
+
+function packageManifest(packageDirectory) {
+  return JSON.parse(fs.readFileSync(path.join(packageDirectory, 'package.json'), 'utf8'));
+}
+
+function declaredEntrypoints(manifest) {
+  assert.ok(manifest.exports && typeof manifest.exports === 'object', `${manifest.name} must declare exports`);
+  const entrypoints = Object.entries(manifest.exports);
+  assert.ok(entrypoints.length > 0, `${manifest.name} must declare at least one export`);
+
+  return entrypoints.map(([entrypoint, target]) => {
+    assert.ok(entrypoint === '.' || entrypoint.startsWith('./'), `${manifest.name} has an invalid export key: ${entrypoint}`);
+    assert.equal(typeof target, 'string', `${manifest.name} export ${entrypoint} must resolve to one file`);
+    assert.ok(target.startsWith('./'), `${manifest.name} export ${entrypoint} must stay inside the package`);
+    return { entrypoint, packedPath: target.slice(2) };
+  });
+}
+
+function writeConsumerProof(consumerDirectory) {
+  const source = `
+import assert from 'node:assert/strict';
+
+const [packageName, encodedEntrypoints] = process.argv.slice(2);
+const entrypoints = JSON.parse(encodedEntrypoints);
+
+for (const entrypoint of entrypoints) {
+  const specifier = entrypoint === '.'
+    ? packageName
+    : \`${'${packageName}'}/${'${entrypoint.slice(2)}'}\`;
+  const namespace = entrypoint === './package.json'
+    ? await import(specifier, { with: { type: 'json' } })
+    : await import(specifier);
+
+  if (entrypoint === './package.json') {
+    assert.equal(namespace.default.name, packageName, \`${'${specifier}'} must resolve to its installed manifest\`);
+  } else {
+    assert.ok(Object.keys(namespace).length > 0, \`${'${specifier}'} must expose a public API\`);
+  }
+}
+`;
+  fs.writeFileSync(path.join(consumerDirectory, 'verify-imports.mjs'), source);
+}
+
+function verifyPackagedEntrypoints(packageDirectory) {
+  const manifest = packageManifest(packageDirectory);
+  const entrypoints = declaredEntrypoints(manifest);
+  const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'skincos-package-proof-'));
+
+  try {
+    const packDirectory = path.join(temporaryRoot, 'pack');
+    const consumerDirectory = path.join(temporaryRoot, 'consumer');
+    const cacheDirectory = path.join(temporaryRoot, 'empty-npm-cache');
+    fs.mkdirSync(packDirectory);
+    fs.mkdirSync(consumerDirectory);
+    fs.mkdirSync(cacheDirectory);
+
+    const packed = JSON.parse(run(npmCommand, [
+      'pack',
+      '--json',
+      '--ignore-scripts',
+      '--pack-destination',
+      packDirectory,
+    ], { cwd: packageDirectory }));
+    assert.equal(packed.length, 1, `${manifest.name} must pack exactly one tarball`);
+    assert.equal(packed[0].name, manifest.name, 'packed name must match package metadata');
+    assert.equal(packed[0].version, manifest.version, 'packed version must match package metadata');
+
+    const packedFiles = new Set((packed[0].files || []).map((file) => file.path));
+    for (const { entrypoint, packedPath } of entrypoints) {
+      assert.ok(packedFiles.has(packedPath), `${manifest.name} tarball omits ${entrypoint}`);
+    }
+
+    const tarball = path.join(packDirectory, packed[0].filename);
+    assert.ok(fs.existsSync(tarball), `${manifest.name} tarball was not written to the temporary pack directory`);
+
+    fs.writeFileSync(path.join(consumerDirectory, 'package.json'), JSON.stringify({
+      name: 'skincos-package-tarball-proof',
+      private: true,
+      version: '0.0.0',
+      type: 'module',
+    }, null, 2));
+    writeConsumerProof(consumerDirectory);
+
+    run(npmCommand, [
+      'install',
+      '--offline',
+      '--ignore-scripts',
+      '--no-audit',
+      '--no-fund',
+      '--no-save',
+      '--package-lock=false',
+      '--cache',
+      cacheDirectory,
+      tarball,
+    ], { cwd: consumerDirectory });
+
+    const installedPackage = path.join(consumerDirectory, 'node_modules', ...manifest.name.split('/'));
+    assert.ok(fs.existsSync(installedPackage), `${manifest.name} must install from its tarball`);
+    run(process.execPath, [
+      path.join(consumerDirectory, 'verify-imports.mjs'),
+      manifest.name,
+      JSON.stringify(entrypoints.map(({ entrypoint }) => entrypoint)),
+    ], { cwd: consumerDirectory });
+  } finally {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+}
+
+for (const relativePackageDirectory of packageDirectories) {
+  test(`${relativePackageDirectory} packs, installs offline, and resolves every public export`, () => {
+    verifyPackagedEntrypoints(path.join(root, relativePackageDirectory));
+  });
+}

--- a/scripts/tests/promotion-evidence-contract-interop.test.mjs
+++ b/scripts/tests/promotion-evidence-contract-interop.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  createPromotionEvidenceV4,
+  verifyPromotionEvidenceV4,
+} from '../../packages/skincos-delivery-contract/src/index.js';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const sha1 = (character) => character.repeat(40);
+const sha256 = (character) => character.repeat(64);
+
+function runPromotion(args, env) {
+  return execFileSync(process.execPath, ['.github/scripts/promotion-evidence.mjs', ...args], {
+    cwd: root,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+}
+
+function v4Environment() {
+  return {
+    PROMOTION_EVIDENCE_SCHEMA_VERSION: '4',
+    PROMOTION_UNIT: 'synthetic-unit',
+    PROMOTION_TARGET: 'preview',
+    PROMOTION_SOURCE_REPOSITORY: 'jubenitogarcia/skincos-meta-ads-reporting',
+    PROMOTION_SOURCE_COMMIT: sha1('a'),
+    PROMOTION_SOURCE_TREE: sha1('b'),
+    PROMOTION_SOURCE_REF: 'refs/heads/main',
+    PROMOTION_DELIVERY_CONTRACT_VERSION: '1.0.0',
+    PROMOTION_CONTRACT_MANIFEST_DIGEST: sha256('c'),
+    PROMOTION_RELEASE_INPUT_DIGEST: sha256('d'),
+    PROMOTION_DEPENDENCY_CLOSURE_DIGEST: sha256('d'),
+    PROMOTION_CONTRACT_VERSIONS_JSON: JSON.stringify([
+      { name: '@jubenitogarcia/skincos-contracts', version: '1.0.0', integrity: sha256('e') },
+    ]),
+    PROMOTION_ARTIFACT_IDENTITIES_JSON: JSON.stringify([
+      { id: 'worker.tgz', digest: sha256('f'), fileDigest: sha256('1') },
+    ]),
+    GITHUB_REPOSITORY: 'jubenitogarcia/skincos-release-evidence',
+    GITHUB_RUN_ID: '33179818924',
+    PROMOTION_EVIDENCE_REPOSITORY: 'jubenitogarcia/skincos-release-evidence',
+    PROMOTION_EVIDENCE_ARTIFACT: 'promotion-evidence-synthetic-unit',
+  };
+}
+
+function verificationEnvironment(evidence) {
+  return {
+    ...v4Environment(),
+    GITHUB_REPOSITORY: 'jubenitogarcia/skincos-release-controller',
+    PROMOTION_EXPECTED_TARGET: 'preview',
+    PROMOTION_EXPECTED_SOURCE_REPOSITORY: evidence.sourceRepository,
+    PROMOTION_EXPECTED_SOURCE_COMMIT: evidence.sourceSha,
+    PROMOTION_EXPECTED_SOURCE_TREE: evidence.sourceTree,
+    PROMOTION_EXPECTED_SOURCE_REF: evidence.sourceRef,
+    PROMOTION_EXPECTED_RELEASE_INPUT_DIGEST: evidence.releaseInputDigest,
+    PROMOTION_EXPECTED_DELIVERY_CONTRACT_VERSION: evidence.deliveryContractVersion,
+    PROMOTION_EXPECTED_CONTRACT_MANIFEST_DIGEST: evidence.contractManifestDigest,
+    PROMOTION_EXPECTED_CONTRACT_VERSIONS_JSON: JSON.stringify(evidence.contractVersions),
+    PROMOTION_EXPECTED_ARTIFACT_IDENTITIES_JSON: JSON.stringify(evidence.artifacts),
+    PROMOTION_EXPECTED_EVIDENCE_REPOSITORY: evidence.evidenceRepository,
+    PROMOTION_EXPECTED_EVIDENCE_RUN_ID: evidence.evidenceRunId,
+    PROMOTION_EXPECTED_EVIDENCE_ARTIFACT: evidence.evidenceArtifact,
+    PROMOTION_EXPECTED_RELEASE_IDENTITY_DIGEST: evidence.releaseIdentityDigest,
+  };
+}
+
+test('promotion evidence gate and delivery-contract package interoperate in both directions', async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'skincos-promotion-contract-interop-'));
+  const gateEvidencePath = path.join(directory, 'gate-evidence.json');
+  const packageEvidencePath = path.join(directory, 'package-evidence.json');
+  const environment = v4Environment();
+
+  runPromotion(['write', gateEvidencePath], environment);
+  const gateEvidence = JSON.parse(fs.readFileSync(gateEvidencePath, 'utf8'));
+  const packageVerification = await verifyPromotionEvidenceV4(gateEvidence, {
+    target: 'preview',
+    sourceRepository: gateEvidence.sourceRepository,
+    sourceCommit: gateEvidence.sourceSha,
+    releaseIdentityDigest: gateEvidence.releaseIdentityDigest,
+  });
+  assert.equal(packageVerification.evidence.releaseIdentityDigest, gateEvidence.releaseIdentityDigest);
+
+  const packageEvidence = await createPromotionEvidenceV4({
+    target: 'preview',
+    createdAt: '2026-08-28T14:23:04.000Z',
+    evidenceRepository: gateEvidence.evidenceRepository,
+    evidenceRunId: gateEvidence.evidenceRunId,
+    evidenceArtifact: gateEvidence.evidenceArtifact,
+    releaseIdentity: gateEvidence.releaseIdentity,
+  });
+  fs.writeFileSync(packageEvidencePath, `${JSON.stringify(packageEvidence)}\n`);
+  runPromotion(['verify', packageEvidencePath], verificationEnvironment(packageEvidence));
+});

--- a/scripts/tests/timekeeping-ci-inventory-rpc.test.mjs
+++ b/scripts/tests/timekeeping-ci-inventory-rpc.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const workflow = fs.readFileSync(new URL('../../.github/workflows/timekeeping-ci.yml', import.meta.url), 'utf8');
+const triggerSection = workflow.slice(0, workflow.indexOf('\npermissions:'));
+
+function triggerBlock(name) {
+  const start = triggerSection.indexOf(`  ${name}:`);
+  assert.ok(start >= 0, `${name} trigger is missing`);
+  const rest = triggerSection.slice(start + name.length + 4);
+  const next = /\n  [A-Za-z_][A-Za-z0-9_-]*:/.exec(rest);
+  return rest.slice(0, next?.index);
+}
+
+test('Inventory/API RPC surfaces trigger Timekeeping CI for pull requests and main pushes', () => {
+  const requiredPaths = [
+    'api/workers/legacy-inventory-durable-objects.js',
+    'api/wrangler.toml',
+    'inventory/src/legacy-api-jobs.js',
+    'inventory/workers/**',
+    'inventory/tests/legacyApiJobsContract.test.mjs',
+    'inventory/wrangler.toml',
+    '.github/scripts/inventory-legacy-jobs-release-guard.test.mjs',
+    'scripts/tests/timekeeping-ci-inventory-rpc.test.mjs',
+  ];
+
+  for (const trigger of ['pull_request', 'push']) {
+    const block = triggerBlock(trigger);
+    for (const entry of requiredPaths) {
+      assert.match(block, new RegExp(`- '${entry.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'`));
+    }
+  }
+});
+
+test('Inventory/API RPC gate executes the contract test and both Inventory dry-runs', () => {
+  const start = workflow.indexOf('      - name: Test gateway routing');
+  const end = workflow.indexOf('      - name: Test governed Ponto release contracts', start);
+  assert.ok(start >= 0 && end > start, 'gateway routing gate is missing');
+  const gate = workflow.slice(start, end);
+
+  assert.match(gate, /node --test inventory\/tests\/legacyApiJobsContract\.test\.mjs/);
+  assert.match(
+    gate,
+    /inventory\/node_modules\/\.bin\/wrangler deploy --dry-run --config inventory\/wrangler\.toml --outdir "\$RUNNER_TEMP\/inventory-production-dry-run"/,
+  );
+  assert.match(
+    gate,
+    /inventory\/node_modules\/\.bin\/wrangler deploy --dry-run --config inventory\/wrangler\.toml --env staging --outdir "\$RUNNER_TEMP\/inventory-staging-dry-run"/,
+  );
+});

--- a/shared/domain-boundaries.json
+++ b/shared/domain-boundaries.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "description": "Only registered contracts, SDKs and adapters under shared/ may cross a module boundary. Direct implementation imports are rejected unless listed as time-boxed migration debt.",
+  "description": "Only registered contracts, SDKs and adapters under shared/ may cross a module boundary. Direct implementation imports are rejected unless listed as time-boxed migration debt. Stateful service bridges are separately registered with source and rollout verification.",
   "contracts": [
     {
       "id": "finance-contracts-v1",
@@ -104,13 +104,65 @@
       "usage": "use the registered Identity runtime adapter; do not import Identity implementation directly"
     }
   ],
-  "legacyDirectImports": [
+  "legacyDirectImports": [],
+  "statefulServiceBindings": [
     {
-      "from": "api/workers/index.js",
-      "specifier": "../../inventory/src/worker.js",
-      "replacementContractId": "service-binding-adapter-v1",
-      "deadline": "2026-09-30",
-      "reason": "The gateway already forwards traffic through the service-binding adapter, but its legacy Durable Object namespaces require an explicit stateful retirement before this compatibility export can be removed."
+      "id": "api-inventory-legacy-jobs-rpc-v1",
+      "consumer": "api",
+      "producer": "inventory",
+      "serviceBinding": "INVENTORY_LEGACY_JOBS",
+      "service": {
+        "production": "skincos-insumos",
+        "staging": "skincos-insumos-staging"
+      },
+      "entrypoint": "InventoryLegacyJobsEntrypoint",
+      "rpcMethod": "runNotificationsRefresh",
+      "dtoContract": "legacy-api-notifications-refresh/v1",
+      "healthCapability": "legacy-api-jobs-rpc/v1",
+      "deployOrder": ["inventory", "api"],
+      "rollbackOrder": ["api", "inventory"],
+      "reviewBy": "2026-11-30",
+      "reviewTrigger": "before extracting API or Inventory, changing the JobQueue Durable Object class, or retiring the bridge",
+      "retirementCondition": "retire only after an explicit Durable Objects data-migration and rollback plan is proven; do not use deleted_classes for the existing API namespaces",
+      "verification": [
+        {
+          "path": "api/wrangler.toml",
+          "mustContain": [
+            "binding = \"INVENTORY_LEGACY_JOBS\"",
+            "service = \"skincos-insumos\"",
+            "service = \"skincos-insumos-staging\"",
+            "entrypoint = \"InventoryLegacyJobsEntrypoint\""
+          ]
+        },
+        {
+          "path": "api/workers/legacy-inventory-durable-objects.js",
+          "mustContain": [
+            "env?.INVENTORY_LEGACY_JOBS",
+            "service.runNotificationsRefresh({ unidade: normalized.unidade })"
+          ]
+        },
+        {
+          "path": "inventory/workers/legacy-api-jobs-entrypoint.js",
+          "mustContain": [
+            "export class InventoryLegacyJobsEntrypoint extends WorkerEntrypoint",
+            "async runNotificationsRefresh(input)"
+          ]
+        },
+        {
+          "path": "inventory/src/worker.js",
+          "mustContain": [
+            "legacyApiJobsRpc: LEGACY_API_JOBS_RPC_CAPABILITY"
+          ]
+        },
+        {
+          "path": ".github/workflows/deploy-core-workers.yml",
+          "mustContain": [
+            "inventory_legacy_jobs_release_sha",
+            "legacy-api-jobs-rpc/v1",
+            "Inventory health did not attest the required InventoryLegacyJobsEntrypoint release in two consecutive samples"
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Objetivo
Estabelece a Wave 0 para extracoes multi-repositorio: contratos portaveis, evidencia de promocao cross-repo, ponte API -> Inventory sem import direto e gates de CI.

## Superficies e risco
- Workflows de promocao, CI e deploy Core; Workers API/Inventory; pacotes privados ainda nao publicados.
- Sem deploy, migration, flag ou alteracao de dado real nesta entrega.

## Entrega
- Pacotes versionaveis com prova de tarball offline; sem publish e sem consumidor migrado.
- Evidencia v4 com repositorio/SHA/arvore/artefatos/contratos, predecessor e branch padrao protegida do produtor.
- API preserva os Durable Objects existentes; Inventory passa a deter a regra de negocio por RPC nomeado.
- CI cobre RPC, dry-runs de Inventory e contratos de pacote.

## Validacao
- 36 testes focalizados de evidencia, RPC, pacotes e workflows.
- architecture:validate, validate-github-governance, validate-progressive-release e parse YAML passaram.
- codex:preflight passou; rollback de codigo e reverter este commit. Para rollout futuro: Inventory antes de API, e API antes de Inventory no rollback.

## Limites remanescentes
Publicacao restrita em registry e consumo autenticado por versao exata ficam para o primeiro repositorio privado dono; nenhum pacote foi publicado neste PR.