### PR TITLE
feat(clientes): establish readonly extraction boundary

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,7 @@
 /ads/ @jubenitogarcia
 /api/ @jubenitogarcia
 /booking/ @jubenitogarcia
+/clientes-readonly/ @jubenitogarcia
 /crm/ @jubenitogarcia
 /finance/ @jubenitogarcia
 /identity/ @jubenitogarcia

--- a/.github/scripts/validate-domain-boundaries.mjs
+++ b/.github/scripts/validate-domain-boundaries.mjs
@@ -4,7 +4,7 @@ import path from "node:path";
 const root = path.resolve(import.meta.dirname, "../..");
 const policyPath = path.join(root, "shared/domain-boundaries.json");
 const governedRoots = new Set([
-  "ads", "api", "booking", "crm", "finance", "identity", "integration", "inventory", "messaging",
+  "ads", "api", "booking", "clientes-readonly", "crm", "finance", "identity", "integration", "inventory", "messaging",
   "ops", "orb", "platform", "service", "shared", "social", "website", "workforce",
 ]);
 const sourceExtensions = new Set([".js", ".cjs", ".mjs", ".jsx", ".ts", ".tsx", ".py"]);

--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -43,6 +43,7 @@ jobs:
       codex: ${{ steps.scope.outputs.codex }}
       observability: ${{ steps.scope.outputs.observability }}
       clientes_runtime_contract: ${{ steps.scope.outputs.clientes_runtime_contract }}
+      clientes_readonly_boundary: ${{ steps.scope.outputs.clientes_readonly_boundary }}
       storage_governance: ${{ steps.scope.outputs.storage_governance }}
       all: ${{ steps.scope.outputs.all }}
       node: ${{ steps.scope.outputs.node }}
@@ -77,16 +78,18 @@ jobs:
           codex="$(changed .codex skills ops/codex scripts/codex-*.mjs scripts/codex-*.sh scripts/*codex*.ps1)"
           observability="$(changed scripts/observability)"
           clientes_runtime_contract="$(changed scripts crm/api ops/runtime/units)"
+          clientes_readonly_boundary="$(changed clientes-readonly ops/governance/global-concurrency-policy.json)"
           storage_governance="$(changed ops/codex/storage-retention-policy.json scripts/skincos-storage-governance.ps1 scripts/dedupe-source-tars.ps1 scripts/tests/test-skincos-storage-governance.ps1)"
           all="$(changed .github/workflows/ci-smoke.yml)"
           node=false
-          if [[ "$website" == true || "$crm_api" == true || "$whatsapp" == true || "$observability" == true || "$clientes_runtime_contract" == true || "$all" == true ]]; then node=true; fi
+          if [[ "$website" == true || "$crm_api" == true || "$whatsapp" == true || "$observability" == true || "$clientes_runtime_contract" == true || "$clientes_readonly_boundary" == true || "$all" == true ]]; then node=true; fi
           echo "website=$website" >> "$GITHUB_OUTPUT"
           echo "crm_api=$crm_api" >> "$GITHUB_OUTPUT"
           echo "whatsapp=$whatsapp" >> "$GITHUB_OUTPUT"
           echo "codex=$codex" >> "$GITHUB_OUTPUT"
           echo "observability=$observability" >> "$GITHUB_OUTPUT"
           echo "clientes_runtime_contract=$clientes_runtime_contract" >> "$GITHUB_OUTPUT"
+          echo "clientes_readonly_boundary=$clientes_readonly_boundary" >> "$GITHUB_OUTPUT"
           echo "storage_governance=$storage_governance" >> "$GITHUB_OUTPUT"
           echo "all=$all" >> "$GITHUB_OUTPUT"
           echo "node=$node" >> "$GITHUB_OUTPUT"
@@ -155,6 +158,10 @@ jobs:
       - name: Verify Clientes staging runtime contract
         if: ${{ needs.changes.outputs.clientes_runtime_contract == 'true' || needs.changes.outputs.all == 'true' }}
         run: node --test scripts/tests/clientes-production-readonly-runtime.test.mjs
+
+      - name: Verify Clientes readonly extraction boundary
+        if: ${{ needs.changes.outputs.clientes_readonly_boundary == 'true' || needs.changes.outputs.all == 'true' }}
+        run: npm --prefix clientes-readonly run check && npm --prefix clientes-readonly run test && node .github/scripts/validate-dependency-closures.mjs
 
       - name: Install website dependencies
         if: ${{ needs.changes.outputs.website == 'true' || needs.changes.outputs.all == 'true' }}

--- a/clientes-readonly/README.md
+++ b/clientes-readonly/README.md
@@ -1,0 +1,20 @@
+# Clientes Readonly boundary
+
+This directory is the source boundary for the future `skincos-clientes-readonly`
+product. It is not a deployed service, does not own a database, and does not
+route production traffic.
+
+`clientes-readonly/v1` accepts only a redacted, explicitly scoped actor and
+projects only the five fields declared by the contract. The only future data
+routes are `GET`/`HEAD /v1/clientes` and `GET`/`HEAD /v1/clientes/:clientId`.
+Until a dedicated read-model is supplied, both routes return
+`503 CLIENTES_READMODEL_UNAVAILABLE`; they never fall back to the CRM runtime,
+commercial flows, Harmonia, or Caixa.
+
+Health remains PII-free. `GET /health` reports the unavailable dependency with
+HTTP 200 so liveness is observable; `GET /readiness` returns HTTP 503 with the
+same code until the read-model is explicitly ready.
+
+The next extraction milestone must provide a dedicated read-model owner,
+authenticated actor adapter, staging proof, rollback, and its own deploy
+surface before this boundary can become a repository or receive traffic.

--- a/clientes-readonly/README.md
+++ b/clientes-readonly/README.md
@@ -7,13 +7,13 @@ route production traffic.
 `clientes-readonly/v1` accepts only a redacted, explicitly scoped actor and
 projects only the five fields declared by the contract. The only future data
 routes are `GET`/`HEAD /v1/clientes` and `GET`/`HEAD /v1/clientes/:clientId`.
-Until a dedicated read-model is supplied, both routes return
-`503 CLIENTES_READMODEL_UNAVAILABLE`; they never fall back to the CRM runtime,
+Until both a dedicated read-model and authenticated actor adapter are supplied,
+both routes return an unavailable error; they never fall back to the CRM runtime,
 commercial flows, Harmonia, or Caixa.
 
 Health remains PII-free. `GET /health` reports the unavailable dependency with
-HTTP 200 so liveness is observable; `GET /readiness` returns HTTP 503 with the
-same code until the read-model is explicitly ready.
+HTTP 200 so liveness is observable; `GET /readiness` returns HTTP 503 until
+both required adapters are explicitly configured and the read-model is ready.
 
 The next extraction milestone must provide a dedicated read-model owner,
 authenticated actor adapter, staging proof, rollback, and its own deploy

--- a/clientes-readonly/package.json
+++ b/clientes-readonly/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@skincos/clientes-readonly-boundary",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Fail-closed readonly boundary for the future Clientes product extraction.",
+  "scripts": {
+    "test": "node --test test/*.test.mjs",
+    "check": "node --check src/contract.js && node --check src/handler.js && node --check src/index.js"
+  }
+}

--- a/clientes-readonly/src/contract.js
+++ b/clientes-readonly/src/contract.js
@@ -48,6 +48,13 @@ function text(value, maxLength = 256) {
   return normalized && normalized.length <= maxLength ? normalized : ''
 }
 
+function optionalQueryText(searchParams, key, maxLength) {
+  const value = searchParams.get(key)
+  if (value === null) return { present: false, value: '' }
+  const normalized = String(value).trim()
+  return { present: true, value: normalized, validLength: normalized.length > 0 && normalized.length <= maxLength }
+}
+
 function unique(values) {
   return [...new Set(values)]
 }
@@ -106,10 +113,14 @@ export function parseClientesReadonlyListQuery(searchParams) {
   }
   const unitId = text(searchParams.get('unitId'), 64)
   if (!UNIT_ID_PATTERN.test(unitId)) return { ok: false, code: 'CLIENTES_UNIT_REQUIRED' }
-  const rawCursor = text(searchParams.get('cursor'), 256)
+  const cursorInput = optionalQueryText(searchParams, 'cursor', 256)
+  if (cursorInput.present && !cursorInput.validLength) return { ok: false, code: 'CLIENTES_CURSOR_INVALID' }
+  const rawCursor = cursorInput.value
   const cursor = normalizeClientesReadonlyCursor(rawCursor)
   if (rawCursor && !cursor) return { ok: false, code: 'CLIENTES_CURSOR_INVALID' }
-  const rawLimit = text(searchParams.get('limit'), 3)
+  const limitInput = optionalQueryText(searchParams, 'limit', 3)
+  if (limitInput.present && !limitInput.validLength) return { ok: false, code: 'CLIENTES_LIMIT_INVALID' }
+  const rawLimit = limitInput.value
   const limit = rawLimit ? Number(rawLimit) : 25
   if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
     return { ok: false, code: 'CLIENTES_LIMIT_INVALID' }

--- a/clientes-readonly/src/contract.js
+++ b/clientes-readonly/src/contract.js
@@ -55,6 +55,14 @@ function optionalQueryText(searchParams, key, maxLength) {
   return { present: true, value: normalized, validLength: normalized.length > 0 && normalized.length <= maxLength }
 }
 
+function validUpdatedAt(value) {
+  if (!UPDATED_AT_PATTERN.test(value)) return false
+  const parsed = new Date(value)
+  if (!Number.isFinite(parsed.getTime())) return false
+  const canonical = value.includes('.') ? value : value.replace(/Z$/, '.000Z')
+  return parsed.toISOString() === canonical
+}
+
 function unique(values) {
   return [...new Set(values)]
 }
@@ -140,6 +148,6 @@ export function projectClientesReadonlyRecord(input) {
     displayName: text(input.displayName, 160) || null,
     unitId,
     status: CLIENTES_READONLY_STATUS_VALUES.includes(status) ? status : null,
-    updatedAt: UPDATED_AT_PATTERN.test(updatedAt) ? updatedAt : null,
+    updatedAt: validUpdatedAt(updatedAt) ? updatedAt : null,
   })
 }

--- a/clientes-readonly/src/contract.js
+++ b/clientes-readonly/src/contract.js
@@ -51,8 +51,12 @@ function text(value, maxLength = 256) {
 function optionalQueryText(searchParams, key, maxLength) {
   const value = searchParams.get(key)
   if (value === null) return { present: false, value: '' }
-  const normalized = String(value).trim()
-  return { present: true, value: normalized, validLength: normalized.length > 0 && normalized.length <= maxLength }
+  const textValue = String(value)
+  return {
+    present: true,
+    value: textValue,
+    validLength: textValue.length > 0 && textValue.length <= maxLength && textValue === textValue.trim(),
+  }
 }
 
 function validUpdatedAt(value) {
@@ -106,8 +110,8 @@ export function actorCanReadClientesUnit(actor, unitId) {
 }
 
 export function normalizeClientesReadonlyCursor(value) {
-  const cursor = text(value, 256)
-  return cursor && CURSOR_PATTERN.test(cursor) ? cursor : null
+  if (typeof value !== 'string' || value.length === 0 || value.length > 256) return null
+  return CURSOR_PATTERN.test(value) ? value : null
 }
 
 export function parseClientesReadonlyListQuery(searchParams) {

--- a/clientes-readonly/src/contract.js
+++ b/clientes-readonly/src/contract.js
@@ -84,16 +84,23 @@ export function normalizeClientesReadonlyActor(input) {
   if (!input || typeof input !== 'object' || Array.isArray(input)) {
     return { ok: false, code: 'CLIENTES_ACTOR_REQUIRED' }
   }
+  if (typeof input.subject !== 'string'
+    || typeof input.role !== 'string'
+    || !Array.isArray(input.unitIds)
+    || input.unitIds.some((unitId) => typeof unitId !== 'string')) {
+    return { ok: false, code: 'CLIENTES_ACTOR_INVALID' }
+  }
   const subject = text(input.subject, 128)
   if (!ACTOR_TEXT_PATTERN.test(subject)) return { ok: false, code: 'CLIENTES_ACTOR_INVALID' }
   const role = text(input.role, 32).toUpperCase()
   if (!CLIENTES_READONLY_ACTOR_ROLES.includes(role)) {
     return { ok: false, code: 'CLIENTES_ACTOR_FORBIDDEN' }
   }
-  const unitIds = unique((Array.isArray(input.unitIds) ? input.unitIds : [])
-    .map((unitId) => text(unitId, 64))
-    .filter((unitId) => UNIT_ID_PATTERN.test(unitId)))
+  const unitIds = unique(input.unitIds.map((unitId) => text(unitId, 64)))
   if (!unitIds.length) return { ok: false, code: 'CLIENTES_UNIT_SCOPE_REQUIRED' }
+  if (unitIds.some((unitId) => !UNIT_ID_PATTERN.test(unitId))) {
+    return { ok: false, code: 'CLIENTES_ACTOR_INVALID' }
+  }
   return {
     ok: true,
     actor: Object.freeze({
@@ -133,6 +140,7 @@ export function parseClientesReadonlyListQuery(searchParams) {
   const limitInput = optionalQueryText(searchParams, 'limit', 3)
   if (limitInput.present && !limitInput.validLength) return { ok: false, code: 'CLIENTES_LIMIT_INVALID' }
   const rawLimit = limitInput.value
+  if (rawLimit && !/^\d+$/.test(rawLimit)) return { ok: false, code: 'CLIENTES_LIMIT_INVALID' }
   const limit = rawLimit ? Number(rawLimit) : 25
   if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
     return { ok: false, code: 'CLIENTES_LIMIT_INVALID' }

--- a/clientes-readonly/src/contract.js
+++ b/clientes-readonly/src/contract.js
@@ -150,6 +150,7 @@ export function parseClientesReadonlyListQuery(searchParams) {
 
 export function projectClientesReadonlyRecord(input) {
   if (!input || typeof input !== 'object' || Array.isArray(input)) return null
+  if (typeof input.clientId !== 'string' || typeof input.unitId !== 'string') return null
   const clientId = text(input.clientId, 128)
   const unitId = text(input.unitId, 64)
   if (!CLIENT_ID_PATTERN.test(clientId) || !UNIT_ID_PATTERN.test(unitId)) return null

--- a/clientes-readonly/src/contract.js
+++ b/clientes-readonly/src/contract.js
@@ -1,0 +1,134 @@
+export const CLIENTES_READONLY_CONTRACT_VERSION = 'clientes-readonly/v1'
+
+export const CLIENTES_READONLY_ACTOR_FIELDS = Object.freeze([
+  'subject',
+  'role',
+  'unitIds',
+])
+
+export const CLIENTES_READONLY_ACTOR_ROLES = Object.freeze([
+  'GESTOR',
+])
+
+export const CLIENTES_READONLY_RECORD_FIELDS = Object.freeze([
+  'clientId',
+  'displayName',
+  'unitId',
+  'status',
+  'updatedAt',
+])
+
+export const CLIENTES_READONLY_STATUS_VALUES = Object.freeze([
+  'active',
+  'inactive',
+  'archived',
+])
+
+export const CLIENTES_READONLY_QUERY_FIELDS = Object.freeze([
+  'unitId',
+  'cursor',
+  'limit',
+])
+
+export const CLIENTES_READONLY_ROUTES = Object.freeze([
+  Object.freeze({ id: 'health', path: '/health', methods: Object.freeze(['GET', 'HEAD']), actorRequired: false }),
+  Object.freeze({ id: 'readiness', path: '/readiness', methods: Object.freeze(['GET', 'HEAD']), actorRequired: false }),
+  Object.freeze({ id: 'list', path: '/v1/clientes', methods: Object.freeze(['GET', 'HEAD']), actorRequired: true }),
+  Object.freeze({ id: 'detail', path: '/v1/clientes/:clientId', methods: Object.freeze(['GET', 'HEAD']), actorRequired: true }),
+])
+
+const ACTOR_TEXT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/
+const UNIT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/
+const CLIENT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/
+const CURSOR_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._~-]{0,255}$/
+const UPDATED_AT_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/
+
+function text(value, maxLength = 256) {
+  const normalized = String(value || '').trim()
+  return normalized && normalized.length <= maxLength ? normalized : ''
+}
+
+function unique(values) {
+  return [...new Set(values)]
+}
+
+export function clientesReadonlyRouteFor(pathname) {
+  const path = String(pathname || '')
+  if (path === '/health') return { route: CLIENTES_READONLY_ROUTES[0] }
+  if (path === '/readiness') return { route: CLIENTES_READONLY_ROUTES[1] }
+  if (path === '/v1/clientes') return { route: CLIENTES_READONLY_ROUTES[2] }
+  const detail = path.match(/^\/v1\/clientes\/([A-Za-z0-9][A-Za-z0-9._-]{0,127})$/)
+  return detail ? { route: CLIENTES_READONLY_ROUTES[3], clientId: detail[1] } : null
+}
+
+export function normalizeClientesReadonlyActor(input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return { ok: false, code: 'CLIENTES_ACTOR_REQUIRED' }
+  }
+  const subject = text(input.subject, 128)
+  if (!ACTOR_TEXT_PATTERN.test(subject)) return { ok: false, code: 'CLIENTES_ACTOR_INVALID' }
+  const role = text(input.role, 32).toUpperCase()
+  if (!CLIENTES_READONLY_ACTOR_ROLES.includes(role)) {
+    return { ok: false, code: 'CLIENTES_ACTOR_FORBIDDEN' }
+  }
+  const unitIds = unique((Array.isArray(input.unitIds) ? input.unitIds : [])
+    .map((unitId) => text(unitId, 64))
+    .filter((unitId) => UNIT_ID_PATTERN.test(unitId)))
+  if (!unitIds.length) return { ok: false, code: 'CLIENTES_UNIT_SCOPE_REQUIRED' }
+  return {
+    ok: true,
+    actor: Object.freeze({
+      subject,
+      role,
+      unitIds: Object.freeze(unitIds),
+    }),
+  }
+}
+
+export function actorCanReadClientesUnit(actor, unitId) {
+  const normalizedUnitId = text(unitId, 64)
+  return Boolean(normalizedUnitId && Array.isArray(actor?.unitIds) && actor.unitIds.includes(normalizedUnitId))
+}
+
+export function normalizeClientesReadonlyCursor(value) {
+  const cursor = text(value, 256)
+  return cursor && CURSOR_PATTERN.test(cursor) ? cursor : null
+}
+
+export function parseClientesReadonlyListQuery(searchParams) {
+  const seen = new Set()
+  for (const key of searchParams.keys()) {
+    if (!CLIENTES_READONLY_QUERY_FIELDS.includes(key)) {
+      return { ok: false, code: 'CLIENTES_QUERY_NOT_ALLOWED' }
+    }
+    if (seen.has(key)) return { ok: false, code: 'CLIENTES_QUERY_AMBIGUOUS' }
+    seen.add(key)
+  }
+  const unitId = text(searchParams.get('unitId'), 64)
+  if (!UNIT_ID_PATTERN.test(unitId)) return { ok: false, code: 'CLIENTES_UNIT_REQUIRED' }
+  const rawCursor = text(searchParams.get('cursor'), 256)
+  const cursor = normalizeClientesReadonlyCursor(rawCursor)
+  if (rawCursor && !cursor) return { ok: false, code: 'CLIENTES_CURSOR_INVALID' }
+  const rawLimit = text(searchParams.get('limit'), 3)
+  const limit = rawLimit ? Number(rawLimit) : 25
+  if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+    return { ok: false, code: 'CLIENTES_LIMIT_INVALID' }
+  }
+  return { ok: true, query: Object.freeze({ unitId, cursor: cursor || null, limit }) }
+}
+
+export function projectClientesReadonlyRecord(input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return null
+  const clientId = text(input.clientId, 128)
+  const unitId = text(input.unitId, 64)
+  if (!CLIENT_ID_PATTERN.test(clientId) || !UNIT_ID_PATTERN.test(unitId)) return null
+  const status = text(input.status, 64)
+  const updatedAt = text(input.updatedAt, 64)
+  return Object.freeze({
+    clientId,
+    displayName: text(input.displayName, 160) || null,
+    unitId,
+    status: CLIENTES_READONLY_STATUS_VALUES.includes(status) ? status : null,
+    updatedAt: UPDATED_AT_PATTERN.test(updatedAt) ? updatedAt : null,
+  })
+}

--- a/clientes-readonly/src/contract.js
+++ b/clientes-readonly/src/contract.js
@@ -151,6 +151,7 @@ export function parseClientesReadonlyListQuery(searchParams) {
 export function projectClientesReadonlyRecord(input) {
   if (!input || typeof input !== 'object' || Array.isArray(input)) return null
   if (typeof input.clientId !== 'string' || typeof input.unitId !== 'string') return null
+  if ([input.displayName, input.status, input.updatedAt].some((value) => value !== undefined && value !== null && typeof value !== 'string')) return null
   const clientId = text(input.clientId, 128)
   const unitId = text(input.unitId, 64)
   if (!CLIENT_ID_PATTERN.test(clientId) || !UNIT_ID_PATTERN.test(unitId)) return null

--- a/clientes-readonly/src/handler.js
+++ b/clientes-readonly/src/handler.js
@@ -132,9 +132,10 @@ export function createClientesReadonlyHandler({ readModel = null, resolveActor =
           return unavailable(request, 'data')
         }
         if (result.items.length > queryResult.query.limit) return unavailable(request, 'data')
-        const items = result.items
-          .map((item) => projectVisibleRecord(item, actorResult.actor, queryResult.query.unitId))
-          .filter(Boolean)
+        const projectedItems = result.items.map(projectClientesReadonlyRecord)
+        if (projectedItems.some((item) => !item)) return unavailable(request, 'data')
+        const items = projectedItems.filter((item) => actorCanReadClientesUnit(actorResult.actor, item.unitId)
+          && item.unitId === queryResult.query.unitId)
         return response(request, 200, {
           ok: true,
           contract: CLIENTES_READONLY_CONTRACT_VERSION,

--- a/clientes-readonly/src/handler.js
+++ b/clientes-readonly/src/handler.js
@@ -75,6 +75,14 @@ function projectVisibleRecord(record, actor, requestedUnitId = null) {
     : null
 }
 
+function projectDetailRecord(record, actor, requestedClientId) {
+  if (record === null) return { state: 'not-found' }
+  const projected = projectClientesReadonlyRecord(record)
+  if (!projected || projected.clientId !== requestedClientId) return { state: 'unavailable' }
+  if (!actorCanReadClientesUnit(actor, projected.unitId)) return { state: 'not-found' }
+  return { state: 'visible', record: projected }
+}
+
 async function resolvedActor(request, resolveActor) {
   try {
     return normalizeClientesReadonlyActor(await resolveActor(request))
@@ -123,6 +131,7 @@ export function createClientesReadonlyHandler({ readModel = null, resolveActor =
           && (typeof result.nextCursor !== 'string' || !nextCursor)) {
           return unavailable(request, 'data')
         }
+        if (result.items.length > queryResult.query.limit) return unavailable(request, 'data')
         const items = result.items
           .map((item) => projectVisibleRecord(item, actorResult.actor, queryResult.query.unitId))
           .filter(Boolean)
@@ -137,15 +146,16 @@ export function createClientesReadonlyHandler({ readModel = null, resolveActor =
     }
 
     try {
-      const record = projectVisibleRecord(await readModel.getClientById({
+      const detail = projectDetailRecord(await readModel.getClientById({
         actor: actorResult.actor,
         clientId: resolved.clientId,
-      }), actorResult.actor)
-      if (!record) return error(request, 404, 'CLIENTES_NOT_FOUND')
+      }), actorResult.actor, resolved.clientId)
+      if (detail.state === 'unavailable') return unavailable(request, 'data')
+      if (detail.state === 'not-found') return error(request, 404, 'CLIENTES_NOT_FOUND')
       return response(request, 200, {
         ok: true,
         contract: CLIENTES_READONLY_CONTRACT_VERSION,
-        data: record,
+        data: detail.record,
       })
     } catch {
       return unavailable(request, 'data')
@@ -155,5 +165,6 @@ export function createClientesReadonlyHandler({ readModel = null, resolveActor =
 
 export const __testables = {
   hasReadyReadModel,
+  projectDetailRecord,
   projectVisibleRecord,
 }

--- a/clientes-readonly/src/handler.js
+++ b/clientes-readonly/src/handler.js
@@ -137,16 +137,16 @@ export function createClientesReadonlyHandler({ readModel = null, resolveActor =
       try {
         const result = await readModel.listClients({ actor: actorResult.actor, query: queryResult.query })
         if (!result || typeof result !== 'object' || Array.isArray(result) || !Array.isArray(result.items)) {
-          return unavailable(request, 'data', { readModelReady, actorAdapterReady })
+          return unavailable(request, 'data', { readModelReady: false, actorAdapterReady })
         }
         const nextCursor = normalizeClientesReadonlyCursor(result.nextCursor)
         if (result.nextCursor !== undefined && result.nextCursor !== null
           && (typeof result.nextCursor !== 'string' || !nextCursor)) {
-          return unavailable(request, 'data', { readModelReady, actorAdapterReady })
+          return unavailable(request, 'data', { readModelReady: false, actorAdapterReady })
         }
-        if (result.items.length > queryResult.query.limit) return unavailable(request, 'data', { readModelReady, actorAdapterReady })
+        if (result.items.length > queryResult.query.limit) return unavailable(request, 'data', { readModelReady: false, actorAdapterReady })
         const projectedItems = result.items.map(projectClientesReadonlyRecord)
-        if (projectedItems.some((item) => !item)) return unavailable(request, 'data', { readModelReady, actorAdapterReady })
+        if (projectedItems.some((item) => !item)) return unavailable(request, 'data', { readModelReady: false, actorAdapterReady })
         const items = projectedItems.filter((item) => actorCanReadClientesUnit(actorResult.actor, item.unitId)
           && item.unitId === queryResult.query.unitId)
         return response(request, 200, {
@@ -155,7 +155,7 @@ export function createClientesReadonlyHandler({ readModel = null, resolveActor =
           data: { items, nextCursor },
         })
       } catch {
-        return unavailable(request, 'data', { readModelReady, actorAdapterReady })
+        return unavailable(request, 'data', { readModelReady: false, actorAdapterReady })
       }
     }
 
@@ -164,7 +164,7 @@ export function createClientesReadonlyHandler({ readModel = null, resolveActor =
         actor: actorResult.actor,
         clientId: resolved.clientId,
       }), actorResult.actor, resolved.clientId)
-      if (detail.state === 'unavailable') return unavailable(request, 'data', { readModelReady, actorAdapterReady })
+      if (detail.state === 'unavailable') return unavailable(request, 'data', { readModelReady: false, actorAdapterReady })
       if (detail.state === 'not-found') return error(request, 404, 'CLIENTES_NOT_FOUND')
       return response(request, 200, {
         ok: true,
@@ -172,7 +172,7 @@ export function createClientesReadonlyHandler({ readModel = null, resolveActor =
         data: detail.record,
       })
     } catch {
-      return unavailable(request, 'data', { readModelReady, actorAdapterReady })
+      return unavailable(request, 'data', { readModelReady: false, actorAdapterReady })
     }
   }
 }

--- a/clientes-readonly/src/handler.js
+++ b/clientes-readonly/src/handler.js
@@ -1,0 +1,147 @@
+import {
+  CLIENTES_READONLY_CONTRACT_VERSION,
+  actorCanReadClientesUnit,
+  clientesReadonlyRouteFor,
+  normalizeClientesReadonlyActor,
+  normalizeClientesReadonlyCursor,
+  parseClientesReadonlyListQuery,
+  projectClientesReadonlyRecord,
+} from './contract.js'
+
+const JSON_HEADERS = {
+  'content-type': 'application/json; charset=utf-8',
+  'cache-control': 'no-store',
+}
+
+function response(request, status, payload, headers = {}) {
+  return new Response(request.method === 'HEAD' ? null : JSON.stringify(payload), {
+    status,
+    headers: { ...JSON_HEADERS, ...headers },
+  })
+}
+
+function error(request, status, code, headers) {
+  return response(request, status, {
+    ok: false,
+    contract: CLIENTES_READONLY_CONTRACT_VERSION,
+    code,
+  }, headers)
+}
+
+function hasReadyReadModel(readModel) {
+  return Boolean(readModel?.ready === true
+    && typeof readModel.listClients === 'function'
+    && typeof readModel.getClientById === 'function')
+}
+
+function unavailable(request, endpoint) {
+  return response(request, endpoint === 'health' ? 200 : 503, {
+    ok: false,
+    unit: 'clientes-readonly',
+    contract: CLIENTES_READONLY_CONTRACT_VERSION,
+    ready: false,
+    code: 'CLIENTES_READMODEL_UNAVAILABLE',
+    dependencies: {
+      readModel: { required: true, state: 'unavailable' },
+    },
+  })
+}
+
+function ready(request, endpoint) {
+  return response(request, 200, {
+    ok: true,
+    unit: 'clientes-readonly',
+    contract: CLIENTES_READONLY_CONTRACT_VERSION,
+    ready: true,
+    endpoint,
+    dependencies: {
+      readModel: { required: true, state: 'healthy' },
+    },
+  })
+}
+
+function actorFailureStatus(code) {
+  if (code === 'CLIENTES_ACTOR_REQUIRED') return 401
+  return 403
+}
+
+function projectVisibleRecord(record, actor) {
+  const projected = projectClientesReadonlyRecord(record)
+  return projected && actorCanReadClientesUnit(actor, projected.unitId) ? projected : null
+}
+
+async function resolvedActor(request, resolveActor) {
+  try {
+    return normalizeClientesReadonlyActor(await resolveActor(request))
+  } catch {
+    return { ok: false, code: 'CLIENTES_ACTOR_REQUIRED' }
+  }
+}
+
+/**
+ * Creates the future product's HTTP contract without selecting a data source.
+ * A caller must explicitly supply a dedicated read-model and actor adapter;
+ * otherwise the handler remains read-only and unavailable.
+ */
+export function createClientesReadonlyHandler({ readModel = null, resolveActor = () => null } = {}) {
+  return async function handleClientesReadonlyRequest(request) {
+    const url = new URL(request.url)
+    const resolved = clientesReadonlyRouteFor(url.pathname)
+    if (!resolved) return error(request, 404, 'CLIENTES_ROUTE_NOT_FOUND')
+    const method = String(request.method || 'GET').toUpperCase()
+    if (!resolved.route.methods.includes(method)) {
+      return error(request, 405, 'READ_ONLY_RUNTIME', { allow: resolved.route.methods.join(', ') })
+    }
+
+    const readModelReady = hasReadyReadModel(readModel)
+    if (resolved.route.id === 'health' || resolved.route.id === 'readiness') {
+      return readModelReady ? ready(request, resolved.route.id) : unavailable(request, resolved.route.id)
+    }
+    if (!readModelReady) return unavailable(request, 'data')
+
+    const actorResult = await resolvedActor(request, resolveActor)
+    if (!actorResult.ok) return error(request, actorFailureStatus(actorResult.code), actorResult.code)
+
+    if (resolved.route.id === 'list') {
+      const queryResult = parseClientesReadonlyListQuery(url.searchParams)
+      if (!queryResult.ok) return error(request, 400, queryResult.code)
+      if (!actorCanReadClientesUnit(actorResult.actor, queryResult.query.unitId)) {
+        return error(request, 403, 'CLIENTES_UNIT_FORBIDDEN')
+      }
+      try {
+        const result = await readModel.listClients({ actor: actorResult.actor, query: queryResult.query })
+        const items = Array.isArray(result?.items)
+          ? result.items.map((item) => projectVisibleRecord(item, actorResult.actor)).filter(Boolean)
+          : []
+        const nextCursor = normalizeClientesReadonlyCursor(result?.nextCursor)
+        return response(request, 200, {
+          ok: true,
+          contract: CLIENTES_READONLY_CONTRACT_VERSION,
+          data: { items, nextCursor },
+        })
+      } catch {
+        return unavailable(request, 'data')
+      }
+    }
+
+    try {
+      const record = projectVisibleRecord(await readModel.getClientById({
+        actor: actorResult.actor,
+        clientId: resolved.clientId,
+      }), actorResult.actor)
+      if (!record) return error(request, 404, 'CLIENTES_NOT_FOUND')
+      return response(request, 200, {
+        ok: true,
+        contract: CLIENTES_READONLY_CONTRACT_VERSION,
+        data: record,
+      })
+    } catch {
+      return unavailable(request, 'data')
+    }
+  }
+}
+
+export const __testables = {
+  hasReadyReadModel,
+  projectVisibleRecord,
+}

--- a/clientes-readonly/src/handler.js
+++ b/clientes-readonly/src/handler.js
@@ -34,15 +34,20 @@ function hasReadyReadModel(readModel) {
     && typeof readModel.getClientById === 'function')
 }
 
-function unavailable(request, endpoint) {
+function hasConfiguredActorAdapter(resolveActor) {
+  return typeof resolveActor === 'function'
+}
+
+function unavailable(request, endpoint, { readModelReady, actorAdapterReady }, code = 'CLIENTES_READMODEL_UNAVAILABLE') {
   return response(request, endpoint === 'health' ? 200 : 503, {
     ok: false,
     unit: 'clientes-readonly',
     contract: CLIENTES_READONLY_CONTRACT_VERSION,
     ready: false,
-    code: 'CLIENTES_READMODEL_UNAVAILABLE',
+    code,
     dependencies: {
-      readModel: { required: true, state: 'unavailable' },
+      readModel: { required: true, state: readModelReady ? 'healthy' : 'unavailable' },
+      actorAdapter: { required: true, state: actorAdapterReady ? 'healthy' : 'unavailable' },
     },
   })
 }
@@ -56,6 +61,7 @@ function ready(request, endpoint) {
     endpoint,
     dependencies: {
       readModel: { required: true, state: 'healthy' },
+      actorAdapter: { required: true, state: 'healthy' },
     },
   })
 }
@@ -96,7 +102,7 @@ async function resolvedActor(request, resolveActor) {
  * A caller must explicitly supply a dedicated read-model and actor adapter;
  * otherwise the handler remains read-only and unavailable.
  */
-export function createClientesReadonlyHandler({ readModel = null, resolveActor = () => null } = {}) {
+export function createClientesReadonlyHandler({ readModel = null, resolveActor = null } = {}) {
   return async function handleClientesReadonlyRequest(request) {
     const url = new URL(request.url)
     const resolved = clientesReadonlyRouteFor(url.pathname)
@@ -107,10 +113,17 @@ export function createClientesReadonlyHandler({ readModel = null, resolveActor =
     }
 
     const readModelReady = hasReadyReadModel(readModel)
+    const actorAdapterReady = hasConfiguredActorAdapter(resolveActor)
+    const unavailableDependencies = { readModelReady, actorAdapterReady }
+    const dependencyCode = readModelReady ? 'CLIENTES_ACTOR_UNAVAILABLE' : 'CLIENTES_READMODEL_UNAVAILABLE'
     if (resolved.route.id === 'health' || resolved.route.id === 'readiness') {
-      return readModelReady ? ready(request, resolved.route.id) : unavailable(request, resolved.route.id)
+      return readModelReady && actorAdapterReady
+        ? ready(request, resolved.route.id)
+        : unavailable(request, resolved.route.id, unavailableDependencies, dependencyCode)
     }
-    if (!readModelReady) return unavailable(request, 'data')
+    if (!readModelReady || !actorAdapterReady) {
+      return unavailable(request, 'data', unavailableDependencies, dependencyCode)
+    }
 
     const actorResult = await resolvedActor(request, resolveActor)
     if (!actorResult.ok) return error(request, actorFailureStatus(actorResult.code), actorResult.code)
@@ -124,16 +137,16 @@ export function createClientesReadonlyHandler({ readModel = null, resolveActor =
       try {
         const result = await readModel.listClients({ actor: actorResult.actor, query: queryResult.query })
         if (!result || typeof result !== 'object' || Array.isArray(result) || !Array.isArray(result.items)) {
-          return unavailable(request, 'data')
+          return unavailable(request, 'data', { readModelReady, actorAdapterReady })
         }
         const nextCursor = normalizeClientesReadonlyCursor(result.nextCursor)
         if (result.nextCursor !== undefined && result.nextCursor !== null
           && (typeof result.nextCursor !== 'string' || !nextCursor)) {
-          return unavailable(request, 'data')
+          return unavailable(request, 'data', { readModelReady, actorAdapterReady })
         }
-        if (result.items.length > queryResult.query.limit) return unavailable(request, 'data')
+        if (result.items.length > queryResult.query.limit) return unavailable(request, 'data', { readModelReady, actorAdapterReady })
         const projectedItems = result.items.map(projectClientesReadonlyRecord)
-        if (projectedItems.some((item) => !item)) return unavailable(request, 'data')
+        if (projectedItems.some((item) => !item)) return unavailable(request, 'data', { readModelReady, actorAdapterReady })
         const items = projectedItems.filter((item) => actorCanReadClientesUnit(actorResult.actor, item.unitId)
           && item.unitId === queryResult.query.unitId)
         return response(request, 200, {
@@ -142,7 +155,7 @@ export function createClientesReadonlyHandler({ readModel = null, resolveActor =
           data: { items, nextCursor },
         })
       } catch {
-        return unavailable(request, 'data')
+        return unavailable(request, 'data', { readModelReady, actorAdapterReady })
       }
     }
 
@@ -151,7 +164,7 @@ export function createClientesReadonlyHandler({ readModel = null, resolveActor =
         actor: actorResult.actor,
         clientId: resolved.clientId,
       }), actorResult.actor, resolved.clientId)
-      if (detail.state === 'unavailable') return unavailable(request, 'data')
+      if (detail.state === 'unavailable') return unavailable(request, 'data', { readModelReady, actorAdapterReady })
       if (detail.state === 'not-found') return error(request, 404, 'CLIENTES_NOT_FOUND')
       return response(request, 200, {
         ok: true,
@@ -159,12 +172,13 @@ export function createClientesReadonlyHandler({ readModel = null, resolveActor =
         data: detail.record,
       })
     } catch {
-      return unavailable(request, 'data')
+      return unavailable(request, 'data', { readModelReady, actorAdapterReady })
     }
   }
 }
 
 export const __testables = {
+  hasConfiguredActorAdapter,
   hasReadyReadModel,
   projectDetailRecord,
   projectVisibleRecord,

--- a/clientes-readonly/src/handler.js
+++ b/clientes-readonly/src/handler.js
@@ -62,19 +62,24 @@ function ready(request, endpoint) {
 
 function actorFailureStatus(code) {
   if (code === 'CLIENTES_ACTOR_REQUIRED') return 401
+  if (code === 'CLIENTES_ACTOR_UNAVAILABLE') return 503
   return 403
 }
 
-function projectVisibleRecord(record, actor) {
+function projectVisibleRecord(record, actor, requestedUnitId = null) {
   const projected = projectClientesReadonlyRecord(record)
-  return projected && actorCanReadClientesUnit(actor, projected.unitId) ? projected : null
+  return projected
+    && actorCanReadClientesUnit(actor, projected.unitId)
+    && (!requestedUnitId || projected.unitId === requestedUnitId)
+    ? projected
+    : null
 }
 
 async function resolvedActor(request, resolveActor) {
   try {
     return normalizeClientesReadonlyActor(await resolveActor(request))
   } catch {
-    return { ok: false, code: 'CLIENTES_ACTOR_REQUIRED' }
+    return { ok: false, code: 'CLIENTES_ACTOR_UNAVAILABLE' }
   }
 }
 
@@ -110,10 +115,17 @@ export function createClientesReadonlyHandler({ readModel = null, resolveActor =
       }
       try {
         const result = await readModel.listClients({ actor: actorResult.actor, query: queryResult.query })
-        const items = Array.isArray(result?.items)
-          ? result.items.map((item) => projectVisibleRecord(item, actorResult.actor)).filter(Boolean)
-          : []
-        const nextCursor = normalizeClientesReadonlyCursor(result?.nextCursor)
+        if (!result || typeof result !== 'object' || Array.isArray(result) || !Array.isArray(result.items)) {
+          return unavailable(request, 'data')
+        }
+        const nextCursor = normalizeClientesReadonlyCursor(result.nextCursor)
+        if (result.nextCursor !== undefined && result.nextCursor !== null
+          && (typeof result.nextCursor !== 'string' || !nextCursor)) {
+          return unavailable(request, 'data')
+        }
+        const items = result.items
+          .map((item) => projectVisibleRecord(item, actorResult.actor, queryResult.query.unitId))
+          .filter(Boolean)
         return response(request, 200, {
           ok: true,
           contract: CLIENTES_READONLY_CONTRACT_VERSION,

--- a/clientes-readonly/src/index.js
+++ b/clientes-readonly/src/index.js
@@ -1,0 +1,17 @@
+export {
+  CLIENTES_READONLY_ACTOR_FIELDS,
+  CLIENTES_READONLY_ACTOR_ROLES,
+  CLIENTES_READONLY_CONTRACT_VERSION,
+  CLIENTES_READONLY_QUERY_FIELDS,
+  CLIENTES_READONLY_RECORD_FIELDS,
+  CLIENTES_READONLY_ROUTES,
+  CLIENTES_READONLY_STATUS_VALUES,
+  actorCanReadClientesUnit,
+  clientesReadonlyRouteFor,
+  normalizeClientesReadonlyActor,
+  normalizeClientesReadonlyCursor,
+  parseClientesReadonlyListQuery,
+  projectClientesReadonlyRecord,
+} from './contract.js'
+
+export { createClientesReadonlyHandler } from './handler.js'

--- a/clientes-readonly/test/closure.test.mjs
+++ b/clientes-readonly/test/closure.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const sourceRoot = path.join(root, 'src')
+
+function sourceFiles(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const resolved = path.join(directory, entry.name)
+    if (entry.isDirectory()) return sourceFiles(resolved)
+    return entry.isFile() && entry.name.endsWith('.js') ? [resolved] : []
+  })
+}
+
+function importSpecifiers(source) {
+  return [...source.matchAll(/(?:from\s+|import\s*\()['"]([^'"]+)['"]/g)].map((match) => match[1])
+}
+
+test('the extraction seed is self-contained and has no commercial implementation import', () => {
+  const files = sourceFiles(sourceRoot)
+  assert.ok(files.length > 0)
+  for (const file of files) {
+    const source = fs.readFileSync(file, 'utf8')
+    for (const specifier of importSpecifiers(source)) {
+      assert.match(specifier, /^\.\//, `${path.relative(root, file)} must not import an external implementation: ${specifier}`)
+      assert.doesNotMatch(specifier, /(?:^|\/)(?:crm|harmonia|caixa)(?:\/|$)|atendimento/i)
+    }
+    assert.doesNotMatch(source, /\bprocess\.env\b/)
+    assert.doesNotMatch(source, /\b(?:fetch|XMLHttpRequest|WebSocket)\s*\(/)
+  }
+})
+
+test('the extraction seed admits no mutable HTTP or data operation', () => {
+  const source = sourceFiles(sourceRoot).map((file) => fs.readFileSync(file, 'utf8')).join('\n')
+  assert.doesNotMatch(source, /\b(?:POST|PUT|PATCH|DELETE|INSERT|UPDATE|CREATE|ALTER|DROP)\b/)
+  assert.doesNotMatch(source, /readModel\.(?:create|update|delete|write|mutate)/)
+  assert.match(source, /readModel\.listClients/)
+  assert.match(source, /readModel\.getClientById/)
+})

--- a/clientes-readonly/test/handler.test.mjs
+++ b/clientes-readonly/test/handler.test.mjs
@@ -188,7 +188,7 @@ test('list results stay inside the requested unit even when the actor may read m
 })
 
 test('malformed list read-model responses fail closed instead of becoming empty results', async () => {
-  for (const malformed of [undefined, null, [], {}, { items: null }, { items: 'not-an-array' }, { items: [], nextCursor: {} }]) {
+  for (const malformed of [undefined, null, [], {}, { items: null }, { items: 'not-an-array' }, { items: [], nextCursor: {} }, { items: [{}] }]) {
     const handler = createClientesReadonlyHandler({
       readModel: {
         ready: true,
@@ -265,6 +265,26 @@ test('actor role, unit scope and query surface are all fail-closed', async () =>
   const overlongLimit = await allowedActor(request('/v1/clientes?unitId=novo-hamburgo&limit=1000'))
   assert.equal(overlongLimit.status, 400)
   assert.equal((await body(overlongLimit)).code, 'CLIENTES_LIMIT_INVALID')
+  const paddedCursor = await allowedActor(request('/v1/clientes?unitId=novo-hamburgo&cursor=%20cursor-2%20'))
+  assert.equal(paddedCursor.status, 400)
+  assert.equal((await body(paddedCursor)).code, 'CLIENTES_CURSOR_INVALID')
+  const paddedLimit = await allowedActor(request('/v1/clientes?unitId=novo-hamburgo&limit=%2020%20'))
+  assert.equal(paddedLimit.status, 400)
+  assert.equal((await body(paddedLimit)).code, 'CLIENTES_LIMIT_INVALID')
+})
+
+test('list results fail closed when an adapter cursor changes bytes under projection', async () => {
+  const handler = createClientesReadonlyHandler({
+    readModel: {
+      ready: true,
+      async listClients() { return { items: [], nextCursor: ' cursor-2 ' } },
+      async getClientById() { return null },
+    },
+    resolveActor: () => ({ subject: 'user-gestor-1', role: 'GESTOR', unitIds: ['novo-hamburgo'] }),
+  })
+  const response = await handler(request('/v1/clientes?unitId=novo-hamburgo'))
+  assert.equal(response.status, 503)
+  assert.equal((await body(response)).code, 'CLIENTES_READMODEL_UNAVAILABLE')
 })
 
 test('a failing actor adapter is unavailable, while a missing actor stays unauthorized', async () => {

--- a/clientes-readonly/test/handler.test.mjs
+++ b/clientes-readonly/test/handler.test.mjs
@@ -191,7 +191,18 @@ test('list results stay inside the requested unit even when the actor may read m
 })
 
 test('malformed list read-model responses fail closed instead of becoming empty results', async () => {
-  for (const malformed of [undefined, null, [], {}, { items: null }, { items: 'not-an-array' }, { items: [], nextCursor: {} }, { items: [{}] }]) {
+  for (const malformed of [
+    undefined,
+    null,
+    [],
+    {},
+    { items: null },
+    { items: 'not-an-array' },
+    { items: [], nextCursor: {} },
+    { items: [{}] },
+    { items: [{ clientId: ['cliente-1'], unitId: 'novo-hamburgo' }] },
+    { items: [{ clientId: 'cliente-1', unitId: ['novo-hamburgo'] }] },
+  ]) {
     const handler = createClientesReadonlyHandler({
       readModel: {
         ready: true,
@@ -385,6 +396,8 @@ test('detail reads fail closed for malformed or mismatched adapter records', asy
   for (const record of [
     undefined,
     {},
+    { clientId: ['cliente-expected'], displayName: 'Malformed ID', unitId: 'novo-hamburgo', status: 'active' },
+    { clientId: 'cliente-expected', displayName: 'Malformed unit', unitId: ['novo-hamburgo'], status: 'active' },
     { clientId: 'cliente-other', displayName: 'Other', unitId: 'novo-hamburgo', status: 'active' },
   ]) {
     const handler = createClientesReadonlyHandler({

--- a/clientes-readonly/test/handler.test.mjs
+++ b/clientes-readonly/test/handler.test.mjs
@@ -202,6 +202,9 @@ test('malformed list read-model responses fail closed instead of becoming empty 
     { items: [{}] },
     { items: [{ clientId: ['cliente-1'], unitId: 'novo-hamburgo' }] },
     { items: [{ clientId: 'cliente-1', unitId: ['novo-hamburgo'] }] },
+    { items: [{ clientId: 'cliente-1', unitId: 'novo-hamburgo', displayName: ['Ana'] }] },
+    { items: [{ clientId: 'cliente-1', unitId: 'novo-hamburgo', status: ['active'] }] },
+    { items: [{ clientId: 'cliente-1', unitId: 'novo-hamburgo', updatedAt: ['2026-08-28T12:00:00Z'] }] },
   ]) {
     const handler = createClientesReadonlyHandler({
       readModel: {
@@ -376,6 +379,23 @@ test('a failing actor adapter is unavailable, while a missing actor stays unauth
   assert.equal(readCalls, 0)
 })
 
+test('runtime read-model failures report the dependency as unavailable', async () => {
+  const handler = createClientesReadonlyHandler({
+    readModel: {
+      ready: true,
+      async listClients() { throw new Error('read model unavailable') },
+      async getClientById() { return null },
+    },
+    resolveActor: () => ({ subject: 'user-gestor-1', role: 'GESTOR', unitIds: ['novo-hamburgo'] }),
+  })
+  const response = await handler(request('/v1/clientes?unitId=novo-hamburgo'))
+  assert.equal(response.status, 503)
+  assert.deepEqual((await body(response)).dependencies, {
+    readModel: { required: true, state: 'unavailable' },
+    actorAdapter: { required: true, state: 'healthy' },
+  })
+})
+
 test('detail reads cannot reveal a record outside the explicit actor unit scope', async () => {
   const handler = createClientesReadonlyHandler({
     readModel: {
@@ -398,6 +418,9 @@ test('detail reads fail closed for malformed or mismatched adapter records', asy
     {},
     { clientId: ['cliente-expected'], displayName: 'Malformed ID', unitId: 'novo-hamburgo', status: 'active' },
     { clientId: 'cliente-expected', displayName: 'Malformed unit', unitId: ['novo-hamburgo'], status: 'active' },
+    { clientId: 'cliente-expected', displayName: ['Malformed display name'], unitId: 'novo-hamburgo', status: 'active' },
+    { clientId: 'cliente-expected', displayName: 'Malformed status', unitId: 'novo-hamburgo', status: ['active'] },
+    { clientId: 'cliente-expected', displayName: 'Malformed timestamp', unitId: 'novo-hamburgo', updatedAt: ['2026-08-28T12:00:00Z'] },
     { clientId: 'cliente-other', displayName: 'Other', unitId: 'novo-hamburgo', status: 'active' },
   ]) {
     const handler = createClientesReadonlyHandler({

--- a/clientes-readonly/test/handler.test.mjs
+++ b/clientes-readonly/test/handler.test.mjs
@@ -148,6 +148,48 @@ test('the handler redacts the incoming actor and projects only visible allowlist
   }])
 })
 
+test('list results stay inside the requested unit even when the actor may read multiple units', async () => {
+  const handler = createClientesReadonlyHandler({
+    readModel: {
+      ready: true,
+      async listClients() {
+        return {
+          items: [
+            { clientId: 'cliente-nh', displayName: 'Novo Hamburgo', unitId: 'novo-hamburgo', status: 'active' },
+            { clientId: 'cliente-poa', displayName: 'Porto Alegre', unitId: 'porto-alegre', status: 'active' },
+          ],
+        }
+      },
+      async getClientById() { return null },
+    },
+    resolveActor: () => ({
+      subject: 'user-gestor-multiu',
+      role: 'GESTOR',
+      unitIds: ['novo-hamburgo', 'porto-alegre'],
+    }),
+  })
+
+  const response = await handler(request('/v1/clientes?unitId=novo-hamburgo'))
+  assert.equal(response.status, 200)
+  assert.deepEqual((await body(response)).data.items.map((item) => item.clientId), ['cliente-nh'])
+})
+
+test('malformed list read-model responses fail closed instead of becoming empty results', async () => {
+  for (const malformed of [undefined, null, [], {}, { items: null }, { items: 'not-an-array' }, { items: [], nextCursor: {} }]) {
+    const handler = createClientesReadonlyHandler({
+      readModel: {
+        ready: true,
+        async listClients() { return malformed },
+        async getClientById() { return null },
+      },
+      resolveActor: () => ({ subject: 'user-gestor-1', role: 'GESTOR', unitIds: ['novo-hamburgo'] }),
+    })
+    const response = await handler(request('/v1/clientes?unitId=novo-hamburgo'))
+    assert.equal(response.status, 503)
+    assert.equal((await body(response)).code, 'CLIENTES_READMODEL_UNAVAILABLE')
+  }
+})
+
 test('actor role, unit scope and query surface are all fail-closed', async () => {
   const readModel = {
     ready: true,
@@ -183,6 +225,34 @@ test('actor role, unit scope and query surface are all fail-closed', async () =>
   const foreignUnit = await allowedActor(request('/v1/clientes?unitId=porto-alegre'))
   assert.equal(foreignUnit.status, 403)
   assert.equal((await body(foreignUnit)).code, 'CLIENTES_UNIT_FORBIDDEN')
+  const overlongCursor = await allowedActor(request(`/v1/clientes?unitId=novo-hamburgo&cursor=${'c'.repeat(257)}`))
+  assert.equal(overlongCursor.status, 400)
+  assert.equal((await body(overlongCursor)).code, 'CLIENTES_CURSOR_INVALID')
+  const overlongLimit = await allowedActor(request('/v1/clientes?unitId=novo-hamburgo&limit=1000'))
+  assert.equal(overlongLimit.status, 400)
+  assert.equal((await body(overlongLimit)).code, 'CLIENTES_LIMIT_INVALID')
+})
+
+test('a failing actor adapter is unavailable, while a missing actor stays unauthorized', async () => {
+  let readCalls = 0
+  const readModel = {
+    ready: true,
+    async listClients() { readCalls += 1; return { items: [] } },
+    async getClientById() { return null },
+  }
+  const unavailableActor = createClientesReadonlyHandler({
+    readModel,
+    resolveActor: () => { throw new Error('identity adapter unavailable') },
+  })
+  const unavailableResponse = await unavailableActor(request('/v1/clientes?unitId=novo-hamburgo'))
+  assert.equal(unavailableResponse.status, 503)
+  assert.equal((await body(unavailableResponse)).code, 'CLIENTES_ACTOR_UNAVAILABLE')
+
+  const missingActor = createClientesReadonlyHandler({ readModel, resolveActor: () => null })
+  const missingResponse = await missingActor(request('/v1/clientes?unitId=novo-hamburgo'))
+  assert.equal(missingResponse.status, 401)
+  assert.equal((await body(missingResponse)).code, 'CLIENTES_ACTOR_REQUIRED')
+  assert.equal(readCalls, 0)
 })
 
 test('detail reads cannot reveal a record outside the explicit actor unit scope', async () => {

--- a/clientes-readonly/test/handler.test.mjs
+++ b/clientes-readonly/test/handler.test.mjs
@@ -106,6 +106,13 @@ test('the handler redacts the incoming actor and projects only visible allowlist
               updatedAt: 'not-a-timestamp',
               commercialScore: 999,
             },
+            {
+              clientId: 'cliente-4',
+              displayName: 'Invalid Calendar Value',
+              unitId: 'novo-hamburgo',
+              status: 'active',
+              updatedAt: '2026-99-99T99:99:99Z',
+            },
           ],
           nextCursor: 'cursor-2',
         }
@@ -137,6 +144,12 @@ test('the handler redacts the incoming actor and projects only visible allowlist
         displayName: 'Contract Sanitized',
         unitId: 'novo-hamburgo',
         status: null,
+        updatedAt: null,
+      }, {
+        clientId: 'cliente-4',
+        displayName: 'Invalid Calendar Value',
+        unitId: 'novo-hamburgo',
+        status: 'active',
         updatedAt: null,
       }],
       nextCursor: 'cursor-2',
@@ -188,6 +201,27 @@ test('malformed list read-model responses fail closed instead of becoming empty 
     assert.equal(response.status, 503)
     assert.equal((await body(response)).code, 'CLIENTES_READMODEL_UNAVAILABLE')
   }
+})
+
+test('list read-model results cannot exceed the requested response cap', async () => {
+  const handler = createClientesReadonlyHandler({
+    readModel: {
+      ready: true,
+      async listClients() {
+        return {
+          items: [
+            { clientId: 'cliente-1', displayName: 'One', unitId: 'novo-hamburgo', status: 'active' },
+            { clientId: 'cliente-2', displayName: 'Two', unitId: 'novo-hamburgo', status: 'active' },
+          ],
+        }
+      },
+      async getClientById() { return null },
+    },
+    resolveActor: () => ({ subject: 'user-gestor-1', role: 'GESTOR', unitIds: ['novo-hamburgo'] }),
+  })
+  const response = await handler(request('/v1/clientes?unitId=novo-hamburgo&limit=1'))
+  assert.equal(response.status, 503)
+  assert.equal((await body(response)).code, 'CLIENTES_READMODEL_UNAVAILABLE')
 })
 
 test('actor role, unit scope and query surface are all fail-closed', async () => {
@@ -269,4 +303,24 @@ test('detail reads cannot reveal a record outside the explicit actor unit scope'
   const response = await handler(request('/v1/clientes/cliente-2'))
   assert.equal(response.status, 404)
   assert.equal((await body(response)).code, 'CLIENTES_NOT_FOUND')
+})
+
+test('detail reads fail closed for malformed or mismatched adapter records', async () => {
+  for (const record of [
+    undefined,
+    {},
+    { clientId: 'cliente-other', displayName: 'Other', unitId: 'novo-hamburgo', status: 'active' },
+  ]) {
+    const handler = createClientesReadonlyHandler({
+      readModel: {
+        ready: true,
+        async listClients() { return { items: [] } },
+        async getClientById() { return record },
+      },
+      resolveActor: () => ({ subject: 'user-gestor-1', role: 'GESTOR', unitIds: ['novo-hamburgo'] }),
+    })
+    const response = await handler(request('/v1/clientes/cliente-expected'))
+    assert.equal(response.status, 503)
+    assert.equal((await body(response)).code, 'CLIENTES_READMODEL_UNAVAILABLE')
+  }
 })

--- a/clientes-readonly/test/handler.test.mjs
+++ b/clientes-readonly/test/handler.test.mjs
@@ -1,0 +1,202 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  CLIENTES_READONLY_ACTOR_FIELDS,
+  CLIENTES_READONLY_ACTOR_ROLES,
+  CLIENTES_READONLY_CONTRACT_VERSION,
+  CLIENTES_READONLY_QUERY_FIELDS,
+  CLIENTES_READONLY_RECORD_FIELDS,
+  CLIENTES_READONLY_ROUTES,
+  CLIENTES_READONLY_STATUS_VALUES,
+  createClientesReadonlyHandler,
+} from '../src/index.js'
+
+async function body(response) {
+  return response.json()
+}
+
+function request(path, options = {}) {
+  return new Request(`https://clientes-readonly.invalid${path}`, options)
+}
+
+test('v1 declares a minimal actor, route, query and record allowlist', () => {
+  assert.equal(CLIENTES_READONLY_CONTRACT_VERSION, 'clientes-readonly/v1')
+  assert.deepEqual(CLIENTES_READONLY_ACTOR_FIELDS, ['subject', 'role', 'unitIds'])
+  assert.deepEqual(CLIENTES_READONLY_ACTOR_ROLES, ['GESTOR'])
+  assert.deepEqual(CLIENTES_READONLY_RECORD_FIELDS, ['clientId', 'displayName', 'unitId', 'status', 'updatedAt'])
+  assert.deepEqual(CLIENTES_READONLY_STATUS_VALUES, ['active', 'inactive', 'archived'])
+  assert.deepEqual(CLIENTES_READONLY_QUERY_FIELDS, ['unitId', 'cursor', 'limit'])
+  assert.deepEqual(CLIENTES_READONLY_ROUTES.map((route) => route.path), [
+    '/health',
+    '/readiness',
+    '/v1/clientes',
+    '/v1/clientes/:clientId',
+  ])
+  assert.ok(CLIENTES_READONLY_ROUTES.every((route) => route.methods.every((method) => ['GET', 'HEAD'].includes(method))))
+})
+
+test('health is observable but data and readiness fail closed without a read-model', async () => {
+  const handler = createClientesReadonlyHandler()
+  const health = await handler(request('/health'))
+  assert.equal(health.status, 200)
+  assert.deepEqual(await body(health), {
+    ok: false,
+    unit: 'clientes-readonly',
+    contract: 'clientes-readonly/v1',
+    ready: false,
+    code: 'CLIENTES_READMODEL_UNAVAILABLE',
+    dependencies: { readModel: { required: true, state: 'unavailable' } },
+  })
+
+  const readiness = await handler(request('/readiness'))
+  assert.equal(readiness.status, 503)
+  assert.equal((await body(readiness)).code, 'CLIENTES_READMODEL_UNAVAILABLE')
+
+  const list = await handler(request('/v1/clientes?unitId=novo-hamburgo'))
+  assert.equal(list.status, 503)
+  assert.equal((await body(list)).code, 'CLIENTES_READMODEL_UNAVAILABLE')
+})
+
+test('every unapproved method is rejected before any read-model call', async () => {
+  let calls = 0
+  const handler = createClientesReadonlyHandler({
+    readModel: {
+      ready: true,
+      async listClients() { calls += 1; return { items: [] } },
+      async getClientById() { calls += 1; return null },
+    },
+  })
+  const response = await handler(request('/v1/clientes?unitId=novo-hamburgo', { method: 'POST' }))
+  assert.equal(response.status, 405)
+  assert.equal(response.headers.get('allow'), 'GET, HEAD')
+  assert.equal((await body(response)).code, 'READ_ONLY_RUNTIME')
+  assert.equal(calls, 0)
+})
+
+test('the handler redacts the incoming actor and projects only visible allowlisted record fields', async () => {
+  const observed = []
+  const handler = createClientesReadonlyHandler({
+    readModel: {
+      ready: true,
+      async listClients(input) {
+        observed.push(input)
+        return {
+          items: [
+            {
+              clientId: 'cliente-1',
+              displayName: 'Ana Example',
+              unitId: 'novo-hamburgo',
+              status: 'active',
+              updatedAt: '2026-08-28T12:00:00.000Z',
+              email: 'must-not-leave-boundary@example.invalid',
+              phone: '+5551999999999',
+              clinicalNotes: 'must-not-leave-boundary',
+            },
+            {
+              clientId: 'cliente-2',
+              displayName: 'Other Unit',
+              unitId: 'porto-alegre',
+              status: 'active',
+            },
+            {
+              clientId: 'cliente-3',
+              displayName: 'Contract Sanitized',
+              unitId: 'novo-hamburgo',
+              status: 'commercial-private-value',
+              updatedAt: 'not-a-timestamp',
+              commercialScore: 999,
+            },
+          ],
+          nextCursor: 'cursor-2',
+        }
+      },
+      async getClientById() { return null },
+    },
+    resolveActor: async () => ({
+      subject: 'user-gestor-1',
+      role: 'GESTOR',
+      unitIds: ['novo-hamburgo'],
+      email: 'must-not-reach-read-model@example.invalid',
+      displayName: 'Must not reach read model',
+    }),
+  })
+  const response = await handler(request('/v1/clientes?unitId=novo-hamburgo&limit=20'))
+  assert.equal(response.status, 200)
+  assert.deepEqual(await body(response), {
+    ok: true,
+    contract: 'clientes-readonly/v1',
+    data: {
+      items: [{
+        clientId: 'cliente-1',
+        displayName: 'Ana Example',
+        unitId: 'novo-hamburgo',
+        status: 'active',
+        updatedAt: '2026-08-28T12:00:00.000Z',
+      }, {
+        clientId: 'cliente-3',
+        displayName: 'Contract Sanitized',
+        unitId: 'novo-hamburgo',
+        status: null,
+        updatedAt: null,
+      }],
+      nextCursor: 'cursor-2',
+    },
+  })
+  assert.deepEqual(observed, [{
+    actor: { subject: 'user-gestor-1', role: 'GESTOR', unitIds: ['novo-hamburgo'] },
+    query: { unitId: 'novo-hamburgo', cursor: null, limit: 20 },
+  }])
+})
+
+test('actor role, unit scope and query surface are all fail-closed', async () => {
+  const readModel = {
+    ready: true,
+    async listClients() { return { items: [] } },
+    async getClientById() { return null },
+  }
+  const forbiddenRole = createClientesReadonlyHandler({
+    readModel,
+    resolveActor: () => ({ subject: 'user-1', role: 'CONSULTOR', unitIds: ['novo-hamburgo'] }),
+  })
+  const roleResponse = await forbiddenRole(request('/v1/clientes?unitId=novo-hamburgo'))
+  assert.equal(roleResponse.status, 403)
+  assert.equal((await body(roleResponse)).code, 'CLIENTES_ACTOR_FORBIDDEN')
+
+  const missingScope = createClientesReadonlyHandler({
+    readModel,
+    resolveActor: () => ({ subject: 'user-1', role: 'GESTOR', unitIds: [] }),
+  })
+  const scopeResponse = await missingScope(request('/v1/clientes?unitId=novo-hamburgo'))
+  assert.equal(scopeResponse.status, 403)
+  assert.equal((await body(scopeResponse)).code, 'CLIENTES_UNIT_SCOPE_REQUIRED')
+
+  const allowedActor = createClientesReadonlyHandler({
+    readModel,
+    resolveActor: () => ({ subject: 'user-1', role: 'GESTOR', unitIds: ['novo-hamburgo'] }),
+  })
+  const extraQuery = await allowedActor(request('/v1/clientes?unitId=novo-hamburgo&include=everything'))
+  assert.equal(extraQuery.status, 400)
+  assert.equal((await body(extraQuery)).code, 'CLIENTES_QUERY_NOT_ALLOWED')
+  const duplicateQuery = await allowedActor(request('/v1/clientes?unitId=novo-hamburgo&unitId=porto-alegre'))
+  assert.equal(duplicateQuery.status, 400)
+  assert.equal((await body(duplicateQuery)).code, 'CLIENTES_QUERY_AMBIGUOUS')
+  const foreignUnit = await allowedActor(request('/v1/clientes?unitId=porto-alegre'))
+  assert.equal(foreignUnit.status, 403)
+  assert.equal((await body(foreignUnit)).code, 'CLIENTES_UNIT_FORBIDDEN')
+})
+
+test('detail reads cannot reveal a record outside the explicit actor unit scope', async () => {
+  const handler = createClientesReadonlyHandler({
+    readModel: {
+      ready: true,
+      async listClients() { return { items: [] } },
+      async getClientById() {
+        return { clientId: 'cliente-2', displayName: 'Other Unit', unitId: 'porto-alegre', status: 'active' }
+      },
+    },
+    resolveActor: () => ({ subject: 'user-gestor-1', role: 'GESTOR', unitIds: ['novo-hamburgo'] }),
+  })
+  const response = await handler(request('/v1/clientes/cliente-2'))
+  assert.equal(response.status, 404)
+  assert.equal((await body(response)).code, 'CLIENTES_NOT_FOUND')
+})

--- a/clientes-readonly/test/handler.test.mjs
+++ b/clientes-readonly/test/handler.test.mjs
@@ -45,7 +45,10 @@ test('health is observable but data and readiness fail closed without a read-mod
     contract: 'clientes-readonly/v1',
     ready: false,
     code: 'CLIENTES_READMODEL_UNAVAILABLE',
-    dependencies: { readModel: { required: true, state: 'unavailable' } },
+    dependencies: {
+      readModel: { required: true, state: 'unavailable' },
+      actorAdapter: { required: true, state: 'unavailable' },
+    },
   })
 
   const readiness = await handler(request('/readiness'))
@@ -271,6 +274,59 @@ test('actor role, unit scope and query surface are all fail-closed', async () =>
   const paddedLimit = await allowedActor(request('/v1/clientes?unitId=novo-hamburgo&limit=%2020%20'))
   assert.equal(paddedLimit.status, 400)
   assert.equal((await body(paddedLimit)).code, 'CLIENTES_LIMIT_INVALID')
+  for (const nonDecimalLimit of ['1e2', '0x1']) {
+    const nonDecimalResponse = await allowedActor(request(`/v1/clientes?unitId=novo-hamburgo&limit=${nonDecimalLimit}`))
+    assert.equal(nonDecimalResponse.status, 400)
+    assert.equal((await body(nonDecimalResponse)).code, 'CLIENTES_LIMIT_INVALID')
+  }
+})
+
+test('actor fields must use the contract primitive types before authorization', async () => {
+  let readCalls = 0
+  const readModel = {
+    ready: true,
+    async listClients() { readCalls += 1; return { items: [] } },
+    async getClientById() { return null },
+  }
+  const malformedActors = [
+    { subject: ['user-1'], role: 'GESTOR', unitIds: ['novo-hamburgo'] },
+    { subject: 'user-1', role: ['GESTOR'], unitIds: ['novo-hamburgo'] },
+    { subject: 'user-1', role: 'GESTOR', unitIds: [{ toString: () => 'novo-hamburgo' }] },
+  ]
+  for (const actor of malformedActors) {
+    const handler = createClientesReadonlyHandler({ readModel, resolveActor: () => actor })
+    const actorResponse = await handler(request('/v1/clientes?unitId=novo-hamburgo'))
+    assert.equal(actorResponse.status, 403)
+    assert.equal((await body(actorResponse)).code, 'CLIENTES_ACTOR_INVALID')
+  }
+  assert.equal(readCalls, 0)
+})
+
+test('readiness requires both a configured actor adapter and a ready read-model', async () => {
+  const readModel = {
+    ready: true,
+    async listClients() { return { items: [] } },
+    async getClientById() { return null },
+  }
+  const missingActorAdapter = createClientesReadonlyHandler({ readModel })
+  const unavailableReadiness = await missingActorAdapter(request('/readiness'))
+  assert.equal(unavailableReadiness.status, 503)
+  assert.deepEqual(await body(unavailableReadiness), {
+    ok: false,
+    unit: 'clientes-readonly',
+    contract: 'clientes-readonly/v1',
+    ready: false,
+    code: 'CLIENTES_ACTOR_UNAVAILABLE',
+    dependencies: {
+      readModel: { required: true, state: 'healthy' },
+      actorAdapter: { required: true, state: 'unavailable' },
+    },
+  })
+
+  const readyHandler = createClientesReadonlyHandler({ readModel, resolveActor: () => null })
+  const readyReadiness = await readyHandler(request('/readiness'))
+  assert.equal(readyReadiness.status, 200)
+  assert.equal((await body(readyReadiness)).ready, true)
 })
 
 test('list results fail closed when an adapter cursor changes bytes under projection', async () => {

--- a/ops/governance/github-repository-transfer-plan.json
+++ b/ops/governance/github-repository-transfer-plan.json
@@ -27,7 +27,7 @@
   ],
   "codeownersBlueprint": [
     {"paths": ["/.github/", "/.githooks/", "/ops/", "/scripts/", "/docs/", "/db/", "/skills/", "/packages/"], "team": "skincos-platform"},
-    {"paths": ["/crm/", "/api/", "/backend/", "/frontend/", "/identity/", "/service/", "/booking/", "/integration/", "/messaging/"], "team": "skincos-crm"},
+    {"paths": ["/crm/", "/api/", "/backend/", "/frontend/", "/identity/", "/service/", "/booking/", "/integration/", "/messaging/", "/clientes-readonly/"], "team": "skincos-crm"},
     {"paths": ["/finance/"], "team": "skincos-finance"},
     {"paths": ["/workforce/"], "team": "skincos-workforce"},
     {"paths": ["/inventory/"], "team": "skincos-inventory"},

--- a/ops/governance/global-concurrency-policy.json
+++ b/ops/governance/global-concurrency-policy.json
@@ -126,7 +126,7 @@
     },
     "clientes-readonly": {
       "patterns": ["clientes-readonly/**"],
-      "sharedInputs": false
+      "sharedInputs": true
     },
     "website": {
       "patterns": ["website/**", "booking/**", ".github/workflows/deploy-website-cloudflare.yml", ".github/workflows/website-instagram-sync.yml", ".github/workflows/sync-website-cloudflare-security.yml"],

--- a/ops/governance/global-concurrency-policy.json
+++ b/ops/governance/global-concurrency-policy.json
@@ -124,6 +124,10 @@
       "patterns": ["crm/console/**", "inventory/**", ".github/workflows/deploy-finance-ui.yml", ".github/workflows/promotion-gate.yml", ".github/scripts/promotion-*.mjs"],
       "sharedInputs": true
     },
+    "clientes-readonly": {
+      "patterns": ["clientes-readonly/**"],
+      "sharedInputs": false
+    },
     "website": {
       "patterns": ["website/**", "booking/**", ".github/workflows/deploy-website-cloudflare.yml", ".github/workflows/website-instagram-sync.yml", ".github/workflows/sync-website-cloudflare-security.yml"],
       "sharedInputs": true


### PR DESCRIPTION
## Objetivo\nEstabelece a fronteira autocontida clientes-readonly/v1 para o futuro produto de Clientes somente-leitura.\n\n## Garantias\n- ator redigido e estritamente limitado a GESTOR + escopo de unidade;\n- apenas GET/HEAD, rotas e campos explicitamente allowlisted;\n- health observável e readiness/dados fail-closed com CLIENTES_READMODEL_UNAVAILABLE;\n- sem import do CRM comercial, Harmonia, Caixa ou Atendimento;\n- sem rede, variáveis de ambiente, operações mutáveis ou read-model implícito.\n\n## Fora de escopo\nNenhum deploy, banco, migration, hostname, tráfego ou integração com o runtime atual.\n\n## Validação\n- check de fontes;\n- 8 testes de contrato/fail-closed;\n- validação de arquitetura, closure e governança local.\n\nEste é um pré-requisito de extração, não o corte de skincos-clientes-readonly.