### PR TITLE
fix(schedule): pin core coordination custody

### DIFF
--- a/.github/workflows/deploy-escala-api.yml
+++ b/.github/workflows/deploy-escala-api.yml
@@ -81,6 +81,8 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           ESCALA_ACTOR_HMAC_KEY: ${{ secrets.ESCALA_ACTOR_HMAC_KEY }}
           SCHEDULE_PUBLIC_READ_CORE_HMAC_KEY: ${{ secrets.SCHEDULE_PUBLIC_READ_CORE_HMAC_KEY }}
+          SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          SKINCOS_GLOBAL_COORDINATION_KEY_ID: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
         run: |
           set -euo pipefail
           if [[ "${ENABLE:-true}" != "true" ]]; then
@@ -102,6 +104,15 @@ jobs:
           fi
           if [[ "$ENABLE_SCHEDULE_PUBLIC_READ" == 'true' && "$ESCALA_ACTOR_HMAC_KEY" == "$SCHEDULE_PUBLIC_READ_CORE_HMAC_KEY" ]]; then
             echo '::error::Schedule public-read core capability must differ from ESCALA_ACTOR_HMAC_KEY'
+            exit 1
+          fi
+          if [[ -n "${SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY:-}" ]]; then
+            if [[ -z "${SKINCOS_GLOBAL_COORDINATION_KEY_ID:-}" || "$SKINCOS_GLOBAL_COORDINATION_KEY_ID" == 'legacy-v1' ]]; then
+              echo '::error::Active global coordination custody requires a non-legacy key ID.'
+              exit 1
+            fi
+          elif [[ -n "${SKINCOS_GLOBAL_COORDINATION_KEY_ID:-}" && "$SKINCOS_GLOBAL_COORDINATION_KEY_ID" != 'legacy-v1' ]]; then
+            echo '::error::Pinned global coordination custody requires the active coordination key.'
             exit 1
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -129,7 +140,8 @@ jobs:
           required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY || secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || 'legacy-v1' }}
           resource: global:crm-cloudflare-writer
           module: escala-api
           source_sha: ${{ needs.promotion.outputs.source_sha }}
@@ -146,7 +158,8 @@ jobs:
           source_sha: ${{ needs.promotion.outputs.source_sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY || secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || 'legacy-v1' }}
 
       - name: Sync Escala worker secret (production)
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
@@ -170,7 +183,8 @@ jobs:
           source_sha: ${{ needs.promotion.outputs.source_sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY || secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || 'legacy-v1' }}
 
       - name: Apply Escala D1 migrations (production)
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
@@ -192,7 +206,8 @@ jobs:
           source_sha: ${{ needs.promotion.outputs.source_sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY || secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || 'legacy-v1' }}
 
       - name: Deploy Escala worker (production)
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'production' }}
@@ -225,7 +240,8 @@ jobs:
           source_sha: ${{ needs.promotion.outputs.source_sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY || secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || 'legacy-v1' }}
 
       - name: Apply Escala D1 migrations (staging)
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' }}
@@ -247,7 +263,8 @@ jobs:
           source_sha: ${{ needs.promotion.outputs.source_sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY || secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || 'legacy-v1' }}
 
       - name: Create unpublished Schedule public-read core candidate with both capabilities
         id: schedule-public-read-core-candidate-version
@@ -284,7 +301,8 @@ jobs:
           source_sha: ${{ needs.promotion.outputs.source_sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY || secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || 'legacy-v1' }}
 
       - name: Deploy Escala worker (staging, default public-read disabled)
         if: ${{ steps.guard.outputs.skip != 'true' && inputs.target == 'staging' && !inputs.enable_schedule_public_read }}
@@ -378,7 +396,8 @@ jobs:
           source_sha: ${{ needs.promotion.outputs.source_sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY || secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || 'legacy-v1' }}
 
       - name: Create automatic disabled Schedule public-read core fallback version
         id: schedule-public-read-core-automatic-disabled-version
@@ -405,7 +424,8 @@ jobs:
           source_sha: ${{ needs.promotion.outputs.source_sha }}
           enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY || secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || 'legacy-v1' }}
 
       - name: Deploy automatic disabled Schedule public-read core fallback
         id: schedule-public-read-core-automatic-disabled-fallback
@@ -433,5 +453,6 @@ jobs:
         with:
           required: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED || 'false' }}
           coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}
-          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY || secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || 'legacy-v1' }}
           proof_file: ${{ runner.temp }}/skincos-global-coordination-escala-api.json

--- a/workforce/schedule/public-read-staging-workflow.test.js
+++ b/workforce/schedule/public-read-staging-workflow.test.js
@@ -44,6 +44,8 @@ function runEscalaDeployGuard(overrides = {}) {
     CLOUDFLARE_ACCOUNT_ID: 'fake-cloudflare-account',
     ESCALA_ACTOR_HMAC_KEY: 'fake-actor-capability',
     SCHEDULE_PUBLIC_READ_CORE_HMAC_KEY: 'fake-core-capability',
+    SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY: 'fake-active-coordination-key',
+    SKINCOS_GLOBAL_COORDINATION_KEY_ID: 'active-v2',
     GITHUB_OUTPUT: githubOutput,
     ...overrides,
   }
@@ -211,6 +213,42 @@ test('Schedule public-read defaults disabled and only the canonical core publish
   assert.doesNotMatch(productionSection, /SCHEDULE_PUBLIC_READ_ENABLED:true/)
 })
 
+test('Escala core coordination custody pins every lease boundary to the active key with exact target URLs', () => {
+  const activeSecret = "shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY || secrets.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET }}"
+  const activeKeyId = "key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID || 'legacy-v1' }}"
+  const targetCoordinator = "coordinator_url: ${{ inputs.target == 'staging' && vars.SKINCOS_GLOBAL_COORDINATOR_URL || vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}"
+  const stagingCoordinator = 'coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}'
+  const productionCoordinator = 'coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_PRODUCTION_URL }}'
+  const expected = [
+    ['Acquire Escala API deployment lease', targetCoordinator],
+    ['Check Escala API deployment lease before secret mutation', targetCoordinator],
+    ['Check Escala API deployment lease before production migration', productionCoordinator],
+    ['Check Escala API deployment lease before production deployment', productionCoordinator],
+    ['Check Escala API deployment lease before staging migration', stagingCoordinator],
+    ['Check Escala API deployment lease before unpublished Schedule public-read core candidate', stagingCoordinator],
+    ['Check Escala API deployment lease before staging deployment', stagingCoordinator],
+    ['Check Escala API deployment lease before automatic disabled Schedule public-read core fallback version', stagingCoordinator],
+    ['Check Escala API deployment lease before automatic disabled Schedule public-read core fallback deployment', stagingCoordinator],
+    ['Release Escala API deployment lease', targetCoordinator],
+  ]
+
+  const leaseSteps = coreWorkflow
+    .split(/(?=^      - name: )/m)
+    .filter((step) => /uses: \.\/\.github\/actions\/global-coordination-(?:acquire|check|release)/.test(step))
+
+  assert.equal(leaseSteps.length, expected.length, 'every Escala core coordination action must be enumerated')
+  assert.deepEqual(
+    leaseSteps.map((step) => step.match(/- name: ([^\r\n]+)/)?.[1]),
+    expected.map(([name]) => name),
+  )
+  for (const [index, [, coordinator]] of expected.entries()) {
+    assert.match(leaseSteps[index], new RegExp(activeSecret.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+    assert.match(leaseSteps[index], new RegExp(activeKeyId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+    assert.match(leaseSteps[index], new RegExp(coordinator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+  }
+  assert.doesNotMatch(coreWorkflow, /shared_secret: \$\{\{ secrets\.SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET \}\}/)
+})
+
 test('Escala core opt-in guard is executable, accepts distinct capabilities, and never emits them', () => {
   const { script, syntax, result, githubOutput } = runEscalaDeployGuard()
 
@@ -234,6 +272,37 @@ test('Escala core opt-in guard rejects equal capabilities without disclosing the
   assert.match(`${result.stdout}${result.stderr}`, /must differ from ESCALA_ACTOR_HMAC_KEY/)
   assert.doesNotMatch(`${result.stdout}${result.stderr}`, new RegExp(capability))
   assert.equal(githubOutput, '')
+})
+
+test('Escala core deploy guard rejects incomplete active coordination custody while preserving legacy fallback', () => {
+  const legacy = runEscalaDeployGuard({
+    SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY: '',
+    SKINCOS_GLOBAL_COORDINATION_KEY_ID: '',
+  })
+  assert.equal(legacy.syntax.status, 0, legacy.syntax.stderr)
+  assert.equal(legacy.result.status, 0, legacy.result.stderr)
+
+  const missingActive = runEscalaDeployGuard({
+    SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY: '',
+    SKINCOS_GLOBAL_COORDINATION_KEY_ID: 'active-v2',
+  })
+  assert.equal(missingActive.syntax.status, 0, missingActive.syntax.stderr)
+  assert.notEqual(missingActive.result.status, 0)
+  assert.match(`${missingActive.result.stdout}${missingActive.result.stderr}`, /Pinned global coordination custody requires the active coordination key/)
+
+  const missingKeyId = runEscalaDeployGuard({
+    SKINCOS_GLOBAL_COORDINATION_KEY_ID: '',
+  })
+  assert.equal(missingKeyId.syntax.status, 0, missingKeyId.syntax.stderr)
+  assert.notEqual(missingKeyId.result.status, 0)
+  assert.match(`${missingKeyId.result.stdout}${missingKeyId.result.stderr}`, /Active global coordination custody requires a non-legacy key ID/)
+
+  const legacyKeyId = runEscalaDeployGuard({
+    SKINCOS_GLOBAL_COORDINATION_KEY_ID: 'legacy-v1',
+  })
+  assert.equal(legacyKeyId.syntax.status, 0, legacyKeyId.syntax.stderr)
+  assert.notEqual(legacyKeyId.result.status, 0)
+  assert.match(`${legacyKeyId.result.stdout}${legacyKeyId.result.stderr}`, /Active global coordination custody requires a non-legacy key ID/)
 })
 
 test('Schedule public-read staging smoke is synthetic, authenticated, and does not handle the core key', () => {


### PR DESCRIPTION
## Contexto

O estágio seguro do Schedule falhou antes de adquirir lease porque o publicador core usava a custódia legada, enquanto o coordenador já exige a chave ativa com `key_id`.

## Mudança

- propaga a chave de coordenação ativa e o `key_id` em cada fronteira de lease do core;
- mantém fallback legado somente quando a configuração inteira é legada;
- falha fechada quando a configuração ativa está incompleta;
- cobre as dez operações de aquisição, verificação e liberação com teste estrutural.

## Validação

- `node --test workforce/schedule/public-read-staging-workflow.test.js scripts/tests/global-concurrency-governance-static.test.mjs` — 29/29;
- `npm run codex:deploy-topology:test` — verde.

Sem deploy, alteração de segredo ou mudança de Website nesta PR.