### PR TITLE
feat(schedule): stage isolated public availability boundary

### DIFF
--- a/.github/workflows/schedule-public-read-contract.yml
+++ b/.github/workflows/schedule-public-read-contract.yml
@@ -1,0 +1,36 @@
+name: Schedule Public Read Contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "workforce/schedule/**"
+      - ".github/workflows/schedule-public-read-contract.yml"
+  push:
+    branches: [main]
+    paths:
+      - "workforce/schedule/**"
+      - ".github/workflows/schedule-public-read-contract.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    name: Schedule public read contract (local-only)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "22.12.0"
+
+      - name: Run isolated contract tests
+        run: node --test workforce/schedule/public-read-contract.test.js workforce/schedule/public-read-core.test.js workforce/schedule/public-read-worker.test.js
+
+      - name: Run no-remote dry run
+        run: node workforce/schedule/scripts/public-read-dry-run.mjs

--- a/workforce/schedule/PUBLIC_READ_CONTRACT.md
+++ b/workforce/schedule/PUBLIC_READ_CONTRACT.md
@@ -1,0 +1,37 @@
+# `schedule-public-read/v1`
+
+This is the private, read-only compatibility boundary for the future
+`skincos-workforce-schedule` repository. It is source-only in this change:
+there is no route, deployment, hostname, D1 migration, secret provisioning or
+Website cutover.
+
+## Contract
+
+The adapter exposes only `GET` requests, authenticated with a distinct
+`SCHEDULE_PUBLIC_READ_HMAC_KEY` and the `website-booking` service identity:
+
+- `GET /health` checks that the adapter is explicitly enabled and fully bound.
+- `GET /schedule-public-read/v1/readiness` checks the Schedule core's D1 read.
+- `GET /schedule-public-read/v1/availability?unit=<unit>&date=YYYY-MM-DD`
+  returns a closed flag and display names scheduled for that day.
+- `GET /schedule-public-read/v1/professionals?unit=<unit>` returns the public
+  professional profile fields used by Website. Phone and email are never in this
+  contract.
+
+Every versioned request carries `x-skincos-schedule-read-*` headers. Its HMAC
+binds the version, timestamp, nonce, `GET` method, exact path/query and fixed
+service name. It is deliberately independent from `ESCALA_ACTOR_HMAC_KEY`,
+which remains the CRM/Ponto writer-and-management credential.
+
+## Staged cut prerequisites
+
+The current Website still reads `SKINCOS_ESCALA_DB` directly and its booking
+routes keep their existing behavior. Before a future consumer migration:
+
+1. Create isolated staging resources and provision the new key to the adapter,
+   Schedule core and Website only.
+2. Compare direct-D1 and adapter responses for synthetic availability and
+   profiles, then prove readiness and rollback.
+3. Decide the customer-facing behavior when Schedule is unavailable: preserve
+   the current fallback or return a booking-unavailable response. This contract
+   does not make that product decision.

--- a/workforce/schedule/PUBLIC_READ_CONTRACT.md
+++ b/workforce/schedule/PUBLIC_READ_CONTRACT.md
@@ -7,8 +7,21 @@ Website cutover.
 
 ## Contract
 
-The adapter exposes only `GET` requests, authenticated with a distinct
-`SCHEDULE_PUBLIC_READ_HMAC_KEY` and the `website-booking` service identity:
+The adapter exposes only `GET` requests across two distinct HMAC capabilities:
+
+- `SCHEDULE_PUBLIC_READ_EDGE_HMAC_KEY` authenticates Website to the adapter
+  with the `website-booking` service identity. It belongs only to Website and
+  the adapter.
+- `SCHEDULE_PUBLIC_READ_CORE_HMAC_KEY` authenticates the adapter to Schedule
+  core with the `schedule-public-read-adapter` service identity. It belongs
+  only to the adapter and Schedule core.
+
+The adapter fails closed unless both normalized key values are present and
+different. The Website edge key therefore cannot authenticate a direct request
+to the core, even while its existing hostname remains part of the legacy
+deployment.
+
+The exposed paths are:
 
 - `GET /health` checks that the adapter is explicitly enabled and fully bound.
 - `GET /schedule-public-read/v1/readiness` checks the Schedule core's D1 read.
@@ -20,18 +33,27 @@ The adapter exposes only `GET` requests, authenticated with a distinct
 
 Every versioned request carries `x-skincos-schedule-read-*` headers. Its HMAC
 binds the version, timestamp, nonce, `GET` method, exact path/query and fixed
-service name. It is deliberately independent from `ESCALA_ACTOR_HMAC_KEY`,
-which remains the CRM/Ponto writer-and-management credential.
+service name. Signing and verification trim the configured key consistently.
+This boundary is deliberately independent from `ESCALA_ACTOR_HMAC_KEY`, which
+remains the CRM/Ponto writer-and-management credential.
+
+Nonce format and timestamp skew are verified today, but this source-only stage
+does not retain consumed nonces. A valid signed request can therefore still be
+replayed inside the permitted skew window. Replay protection is an explicit
+cutover prerequisite; no replay store or binding is introduced by this change.
 
 ## Staged cut prerequisites
 
 The current Website still reads `SKINCOS_ESCALA_DB` directly and its booking
 routes keep their existing behavior. Before a future consumer migration:
 
-1. Create isolated staging resources and provision the new key to the adapter,
-   Schedule core and Website only.
-2. Compare direct-D1 and adapter responses for synthetic availability and
+1. Create isolated staging resources and provision two different normalized
+   values: the edge key to Website and adapter only, and the core key to
+   adapter and Schedule core only.
+2. Select, provision and test bounded nonce replay protection before enabling
+   either capability, route or consumer cutover.
+3. Compare direct-D1 and adapter responses for synthetic availability and
    profiles, then prove readiness and rollback.
-3. Decide the customer-facing behavior when Schedule is unavailable: preserve
+4. Decide the customer-facing behavior when Schedule is unavailable: preserve
    the current fallback or return a booking-unavailable response. This contract
    does not make that product decision.

--- a/workforce/schedule/package.json
+++ b/workforce/schedule/package.json
@@ -4,7 +4,8 @@
   "version": "0.2.0",
   "type": "module",
   "scripts": {
-    "test": "node --test worker.test.js",
+    "test": "node --test *.test.js",
+    "public-read:dry-run": "node ./scripts/public-read-dry-run.mjs",
     "smoke": "node ./scripts/smoke.mjs",
     "deploy": "wrangler deploy",
     "migrate:remote": "wrangler d1 migrations apply skincos-escala --remote",

--- a/workforce/schedule/public-read-contract.js
+++ b/workforce/schedule/public-read-contract.js
@@ -1,0 +1,123 @@
+export const SCHEDULE_PUBLIC_READ_CONTRACT_VERSION = 'schedule-public-read/v1'
+export const SCHEDULE_PUBLIC_READ_SIGNATURE_VERSION = 'v1'
+export const SCHEDULE_PUBLIC_READ_SERVICE = 'website-booking'
+export const SCHEDULE_PUBLIC_READ_MAX_SKEW_MS = 5 * 60 * 1000
+
+const encoder = new TextEncoder()
+const noncePattern = /^[A-Za-z0-9][A-Za-z0-9._-]{15,127}$/
+
+function base64UrlEncode(bytes) {
+  let binary = ''
+  for (const byte of new Uint8Array(bytes)) binary += String.fromCharCode(byte)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+function constantTimeEqual(left, right) {
+  const leftValue = String(left || '')
+  const rightValue = String(right || '')
+  const maxLength = Math.max(leftValue.length, rightValue.length)
+  let mismatch = leftValue.length ^ rightValue.length
+  for (let index = 0; index < maxLength; index += 1) {
+    mismatch |= (leftValue.charCodeAt(index) || 0) ^ (rightValue.charCodeAt(index) || 0)
+  }
+  return mismatch === 0
+}
+
+function requestPath(value) {
+  const url = new URL(value)
+  return `${url.pathname}${url.search}`
+}
+
+function normalizedMethod(value) {
+  return String(value || '').trim().toUpperCase()
+}
+
+function signingPayload({ timestamp, nonce, method, path, service }) {
+  return [
+    SCHEDULE_PUBLIC_READ_CONTRACT_VERSION,
+    String(timestamp),
+    String(nonce),
+    normalizedMethod(method),
+    String(path),
+    String(service),
+  ].join('.')
+}
+
+export async function signSchedulePublicReadRequest({ secret, timestamp, nonce, method, path, service = SCHEDULE_PUBLIC_READ_SERVICE }) {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(String(secret || '')),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  const signature = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    encoder.encode(signingPayload({ timestamp, nonce, method, path, service })),
+  )
+  return base64UrlEncode(signature)
+}
+
+export async function createSchedulePublicReadHeaders({
+  secret,
+  url,
+  method = 'GET',
+  service = SCHEDULE_PUBLIC_READ_SERVICE,
+  timestamp = String(Date.now()),
+  nonce = crypto.randomUUID(),
+} = {}) {
+  const path = requestPath(url)
+  const signature = await signSchedulePublicReadRequest({ secret, timestamp, nonce, method, path, service })
+  return {
+    'x-skincos-schedule-read-version': SCHEDULE_PUBLIC_READ_SIGNATURE_VERSION,
+    'x-skincos-schedule-read-service': String(service),
+    'x-skincos-schedule-read-ts': String(timestamp),
+    'x-skincos-schedule-read-nonce': String(nonce),
+    'x-skincos-schedule-read-signature': signature,
+  }
+}
+
+export async function verifySchedulePublicReadRequest(request, secret, {
+  allowedService = SCHEDULE_PUBLIC_READ_SERVICE,
+  now = Date.now(),
+} = {}) {
+  if (normalizedMethod(request?.method) !== 'GET') return { ok: false, error: 'METHOD_NOT_ALLOWED' }
+  const key = String(secret || '').trim()
+  if (!key) return { ok: false, error: 'KEY_MISSING' }
+
+  const version = String(request.headers.get('x-skincos-schedule-read-version') || '')
+  const service = String(request.headers.get('x-skincos-schedule-read-service') || '')
+  const timestamp = String(request.headers.get('x-skincos-schedule-read-ts') || '')
+  const nonce = String(request.headers.get('x-skincos-schedule-read-nonce') || '')
+  const signature = String(request.headers.get('x-skincos-schedule-read-signature') || '')
+  const timestampMs = Number(timestamp)
+
+  if (
+    version !== SCHEDULE_PUBLIC_READ_SIGNATURE_VERSION
+    || service !== allowedService
+    || !noncePattern.test(nonce)
+    || !Number.isFinite(timestampMs)
+    || Math.abs(now - timestampMs) > SCHEDULE_PUBLIC_READ_MAX_SKEW_MS
+    || !signature
+  ) {
+    return { ok: false, error: 'UNAUTHORIZED' }
+  }
+
+  const expected = await signSchedulePublicReadRequest({
+    secret: key,
+    timestamp,
+    nonce,
+    method: request.method,
+    path: requestPath(request.url),
+    service,
+  })
+  if (!constantTimeEqual(expected, signature)) return { ok: false, error: 'UNAUTHORIZED' }
+  return { ok: true, service }
+}
+
+export const __testables = {
+  constantTimeEqual,
+  requestPath,
+  signingPayload,
+}

--- a/workforce/schedule/public-read-contract.js
+++ b/workforce/schedule/public-read-contract.js
@@ -1,6 +1,7 @@
 export const SCHEDULE_PUBLIC_READ_CONTRACT_VERSION = 'schedule-public-read/v1'
 export const SCHEDULE_PUBLIC_READ_SIGNATURE_VERSION = 'v1'
-export const SCHEDULE_PUBLIC_READ_SERVICE = 'website-booking'
+export const SCHEDULE_PUBLIC_READ_EDGE_SERVICE = 'website-booking'
+export const SCHEDULE_PUBLIC_READ_CORE_SERVICE = 'schedule-public-read-adapter'
 export const SCHEDULE_PUBLIC_READ_MAX_SKEW_MS = 5 * 60 * 1000
 
 const encoder = new TextEncoder()
@@ -32,6 +33,10 @@ function normalizedMethod(value) {
   return String(value || '').trim().toUpperCase()
 }
 
+export function normalizeSchedulePublicReadSecret(value) {
+  return String(value ?? '').trim()
+}
+
 function signingPayload({ timestamp, nonce, method, path, service }) {
   return [
     SCHEDULE_PUBLIC_READ_CONTRACT_VERSION,
@@ -43,10 +48,11 @@ function signingPayload({ timestamp, nonce, method, path, service }) {
   ].join('.')
 }
 
-export async function signSchedulePublicReadRequest({ secret, timestamp, nonce, method, path, service = SCHEDULE_PUBLIC_READ_SERVICE }) {
+export async function signSchedulePublicReadRequest({ secret, timestamp, nonce, method, path, service = SCHEDULE_PUBLIC_READ_EDGE_SERVICE }) {
+  const normalizedSecret = normalizeSchedulePublicReadSecret(secret)
   const key = await crypto.subtle.importKey(
     'raw',
-    encoder.encode(String(secret || '')),
+    encoder.encode(normalizedSecret),
     { name: 'HMAC', hash: 'SHA-256' },
     false,
     ['sign'],
@@ -63,7 +69,7 @@ export async function createSchedulePublicReadHeaders({
   secret,
   url,
   method = 'GET',
-  service = SCHEDULE_PUBLIC_READ_SERVICE,
+  service = SCHEDULE_PUBLIC_READ_EDGE_SERVICE,
   timestamp = String(Date.now()),
   nonce = crypto.randomUUID(),
 } = {}) {
@@ -79,11 +85,11 @@ export async function createSchedulePublicReadHeaders({
 }
 
 export async function verifySchedulePublicReadRequest(request, secret, {
-  allowedService = SCHEDULE_PUBLIC_READ_SERVICE,
+  allowedService = SCHEDULE_PUBLIC_READ_EDGE_SERVICE,
   now = Date.now(),
 } = {}) {
   if (normalizedMethod(request?.method) !== 'GET') return { ok: false, error: 'METHOD_NOT_ALLOWED' }
-  const key = String(secret || '').trim()
+  const key = normalizeSchedulePublicReadSecret(secret)
   if (!key) return { ok: false, error: 'KEY_MISSING' }
 
   const version = String(request.headers.get('x-skincos-schedule-read-version') || '')

--- a/workforce/schedule/public-read-contract.test.js
+++ b/workforce/schedule/public-read-contract.test.js
@@ -2,7 +2,8 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
-  SCHEDULE_PUBLIC_READ_SERVICE,
+  SCHEDULE_PUBLIC_READ_CORE_SERVICE,
+  SCHEDULE_PUBLIC_READ_EDGE_SERVICE,
   createSchedulePublicReadHeaders,
   verifySchedulePublicReadRequest,
 } from './public-read-contract.js'
@@ -10,7 +11,7 @@ import {
 const key = 'schedule-public-read-test-key'
 const target = 'https://schedule.local/schedule-public-read/v1/availability?unit=novo-hamburgo&date=2026-09-15'
 
-test('schedule public read HMAC binds exact read request and fixed Website service', async () => {
+test('schedule public read HMAC binds exact read request and fixed Website edge service', async () => {
   const timestamp = String(Date.now())
   const headers = await createSchedulePublicReadHeaders({
     secret: key,
@@ -20,7 +21,7 @@ test('schedule public read HMAC binds exact read request and fixed Website servi
   })
   const request = new Request(target, { headers })
 
-  assert.deepEqual(await verifySchedulePublicReadRequest(request, key), { ok: true, service: SCHEDULE_PUBLIC_READ_SERVICE })
+  assert.deepEqual(await verifySchedulePublicReadRequest(request, key), { ok: true, service: SCHEDULE_PUBLIC_READ_EDGE_SERVICE })
   assert.equal((await verifySchedulePublicReadRequest(new Request('https://schedule.local/schedule-public-read/v1/availability?unit=novo-hamburgo&date=2026-09-16', { headers }), key)).ok, false)
   assert.equal((await verifySchedulePublicReadRequest(new Request(target, { method: 'POST', headers }), key)).error, 'METHOD_NOT_ALLOWED')
   assert.equal((await verifySchedulePublicReadRequest(request, 'another-key')).ok, false)
@@ -43,4 +44,25 @@ test('schedule public read HMAC rejects stale nonces and another service identit
     nonce: 'schedule-public-read-contract-0003',
   })
   assert.equal((await verifySchedulePublicReadRequest(new Request(target, { headers: wrongServiceHeaders }), key)).ok, false)
+})
+
+test('schedule public read signer and verifier normalize keys and keep hop identities distinct', async () => {
+  const coreKey = 'schedule-public-read-core-test-key'
+  const headers = await createSchedulePublicReadHeaders({
+    secret: `  ${coreKey}  `,
+    url: target,
+    service: SCHEDULE_PUBLIC_READ_CORE_SERVICE,
+    nonce: 'schedule-public-read-contract-0004',
+  })
+  const request = new Request(target, { headers })
+
+  assert.deepEqual(
+    await verifySchedulePublicReadRequest(request, coreKey, { allowedService: SCHEDULE_PUBLIC_READ_CORE_SERVICE }),
+    { ok: true, service: SCHEDULE_PUBLIC_READ_CORE_SERVICE },
+  )
+  assert.deepEqual(
+    await verifySchedulePublicReadRequest(request, `\t${coreKey}\n`, { allowedService: SCHEDULE_PUBLIC_READ_CORE_SERVICE }),
+    { ok: true, service: SCHEDULE_PUBLIC_READ_CORE_SERVICE },
+  )
+  assert.equal((await verifySchedulePublicReadRequest(request, coreKey)).ok, false)
 })

--- a/workforce/schedule/public-read-contract.test.js
+++ b/workforce/schedule/public-read-contract.test.js
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  SCHEDULE_PUBLIC_READ_SERVICE,
+  createSchedulePublicReadHeaders,
+  verifySchedulePublicReadRequest,
+} from './public-read-contract.js'
+
+const key = 'schedule-public-read-test-key'
+const target = 'https://schedule.local/schedule-public-read/v1/availability?unit=novo-hamburgo&date=2026-09-15'
+
+test('schedule public read HMAC binds exact read request and fixed Website service', async () => {
+  const timestamp = String(Date.now())
+  const headers = await createSchedulePublicReadHeaders({
+    secret: key,
+    url: target,
+    timestamp,
+    nonce: 'schedule-public-read-contract-0001',
+  })
+  const request = new Request(target, { headers })
+
+  assert.deepEqual(await verifySchedulePublicReadRequest(request, key), { ok: true, service: SCHEDULE_PUBLIC_READ_SERVICE })
+  assert.equal((await verifySchedulePublicReadRequest(new Request('https://schedule.local/schedule-public-read/v1/availability?unit=novo-hamburgo&date=2026-09-16', { headers }), key)).ok, false)
+  assert.equal((await verifySchedulePublicReadRequest(new Request(target, { method: 'POST', headers }), key)).error, 'METHOD_NOT_ALLOWED')
+  assert.equal((await verifySchedulePublicReadRequest(request, 'another-key')).ok, false)
+})
+
+test('schedule public read HMAC rejects stale nonces and another service identity', async () => {
+  const staleTimestamp = String(Date.now() - (6 * 60 * 1000))
+  const staleHeaders = await createSchedulePublicReadHeaders({
+    secret: key,
+    url: target,
+    timestamp: staleTimestamp,
+    nonce: 'schedule-public-read-contract-0002',
+  })
+  assert.equal((await verifySchedulePublicReadRequest(new Request(target, { headers: staleHeaders }), key)).ok, false)
+
+  const wrongServiceHeaders = await createSchedulePublicReadHeaders({
+    secret: key,
+    url: target,
+    service: 'crm-escala',
+    nonce: 'schedule-public-read-contract-0003',
+  })
+  assert.equal((await verifySchedulePublicReadRequest(new Request(target, { headers: wrongServiceHeaders }), key)).ok, false)
+})

--- a/workforce/schedule/public-read-core.test.js
+++ b/workforce/schedule/public-read-core.test.js
@@ -2,12 +2,14 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  SCHEDULE_PUBLIC_READ_CORE_SERVICE,
   createSchedulePublicReadHeaders,
 } from './public-read-contract.js'
 import worker from './worker.js'
 import { PublicReadTestD1, createPublicReadTestDb } from './public-read-test-support.js'
 
-const publicReadKey = 'schedule-public-read-test-key'
+const coreReadKey = 'schedule-public-read-core-test-key'
+const edgeReadKey = 'schedule-public-read-edge-key-must-not-authorize-core'
 const legacyEscalaKey = 'legacy-escala-key-must-not-authorize-public-read'
 
 function publicReadEnv(db = createPublicReadTestDb(), overrides = {}) {
@@ -15,18 +17,19 @@ function publicReadEnv(db = createPublicReadTestDb(), overrides = {}) {
     APP_ORIGIN: 'https://crm.local',
     DB: db,
     SCHEDULE_PUBLIC_READ_ENABLED: 'true',
-    SCHEDULE_PUBLIC_READ_HMAC_KEY: publicReadKey,
+    SCHEDULE_PUBLIC_READ_CORE_HMAC_KEY: coreReadKey,
     ESCALA_ACTOR_HMAC_KEY: legacyEscalaKey,
     ...overrides,
   }
 }
 
-async function signedCoreRequest(path, { secret = publicReadKey, method = 'GET' } = {}) {
+async function signedCoreRequest(path, { secret = coreReadKey, method = 'GET' } = {}) {
   const url = `https://schedule.internal${path}`
   const headers = await createSchedulePublicReadHeaders({
     secret,
     url,
     method,
+    service: SCHEDULE_PUBLIC_READ_CORE_SERVICE,
     nonce: `schedule-public-read-core-${crypto.randomUUID()}`,
   })
   return new Request(url, { method, headers })
@@ -79,6 +82,13 @@ test('Schedule core readiness and public-read routes fail closed without the new
   )
   assert.equal(usingLegacyEscalaKey.status, 401)
   assert.equal((await usingLegacyEscalaKey.json()).error, 'SCHEDULE_PUBLIC_READ_UNAUTHORIZED')
+
+  const usingEdgeReadKey = await worker.fetch(
+    await signedCoreRequest(path, { secret: edgeReadKey }),
+    publicReadEnv(),
+  )
+  assert.equal(usingEdgeReadKey.status, 401)
+  assert.equal((await usingEdgeReadKey.json()).error, 'SCHEDULE_PUBLIC_READ_UNAUTHORIZED')
 
   const unavailableDb = await worker.fetch(
     await signedCoreRequest(path),

--- a/workforce/schedule/public-read-core.test.js
+++ b/workforce/schedule/public-read-core.test.js
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  createSchedulePublicReadHeaders,
+} from './public-read-contract.js'
+import worker from './worker.js'
+import { PublicReadTestD1, createPublicReadTestDb } from './public-read-test-support.js'
+
+const publicReadKey = 'schedule-public-read-test-key'
+const legacyEscalaKey = 'legacy-escala-key-must-not-authorize-public-read'
+
+function publicReadEnv(db = createPublicReadTestDb(), overrides = {}) {
+  return {
+    APP_ORIGIN: 'https://crm.local',
+    DB: db,
+    SCHEDULE_PUBLIC_READ_ENABLED: 'true',
+    SCHEDULE_PUBLIC_READ_HMAC_KEY: publicReadKey,
+    ESCALA_ACTOR_HMAC_KEY: legacyEscalaKey,
+    ...overrides,
+  }
+}
+
+async function signedCoreRequest(path, { secret = publicReadKey, method = 'GET' } = {}) {
+  const url = `https://schedule.internal${path}`
+  const headers = await createSchedulePublicReadHeaders({
+    secret,
+    url,
+    method,
+    nonce: `schedule-public-read-core-${crypto.randomUUID()}`,
+  })
+  return new Request(url, { method, headers })
+}
+
+test('Schedule core exposes only the HMAC-authenticated v1 availability and profile projection', async () => {
+  const env = publicReadEnv()
+  const availability = await worker.fetch(
+    await signedCoreRequest('/api/escala/internal/schedule-public-read/v1/availability?unit=novo-hamburgo&date=2026-09-15'),
+    env,
+  )
+  assert.equal(availability.status, 200)
+  assert.deepEqual((await availability.json()).data, {
+    unit: 'novohamburgo',
+    date: '2026-09-15',
+    closed: false,
+    professionalNames: ['Dra. Ana Teste'],
+  })
+
+  const profiles = await worker.fetch(
+    await signedCoreRequest('/api/escala/internal/schedule-public-read/v1/professionals?unit=novo-hamburgo'),
+    env,
+  )
+  assert.equal(profiles.status, 200)
+  const profileBody = await profiles.json()
+  assert.equal(profileBody.data.professionals.length, 1)
+  assert.deepEqual(profileBody.data.professionals[0], {
+    name: 'Dra. Ana Teste',
+    status: 'Ativo',
+    role: 'Injetora',
+    nickname: 'Ana',
+    instagram: 'dra.ana.teste',
+    units: ['Novo Hamburgo'],
+  })
+  assert.equal(JSON.stringify(profileBody).includes('private-phone-must-not-leak'), false)
+  assert.equal(JSON.stringify(profileBody).includes('private-email-must-not-leak'), false)
+})
+
+test('Schedule core readiness and public-read routes fail closed without the new dedicated capability', async () => {
+  const path = '/api/escala/internal/schedule-public-read/v1/readiness'
+  const missingCapability = await worker.fetch(await signedCoreRequest(path), publicReadEnv(createPublicReadTestDb(), {
+    SCHEDULE_PUBLIC_READ_ENABLED: 'false',
+  }))
+  assert.equal(missingCapability.status, 503)
+  assert.equal((await missingCapability.json()).error, 'SCHEDULE_PUBLIC_READ_UNAVAILABLE')
+
+  const usingLegacyEscalaKey = await worker.fetch(
+    await signedCoreRequest(path, { secret: legacyEscalaKey }),
+    publicReadEnv(),
+  )
+  assert.equal(usingLegacyEscalaKey.status, 401)
+  assert.equal((await usingLegacyEscalaKey.json()).error, 'SCHEDULE_PUBLIC_READ_UNAUTHORIZED')
+
+  const unavailableDb = await worker.fetch(
+    await signedCoreRequest(path),
+    publicReadEnv(new PublicReadTestD1({ available: false })),
+  )
+  assert.equal(unavailableDb.status, 503)
+  assert.equal((await unavailableDb.json()).error, 'SCHEDULE_PUBLIC_READ_NOT_READY')
+})
+
+test('Schedule core rejects unsigned, malformed and non-read public-read requests', async () => {
+  const env = publicReadEnv()
+  const path = '/api/escala/internal/schedule-public-read/v1/availability?unit=novo-hamburgo&date=2026-09-15'
+  const unsigned = await worker.fetch(new Request(`https://schedule.internal${path}`), env)
+  assert.equal(unsigned.status, 401)
+
+  const malformed = await worker.fetch(
+    await signedCoreRequest('/api/escala/internal/schedule-public-read/v1/availability?unit=unknown&date=not-a-date'),
+    env,
+  )
+  assert.equal(malformed.status, 400)
+  assert.equal((await malformed.json()).error, 'INVALID_UNIT')
+
+  const write = await worker.fetch(
+    await signedCoreRequest(path, { method: 'POST' }),
+    env,
+  )
+  assert.equal(write.status, 405)
+})

--- a/workforce/schedule/public-read-test-support.js
+++ b/workforce/schedule/public-read-test-support.js
@@ -1,0 +1,100 @@
+function normalizedSql(sql) {
+  return String(sql || '').replace(/\s+/g, ' ').trim().toLowerCase()
+}
+
+class Statement {
+  constructor(db, sql) {
+    this.db = db
+    this.sql = sql
+    this.params = []
+  }
+
+  bind(...params) {
+    this.params = params
+    return this
+  }
+
+  async first() {
+    return this.db.first(this.sql, this.params)
+  }
+
+  async all() {
+    return { results: this.db.all(this.sql, this.params) }
+  }
+}
+
+export class PublicReadTestD1 {
+  constructor({ professionals = [], scheduleEntries = [], closedDays = [], holidays = [], available = true } = {}) {
+    this.professionals = professionals
+    this.scheduleEntries = scheduleEntries
+    this.closedDays = closedDays
+    this.holidays = holidays
+    this.available = available
+  }
+
+  prepare(sql) {
+    return new Statement(this, sql)
+  }
+
+  first(sql, params) {
+    if (!this.available) throw new Error('database unavailable')
+    const query = normalizedSql(sql)
+    if (query === 'select 1 as ready') return { ready: 1 }
+    if (query.includes('from closed_days')) {
+      return this.closedDays.some((entry) => entry.unit === params[0] && entry.date === params[1]) ? { found: 1 } : null
+    }
+    if (query.includes('from holidays')) {
+      return this.holidays.some((entry) => entry.unit === params[0] && entry.date === params[1]) ? { found: 1 } : null
+    }
+    throw new Error(`unsupported first query: ${sql}`)
+  }
+
+  all(sql, params) {
+    if (!this.available) throw new Error('database unavailable')
+    const query = normalizedSql(sql)
+    if (query.includes('from schedule_entries')) {
+      return this.scheduleEntries
+        .filter((entry) => entry.unit === params[0] && entry.date === params[1])
+        .sort((left, right) => String(left.professional_name).localeCompare(String(right.professional_name)))
+        .map((entry) => ({ professional: entry.professional_name }))
+    }
+    if (query.includes('from professionals')) {
+      return [...this.professionals]
+        .sort((left, right) => String(left.name).localeCompare(String(right.name)))
+        .map((entry) => ({ ...entry }))
+    }
+    throw new Error(`unsupported all query: ${sql}`)
+  }
+}
+
+export function createPublicReadTestDb() {
+  return new PublicReadTestD1({
+    professionals: [
+      {
+        name: 'Dra. Ana Teste',
+        status: 'Ativo',
+        role: 'Injetora',
+        nickname: 'Ana',
+        instagram: '@dra.ana.teste',
+        phone: 'private-phone-must-not-leak',
+        email: 'private-email-must-not-leak@example.invalid',
+        units_json: JSON.stringify(['Novo Hamburgo']),
+      },
+      {
+        name: 'Dra. Inativa Teste',
+        status: 'Inativo',
+        role: 'Injetora',
+        nickname: 'Inativa',
+        instagram: '@dra.inativa',
+        phone: 'private-phone-must-not-leak',
+        email: 'private-email-must-not-leak@example.invalid',
+        units_json: JSON.stringify(['Novo Hamburgo']),
+      },
+    ],
+    scheduleEntries: [
+      { unit: 'Novo Hamburgo', date: '2026-09-15', professional_name: 'Dra. Ana Teste' },
+    ],
+    closedDays: [],
+    holidays: [],
+  })
+}

--- a/workforce/schedule/public-read-worker.js
+++ b/workforce/schedule/public-read-worker.js
@@ -1,0 +1,101 @@
+import {
+  SCHEDULE_PUBLIC_READ_CONTRACT_VERSION,
+  createSchedulePublicReadHeaders,
+  verifySchedulePublicReadRequest,
+} from './public-read-contract.js'
+
+const PUBLIC_PREFIX = '/schedule-public-read/v1'
+const CORE_PREFIX = '/api/escala/internal/schedule-public-read/v1'
+
+function json(body, init = {}) {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'no-store',
+      'x-skincos-schedule-public-read-contract': SCHEDULE_PUBLIC_READ_CONTRACT_VERSION,
+      ...(init.headers || {}),
+    },
+  })
+}
+
+function requestId(request) {
+  return String(request.headers.get('x-request-id') || crypto.randomUUID())
+}
+
+function runtimeConfigured(env) {
+  return String(env?.SCHEDULE_PUBLIC_READ_ENABLED || '').trim().toLowerCase() === 'true'
+    && Boolean(String(env?.SCHEDULE_PUBLIC_READ_HMAC_KEY || '').trim())
+    && typeof env?.SCHEDULE_CORE?.fetch === 'function'
+}
+
+function unavailable(id) {
+  return json({
+    ok: false,
+    contract: SCHEDULE_PUBLIC_READ_CONTRACT_VERSION,
+    ready: false,
+    error: 'SCHEDULE_PUBLIC_READ_UNAVAILABLE',
+  }, { status: 503, headers: { 'x-request-id': id } })
+}
+
+function notFound(id) {
+  return json({ ok: false, error: 'NOT_FOUND' }, { status: 404, headers: { 'x-request-id': id } })
+}
+
+function methodNotAllowed(id) {
+  return json({ ok: false, error: 'METHOD_NOT_ALLOWED' }, { status: 405, headers: { 'x-request-id': id } })
+}
+
+function unauthorized(id) {
+  return json({ ok: false, error: 'SCHEDULE_PUBLIC_READ_UNAUTHORIZED' }, { status: 401, headers: { 'x-request-id': id } })
+}
+
+async function requestCore(request, env, corePath, id) {
+  const target = new URL(`https://schedule-core.internal${corePath}`)
+  const headers = new Headers(await createSchedulePublicReadHeaders({
+    secret: env.SCHEDULE_PUBLIC_READ_HMAC_KEY,
+    url: target,
+    method: 'GET',
+  }))
+  headers.set('x-request-id', id)
+  let response
+  try {
+    response = await env.SCHEDULE_CORE.fetch(new Request(target.toString(), { method: 'GET', headers }))
+  } catch {
+    return unavailable(id)
+  }
+  const outputHeaders = new Headers(response.headers)
+  outputHeaders.set('cache-control', 'no-store')
+  outputHeaders.set('x-request-id', id)
+  outputHeaders.set('x-skincos-schedule-public-read-contract', SCHEDULE_PUBLIC_READ_CONTRACT_VERSION)
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: outputHeaders,
+  })
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url)
+    const id = requestId(request)
+
+    if (url.pathname === '/health') {
+      if (!runtimeConfigured(env)) return unavailable(id)
+      return json({ ok: true, contract: SCHEDULE_PUBLIC_READ_CONTRACT_VERSION, ready: true }, { headers: { 'x-request-id': id } })
+    }
+
+    if (!url.pathname.startsWith(PUBLIC_PREFIX)) return notFound(id)
+    if (request.method !== 'GET') return methodNotAllowed(id)
+    if (!runtimeConfigured(env)) return unavailable(id)
+
+    const authorization = await verifySchedulePublicReadRequest(request, env.SCHEDULE_PUBLIC_READ_HMAC_KEY)
+    if (!authorization.ok) return unauthorized(id)
+
+    const suffix = url.pathname.slice(PUBLIC_PREFIX.length)
+    if (!['/readiness', '/availability', '/professionals'].includes(suffix)) return notFound(id)
+    return requestCore(request, env, `${CORE_PREFIX}${suffix}${url.search}`, id)
+  },
+}
+
+export const __testables = { runtimeConfigured }

--- a/workforce/schedule/public-read-worker.js
+++ b/workforce/schedule/public-read-worker.js
@@ -1,6 +1,9 @@
 import {
   SCHEDULE_PUBLIC_READ_CONTRACT_VERSION,
+  SCHEDULE_PUBLIC_READ_CORE_SERVICE,
+  SCHEDULE_PUBLIC_READ_EDGE_SERVICE,
   createSchedulePublicReadHeaders,
+  normalizeSchedulePublicReadSecret,
   verifySchedulePublicReadRequest,
 } from './public-read-contract.js'
 
@@ -24,8 +27,12 @@ function requestId(request) {
 }
 
 function runtimeConfigured(env) {
+  const edgeKey = normalizeSchedulePublicReadSecret(env?.SCHEDULE_PUBLIC_READ_EDGE_HMAC_KEY)
+  const coreKey = normalizeSchedulePublicReadSecret(env?.SCHEDULE_PUBLIC_READ_CORE_HMAC_KEY)
   return String(env?.SCHEDULE_PUBLIC_READ_ENABLED || '').trim().toLowerCase() === 'true'
-    && Boolean(String(env?.SCHEDULE_PUBLIC_READ_HMAC_KEY || '').trim())
+    && Boolean(edgeKey)
+    && Boolean(coreKey)
+    && edgeKey !== coreKey
     && typeof env?.SCHEDULE_CORE?.fetch === 'function'
 }
 
@@ -53,9 +60,10 @@ function unauthorized(id) {
 async function requestCore(request, env, corePath, id) {
   const target = new URL(`https://schedule-core.internal${corePath}`)
   const headers = new Headers(await createSchedulePublicReadHeaders({
-    secret: env.SCHEDULE_PUBLIC_READ_HMAC_KEY,
+    secret: normalizeSchedulePublicReadSecret(env.SCHEDULE_PUBLIC_READ_CORE_HMAC_KEY),
     url: target,
     method: 'GET',
+    service: SCHEDULE_PUBLIC_READ_CORE_SERVICE,
   }))
   headers.set('x-request-id', id)
   let response
@@ -90,7 +98,11 @@ export default {
     if (request.method !== 'GET') return methodNotAllowed(id)
     if (!runtimeConfigured(env)) return unavailable(id)
 
-    const authorization = await verifySchedulePublicReadRequest(request, env.SCHEDULE_PUBLIC_READ_HMAC_KEY)
+    const authorization = await verifySchedulePublicReadRequest(
+      request,
+      normalizeSchedulePublicReadSecret(env.SCHEDULE_PUBLIC_READ_EDGE_HMAC_KEY),
+      { allowedService: SCHEDULE_PUBLIC_READ_EDGE_SERVICE },
+    )
     if (!authorization.ok) return unauthorized(id)
 
     const suffix = url.pathname.slice(PUBLIC_PREFIX.length)

--- a/workforce/schedule/public-read-worker.js
+++ b/workforce/schedule/public-read-worker.js
@@ -81,6 +81,7 @@ export default {
     const id = requestId(request)
 
     if (url.pathname === '/health') {
+      if (request.method !== 'GET') return methodNotAllowed(id)
       if (!runtimeConfigured(env)) return unavailable(id)
       return json({ ok: true, contract: SCHEDULE_PUBLIC_READ_CONTRACT_VERSION, ready: true }, { headers: { 'x-request-id': id } })
     }

--- a/workforce/schedule/public-read-worker.test.js
+++ b/workforce/schedule/public-read-worker.test.js
@@ -72,6 +72,9 @@ test('adapter health, readiness and reads fail closed until the isolated rollout
     configuredAdapterEnv({ SCHEDULE_PUBLIC_READ_ENABLED: 'false' }),
   )
   assert.equal(disabled.status, 503)
+
+  const healthWrite = await adapter.fetch(new Request('https://adapter.internal/health', { method: 'POST' }), configuredAdapterEnv())
+  assert.equal(healthWrite.status, 405)
 })
 
 test('adapter rejects legacy Escala HMACs and methods that would expand its read-only contract', async () => {

--- a/workforce/schedule/public-read-worker.test.js
+++ b/workforce/schedule/public-read-worker.test.js
@@ -3,25 +3,32 @@ import { readFileSync } from 'node:fs'
 import test from 'node:test'
 
 import {
+  SCHEDULE_PUBLIC_READ_CORE_SERVICE,
   createSchedulePublicReadHeaders,
-  verifySchedulePublicReadRequest,
 } from './public-read-contract.js'
 import coreWorker from './worker.js'
 import adapter from './public-read-worker.js'
 import { createPublicReadTestDb } from './public-read-test-support.js'
 
-const key = 'schedule-public-read-adapter-key'
+const edgeKey = 'schedule-public-read-edge-key'
+const coreKey = 'schedule-public-read-core-key'
 
-function configuredAdapterEnv(overrides = {}) {
-  const coreEnv = {
+function configuredCoreEnv(overrides = {}) {
+  return {
     APP_ORIGIN: 'https://crm.local',
     DB: createPublicReadTestDb(),
     SCHEDULE_PUBLIC_READ_ENABLED: 'true',
-    SCHEDULE_PUBLIC_READ_HMAC_KEY: key,
+    SCHEDULE_PUBLIC_READ_CORE_HMAC_KEY: coreKey,
+    ...overrides,
   }
+}
+
+function configuredAdapterEnv(overrides = {}) {
+  const coreEnv = configuredCoreEnv()
   return {
     SCHEDULE_PUBLIC_READ_ENABLED: 'true',
-    SCHEDULE_PUBLIC_READ_HMAC_KEY: key,
+    SCHEDULE_PUBLIC_READ_EDGE_HMAC_KEY: edgeKey,
+    SCHEDULE_PUBLIC_READ_CORE_HMAC_KEY: coreKey,
     SCHEDULE_CORE: {
       fetch: (request) => coreWorker.fetch(request, coreEnv),
     },
@@ -29,7 +36,7 @@ function configuredAdapterEnv(overrides = {}) {
   }
 }
 
-async function signedAdapterRequest(path, { secret = key, method = 'GET' } = {}) {
+async function signedAdapterRequest(path, { secret = edgeKey, method = 'GET' } = {}) {
   const url = `https://adapter.internal${path}`
   const headers = await createSchedulePublicReadHeaders({
     secret,
@@ -40,7 +47,7 @@ async function signedAdapterRequest(path, { secret = key, method = 'GET' } = {})
   return new Request(url, { method, headers })
 }
 
-test('adapter forwards a new dedicated HMAC envelope to Schedule core without a public route', async () => {
+test('adapter forwards a distinct core HMAC envelope after Website edge authentication', async () => {
   const response = await adapter.fetch(
     await signedAdapterRequest('/schedule-public-read/v1/availability?unit=novo-hamburgo&date=2026-09-15'),
     configuredAdapterEnv(),
@@ -73,11 +80,17 @@ test('adapter health, readiness and reads fail closed until the isolated rollout
   )
   assert.equal(disabled.status, 503)
 
+  const sharedKeys = await adapter.fetch(
+    new Request('https://adapter.internal/health'),
+    configuredAdapterEnv({ SCHEDULE_PUBLIC_READ_CORE_HMAC_KEY: ` ${edgeKey} ` }),
+  )
+  assert.equal(sharedKeys.status, 503)
+
   const healthWrite = await adapter.fetch(new Request('https://adapter.internal/health', { method: 'POST' }), configuredAdapterEnv())
   assert.equal(healthWrite.status, 405)
 })
 
-test('adapter rejects legacy Escala HMACs and methods that would expand its read-only contract', async () => {
+test('adapter rejects legacy Escala HMACs and the edge key cannot authenticate direct core access', async () => {
   const path = '/schedule-public-read/v1/professionals?unit=novo-hamburgo'
   const usingLegacyKey = await adapter.fetch(
     await signedAdapterRequest(path, { secret: 'legacy-escala-key' }),
@@ -92,12 +105,29 @@ test('adapter rejects legacy Escala HMACs and methods that would expand its read
   assert.equal(write.status, 405)
 
   const coreUrl = 'https://schedule-core.internal/api/escala/internal/schedule-public-read/v1/professionals?unit=novo-hamburgo'
-  const coreHeaders = await createSchedulePublicReadHeaders({
-    secret: key,
+  const edgeHeaders = await createSchedulePublicReadHeaders({
+    secret: edgeKey,
     url: coreUrl,
+    service: SCHEDULE_PUBLIC_READ_CORE_SERVICE,
     nonce: `schedule-public-read-assert-${crypto.randomUUID()}`,
   })
-  assert.equal((await verifySchedulePublicReadRequest(new Request(coreUrl, { headers: coreHeaders }), key)).ok, true)
+  const directCoreWithEdgeKey = await coreWorker.fetch(
+    new Request(coreUrl, { headers: edgeHeaders }),
+    configuredCoreEnv(),
+  )
+  assert.equal(directCoreWithEdgeKey.status, 401)
+
+  const coreHeaders = await createSchedulePublicReadHeaders({
+    secret: coreKey,
+    url: coreUrl,
+    service: SCHEDULE_PUBLIC_READ_CORE_SERVICE,
+    nonce: `schedule-public-read-core-${crypto.randomUUID()}`,
+  })
+  const directCoreWithCoreKey = await coreWorker.fetch(
+    new Request(coreUrl, { headers: coreHeaders }),
+    configuredCoreEnv(),
+  )
+  assert.equal(directCoreWithCoreKey.status, 200)
 })
 
 test('adapter source stays disabled and isolated until a later staged resource cut', () => {
@@ -107,4 +137,5 @@ test('adapter source stays disabled and isolated until a later staged resource c
   assert.equal(/\broutes\s*=/.test(config), false)
   assert.equal(/\[\[d1_databases\]\]/.test(config), false)
   assert.equal(source.includes('ESCALA_ACTOR_HMAC_KEY'), false)
+  assert.equal(source.includes('SCHEDULE_PUBLIC_READ_HMAC_KEY'), false)
 })

--- a/workforce/schedule/public-read-worker.test.js
+++ b/workforce/schedule/public-read-worker.test.js
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+import {
+  createSchedulePublicReadHeaders,
+  verifySchedulePublicReadRequest,
+} from './public-read-contract.js'
+import coreWorker from './worker.js'
+import adapter from './public-read-worker.js'
+import { createPublicReadTestDb } from './public-read-test-support.js'
+
+const key = 'schedule-public-read-adapter-key'
+
+function configuredAdapterEnv(overrides = {}) {
+  const coreEnv = {
+    APP_ORIGIN: 'https://crm.local',
+    DB: createPublicReadTestDb(),
+    SCHEDULE_PUBLIC_READ_ENABLED: 'true',
+    SCHEDULE_PUBLIC_READ_HMAC_KEY: key,
+  }
+  return {
+    SCHEDULE_PUBLIC_READ_ENABLED: 'true',
+    SCHEDULE_PUBLIC_READ_HMAC_KEY: key,
+    SCHEDULE_CORE: {
+      fetch: (request) => coreWorker.fetch(request, coreEnv),
+    },
+    ...overrides,
+  }
+}
+
+async function signedAdapterRequest(path, { secret = key, method = 'GET' } = {}) {
+  const url = `https://adapter.internal${path}`
+  const headers = await createSchedulePublicReadHeaders({
+    secret,
+    url,
+    method,
+    nonce: `schedule-public-read-adapter-${crypto.randomUUID()}`,
+  })
+  return new Request(url, { method, headers })
+}
+
+test('adapter forwards a new dedicated HMAC envelope to Schedule core without a public route', async () => {
+  const response = await adapter.fetch(
+    await signedAdapterRequest('/schedule-public-read/v1/availability?unit=novo-hamburgo&date=2026-09-15'),
+    configuredAdapterEnv(),
+  )
+  assert.equal(response.status, 200)
+  assert.equal(response.headers.get('x-skincos-schedule-public-read-contract'), 'schedule-public-read/v1')
+  assert.deepEqual((await response.json()).data, {
+    unit: 'novohamburgo',
+    date: '2026-09-15',
+    closed: false,
+    professionalNames: ['Dra. Ana Teste'],
+  })
+})
+
+test('adapter health, readiness and reads fail closed until the isolated rollout is configured', async () => {
+  const health = await adapter.fetch(new Request('https://adapter.internal/health'), {})
+  assert.equal(health.status, 503)
+  assert.equal((await health.json()).error, 'SCHEDULE_PUBLIC_READ_UNAVAILABLE')
+
+  const readiness = await adapter.fetch(
+    await signedAdapterRequest('/schedule-public-read/v1/readiness'),
+    configuredAdapterEnv(),
+  )
+  assert.equal(readiness.status, 200)
+  assert.equal((await readiness.json()).ready, true)
+
+  const disabled = await adapter.fetch(
+    await signedAdapterRequest('/schedule-public-read/v1/availability?unit=novo-hamburgo&date=2026-09-15'),
+    configuredAdapterEnv({ SCHEDULE_PUBLIC_READ_ENABLED: 'false' }),
+  )
+  assert.equal(disabled.status, 503)
+})
+
+test('adapter rejects legacy Escala HMACs and methods that would expand its read-only contract', async () => {
+  const path = '/schedule-public-read/v1/professionals?unit=novo-hamburgo'
+  const usingLegacyKey = await adapter.fetch(
+    await signedAdapterRequest(path, { secret: 'legacy-escala-key' }),
+    configuredAdapterEnv(),
+  )
+  assert.equal(usingLegacyKey.status, 401)
+
+  const write = await adapter.fetch(
+    await signedAdapterRequest(path, { method: 'POST' }),
+    configuredAdapterEnv(),
+  )
+  assert.equal(write.status, 405)
+
+  const coreUrl = 'https://schedule-core.internal/api/escala/internal/schedule-public-read/v1/professionals?unit=novo-hamburgo'
+  const coreHeaders = await createSchedulePublicReadHeaders({
+    secret: key,
+    url: coreUrl,
+    nonce: `schedule-public-read-assert-${crypto.randomUUID()}`,
+  })
+  assert.equal((await verifySchedulePublicReadRequest(new Request(coreUrl, { headers: coreHeaders }), key)).ok, true)
+})
+
+test('adapter source stays disabled and isolated until a later staged resource cut', () => {
+  const config = readFileSync(new URL('./public-read.wrangler.toml', import.meta.url), 'utf8')
+  const source = readFileSync(new URL('./public-read-worker.js', import.meta.url), 'utf8')
+  assert.match(config, /SCHEDULE_PUBLIC_READ_ENABLED = "false"/)
+  assert.equal(/\broutes\s*=/.test(config), false)
+  assert.equal(/\[\[d1_databases\]\]/.test(config), false)
+  assert.equal(source.includes('ESCALA_ACTOR_HMAC_KEY'), false)
+})

--- a/workforce/schedule/public-read.wrangler.toml
+++ b/workforce/schedule/public-read.wrangler.toml
@@ -1,0 +1,28 @@
+# Staged compatibility adapter for the future skincos-workforce-schedule owner.
+# It intentionally has no route, D1 binding, deploy workflow or configured secret.
+# A later staged cut may provision SCHEDULE_PUBLIC_READ_HMAC_KEY to this Worker,
+# the Schedule core and the Website consumer after equivalence validation.
+name = "skincos-schedule-public-read"
+main = "public-read-worker.js"
+compatibility_date = "2026-03-02"
+workers_dev = false
+preview_urls = false
+
+[vars]
+SCHEDULE_PUBLIC_READ_ENABLED = "false"
+
+[[services]]
+binding = "SCHEDULE_CORE"
+service = "skincos-escala-api"
+
+[env.staging]
+name = "skincos-schedule-public-read-staging"
+workers_dev = false
+preview_urls = false
+
+[env.staging.vars]
+SCHEDULE_PUBLIC_READ_ENABLED = "false"
+
+[[env.staging.services]]
+binding = "SCHEDULE_CORE"
+service = "skincos-escala-api-staging"

--- a/workforce/schedule/public-read.wrangler.toml
+++ b/workforce/schedule/public-read.wrangler.toml
@@ -1,7 +1,10 @@
 # Staged compatibility adapter for the future skincos-workforce-schedule owner.
 # It intentionally has no route, D1 binding, deploy workflow or configured secret.
-# A later staged cut may provision SCHEDULE_PUBLIC_READ_HMAC_KEY to this Worker,
-# the Schedule core and the Website consumer after equivalence validation.
+# A later staged cut may provision SCHEDULE_PUBLIC_READ_EDGE_HMAC_KEY only to
+# this Worker and Website, plus SCHEDULE_PUBLIC_READ_CORE_HMAC_KEY only to this
+# Worker and Schedule core. Both normalized values must differ. Replay
+# protection remains a cutover prerequisite; this source-only stage has no
+# replay store or binding.
 name = "skincos-schedule-public-read"
 main = "public-read-worker.js"
 compatibility_date = "2026-03-02"

--- a/workforce/schedule/scripts/public-read-dry-run.mjs
+++ b/workforce/schedule/scripts/public-read-dry-run.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+
+import { createSchedulePublicReadHeaders } from '../public-read-contract.js'
+import adapter from '../public-read-worker.js'
+
+const key = 'local-only-schedule-public-read-dry-run-key'
+const path = '/schedule-public-read/v1/availability?unit=novo-hamburgo&date=2026-09-15'
+
+const disabled = await adapter.fetch(new Request('https://adapter.local/health'), {})
+assert.equal(disabled.status, 503)
+
+const url = `https://adapter.local${path}`
+const headers = await createSchedulePublicReadHeaders({
+  secret: key,
+  url,
+  nonce: 'schedule-public-read-dry-run-0001',
+})
+let forwardedPath = ''
+const response = await adapter.fetch(new Request(url, { headers }), {
+  SCHEDULE_PUBLIC_READ_ENABLED: 'true',
+  SCHEDULE_PUBLIC_READ_HMAC_KEY: key,
+  SCHEDULE_CORE: {
+    async fetch(request) {
+      forwardedPath = `${new URL(request.url).pathname}${new URL(request.url).search}`
+      return Response.json({
+        ok: true,
+        contract: 'schedule-public-read/v1',
+        data: { unit: 'novohamburgo', date: '2026-09-15', closed: false, professionalNames: [] },
+      })
+    },
+  },
+})
+assert.equal(response.status, 200)
+assert.equal(forwardedPath, '/api/escala/internal/schedule-public-read/v1/availability?unit=novo-hamburgo&date=2026-09-15')
+assert.equal((await response.json()).contract, 'schedule-public-read/v1')
+
+console.log(JSON.stringify({
+  ok: true,
+  mode: 'local-only',
+  defaultDisabledStatus: disabled.status,
+  authenticatedForwardStatus: response.status,
+  forwardedPath,
+}))

--- a/workforce/schedule/scripts/public-read-dry-run.mjs
+++ b/workforce/schedule/scripts/public-read-dry-run.mjs
@@ -1,9 +1,14 @@
 import assert from 'node:assert/strict'
 
-import { createSchedulePublicReadHeaders } from '../public-read-contract.js'
+import {
+  SCHEDULE_PUBLIC_READ_CORE_SERVICE,
+  createSchedulePublicReadHeaders,
+  verifySchedulePublicReadRequest,
+} from '../public-read-contract.js'
 import adapter from '../public-read-worker.js'
 
-const key = 'local-only-schedule-public-read-dry-run-key'
+const edgeKey = 'local-only-schedule-public-read-edge-key'
+const coreKey = 'local-only-schedule-public-read-core-key'
 const path = '/schedule-public-read/v1/availability?unit=novo-hamburgo&date=2026-09-15'
 
 const disabled = await adapter.fetch(new Request('https://adapter.local/health'), {})
@@ -11,16 +16,21 @@ assert.equal(disabled.status, 503)
 
 const url = `https://adapter.local${path}`
 const headers = await createSchedulePublicReadHeaders({
-  secret: key,
+  secret: edgeKey,
   url,
   nonce: 'schedule-public-read-dry-run-0001',
 })
 let forwardedPath = ''
 const response = await adapter.fetch(new Request(url, { headers }), {
   SCHEDULE_PUBLIC_READ_ENABLED: 'true',
-  SCHEDULE_PUBLIC_READ_HMAC_KEY: key,
+  SCHEDULE_PUBLIC_READ_EDGE_HMAC_KEY: edgeKey,
+  SCHEDULE_PUBLIC_READ_CORE_HMAC_KEY: coreKey,
   SCHEDULE_CORE: {
     async fetch(request) {
+      const authorization = await verifySchedulePublicReadRequest(request, coreKey, {
+        allowedService: SCHEDULE_PUBLIC_READ_CORE_SERVICE,
+      })
+      assert.equal(authorization.ok, true)
       forwardedPath = `${new URL(request.url).pathname}${new URL(request.url).search}`
       return Response.json({
         ok: true,

--- a/workforce/schedule/worker.js
+++ b/workforce/schedule/worker.js
@@ -1,5 +1,7 @@
 import {
   SCHEDULE_PUBLIC_READ_CONTRACT_VERSION,
+  SCHEDULE_PUBLIC_READ_CORE_SERVICE,
+  normalizeSchedulePublicReadSecret,
   verifySchedulePublicReadRequest,
 } from './public-read-contract.js'
 
@@ -268,13 +270,15 @@ function publicInstagramHandle(value) {
 }
 
 async function handleSchedulePublicRead(request, env, url, corsHeaders, requestId) {
-  const secret = String(env?.SCHEDULE_PUBLIC_READ_HMAC_KEY || '').trim()
+  const secret = normalizeSchedulePublicReadSecret(env?.SCHEDULE_PUBLIC_READ_CORE_HMAC_KEY)
   if (!schedulePublicReadEnabled(env) || !secret || !env?.DB) {
     return schedulePublicReadUnavailable(corsHeaders, requestId)
   }
   if (request.method !== 'GET') return schedulePublicReadMethodNotAllowed(corsHeaders, requestId)
 
-  const authorization = await verifySchedulePublicReadRequest(request, secret)
+  const authorization = await verifySchedulePublicReadRequest(request, secret, {
+    allowedService: SCHEDULE_PUBLIC_READ_CORE_SERVICE,
+  })
   if (!authorization.ok) return schedulePublicReadUnauthorized(corsHeaders, requestId)
 
   const suffix = url.pathname.slice(SCHEDULE_PUBLIC_READ_INTERNAL_PREFIX.length)

--- a/workforce/schedule/worker.js
+++ b/workforce/schedule/worker.js
@@ -1,4 +1,10 @@
+import {
+  SCHEDULE_PUBLIC_READ_CONTRACT_VERSION,
+  verifySchedulePublicReadRequest,
+} from './public-read-contract.js'
+
 const ACTOR_SKEW_MS = 5 * 60 * 1000
+const SCHEDULE_PUBLIC_READ_INTERNAL_PREFIX = '/api/escala/internal/schedule-public-read/v1'
 
 function jsonResponse(body, init = {}) {
   return new Response(JSON.stringify(body), {
@@ -175,6 +181,182 @@ function normalizeUnitKey(value) {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '')
     .trim()
+}
+
+function schedulePublicReadUnit(value) {
+  const key = normalizeUnitKey(value)
+  if (key === 'barrashoppingsul') return { slug: 'barrashoppingsul', label: 'BarraShoppingSul' }
+  if (key === 'novohamburgo') return { slug: 'novohamburgo', label: 'Novo Hamburgo' }
+  return null
+}
+
+function schedulePublicReadEnabled(env) {
+  return String(env?.SCHEDULE_PUBLIC_READ_ENABLED || '').trim().toLowerCase() === 'true'
+}
+
+function schedulePublicReadHeaders(corsHeaders, requestId) {
+  return {
+    ...corsHeaders,
+    'cache-control': 'no-store',
+    'x-request-id': requestId,
+    'x-skincos-schedule-public-read-contract': SCHEDULE_PUBLIC_READ_CONTRACT_VERSION,
+  }
+}
+
+function schedulePublicReadUnavailable(corsHeaders, requestId, error = 'SCHEDULE_PUBLIC_READ_UNAVAILABLE') {
+  return jsonResponse({
+    ok: false,
+    contract: SCHEDULE_PUBLIC_READ_CONTRACT_VERSION,
+    ready: false,
+    error,
+  }, {
+    status: 503,
+    headers: schedulePublicReadHeaders(corsHeaders, requestId),
+  })
+}
+
+function schedulePublicReadUnauthorized(corsHeaders, requestId) {
+  return jsonResponse({ ok: false, error: 'SCHEDULE_PUBLIC_READ_UNAUTHORIZED' }, {
+    status: 401,
+    headers: schedulePublicReadHeaders(corsHeaders, requestId),
+  })
+}
+
+function schedulePublicReadMethodNotAllowed(corsHeaders, requestId) {
+  return jsonResponse({ ok: false, error: 'METHOD_NOT_ALLOWED' }, {
+    status: 405,
+    headers: schedulePublicReadHeaders(corsHeaders, requestId),
+  })
+}
+
+function schedulePublicReadNotFound(corsHeaders, requestId) {
+  return jsonResponse({ ok: false, error: 'NOT_FOUND' }, {
+    status: 404,
+    headers: schedulePublicReadHeaders(corsHeaders, requestId),
+  })
+}
+
+function schedulePublicReadBadRequest(corsHeaders, requestId, error) {
+  return jsonResponse({ ok: false, error }, {
+    status: 400,
+    headers: schedulePublicReadHeaders(corsHeaders, requestId),
+  })
+}
+
+function parseSchedulePublicReadUnits(value) {
+  try {
+    const parsed = JSON.parse(String(value || '[]'))
+    return Array.isArray(parsed)
+      ? parsed.map((unit) => String(unit || '').trim()).filter(Boolean)
+      : []
+  } catch {
+    return []
+  }
+}
+
+function publicOneLine(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim()
+}
+
+function publicInstagramHandle(value) {
+  const raw = publicOneLine(value)
+  if (!raw) return null
+  const withoutAt = raw.startsWith('@') ? raw.slice(1) : raw
+  const handle = (withoutAt.match(/instagram\.com\/(?:@)?([^/?#]+)/i)?.[1] || withoutAt)
+    .replace(/[^a-zA-Z0-9._]/g, '')
+  return handle || null
+}
+
+async function handleSchedulePublicRead(request, env, url, corsHeaders, requestId) {
+  const secret = String(env?.SCHEDULE_PUBLIC_READ_HMAC_KEY || '').trim()
+  if (!schedulePublicReadEnabled(env) || !secret || !env?.DB) {
+    return schedulePublicReadUnavailable(corsHeaders, requestId)
+  }
+  if (request.method !== 'GET') return schedulePublicReadMethodNotAllowed(corsHeaders, requestId)
+
+  const authorization = await verifySchedulePublicReadRequest(request, secret)
+  if (!authorization.ok) return schedulePublicReadUnauthorized(corsHeaders, requestId)
+
+  const suffix = url.pathname.slice(SCHEDULE_PUBLIC_READ_INTERNAL_PREFIX.length)
+  if (!['/readiness', '/availability', '/professionals'].includes(suffix)) {
+    return schedulePublicReadNotFound(corsHeaders, requestId)
+  }
+
+  try {
+    if (suffix === '/readiness') {
+      await env.DB.prepare('select 1 as ready').first()
+      return jsonResponse({
+        ok: true,
+        contract: SCHEDULE_PUBLIC_READ_CONTRACT_VERSION,
+        ready: true,
+        dependencies: { schedule: 'available' },
+      }, { headers: schedulePublicReadHeaders(corsHeaders, requestId) })
+    }
+
+    const unit = schedulePublicReadUnit(url.searchParams.get('unit'))
+    if (!unit) return schedulePublicReadBadRequest(corsHeaders, requestId, 'INVALID_UNIT')
+
+    if (suffix === '/availability') {
+      const date = String(url.searchParams.get('date') || '').trim()
+      if (!isValidDate(date)) return schedulePublicReadBadRequest(corsHeaders, requestId, 'INVALID_DATE')
+
+      const [scheduleResult, closedDay, holiday] = await Promise.all([
+        env.DB.prepare(
+          `select professional_name as professional
+           from schedule_entries
+           where unit = ?1 and date = ?2
+           order by professional_name asc`,
+        ).bind(unit.label, date).all(),
+        env.DB.prepare(
+          'select 1 as found from closed_days where unit = ?1 and date = ?2 limit 1',
+        ).bind(unit.label, date).first(),
+        env.DB.prepare(
+          'select 1 as found from holidays where unit = ?1 and date = ?2 limit 1',
+        ).bind(unit.label, date).first(),
+      ])
+      const professionalNames = Array.from(new Set(
+        (scheduleResult.results || []).map((row) => publicOneLine(row.professional)).filter(Boolean),
+      ))
+      return jsonResponse({
+        ok: true,
+        contract: SCHEDULE_PUBLIC_READ_CONTRACT_VERSION,
+        data: {
+          unit: unit.slug,
+          date,
+          closed: Boolean(closedDay || holiday),
+          professionalNames,
+        },
+      }, { headers: schedulePublicReadHeaders(corsHeaders, requestId) })
+    }
+
+    const result = await env.DB.prepare(
+      `select name, status, role, nickname, instagram, units_json
+       from professionals
+       order by name asc`,
+    ).all()
+    const professionals = (result.results || [])
+      .map((row) => {
+        const units = parseSchedulePublicReadUnits(row.units_json)
+        return {
+          name: publicOneLine(row.name),
+          status: publicOneLine(row.status) || null,
+          role: publicOneLine(row.role) || null,
+          nickname: publicOneLine(row.nickname) || null,
+          instagram: publicInstagramHandle(row.instagram),
+          units,
+        }
+      })
+      .filter((row) => row.name && (!row.status || row.status.toLowerCase() === 'ativo'))
+      .filter((row) => row.units.some((entry) => schedulePublicReadUnit(entry)?.slug === unit.slug))
+
+    return jsonResponse({
+      ok: true,
+      contract: SCHEDULE_PUBLIC_READ_CONTRACT_VERSION,
+      data: { unit: unit.slug, professionals },
+    }, { headers: schedulePublicReadHeaders(corsHeaders, requestId) })
+  } catch {
+    return schedulePublicReadUnavailable(corsHeaders, requestId, 'SCHEDULE_PUBLIC_READ_NOT_READY')
+  }
 }
 
 async function getTableColumns(env, tableName) {
@@ -1208,6 +1390,13 @@ export default {
 
     if (path === '/health' || path === '/api/escala/health') {
       return jsonResponse({ ok: true }, { headers: { ...corsHeaders, 'x-request-id': requestId } })
+    }
+
+    // This adapter-facing route deliberately bypasses CRM actor parsing. It is
+    // reachable only through its separate, fixed-service HMAC contract and is
+    // read-only; ESCALA_ACTOR_HMAC_KEY remains exclusive to CRM/Ponto flows.
+    if (path.startsWith(SCHEDULE_PUBLIC_READ_INTERNAL_PREFIX)) {
+      return handleSchedulePublicRead(request, env, url, corsHeaders, requestId)
     }
 
     if (!path.startsWith('/api/escala')) {


### PR DESCRIPTION
## What\n- adds a default-off, GET-only Schedule public-read adapter boundary\n- splits Website-to-adapter and adapter-to-core HMAC capabilities\n- proves the Website edge key cannot call the Schedule core directly\n\n## Deliberately not included\n- no route, D1 binding, secret provisioning, Website/Booking consumer cutover, or deploy\n- replay protection and customer-facing unavailable behavior remain explicit staged-cut gates\n\n## Validation\n- npm test in workforce/schedule (22 passing)\n- npm run public-read:dry-run\n- git diff --check