### PR TITLE
fix(schedule): define public-read adapter release closure

### DIFF
--- a/.github/scripts/validate-dependency-closures.test.mjs
+++ b/.github/scripts/validate-dependency-closures.test.mjs
@@ -125,3 +125,10 @@ test("promotion source-ref validation remains in every shared release closure", 
   const policy = JSON.parse(readFileSync(new URL("../../ops/governance/global-concurrency-policy.json", import.meta.url), "utf8"));
   assert.ok(policy.sharedInputs.includes(".github/scripts/validate-promotion-source-ref.mjs"));
 });
+
+test("Schedule public-read adapter closure contains every locally observable release dependency", () => {
+  const result = validateDependencyClosures({ modules: ["schedule-public-read-adapter"] });
+  assert.deepEqual(result.errors, []);
+  assert.deepEqual(result.reports.map((entry) => entry.module), ["schedule-public-read-adapter"]);
+  assert.match(result.reports[0].dependencyClosureDigest, /^[0-9a-f]{64}$/);
+});

--- a/ops/governance/global-concurrency-policy.json
+++ b/ops/governance/global-concurrency-policy.json
@@ -136,6 +136,24 @@
       "patterns": ["workforce/schedule/**", "inventory/**", ".github/workflows/deploy-escala-api.yml", ".github/workflows/cloudflare-pages-sync-escala.yml", ".github/scripts/promotion-*.mjs"],
       "sharedInputs": true
     },
+    "schedule-public-read-adapter": {
+      "patterns": [
+        "workforce/schedule/public-read-*.js",
+        "workforce/schedule/public-read.wrangler.toml",
+        "workforce/schedule/scripts/public-read-*.mjs",
+        "workforce/schedule/worker.js",
+        "workforce/schedule/wrangler.toml",
+        "workforce/schedule/package.json",
+        "platform/deploy/operational-units.json",
+        ".github/governance/cloudflare-single-writer-policy.json",
+        ".github/workflows/deploy-schedule-public-read-adapter.yml",
+        ".github/actions/global-coordination-acquire/**",
+        ".github/actions/global-coordination-check/**",
+        ".github/actions/global-coordination-release/**",
+        ".github/scripts/promotion-*.mjs"
+      ],
+      "sharedInputs": true
+    },
     "meta-ads-report": {
       "patterns": ["ads/meta/apps/report-ingest-worker/**", ".github/workflows/deploy-meta-ads-report-worker.yml", ".github/workflows/cloudflare-pages-sync-meta-ads-report-secret.yml", ".github/scripts/promotion-*.mjs"],
       "sharedInputs": true

--- a/scripts/tests/codex-global-coordination.test.mjs
+++ b/scripts/tests/codex-global-coordination.test.mjs
@@ -479,6 +479,49 @@ test("the policy and current Ponto source produce a deterministic dependency clo
   assert.ok(closure.inputs.some((entry) => entry.path === "package.json"));
 });
 
+test("Schedule public-read adapter uses an explicit immutable release closure", () => {
+  const policy = loadGlobalPolicy();
+  const configured = policy.releaseClosures["schedule-public-read-adapter"];
+  assert.ok(configured, "Schedule public-read adapter must not fall back to the default closure");
+  assert.equal(configured.sharedInputs, true);
+  for (const pattern of [
+    "workforce/schedule/public-read-*.js",
+    "workforce/schedule/public-read.wrangler.toml",
+    "workforce/schedule/scripts/public-read-*.mjs",
+    "workforce/schedule/worker.js",
+    "workforce/schedule/wrangler.toml",
+    ".github/workflows/deploy-schedule-public-read-adapter.yml",
+    ".github/actions/global-coordination-acquire/**",
+    ".github/actions/global-coordination-check/**",
+    ".github/actions/global-coordination-release/**",
+    ".github/scripts/promotion-*.mjs",
+  ]) {
+    assert.ok(configured.patterns.includes(pattern), `missing immutable Schedule adapter release input pattern: ${pattern}`);
+  }
+
+  const closure = dependencyClosureForSource({ module: "schedule-public-read-adapter", sourceCommit: "HEAD" });
+  assert.match(closure.digest, /^[0-9a-f]{64}$/);
+  for (const input of [
+    "workforce/schedule/public-read-worker.js",
+    "workforce/schedule/public-read-adapter-runtime.js",
+    "workforce/schedule/public-read-contract.js",
+    "workforce/schedule/public-read-nonce-guard.js",
+    "workforce/schedule/public-read-nonce-state.js",
+    "workforce/schedule/public-read-test-support.js",
+    "workforce/schedule/worker.js",
+    "workforce/schedule/public-read.wrangler.toml",
+    "workforce/schedule/wrangler.toml",
+    "workforce/schedule/scripts/public-read-bootstrap-evidence.mjs",
+    ".github/workflows/deploy-schedule-public-read-adapter.yml",
+    ".github/actions/global-coordination-acquire/action.yml",
+    ".github/actions/global-coordination-check/action.yml",
+    ".github/actions/global-coordination-release/action.yml",
+    ".github/scripts/promotion-evidence.mjs",
+  ]) {
+    assert.ok(closure.inputs.some((entry) => entry.path === input), `missing immutable Schedule adapter release input: ${input}`);
+  }
+});
+
 test("Ponto closure excludes independent CRM API changes while retaining the shared Pages artifact", () => {
   const closure = dependencyClosureFromTree({
     module: "ponto",


### PR DESCRIPTION
## Contexto

O bootstrap de staging do adaptador público de escala falhou antes de qualquer mutação porque a política de coordenação não definia uma dependency closure para `schedule-public-read-adapter`.

## Alteração

- declara uma closure explícita e versionada para o Worker, configuração, fluxo de release, coordenação e evidência;
- cobre a closure com testes de dependências observáveis e integridade;
- preserva o comportamento fail-closed: não há bypass, override manual ou redução de escopo.

## Validação

- `node .github/scripts/validate-dependency-closures.mjs`
- `node --test .github/scripts/validate-dependency-closures.test.mjs scripts/tests/codex-global-coordination.test.mjs`
- `git diff --check origin/main...HEAD`

Sem deploy, segredo, flag de ativação, recurso Cloudflare ou mudança em Website/Booking.