### PR TITLE
test(schedule): cover readiness convergence in CI

### DIFF
--- a/.github/workflows/deploy-schedule-public-read-adapter.yml
+++ b/.github/workflows/deploy-schedule-public-read-adapter.yml
@@ -81,7 +81,7 @@ jobs:
           grep -q 'workers_dev = true' workforce/schedule/public-read.wrangler.toml || { echo 'isolated staging workers.dev surface is missing'; exit 1; }
 
       - name: Run isolated adapter contract tests
-        run: node --test workforce/schedule/public-read-contract.test.js workforce/schedule/public-read-core.test.js workforce/schedule/public-read-core-opt-in-evidence.test.js workforce/schedule/public-read-bootstrap-evidence.test.js workforce/schedule/public-read-disabled-health.test.js workforce/schedule/public-read-nonce-guard.test.js workforce/schedule/public-read-worker.test.js workforce/schedule/public-read-staging-workflow.test.js
+        run: node --test workforce/schedule/public-read-contract.test.js workforce/schedule/public-read-core.test.js workforce/schedule/public-read-core-opt-in-evidence.test.js workforce/schedule/public-read-bootstrap-evidence.test.js workforce/schedule/public-read-disabled-health.test.js workforce/schedule/public-read-ready-health.test.js workforce/schedule/public-read-nonce-guard.test.js workforce/schedule/public-read-worker.test.js workforce/schedule/public-read-staging-workflow.test.js
 
       - name: Validate staging adapter configuration without a remote mutation
         run: npx --yes wrangler@4.120.0 deploy --dry-run --config workforce/schedule/public-read.wrangler.toml --env staging --outdir "$RUNNER_TEMP/schedule-public-read-adapter-preview"
@@ -134,7 +134,7 @@ jobs:
           grep -q 'service = "skincos-escala-api-staging"' workforce/schedule/public-read.wrangler.toml || { echo 'adapter must bind only the isolated staging Schedule core'; exit 1; }
 
       - name: Run isolated adapter contract tests
-        run: node --test workforce/schedule/public-read-contract.test.js workforce/schedule/public-read-core.test.js workforce/schedule/public-read-core-opt-in-evidence.test.js workforce/schedule/public-read-bootstrap-evidence.test.js workforce/schedule/public-read-disabled-health.test.js workforce/schedule/public-read-nonce-guard.test.js workforce/schedule/public-read-worker.test.js workforce/schedule/public-read-staging-workflow.test.js
+        run: node --test workforce/schedule/public-read-contract.test.js workforce/schedule/public-read-core.test.js workforce/schedule/public-read-core-opt-in-evidence.test.js workforce/schedule/public-read-bootstrap-evidence.test.js workforce/schedule/public-read-disabled-health.test.js workforce/schedule/public-read-ready-health.test.js workforce/schedule/public-read-nonce-guard.test.js workforce/schedule/public-read-worker.test.js workforce/schedule/public-read-staging-workflow.test.js
 
       - name: Verify exact Escala staging predecessor for candidate enablement
         if: ${{ inputs.operation == 'deploy' }}

--- a/.github/workflows/schedule-public-read-contract.yml
+++ b/.github/workflows/schedule-public-read-contract.yml
@@ -38,7 +38,7 @@ jobs:
           node-version: "22.12.0"
 
       - name: Run isolated contract tests
-        run: node --test workforce/schedule/public-read-contract.test.js workforce/schedule/public-read-core.test.js workforce/schedule/public-read-core-opt-in-evidence.test.js workforce/schedule/public-read-bootstrap-evidence.test.js workforce/schedule/public-read-nonce-guard.test.js workforce/schedule/public-read-worker.test.js workforce/schedule/public-read-staging-workflow.test.js
+        run: node --test workforce/schedule/public-read-contract.test.js workforce/schedule/public-read-core.test.js workforce/schedule/public-read-core-opt-in-evidence.test.js workforce/schedule/public-read-bootstrap-evidence.test.js workforce/schedule/public-read-disabled-health.test.js workforce/schedule/public-read-ready-health.test.js workforce/schedule/public-read-nonce-guard.test.js workforce/schedule/public-read-worker.test.js workforce/schedule/public-read-staging-workflow.test.js
 
       - name: Run no-remote dry run
         run: node workforce/schedule/scripts/public-read-dry-run.mjs

--- a/workforce/schedule/public-read-staging-workflow.test.js
+++ b/workforce/schedule/public-read-staging-workflow.test.js
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import test from 'node:test'
 
 const workflow = readFileSync(new URL('../../.github/workflows/deploy-schedule-public-read-adapter.yml', import.meta.url), 'utf8')
+const contractWorkflow = readFileSync(new URL('../../.github/workflows/schedule-public-read-contract.yml', import.meta.url), 'utf8')
 const coreWorkflow = readFileSync(new URL('../../.github/workflows/deploy-escala-api.yml', import.meta.url), 'utf8')
 const adapterConfig = readFileSync(new URL('./public-read.wrangler.toml', import.meta.url), 'utf8')
 const coreConfig = readFileSync(new URL('./wrangler.toml', import.meta.url), 'utf8')
@@ -80,6 +81,13 @@ test('Schedule public-read adapter is a manual preview/staging-only publisher', 
   assert.match(workflow, /environment: staging/)
   assert.match(workflow, /DISPATCH_REF.*refs\/heads\/main/)
   assert.match(workflow, /RUN_ATTEMPT.*== '1'/)
+})
+
+test('Schedule public-read contract runners execute bounded disabled and ready health convergence coverage', () => {
+  assert.equal((workflow.match(/public-read-disabled-health\.test\.js/g) || []).length, 2)
+  assert.equal((workflow.match(/public-read-ready-health\.test\.js/g) || []).length, 2)
+  assert.match(contractWorkflow, /public-read-disabled-health\.test\.js/)
+  assert.match(contractWorkflow, /public-read-ready-health\.test\.js/)
 })
 
 test('Schedule public-read adapter keeps core publication and Website outside its writer scope', () => {


### PR DESCRIPTION
## Summary
- executes bounded ready-health convergence coverage in both adapter deploy runners and contract CI
- preserves fail-closed behavior for non-transient health failures

## Validation
- 38 focused Schedule public-read tests passed via WSL
- public-read-dry-run.mjs passed
- existing staging evidence at 49f097: core run 33439410000 and adapter run 33439562005 both passed, including authenticated readiness, replay rejection, and unsigned rejection

No deploy or remote data mutation is included in this PR.