### PR TITLE
test(finance): isolate boundary checks from crm sources

### DIFF
--- a/.github/workflows/finance-boundary-ci.yml
+++ b/.github/workflows/finance-boundary-ci.yml
@@ -1,0 +1,94 @@
+name: Finance Boundary CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'finance/**'
+      - 'api/src/gateway.js'
+      - 'api/src/router.js'
+      - 'api/test/gateway.test.mjs'
+      - 'api/wrangler.toml'
+      - 'api/package.json'
+      - 'api/package-lock.json'
+      - '.github/scripts/finance-production-preflight.mjs'
+      - 'scripts/run-local-finance.sh'
+      - 'shared/finance-contracts/**'
+      - 'shared/crm-auth/**'
+      - 'shared/identity-contract/**'
+      - 'shared/module-availability/**'
+      - 'shared/module-sdk/**'
+      - 'shared/observability/**'
+      - 'shared/service-adapters/**'
+      - 'crm/console/App.tsx'
+      - 'crm/console/Finance*.tsx'
+      - 'crm/console/finance-remote/**'
+      - 'crm/console/financeApi.ts'
+      - 'crm/console/financeBootstrap.ts'
+      - 'crm/console/functions/api/finance/**'
+      - 'crm/console/main.css'
+      - 'crm/console/modules/RemoteFinanceModule.tsx'
+      - 'crm/console/modules/registry.tsx'
+      - 'crm/console/tests/finance*.test.ts'
+      - 'crm/console/tests/moduleRegistry.test.ts'
+      - 'crm/console/package.json'
+      - 'crm/console/package-lock.json'
+      - 'crm/console/tsconfig*.json'
+      - 'crm/console/vite.finance.config.ts'
+      - '.github/workflows/finance-boundary-ci.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  finance-domain:
+    name: Finance domain install, check and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.0.0
+        with:
+          node-version: '22.23.1'
+          cache: npm
+          cache-dependency-path: |
+            finance/package-lock.json
+            api/package-lock.json
+            crm/console/package-lock.json
+      - name: Install pinned Finance toolchain without lifecycle scripts
+        run: npm --prefix finance ci --ignore-scripts
+      - name: Check Finance worker sources
+        run: npm --prefix finance run check
+      - name: Test Finance domain contracts
+        run: npm --prefix finance test
+
+  direct-contracts:
+    name: Finance gateway and CRM direct contracts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.0.0
+        with:
+          node-version: '22.23.1'
+          cache: npm
+          cache-dependency-path: |
+            api/package-lock.json
+            crm/console/package-lock.json
+      - name: Install pinned API toolchain without lifecycle scripts
+        run: npm --prefix api ci --ignore-scripts
+      - name: Test Finance gateway contract
+        run: npm --prefix api test
+      - name: Install pinned CRM toolchain without lifecycle scripts
+        run: npm --prefix crm/console ci --ignore-scripts
+      - name: Check CRM Finance contract types
+        run: npm --prefix crm/console run typecheck
+      - name: Build the dedicated Finance artifact
+        working-directory: crm/console
+        run: npx vite build --config vite.finance.config.ts
+      - name: Test CRM Finance loader, fallback and proxy contracts
+        run: >-
+          npm --prefix crm/console run test --
+          tests/financeBootstrap.test.ts
+          tests/financeApi.test.ts
+          tests/financeProxy.test.ts
+          tests/financeRemote.test.ts
+          tests/moduleRegistry.test.ts

--- a/crm/console/tests/financeRemote.test.ts
+++ b/crm/console/tests/financeRemote.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('Finance remote module boundary', () => {
+  it('keeps the independently published module loader and isolated fallback in the CRM shell', () => {
+    const remoteModule = readFileSync(new URL('../modules/RemoteFinanceModule.tsx', import.meta.url), 'utf8')
+    const financeViteConfig = readFileSync(new URL('../vite.finance.config.ts', import.meta.url), 'utf8')
+
+    expect(remoteModule).toContain('import(/* @vite-ignore */ remoteUrl)')
+    expect(remoteModule).toContain('data-testid="finance-remote-unavailable"')
+    expect(remoteModule).toContain('data-finance-remote-error')
+    expect(remoteModule).toContain('remoteFailureKind(cause)')
+    expect(remoteModule).toContain('A navegação e os demais módulos continuam disponíveis.')
+    expect(financeViteConfig).toContain("'process.env.NODE_ENV': '\"production\"'")
+  })
+})

--- a/finance/test/staging-smoke-transport.test.mjs
+++ b/finance/test/staging-smoke-transport.test.mjs
@@ -5,11 +5,9 @@ import test from 'node:test';
 const read = (file) => readFile(new URL(`../scripts/${file}`, import.meta.url), 'utf8');
 
 test('staging Finance API smokes use the authenticated Pages transport', async () => {
-  const [canary, importer, remoteFinanceModule, financeViteConfig] = await Promise.all([
+  const [canary, importer] = await Promise.all([
     read('staging-synthetic-canary.mjs'),
     read('staging-import-smoke.mjs'),
-    readFile(new URL('../../crm/console/modules/RemoteFinanceModule.tsx', import.meta.url), 'utf8'),
-    readFile(new URL('../../crm/console/vite.finance.config.ts', import.meta.url), 'utf8'),
   ]);
 
   for (const source of [canary, importer]) {
@@ -38,7 +36,4 @@ test('staging Finance API smokes use the authenticated Pages transport', async (
   assert.match(importer, /batchStatus: loaded\.batch\.status/);
   assert.match(importer, /compensated: true/);
   assert.match(importer, /compensatedAt: loaded\.batch\.undone_at/);
-  assert.match(remoteFinanceModule, /data-finance-remote-error/);
-  assert.match(remoteFinanceModule, /remoteFailureKind\(cause\)/);
-  assert.match(financeViteConfig, /'process\.env\.NODE_ENV': '\"production\"'/);
 });


### PR DESCRIPTION
## Objetivo\nPrepara o primeiro corte de Finance, removendo a dependência de testes Finance em fontes da UI CRM e deixando a responsabilidade de teste do loader remoto no próprio CRM.\n\n## Escopo\n- adiciona CI focal de Finance, gateway e contrato CRM;\n- mantém inance/test limitado a fontes Finance;\n- adiciona cobertura do fallback do módulo remoto sob crm/console.\n\n## Fora de escopo\nNenhum deploy, migration, mudança de dados, extração de runtime ou publicação de pacote.\n\n## Validação local\n- Finance check e 57 testes;\n- gateway/API: 33 testes;\n- CRM typecheck e 27 testes focais;\n- validação de YAML, governança e fronteiras.\n\nEsta PR é um pré-requisito de independência; não afirma o corte de skincos-finance ainda.