### PR TITLE
fix(schedule): wait for adapter readiness convergence

### DIFF
--- a/workforce/schedule/public-read-ready-health.test.js
+++ b/workforce/schedule/public-read-ready-health.test.js
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { waitForReadySchedulePublicReadHealth } from './scripts/public-read-ready-health.mjs'
+
+function health(status, body = undefined) {
+  return {
+    status,
+    json: async () => body,
+  }
+}
+
+test('ready staging health retries only transient pre-convergence responses until the ready endpoint is available', async () => {
+  let now = 0
+  const requestTimeouts = []
+  const sleeps = []
+  const transientTimeout = Object.assign(new Error('request timed out'), { name: 'TimeoutError' })
+  const outcomes = [
+    health(404),
+    health(503, { ok: false, error: 'SCHEDULE_PUBLIC_READ_UNAVAILABLE' }),
+    transientTimeout,
+    health(200, { ok: true, ready: true }),
+  ]
+
+  const response = await waitForReadySchedulePublicReadHealth({
+    request: async ({ timeoutMs }) => {
+      requestTimeouts.push(timeoutMs)
+      const outcome = outcomes.shift()
+      if (outcome instanceof Error) throw outcome
+      return outcome
+    },
+    now: () => now,
+    sleep: async (milliseconds) => {
+      sleeps.push(milliseconds)
+      now += milliseconds
+    },
+    maxWaitMs: 5_000,
+    retryDelayMs: 1_000,
+  })
+
+  assert.equal(response.status, 200)
+  assert.deepEqual(requestTimeouts, [5_000, 4_000, 3_000, 2_000])
+  assert.deepEqual(sleeps, [1_000, 1_000, 1_000])
+})
+
+test('ready staging health fails closed when a 503 is not the known disabled contract', async () => {
+  let attempts = 0
+  let sleeps = 0
+
+  await assert.rejects(
+    () => waitForReadySchedulePublicReadHealth({
+      request: async () => {
+        attempts += 1
+        return health(503, { ok: false, error: 'SCHEDULE_PUBLIC_READ_UPSTREAM_UNAVAILABLE' })
+      },
+      sleep: async () => {
+        sleeps += 1
+      },
+    }),
+    /unexpected error code/,
+  )
+
+  assert.equal(attempts, 1)
+  assert.equal(sleeps, 0)
+})
+
+test('ready staging health fails closed without retrying a wrong stable response', async () => {
+  let attempts = 0
+  let sleeps = 0
+
+  await assert.rejects(
+    () => waitForReadySchedulePublicReadHealth({
+      request: async () => {
+        attempts += 1
+        return health(401)
+      },
+      sleep: async () => {
+        sleeps += 1
+      },
+    }),
+    /returned HTTP 401; expected 200/,
+  )
+
+  assert.equal(attempts, 1)
+  assert.equal(sleeps, 0)
+})

--- a/workforce/schedule/public-read-staging-workflow.test.js
+++ b/workforce/schedule/public-read-staging-workflow.test.js
@@ -11,6 +11,7 @@ const adapterConfig = readFileSync(new URL('./public-read.wrangler.toml', import
 const coreConfig = readFileSync(new URL('./wrangler.toml', import.meta.url), 'utf8')
 const smoke = readFileSync(new URL('./scripts/public-read-staging-smoke.mjs', import.meta.url), 'utf8')
 const disabledHealth = readFileSync(new URL('./scripts/public-read-disabled-health.mjs', import.meta.url), 'utf8')
+const readyHealth = readFileSync(new URL('./scripts/public-read-ready-health.mjs', import.meta.url), 'utf8')
 const coreSmoke = readFileSync(new URL('./scripts/public-read-core-staging-smoke.mjs', import.meta.url), 'utf8')
 const units = JSON.parse(readFileSync(new URL('../../platform/deploy/operational-units.json', import.meta.url), 'utf8'))
 const singleWriter = JSON.parse(readFileSync(new URL('../../.github/governance/cloudflare-single-writer-policy.json', import.meta.url), 'utf8'))
@@ -308,6 +309,7 @@ test('Escala core deploy guard rejects incomplete active coordination custody wh
 test('Schedule public-read staging smoke is synthetic, authenticated, and does not handle the core key', () => {
   assert.match(smoke, /allowedOrigin = 'https:\/\/skincos-schedule-public-read-staging\.skincos\.workers\.dev'/)
   assert.match(smoke, /waitForDisabledSchedulePublicReadHealth/)
+  assert.match(smoke, /waitForReadySchedulePublicReadHealth/)
   assert.match(smoke, /SCHEDULE_PUBLIC_READ_EDGE_HMAC_KEY/)
   assert.doesNotMatch(smoke, /SCHEDULE_PUBLIC_READ_CORE_HMAC_KEY/)
   assert.match(smoke, /SCHEDULE_PUBLIC_READ_REPLAYED/)
@@ -317,6 +319,9 @@ test('Schedule public-read staging smoke is synthetic, authenticated, and does n
   assert.match(disabledHealth, /DISABLED_STAGING_SMOKE_MAX_WAIT_MS = 30_000/)
   assert.match(disabledHealth, /response\?\.status !== 404/)
   assert.doesNotMatch(disabledHealth, /SCHEDULE_PUBLIC_READ_SMOKE_RETRY/)
+  assert.match(readyHealth, /READY_STAGING_SMOKE_MAX_WAIT_MS = 30_000/)
+  assert.match(readyHealth, /response\?\.status === 503/)
+  assert.match(readyHealth, /assertDisabledSchedulePublicReadHealth\(response\)/)
 })
 
 test('Schedule public-read core staging smoke uses only the core capability and proves disabled rollback', () => {

--- a/workforce/schedule/scripts/public-read-ready-health.mjs
+++ b/workforce/schedule/scripts/public-read-ready-health.mjs
@@ -1,0 +1,84 @@
+import {
+  assertDisabledSchedulePublicReadHealth,
+  isTransientDisabledHealthError,
+} from './public-read-disabled-health.mjs'
+
+export const READY_STAGING_SMOKE_MAX_WAIT_MS = 30_000
+export const READY_STAGING_SMOKE_RETRY_DELAY_MS = 1_000
+export const READY_STAGING_SMOKE_REQUEST_TIMEOUT_MS = 15_000
+
+function requirePositiveInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${label} must be a positive integer`)
+  }
+}
+
+function describeTransientError(error) {
+  const code = String(error?.code || error?.cause?.code || '')
+  if (code) return `network ${code}`
+  const name = String(error?.name || '')
+  return name === 'AbortError' || name === 'TimeoutError' ? name : 'network error'
+}
+
+function convergenceError({ attempts, lastTransient, maxWaitMs }) {
+  return new Error(
+    `ready Schedule public-read health did not converge to 200 within ${maxWaitMs}ms after ${attempts} attempts (last transient: ${lastTransient})`,
+  )
+}
+
+export async function waitForReadySchedulePublicReadHealth({
+  request,
+  now = () => Date.now(),
+  sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  maxWaitMs = READY_STAGING_SMOKE_MAX_WAIT_MS,
+  retryDelayMs = READY_STAGING_SMOKE_RETRY_DELAY_MS,
+  requestTimeoutMs = READY_STAGING_SMOKE_REQUEST_TIMEOUT_MS,
+} = {}) {
+  if (typeof request !== 'function') throw new Error('ready Schedule public-read health request is required')
+  if (typeof now !== 'function') throw new Error('ready Schedule public-read health clock is required')
+  if (typeof sleep !== 'function') throw new Error('ready Schedule public-read health sleep is required')
+  requirePositiveInteger(maxWaitMs, 'ready Schedule public-read health maxWaitMs')
+  requirePositiveInteger(retryDelayMs, 'ready Schedule public-read health retryDelayMs')
+  requirePositiveInteger(requestTimeoutMs, 'ready Schedule public-read health requestTimeoutMs')
+
+  const deadline = now() + maxWaitMs
+  let attempts = 0
+  let lastTransient = 'none'
+
+  while (true) {
+    if (attempts > 0 && now() >= deadline) {
+      throw convergenceError({ attempts, lastTransient, maxWaitMs })
+    }
+
+    const remainingBeforeRequest = Math.max(1, deadline - now())
+    attempts += 1
+    let response
+    let transientRequestFailure = false
+
+    try {
+      response = await request({ timeoutMs: Math.min(requestTimeoutMs, remainingBeforeRequest) })
+    } catch (error) {
+      if (!isTransientDisabledHealthError(error)) throw error
+      transientRequestFailure = true
+      lastTransient = describeTransientError(error)
+    }
+
+    if (!transientRequestFailure) {
+      if (response?.status === 200) return response
+      if (response?.status === 503) {
+        await assertDisabledSchedulePublicReadHealth(response)
+        lastTransient = 'HTTP 503 disabled'
+      } else if (response?.status === 404) {
+        lastTransient = 'HTTP 404'
+      } else {
+        throw new Error(`ready Schedule public-read health returned HTTP ${response?.status ?? 'unknown'}; expected 200`)
+      }
+    }
+
+    const remainingBeforeRetry = deadline - now()
+    if (remainingBeforeRetry <= 0) {
+      throw convergenceError({ attempts, lastTransient, maxWaitMs })
+    }
+    await sleep(Math.min(retryDelayMs, remainingBeforeRetry))
+  }
+}

--- a/workforce/schedule/scripts/public-read-staging-smoke.mjs
+++ b/workforce/schedule/scripts/public-read-staging-smoke.mjs
@@ -6,6 +6,7 @@ import {
   normalizeSchedulePublicReadSecret,
 } from '../public-read-contract.js'
 import { waitForDisabledSchedulePublicReadHealth } from './public-read-disabled-health.mjs'
+import { waitForReadySchedulePublicReadHealth } from './public-read-ready-health.mjs'
 
 const allowedOrigin = 'https://skincos-schedule-public-read-staging.skincos.workers.dev'
 const mode = String(process.env.SCHEDULE_PUBLIC_READ_SMOKE_MODE || 'ready').trim()
@@ -38,8 +39,9 @@ if (mode === 'disabled') {
 const edgeKey = normalizeSchedulePublicReadSecret(process.env.SCHEDULE_PUBLIC_READ_EDGE_HMAC_KEY)
 if (!edgeKey) throw new Error('SCHEDULE_PUBLIC_READ_EDGE_HMAC_KEY is required for the staging smoke')
 
-const health = await request('/health')
-assert.equal(health.status, 200)
+const health = await waitForReadySchedulePublicReadHealth({
+  request: ({ timeoutMs }) => request('/health', {}, timeoutMs),
+})
 const healthBody = await json(health, 'health')
 assert.equal(healthBody.ok, true)
 assert.equal(healthBody.contract, SCHEDULE_PUBLIC_READ_CONTRACT_VERSION)


### PR DESCRIPTION
## Contexto

O primeiro candidato HMAC do adaptador foi publicado com sucesso, mas o smoke consultou o Worker quatro segundos depois e recebeu a versão anterior, deliberadamente desabilitada (`503`). O fallback automático foi aplicado e o lease foi liberado.

## Mudança

- adiciona espera limitada de até 30 s para a convergência de `/health` até `200`;
- só reintenta `404`, falha de rede transitória e o `503` que satisfaz exatamente o contrato desabilitado;
- falha imediatamente para qualquer resposta estável inesperada ou `503` de outro contrato;
- mantém HMAC, replay e requisição sem assinatura como asserções posteriores obrigatórias.

## Validação

- 42 testes focais de Schedule/governança verdes;
- `npm run codex:deploy-topology:test` verde.

Sem Website, deploy de produção, domínio ou alteração de segredo.