### PR TITLE
fix(schedule): retry disabled smoke convergence

### DIFF
--- a/.github/workflows/deploy-schedule-public-read-adapter.yml
+++ b/.github/workflows/deploy-schedule-public-read-adapter.yml
@@ -81,7 +81,7 @@ jobs:
           grep -q 'workers_dev = true' workforce/schedule/public-read.wrangler.toml || { echo 'isolated staging workers.dev surface is missing'; exit 1; }
 
       - name: Run isolated adapter contract tests
-        run: node --test workforce/schedule/public-read-contract.test.js workforce/schedule/public-read-core.test.js workforce/schedule/public-read-core-opt-in-evidence.test.js workforce/schedule/public-read-bootstrap-evidence.test.js workforce/schedule/public-read-nonce-guard.test.js workforce/schedule/public-read-worker.test.js workforce/schedule/public-read-staging-workflow.test.js
+        run: node --test workforce/schedule/public-read-contract.test.js workforce/schedule/public-read-core.test.js workforce/schedule/public-read-core-opt-in-evidence.test.js workforce/schedule/public-read-bootstrap-evidence.test.js workforce/schedule/public-read-disabled-health.test.js workforce/schedule/public-read-nonce-guard.test.js workforce/schedule/public-read-worker.test.js workforce/schedule/public-read-staging-workflow.test.js
 
       - name: Validate staging adapter configuration without a remote mutation
         run: npx --yes wrangler@4.120.0 deploy --dry-run --config workforce/schedule/public-read.wrangler.toml --env staging --outdir "$RUNNER_TEMP/schedule-public-read-adapter-preview"
@@ -134,7 +134,7 @@ jobs:
           grep -q 'service = "skincos-escala-api-staging"' workforce/schedule/public-read.wrangler.toml || { echo 'adapter must bind only the isolated staging Schedule core'; exit 1; }
 
       - name: Run isolated adapter contract tests
-        run: node --test workforce/schedule/public-read-contract.test.js workforce/schedule/public-read-core.test.js workforce/schedule/public-read-core-opt-in-evidence.test.js workforce/schedule/public-read-bootstrap-evidence.test.js workforce/schedule/public-read-nonce-guard.test.js workforce/schedule/public-read-worker.test.js workforce/schedule/public-read-staging-workflow.test.js
+        run: node --test workforce/schedule/public-read-contract.test.js workforce/schedule/public-read-core.test.js workforce/schedule/public-read-core-opt-in-evidence.test.js workforce/schedule/public-read-bootstrap-evidence.test.js workforce/schedule/public-read-disabled-health.test.js workforce/schedule/public-read-nonce-guard.test.js workforce/schedule/public-read-worker.test.js workforce/schedule/public-read-staging-workflow.test.js
 
       - name: Verify exact Escala staging predecessor for candidate enablement
         if: ${{ inputs.operation == 'deploy' }}

--- a/workforce/schedule/public-read-disabled-health.test.js
+++ b/workforce/schedule/public-read-disabled-health.test.js
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { waitForDisabledSchedulePublicReadHealth } from './scripts/public-read-disabled-health.mjs'
+
+function health(status, body = undefined) {
+  return {
+    status,
+    json: async () => body,
+  }
+}
+
+test('disabled staging health retries 404 and transient network delay until the disabled contract converges', async () => {
+  let now = 0
+  const requestTimeouts = []
+  const sleeps = []
+  const transientTimeout = Object.assign(new Error('request timed out'), { name: 'TimeoutError' })
+  const outcomes = [health(404), transientTimeout, health(503, {
+    ok: false,
+    error: 'SCHEDULE_PUBLIC_READ_UNAVAILABLE',
+  })]
+
+  const response = await waitForDisabledSchedulePublicReadHealth({
+    request: async ({ timeoutMs }) => {
+      requestTimeouts.push(timeoutMs)
+      const outcome = outcomes.shift()
+      if (outcome instanceof Error) throw outcome
+      return outcome
+    },
+    now: () => now,
+    sleep: async (milliseconds) => {
+      sleeps.push(milliseconds)
+      now += milliseconds
+    },
+    maxWaitMs: 5_000,
+    retryDelayMs: 1_000,
+  })
+
+  assert.equal(response.status, 503)
+  assert.deepEqual(requestTimeouts, [5_000, 4_000, 3_000])
+  assert.deepEqual(sleeps, [1_000, 1_000])
+})
+
+test('disabled staging health times out after the bounded transient 404 window', async () => {
+  let now = 0
+  let attempts = 0
+  const sleeps = []
+
+  await assert.rejects(
+    () => waitForDisabledSchedulePublicReadHealth({
+      request: async () => {
+        attempts += 1
+        return health(404)
+      },
+      now: () => now,
+      sleep: async (milliseconds) => {
+        sleeps.push(milliseconds)
+        now += milliseconds
+      },
+      maxWaitMs: 2_500,
+      retryDelayMs: 1_000,
+    }),
+    /did not converge to 503 within 2500ms after 3 attempts \(last transient: HTTP 404\)/,
+  )
+
+  assert.equal(attempts, 3)
+  assert.deepEqual(sleeps, [1_000, 1_000, 500])
+})
+
+test('disabled staging health fails closed without retrying a wrong response', async () => {
+  let attempts = 0
+  let sleeps = 0
+
+  await assert.rejects(
+    () => waitForDisabledSchedulePublicReadHealth({
+      request: async () => {
+        attempts += 1
+        return health(200, { ok: true })
+      },
+      sleep: async () => {
+        sleeps += 1
+      },
+      maxWaitMs: 5_000,
+      retryDelayMs: 1_000,
+    }),
+    /returned HTTP 200; expected 503/,
+  )
+
+  assert.equal(attempts, 1)
+  assert.equal(sleeps, 0)
+})
+
+test('disabled staging health fails closed when a 503 does not satisfy the disabled contract', async () => {
+  let attempts = 0
+  let sleeps = 0
+
+  await assert.rejects(
+    () => waitForDisabledSchedulePublicReadHealth({
+      request: async () => {
+        attempts += 1
+        return health(503, { ok: true })
+      },
+      sleep: async () => {
+        sleeps += 1
+      },
+      maxWaitMs: 5_000,
+      retryDelayMs: 1_000,
+    }),
+    /must return ok=false/,
+  )
+
+  assert.equal(attempts, 1)
+  assert.equal(sleeps, 0)
+})

--- a/workforce/schedule/public-read-staging-workflow.test.js
+++ b/workforce/schedule/public-read-staging-workflow.test.js
@@ -7,6 +7,7 @@ const coreWorkflow = readFileSync(new URL('../../.github/workflows/deploy-escala
 const adapterConfig = readFileSync(new URL('./public-read.wrangler.toml', import.meta.url), 'utf8')
 const coreConfig = readFileSync(new URL('./wrangler.toml', import.meta.url), 'utf8')
 const smoke = readFileSync(new URL('./scripts/public-read-staging-smoke.mjs', import.meta.url), 'utf8')
+const disabledHealth = readFileSync(new URL('./scripts/public-read-disabled-health.mjs', import.meta.url), 'utf8')
 const coreSmoke = readFileSync(new URL('./scripts/public-read-core-staging-smoke.mjs', import.meta.url), 'utf8')
 const units = JSON.parse(readFileSync(new URL('../../platform/deploy/operational-units.json', import.meta.url), 'utf8'))
 const singleWriter = JSON.parse(readFileSync(new URL('../../.github/governance/cloudflare-single-writer-policy.json', import.meta.url), 'utf8'))
@@ -171,12 +172,16 @@ test('Schedule public-read defaults disabled and only the canonical core publish
 
 test('Schedule public-read staging smoke is synthetic, authenticated, and does not handle the core key', () => {
   assert.match(smoke, /allowedOrigin = 'https:\/\/skincos-schedule-public-read-staging\.skincos\.workers\.dev'/)
+  assert.match(smoke, /waitForDisabledSchedulePublicReadHealth/)
   assert.match(smoke, /SCHEDULE_PUBLIC_READ_EDGE_HMAC_KEY/)
   assert.doesNotMatch(smoke, /SCHEDULE_PUBLIC_READ_CORE_HMAC_KEY/)
   assert.match(smoke, /SCHEDULE_PUBLIC_READ_REPLAYED/)
   assert.match(smoke, /SCHEDULE_PUBLIC_READ_UNAUTHORIZED/)
-  assert.match(smoke, /SCHEDULE_PUBLIC_READ_UNAVAILABLE/)
+  assert.match(disabledHealth, /SCHEDULE_PUBLIC_READ_UNAVAILABLE/)
   assert.doesNotMatch(smoke, /console\.log\([^\n]*(?:EDGE_HMAC|CORE_HMAC|edgeKey)/)
+  assert.match(disabledHealth, /DISABLED_STAGING_SMOKE_MAX_WAIT_MS = 30_000/)
+  assert.match(disabledHealth, /response\?\.status !== 404/)
+  assert.doesNotMatch(disabledHealth, /SCHEDULE_PUBLIC_READ_SMOKE_RETRY/)
 })
 
 test('Schedule public-read core staging smoke uses only the core capability and proves disabled rollback', () => {

--- a/workforce/schedule/scripts/public-read-disabled-health.mjs
+++ b/workforce/schedule/scripts/public-read-disabled-health.mjs
@@ -1,0 +1,124 @@
+export const DISABLED_STAGING_SMOKE_MAX_WAIT_MS = 30_000
+export const DISABLED_STAGING_SMOKE_RETRY_DELAY_MS = 1_000
+export const DISABLED_STAGING_SMOKE_REQUEST_TIMEOUT_MS = 15_000
+
+const transientNetworkCodes = new Set([
+  'ECONNABORTED',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EAI_AGAIN',
+  'ENETDOWN',
+  'ENETUNREACH',
+  'ENOTFOUND',
+  'ETIMEDOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+])
+
+function requirePositiveInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${label} must be a positive integer`)
+  }
+}
+
+function transientNetworkCode(error) {
+  let current = error
+  for (let depth = 0; current && depth < 3; depth += 1) {
+    const code = String(current.code || '')
+    if (transientNetworkCodes.has(code)) return code
+    current = current.cause
+  }
+  return null
+}
+
+export function isTransientDisabledHealthError(error) {
+  const name = String(error?.name || '')
+  if (name === 'AbortError' || name === 'TimeoutError') return true
+  if (transientNetworkCode(error)) return true
+  return name === 'TypeError'
+    && /(?:fetch failed|network(?:\s+error)?|socket|connection (?:reset|refused)|request timed out|timed out)/i.test(String(error?.message || ''))
+}
+
+function describeTransientError(error) {
+  const code = transientNetworkCode(error)
+  if (code) return `network ${code}`
+  const name = String(error?.name || '')
+  return name === 'AbortError' || name === 'TimeoutError' ? name : 'network error'
+}
+
+function convergenceError({ attempts, lastTransient, maxWaitMs }) {
+  return new Error(
+    `disabled Schedule public-read health did not converge to 503 within ${maxWaitMs}ms after ${attempts} attempts (last transient: ${lastTransient})`,
+  )
+}
+
+export async function assertDisabledSchedulePublicReadHealth(response) {
+  if (response?.status !== 503) {
+    throw new Error(`disabled Schedule public-read health returned HTTP ${response?.status ?? 'unknown'}; expected 503`)
+  }
+
+  const body = await response.json().catch(() => null)
+  if (!body || typeof body !== 'object') {
+    throw new Error('disabled Schedule public-read health must return JSON')
+  }
+  if (body.ok !== false) {
+    throw new Error('disabled Schedule public-read health must return ok=false')
+  }
+  if (body.error !== 'SCHEDULE_PUBLIC_READ_UNAVAILABLE') {
+    throw new Error('disabled Schedule public-read health returned an unexpected error code')
+  }
+  return response
+}
+
+export async function waitForDisabledSchedulePublicReadHealth({
+  request,
+  now = () => Date.now(),
+  sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  maxWaitMs = DISABLED_STAGING_SMOKE_MAX_WAIT_MS,
+  retryDelayMs = DISABLED_STAGING_SMOKE_RETRY_DELAY_MS,
+  requestTimeoutMs = DISABLED_STAGING_SMOKE_REQUEST_TIMEOUT_MS,
+} = {}) {
+  if (typeof request !== 'function') throw new Error('disabled Schedule public-read health request is required')
+  if (typeof now !== 'function') throw new Error('disabled Schedule public-read health clock is required')
+  if (typeof sleep !== 'function') throw new Error('disabled Schedule public-read health sleep is required')
+  requirePositiveInteger(maxWaitMs, 'disabled Schedule public-read health maxWaitMs')
+  requirePositiveInteger(retryDelayMs, 'disabled Schedule public-read health retryDelayMs')
+  requirePositiveInteger(requestTimeoutMs, 'disabled Schedule public-read health requestTimeoutMs')
+
+  const deadline = now() + maxWaitMs
+  let attempts = 0
+  let lastTransient = 'none'
+
+  while (true) {
+    if (attempts > 0 && now() >= deadline) {
+      throw convergenceError({ attempts, lastTransient, maxWaitMs })
+    }
+
+    const remainingBeforeRequest = Math.max(1, deadline - now())
+    attempts += 1
+    let response
+    let transientRequestFailure = false
+
+    try {
+      response = await request({ timeoutMs: Math.min(requestTimeoutMs, remainingBeforeRequest) })
+    } catch (error) {
+      if (!isTransientDisabledHealthError(error)) throw error
+      transientRequestFailure = true
+      lastTransient = describeTransientError(error)
+    }
+
+    if (!transientRequestFailure) {
+      if (response?.status === 503) return assertDisabledSchedulePublicReadHealth(response)
+      if (response?.status !== 404) {
+        throw new Error(`disabled Schedule public-read health returned HTTP ${response?.status ?? 'unknown'}; expected 503`)
+      }
+      lastTransient = 'HTTP 404'
+    }
+
+    const remainingBeforeRetry = deadline - now()
+    if (remainingBeforeRetry <= 0) {
+      throw convergenceError({ attempts, lastTransient, maxWaitMs })
+    }
+    await sleep(Math.min(retryDelayMs, remainingBeforeRetry))
+  }
+}

--- a/workforce/schedule/scripts/public-read-staging-smoke.mjs
+++ b/workforce/schedule/scripts/public-read-staging-smoke.mjs
@@ -5,6 +5,7 @@ import {
   createSchedulePublicReadHeaders,
   normalizeSchedulePublicReadSecret,
 } from '../public-read-contract.js'
+import { waitForDisabledSchedulePublicReadHealth } from './public-read-disabled-health.mjs'
 
 const allowedOrigin = 'https://skincos-schedule-public-read-staging.skincos.workers.dev'
 const mode = String(process.env.SCHEDULE_PUBLIC_READ_SMOKE_MODE || 'ready').trim()
@@ -13,10 +14,10 @@ const configuredOrigin = String(process.env.SCHEDULE_PUBLIC_READ_SMOKE_BASE_URL 
 if (!['ready', 'disabled'].includes(mode)) throw new Error('SCHEDULE_PUBLIC_READ_SMOKE_MODE must be ready or disabled')
 if (configuredOrigin !== allowedOrigin) throw new Error('Schedule public-read smoke is pinned to the isolated staging workers.dev origin')
 
-async function request(path, init = {}) {
+async function request(path, init = {}, timeoutMs = 15_000) {
   return fetch(`${configuredOrigin}${path}`, {
     ...init,
-    signal: AbortSignal.timeout(15_000),
+    signal: AbortSignal.timeout(timeoutMs),
   })
 }
 
@@ -27,11 +28,9 @@ async function json(response, label) {
 }
 
 if (mode === 'disabled') {
-  const response = await request('/health')
-  assert.equal(response.status, 503)
-  const body = await json(response, 'disabled health')
-  assert.equal(body.ok, false)
-  assert.equal(body.error, 'SCHEDULE_PUBLIC_READ_UNAVAILABLE')
+  const response = await waitForDisabledSchedulePublicReadHealth({
+    request: ({ timeoutMs }) => request('/health', {}, timeoutMs),
+  })
   console.log(JSON.stringify({ ok: true, mode, healthStatus: response.status }))
   process.exit(0)
 }


### PR DESCRIPTION
## Contexto

O primeiro bootstrap desabilitado do adaptador de leitura de escala implantou corretamente o Worker e o Durable Object, mas o smoke consultou o endpoint imediatamente e recebeu o `404` transitório de convergência antes de a versão chegar ao `workers.dev`. Segundos depois, a mesma saúde respondeu ao contrato esperado `503` com `SCHEDULE_PUBLIC_READ_UNAVAILABLE`.

## Alteração

- espera no máximo 30 segundos somente por `404` ou falha de rede/timeout transitória;
- mantém falha imediata para qualquer outro status, inclusive `200`, e para qualquer `503` com JSON incompatível;
- adiciona testes determinísticos para convergência, timeout e comportamento fail-closed;
- incorpora esses testes em preview e staging.

## Validação

`node --test workforce/schedule/public-read-contract.test.js workforce/schedule/public-read-core.test.js workforce/schedule/public-read-core-opt-in-evidence.test.js workforce/schedule/public-read-bootstrap-evidence.test.js workforce/schedule/public-read-disabled-health.test.js workforce/schedule/public-read-nonce-guard.test.js workforce/schedule/public-read-worker.test.js workforce/schedule/public-read-staging-workflow.test.js` — 30/30 verde.

Não há mudança em Website/Booking, segredos, capacidades, rotas ou dados. O Worker existente permanece desabilitado até a nova prova ser aceita.