### PR TITLE
feat(messaging): prepare immutable WhatsApp release boundary

### DIFF
--- a/.github/workflows/messaging-whatsapp-release-contract.yml
+++ b/.github/workflows/messaging-whatsapp-release-contract.yml
@@ -1,0 +1,69 @@
+name: Messaging WhatsApp immutable release contract
+
+on:
+  pull_request:
+    paths:
+      - "messaging/**"
+      - "ops/runtime/units/messaging-whatsapp.service"
+      - "ops/governance/global-concurrency-policy.json"
+      - "ops/governance/global-coordination-core.mjs"
+      - "ops/codex/risk-policy.json"
+      - "scripts/codex-autonomy-lib.mjs"
+      - "scripts/codex-global-coordinator.mjs"
+      - "scripts/codex-global-coordination-workflow.mjs"
+      - "scripts/codex-release-manifest.mjs"
+      - "scripts/runtime/global-coordination-mini-pc.sh"
+      - "scripts/runtime/messaging-whatsapp-release-contract.mjs"
+      - "scripts/runtime/messaging-whatsapp-release-contract.test.mjs"
+      - "scripts/runtime/prepare-messaging-whatsapp-release.sh"
+      - "scripts/runtime/rollback-messaging-whatsapp-release.sh"
+      - "scripts/runtime/run-messaging-whatsapp-release.sh"
+      - "scripts/runtime/test-prepare-messaging-whatsapp-release.sh"
+      - "scripts/runtime/test-rollback-messaging-whatsapp-release.sh"
+      - "scripts/runtime/test-run-messaging-whatsapp-release.sh"
+      - ".github/workflows/prepare-release-candidate.yml"
+      - ".github/workflows/messaging-whatsapp-release-contract.yml"
+  push:
+    branches: [main]
+    paths:
+      - "messaging/**"
+      - "ops/runtime/units/messaging-whatsapp.service"
+      - "ops/governance/global-concurrency-policy.json"
+      - "ops/governance/global-coordination-core.mjs"
+      - "ops/codex/risk-policy.json"
+      - "scripts/codex-autonomy-lib.mjs"
+      - "scripts/codex-global-coordinator.mjs"
+      - "scripts/codex-global-coordination-workflow.mjs"
+      - "scripts/codex-release-manifest.mjs"
+      - "scripts/runtime/global-coordination-mini-pc.sh"
+      - "scripts/runtime/messaging-whatsapp-release-contract.mjs"
+      - "scripts/runtime/messaging-whatsapp-release-contract.test.mjs"
+      - "scripts/runtime/prepare-messaging-whatsapp-release.sh"
+      - "scripts/runtime/rollback-messaging-whatsapp-release.sh"
+      - "scripts/runtime/run-messaging-whatsapp-release.sh"
+      - "scripts/runtime/test-prepare-messaging-whatsapp-release.sh"
+      - "scripts/runtime/test-rollback-messaging-whatsapp-release.sh"
+      - "scripts/runtime/test-run-messaging-whatsapp-release.sh"
+      - ".github/workflows/prepare-release-candidate.yml"
+      - ".github/workflows/messaging-whatsapp-release-contract.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    name: Validate immutable candidate, provenance and rollback boundary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22
+      - name: Test release candidate identity and negative provenance cases
+        run: node --test scripts/runtime/messaging-whatsapp-release-contract.test.mjs
+      - name: Test preparation, launcher and rollback guards
+        run: |
+          bash scripts/runtime/test-prepare-messaging-whatsapp-release.sh
+          bash scripts/runtime/test-run-messaging-whatsapp-release.sh
+          bash scripts/runtime/test-rollback-messaging-whatsapp-release.sh

--- a/.github/workflows/messaging-whatsapp-release-contract.yml
+++ b/.github/workflows/messaging-whatsapp-release-contract.yml
@@ -57,6 +57,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # The preparation contract derives a manifest against HEAD^; retain
+          # only that immutable parent instead of relying on a full clone.
+          fetch-depth: 2
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22

--- a/.github/workflows/prepare-release-candidate.yml
+++ b/.github/workflows/prepare-release-candidate.yml
@@ -56,6 +56,8 @@ jobs:
           git fetch --no-tags origin main
           git cat-file -e "$release_sha^{commit}"
           git merge-base --is-ancestor "$release_sha" origin/main || { echo "::error::$release_sha is not reachable from origin/main"; exit 1; }
+          git checkout --detach "$release_sha"
+          [[ "$(git rev-parse HEAD)" == "$release_sha" ]] || { echo "::error::failed to load the requested immutable source"; exit 1; }
           echo "source_sha=$release_sha" >> "$GITHUB_OUTPUT"
       - name: Archive and attest source
         env:
@@ -67,9 +69,12 @@ jobs:
           sha256sum release-candidate/source.tar.gz | awk '{print $1}' > release-candidate/source.sha256
           export SOURCE_TREE="$(git rev-parse "${RELEASE_SHA}^{tree}")"
           node - <<'NODE'
-          const fs = require("fs");
-          fs.writeFileSync("release-candidate/release.json", `${JSON.stringify({schemaVersion: 1, sourceSha: process.env.RELEASE_SHA, sourceTree: process.env.SOURCE_TREE, sourceArchiveSha256: fs.readFileSync("release-candidate/source.sha256", "utf8").trim(), createdAt: new Date().toISOString()}, null, 2)}\n`);
+           const fs = require("fs");
+           fs.writeFileSync("release-candidate/release.json", `${JSON.stringify({schemaVersion: 1, sourceSha: process.env.RELEASE_SHA, sourceTree: process.env.SOURCE_TREE, sourceArchiveSha256: fs.readFileSync("release-candidate/source.sha256", "utf8").trim(), createdAt: new Date().toISOString()}, null, 2)}\n`);
           NODE
+          node scripts/codex-global-coordinator.mjs closure \
+            --module messaging-whatsapp \
+            --source "$RELEASE_SHA" > release-candidate/messaging-whatsapp-closure.json
           node scripts/codex-release-manifest.mjs \
             --source "$RELEASE_SHA" \
             --base "${RELEASE_SHA}^" \

--- a/messaging/channels/whatsapp/README.md
+++ b/messaging/channels/whatsapp/README.md
@@ -11,11 +11,22 @@ It is built into a native Linux release and started by
 - logs: `/var/log/skincos/messaging-whatsapp`
 - local API: `http://127.0.0.1:8080`
 - public ingress: `https://wa.skincos.com.br`
+- service and release owner: `@jubenitogarcia` (Messaging)
 
 CRM uses the private `/etc/skincos/crm-whatsapp.env` overlay and always talks
 to the local engine. The compatibility adapter in
 `crm/api/services/whatsappOrchestrator.js` delegates to the same engine and
 does not spawn a second service.
+
+Native promotion and rollback use only a Linux-native
+`release-source-<SHA>` artifact with its `messaging-whatsapp` closure. A
+promotion requires an installed attested predecessor; rollback accepts only that
+recorded predecessor, then verifies `messaging-whatsapp.service` and the local
+`/health` endpoint. The mutable checkout is never a runtime or release input.
+Before either `--apply` path can be enabled, the service owner must provision an
+external authenticated custody verifier that binds the GitHub workflow run,
+artifact identity and source-archive digest; the current scripts deliberately
+fail closed and do not accept self-attested environment flags or files.
 
 Build and runtime checks:
 

--- a/ops/governance/global-concurrency-policy.json
+++ b/ops/governance/global-concurrency-policy.json
@@ -163,6 +163,22 @@
       "patterns": ["backend/scripts/cloudflare-alerting-apply.sh", ".github/workflows/cloudflare-alerting-apply.yml"],
       "sharedInputs": true
     },
+    "messaging-whatsapp": {
+      "patterns": [
+        "messaging/**",
+        "ops/runtime/units/messaging-whatsapp.service",
+        "scripts/runtime/global-coordination-mini-pc.sh",
+        "scripts/runtime/messaging-whatsapp-release-contract.mjs",
+        "scripts/runtime/messaging-whatsapp-release-contract.test.mjs",
+        "scripts/runtime/prepare-messaging-whatsapp-release.sh",
+        "scripts/runtime/rollback-messaging-whatsapp-release.sh",
+        "scripts/runtime/run-messaging-whatsapp-release.sh",
+        "scripts/runtime/test-prepare-messaging-whatsapp-release.sh",
+        "scripts/runtime/test-rollback-messaging-whatsapp-release.sh",
+        "scripts/runtime/test-run-messaging-whatsapp-release.sh"
+      ],
+      "sharedInputs": true
+    },
     "native-runtime": {
       "patterns": [
         "crm/api/**",

--- a/ops/runtime/units/messaging-whatsapp.service
+++ b/ops/runtime/units/messaging-whatsapp.service
@@ -15,7 +15,7 @@ Environment=EVOLUTION_API_INSTANCES_DIR=__STATE_ROOT__/messaging-whatsapp/instan
 Environment=EVOLUTION_API_STORE_DIR=__STATE_ROOT__/messaging-whatsapp/store
 Environment=NODE20_BIN=/usr/bin
 EnvironmentFile=-__CONFIG_ROOT__/messaging-whatsapp.env
-ExecStart=__REPO_ROOT__/scripts/runtime/run-messaging-whatsapp-release.sh
+ExecStart=/opt/skincos/current/messaging-whatsapp/.skincos-run-messaging-whatsapp-release.sh
 Restart=always
 RestartSec=10
 NoNewPrivileges=true

--- a/scripts/runtime/messaging-whatsapp-release-contract.mjs
+++ b/scripts/runtime/messaging-whatsapp-release-contract.mjs
@@ -1,0 +1,1123 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { gunzipSync } from "node:zlib";
+
+export const MODULE = "messaging-whatsapp";
+export const FULL_SHA = /^[0-9a-f]{40}$/i;
+export const SHA256 = /^[0-9a-f]{64}$/i;
+
+const TAR_BLOCK_BYTES = 512;
+const MAX_RELEASE_ARCHIVE_BYTES = 256 * 1024 * 1024;
+const MAX_RELEASE_TAR_BYTES = 512 * 1024 * 1024;
+const MAX_RELEASE_TAR_ENTRIES = 200_000;
+const MAX_RELEASE_METADATA_BYTES = 8 * 1024 * 1024;
+const SNAPSHOT_ARTIFACTS = Object.freeze([
+  "source.tar.gz",
+  "source.sha256",
+  "release.json",
+  "release-manifest.json",
+  "messaging-whatsapp-closure.json",
+]);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function text(value) {
+  return String(value ?? "").trim();
+}
+
+function lower(value) {
+  return text(value).toLowerCase();
+}
+
+function fullSha(value, label) {
+  const normalized = lower(value);
+  if (!FULL_SHA.test(normalized)) fail(label + " must be a full SHA.");
+  return normalized;
+}
+
+function digest(value, label) {
+  const normalized = lower(value);
+  if (!SHA256.test(normalized)) fail(label + " must be a SHA-256 digest.");
+  return normalized;
+}
+
+function safeRelativePath(value, label) {
+  const normalized = text(value).replaceAll("\\", "/");
+  if (!normalized || normalized.startsWith("/") || normalized.split("/").includes("..")) {
+    fail(label + " is not a safe relative path.");
+  }
+  return normalized;
+}
+
+export function canonicalJson(value) {
+  if (Array.isArray(value)) return "[" + value.map(canonicalJson).join(",") + "]";
+  if (value && typeof value === "object") {
+    return "{" + Object.keys(value).sort().map((key) => JSON.stringify(key) + ":" + canonicalJson(value[key])).join(",") + "}";
+  }
+  return JSON.stringify(value);
+}
+
+export function sha256Text(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+export function sha256File(file) {
+  return crypto.createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+}
+
+export function isNativeLinuxPath(candidate) {
+  const normalized = path.resolve(String(candidate || ""));
+  return normalized !== "/mnt" && !normalized.startsWith("/mnt/");
+}
+
+function nativeDirectory(candidate, label) {
+  const requested = path.resolve(String(candidate || ""));
+  if (!isNativeLinuxPath(requested)) fail(label + " must already be on native Linux storage, not /mnt.");
+  let resolved;
+  try {
+    resolved = fs.realpathSync(requested);
+  } catch {
+    fail(label + " is unavailable.");
+  }
+  if (!isNativeLinuxPath(resolved)) fail(label + " must resolve to native Linux storage.");
+  const stat = fs.statSync(resolved);
+  if (!stat.isDirectory()) fail(label + " must be a directory.");
+  let gitMarker = null;
+  try {
+    gitMarker = fs.lstatSync(path.join(resolved, ".git"));
+  } catch (error) {
+    if (error?.code !== "ENOENT") fail(label + " cannot verify whether it is a checkout or worktree.");
+  }
+  if (gitMarker) fail(label + " must not be a checkout or worktree.");
+  return resolved;
+}
+
+function regularFile(root, relative, label) {
+  const candidate = path.resolve(root, relative);
+  if (candidate === root || !candidate.startsWith(root + path.sep)) fail(label + " escapes its release root.");
+  let entry;
+  try {
+    entry = fs.lstatSync(candidate);
+  } catch {
+    fail(label + " is unavailable.");
+  }
+  if (!entry.isFile() || entry.isSymbolicLink()) fail(label + " must be a regular file.");
+  return candidate;
+}
+
+function boundedRegularFile(file, label, maximumBytes) {
+  try {
+    const stat = fs.lstatSync(file);
+    if (!stat.isFile() || stat.isSymbolicLink()) fail(label + " must be a regular file.");
+    if (stat.size > maximumBytes) {
+      fail(label + " exceeds the safe size limit.");
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith(label)) throw error;
+    fail(label + " size cannot be verified.");
+  }
+  return file;
+}
+
+function boundedArchiveFile(file) {
+  try {
+    return boundedRegularFile(file, "Release source archive compressed size", MAX_RELEASE_ARCHIVE_BYTES);
+  } catch (error) {
+    if (error instanceof Error && /exceeds the safe size limit/.test(error.message)) {
+      fail("Release source archive compressed size exceeds the safe limit.");
+    }
+    throw error;
+  }
+}
+
+function boundedMetadataFile(file, label) {
+  return boundedRegularFile(file, label, MAX_RELEASE_METADATA_BYTES);
+}
+
+function withBoundedRegularFile(file, label, maximumBytes, operation) {
+  const noFollow = fs.constants.O_NOFOLLOW;
+  const nonBlock = fs.constants.O_NONBLOCK;
+  if (!Number.isInteger(noFollow) || !Number.isInteger(nonBlock)) {
+    fail(label + " requires native no-follow and non-blocking file support.");
+  }
+  let descriptor = null;
+  try {
+    descriptor = fs.openSync(file, fs.constants.O_RDONLY | noFollow | nonBlock);
+  } catch {
+    fail(label + " cannot be opened without following links.");
+  }
+  try {
+    const before = fs.fstatSync(descriptor);
+    if (!before.isFile()) fail(label + " must be a regular file.");
+    if (before.size > maximumBytes) fail(label + " exceeds the safe size limit.");
+    const result = operation(descriptor, before.size);
+    const after = fs.fstatSync(descriptor);
+    if (after.dev !== before.dev || after.ino !== before.ino || after.size !== before.size) {
+      fail(label + " changed while it was read.");
+    }
+    return result;
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function readBoundedRegularFile(file, label, maximumBytes) {
+  return withBoundedRegularFile(file, label, maximumBytes, (descriptor, size) => {
+    const contents = Buffer.allocUnsafe(size);
+    let offset = 0;
+    while (offset < size) {
+      const bytesRead = fs.readSync(descriptor, contents, offset, size - offset, null);
+      if (bytesRead <= 0) fail(label + " changed while it was read.");
+      offset += bytesRead;
+    }
+    return contents;
+  });
+}
+
+function sha256BoundedRegularFile(file, label, maximumBytes) {
+  return withBoundedRegularFile(file, label, maximumBytes, (descriptor, size) => {
+    const hash = crypto.createHash("sha256");
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    let remaining = size;
+    while (remaining > 0) {
+      const bytesRead = fs.readSync(descriptor, buffer, 0, Math.min(buffer.length, remaining), null);
+      if (bytesRead <= 0) fail(label + " changed while it was read.");
+      hash.update(buffer.subarray(0, bytesRead));
+      remaining -= bytesRead;
+    }
+    return hash.digest("hex");
+  });
+}
+
+export function isolatedGitEnvironment(environment = process.env) {
+  return Object.fromEntries(Object.entries(environment).filter(([name]) => !name.toUpperCase().startsWith("GIT_")));
+}
+
+function archiveGitCommit(archiveFile) {
+  // `git get-tar-commit-id` stops after the PAX header.  For a sufficiently
+  // large archive gzip can then legitimately exit with SIGPIPE (141), even
+  // though Git read and verified the source header successfully.  Capture the
+  // two process statuses explicitly so that only that narrow, expected case is
+  // accepted; any other decompression or Git failure remains fail-closed.
+  const gitHome = fs.mkdtempSync("/var/tmp/skincos-messaging-git-home-");
+  let result;
+  try {
+    result = spawnSync(
+      "/usr/bin/bash",
+      [
+        "-c",
+        [
+          "set +e",
+          "set +o pipefail",
+          "gzip -cd -- \"$1\" | git get-tar-commit-id",
+          "statuses=(\"${PIPESTATUS[@]}\")",
+          "printf '__SKINCOS_ARCHIVE_PIPESTATUS__=%s,%s\\n' \"${statuses[0]}\" \"${statuses[1]}\" >&2",
+          "exit 0",
+        ].join("\n"),
+        "messaging-release-candidate",
+        archiveFile,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          PATH: "/usr/bin:/bin",
+          HOME: gitHome,
+          XDG_CONFIG_HOME: path.join(gitHome, "xdg"),
+          GIT_CONFIG_NOSYSTEM: "1",
+          LANG: "C",
+          LC_ALL: "C",
+        },
+        cwd: gitHome,
+        stdio: ["ignore", "pipe", "pipe"],
+        maxBuffer: 128 * 1024 * 1024,
+      },
+    );
+  } finally {
+    fs.rmSync(gitHome, { recursive: true, force: true });
+  }
+  const marker = /__SKINCOS_ARCHIVE_PIPESTATUS__=(\d+),(\d+)/.exec(String(result.stderr || ""));
+  if (result.error || result.status !== 0 || result.signal || !marker) {
+    fail("Release source archive Git commit could not be verified.");
+  }
+  const gzipStatus = Number(marker[1]);
+  const gitStatus = Number(marker[2]);
+  if (gitStatus !== 0 || (gzipStatus !== 0 && gzipStatus !== 141)) {
+    fail("Release source archive Git commit could not be verified.");
+  }
+  return lower(result.stdout);
+}
+
+function boundedTarNumber(value, label) {
+  if (value < 0n || value > BigInt(Number.MAX_SAFE_INTEGER)) fail(label + " is out of range.");
+  return Number(value);
+}
+
+function tarNumber(field, label) {
+  if (field.length === 0) return 0;
+  if (field[0] & 0x80) {
+    if (field[0] & 0x40) fail(label + " cannot be negative.");
+    let value = BigInt(field[0] & 0x7f);
+    for (let index = 1; index < field.length; index += 1) value = (value << 8n) + BigInt(field[index]);
+    return boundedTarNumber(value, label);
+  }
+  const terminator = field.indexOf(0);
+  const raw = field.subarray(0, terminator === -1 ? field.length : terminator).toString("ascii").trim();
+  if (!raw) return 0;
+  if (!/^[0-7]+$/.test(raw)) fail(label + " is not an octal TAR number.");
+  return boundedTarNumber(BigInt("0o" + raw), label);
+}
+
+function paxNumber(value, label) {
+  if (!/^[0-9]+$/.test(value)) fail(label + " is not a decimal PAX number.");
+  return boundedTarNumber(BigInt(value), label);
+}
+
+function tarString(field) {
+  const terminator = field.indexOf(0);
+  return field.subarray(0, terminator === -1 ? field.length : terminator).toString("utf8");
+}
+
+function isZeroTarBlock(block) {
+  return block.every((byte) => byte === 0);
+}
+
+function assertTarChecksum(header) {
+  const expected = tarNumber(header.subarray(148, 156), "Release source archive header checksum");
+  let actual = 0;
+  for (let index = 0; index < TAR_BLOCK_BYTES; index += 1) {
+    actual += index >= 148 && index < 156 ? 0x20 : header[index];
+  }
+  if (actual !== expected) fail("Release source archive header checksum is invalid.");
+}
+
+function parsePaxAttributes(payload, label) {
+  const attributes = new Map();
+  let offset = 0;
+  while (offset < payload.length) {
+    const separator = payload.indexOf(0x20, offset);
+    if (separator <= offset) fail(label + " has an invalid record length.");
+    const recordLength = paxNumber(payload.subarray(offset, separator).toString("ascii"), label + " record length");
+    const end = offset + recordLength;
+    if (end > payload.length || payload[end - 1] !== 0x0a) fail(label + " has a truncated record.");
+    const record = payload.subarray(separator + 1, end - 1);
+    const equals = record.indexOf(0x3d);
+    if (equals <= 0) fail(label + " has an invalid key.");
+    const key = record.subarray(0, equals).toString("utf8");
+    const value = record.subarray(equals + 1).toString("utf8");
+    if (!key || key.includes("\0") || value.includes("\0")) fail(label + " contains a NUL byte.");
+    attributes.set(key, value);
+    offset = end;
+  }
+  return attributes;
+}
+
+function tarArchivePathParts(entryPath, sourceCommit) {
+  const prefix = "skincos-" + sourceCommit + "/";
+  if (typeof entryPath !== "string" || entryPath.includes("\0") || /[\r\n]/.test(entryPath) || !entryPath.startsWith(prefix)) {
+    fail("Release source archive contains an entry outside its immutable source prefix.");
+  }
+  const relative = entryPath.slice(prefix.length).replace(/\/+$/, "");
+  if (!relative) return [];
+  const parts = relative.split("/");
+  if (parts.some((part) => !part || part === "." || part === ".." || part === ".git")) {
+    fail("Release source archive contains checkout metadata or an escaping path.");
+  }
+  return parts;
+}
+
+function archiveDestination(sourceRoot, parts) {
+  const destination = path.resolve(sourceRoot, ...parts);
+  if (destination !== sourceRoot && !destination.startsWith(sourceRoot + path.sep)) {
+    fail("Release source archive entry escapes its native extraction stage.");
+  }
+  return destination;
+}
+
+function ensureArchiveParents(sourceRoot, parts, entries) {
+  let current = sourceRoot;
+  const parentParts = parts.slice(0, -1);
+  for (let index = 0; index < parentParts.length; index += 1) {
+    current = path.join(current, parentParts[index]);
+    const relative = parentParts.slice(0, index + 1).join("/");
+    const known = entries.get(relative);
+    if (known === "file" || known === "symlink") {
+      fail("Release source archive writes through a non-directory ancestor.");
+    }
+    if (!known) {
+      try {
+        const stat = fs.lstatSync(current);
+        if (!stat.isDirectory() || stat.isSymbolicLink()) {
+          fail("Release source archive parent is not a confined directory.");
+        }
+      } catch (error) {
+        if (error?.code !== "ENOENT") throw error;
+        fs.mkdirSync(current, { mode: 0o755 });
+      }
+      entries.set(relative, "implicit-directory");
+    }
+  }
+}
+
+function opaqueSymlinkTarget(target) {
+  if (!target || target.includes("\0")) {
+    fail("Release source archive symlink target is invalid.");
+  }
+  return target;
+}
+
+function materializeGitArchive(archiveFile, stage, sourceCommit) {
+  let tarBytes;
+  try {
+    boundedArchiveFile(archiveFile);
+    tarBytes = gunzipSync(
+      readBoundedRegularFile(archiveFile, "Release source archive", MAX_RELEASE_ARCHIVE_BYTES),
+      { maxOutputLength: MAX_RELEASE_TAR_BYTES },
+    );
+  } catch {
+    fail("Release source archive cannot be decompressed safely.");
+  }
+  if (!tarBytes.length || tarBytes.length % TAR_BLOCK_BYTES !== 0) {
+    fail("Release source archive is not a block-aligned TAR stream.");
+  }
+
+  const sourceRoot = path.join(stage, "skincos-" + sourceCommit);
+  fs.mkdirSync(sourceRoot, { mode: 0o755 });
+  const entries = new Map([["", "implicit-directory"]]);
+  const globalPax = new Map();
+  const symlinks = [];
+  let pendingPax = new Map();
+  let offset = 0;
+  let terminated = false;
+  let headerCount = 0;
+  while (offset < tarBytes.length) {
+    const header = tarBytes.subarray(offset, offset + TAR_BLOCK_BYTES);
+    if (isZeroTarBlock(header)) {
+      if (offset + (2 * TAR_BLOCK_BYTES) > tarBytes.length
+        || !isZeroTarBlock(tarBytes.subarray(offset + TAR_BLOCK_BYTES, offset + (2 * TAR_BLOCK_BYTES)))
+        || !isZeroTarBlock(tarBytes.subarray(offset + (2 * TAR_BLOCK_BYTES)))) {
+        fail("Release source archive has data after its TAR terminator.");
+      }
+      terminated = true;
+      break;
+    }
+    headerCount += 1;
+    if (headerCount > MAX_RELEASE_TAR_ENTRIES) fail("Release source archive exceeds the safe entry limit.");
+    assertTarChecksum(header);
+    const headerName = tarString(header.subarray(0, 100));
+    const headerPrefix = tarString(header.subarray(345, 500));
+    const headerPath = headerPrefix ? headerPrefix + "/" + headerName : headerName;
+    const type = String.fromCharCode(header[156] || 0);
+    const headerSize = tarNumber(header.subarray(124, 136), "Release source archive entry size");
+    const headerMode = tarNumber(header.subarray(100, 108), "Release source archive entry mode");
+    const rawPayloadStart = offset + TAR_BLOCK_BYTES;
+    const rawPayloadEnd = rawPayloadStart + headerSize;
+    const nextOffset = rawPayloadStart + (Math.ceil(headerSize / TAR_BLOCK_BYTES) * TAR_BLOCK_BYTES);
+    if (rawPayloadEnd > tarBytes.length || nextOffset > tarBytes.length) fail("Release source archive entry is truncated.");
+    const rawPayload = tarBytes.subarray(rawPayloadStart, rawPayloadEnd);
+    offset = nextOffset;
+
+    if (type === "g" || type === "x") {
+      const attributes = parsePaxAttributes(rawPayload, "Release source archive PAX header");
+      if (type === "g") {
+        if (attributes.has("path") || attributes.has("linkpath") || attributes.has("size")) {
+          fail("Release source archive global PAX header changes entry identity.");
+        }
+        for (const [key, value] of attributes) globalPax.set(key, value);
+      } else {
+        for (const [key, value] of attributes) pendingPax.set(key, value);
+      }
+      continue;
+    }
+
+    const attributes = new Map([...globalPax, ...pendingPax]);
+    pendingPax = new Map();
+    const payloadSize = attributes.has("size")
+      ? paxNumber(attributes.get("size"), "Release source archive PAX entry size")
+      : headerSize;
+    if (payloadSize !== headerSize) {
+      fail("Release source archive PAX size does not match its TAR entry.");
+    }
+    const entryPath = attributes.get("path") || headerPath;
+    const parts = tarArchivePathParts(entryPath, sourceCommit);
+    const destination = archiveDestination(sourceRoot, parts);
+    const relative = parts.join("/");
+
+    if (type === "1") fail("Release source archive hard links are not permitted.");
+    if (type !== "\0" && type !== "0" && type !== "2" && type !== "5") {
+      fail("Release source archive contains an unsupported TAR entry type.");
+    }
+    if ((type === "2" || type === "5") && rawPayload.length !== 0) {
+      fail("Release source archive link or directory entry has unexpected data.");
+    }
+    if (parts.length === 0) {
+      if (type !== "5") fail("Release source archive root is not a directory.");
+      entries.set("", "directory");
+      continue;
+    }
+    ensureArchiveParents(sourceRoot, parts, entries);
+    const existing = entries.get(relative);
+    if (type === "5") {
+      if (existing === "implicit-directory") {
+        entries.set(relative, "directory");
+        continue;
+      }
+      if (existing) fail("Release source archive contains duplicate entries.");
+      fs.mkdirSync(destination, { mode: 0o755 });
+      entries.set(relative, "directory");
+      continue;
+    }
+    if (existing) fail("Release source archive contains duplicate entries.");
+    if (type === "2") {
+      const target = attributes.get("linkpath") || tarString(header.subarray(157, 257));
+      symlinks.push({ destination, target: opaqueSymlinkTarget(target) });
+      entries.set(relative, "symlink");
+      continue;
+    }
+    fs.writeFileSync(destination, rawPayload, {
+      flag: "wx",
+      mode: headerMode & 0o111 ? 0o755 : 0o644,
+    });
+    entries.set(relative, "file");
+  }
+  if (!terminated || pendingPax.size > 0) fail("Release source archive is missing a complete TAR terminator.");
+  for (const { destination, target } of symlinks) fs.symlinkSync(target, destination);
+  return sourceRoot;
+}
+
+function gitObjectDigest(type, contents) {
+  const header = Buffer.from(type + " " + contents.length + "\0", "utf8");
+  return crypto.createHash("sha1").update(header).update(contents).digest("hex");
+}
+
+function gitBlobDigest(file) {
+  const stat = fs.lstatSync(file);
+  if (!stat.isFile() || stat.isSymbolicLink()) fail("Release source archive Git blob is not a regular file.");
+  const hash = crypto.createHash("sha1");
+  hash.update(Buffer.from("blob " + stat.size + "\0", "utf8"));
+  const descriptor = fs.openSync(file, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+  try {
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    let remaining = stat.size;
+    while (remaining > 0) {
+      const bytesRead = fs.readSync(descriptor, buffer, 0, Math.min(buffer.length, remaining), null);
+      if (bytesRead <= 0) fail("Release source archive Git blob changed while its tree was reconstructed.");
+      hash.update(buffer.subarray(0, bytesRead));
+      remaining -= bytesRead;
+    }
+    const after = fs.fstatSync(descriptor);
+    if (after.dev !== stat.dev || after.ino !== stat.ino || after.size !== stat.size) {
+      fail("Release source archive Git blob changed while its tree was reconstructed.");
+    }
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  return hash.digest("hex");
+}
+
+function gitTreeSort(left, right) {
+  const leftName = Buffer.from(left.name + (left.kind === "tree" ? "/" : ""), "utf8");
+  const rightName = Buffer.from(right.name + (right.kind === "tree" ? "/" : ""), "utf8");
+  return Buffer.compare(leftName, rightName);
+}
+
+function reconstructedTreeEntries(sourceRoot, sourceTree) {
+  const entries = new Map();
+  const rebuildDirectory = (directory, prefix) => {
+    const treeEntries = [];
+    for (const name of fs.readdirSync(directory)) {
+      if (!name || name.includes("\0") || /[\r\n]/.test(name) || name === ".git") {
+        fail("Release source archive Git tree path is invalid.");
+      }
+      const candidate = path.join(directory, name);
+      const relative = prefix ? prefix + "/" + name : name;
+      const stat = fs.lstatSync(candidate);
+      if (stat.isDirectory() && !stat.isSymbolicLink()) {
+        treeEntries.push({ name, kind: "tree", mode: "40000", digest: rebuildDirectory(candidate, relative) });
+        continue;
+      }
+      if (stat.isSymbolicLink()) {
+        const target = fs.readlinkSync(candidate);
+        if (!target || target.includes("\0")) fail("Release source archive symlink target is invalid.");
+        const blob = gitObjectDigest("blob", Buffer.from(target, "utf8"));
+        if (entries.has(relative)) fail("Release source archive Git tree contains duplicate paths.");
+        entries.set(relative, blob);
+        treeEntries.push({ name, kind: "blob", mode: "120000", digest: blob });
+        continue;
+      }
+      if (!stat.isFile()) fail("Release source archive contains an unsupported materialized entry.");
+      const blob = gitBlobDigest(candidate);
+      if (entries.has(relative)) fail("Release source archive Git tree contains duplicate paths.");
+      entries.set(relative, blob);
+      treeEntries.push({ name, kind: "blob", mode: stat.mode & 0o111 ? "100755" : "100644", digest: blob });
+    }
+    treeEntries.sort(gitTreeSort);
+    const contents = Buffer.concat(treeEntries.map((entry) => Buffer.concat([
+      Buffer.from(entry.mode + " " + entry.name + "\0", "utf8"),
+      Buffer.from(entry.digest, "hex"),
+    ])));
+    return gitObjectDigest("tree", contents);
+  };
+
+  const rebuiltTree = rebuildDirectory(sourceRoot, "");
+  if (rebuiltTree !== sourceTree) {
+    fail("Release source archive tree differs from the requested immutable source tree.");
+  }
+  return entries;
+}
+
+function validateArchiveGitProvenance({ archiveFile, sourceCommit, sourceTree }) {
+  const archiveCommit = archiveGitCommit(archiveFile);
+  if (archiveCommit !== sourceCommit) {
+    fail("Release source archive Git commit differs from the requested immutable source SHA.");
+  }
+
+  // The archive's PAX header binds it to the Git source SHA. Reconstruct the
+  // complete Git tree directly from raw materialized blobs and canonical Git
+  // tree objects. This deliberately never runs `git add`, so candidate
+  // .gitattributes and any user/system clean/process filters cannot execute.
+  const stage = fs.mkdtempSync("/var/tmp/skincos-messaging-candidate-tree-");
+  try {
+    const sourceRoot = materializeGitArchive(archiveFile, stage, sourceCommit);
+    return reconstructedTreeEntries(sourceRoot, sourceTree);
+  } finally {
+    fs.rmSync(stage, { recursive: true, force: true });
+  }
+}
+
+function externalRegularFile(candidate, label) {
+  const resolved = path.resolve(String(candidate || ""));
+  let entry;
+  try {
+    entry = fs.lstatSync(resolved);
+  } catch {
+    fail(label + " is unavailable.");
+  }
+  if (!entry.isFile() || entry.isSymbolicLink()) fail(label + " must be a regular file.");
+  return resolved;
+}
+
+function jsonFile(file, label) {
+  try {
+    const value = JSON.parse(readBoundedRegularFile(file, label, MAX_RELEASE_METADATA_BYTES).toString("utf8"));
+    if (!value || typeof value !== "object" || Array.isArray(value)) fail(label + " must contain a JSON object.");
+    return value;
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith(label)) throw error;
+    fail(label + " is not valid JSON.");
+  }
+}
+
+function matchingArtifact(records, name, expectedDigest, label) {
+  if (!Array.isArray(records)) fail(label + " artifacts are missing.");
+  const matches = records.filter((entry) => entry && typeof entry === "object" && entry.name === name);
+  if (matches.length !== 1) fail(label + " must include exactly one " + name + " artifact.");
+  if (digest(matches[0].digest, label + " artifact digest") !== expectedDigest) {
+    fail(label + " " + name + " artifact digest differs from the attested source archive.");
+  }
+  return matches[0];
+}
+
+export function validateMessagingClosure(closureFile, { sourceSha, sourceTree, sourceEntries = null } = {}) {
+  const closure = jsonFile(closureFile, "Messaging closure");
+  const expectedSourceSha = fullSha(sourceSha, "Expected source SHA");
+  const expectedSourceTree = fullSha(sourceTree, "Expected source tree");
+  if (closure.schemaVersion !== 1 || lower(closure.module) !== MODULE) {
+    fail("Messaging closure module is invalid.");
+  }
+  if (fullSha(closure.sourceCommit, "Messaging closure source commit") !== expectedSourceSha) {
+    fail("Messaging closure source SHA differs from the release candidate.");
+  }
+  if (fullSha(closure.sourceTree, "Messaging closure source tree") !== expectedSourceTree) {
+    fail("Messaging closure source tree differs from the release candidate.");
+  }
+  const closureDigest = digest(closure.digest, "Messaging closure digest");
+  const material = closure.material;
+  if (!material || typeof material !== "object" || Array.isArray(material)
+    || material.schemaVersion !== 1 || lower(material.module) !== MODULE || !Array.isArray(material.inputs) || material.inputs.length === 0) {
+    fail("Messaging closure material is invalid.");
+  }
+  if (sha256Text(canonicalJson(material)) !== closureDigest) {
+    fail("Messaging closure digest does not match its material.");
+  }
+  const inputs = material.inputs.map((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) fail("Messaging closure input is invalid.");
+    return {
+      path: safeRelativePath(entry.path, "Messaging closure input path"),
+      blob: fullSha(entry.blob, "Messaging closure input blob"),
+    };
+  });
+  const sortedPaths = [...inputs.map((entry) => entry.path)].sort((left, right) => left.localeCompare(right));
+  if (new Set(sortedPaths).size !== sortedPaths.length || canonicalJson(inputs.map((entry) => entry.path)) !== canonicalJson(sortedPaths)) {
+    fail("Messaging closure inputs must be unique and sorted.");
+  }
+  const declaredPaths = Array.isArray(closure.dependencyClosurePaths)
+    ? closure.dependencyClosurePaths.map((entry) => safeRelativePath(entry, "Messaging closure declared path")).sort((left, right) => left.localeCompare(right))
+    : sortedPaths;
+  if (canonicalJson(declaredPaths) !== canonicalJson(sortedPaths)) {
+    fail("Messaging closure declared paths are not bound to its material.");
+  }
+  if (!Array.isArray(material.dependencyClosurePatterns) || !material.dependencyClosurePatterns.includes("messaging/**")) {
+    fail("Messaging closure does not declare the messaging source boundary.");
+  }
+  if (sourceEntries) {
+    for (const entry of inputs) {
+      if (sourceEntries.get(entry.path) !== entry.blob) {
+        fail("Messaging closure input does not match the immutable source tree.");
+      }
+    }
+  }
+  return {
+    sourceCommit: expectedSourceSha,
+    sourceTree: expectedSourceTree,
+    digest: closureDigest,
+    paths: sortedPaths,
+  };
+}
+
+export function validateMessagingReleaseCandidate({ candidateDirectory, releaseSha }) {
+  const sourceCommit = fullSha(releaseSha, "Release SHA");
+  const root = nativeDirectory(candidateDirectory, "Release candidate");
+  if (path.basename(root) !== "release-source-" + sourceCommit) {
+    fail("Release candidate must be named release-source-" + sourceCommit + ".");
+  }
+
+  const archiveFile = boundedArchiveFile(regularFile(root, "source.tar.gz", "Release source archive"));
+  const checksumFile = boundedMetadataFile(regularFile(root, "source.sha256", "Release source checksum"), "Release source checksum");
+  const releaseFile = boundedMetadataFile(regularFile(root, "release.json", "Release source identity"), "Release source identity");
+  const manifestFile = boundedMetadataFile(regularFile(root, "release-manifest.json", "Release source manifest"), "Release source manifest");
+  const closureFile = boundedMetadataFile(regularFile(root, "messaging-whatsapp-closure.json", "Messaging closure"), "Messaging closure");
+  const archiveDigest = sha256BoundedRegularFile(archiveFile, "Release source archive", MAX_RELEASE_ARCHIVE_BYTES);
+  if (lower(readBoundedRegularFile(checksumFile, "Release source checksum", MAX_RELEASE_METADATA_BYTES).toString("utf8")) !== archiveDigest) {
+    fail("Release source checksum does not match the native archive.");
+  }
+
+  const release = jsonFile(releaseFile, "Release source identity");
+  if (release.schemaVersion !== 1
+    || fullSha(release.sourceSha, "Release source SHA") !== sourceCommit
+    || !FULL_SHA.test(lower(release.sourceTree))
+    || digest(release.sourceArchiveSha256, "Release source archive checksum") !== archiveDigest) {
+    fail("Release source identity does not match the requested candidate.");
+  }
+  const sourceTree = lower(release.sourceTree);
+  const sourceEntries = validateArchiveGitProvenance({ archiveFile, sourceCommit, sourceTree });
+
+  const manifest = jsonFile(manifestFile, "Release source manifest");
+  if (manifest.schemaVersion !== 1
+    || fullSha(manifest.sourceCommit, "Release manifest source SHA") !== sourceCommit
+    || fullSha(manifest.sourceTree, "Release manifest source tree") !== sourceTree) {
+    fail("Release source manifest identity differs from the candidate.");
+  }
+  matchingArtifact(manifest.artifacts, "source-archive", archiveDigest, "Release source manifest");
+  if (!manifest.artifactManifest || typeof manifest.artifactManifest !== "object"
+    || fullSha(manifest.artifactManifest.sourceCommit, "Release artifact manifest source SHA") !== sourceCommit
+    || fullSha(manifest.artifactManifest.sourceTree, "Release artifact manifest source tree") !== sourceTree) {
+    fail("Release artifact manifest identity differs from the candidate.");
+  }
+  matchingArtifact(manifest.artifactManifest.artifacts, "source-archive", archiveDigest, "Release artifact manifest");
+  if (!manifest.releaseIdentity || typeof manifest.releaseIdentity !== "object"
+    || fullSha(manifest.releaseIdentity.sourceCommit, "Release manifest identity source SHA") !== sourceCommit
+    || fullSha(manifest.releaseIdentity.sourceTree, "Release manifest identity source tree") !== sourceTree) {
+    fail("Release manifest release identity differs from the candidate.");
+  }
+  matchingArtifact(manifest.releaseIdentity.artifacts, "source-archive", archiveDigest, "Release manifest release identity");
+
+  const closure = validateMessagingClosure(closureFile, { sourceSha: sourceCommit, sourceTree, sourceEntries });
+  return {
+    sourceCommit,
+    sourceTree,
+    sourceArchiveSha256: archiveDigest,
+    releaseManifestSha256: sha256BoundedRegularFile(manifestFile, "Release source manifest", MAX_RELEASE_METADATA_BYTES),
+    closureDigest: closure.digest,
+    closureFile,
+    archiveFile,
+  };
+}
+
+function snapshotArtifactLimit(relative) {
+  return relative === "source.tar.gz" ? MAX_RELEASE_ARCHIVE_BYTES : MAX_RELEASE_METADATA_BYTES;
+}
+
+function copySnapshotRegularFile(root, snapshot, relative) {
+  const label = "Release candidate " + relative;
+  const candidate = path.resolve(root, relative);
+  if (!candidate.startsWith(root + path.sep)) fail(label + " escapes its release root.");
+  const noFollow = fs.constants.O_NOFOLLOW;
+  const nonBlock = fs.constants.O_NONBLOCK;
+  if (!Number.isInteger(noFollow) || !Number.isInteger(nonBlock)) {
+    fail("Release candidate snapshot requires native no-follow and non-blocking file support.");
+  }
+  let sourceDescriptor = null;
+  let snapshotDescriptor = null;
+  try {
+    sourceDescriptor = fs.openSync(candidate, fs.constants.O_RDONLY | noFollow | nonBlock);
+  } catch {
+    fail(label + " cannot be opened without following links.");
+  }
+  try {
+    const before = fs.fstatSync(sourceDescriptor);
+    if (!before.isFile()) fail(label + " must be a regular file.");
+    if (before.size > snapshotArtifactLimit(relative)) {
+      fail(label + " exceeds the safe snapshot size limit.");
+    }
+    const destination = path.join(snapshot, relative);
+    snapshotDescriptor = fs.openSync(
+      destination,
+      fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL,
+      0o600,
+    );
+    const buffer = Buffer.allocUnsafe(Math.min(64 * 1024, Math.max(before.size, 1)));
+    let copied = 0;
+    while (copied < before.size) {
+      const bytesRead = fs.readSync(sourceDescriptor, buffer, 0, Math.min(buffer.length, before.size - copied), null);
+      if (bytesRead <= 0) fail(label + " changed while its private snapshot was captured.");
+      let written = 0;
+      while (written < bytesRead) {
+        const bytesWritten = fs.writeSync(snapshotDescriptor, buffer, written, bytesRead - written, null);
+        if (bytesWritten <= 0) fail(label + " cannot be copied into the private snapshot.");
+        written += bytesWritten;
+      }
+      copied += bytesRead;
+    }
+    const after = fs.fstatSync(sourceDescriptor);
+    if (after.dev !== before.dev || after.ino !== before.ino || after.size !== before.size) {
+      fail(label + " changed while its private snapshot was captured.");
+    }
+    fs.fsyncSync(snapshotDescriptor);
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith(label)) throw error;
+    fail(label + " cannot be copied into the private snapshot.");
+  } finally {
+    if (snapshotDescriptor !== null) fs.closeSync(snapshotDescriptor);
+    if (sourceDescriptor !== null) fs.closeSync(sourceDescriptor);
+  }
+}
+
+function privateSnapshotDirectory(snapshotDirectory, sourceCommit) {
+  const requested = path.resolve(String(snapshotDirectory || ""));
+  const expectedName = "release-source-" + sourceCommit;
+  if (path.basename(requested) !== expectedName) {
+    fail("Release candidate snapshot must be named " + expectedName + ".");
+  }
+  const parent = nativeDirectory(path.dirname(requested), "Release candidate snapshot parent");
+  const snapshot = path.join(parent, expectedName);
+  if (!isNativeLinuxPath(snapshot)) fail("Release candidate snapshot must be on native Linux storage.");
+  try {
+    fs.mkdirSync(snapshot, { mode: 0o700 });
+    fs.chmodSync(snapshot, 0o700);
+  } catch {
+    fail("Release candidate snapshot directory cannot be created privately.");
+  }
+  return snapshot;
+}
+
+export function snapshotMessagingReleaseCandidate({ candidateDirectory, releaseSha, snapshotDirectory } = {}) {
+  const sourceCommit = fullSha(releaseSha, "Release SHA");
+  const root = nativeDirectory(candidateDirectory, "Release candidate");
+  if (path.basename(root) !== "release-source-" + sourceCommit) {
+    fail("Release candidate must be named release-source-" + sourceCommit + ".");
+  }
+  const snapshot = privateSnapshotDirectory(snapshotDirectory, sourceCommit);
+  try {
+    for (const artifact of SNAPSHOT_ARTIFACTS) {
+      copySnapshotRegularFile(root, snapshot, artifact);
+    }
+    return validateMessagingReleaseCandidate({ candidateDirectory: snapshot, releaseSha: sourceCommit });
+  } catch (error) {
+    fs.rmSync(snapshot, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+export function materializeMessagingReleaseCandidate({ candidateDirectory, releaseSha, stageDirectory } = {}) {
+  const candidate = validateMessagingReleaseCandidate({ candidateDirectory, releaseSha });
+  const stage = nativeDirectory(stageDirectory, "Release candidate materialization stage");
+  if (fs.readdirSync(stage).length !== 0) fail("Release candidate materialization stage must be empty.");
+  const sourceRoot = materializeGitArchive(candidate.archiveFile, stage, candidate.sourceCommit);
+  const sourceEntries = reconstructedTreeEntries(sourceRoot, candidate.sourceTree);
+  const closure = validateMessagingClosure(candidate.closureFile, {
+    sourceSha: candidate.sourceCommit,
+    sourceTree: candidate.sourceTree,
+    sourceEntries,
+  });
+  if (closure.digest !== candidate.closureDigest) {
+    fail("Release candidate materialization closure differs from its private snapshot.");
+  }
+  return { ...candidate, sourceRoot };
+}
+
+function releaseIdentityObject(identityFile) {
+  const identity = jsonFile(identityFile, "Installed messaging release identity");
+  if (identity.schemaVersion !== 2 || lower(identity.module) !== MODULE) {
+    fail("Installed messaging release identity schema or module is invalid.");
+  }
+  const sourceCommit = fullSha(identity.sourceCommit, "Installed messaging source commit");
+  const sourceTree = fullSha(identity.sourceTree, "Installed messaging source tree");
+  const sourceArchiveSha256 = digest(identity.sourceArchiveSha256, "Installed messaging source archive checksum");
+  const releaseManifestSha256 = digest(identity.releaseManifestSha256, "Installed messaging release manifest checksum");
+  const dependencyClosureDigest = digest(identity.dependencyClosureDigest, "Installed messaging closure digest");
+  const identityDigest = digest(identity.identityDigest, "Installed messaging identity digest");
+  const signed = { ...identity };
+  delete signed.identityDigest;
+  if (sha256Text(canonicalJson(signed)) !== identityDigest) {
+    fail("Installed messaging identity digest does not match its content.");
+  }
+  return {
+    identity,
+    sourceCommit,
+    sourceTree,
+    sourceArchiveSha256,
+    releaseManifestSha256,
+    dependencyClosureDigest,
+    identityDigest,
+  };
+}
+
+export function validateInstalledMessagingRelease({
+  releaseRoot,
+  expectedReleaseSha = null,
+  expectedSourceTree = null,
+  expectedClosureDigest = null,
+  expectedPredecessorSha = null,
+} = {}) {
+  const root = nativeDirectory(releaseRoot, "Installed messaging release");
+  const identityFile = regularFile(root, ".skincos-release-identity-messaging-whatsapp.json", "Installed messaging release identity");
+  const closureFile = regularFile(root, ".skincos-global-coordination-messaging-whatsapp.json", "Installed messaging closure");
+  const artifactFile = regularFile(root, "dist/main.js", "Installed messaging artifact");
+  const parsed = releaseIdentityObject(identityFile);
+  if (expectedReleaseSha && parsed.sourceCommit !== fullSha(expectedReleaseSha, "Expected installed release SHA")) {
+    fail("Installed messaging release SHA differs from the required release.");
+  }
+  if (expectedSourceTree && parsed.sourceTree !== fullSha(expectedSourceTree, "Expected installed source tree")) {
+    fail("Installed messaging source tree differs from the required source tree.");
+  }
+  if (expectedClosureDigest && parsed.dependencyClosureDigest !== digest(expectedClosureDigest, "Expected installed closure digest")) {
+    fail("Installed messaging closure digest differs from the required closure.");
+  }
+  const artifact = matchingArtifact(parsed.identity.artifacts, "whatsapp-dist-main", sha256File(artifactFile), "Installed messaging release");
+  if (text(artifact.id) !== "whatsapp-dist:" + parsed.sourceCommit) {
+    fail("Installed messaging artifact ID is not bound to its immutable source.");
+  }
+  const sourceArchive = matchingArtifact(parsed.identity.artifacts, "release-source-archive", parsed.sourceArchiveSha256, "Installed messaging release");
+  if (text(sourceArchive.id) !== "release-source:" + parsed.sourceCommit) {
+    fail("Installed messaging source archive ID is not bound to its immutable source.");
+  }
+  const closure = validateMessagingClosure(closureFile, {
+    sourceSha: parsed.sourceCommit,
+    sourceTree: parsed.sourceTree,
+  });
+  if (closure.digest !== parsed.dependencyClosureDigest) {
+    fail("Installed messaging closure differs from its release identity.");
+  }
+
+  const predecessor = parsed.identity.predecessor;
+  if (expectedPredecessorSha) {
+    const expected = fullSha(expectedPredecessorSha, "Expected predecessor SHA");
+    if (!predecessor || typeof predecessor !== "object" || Array.isArray(predecessor)
+      || fullSha(predecessor.sourceCommit, "Installed messaging predecessor source SHA") !== expected
+      || expected === parsed.sourceCommit
+      || !FULL_SHA.test(lower(predecessor.sourceTree))
+      || !SHA256.test(lower(predecessor.identityDigest))
+      || !SHA256.test(lower(predecessor.artifactDigest))) {
+      fail("Installed messaging release does not attest the exact rollback predecessor.");
+    }
+  }
+  return {
+    sourceCommit: parsed.sourceCommit,
+    sourceTree: parsed.sourceTree,
+    dependencyClosureDigest: parsed.dependencyClosureDigest,
+    sourceArchiveSha256: parsed.sourceArchiveSha256,
+    releaseManifestSha256: parsed.releaseManifestSha256,
+    identityDigest: parsed.identityDigest,
+    artifactDigest: artifact.digest,
+    predecessor: predecessor || null,
+  };
+}
+
+export function buildMessagingReleaseIdentity({ candidateDirectory, releaseSha, artifactFile, predecessorReleaseRoot }) {
+  const candidate = validateMessagingReleaseCandidate({ candidateDirectory, releaseSha });
+  const artifact = externalRegularFile(artifactFile, "Messaging build artifact");
+  const predecessor = validateInstalledMessagingRelease({ releaseRoot: predecessorReleaseRoot });
+  if (predecessor.sourceCommit === candidate.sourceCommit) {
+    fail("Messaging release predecessor must differ from the candidate source.");
+  }
+  const identity = {
+    schemaVersion: 2,
+    module: MODULE,
+    sourceCommit: candidate.sourceCommit,
+    sourceTree: candidate.sourceTree,
+    sourceArchiveSha256: candidate.sourceArchiveSha256,
+    releaseManifestSha256: candidate.releaseManifestSha256,
+    dependencyClosureDigest: candidate.closureDigest,
+    artifacts: [
+      { name: "release-source-archive", id: "release-source:" + candidate.sourceCommit, digest: candidate.sourceArchiveSha256 },
+      { name: "whatsapp-dist-main", id: "whatsapp-dist:" + candidate.sourceCommit, digest: sha256File(artifact) },
+    ],
+    predecessor: {
+      sourceCommit: predecessor.sourceCommit,
+      sourceTree: predecessor.sourceTree,
+      identityDigest: predecessor.identityDigest,
+      artifactDigest: predecessor.artifactDigest,
+    },
+  };
+  return { ...identity, identityDigest: sha256Text(canonicalJson(identity)) };
+}
+
+export function validateMessagingRollbackPair({
+  currentReleaseRoot,
+  predecessorReleaseRoot,
+  predecessorCandidateDirectory,
+  predecessorReleaseSha,
+} = {}) {
+  const candidate = validateMessagingReleaseCandidate({
+    candidateDirectory: predecessorCandidateDirectory,
+    releaseSha: predecessorReleaseSha,
+  });
+  const predecessor = validateInstalledMessagingRelease({
+    releaseRoot: predecessorReleaseRoot,
+    expectedReleaseSha: candidate.sourceCommit,
+    expectedSourceTree: candidate.sourceTree,
+    expectedClosureDigest: candidate.closureDigest,
+  });
+  const current = validateInstalledMessagingRelease({
+    releaseRoot: currentReleaseRoot,
+    expectedPredecessorSha: predecessor.sourceCommit,
+  });
+  const recorded = current.predecessor;
+  if (!recorded
+    || lower(recorded.sourceTree) !== predecessor.sourceTree
+    || lower(recorded.identityDigest) !== predecessor.identityDigest
+    || lower(recorded.artifactDigest) !== predecessor.artifactDigest) {
+    fail("Messaging rollback predecessor identity differs from the installed attested release.");
+  }
+  return { current, predecessor, candidate };
+}
+
+function argument(args, name, fallback = null) {
+  const index = args.indexOf(name);
+  return index === -1 ? fallback : args[index + 1];
+}
+
+function requiredArgument(args, name) {
+  const value = argument(args, name);
+  if (!value) fail(name + " is required.");
+  return value;
+}
+
+function output(value) {
+  process.stdout.write(JSON.stringify(value, null, 2) + "\n");
+}
+
+function candidateSummary(candidate) {
+  return {
+    module: MODULE,
+    sourceCommit: candidate.sourceCommit,
+    sourceTree: candidate.sourceTree,
+    sourceArchiveSha256: candidate.sourceArchiveSha256,
+    releaseManifestSha256: candidate.releaseManifestSha256,
+    dependencyClosureDigest: candidate.closureDigest,
+  };
+}
+
+function installedSummary(release) {
+  return {
+    module: MODULE,
+    sourceCommit: release.sourceCommit,
+    sourceTree: release.sourceTree,
+    dependencyClosureDigest: release.dependencyClosureDigest,
+    sourceArchiveSha256: release.sourceArchiveSha256,
+    releaseManifestSha256: release.releaseManifestSha256,
+    identityDigest: release.identityDigest,
+    artifactDigest: release.artifactDigest,
+  };
+}
+
+async function main(args) {
+  const command = args[0];
+  if (command === "verify-candidate") {
+    output(candidateSummary(validateMessagingReleaseCandidate({
+      candidateDirectory: requiredArgument(args, "--candidate"),
+      releaseSha: requiredArgument(args, "--release-sha"),
+    })));
+    return;
+  }
+  if (command === "snapshot-candidate") {
+    output(candidateSummary(snapshotMessagingReleaseCandidate({
+      candidateDirectory: requiredArgument(args, "--candidate"),
+      releaseSha: requiredArgument(args, "--release-sha"),
+      snapshotDirectory: requiredArgument(args, "--snapshot"),
+    })));
+    return;
+  }
+  if (command === "materialize-candidate") {
+    const result = materializeMessagingReleaseCandidate({
+      candidateDirectory: requiredArgument(args, "--candidate"),
+      releaseSha: requiredArgument(args, "--release-sha"),
+      stageDirectory: requiredArgument(args, "--stage"),
+    });
+    output({ ...candidateSummary(result), sourceRoot: result.sourceRoot });
+    return;
+  }
+  if (command === "verify-installed") {
+    output(installedSummary(validateInstalledMessagingRelease({
+      releaseRoot: requiredArgument(args, "--release-root"),
+      expectedReleaseSha: argument(args, "--expected-release-sha"),
+      expectedSourceTree: argument(args, "--expected-source-tree"),
+      expectedClosureDigest: argument(args, "--expected-closure-digest"),
+      expectedPredecessorSha: argument(args, "--expected-predecessor-sha"),
+    })));
+    return;
+  }
+  if (command === "verify-installed-candidate") {
+    const candidate = validateMessagingReleaseCandidate({
+      candidateDirectory: requiredArgument(args, "--candidate"),
+      releaseSha: requiredArgument(args, "--release-sha"),
+    });
+    output(installedSummary(validateInstalledMessagingRelease({
+      releaseRoot: requiredArgument(args, "--release-root"),
+      expectedReleaseSha: candidate.sourceCommit,
+      expectedSourceTree: candidate.sourceTree,
+      expectedClosureDigest: candidate.closureDigest,
+    })));
+    return;
+  }
+  if (command === "verify-rollback-pair") {
+    const result = validateMessagingRollbackPair({
+      currentReleaseRoot: requiredArgument(args, "--current-release-root"),
+      predecessorReleaseRoot: requiredArgument(args, "--predecessor-release-root"),
+      predecessorCandidateDirectory: requiredArgument(args, "--predecessor-candidate"),
+      predecessorReleaseSha: requiredArgument(args, "--predecessor-release-sha"),
+    });
+    output({
+      module: MODULE,
+      currentSourceCommit: result.current.sourceCommit,
+      predecessorSourceCommit: result.predecessor.sourceCommit,
+      predecessorIdentityDigest: result.predecessor.identityDigest,
+      predecessorArtifactDigest: result.predecessor.artifactDigest,
+    });
+    return;
+  }
+  if (command === "build-identity") {
+    output(buildMessagingReleaseIdentity({
+      candidateDirectory: requiredArgument(args, "--candidate"),
+      releaseSha: requiredArgument(args, "--release-sha"),
+      artifactFile: requiredArgument(args, "--artifact"),
+      predecessorReleaseRoot: requiredArgument(args, "--predecessor-release-root"),
+    }));
+    return;
+  }
+  fail("Usage: messaging-whatsapp-release-contract.mjs verify-candidate|snapshot-candidate|materialize-candidate|verify-installed|verify-installed-candidate|verify-rollback-pair|build-identity ...");
+}
+
+const invokedAsScript = process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (invokedAsScript) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write((error instanceof Error ? error.message : String(error)) + "\n");
+    process.exitCode = 1;
+  });
+}

--- a/scripts/runtime/messaging-whatsapp-release-contract.test.mjs
+++ b/scripts/runtime/messaging-whatsapp-release-contract.test.mjs
@@ -1,0 +1,787 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { gunzipSync, gzipSync } from "node:zlib";
+import {
+  canonicalJson,
+  buildMessagingReleaseIdentity,
+  isNativeLinuxPath,
+  isolatedGitEnvironment,
+  materializeMessagingReleaseCandidate,
+  sha256File,
+  sha256Text,
+  snapshotMessagingReleaseCandidate,
+  validateInstalledMessagingRelease,
+  validateMessagingRollbackPair,
+  validateMessagingReleaseCandidate,
+} from "./messaging-whatsapp-release-contract.mjs";
+
+const sha = (seed) => crypto.createHash("sha1").update(seed).digest("hex");
+const contractCli = fileURLToPath(new URL("./messaging-whatsapp-release-contract.mjs", import.meta.url));
+
+function writeJson(file, value) {
+  fs.writeFileSync(file, JSON.stringify(value, null, 2) + "\n");
+}
+
+function gitOutput(args) {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    env: isolatedGitEnvironment(),
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function gitBuffer(args) {
+  return execFileSync("git", args, {
+    env: isolatedGitEnvironment(),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function closure({ sourceCommit, sourceTree, inputBlob = sha("engine-input") }) {
+  const material = {
+    schemaVersion: 1,
+    module: "messaging-whatsapp",
+    inputs: [{ path: "messaging/channels/whatsapp/engine/src/main.ts", blob: inputBlob }],
+    dependencyClosurePatterns: ["messaging/**"],
+    dependencyClosureSharedInputPaths: [],
+    dependencyClosureSharedInputs: false,
+  };
+  return {
+    schemaVersion: 1,
+    module: "messaging-whatsapp",
+    sourceCommit,
+    sourceTree,
+    inputs: material.inputs,
+    dependencyClosurePaths: material.inputs.map((entry) => entry.path),
+    dependencyClosurePatterns: material.dependencyClosurePatterns,
+    dependencyClosureSharedInputPaths: material.dependencyClosureSharedInputPaths,
+    dependencyClosureSharedInputs: false,
+    digest: sha256Text(canonicalJson(material)),
+    material,
+  };
+}
+
+function createCandidate(root, sourceCommit, sourceTree, repository) {
+  assert.ok(repository, "A real Git source repository is required for a candidate fixture.");
+  const candidate = path.join(root, "release-source-" + sourceCommit);
+  fs.mkdirSync(candidate, { recursive: true });
+  const archive = path.join(candidate, "source.tar.gz");
+  fs.writeFileSync(archive, gitBuffer([
+    "-C",
+    repository,
+    "archive",
+    "--format=tar.gz",
+    "--prefix=skincos-" + sourceCommit + "/",
+    sourceCommit,
+  ]));
+  const archiveDigest = sha256File(archive);
+  fs.writeFileSync(path.join(candidate, "source.sha256"), archiveDigest + "\n");
+  writeJson(path.join(candidate, "release.json"), {
+    schemaVersion: 1,
+    sourceSha: sourceCommit,
+    sourceTree,
+    sourceArchiveSha256: archiveDigest,
+  });
+  const artifacts = [{ name: "source-archive", id: "source-archive", digest: archiveDigest }];
+  writeJson(path.join(candidate, "release-manifest.json"), {
+    schemaVersion: 1,
+    sourceCommit,
+    sourceTree,
+    artifacts,
+    artifactManifest: { schemaVersion: 1, sourceCommit, sourceTree, artifacts },
+    releaseIdentity: { schemaVersion: 1, sourceCommit, sourceTree, artifacts },
+  });
+  const inputBlob = gitOutput([
+    "-C",
+    repository,
+    "rev-parse",
+    sourceCommit + ":messaging/channels/whatsapp/engine/src/main.ts",
+  ]);
+  writeJson(path.join(candidate, "messaging-whatsapp-closure.json"), closure({ sourceCommit, sourceTree, inputBlob }));
+  return { candidate, sourceCommit, sourceTree, archiveDigest };
+}
+
+function createInstalledRelease(root, {
+  sourceCommit,
+  sourceTree,
+  sourceArchiveSha256,
+  releaseManifestSha256,
+  closureValue,
+  predecessor = null,
+}) {
+  fs.mkdirSync(path.join(root, "dist"), { recursive: true });
+  fs.writeFileSync(path.join(root, "dist", "main.js"), "console.log('immutable');\n");
+  writeJson(path.join(root, ".skincos-global-coordination-messaging-whatsapp.json"), closureValue);
+  const artifactDigest = sha256File(path.join(root, "dist", "main.js"));
+  const identity = {
+    schemaVersion: 2,
+    module: "messaging-whatsapp",
+    sourceCommit,
+    sourceTree,
+    sourceArchiveSha256,
+    releaseManifestSha256,
+    dependencyClosureDigest: closureValue.digest,
+    artifacts: [
+      { name: "release-source-archive", id: "release-source:" + sourceCommit, digest: sourceArchiveSha256 },
+      { name: "whatsapp-dist-main", id: "whatsapp-dist:" + sourceCommit, digest: artifactDigest },
+    ],
+    ...(predecessor ? { predecessor } : {}),
+  };
+  identity.identityDigest = sha256Text(canonicalJson(identity));
+  writeJson(path.join(root, ".skincos-release-identity-messaging-whatsapp.json"), identity);
+  return { ...identity, artifactDigest };
+}
+
+function fixture({ symlink = false, longPath = false, attributesFilter = false } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "skincos-messaging-contract-"));
+  const repository = path.join(root, "source");
+  fs.mkdirSync(path.join(repository, "messaging", "channels", "whatsapp", "engine", "src"), { recursive: true });
+  gitOutput(["init", "--quiet", repository]);
+  const sourceFile = path.join(repository, "messaging", "channels", "whatsapp", "engine", "src", "main.ts");
+  fs.writeFileSync(sourceFile, "export const release = 'predecessor';\n");
+  if (symlink) {
+    fs.symlinkSync("src/main.ts", path.join(repository, "messaging", "channels", "whatsapp", "engine", "linked-main.ts"));
+  }
+  if (longPath) {
+    const longDirectory = path.join(repository, "messaging", "channels", "whatsapp", "engine", "fixtures", "nested-".repeat(18));
+    fs.mkdirSync(longDirectory, { recursive: true });
+    fs.writeFileSync(path.join(longDirectory, "long-path.ts"), "export const longPath = true;\n");
+  }
+  if (attributesFilter) {
+    fs.writeFileSync(path.join(repository, ".gitattributes"), "*.ts filter=untrusted-clean\n");
+  }
+  gitOutput(["-C", repository, "add", "--all"]);
+  gitOutput([
+    "-C",
+    repository,
+    "-c",
+    "user.email=messaging-contract@example.invalid",
+    "-c",
+    "user.name=Messaging Contract",
+    "-c",
+    "commit.gpgSign=false",
+    "commit",
+    "--quiet",
+    "-m",
+    "predecessor",
+  ]);
+  const predecessor = {
+    sourceCommit: gitOutput(["-C", repository, "rev-parse", "HEAD"]),
+    sourceTree: gitOutput(["-C", repository, "rev-parse", "HEAD^{tree}"]),
+  };
+  fs.writeFileSync(sourceFile, "export const release = 'current';\n");
+  gitOutput(["-C", repository, "add", "--all"]);
+  gitOutput([
+    "-C",
+    repository,
+    "-c",
+    "user.email=messaging-contract@example.invalid",
+    "-c",
+    "user.name=Messaging Contract",
+    "-c",
+    "commit.gpgSign=false",
+    "commit",
+    "--quiet",
+    "-m",
+    "current",
+  ]);
+  const sourceCommit = gitOutput(["-C", repository, "rev-parse", "HEAD"]);
+  const sourceTree = gitOutput(["-C", repository, "rev-parse", "HEAD^{tree}"]);
+  const candidate = createCandidate(root, sourceCommit, sourceTree, repository);
+  return { root, repository, predecessor, ...candidate };
+}
+
+function tarText(header, offset, length, value) {
+  const bytes = Buffer.from(value, "utf8");
+  assert.ok(bytes.length <= length, "Synthetic TAR field must fit its header.");
+  bytes.copy(header, offset);
+}
+
+function tarOctal(header, offset, length, value) {
+  tarText(header, offset, length, value.toString(8).padStart(length - 1, "0") + "\0");
+}
+
+function tarHeader({ name, type = "0", data = Buffer.alloc(0), linkname = "", mode = 0o644 }) {
+  const header = Buffer.alloc(512);
+  tarText(header, 0, 100, name);
+  tarOctal(header, 100, 8, mode);
+  tarOctal(header, 108, 8, 0);
+  tarOctal(header, 116, 8, 0);
+  tarOctal(header, 124, 12, data.length);
+  tarOctal(header, 136, 12, 0);
+  header.fill(0x20, 148, 156);
+  header[156] = type.charCodeAt(0);
+  tarText(header, 157, 100, linkname);
+  tarText(header, 257, 6, "ustar\0");
+  tarText(header, 263, 2, "00");
+  const checksum = header.reduce((total, byte) => total + byte, 0);
+  tarText(header, 148, 8, checksum.toString(8).padStart(6, "0") + "\0 ");
+  return header;
+}
+
+function paddedTarPayload(data) {
+  const padding = (512 - (data.length % 512)) % 512;
+  return padding === 0 ? data : Buffer.concat([data, Buffer.alloc(padding)]);
+}
+
+function paxRecord(key, value) {
+  const suffix = " " + key + "=" + value + "\n";
+  let size = Buffer.byteLength(suffix);
+  while (true) {
+    const record = String(size) + suffix;
+    const next = Buffer.byteLength(record);
+    if (next === size) return Buffer.from(record, "utf8");
+    size = next;
+  }
+}
+
+function appendTarEntries(archive, entries) {
+  const original = gunzipSync(fs.readFileSync(archive));
+  let end = original.length;
+  while (end >= 512 && original.subarray(end - 512, end).every((byte) => byte === 0)) end -= 512;
+  const additions = [];
+  for (const entry of entries) {
+    const data = Buffer.isBuffer(entry.data) ? entry.data : Buffer.from(entry.data || "", "utf8");
+    additions.push(tarHeader({ ...entry, data }), paddedTarPayload(data));
+  }
+  fs.writeFileSync(archive, gzipSync(Buffer.concat([
+    original.subarray(0, end),
+    ...additions,
+    Buffer.alloc(1024),
+  ])));
+}
+
+function refreshCandidateArchiveMetadata(candidate) {
+  const archive = path.join(candidate, "source.tar.gz");
+  const archiveDigest = sha256File(archive);
+  fs.writeFileSync(path.join(candidate, "source.sha256"), archiveDigest + "\n");
+  const releaseFile = path.join(candidate, "release.json");
+  const release = JSON.parse(fs.readFileSync(releaseFile, "utf8"));
+  release.sourceArchiveSha256 = archiveDigest;
+  writeJson(releaseFile, release);
+  const manifestFile = path.join(candidate, "release-manifest.json");
+  const manifest = JSON.parse(fs.readFileSync(manifestFile, "utf8"));
+  for (const artifacts of [manifest.artifacts, manifest.artifactManifest.artifacts, manifest.releaseIdentity.artifacts]) {
+    artifacts.find((entry) => entry.name === "source-archive").digest = archiveDigest;
+  }
+  writeJson(manifestFile, manifest);
+  return archiveDigest;
+}
+
+test("candidate fixture Git helpers never inherit shared worktree routing", () => {
+  const environment = isolatedGitEnvironment({
+    PATH: process.env.PATH,
+    GIT_DIR: "/shared/.git",
+    GIT_WORK_TREE: "/shared/worktree",
+    GIT_COMMON_DIR: "/shared/common",
+    GIT_CONFIG_COUNT: "1",
+    git_dir: "/shared/lowercase.git",
+  });
+  assert.equal(environment.GIT_DIR, undefined);
+  assert.equal(environment.GIT_WORK_TREE, undefined);
+  assert.equal(environment.GIT_COMMON_DIR, undefined);
+  assert.equal(environment.git_dir, undefined);
+  assert.equal(Object.keys(environment).some((name) => name.toUpperCase().startsWith("GIT_")), false);
+});
+
+test("accepts a native release-source candidate bound by SHA, tree, archive and messaging closure", () => {
+  const current = fixture();
+  try {
+    const result = validateMessagingReleaseCandidate({
+      candidateDirectory: current.candidate,
+      releaseSha: current.sourceCommit,
+    });
+    assert.equal(result.sourceCommit, current.sourceCommit);
+    assert.equal(result.sourceTree, current.sourceTree);
+    assert.equal(result.sourceArchiveSha256, current.archiveDigest);
+  } finally {
+    fs.rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("accepts Git archive PAX paths and opaque symlink records without following them", () => {
+  const current = fixture({ symlink: true, longPath: true });
+  try {
+    const result = validateMessagingReleaseCandidate({
+      candidateDirectory: current.candidate,
+      releaseSha: current.sourceCommit,
+    });
+    assert.equal(result.sourceTree, current.sourceTree);
+  } finally {
+    fs.rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("captures a private candidate snapshot before later source-directory changes", () => {
+  const current = fixture();
+  try {
+    const snapshotParent = path.join(current.root, "private-snapshot-parent");
+    fs.mkdirSync(snapshotParent, { mode: 0o700 });
+    const snapshotDirectory = path.join(snapshotParent, "release-source-" + current.sourceCommit);
+    const originalArtifacts = new Map([
+      "source.tar.gz",
+      "source.sha256",
+      "release.json",
+      "release-manifest.json",
+      "messaging-whatsapp-closure.json",
+    ].map((artifact) => [artifact, fs.readFileSync(path.join(current.candidate, artifact))]));
+    const snapshot = snapshotMessagingReleaseCandidate({
+      candidateDirectory: current.candidate,
+      releaseSha: current.sourceCommit,
+      snapshotDirectory,
+    });
+    assert.equal(snapshot.sourceArchiveSha256, current.archiveDigest);
+    for (const [artifact, contents] of originalArtifacts) {
+      const copied = path.join(snapshotDirectory, artifact);
+      assert.deepEqual(fs.readFileSync(copied), contents);
+      assert.equal(fs.statSync(copied).mode & 0o077, 0);
+    }
+
+    fs.writeFileSync(path.join(current.candidate, "source.tar.gz"), "swapped-after-snapshot");
+    const stage = path.join(current.root, "private-materialization-stage");
+    fs.mkdirSync(stage, { mode: 0o700 });
+    const materialized = materializeMessagingReleaseCandidate({
+      candidateDirectory: snapshotDirectory,
+      releaseSha: current.sourceCommit,
+      stageDirectory: stage,
+    });
+    assert.equal(materialized.sourceRoot, path.join(stage, "skincos-" + current.sourceCommit));
+    assert.ok(fs.existsSync(path.join(materialized.sourceRoot, "messaging", "channels", "whatsapp", "engine", "src", "main.ts")));
+  } finally {
+    fs.rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("rejects an oversized gzip before snapshotting reads it into memory", () => {
+  const current = fixture();
+  try {
+    const snapshotParent = path.join(current.root, "oversized-snapshot-parent");
+    fs.mkdirSync(snapshotParent, { mode: 0o700 });
+    const snapshotDirectory = path.join(snapshotParent, "release-source-" + current.sourceCommit);
+    fs.truncateSync(path.join(current.candidate, "source.tar.gz"), (256 * 1024 * 1024) + 1);
+    assert.throws(
+      () => snapshotMessagingReleaseCandidate({
+        candidateDirectory: current.candidate,
+        releaseSha: current.sourceCommit,
+        snapshotDirectory,
+      }),
+      /safe snapshot size limit/,
+    );
+    assert.equal(fs.existsSync(snapshotDirectory), false);
+  } finally {
+    fs.rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("snapshot-candidate rejects a FIFO source archive without blocking", () => {
+  const current = fixture();
+  try {
+    const archive = path.join(current.candidate, "source.tar.gz");
+    fs.rmSync(archive);
+    execFileSync("mkfifo", [archive]);
+    const snapshotParent = path.join(current.root, "fifo-snapshot-parent");
+    fs.mkdirSync(snapshotParent, { mode: 0o700 });
+    const snapshotDirectory = path.join(snapshotParent, "release-source-" + current.sourceCommit);
+    const result = spawnSync(process.execPath, [
+      contractCli,
+      "snapshot-candidate",
+      "--candidate", current.candidate,
+      "--release-sha", current.sourceCommit,
+      "--snapshot", snapshotDirectory,
+    ], {
+      encoding: "utf8",
+      env: isolatedGitEnvironment(),
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(String(result.stderr), /must be a regular file/);
+    assert.equal(fs.existsSync(snapshotDirectory), false);
+  } finally {
+    fs.rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("rejects oversized metadata before JSON parsing in direct candidate validation", () => {
+  const current = fixture();
+  try {
+    fs.truncateSync(path.join(current.candidate, "release.json"), (8 * 1024 * 1024) + 1);
+    assert.throws(
+      () => validateMessagingReleaseCandidate({ candidateDirectory: current.candidate, releaseSha: current.sourceCommit }),
+      /Release source identity exceeds the safe size limit/,
+    );
+  } finally {
+    fs.rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("reconstructs raw Git trees without candidate attributes or HOME clean filters", () => {
+  const current = fixture({ attributesFilter: true });
+  const unsafeHome = path.join(current.root, "unsafe-home");
+  const marker = path.join(current.root, "candidate-filter-executed");
+  const bashMarker = path.join(current.root, "candidate-bash-env-executed");
+  const unsafeBashEnv = path.join(current.root, "unsafe-bash-env");
+  const priorHome = process.env.HOME;
+  const priorBashEnv = process.env.BASH_ENV;
+  try {
+    fs.mkdirSync(unsafeHome, { mode: 0o700 });
+    fs.writeFileSync(path.join(unsafeHome, ".gitconfig"), [
+      '[filter "untrusted-clean"]',
+      "\tclean = /bin/sh -c 'printf executed > " + marker + "'",
+      "",
+    ].join("\n"));
+    fs.writeFileSync(unsafeBashEnv, "printf executed > " + bashMarker + "\n");
+    process.env.HOME = unsafeHome;
+    process.env.BASH_ENV = unsafeBashEnv;
+    const result = validateMessagingReleaseCandidate({
+      candidateDirectory: current.candidate,
+      releaseSha: current.sourceCommit,
+    });
+    assert.equal(result.sourceTree, current.sourceTree);
+    assert.equal(fs.existsSync(marker), false);
+    assert.equal(fs.existsSync(bashMarker), false);
+  } finally {
+    if (priorHome === undefined) delete process.env.HOME;
+    else process.env.HOME = priorHome;
+    if (priorBashEnv === undefined) delete process.env.BASH_ENV;
+    else process.env.BASH_ENV = priorBashEnv;
+    fs.rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("rejects hostile TAR records before they can escape the native stage", () => {
+  const cases = [
+    {
+      name: "hard link",
+      entries: ({ sourceCommit }) => [{
+        name: "skincos-" + sourceCommit + "/hard-link",
+        type: "1",
+        linkname: "../../outside",
+      }],
+      expected: /hard links are not permitted/,
+    },
+    {
+      name: "special file",
+      entries: ({ sourceCommit }) => [{
+        name: "skincos-" + sourceCommit + "/named-pipe",
+        type: "6",
+      }],
+      expected: /unsupported TAR entry type/,
+    },
+    {
+      name: "path traversal",
+      entries: ({ sourceCommit }) => [{
+        name: "skincos-" + sourceCommit + "/../escaped",
+      }],
+      expected: /checkout metadata or an escaping path/,
+    },
+    {
+      name: "PAX effective path traversal",
+      entries: ({ sourceCommit }) => [
+        { name: "PaxHeaders.unsafe", type: "x", data: paxRecord("path", "skincos-" + sourceCommit + "/../escaped") },
+        { name: "safe", data: "unsafe" },
+      ],
+      expected: /checkout metadata or an escaping path/,
+    },
+    {
+      name: "PAX effective collision",
+      entries: ({ sourceCommit }) => [
+        { name: "PaxHeaders.collision", type: "x", data: paxRecord("path", "skincos-" + sourceCommit + "/messaging/channels/whatsapp/engine/src/main.ts") },
+        { name: "replacement", data: "unsafe" },
+      ],
+      expected: /duplicate entries/,
+    },
+    {
+      name: "child below a symlink pivot",
+      entries: ({ sourceCommit, outside }) => [
+        { name: "skincos-" + sourceCommit + "/pivot", type: "2", linkname: outside },
+        { name: "skincos-" + sourceCommit + "/pivot/escaped", data: "unsafe" },
+      ],
+      expected: /writes through a non-directory ancestor/,
+      assertNoEscape: true,
+    },
+  ];
+  for (const hostile of cases) {
+    const current = fixture();
+    try {
+      const outside = path.join(current.root, "must-not-exist-outside-stage");
+      appendTarEntries(path.join(current.candidate, "source.tar.gz"), hostile.entries({ ...current, outside }));
+      refreshCandidateArchiveMetadata(current.candidate);
+      assert.throws(
+        () => validateMessagingReleaseCandidate({ candidateDirectory: current.candidate, releaseSha: current.sourceCommit }),
+        hostile.expected,
+        hostile.name,
+      );
+      if (hostile.assertNoEscape) assert.equal(fs.existsSync(outside), false);
+    } finally {
+      fs.rmSync(current.root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("rejects an oversized compressed archive before reading it into memory", () => {
+  const current = fixture();
+  try {
+    fs.truncateSync(path.join(current.candidate, "source.tar.gz"), (256 * 1024 * 1024) + 1);
+    assert.throws(
+      () => validateMessagingReleaseCandidate({ candidateDirectory: current.candidate, releaseSha: current.sourceCommit }),
+      /compressed size exceeds the safe limit/,
+    );
+  } finally {
+    fs.rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("rejects a candidate whose source SHA differs from its release-source directory", () => {
+  const current = fixture();
+  try {
+    const releaseFile = path.join(current.candidate, "release.json");
+    const release = JSON.parse(fs.readFileSync(releaseFile, "utf8"));
+    release.sourceSha = sha("different-source");
+    writeJson(releaseFile, release);
+    assert.throws(
+      () => validateMessagingReleaseCandidate({ candidateDirectory: current.candidate, releaseSha: current.sourceCommit }),
+      /source identity does not match|source SHA/,
+    );
+  } finally {
+    fs.rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("rejects an archive whose refreshed digest metadata does not prove the claimed Git source", () => {
+  const current = fixture();
+  try {
+    const sourceFile = path.join(current.repository, "messaging", "channels", "whatsapp", "engine", "src", "main.ts");
+    fs.writeFileSync(sourceFile, "export const release = 'forged';\n");
+    gitOutput(["-C", current.repository, "add", "--all"]);
+    gitOutput([
+      "-C",
+      current.repository,
+      "-c",
+      "user.email=messaging-contract@example.invalid",
+      "-c",
+      "user.name=Messaging Contract",
+      "-c",
+      "commit.gpgSign=false",
+      "commit",
+      "--quiet",
+      "-m",
+      "forged",
+    ]);
+    const forgedCommit = gitOutput(["-C", current.repository, "rev-parse", "HEAD"]);
+    const archive = path.join(current.candidate, "source.tar.gz");
+    fs.writeFileSync(archive, gitBuffer([
+      "-C",
+      current.repository,
+      "archive",
+      "--format=tar.gz",
+      "--prefix=skincos-" + current.sourceCommit + "/",
+      forgedCommit,
+    ]));
+    const archiveDigest = sha256File(archive);
+    fs.writeFileSync(path.join(current.candidate, "source.sha256"), archiveDigest + "\n");
+    const releaseFile = path.join(current.candidate, "release.json");
+    const release = JSON.parse(fs.readFileSync(releaseFile, "utf8"));
+    release.sourceArchiveSha256 = archiveDigest;
+    writeJson(releaseFile, release);
+    const manifestFile = path.join(current.candidate, "release-manifest.json");
+    const manifest = JSON.parse(fs.readFileSync(manifestFile, "utf8"));
+    for (const artifacts of [manifest.artifacts, manifest.artifactManifest.artifacts, manifest.releaseIdentity.artifacts]) {
+      artifacts.find((entry) => entry.name === "source-archive").digest = archiveDigest;
+    }
+    writeJson(manifestFile, manifest);
+    assert.throws(
+      () => validateMessagingReleaseCandidate({ candidateDirectory: current.candidate, releaseSha: current.sourceCommit }),
+      /Git commit differs/,
+    );
+  } finally {
+    fs.rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("rejects an archive whose self-consistent metadata claims a different source tree", () => {
+  const current = fixture();
+  try {
+    const forgedTree = sha("forged-source-tree");
+    const releaseFile = path.join(current.candidate, "release.json");
+    const release = JSON.parse(fs.readFileSync(releaseFile, "utf8"));
+    release.sourceTree = forgedTree;
+    writeJson(releaseFile, release);
+
+    const manifestFile = path.join(current.candidate, "release-manifest.json");
+    const manifest = JSON.parse(fs.readFileSync(manifestFile, "utf8"));
+    manifest.sourceTree = forgedTree;
+    manifest.artifactManifest.sourceTree = forgedTree;
+    manifest.releaseIdentity.sourceTree = forgedTree;
+    writeJson(manifestFile, manifest);
+
+    const closureFile = path.join(current.candidate, "messaging-whatsapp-closure.json");
+    const originalClosure = JSON.parse(fs.readFileSync(closureFile, "utf8"));
+    writeJson(closureFile, closure({
+      sourceCommit: current.sourceCommit,
+      sourceTree: forgedTree,
+      inputBlob: originalClosure.material.inputs[0].blob,
+    }));
+
+    assert.throws(
+      () => validateMessagingReleaseCandidate({ candidateDirectory: current.candidate, releaseSha: current.sourceCommit }),
+      /archive tree differs/,
+    );
+  } finally {
+    fs.rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("rejects a release candidate placed in a checkout or worktree", () => {
+  const current = fixture();
+  try {
+    fs.writeFileSync(path.join(current.candidate, ".git"), "gitdir: /synthetic/worktree\\n");
+    assert.throws(
+      () => validateMessagingReleaseCandidate({ candidateDirectory: current.candidate, releaseSha: current.sourceCommit }),
+      /must not be a checkout or worktree/,
+    );
+  } finally {
+    fs.rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("rejects a messaging closure whose tree differs even when its digest is internally valid", () => {
+  const current = fixture();
+  try {
+    const closureFile = path.join(current.candidate, "messaging-whatsapp-closure.json");
+    writeJson(closureFile, closure({ sourceCommit: current.sourceCommit, sourceTree: sha("different-tree") }));
+    assert.throws(
+      () => validateMessagingReleaseCandidate({ candidateDirectory: current.candidate, releaseSha: current.sourceCommit }),
+      /closure source tree differs/,
+    );
+  } finally {
+    fs.rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("rejects a messaging closure whose input blob differs from the immutable source tree", () => {
+  const current = fixture();
+  try {
+    const closureFile = path.join(current.candidate, "messaging-whatsapp-closure.json");
+    const value = JSON.parse(fs.readFileSync(closureFile, "utf8"));
+    value.inputs[0].blob = sha("forged-engine-input");
+    value.material.inputs[0].blob = value.inputs[0].blob;
+    value.digest = sha256Text(canonicalJson(value.material));
+    writeJson(closureFile, value);
+    assert.throws(
+      () => validateMessagingReleaseCandidate({ candidateDirectory: current.candidate, releaseSha: current.sourceCommit }),
+      /closure input does not match the immutable source tree/,
+    );
+  } finally {
+    fs.rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("does not treat a Windows-mounted path as a native release candidate", () => {
+  assert.equal(isNativeLinuxPath("/mnt/c/skincos/release-source-" + sha("candidate")), false);
+});
+
+test("builds a new release identity only from an attested installed predecessor", () => {
+  const current = fixture();
+  try {
+    const predecessorCommit = current.predecessor.sourceCommit;
+    const predecessorTree = current.predecessor.sourceTree;
+    const predecessorCandidate = createCandidate(current.root, predecessorCommit, predecessorTree, current.repository);
+    const predecessorClosure = JSON.parse(
+      fs.readFileSync(path.join(predecessorCandidate.candidate, "messaging-whatsapp-closure.json"), "utf8"),
+    );
+    const predecessorRoot = path.join(current.root, "releases", predecessorCommit, "messaging-whatsapp");
+    const predecessor = createInstalledRelease(predecessorRoot, {
+      sourceCommit: predecessorCommit,
+      sourceTree: predecessorTree,
+      sourceArchiveSha256: predecessorCandidate.archiveDigest,
+      releaseManifestSha256: sha256Text("predecessor-manifest"),
+      closureValue: predecessorClosure,
+    });
+    const artifact = path.join(current.root, "candidate-dist.js");
+    fs.writeFileSync(artifact, "console.log('candidate');\n");
+    const identity = buildMessagingReleaseIdentity({
+      candidateDirectory: current.candidate,
+      releaseSha: current.sourceCommit,
+      artifactFile: artifact,
+      predecessorReleaseRoot: predecessorRoot,
+    });
+    assert.equal(identity.predecessor.sourceCommit, predecessor.sourceCommit);
+    assert.equal(identity.predecessor.identityDigest, predecessor.identityDigest);
+    assert.match(identity.identityDigest, /^[0-9a-f]{64}$/);
+  } finally {
+    fs.rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("rejects rollback when the current identity does not attest the requested predecessor", () => {
+  const current = fixture();
+  try {
+    const predecessorCommit = current.predecessor.sourceCommit;
+    const predecessorTree = current.predecessor.sourceTree;
+    const predecessorCandidate = createCandidate(current.root, predecessorCommit, predecessorTree, current.repository);
+    const predecessorClosure = JSON.parse(
+      fs.readFileSync(path.join(predecessorCandidate.candidate, "messaging-whatsapp-closure.json"), "utf8"),
+    );
+    const predecessorRoot = path.join(current.root, "releases", predecessorCommit, "messaging-whatsapp");
+    const predecessor = createInstalledRelease(predecessorRoot, {
+      sourceCommit: predecessorCommit,
+      sourceTree: predecessorTree,
+      sourceArchiveSha256: predecessorCandidate.archiveDigest,
+      releaseManifestSha256: sha256Text("predecessor-manifest"),
+      closureValue: predecessorClosure,
+    });
+    const currentClosure = closure({ sourceCommit: current.sourceCommit, sourceTree: current.sourceTree });
+    const currentRoot = path.join(current.root, "releases", current.sourceCommit, "messaging-whatsapp");
+    createInstalledRelease(currentRoot, {
+      sourceCommit: current.sourceCommit,
+      sourceTree: current.sourceTree,
+      sourceArchiveSha256: current.archiveDigest,
+      releaseManifestSha256: sha256Text("candidate-manifest"),
+      closureValue: currentClosure,
+      predecessor: {
+        sourceCommit: sha("wrong-predecessor"),
+        sourceTree: predecessor.sourceTree,
+        identityDigest: predecessor.identityDigest,
+        artifactDigest: predecessor.artifactDigest,
+      },
+    });
+    assert.throws(
+      () => validateMessagingRollbackPair({
+        currentReleaseRoot: currentRoot,
+        predecessorReleaseRoot: predecessorRoot,
+        predecessorCandidateDirectory: predecessorCandidate.candidate,
+        predecessorReleaseSha: predecessorCommit,
+      }),
+      /does not attest the exact rollback predecessor/,
+    );
+  } finally {
+    fs.rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("rejects an installed release whose built artifact changed after identity attestation", () => {
+  const current = fixture();
+  try {
+    const releaseRoot = path.join(current.root, "release");
+    const releaseClosure = closure({ sourceCommit: current.sourceCommit, sourceTree: current.sourceTree });
+    createInstalledRelease(releaseRoot, {
+      sourceCommit: current.sourceCommit,
+      sourceTree: current.sourceTree,
+      sourceArchiveSha256: current.archiveDigest,
+      releaseManifestSha256: sha256Text("candidate-manifest"),
+      closureValue: releaseClosure,
+    });
+    fs.writeFileSync(path.join(releaseRoot, "dist", "main.js"), "console.log('tampered');\n");
+    assert.throws(
+      () => validateInstalledMessagingRelease({ releaseRoot }),
+      /whatsapp-dist-main artifact digest differs/,
+    );
+  } finally {
+    fs.rmSync(current.root, { recursive: true, force: true });
+  }
+});

--- a/scripts/runtime/prepare-messaging-whatsapp-release.sh
+++ b/scripts/runtime/prepare-messaging-whatsapp-release.sh
@@ -1,149 +1,247 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-SOURCE_DIR="$ROOT_DIR/messaging/channels/whatsapp/engine"
+# A WhatsApp promotion may build only from a native copy of the GitHub
+# release-source-<SHA> artifact. In particular, never use the checkout or a
+# worktree as engine input: their contents can drift after the candidate was
+# attested.
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+CALLER_CONTRACT="$ROOT_DIR/scripts/runtime/messaging-whatsapp-release-contract.mjs"
+CALLER_COORDINATION="$ROOT_DIR/scripts/runtime/global-coordination-mini-pc.sh"
+CALLER_RUNNER="$ROOT_DIR/scripts/runtime/run-messaging-whatsapp-release.sh"
 RELEASE_BASE="${MESSAGING_RELEASE_BASE:-/opt/skincos/releases}"
 CURRENT_LINK="${MESSAGING_CURRENT_LINK:-/opt/skincos/current/messaging-whatsapp}"
 RELEASE_ID="${MESSAGING_RELEASE_ID:-}"
-DESTINATION="$RELEASE_BASE/$RELEASE_ID/messaging-whatsapp"
-STAGING="$RELEASE_BASE/.staging-$RELEASE_ID-$$"
 NPM_CACHE="${MESSAGING_NPM_CACHE:-/var/lib/skincos-runtime/cache/npm}"
-COORDINATION_CLOSURE="${SKINCOS_GLOBAL_COORDINATION_CLOSURE_FILE:-}"
+RELEASE_CANDIDATE=""
+PREDECESSOR_RELEASE=""
 APPLY=0
+SNAPSHOT_STAGE=""
+SNAPSHOT_CANDIDATE=""
+SOURCE_STAGE=""
+IMMUTABLE_ROOT=""
+IMMUTABLE_ENGINE=""
+STAGING=""
+DESTINATION=""
+COORDINATION_PROOF=""
+ARTIFACT_IDENTITY_FILE=""
+coordination_acquired=0
 
 usage() {
   cat <<'EOF'
-Usage: scripts/runtime/prepare-messaging-whatsapp-release.sh [--coordination-closure <json>] [--apply]
+Usage: scripts/runtime/prepare-messaging-whatsapp-release.sh --release-candidate <native/release-source-SHA> [--predecessor-release <sha>] [--apply]
 
-Stages the WhatsApp engine as a native Linux release. With --apply it copies
-only tracked source and lockfiles, installs dependencies, generates Prisma,
-builds dist/main.js, and atomically updates the current symlink. It never reads
-or copies .env files; systemd loads the private environment separately.
+Validates and builds the WhatsApp engine exclusively from a Linux-native
+release-source-<SHA> artifact. The candidate must contain source.tar.gz,
+source.sha256, release.json, release-manifest.json and the
+messaging-whatsapp closure attestation. It is first copied into a private
+native snapshot, and every validation, extraction and identity read uses only
+that snapshot. --apply is fail-closed until external authenticated custody
+binds the GitHub workflow run, artifact identity and source archive digest.
 
-Set MESSAGING_RELEASE_ID to the reviewed main commit SHA before invoking this
-script. It is explicit because WSL cannot reliably resolve Windows worktree
-gitdir indirections during a production cutover.
+No checkout, worktree, /mnt path, .env file or generated source tree is used as
+the engine input. Systemd loads its private environment separately.
 EOF
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --apply) APPLY=1 ;;
-    --coordination-closure) shift; COORDINATION_CLOSURE="${1:-}" ;;
+    --release-candidate)
+      [[ "$#" -ge 2 ]] || { echo '--release-candidate requires a value.' >&2; exit 64; }
+      RELEASE_CANDIDATE="$2"
+      shift
+      ;;
+    --predecessor-release)
+      [[ "$#" -ge 2 ]] || { echo '--predecessor-release requires a value.' >&2; exit 64; }
+      PREDECESSOR_RELEASE="$2"
+      shift
+      ;;
     -h|--help) usage; exit 0 ;;
-    *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 64 ;;
   esac
   shift
 done
 
-[[ -f "$SOURCE_DIR/package-lock.json" ]] || { echo "Missing lockfile: $SOURCE_DIR/package-lock.json" >&2; exit 1; }
-[[ -f "$SOURCE_DIR/src/main.ts" ]] || { echo "Missing source entrypoint: $SOURCE_DIR/src/main.ts" >&2; exit 1; }
-[[ "$RELEASE_ID" =~ ^[0-9a-f]{40}$ ]] || { echo 'MESSAGING_RELEASE_ID must be a full reviewed commit SHA.' >&2; exit 1; }
-[[ ! -e "$DESTINATION" ]] || { echo "Release destination already exists: $DESTINATION" >&2; exit 1; }
+[[ "$RELEASE_ID" =~ ^[0-9a-f]{40}$ ]] || { echo 'MESSAGING_RELEASE_ID must be a full lowercase reviewed commit SHA.' >&2; exit 78; }
+[[ -n "$RELEASE_CANDIDATE" ]] || { echo '--release-candidate is required.' >&2; exit 64; }
+[[ -f "$CALLER_CONTRACT" ]] || { echo 'Messaging release contract is unavailable.' >&2; exit 78; }
+[[ -f "$CALLER_COORDINATION" && -f "$CALLER_RUNNER" ]] || { echo 'Trusted messaging release helpers are unavailable.' >&2; exit 78; }
+[[ "$RELEASE_BASE" == /* && "$RELEASE_BASE" != /mnt/* ]] || { echo 'Messaging release base must be an absolute native Linux path.' >&2; exit 78; }
+[[ "$CURRENT_LINK" == /* && "$CURRENT_LINK" != /mnt/* ]] || { echo 'Messaging current link must be an absolute native Linux path.' >&2; exit 78; }
+[[ "$NPM_CACHE" == /* && "$NPM_CACHE" != /mnt/* ]] || { echo 'Messaging npm cache must be an absolute native Linux path.' >&2; exit 78; }
+[[ "$RELEASE_CANDIDATE" != /mnt/* ]] || { echo 'Release candidate must already be on native Linux storage.' >&2; exit 78; }
 
-echo "Release ID: $RELEASE_ID"
-echo "Source: $SOURCE_DIR"
-echo "Destination: $DESTINATION"
-if [[ "$APPLY" != "1" ]]; then
-  echo "Dry run complete. Use --apply after backup, CI and cutover gates pass."
-  exit 0
+# A candidate is internally verified only after snapshotting, but that is not
+# evidence that GitHub released it. No authenticated custody verifier binding
+# the workflow run, artifact identity and archive digest exists in this native
+# path yet. Refuse --apply before touching untrusted candidate bytes; never
+# accept a self-asserted flag, file or environment variable.
+if [[ "$APPLY" == 1 ]]; then
+  echo 'Native WhatsApp promotion is fail-closed: --apply requires external authenticated release custody bound to the GitHub workflow run, artifact identity and source archive digest.' >&2
+  exit 78
 fi
 
-[[ -n "$COORDINATION_CLOSURE" && -f "$COORDINATION_CLOSURE" ]] || {
-  echo 'An immutable messaging dependency-closure attestation is required for WhatsApp artifact promotion.' >&2
+SOURCE_STAGE="$(mktemp -d "/var/tmp/skincos-messaging-source-$RELEASE_ID.XXXXXX")"
+SNAPSHOT_STAGE="$(mktemp -d "/var/tmp/skincos-messaging-candidate-$RELEASE_ID.XXXXXX")"
+SNAPSHOT_CANDIDATE="$SNAPSHOT_STAGE/release-source-$RELEASE_ID"
+cleanup() {
+  if (( coordination_acquired == 1 )); then
+    if [[ -n "$STAGING" && -d "$STAGING" ]]; then
+      if coordination_run check \
+        --resource release:messaging-whatsapp --module messaging-whatsapp --source "$RELEASE_ID" \
+        --closure-file "$CANDIDATE_CLOSURE" >/dev/null 2>&1; then
+        sudo -n rm -rf -- "$STAGING" || true
+      else
+        echo 'Messaging staging was left intact because coordination proof could not be revalidated.' >&2
+      fi
+    fi
+    coordination_run release >/dev/null 2>&1 || echo 'Unable to release the messaging lease; it will expire fail-closed.' >&2
+    coordination_acquired=0
+  fi
+  [[ -z "$ARTIFACT_IDENTITY_FILE" ]] || rm -f -- "$ARTIFACT_IDENTITY_FILE"
+  if [[ "$SNAPSHOT_STAGE" =~ ^/var/tmp/skincos-messaging-candidate-[0-9a-f]{40}\.[A-Za-z0-9]+$ ]]; then
+    rm -rf -- "$SNAPSHOT_STAGE"
+  fi
+  if [[ "$SOURCE_STAGE" =~ ^/var/tmp/skincos-messaging-source-[0-9a-f]{40}\.[A-Za-z0-9]+$ ]]; then
+    rm -rf -- "$SOURCE_STAGE"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+assert_confined_immutable_engine() {
+  local current="$IMMUTABLE_ROOT"
+  local segment
+  for segment in messaging channels whatsapp engine; do
+    current="$current/$segment"
+    [[ -d "$current" && ! -L "$current" ]] || return 1
+  done
+  IMMUTABLE_ENGINE="$(readlink -f -- "$current")"
+  [[ "$IMMUTABLE_ENGINE" == "$IMMUTABLE_ROOT/"* ]]
+}
+
+# The untrusted delivered directory can be swapped at any point. Capture all
+# five candidate artifacts inside a fresh 0700 native directory before doing
+# any provenance, TAR or build work. The contract's parser never invokes a
+# generic extractor and rejects links/special records that could escape stage.
+node "$CALLER_CONTRACT" snapshot-candidate \
+  --candidate "$RELEASE_CANDIDATE" --release-sha "$RELEASE_ID" \
+  --snapshot "$SNAPSHOT_CANDIDATE" >/dev/null
+CANDIDATE_ROOT="$SNAPSHOT_CANDIDATE"
+CANDIDATE_CLOSURE="$CANDIDATE_ROOT/messaging-whatsapp-closure.json"
+node "$CALLER_CONTRACT" materialize-candidate \
+  --candidate "$CANDIDATE_ROOT" --release-sha "$RELEASE_ID" --stage "$SOURCE_STAGE" >/dev/null
+IMMUTABLE_ROOT="$SOURCE_STAGE/skincos-$RELEASE_ID"
+if ! assert_confined_immutable_engine; then
+  echo 'Release source candidate lacks the immutable WhatsApp engine.' >&2
+  exit 78
+fi
+node "$CALLER_CONTRACT" verify-candidate \
+  --candidate "$CANDIDATE_ROOT" --release-sha "$RELEASE_ID" >/dev/null
+
+DESTINATION="$RELEASE_BASE/$RELEASE_ID/messaging-whatsapp"
+STAGING="$RELEASE_BASE/.messaging-whatsapp-staging-$RELEASE_ID-$$"
+[[ "$STAGING" == "$RELEASE_BASE/.messaging-whatsapp-staging-$RELEASE_ID-"* ]] || {
+  echo 'Messaging staging target is invalid.' >&2
   exit 78
 }
-coordination_proof="${SKINCOS_GLOBAL_COORDINATION_PROOF_FILE:-/var/lib/skincos-runtime/global-coordination/release-messaging-whatsapp-$RELEASE_ID-$$.json}"
-artifact_identity_file="$(mktemp /tmp/skincos-whatsapp-release-identity.XXXXXX)"
-coordination_acquired=0
-coordination_run() {
-  "$ROOT_DIR/scripts/runtime/global-coordination-mini-pc.sh" "$@" --proof-file "$coordination_proof"
-}
-cleanup_staging() {
-  sudo -n rm -rf "$STAGING"
-}
-cleanup_coordination() {
-  if (( coordination_acquired == 1 )); then
-    coordination_run release >/dev/null 2>&1 || echo 'Unable to release the mini-PC messaging lease; it will expire fail-closed.' >&2
-  fi
-  cleanup_staging
-  rm -f -- "$artifact_identity_file"
-}
-trap cleanup_coordination EXIT INT TERM
-coordination_run acquire \
-  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$RELEASE_ID" --closure-file "$COORDINATION_CLOSURE" \
-  --operation mutation --idempotency-key "mini-pc:release:messaging-whatsapp:build:$RELEASE_ID:$$" >/dev/null
-coordination_acquired=1
-coordination_run check \
-  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$RELEASE_ID" --closure-file "$COORDINATION_CLOSURE" >/dev/null
+[[ ! -e "$DESTINATION" ]] || { echo "Release destination already exists: $DESTINATION" >&2; exit 78; }
 
-command -v rsync >/dev/null 2>&1 || { echo 'Missing required command: rsync' >&2; exit 1; }
-command -v npm >/dev/null 2>&1 || { echo 'Missing required command: npm' >&2; exit 1; }
-command -v sha256sum >/dev/null 2>&1 || { echo 'Missing required command: sha256sum' >&2; exit 1; }
-command -v awk >/dev/null 2>&1 || { echo 'Missing required command: awk' >&2; exit 1; }
-command -v sudo >/dev/null 2>&1 || { echo 'Missing required command: sudo' >&2; exit 1; }
+node "$CALLER_CONTRACT" verify-candidate \
+  --candidate "$CANDIDATE_ROOT" --release-sha "$RELEASE_ID"
+echo 'dry_run=true'
+echo 'apply_requires=attested-predecessor-release'
+echo 'apply_requires=external-authenticated-release-custody-run-artifact-digest'
+exit 0
+
+[[ "$PREDECESSOR_RELEASE" =~ ^[0-9a-f]{40}$ && "$PREDECESSOR_RELEASE" != "$RELEASE_ID" ]] || {
+  echo '--predecessor-release must name a distinct full lowercase SHA.' >&2
+  exit 78
+}
+PREDECESSOR_ROOT="$RELEASE_BASE/$PREDECESSOR_RELEASE/messaging-whatsapp"
+node "$CALLER_CONTRACT" verify-installed \
+  --release-root "$PREDECESSOR_ROOT" --expected-release-sha "$PREDECESSOR_RELEASE" >/dev/null
+
+for command in node npm rsync sha256sum awk sudo readlink mktemp; do
+  command -v "$command" >/dev/null 2>&1 || { echo "Missing required command: $command" >&2; exit 78; }
+done
 sudo -n true
 
+COORDINATION_PROOF="${SKINCOS_GLOBAL_COORDINATION_PROOF_FILE:-/var/lib/skincos-runtime/global-coordination/release-messaging-whatsapp-$RELEASE_ID-$$.json}"
+coordination_run() {
+  "$CALLER_COORDINATION" "$@" --proof-file "$COORDINATION_PROOF"
+}
+
+coordination_run acquire \
+  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$RELEASE_ID" \
+  --closure-file "$CANDIDATE_CLOSURE" --operation mutation \
+  --idempotency-key "mini-pc:release:messaging-whatsapp:build:$RELEASE_ID:$$" >/dev/null
+coordination_acquired=1
 coordination_run check \
-  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$RELEASE_ID" --closure-file "$COORDINATION_CLOSURE" >/dev/null
-sudo -n install -d -o skincos -g skincos -m 0750 "$STAGING" "$NPM_CACHE"
-# The cache is durable runtime state. A prior diagnostic run as another user
-# must not make a later production release fail before dependencies are built.
-sudo -n chown -R skincos:skincos "$NPM_CACHE"
+  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$RELEASE_ID" \
+  --closure-file "$CANDIDATE_CLOSURE" >/dev/null
+
+sudo -n install -d -o root -g skincos -m 0750 "$STAGING" "$NPM_CACHE"
+coordination_run check \
+  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$RELEASE_ID" \
+  --closure-file "$CANDIDATE_CLOSURE" >/dev/null
 sudo -n rsync -a --delete \
   --exclude '.env' --exclude '.env.*' --exclude 'node_modules' --exclude 'dist' \
-  "$SOURCE_DIR/" "$STAGING/"
-sudo -n chown -R skincos:skincos "$STAGING"
-# tsconfig writes its incremental build info under dist before tsup runs. The
-# release copy intentionally excludes generated dist, so create the native
-# output directory explicitly instead of depending on an old worktree build.
+  "$IMMUTABLE_ENGINE/" "$STAGING/"
+sudo -n install -o root -g skincos -m 0750 \
+  "$CALLER_RUNNER" "$STAGING/.skincos-run-messaging-whatsapp-release.sh"
+sudo -n install -o root -g skincos -m 0640 \
+  "$CANDIDATE_CLOSURE" "$STAGING/.skincos-global-coordination-messaging-whatsapp.json"
+sudo -n chown -R skincos:skincos "$STAGING" "$NPM_CACHE"
 sudo -n install -d -o skincos -g skincos -m 0750 "$STAGING/dist"
 
-sudo -n -u skincos env npm_config_cache="$NPM_CACHE" \
-  npm --prefix "$STAGING" ci --ignore-scripts
+coordination_run check \
+  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$RELEASE_ID" \
+  --closure-file "$CANDIDATE_CLOSURE" >/dev/null
+sudo -n -u skincos env npm_config_cache="$NPM_CACHE" npm --prefix "$STAGING" ci --ignore-scripts
 sudo -n -u skincos npm --prefix "$STAGING" run db:generate
 sudo -n -u skincos npm --prefix "$STAGING" run build
-[[ -f "$STAGING/dist/main.js" ]] || { echo "Build did not produce dist/main.js" >&2; exit 1; }
+[[ -f "$STAGING/dist/main.js" ]] || { echo 'Build did not produce dist/main.js.' >&2; exit 78; }
 
-artifact_digest="$(sha256sum "$STAGING/dist/main.js" | awk '{print $1}')"
-node - "$COORDINATION_CLOSURE" "$RELEASE_ID" "$artifact_digest" > "$artifact_identity_file" <<'NODE'
-const fs = require('fs');
-const [closureFile, releaseId, artifactDigest] = process.argv.slice(2);
-const closure = JSON.parse(fs.readFileSync(closureFile, 'utf8'));
-const identity = {
-  schemaVersion: 1,
-  module: 'messaging-whatsapp',
-  sourceCommit: String(closure.sourceCommit).toLowerCase(),
-  sourceTree: String(closure.sourceTree).toLowerCase(),
-  dependencyClosureDigest: String(closure.digest).toLowerCase(),
-  artifacts: [{ name: 'whatsapp-dist-main', id: `whatsapp-dist:${releaseId}`, digest: artifactDigest }],
-};
-process.stdout.write(`${JSON.stringify(identity, null, 2)}\n`);
-NODE
+ARTIFACT_IDENTITY_FILE="$(mktemp /tmp/skincos-messaging-release-identity.XXXXXX)"
+node "$CALLER_CONTRACT" build-identity \
+  --candidate "$CANDIDATE_ROOT" --release-sha "$RELEASE_ID" \
+  --artifact "$STAGING/dist/main.js" --predecessor-release-root "$PREDECESSOR_ROOT" \
+  > "$ARTIFACT_IDENTITY_FILE"
+sudo -n install -o root -g skincos -m 0640 \
+  "$ARTIFACT_IDENTITY_FILE" "$STAGING/.skincos-release-identity-messaging-whatsapp.json"
+node "$CALLER_CONTRACT" verify-installed \
+  --release-root "$STAGING" --expected-release-sha "$RELEASE_ID" >/dev/null
+sudo -n chown -R root:skincos "$STAGING"
+sudo -n find "$STAGING" -type d -exec chmod 0750 {} +
+sudo -n find "$STAGING" -type f -exec chmod 0640 {} +
+sudo -n chmod 0750 "$STAGING/.skincos-run-messaging-whatsapp-release.sh"
 
+# The build lease owns only staging. Reacquire a promotion lease carrying the
+# final artifact identity immediately before the immutable destination and link
+# mutation.
 coordination_run check \
-  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$RELEASE_ID" --closure-file "$COORDINATION_CLOSURE" >/dev/null
-sudo -n install -d -o root -g skincos -m 0750 "$(dirname "$DESTINATION")"
-coordination_run check \
-  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$RELEASE_ID" --closure-file "$COORDINATION_CLOSURE" >/dev/null
+  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$RELEASE_ID" \
+  --closure-file "$CANDIDATE_CLOSURE" >/dev/null
 coordination_run release >/dev/null
 coordination_acquired=0
 coordination_run acquire \
-  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$RELEASE_ID" --closure-file "$COORDINATION_CLOSURE" \
-  --operation promotion --release-identity-file "$artifact_identity_file" \
+  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$RELEASE_ID" \
+  --closure-file "$CANDIDATE_CLOSURE" --operation promotion \
+  --release-identity-file "$ARTIFACT_IDENTITY_FILE" \
   --idempotency-key "mini-pc:release:messaging-whatsapp:promote:$RELEASE_ID:$$" >/dev/null
 coordination_acquired=1
 coordination_run check \
-  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$RELEASE_ID" --closure-file "$COORDINATION_CLOSURE" >/dev/null
-sudo -n install -m 0640 "$artifact_identity_file" "$STAGING/.skincos-release-identity-messaging-whatsapp.json"
+  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$RELEASE_ID" \
+  --closure-file "$CANDIDATE_CLOSURE" >/dev/null
+sudo -n install -d -o root -g skincos -m 0750 "$(dirname "$DESTINATION")" "$(dirname "$CURRENT_LINK")"
 coordination_run check \
-  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$RELEASE_ID" --closure-file "$COORDINATION_CLOSURE" >/dev/null
-sudo -n mv "$STAGING" "$DESTINATION"
+  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$RELEASE_ID" \
+  --closure-file "$CANDIDATE_CLOSURE" >/dev/null
+sudo -n mv -- "$STAGING" "$DESTINATION"
 coordination_run check \
-  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$RELEASE_ID" --closure-file "$COORDINATION_CLOSURE" >/dev/null
-sudo -n install -d -o root -g skincos -m 0750 "$(dirname "$CURRENT_LINK")"
-coordination_run check \
-  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$RELEASE_ID" --closure-file "$COORDINATION_CLOSURE" >/dev/null
-sudo -n ln -sfn "$DESTINATION" "$CURRENT_LINK"
+  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$RELEASE_ID" \
+  --closure-file "$CANDIDATE_CLOSURE" >/dev/null
+sudo -n ln -sfn -- "$DESTINATION" "$CURRENT_LINK"
+
 echo "Native WhatsApp release prepared: $CURRENT_LINK -> $DESTINATION"

--- a/scripts/runtime/rollback-messaging-whatsapp-release.sh
+++ b/scripts/runtime/rollback-messaging-whatsapp-release.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+CALLER_CONTRACT="$ROOT_DIR/scripts/runtime/messaging-whatsapp-release-contract.mjs"
+CALLER_COORDINATION="$ROOT_DIR/scripts/runtime/global-coordination-mini-pc.sh"
+RELEASE_BASE="${MESSAGING_RELEASE_BASE:-/opt/skincos/releases}"
+CURRENT_LINK="${MESSAGING_CURRENT_LINK:-/opt/skincos/current/messaging-whatsapp}"
+PREDECESSOR_RELEASE=""
+PREDECESSOR_CANDIDATE=""
+APPLY=0
+SNAPSHOT_STAGE=""
+SNAPSHOT_CANDIDATE=""
+SOURCE_STAGE=""
+IMMUTABLE_ROOT=""
+IMMUTABLE_ENGINE=""
+COORDINATION_PROOF=""
+coordination_acquired=0
+link_switched=0
+CURRENT_TARGET=""
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/runtime/rollback-messaging-whatsapp-release.sh --predecessor-release <sha> --predecessor-candidate <native/release-source-SHA> [--apply]
+
+Rolls the active WhatsApp engine back only to the exact predecessor recorded by
+the active release identity. The predecessor must also match a native
+release-source-<SHA> candidate and its closure. --apply restarts the service and
+requires both systemd active state and the loopback /health smoke to succeed.
+The candidate is first captured into a private native snapshot; external
+authenticated release custody is required before any --apply activation.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply) APPLY=1 ;;
+    --predecessor-release)
+      [[ "$#" -ge 2 ]] || { echo '--predecessor-release requires a value.' >&2; exit 64; }
+      PREDECESSOR_RELEASE="$2"
+      shift
+      ;;
+    --predecessor-candidate)
+      [[ "$#" -ge 2 ]] || { echo '--predecessor-candidate requires a value.' >&2; exit 64; }
+      PREDECESSOR_CANDIDATE="$2"
+      shift
+      ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 64 ;;
+  esac
+  shift
+done
+
+[[ "$PREDECESSOR_RELEASE" =~ ^[0-9a-f]{40}$ ]] || {
+  echo '--predecessor-release must be a full lowercase SHA.' >&2
+  exit 78
+}
+[[ -n "$PREDECESSOR_CANDIDATE" && -f "$CALLER_CONTRACT" && -f "$CALLER_COORDINATION" ]] || {
+  echo '--predecessor-candidate and trusted messaging release helpers are required.' >&2
+  exit 78
+}
+[[ "$RELEASE_BASE" == /* && "$RELEASE_BASE" != /mnt/* ]] || { echo 'Messaging release base must be a native Linux path.' >&2; exit 78; }
+[[ "$CURRENT_LINK" == /* && "$CURRENT_LINK" != /mnt/* ]] || { echo 'Messaging current link must be a native Linux path.' >&2; exit 78; }
+
+# External authenticated custody is unavailable for this native path. Reject
+# activation before any candidate archive is opened, rather than treating its
+# self-consistent metadata as a GitHub release proof.
+if [[ "$APPLY" == 1 ]]; then
+  echo 'Native WhatsApp rollback is fail-closed: --apply requires external authenticated release custody bound to the GitHub workflow run, artifact identity and source archive digest.' >&2
+  exit 78
+fi
+
+SOURCE_STAGE="$(mktemp -d "/var/tmp/skincos-messaging-rollback-source-$PREDECESSOR_RELEASE.XXXXXX")"
+SNAPSHOT_STAGE="$(mktemp -d "/var/tmp/skincos-messaging-rollback-candidate-$PREDECESSOR_RELEASE.XXXXXX")"
+SNAPSHOT_CANDIDATE="$SNAPSHOT_STAGE/release-source-$PREDECESSOR_RELEASE"
+cleanup() {
+  if (( coordination_acquired == 1 )); then
+    coordination_run release >/dev/null 2>&1 || echo 'Unable to release the messaging rollback lease; it will expire fail-closed.' >&2
+    coordination_acquired=0
+  fi
+  if [[ "$SNAPSHOT_STAGE" =~ ^/var/tmp/skincos-messaging-rollback-candidate-[0-9a-f]{40}\.[A-Za-z0-9]+$ ]]; then
+    rm -rf -- "$SNAPSHOT_STAGE"
+  fi
+  if [[ "$SOURCE_STAGE" =~ ^/var/tmp/skincos-messaging-rollback-source-[0-9a-f]{40}\.[A-Za-z0-9]+$ ]]; then
+    rm -rf -- "$SOURCE_STAGE"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+assert_confined_immutable_engine() {
+  local current="$IMMUTABLE_ROOT"
+  local segment
+  for segment in messaging channels whatsapp engine; do
+    current="$current/$segment"
+    [[ -d "$current" && ! -L "$current" ]] || return 1
+  done
+  IMMUTABLE_ENGINE="$(readlink -f -- "$current")"
+  [[ "$IMMUTABLE_ENGINE" == "$IMMUTABLE_ROOT/"* ]]
+}
+
+# Capture all five artifacts once, privately, before the contract examines the
+# predecessor. A later replacement of the delivered directory cannot influence
+# either extraction, rollback-pair proof, or service identity.
+node "$CALLER_CONTRACT" snapshot-candidate \
+  --candidate "$PREDECESSOR_CANDIDATE" --release-sha "$PREDECESSOR_RELEASE" \
+  --snapshot "$SNAPSHOT_CANDIDATE" >/dev/null
+CANDIDATE_ROOT="$SNAPSHOT_CANDIDATE"
+CANDIDATE_CLOSURE="$CANDIDATE_ROOT/messaging-whatsapp-closure.json"
+node "$CALLER_CONTRACT" materialize-candidate \
+  --candidate "$CANDIDATE_ROOT" --release-sha "$PREDECESSOR_RELEASE" --stage "$SOURCE_STAGE" >/dev/null
+IMMUTABLE_ROOT="$SOURCE_STAGE/skincos-$PREDECESSOR_RELEASE"
+if ! assert_confined_immutable_engine; then
+  echo 'Predecessor candidate lacks the immutable WhatsApp engine.' >&2
+  exit 78
+fi
+node "$CALLER_CONTRACT" verify-candidate \
+  --candidate "$CANDIDATE_ROOT" --release-sha "$PREDECESSOR_RELEASE" >/dev/null
+
+PREDECESSOR_ROOT="$RELEASE_BASE/$PREDECESSOR_RELEASE/messaging-whatsapp"
+CURRENT_TARGET="$(readlink -f -- "$CURRENT_LINK")"
+[[ "$CURRENT_TARGET" == "$RELEASE_BASE/"*/messaging-whatsapp ]] || {
+  echo 'Current WhatsApp link does not resolve to an immutable messaging release.' >&2
+  exit 78
+}
+CURRENT_RELEASE="$(basename "$(dirname "$CURRENT_TARGET")")"
+[[ "$CURRENT_RELEASE" =~ ^[0-9a-f]{40}$ && "$CURRENT_RELEASE" != "$PREDECESSOR_RELEASE" ]] || {
+  echo 'Current WhatsApp release is not a distinct immutable candidate.' >&2
+  exit 78
+}
+node "$CALLER_CONTRACT" verify-rollback-pair \
+  --current-release-root "$CURRENT_TARGET" \
+  --predecessor-release-root "$PREDECESSOR_ROOT" \
+  --predecessor-candidate "$CANDIDATE_ROOT" \
+  --predecessor-release-sha "$PREDECESSOR_RELEASE" >/dev/null
+
+echo "current_release=$CURRENT_RELEASE"
+echo "predecessor_release=$PREDECESSOR_RELEASE"
+echo 'dry_run=true'
+echo 'post_rollback_smoke=systemctl-active-and-loopback-health'
+echo 'apply_requires=external-authenticated-release-custody-run-artifact-digest'
+exit 0
+
+for command in node sudo systemctl curl readlink mktemp; do
+  command -v "$command" >/dev/null 2>&1 || { echo "Missing required command: $command" >&2; exit 78; }
+done
+sudo -n true
+
+COORDINATION_PROOF="${SKINCOS_GLOBAL_COORDINATION_PROOF_FILE:-/var/lib/skincos-runtime/global-coordination/rollback-messaging-whatsapp-$PREDECESSOR_RELEASE-$$.json}"
+coordination_run() {
+  "$CALLER_COORDINATION" "$@" --proof-file "$COORDINATION_PROOF"
+}
+
+restore_current_release() {
+  if (( link_switched != 1 )); then
+    echo 'Rollback compensation was not attempted because the current link was never switched.' >&2
+    return 1
+  fi
+  if ! coordination_run check \
+    --resource release:messaging-whatsapp --module messaging-whatsapp --source "$PREDECESSOR_RELEASE" \
+    --closure-file "$CANDIDATE_CLOSURE" >/dev/null 2>&1; then
+    echo 'Rollback compensation could not safely restore the prior link because the lease proof is unavailable.' >&2
+    return 1
+  fi
+  if ! sudo -n ln -sfn -- "$CURRENT_TARGET" "$CURRENT_LINK" \
+    || ! sudo -n systemctl restart messaging-whatsapp.service \
+    || ! systemctl --quiet is-active messaging-whatsapp.service \
+    || ! curl --fail --silent --show-error --max-time 5 http://127.0.0.1:8080/health >/dev/null; then
+    echo 'Rollback compensation could not confirm the prior release health after restoring its link.' >&2
+    return 1
+  fi
+  link_switched=0
+  return 0
+}
+
+coordination_run acquire \
+  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$PREDECESSOR_RELEASE" \
+  --closure-file "$CANDIDATE_CLOSURE" --operation promotion \
+  --release-identity-file "$PREDECESSOR_ROOT/.skincos-release-identity-messaging-whatsapp.json" \
+  --idempotency-key "mini-pc:release:messaging-whatsapp:rollback:$CURRENT_RELEASE:$PREDECESSOR_RELEASE:$$" >/dev/null
+coordination_acquired=1
+coordination_run check \
+  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$PREDECESSOR_RELEASE" \
+  --closure-file "$CANDIDATE_CLOSURE" >/dev/null
+sudo -n ln -sfn -- "$PREDECESSOR_ROOT" "$CURRENT_LINK"
+link_switched=1
+
+if ! coordination_run check \
+  --resource release:messaging-whatsapp --module messaging-whatsapp --source "$PREDECESSOR_RELEASE" \
+  --closure-file "$CANDIDATE_CLOSURE" >/dev/null \
+  || ! sudo -n systemctl restart messaging-whatsapp.service \
+  || ! systemctl --quiet is-active messaging-whatsapp.service \
+  || ! curl --fail --silent --show-error --max-time 5 http://127.0.0.1:8080/health >/dev/null; then
+  if restore_current_release; then
+    echo 'Messaging rollback health or smoke failed; the prior release was restored and revalidated.' >&2
+  else
+    echo 'Messaging rollback health or smoke failed and compensation could not be confirmed; operator intervention is required.' >&2
+  fi
+  exit 78
+fi
+
+echo "Messaging WhatsApp rollback completed: $CURRENT_RELEASE -> $PREDECESSOR_RELEASE"

--- a/scripts/runtime/run-messaging-whatsapp-release.sh
+++ b/scripts/runtime/run-messaging-whatsapp-release.sh
@@ -7,11 +7,56 @@ set -euo pipefail
 RELEASE_ROOT="${MESSAGING_RELEASE_ROOT:-/opt/skincos/current/messaging-whatsapp}"
 ENV_FILE="${EVOLUTION_API_ENV_FILE:-/etc/skincos/messaging-whatsapp.env}"
 NODE_BIN="${NODE_BIN:-/usr/bin/node}"
+IDENTITY_FILE="$RELEASE_ROOT/.skincos-release-identity-messaging-whatsapp.json"
 
 [[ -x "$NODE_BIN" ]] || { echo "Node runtime is unavailable: $NODE_BIN" >&2; exit 1; }
 [[ -d "$RELEASE_ROOT/node_modules" ]] || { echo "Native dependencies are unavailable: $RELEASE_ROOT/node_modules" >&2; exit 1; }
 [[ -f "$RELEASE_ROOT/dist/main.js" ]] || { echo "Release artifact is unavailable: $RELEASE_ROOT/dist/main.js" >&2; exit 1; }
+[[ -r "$IDENTITY_FILE" ]] || { echo "Messaging release identity is unavailable: $IDENTITY_FILE" >&2; exit 1; }
 [[ -r "$ENV_FILE" ]] || { echo "Private WhatsApp environment is unavailable: $ENV_FILE" >&2; exit 1; }
+command -v sha256sum >/dev/null 2>&1 || { echo 'sha256sum is required to verify the messaging artifact.' >&2; exit 1; }
+
+expected_artifact_digest="$("$NODE_BIN" - "$IDENTITY_FILE" <<'NODE'
+const crypto = require('crypto');
+const fs = require('fs');
+const [file] = process.argv.slice(2);
+const identity = JSON.parse(fs.readFileSync(file, 'utf8'));
+const canonicalJson = (value) => Array.isArray(value)
+  ? '[' + value.map(canonicalJson).join(',') + ']'
+  : value && typeof value === 'object'
+    ? '{' + Object.keys(value).sort().map((key) => JSON.stringify(key) + ':' + canonicalJson(value[key])).join(',') + '}'
+    : JSON.stringify(value);
+if (identity?.schemaVersion !== 2
+  || identity.module !== 'messaging-whatsapp'
+  || !/^[0-9a-f]{40}$/i.test(String(identity.sourceCommit || ''))
+  || !/^[0-9a-f]{40}$/i.test(String(identity.sourceTree || ''))
+  || !/^[0-9a-f]{64}$/i.test(String(identity.sourceArchiveSha256 || ''))
+  || !/^[0-9a-f]{64}$/i.test(String(identity.releaseManifestSha256 || ''))
+  || !/^[0-9a-f]{64}$/i.test(String(identity.dependencyClosureDigest || ''))
+  || !/^[0-9a-f]{64}$/i.test(String(identity.identityDigest || ''))) {
+  throw new Error('Messaging release identity is malformed.');
+}
+const signed = { ...identity };
+delete signed.identityDigest;
+const observedIdentityDigest = crypto.createHash('sha256').update(canonicalJson(signed)).digest('hex');
+if (observedIdentityDigest !== String(identity.identityDigest).toLowerCase()) {
+  throw new Error('Messaging release identity digest is invalid.');
+}
+const artifacts = Array.isArray(identity.artifacts) ? identity.artifacts : [];
+const artifact = artifacts.find((entry) => entry?.name === 'whatsapp-dist-main');
+if (!artifact
+  || artifact.id !== 'whatsapp-dist:' + String(identity.sourceCommit).toLowerCase()
+  || !/^[0-9a-f]{64}$/i.test(String(artifact.digest || ''))) {
+  throw new Error('Messaging release artifact identity is invalid.');
+}
+process.stdout.write(String(artifact.digest).toLowerCase());
+NODE
+)" || { echo 'Messaging release identity verification failed.' >&2; exit 1; }
+actual_artifact_digest="$(sha256sum "$RELEASE_ROOT/dist/main.js" | awk '{print $1}')"
+[[ "$actual_artifact_digest" == "$expected_artifact_digest" ]] || {
+  echo 'Messaging release artifact digest differs from its immutable identity.' >&2
+  exit 1
+}
 
 set -a
 # shellcheck disable=SC1090

--- a/scripts/runtime/test-prepare-messaging-whatsapp-release.sh
+++ b/scripts/runtime/test-prepare-messaging-whatsapp-release.sh
@@ -1,16 +1,225 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 PREPARE="$ROOT_DIR/scripts/runtime/prepare-messaging-whatsapp-release.sh"
+CONTRACT="$ROOT_DIR/scripts/runtime/messaging-whatsapp-release-contract.mjs"
+CANDIDATE_WORKFLOW="$ROOT_DIR/.github/workflows/prepare-release-candidate.yml"
+CONTRACT_WORKFLOW="$ROOT_DIR/.github/workflows/messaging-whatsapp-release-contract.yml"
+
+# The WSL wrapper's Git routing is required to read ROOT_DIR because the
+# worktree metadata is Windows-owned. The dynamic candidate below is created
+# only under /tmp with every inherited GIT_* variable removed, so its fixture
+# Git repository cannot rewrite shared worktree configuration.
 
 bash -n "$PREPARE"
+grep -F -- 'git checkout --detach "$release_sha"' "$CANDIDATE_WORKFLOW" >/dev/null || {
+  echo 'Release candidate workflow must load the requested immutable source before deriving closure or manifest.' >&2
+  exit 1
+}
+grep -F -- '> release-candidate/messaging-whatsapp-closure.json' "$CANDIDATE_WORKFLOW" >/dev/null || {
+  echo 'Release candidate workflow must persist the messaging closure inside the candidate artifact.' >&2
+  exit 1
+}
+for path in \
+  'ops/governance/global-coordination-core.mjs' \
+  'ops/codex/risk-policy.json' \
+  'scripts/codex-autonomy-lib.mjs' \
+  'scripts/codex-global-coordinator.mjs' \
+  'scripts/codex-global-coordination-workflow.mjs' \
+  'scripts/codex-release-manifest.mjs'; do
+  [[ "$(grep -Fc -- "      - \"$path\"" "$CONTRACT_WORKFLOW")" -eq 2 ]] || {
+    echo "Messaging contract CI must cover both path filters for $path." >&2
+    exit 1
+  }
+done
 
-mkdir_line="$(grep -nF 'install -d -o skincos -g skincos -m 0750 "$STAGING/dist"' "$PREPARE" | cut -d: -f1)"
-build_line="$(grep -nF 'npm --prefix "$STAGING" run build' "$PREPARE" | cut -d: -f1)"
-[[ -n "$mkdir_line" && -n "$build_line" && "$mkdir_line" -lt "$build_line" ]] || {
-  echo 'Messaging release preparation must create native dist before the build.' >&2
+required=(
+  '--release-candidate'
+  '--predecessor-release'
+  'release-source-<SHA>'
+  'source.tar.gz'
+  'source.sha256'
+  'release-manifest.json'
+  'messaging-whatsapp-closure.json'
+  'must already be on native Linux storage'
+  'IMMUTABLE_ENGINE/'
+  'CALLER_CONTRACT'
+  'CALLER_COORDINATION'
+  'CALLER_RUNNER'
+  'verify-candidate'
+  'snapshot-candidate'
+  'materialize-candidate'
+  'SNAPSHOT_CANDIDATE'
+  'assert_confined_immutable_engine'
+  'IMMUTABLE_ENGINE'
+  'build-identity'
+  '.skincos-global-coordination-messaging-whatsapp.json'
+  '.skincos-release-identity-messaging-whatsapp.json'
+  '--release-identity-file "$ARTIFACT_IDENTITY_FILE"'
+  '--operation promotion'
+  'attested-predecessor-release'
+  'external authenticated release custody'
+  'source archive digest'
+)
+
+for pattern in "${required[@]}"; do
+  grep -F -- "$pattern" "$PREPARE" >/dev/null || {
+    echo "Missing immutable messaging preparation guard: $pattern" >&2
+    exit 1
+  }
+done
+
+if grep -F -- 'SOURCE_DIR=' "$PREPARE" >/dev/null \
+  || grep -F -- '"$ROOT_DIR/messaging/channels/whatsapp/engine/"' "$PREPARE" >/dev/null \
+  || grep -F -- 'tar -tzf' "$PREPARE" >/dev/null \
+  || grep -F -- 'tar -xzf' "$PREPARE" >/dev/null; then
+  echo 'Messaging preparation must not consume a checkout or worktree as engine source.' >&2
+  exit 1
+fi
+
+if grep -F -- 'node "$IMMUTABLE_CONTRACT"' "$PREPARE" >/dev/null \
+  || grep -F -- '"$IMMUTABLE_COORDINATION"' "$PREPARE" >/dev/null \
+  || grep -F -- '"$IMMUTABLE_RUNNER"' "$PREPARE" >/dev/null; then
+  echo 'Messaging preparation must not execute release-source scripts before external custody is verified.' >&2
+  exit 1
+fi
+
+apply_guard_line="$(grep -n -m1 -F 'if [[ "$APPLY" == 1 ]]' "$PREPARE" | cut -d: -f1)"
+snapshot_line="$(grep -n -m1 -F 'snapshot-candidate' "$PREPARE" | cut -d: -f1)"
+[[ -n "$apply_guard_line" && -n "$snapshot_line" && "$apply_guard_line" -lt "$snapshot_line" ]] || {
+  echo 'Messaging --apply custody gate must deny before opening a release candidate.' >&2
   exit 1
 }
 
-echo 'Messaging WhatsApp native release preparation checks passed'
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# Verify the caller contract against a complete archive of this worktree's
+# immutable HEAD first. This covers Git's legitimate gzip SIGPIPE behavior
+# after `git get-tar-commit-id` reads a large PAX header, without allowing a
+# detached archive to bypass SHA, tree, digest, or closure verification.
+caller_release_sha="$(git -C "$ROOT_DIR" rev-parse HEAD)"
+caller_source_tree="$(git -C "$ROOT_DIR" rev-parse "${caller_release_sha}^{tree}")"
+caller_candidate="$tmp_dir/release-source-$caller_release_sha"
+mkdir -p "$caller_candidate"
+git -C "$ROOT_DIR" archive --format=tar.gz --prefix="skincos-$caller_release_sha/" "$caller_release_sha" >"$caller_candidate/source.tar.gz"
+caller_archive_digest="$(sha256sum "$caller_candidate/source.tar.gz" | awk '{print $1}')"
+printf '%s\n' "$caller_archive_digest" >"$caller_candidate/source.sha256"
+/usr/bin/node - "$caller_candidate/release.json" "$caller_release_sha" "$caller_source_tree" "$caller_archive_digest" <<'NODE'
+const fs = require('fs');
+const [file, sourceSha, sourceTree, sourceArchiveSha256] = process.argv.slice(2);
+fs.writeFileSync(file, JSON.stringify({ schemaVersion: 1, sourceSha, sourceTree, sourceArchiveSha256 }, null, 2) + '\n');
+NODE
+/usr/bin/node "$ROOT_DIR/scripts/codex-global-coordinator.mjs" closure \
+  --module messaging-whatsapp --source "$caller_release_sha" >"$caller_candidate/messaging-whatsapp-closure.json"
+/usr/bin/node "$ROOT_DIR/scripts/codex-release-manifest.mjs" \
+  --source "$caller_release_sha" --base "${caller_release_sha}^" --allow-empty \
+  --artifact "source-archive=$caller_archive_digest" --output "$caller_candidate/release-manifest.json"
+node "$CONTRACT" verify-candidate \
+  --candidate "$caller_candidate" --release-sha "$caller_release_sha" >/dev/null
+
+if apply_output="$(MESSAGING_RELEASE_ID="$caller_release_sha" \
+  bash "$PREPARE" --release-candidate "$tmp_dir/must-not-be-opened" --apply 2>&1)"; then
+  echo 'Messaging --apply unexpectedly bypassed the external custody gate.' >&2
+  exit 1
+fi
+grep -F -- 'external authenticated release custody' <<<"$apply_output" >/dev/null || {
+  echo 'Messaging --apply opened an untrusted candidate before the custody gate.' >&2
+  exit 1
+}
+
+source_repo="$tmp_dir/source"
+mkdir -p "$source_repo"
+git -C "$ROOT_DIR" archive --format=tar HEAD | tar -xf - -C "$source_repo"
+
+# Overlay the in-flight contract under test, then make a native temporary Git
+# source. This lets prepare verify the same immutable contract after extraction
+# without requiring a commit in the caller worktree.
+cp "$ROOT_DIR/scripts/runtime/messaging-whatsapp-release-contract.mjs" \
+  "$source_repo/scripts/runtime/messaging-whatsapp-release-contract.mjs"
+declare -a git_env_unsets=()
+while IFS= read -r environment_entry; do
+  environment_name="${environment_entry%%=*}"
+  if [[ "${environment_name^^}" == GIT_* ]]; then
+    git_env_unsets+=("-u" "$environment_name")
+  fi
+done < <(env)
+git_isolated() {
+  env "${git_env_unsets[@]}" git "$@"
+}
+node_isolated() {
+  env "${git_env_unsets[@]}" /usr/bin/node "$@"
+}
+git_isolated init --quiet "$source_repo"
+git_isolated -C "$source_repo" -c user.email=messaging-contract@example.invalid \
+  -c user.name='Messaging Contract' -c commit.gpgSign=false commit --quiet --allow-empty -m base
+git_isolated -C "$source_repo" add --all
+git_isolated -C "$source_repo" -c user.email=messaging-contract@example.invalid \
+  -c user.name='Messaging Contract' -c commit.gpgSign=false commit --quiet -m candidate
+release_sha="$(git_isolated -C "$source_repo" rev-parse HEAD)"
+source_tree="$(git_isolated -C "$source_repo" rev-parse "${release_sha}^{tree}")"
+candidate="$tmp_dir/release-source-$release_sha"
+mkdir -p "$candidate"
+git_isolated -C "$source_repo" archive --format=tar.gz --prefix="skincos-$release_sha/" "$release_sha" >"$candidate/source.tar.gz"
+archive_digest="$(sha256sum "$candidate/source.tar.gz" | awk '{print $1}')"
+printf '%s\n' "$archive_digest" >"$candidate/source.sha256"
+/usr/bin/node - "$candidate/release.json" "$release_sha" "$source_tree" "$archive_digest" <<'NODE'
+const fs = require('fs');
+const [file, sourceSha, sourceTree, sourceArchiveSha256] = process.argv.slice(2);
+fs.writeFileSync(file, JSON.stringify({ schemaVersion: 1, sourceSha, sourceTree, sourceArchiveSha256 }, null, 2) + '\n');
+NODE
+node_isolated "$source_repo/scripts/codex-global-coordinator.mjs" closure \
+  --module messaging-whatsapp --source "$release_sha" >"$candidate/messaging-whatsapp-closure.json"
+node_isolated "$source_repo/scripts/codex-release-manifest.mjs" \
+  --source "$release_sha" --base "${release_sha}^" --allow-empty \
+  --artifact "source-archive=$archive_digest" --output "$candidate/release-manifest.json"
+output="$(MESSAGING_RELEASE_ID="$release_sha" \
+  MESSAGING_RELEASE_BASE="$tmp_dir/releases" \
+  MESSAGING_CURRENT_LINK="$tmp_dir/current/messaging-whatsapp" \
+  bash "$PREPARE" --release-candidate "$candidate")"
+grep -Fx 'dry_run=true' <<<"$output" >/dev/null
+grep -Fx 'apply_requires=attested-predecessor-release' <<<"$output" >/dev/null
+grep -Fx 'apply_requires=external-authenticated-release-custody-run-artifact-digest' <<<"$output" >/dev/null
+
+# A self-consistent candidate can put arbitrary JavaScript at its own release
+# entrypoint. Dry-run must parse and reconstruct that source as data only; it
+# may never run candidate-controlled contract/coordination/runner code before
+# externally authenticated custody exists.
+malicious_marker="$tmp_dir/candidate-contract-executed"
+/usr/bin/node - "$source_repo/scripts/runtime/messaging-whatsapp-release-contract.mjs" "$malicious_marker" <<'NODE'
+const fs = require('fs');
+const [file, marker] = process.argv.slice(2);
+fs.writeFileSync(file, `import { writeFileSync } from "node:fs";\nwriteFileSync(${JSON.stringify(marker)}, "executed");\nthrow new Error("candidate contract must not execute");\n`);
+NODE
+git_isolated -C "$source_repo" add --all
+git_isolated -C "$source_repo" -c user.email=messaging-contract@example.invalid \
+  -c user.name='Messaging Contract' -c commit.gpgSign=false commit --quiet -m malicious-candidate-contract
+malicious_release_sha="$(git_isolated -C "$source_repo" rev-parse HEAD)"
+malicious_source_tree="$(git_isolated -C "$source_repo" rev-parse "${malicious_release_sha}^{tree}")"
+malicious_candidate="$tmp_dir/release-source-$malicious_release_sha"
+mkdir -p "$malicious_candidate"
+git_isolated -C "$source_repo" archive --format=tar.gz --prefix="skincos-$malicious_release_sha/" "$malicious_release_sha" >"$malicious_candidate/source.tar.gz"
+malicious_archive_digest="$(sha256sum "$malicious_candidate/source.tar.gz" | awk '{print $1}')"
+printf '%s\n' "$malicious_archive_digest" >"$malicious_candidate/source.sha256"
+/usr/bin/node - "$malicious_candidate/release.json" "$malicious_release_sha" "$malicious_source_tree" "$malicious_archive_digest" <<'NODE'
+const fs = require('fs');
+const [file, sourceSha, sourceTree, sourceArchiveSha256] = process.argv.slice(2);
+fs.writeFileSync(file, JSON.stringify({ schemaVersion: 1, sourceSha, sourceTree, sourceArchiveSha256 }, null, 2) + '\n');
+NODE
+node_isolated "$source_repo/scripts/codex-global-coordinator.mjs" closure \
+  --module messaging-whatsapp --source "$malicious_release_sha" >"$malicious_candidate/messaging-whatsapp-closure.json"
+node_isolated "$source_repo/scripts/codex-release-manifest.mjs" \
+  --source "$malicious_release_sha" --base "${malicious_release_sha}^" --allow-empty \
+  --artifact "source-archive=$malicious_archive_digest" --output "$malicious_candidate/release-manifest.json"
+malicious_output="$(MESSAGING_RELEASE_ID="$malicious_release_sha" \
+  MESSAGING_RELEASE_BASE="$tmp_dir/malicious-releases" \
+  MESSAGING_CURRENT_LINK="$tmp_dir/malicious-current/messaging-whatsapp" \
+  bash "$PREPARE" --release-candidate "$malicious_candidate")"
+grep -Fx 'dry_run=true' <<<"$malicious_output" >/dev/null
+[[ ! -e "$malicious_marker" ]] || {
+  echo 'Candidate-controlled contract executed before custody verification.' >&2
+  exit 1
+}
+
+echo 'Messaging WhatsApp immutable release preparation checks passed'

--- a/scripts/runtime/test-prepare-messaging-whatsapp-release.sh
+++ b/scripts/runtime/test-prepare-messaging-whatsapp-release.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 PREPARE="$ROOT_DIR/scripts/runtime/prepare-messaging-whatsapp-release.sh"
 CONTRACT="$ROOT_DIR/scripts/runtime/messaging-whatsapp-release-contract.mjs"
+NODE_BIN="$(command -v node)"
+
+[[ -x "$NODE_BIN" ]] || { echo 'Node runtime is unavailable to the messaging release test.' >&2; exit 1; }
 CANDIDATE_WORKFLOW="$ROOT_DIR/.github/workflows/prepare-release-candidate.yml"
 CONTRACT_WORKFLOW="$ROOT_DIR/.github/workflows/messaging-whatsapp-release-contract.yml"
 
@@ -106,14 +109,14 @@ mkdir -p "$caller_candidate"
 git -C "$ROOT_DIR" archive --format=tar.gz --prefix="skincos-$caller_release_sha/" "$caller_release_sha" >"$caller_candidate/source.tar.gz"
 caller_archive_digest="$(sha256sum "$caller_candidate/source.tar.gz" | awk '{print $1}')"
 printf '%s\n' "$caller_archive_digest" >"$caller_candidate/source.sha256"
-/usr/bin/node - "$caller_candidate/release.json" "$caller_release_sha" "$caller_source_tree" "$caller_archive_digest" <<'NODE'
+"$NODE_BIN" - "$caller_candidate/release.json" "$caller_release_sha" "$caller_source_tree" "$caller_archive_digest" <<'NODE'
 const fs = require('fs');
 const [file, sourceSha, sourceTree, sourceArchiveSha256] = process.argv.slice(2);
 fs.writeFileSync(file, JSON.stringify({ schemaVersion: 1, sourceSha, sourceTree, sourceArchiveSha256 }, null, 2) + '\n');
 NODE
-/usr/bin/node "$ROOT_DIR/scripts/codex-global-coordinator.mjs" closure \
+"$NODE_BIN" "$ROOT_DIR/scripts/codex-global-coordinator.mjs" closure \
   --module messaging-whatsapp --source "$caller_release_sha" >"$caller_candidate/messaging-whatsapp-closure.json"
-/usr/bin/node "$ROOT_DIR/scripts/codex-release-manifest.mjs" \
+"$NODE_BIN" "$ROOT_DIR/scripts/codex-release-manifest.mjs" \
   --source "$caller_release_sha" --base "${caller_release_sha}^" --allow-empty \
   --artifact "source-archive=$caller_archive_digest" --output "$caller_candidate/release-manifest.json"
 node "$CONTRACT" verify-candidate \
@@ -149,7 +152,7 @@ git_isolated() {
   env "${git_env_unsets[@]}" git "$@"
 }
 node_isolated() {
-  env "${git_env_unsets[@]}" /usr/bin/node "$@"
+  env "${git_env_unsets[@]}" "$NODE_BIN" "$@"
 }
 git_isolated init --quiet "$source_repo"
 git_isolated -C "$source_repo" -c user.email=messaging-contract@example.invalid \
@@ -164,7 +167,7 @@ mkdir -p "$candidate"
 git_isolated -C "$source_repo" archive --format=tar.gz --prefix="skincos-$release_sha/" "$release_sha" >"$candidate/source.tar.gz"
 archive_digest="$(sha256sum "$candidate/source.tar.gz" | awk '{print $1}')"
 printf '%s\n' "$archive_digest" >"$candidate/source.sha256"
-/usr/bin/node - "$candidate/release.json" "$release_sha" "$source_tree" "$archive_digest" <<'NODE'
+"$NODE_BIN" - "$candidate/release.json" "$release_sha" "$source_tree" "$archive_digest" <<'NODE'
 const fs = require('fs');
 const [file, sourceSha, sourceTree, sourceArchiveSha256] = process.argv.slice(2);
 fs.writeFileSync(file, JSON.stringify({ schemaVersion: 1, sourceSha, sourceTree, sourceArchiveSha256 }, null, 2) + '\n');
@@ -187,7 +190,7 @@ grep -Fx 'apply_requires=external-authenticated-release-custody-run-artifact-dig
 # may never run candidate-controlled contract/coordination/runner code before
 # externally authenticated custody exists.
 malicious_marker="$tmp_dir/candidate-contract-executed"
-/usr/bin/node - "$source_repo/scripts/runtime/messaging-whatsapp-release-contract.mjs" "$malicious_marker" <<'NODE'
+"$NODE_BIN" - "$source_repo/scripts/runtime/messaging-whatsapp-release-contract.mjs" "$malicious_marker" <<'NODE'
 const fs = require('fs');
 const [file, marker] = process.argv.slice(2);
 fs.writeFileSync(file, `import { writeFileSync } from "node:fs";\nwriteFileSync(${JSON.stringify(marker)}, "executed");\nthrow new Error("candidate contract must not execute");\n`);
@@ -202,7 +205,7 @@ mkdir -p "$malicious_candidate"
 git_isolated -C "$source_repo" archive --format=tar.gz --prefix="skincos-$malicious_release_sha/" "$malicious_release_sha" >"$malicious_candidate/source.tar.gz"
 malicious_archive_digest="$(sha256sum "$malicious_candidate/source.tar.gz" | awk '{print $1}')"
 printf '%s\n' "$malicious_archive_digest" >"$malicious_candidate/source.sha256"
-/usr/bin/node - "$malicious_candidate/release.json" "$malicious_release_sha" "$malicious_source_tree" "$malicious_archive_digest" <<'NODE'
+"$NODE_BIN" - "$malicious_candidate/release.json" "$malicious_release_sha" "$malicious_source_tree" "$malicious_archive_digest" <<'NODE'
 const fs = require('fs');
 const [file, sourceSha, sourceTree, sourceArchiveSha256] = process.argv.slice(2);
 fs.writeFileSync(file, JSON.stringify({ schemaVersion: 1, sourceSha, sourceTree, sourceArchiveSha256 }, null, 2) + '\n');

--- a/scripts/runtime/test-rollback-messaging-whatsapp-release.sh
+++ b/scripts/runtime/test-rollback-messaging-whatsapp-release.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+ROLLBACK="$ROOT_DIR/scripts/runtime/rollback-messaging-whatsapp-release.sh"
+
+bash -n "$ROLLBACK"
+
+required=(
+  '--predecessor-release'
+  '--predecessor-candidate'
+  'verify-rollback-pair'
+  'release-source-<SHA>'
+  'snapshot-candidate'
+  'materialize-candidate'
+  'SNAPSHOT_CANDIDATE'
+  'assert_confined_immutable_engine'
+  'IMMUTABLE_ENGINE'
+  'external authenticated release custody'
+  'source archive digest'
+  '--release-identity-file "$PREDECESSOR_ROOT/.skincos-release-identity-messaging-whatsapp.json"'
+  '--operation promotion'
+  'systemctl restart messaging-whatsapp.service'
+  'systemctl --quiet is-active messaging-whatsapp.service'
+  'http://127.0.0.1:8080/health'
+  'restore_current_release'
+  'the prior release was restored and revalidated.'
+)
+
+for pattern in "${required[@]}"; do
+  grep -F -- "$pattern" "$ROLLBACK" >/dev/null || {
+    echo "Missing immutable messaging rollback guard: $pattern" >&2
+    exit 1
+  }
+done
+
+if grep -F -- 'tar -tzf' "$ROLLBACK" >/dev/null \
+  || grep -F -- 'tar -xzf' "$ROLLBACK" >/dev/null; then
+  echo 'Messaging rollback must materialize the private candidate through the contract, not tar.' >&2
+  exit 1
+fi
+
+if grep -F -- 'node "$IMMUTABLE_CONTRACT"' "$ROLLBACK" >/dev/null \
+  || grep -F -- '"$IMMUTABLE_COORDINATION"' "$ROLLBACK" >/dev/null; then
+  echo 'Messaging rollback must not execute release-source scripts before external custody is verified.' >&2
+  exit 1
+fi
+
+apply_guard_line="$(grep -n -m1 -F 'if [[ "$APPLY" == 1 ]]' "$ROLLBACK" | cut -d: -f1)"
+snapshot_line="$(grep -n -m1 -F 'snapshot-candidate' "$ROLLBACK" | cut -d: -f1)"
+[[ -n "$apply_guard_line" && -n "$snapshot_line" && "$apply_guard_line" -lt "$snapshot_line" ]] || {
+  echo 'Messaging rollback --apply custody gate must deny before opening a predecessor candidate.' >&2
+  exit 1
+}
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+test_sha='0123456789abcdef0123456789abcdef01234567'
+if apply_output="$(bash "$ROLLBACK" --predecessor-release "$test_sha" --predecessor-candidate "$tmp_dir/must-not-be-opened" --apply 2>&1)"; then
+  echo 'Messaging rollback --apply unexpectedly bypassed the external custody gate.' >&2
+  exit 1
+fi
+grep -F -- 'external authenticated release custody' <<<"$apply_output" >/dev/null || {
+  echo 'Messaging rollback --apply opened an untrusted predecessor before the custody gate.' >&2
+  exit 1
+}
+
+restore_current_release_body="$(sed -n '/^restore_current_release()/,/^}/p' "$ROLLBACK")"
+for pattern in \
+  'systemctl --quiet is-active messaging-whatsapp.service' \
+  'http://127.0.0.1:8080/health' \
+  'could not confirm the prior release health'; do
+  grep -F -- "$pattern" <<<"$restore_current_release_body" >/dev/null || {
+    echo "Rollback compensation must revalidate the restored prior release: $pattern" >&2
+    exit 1
+  }
+done
+
+echo 'Messaging WhatsApp immutable rollback checks passed'

--- a/scripts/runtime/test-run-messaging-whatsapp-release.sh
+++ b/scripts/runtime/test-run-messaging-whatsapp-release.sh
@@ -3,14 +3,17 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 LAUNCHER="$ROOT_DIR/scripts/runtime/run-messaging-whatsapp-release.sh"
+HOST_NODE_BIN="$(command -v node)"
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
+
+[[ -x "$HOST_NODE_BIN" ]] || { echo 'Node runtime is unavailable to the messaging launcher test.' >&2; exit 1; }
 
 mkdir -p "$tmp_dir/release/node_modules" "$tmp_dir/release/dist" "$tmp_dir/bin"
 printf 'process.exit(0);\n' >"$tmp_dir/release/dist/main.js"
 printf 'PRIVATE_TEST_VALUE=loaded\n' >"$tmp_dir/runtime.env"
 
-/usr/bin/node - "$tmp_dir/release" <<'NODE'
+"$HOST_NODE_BIN" - "$tmp_dir/release" <<'NODE'
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
@@ -46,7 +49,7 @@ fs.writeFileSync(path.join(root, '.skincos-release-identity-messaging-whatsapp.j
 NODE
 
 printf '%s\n' '#!/usr/bin/env bash' \
-  'if [[ "$1" == "-" ]]; then exec /usr/bin/node "$@"; fi' \
+  "if [[ \"\$1\" == \"-\" ]]; then exec \"$HOST_NODE_BIN\" \"\$@\"; fi" \
   'test "$PRIVATE_TEST_VALUE" = loaded' \
   'test "$1" = dist/main.js' >"$tmp_dir/bin/node"
 chmod +x "$tmp_dir/bin/node"

--- a/scripts/runtime/test-run-messaging-whatsapp-release.sh
+++ b/scripts/runtime/test-run-messaging-whatsapp-release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 LAUNCHER="$ROOT_DIR/scripts/runtime/run-messaging-whatsapp-release.sh"
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
@@ -9,15 +9,54 @@ trap 'rm -rf "$tmp_dir"' EXIT
 mkdir -p "$tmp_dir/release/node_modules" "$tmp_dir/release/dist" "$tmp_dir/bin"
 printf 'process.exit(0);\n' >"$tmp_dir/release/dist/main.js"
 printf 'PRIVATE_TEST_VALUE=loaded\n' >"$tmp_dir/runtime.env"
-printf '%s\n' '#!/usr/bin/env bash' 'test "$PRIVATE_TEST_VALUE" = loaded' 'test "$1" = dist/main.js' >"$tmp_dir/bin/node"
+
+/usr/bin/node - "$tmp_dir/release" <<'NODE'
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const root = process.argv[2];
+const canonicalJson = (value) => Array.isArray(value)
+  ? '[' + value.map(canonicalJson).join(',') + ']'
+  : value && typeof value === 'object'
+    ? '{' + Object.keys(value).sort().map((key) => JSON.stringify(key) + ':' + canonicalJson(value[key])).join(',') + '}'
+    : JSON.stringify(value);
+const digestFile = (file) => crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+const sourceCommit = 'a'.repeat(40);
+const identity = {
+  schemaVersion: 2,
+  module: 'messaging-whatsapp',
+  sourceCommit,
+  sourceTree: 'b'.repeat(40),
+  sourceArchiveSha256: 'c'.repeat(64),
+  releaseManifestSha256: 'd'.repeat(64),
+  dependencyClosureDigest: 'e'.repeat(64),
+  artifacts: [
+    { name: 'release-source-archive', id: 'release-source:' + sourceCommit, digest: 'c'.repeat(64) },
+    { name: 'whatsapp-dist-main', id: 'whatsapp-dist:' + sourceCommit, digest: digestFile(path.join(root, 'dist', 'main.js')) },
+  ],
+  predecessor: {
+    sourceCommit: 'f'.repeat(40),
+    sourceTree: '0'.repeat(40),
+    identityDigest: '1'.repeat(64),
+    artifactDigest: '2'.repeat(64),
+  },
+};
+identity.identityDigest = crypto.createHash('sha256').update(canonicalJson(identity)).digest('hex');
+fs.writeFileSync(path.join(root, '.skincos-release-identity-messaging-whatsapp.json'), JSON.stringify(identity, null, 2) + '\n');
+NODE
+
+printf '%s\n' '#!/usr/bin/env bash' \
+  'if [[ "$1" == "-" ]]; then exec /usr/bin/node "$@"; fi' \
+  'test "$PRIVATE_TEST_VALUE" = loaded' \
+  'test "$1" = dist/main.js' >"$tmp_dir/bin/node"
 chmod +x "$tmp_dir/bin/node"
 
 MESSAGING_RELEASE_ROOT="$tmp_dir/release" EVOLUTION_API_ENV_FILE="$tmp_dir/runtime.env" NODE_BIN="$tmp_dir/bin/node" \
   "$LAUNCHER"
 
-rm -f "$tmp_dir/release/dist/main.js"
+printf 'tampered\n' >"$tmp_dir/release/dist/main.js"
 if MESSAGING_RELEASE_ROOT="$tmp_dir/release" EVOLUTION_API_ENV_FILE="$tmp_dir/runtime.env" NODE_BIN="$tmp_dir/bin/node" "$LAUNCHER"; then
-  echo 'Launcher must fail closed without the built artifact.' >&2
+  echo 'Launcher must fail closed when the built artifact differs from its immutable identity.' >&2
   exit 1
 fi
 

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -536,7 +536,10 @@ test("native mini-PC mutations use the common coordinator and detached closure p
 
   const whatsapp = read("scripts/runtime/prepare-messaging-whatsapp-release.sh");
   assert.match(whatsapp, /--resource release:messaging-whatsapp/);
-  assert.match(whatsapp, /--coordination-closure/);
+  assert.match(whatsapp, /--release-candidate/);
+  assert.match(whatsapp, /messaging-whatsapp-closure\.json/);
+  assert.ok(JSON.parse(read("ops/governance/global-concurrency-policy.json")).releaseClosures["messaging-whatsapp"]);
+  assert.match(read("scripts/runtime/rollback-messaging-whatsapp-release.sh"), /verify-rollback-pair/);
 
   const dns = read("scripts/runtime/route-atendimento-production-dns.sh");
   assert.match(dns, /--resource cloudflare:atendimento:production/);


### PR DESCRIPTION
## Objetivo
Prepara a fronteira de release imutável do serviço WhatsApp como pré-requisito para sua extração operacional, sem ativar ou mover o serviço.

## Mudanças
- candidato é capturado em snapshot Linux privado e validado por SHA, árvore Git, arquivo e closure;
- parser TAR/PAX confinado rejeita links rígidos, especiais, pivôs e caminhos inseguros;
- árvore Git é reconstruída sem `git add` nem filtros controlados pelo candidato;
- runner valida a identidade e o digest do artefato antes da execução;
- preparação e rollback usam apenas helpers confiáveis do checkout.

## Limite deliberado
`--apply` falha fechado antes de abrir o candidato até existir custody externa autenticada que vincule run do GitHub, identidade do artefato e digest do arquivo. Esta PR não faz deploy, não reinicia serviço, não altera segredos nem dados reais.

## Validação
- `node --test scripts/runtime/messaging-whatsapp-release-contract.test.mjs` (20/20)
- `bash scripts/runtime/test-prepare-messaging-whatsapp-release.sh`
- `bash scripts/runtime/test-run-messaging-whatsapp-release.sh`
- `bash scripts/runtime/test-rollback-messaging-whatsapp-release.sh`
- `node --test scripts/tests/global-concurrency-governance-static.test.mjs` (18/18)
- validadores de domain boundaries e dependency closures