### PR TITLE
feat(identity): prepare private CRM delivery input

### DIFF
--- a/identity/README.md
+++ b/identity/README.md
@@ -27,3 +27,24 @@ Inventory Worker as an HTTP compatibility host. Invitation policy and mail are
 already supplied by Identity; moving the remaining handlers behind the
 independent Identity binding is a separate cutover and must not change cookies,
 users, or existing sessions.
+
+## CRM delivery preparation
+
+`identity/delivery/crm-envelope-v1.js` is a pure, disabled-by-default helper
+for the future private Identity-to-CRM delivery path. It prepares only the
+minimized, unsigned `identity-crm-delivery/v1` header and claims after an
+explicit caller opt-in. It does not resolve a session, read runtime
+configuration, use a secret, serialize or sign a JWS, register a route, add a
+Worker binding, or publish an artifact.
+
+Until a clean installation of the exact private contracts package is proven,
+this helper is only a disconnected preparation guard; it is not the canonical
+wire-contract parser, serializer or compatibility proof. The future private
+entrypoint must delegate those responsibilities to the published package.
+
+The helper refuses the current username-based actor. A future additive Identity
+migration must first provide a stable opaque `identitySubject` and preserve it
+through creation, rename, restore and session resolution. Only after that
+migration, the exact private contracts package is installed, and the CRM has a
+verifier plus replay ledger may a separately deployed, non-public
+`WorkerEntrypoint` sign this input through a service binding.

--- a/identity/delivery/crm-envelope-v1.js
+++ b/identity/delivery/crm-envelope-v1.js
@@ -9,6 +9,7 @@ const DELIVERY_METHODS = new Set(['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE
 const OPAQUE_SUBJECT_PATTERN = /^idn:[A-Za-z0-9_-]{16,160}$/;
 const ROLE_PATTERN = /^[A-Z][A-Z0-9_]{0,63}$/;
 const SCOPE_ITEM_PATTERN = /^[a-z][a-z0-9:-]{0,159}$/;
+const PERMISSION_ITEM_PATTERN = /^[a-z][a-z0-9:.-]{0,159}$/;
 const JTI_PATTERN = /^[A-Za-z0-9_-]{16,160}$/;
 const KEY_ID_PATTERN = /^[A-Za-z0-9._-]{1,160}$/;
 const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/;
@@ -18,8 +19,18 @@ function fail(code) {
 }
 
 function assertOnlyKeys(value, allowedKeys, code) {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(code);
-  if (Object.keys(value).some((key) => !allowedKeys.includes(key))) fail(code);
+  if (!value || typeof value !== 'object' || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) fail(code);
+  const keys = Reflect.ownKeys(value);
+  if (keys.some((key) => typeof key !== 'string' || !allowedKeys.includes(key))) fail(code);
+  if (keys.some((key) => {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return !descriptor || !descriptor.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value');
+  })) fail(code);
+}
+
+function assertExactKeys(value, allowedKeys, code) {
+  assertOnlyKeys(value, allowedKeys, code);
+  if (Reflect.ownKeys(value).length !== allowedKeys.length) fail(code);
 }
 
 function assertEnabled(value) {
@@ -52,14 +63,13 @@ function strictSortedScope(value, name, pattern) {
 }
 
 function assertScopes(value) {
-  assertOnlyKeys(value, ['units', 'modules', 'permissions'], 'IDENTITY_SCOPES_INVALID');
-  if (Object.keys(value).length !== 3) fail('IDENTITY_SCOPES_INVALID');
+  assertExactKeys(value, ['units', 'modules', 'permissions'], 'IDENTITY_SCOPES_INVALID');
   const units = strictSortedScope(value.units, 'IDENTITY_SCOPE_UNITS', /^[a-z][a-z0-9-]{0,159}$/);
   if (units.some((unit) => !isCanonicalUnitScope(unit))) fail('IDENTITY_SCOPE_UNITS_INVALID');
   return Object.freeze({
     units,
     modules: strictSortedScope(value.modules, 'IDENTITY_SCOPE_MODULES', SCOPE_ITEM_PATTERN),
-    permissions: strictSortedScope(value.permissions, 'IDENTITY_SCOPE_PERMISSIONS', SCOPE_ITEM_PATTERN),
+    permissions: strictSortedScope(value.permissions, 'IDENTITY_SCOPE_PERMISSIONS', PERMISSION_ITEM_PATTERN),
   });
 }
 
@@ -68,13 +78,12 @@ function assertCanonicalTarget(value) {
   if (!value.startsWith('/api/crm') || !['/', '?', undefined].includes(value.at(8))) fail('CRM_TARGET_INVALID');
   if (value.includes('#') || value.includes('\\') || /[^\x21-\x7e]/.test(value)) fail('CRM_TARGET_INVALID');
   if (value.endsWith('?') || /\/{2,}|\/(?:\.{1,2})(?:\/|$)/.test(value)) fail('CRM_TARGET_INVALID');
-  if (/%(?![0-9A-F]{2})/.test(value) || /%(?:2F|5C)/.test(value)) fail('CRM_TARGET_INVALID');
+  if (/%(?![0-9A-F]{2})/.test(value) || /%(?:2E|2F|5C)/.test(value)) fail('CRM_TARGET_INVALID');
   return value;
 }
 
 function assertRequestBinding(value) {
-  assertOnlyKeys(value, ['method', 'target', 'bodyDigest'], 'CRM_REQUEST_BINDING_INVALID');
-  if (Object.keys(value).length !== 3) fail('CRM_REQUEST_BINDING_INVALID');
+  assertExactKeys(value, ['method', 'target', 'bodyDigest'], 'CRM_REQUEST_BINDING_INVALID');
   const method = value.method;
   if (typeof method !== 'string' || !DELIVERY_METHODS.has(method)) fail('CRM_METHOD_INVALID');
   const bodyDigest = value.bodyDigest;
@@ -108,8 +117,7 @@ export function prepareCrmIdentityDeliveryV1(input = {}) {
     keyId,
   } = input;
   assertEnabled(enabled);
-  assertOnlyKeys(identity, ['identitySubject', 'role', 'scopes'], 'IDENTITY_ACTOR_INVALID');
-  if (Object.keys(identity).length !== 3) fail('IDENTITY_ACTOR_INVALID');
+  assertExactKeys(identity, ['identitySubject', 'role', 'scopes'], 'IDENTITY_ACTOR_INVALID');
   const iat = assertEpochSeconds(issuedAt, 'IDENTITY_ISSUED_AT');
   const ttl = assertEpochSeconds(ttlSeconds, 'IDENTITY_TTL');
   if (ttl < 1 || ttl > IDENTITY_CRM_DELIVERY_MAX_TTL_SECONDS) fail('IDENTITY_TTL_INVALID');

--- a/identity/delivery/crm-envelope-v1.js
+++ b/identity/delivery/crm-envelope-v1.js
@@ -1,0 +1,141 @@
+import { isCanonicalUnitScope } from '../../shared/identity-contract/index.js';
+
+export const IDENTITY_CRM_DELIVERY_VERSION = 'identity-crm-delivery/v1';
+export const IDENTITY_CRM_DELIVERY_ISSUER = 'skincos-identity';
+export const IDENTITY_CRM_DELIVERY_AUDIENCE = 'skincos-crm-core';
+export const IDENTITY_CRM_DELIVERY_MAX_TTL_SECONDS = 60;
+
+const DELIVERY_METHODS = new Set(['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE']);
+const OPAQUE_SUBJECT_PATTERN = /^idn:[A-Za-z0-9_-]{16,160}$/;
+const ROLE_PATTERN = /^[A-Z][A-Z0-9_]{0,63}$/;
+const SCOPE_ITEM_PATTERN = /^[a-z][a-z0-9:-]{0,159}$/;
+const JTI_PATTERN = /^[A-Za-z0-9_-]{16,160}$/;
+const KEY_ID_PATTERN = /^[A-Za-z0-9._-]{1,160}$/;
+const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/;
+
+function fail(code) {
+  throw new TypeError(code);
+}
+
+function assertOnlyKeys(value, allowedKeys, code) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(code);
+  if (Object.keys(value).some((key) => !allowedKeys.includes(key))) fail(code);
+}
+
+function assertEnabled(value) {
+  if (value !== true) fail('IDENTITY_CRM_DELIVERY_DISABLED');
+}
+
+function assertEpochSeconds(value, name) {
+  if (!Number.isSafeInteger(value) || value < 0) fail(`${name}_INVALID`);
+  return value;
+}
+
+function assertOpaqueSubject(value) {
+  if (typeof value !== 'string' || !OPAQUE_SUBJECT_PATTERN.test(value)) {
+    fail('IDENTITY_SUBJECT_REQUIRED');
+  }
+  return value;
+}
+
+function assertRole(value) {
+  if (typeof value !== 'string' || !ROLE_PATTERN.test(value)) fail('IDENTITY_ROLE_INVALID');
+  return value;
+}
+
+function strictSortedScope(value, name, pattern) {
+  if (!Array.isArray(value) || value.length > 64) fail(`${name}_INVALID`);
+  const items = value;
+  if (items.some((item) => typeof item !== 'string' || !item || !pattern.test(item))) fail(`${name}_INVALID`);
+  if (items.some((item, index) => index > 0 && items[index - 1] >= item)) fail(`${name}_INVALID`);
+  return Object.freeze([...items]);
+}
+
+function assertScopes(value) {
+  assertOnlyKeys(value, ['units', 'modules', 'permissions'], 'IDENTITY_SCOPES_INVALID');
+  if (Object.keys(value).length !== 3) fail('IDENTITY_SCOPES_INVALID');
+  const units = strictSortedScope(value.units, 'IDENTITY_SCOPE_UNITS', /^[a-z][a-z0-9-]{0,159}$/);
+  if (units.some((unit) => !isCanonicalUnitScope(unit))) fail('IDENTITY_SCOPE_UNITS_INVALID');
+  return Object.freeze({
+    units,
+    modules: strictSortedScope(value.modules, 'IDENTITY_SCOPE_MODULES', SCOPE_ITEM_PATTERN),
+    permissions: strictSortedScope(value.permissions, 'IDENTITY_SCOPE_PERMISSIONS', SCOPE_ITEM_PATTERN),
+  });
+}
+
+function assertCanonicalTarget(value) {
+  if (typeof value !== 'string' || value.length < 8 || value.length > 2048) fail('CRM_TARGET_INVALID');
+  if (!value.startsWith('/api/crm') || !['/', '?', undefined].includes(value.at(8))) fail('CRM_TARGET_INVALID');
+  if (value.includes('#') || value.includes('\\') || /[^\x21-\x7e]/.test(value)) fail('CRM_TARGET_INVALID');
+  if (value.endsWith('?') || /\/{2,}|\/(?:\.{1,2})(?:\/|$)/.test(value)) fail('CRM_TARGET_INVALID');
+  if (/%(?![0-9A-F]{2})/.test(value) || /%(?:2F|5C)/.test(value)) fail('CRM_TARGET_INVALID');
+  return value;
+}
+
+function assertRequestBinding(value) {
+  assertOnlyKeys(value, ['method', 'target', 'bodyDigest'], 'CRM_REQUEST_BINDING_INVALID');
+  if (Object.keys(value).length !== 3) fail('CRM_REQUEST_BINDING_INVALID');
+  const method = value.method;
+  if (typeof method !== 'string' || !DELIVERY_METHODS.has(method)) fail('CRM_METHOD_INVALID');
+  const bodyDigest = value.bodyDigest;
+  if (typeof bodyDigest !== 'string') fail('CRM_BODY_DIGEST_INVALID');
+  if (!SHA256_HEX_PATTERN.test(bodyDigest)) fail('CRM_BODY_DIGEST_INVALID');
+  return Object.freeze({
+    htm: method,
+    htu: assertCanonicalTarget(value.target),
+    bdh: bodyDigest,
+  });
+}
+
+/**
+ * Produces only the minimal, unsigned input for a future private Identity
+ * WorkerEntrypoint. It deliberately does not read runtime configuration,
+ * resolve a session, serialize a JWS, sign, route, persist, or publish.
+ * The published contracts package remains the canonical parser, serializer and
+ * validator when this preparation is later connected through a clean install.
+ */
+export function prepareCrmIdentityDeliveryV1(input = {}) {
+  assertOnlyKeys(input, [
+    'enabled', 'identity', 'requestBinding', 'issuedAt', 'ttlSeconds', 'jti', 'keyId',
+  ], 'IDENTITY_CRM_DELIVERY_INPUT_INVALID');
+  const {
+    enabled,
+    identity,
+    requestBinding,
+    issuedAt,
+    ttlSeconds = IDENTITY_CRM_DELIVERY_MAX_TTL_SECONDS,
+    jti,
+    keyId,
+  } = input;
+  assertEnabled(enabled);
+  assertOnlyKeys(identity, ['identitySubject', 'role', 'scopes'], 'IDENTITY_ACTOR_INVALID');
+  if (Object.keys(identity).length !== 3) fail('IDENTITY_ACTOR_INVALID');
+  const iat = assertEpochSeconds(issuedAt, 'IDENTITY_ISSUED_AT');
+  const ttl = assertEpochSeconds(ttlSeconds, 'IDENTITY_TTL');
+  if (ttl < 1 || ttl > IDENTITY_CRM_DELIVERY_MAX_TTL_SECONDS) fail('IDENTITY_TTL_INVALID');
+  const exp = assertEpochSeconds(iat + ttl, 'IDENTITY_EXPIRES_AT');
+  if (typeof jti !== 'string' || !JTI_PATTERN.test(jti)) fail('IDENTITY_JTI_INVALID');
+  if (typeof keyId !== 'string' || !KEY_ID_PATTERN.test(keyId)) fail('IDENTITY_KEY_ID_INVALID');
+
+  const request = assertRequestBinding(requestBinding);
+  const protectedHeader = Object.freeze({
+    alg: 'EdDSA',
+    kid: keyId,
+    typ: 'skincos-identity-delivery+jws',
+  });
+  const claims = Object.freeze({
+    version: IDENTITY_CRM_DELIVERY_VERSION,
+    actorContractVersion: 'identity-actor/v1',
+    iss: IDENTITY_CRM_DELIVERY_ISSUER,
+    aud: IDENTITY_CRM_DELIVERY_AUDIENCE,
+    sub: assertOpaqueSubject(identity.identitySubject),
+    role: assertRole(identity.role),
+    scopes: assertScopes(identity.scopes),
+    iat,
+    exp,
+    jti,
+    ...request,
+  });
+
+  return Object.freeze({ protectedHeader, claims });
+}

--- a/identity/delivery/crm-envelope-v1.js
+++ b/identity/delivery/crm-envelope-v1.js
@@ -55,11 +55,22 @@ function assertRole(value) {
 }
 
 function strictSortedScope(value, name, pattern) {
-  if (!Array.isArray(value) || value.length > 64) fail(`${name}_INVALID`);
-  const items = value;
+  if (!Array.isArray(value) || Object.getPrototypeOf(value) !== Array.prototype || value.length > 64) fail(`${name}_INVALID`);
+  const length = value.length;
+  const expectedKeys = new Set(Array.from({ length }, (_, index) => String(index)));
+  const keys = Reflect.ownKeys(value);
+  if (keys.length !== length + 1 || keys.some((key) => key !== 'length' && (typeof key !== 'string' || !expectedKeys.has(key)))) {
+    fail(`${name}_INVALID`);
+  }
+  const items = [];
+  for (let index = 0; index < length; index += 1) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+    if (!descriptor || !descriptor.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) fail(`${name}_INVALID`);
+    items.push(descriptor.value);
+  }
   if (items.some((item) => typeof item !== 'string' || !item || !pattern.test(item))) fail(`${name}_INVALID`);
   if (items.some((item, index) => index > 0 && items[index - 1] >= item)) fail(`${name}_INVALID`);
-  return Object.freeze([...items]);
+  return Object.freeze(items);
 }
 
 function assertScopes(value) {
@@ -77,8 +88,10 @@ function assertCanonicalTarget(value) {
   if (typeof value !== 'string' || value.length < 8 || value.length > 2048) fail('CRM_TARGET_INVALID');
   if (!value.startsWith('/api/crm') || !['/', '?', undefined].includes(value.at(8))) fail('CRM_TARGET_INVALID');
   if (value.includes('#') || value.includes('\\') || /[^\x21-\x7e]/.test(value)) fail('CRM_TARGET_INVALID');
-  if (value.endsWith('?') || /\/{2,}|\/(?:\.{1,2})(?:\/|$)/.test(value)) fail('CRM_TARGET_INVALID');
-  if (/%(?![0-9A-F]{2})/.test(value) || /%(?:2E|2F|5C)/.test(value)) fail('CRM_TARGET_INVALID');
+  const queryIndex = value.indexOf('?');
+  const pathname = queryIndex === -1 ? value : value.slice(0, queryIndex);
+  if (value.endsWith('?') || /\/{2,}|\/(?:\.{1,2})(?:\/|$)/.test(pathname)) fail('CRM_TARGET_INVALID');
+  if (/%(?![0-9A-F]{2})/.test(value) || /%(?:2E|2F|5C)/.test(pathname)) fail('CRM_TARGET_INVALID');
   return value;
 }
 

--- a/identity/test/crm-envelope-v1.test.mjs
+++ b/identity/test/crm-envelope-v1.test.mjs
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+import { toAuthenticatedActor } from '../../shared/identity-contract/index.js';
+import {
+  IDENTITY_CRM_DELIVERY_AUDIENCE,
+  IDENTITY_CRM_DELIVERY_ISSUER,
+  IDENTITY_CRM_DELIVERY_VERSION,
+  prepareCrmIdentityDeliveryV1,
+} from '../delivery/crm-envelope-v1.js';
+
+const baseInput = Object.freeze({
+  enabled: true,
+  identity: Object.freeze({
+    identitySubject: 'idn:fixture_identity_actor_0001',
+    role: 'GESTOR',
+    scopes: Object.freeze({
+      units: Object.freeze(['novo-hamburgo']),
+      modules: Object.freeze(['clients', 'finance']),
+      permissions: Object.freeze(['clients:read', 'finance:read']),
+    }),
+  }),
+  requestBinding: Object.freeze({
+    method: 'POST',
+    target: '/api/crm/leads?unit=novo-hamburgo',
+    bodyDigest: 'a'.repeat(64),
+  }),
+  issuedAt: 1788292800,
+  ttlSeconds: 60,
+  jti: 'fixture_nonce_00000001',
+  keyId: 'identity-test-2026-09',
+});
+
+function input(overrides = {}) {
+  return { ...baseInput, ...overrides };
+}
+
+test('the private CRM delivery preparation is disabled unless a caller explicitly opts in', () => {
+  assert.throws(() => prepareCrmIdentityDeliveryV1(input({ enabled: false })), /IDENTITY_CRM_DELIVERY_DISABLED/);
+  assert.throws(() => prepareCrmIdentityDeliveryV1({}), /IDENTITY_CRM_DELIVERY_DISABLED/);
+});
+
+test('the preparation returns only the minimized Identity CRM delivery input', () => {
+  const prepared = prepareCrmIdentityDeliveryV1(input());
+
+  assert.deepEqual(prepared.protectedHeader, {
+    alg: 'EdDSA',
+    kid: 'identity-test-2026-09',
+    typ: 'skincos-identity-delivery+jws',
+  });
+  assert.deepEqual(prepared.claims, {
+    version: IDENTITY_CRM_DELIVERY_VERSION,
+    actorContractVersion: 'identity-actor/v1',
+    iss: IDENTITY_CRM_DELIVERY_ISSUER,
+    aud: IDENTITY_CRM_DELIVERY_AUDIENCE,
+    sub: 'idn:fixture_identity_actor_0001',
+    role: 'GESTOR',
+    scopes: {
+      units: ['novo-hamburgo'],
+      modules: ['clients', 'finance'],
+      permissions: ['clients:read', 'finance:read'],
+    },
+    iat: 1788292800,
+    exp: 1788292860,
+    jti: 'fixture_nonce_00000001',
+    htm: 'POST',
+    htu: '/api/crm/leads?unit=novo-hamburgo',
+    bdh: 'a'.repeat(64),
+  });
+  assert.doesNotMatch(JSON.stringify(prepared), /email|username|displayname|cookie|session|csrf/i);
+  assert.equal(Object.isFrozen(prepared), true);
+  assert.equal(Object.isFrozen(prepared.claims.scopes), true);
+});
+
+test('legacy actors cannot be promoted to a CRM delivery subject', () => {
+  const legacyActor = toAuthenticatedActor({
+    username: 'pilot',
+    email: 'pilot@example.test',
+    role: 'GESTOR',
+    allowedUnits: ['novo-hamburgo'],
+    allowedModules: ['finance'],
+    permissions: ['finance:read'],
+  });
+
+  assert.throws(() => prepareCrmIdentityDeliveryV1(input({ identity: legacyActor })), /IDENTITY_ACTOR_INVALID/);
+});
+
+test('the preparation fails closed for invalid opaque identity, scopes, request binding and lifetime', () => {
+  assert.throws(() => prepareCrmIdentityDeliveryV1(input({ identity: { ...baseInput.identity, identitySubject: 'pilot' } })), /IDENTITY_SUBJECT_REQUIRED/);
+  assert.throws(() => prepareCrmIdentityDeliveryV1(input({ identity: { ...baseInput.identity, role: 'gestor' } })), /IDENTITY_ROLE_INVALID/);
+  assert.throws(() => prepareCrmIdentityDeliveryV1(input({ identity: { ...baseInput.identity, email: 'pilot@example.test' } })), /IDENTITY_ACTOR_INVALID/);
+  assert.throws(() => prepareCrmIdentityDeliveryV1({ ...input(), extra: 'rejected' }), /IDENTITY_CRM_DELIVERY_INPUT_INVALID/);
+  assert.throws(() => prepareCrmIdentityDeliveryV1(input({ identity: { ...baseInput.identity, scopes: { ...baseInput.identity.scopes, units: ['NH'] } } })), /IDENTITY_SCOPE_UNITS_INVALID/);
+  assert.throws(() => prepareCrmIdentityDeliveryV1(input({ identity: { ...baseInput.identity, scopes: { ...baseInput.identity.scopes, modules: ['finance', 'finance'] } } })), /IDENTITY_SCOPE_MODULES_INVALID/);
+  assert.throws(() => prepareCrmIdentityDeliveryV1(input({ identity: { ...baseInput.identity, scopes: { ...baseInput.identity.scopes, modules: ['finance', 'clients'] } } })), /IDENTITY_SCOPE_MODULES_INVALID/);
+  assert.throws(() => prepareCrmIdentityDeliveryV1(input({ requestBinding: { ...baseInput.requestBinding, method: 'post' } })), /CRM_METHOD_INVALID/);
+  assert.throws(() => prepareCrmIdentityDeliveryV1(input({ requestBinding: { ...baseInput.requestBinding, extra: 'rejected' } })), /CRM_REQUEST_BINDING_INVALID/);
+  assert.throws(() => prepareCrmIdentityDeliveryV1(input({ requestBinding: { ...baseInput.requestBinding, target: 'https://crm.example.test/api/crm/leads' } })), /CRM_TARGET_INVALID/);
+  assert.throws(() => prepareCrmIdentityDeliveryV1(input({ requestBinding: { ...baseInput.requestBinding, bodyDigest: 'A'.repeat(64) } })), /CRM_BODY_DIGEST_INVALID/);
+  assert.throws(() => prepareCrmIdentityDeliveryV1(input({ ttlSeconds: 61 })), /IDENTITY_TTL_INVALID/);
+  assert.throws(() => prepareCrmIdentityDeliveryV1(input({ issuedAt: Number.MAX_SAFE_INTEGER })), /IDENTITY_EXPIRES_AT_INVALID/);
+});
+
+test('the source-only helper is not connected to the legacy public runtime or a secret', async () => {
+  const [helper, authRoutes, inventoryWorker] = await Promise.all([
+    readFile(new URL('../delivery/crm-envelope-v1.js', import.meta.url), 'utf8'),
+    readFile(new URL('../routes/auth.js', import.meta.url), 'utf8'),
+    readFile(new URL('../../inventory/src/worker.js', import.meta.url), 'utf8'),
+  ]);
+
+  assert.doesNotMatch(helper, /SESSION_SECRET|resolveIdentityActor|crypto\.subtle/i);
+  assert.doesNotMatch(helper, /from ['"]cloudflare:workers['"]/i);
+  assert.doesNotMatch(authRoutes, /crm-envelope-v1/);
+  assert.doesNotMatch(inventoryWorker, /crm-envelope-v1/);
+});

--- a/identity/test/crm-envelope-v1.test.mjs
+++ b/identity/test/crm-envelope-v1.test.mjs
@@ -98,6 +98,7 @@ test('the preparation fails closed for invalid opaque identity, scopes, request 
   assert.throws(() => prepareCrmIdentityDeliveryV1(input({ requestBinding: { ...baseInput.requestBinding, extra: 'rejected' } })), /CRM_REQUEST_BINDING_INVALID/);
   assert.throws(() => prepareCrmIdentityDeliveryV1(input({ requestBinding: { ...baseInput.requestBinding, target: 'https://crm.example.test/api/crm/leads' } })), /CRM_TARGET_INVALID/);
   assert.throws(() => prepareCrmIdentityDeliveryV1(input({ requestBinding: { ...baseInput.requestBinding, target: '/api/crm/admin/%2E%2E/leads' } })), /CRM_TARGET_INVALID/);
+  assert.doesNotThrow(() => prepareCrmIdentityDeliveryV1(input({ requestBinding: { ...baseInput.requestBinding, target: '/api/crm/clients?q=ACME%2Ffilial' } })));
   assert.throws(() => prepareCrmIdentityDeliveryV1(input({ requestBinding: { ...baseInput.requestBinding, bodyDigest: 'A'.repeat(64) } })), /CRM_BODY_DIGEST_INVALID/);
   assert.throws(() => prepareCrmIdentityDeliveryV1(input({ ttlSeconds: 61 })), /IDENTITY_TTL_INVALID/);
   assert.throws(() => prepareCrmIdentityDeliveryV1(input({ issuedAt: Number.MAX_SAFE_INTEGER })), /IDENTITY_EXPIRES_AT_INVALID/);
@@ -118,6 +119,28 @@ test('the preparation rejects hidden, symbolic, inherited and accessor input fie
   const accessor = input();
   Object.defineProperty(accessor, 'jti', { enumerable: true, get: () => baseInput.jti });
   assert.throws(() => prepareCrmIdentityDeliveryV1(accessor), /IDENTITY_CRM_DELIVERY_INPUT_INVALID/);
+});
+
+test('the preparation snapshots scope array data before validation and output', () => {
+  const source = ['module.clients.access'];
+  let indexGets = 0;
+  const proxied = new Proxy(source, {
+    get(target, property, receiver) {
+      if (property === '0') indexGets += 1;
+      return Reflect.get(target, property, receiver);
+    },
+  });
+  const prepared = prepareCrmIdentityDeliveryV1(input({
+    identity: { ...baseInput.identity, scopes: { ...baseInput.identity.scopes, permissions: proxied } },
+  }));
+  assert.deepEqual(prepared.claims.scopes.permissions, ['module.clients.access']);
+  assert.equal(indexGets, 0);
+
+  const accessorScope = [];
+  Object.defineProperty(accessorScope, '0', { enumerable: true, get: () => 'module.clients.access' });
+  assert.throws(() => prepareCrmIdentityDeliveryV1(input({
+    identity: { ...baseInput.identity, scopes: { ...baseInput.identity.scopes, permissions: accessorScope } },
+  })), /IDENTITY_SCOPE_PERMISSIONS_INVALID/);
 });
 
 test('the source-only helper is not connected to the legacy public runtime or a secret', async () => {

--- a/identity/test/crm-envelope-v1.test.mjs
+++ b/identity/test/crm-envelope-v1.test.mjs
@@ -18,7 +18,7 @@ const baseInput = Object.freeze({
     scopes: Object.freeze({
       units: Object.freeze(['novo-hamburgo']),
       modules: Object.freeze(['clients', 'finance']),
-      permissions: Object.freeze(['clients:read', 'finance:read']),
+      permissions: Object.freeze(['module.clients.access', 'module.finance.access']),
     }),
   }),
   requestBinding: Object.freeze({
@@ -59,7 +59,7 @@ test('the preparation returns only the minimized Identity CRM delivery input', (
     scopes: {
       units: ['novo-hamburgo'],
       modules: ['clients', 'finance'],
-      permissions: ['clients:read', 'finance:read'],
+      permissions: ['module.clients.access', 'module.finance.access'],
     },
     iat: 1788292800,
     exp: 1788292860,
@@ -97,9 +97,27 @@ test('the preparation fails closed for invalid opaque identity, scopes, request 
   assert.throws(() => prepareCrmIdentityDeliveryV1(input({ requestBinding: { ...baseInput.requestBinding, method: 'post' } })), /CRM_METHOD_INVALID/);
   assert.throws(() => prepareCrmIdentityDeliveryV1(input({ requestBinding: { ...baseInput.requestBinding, extra: 'rejected' } })), /CRM_REQUEST_BINDING_INVALID/);
   assert.throws(() => prepareCrmIdentityDeliveryV1(input({ requestBinding: { ...baseInput.requestBinding, target: 'https://crm.example.test/api/crm/leads' } })), /CRM_TARGET_INVALID/);
+  assert.throws(() => prepareCrmIdentityDeliveryV1(input({ requestBinding: { ...baseInput.requestBinding, target: '/api/crm/admin/%2E%2E/leads' } })), /CRM_TARGET_INVALID/);
   assert.throws(() => prepareCrmIdentityDeliveryV1(input({ requestBinding: { ...baseInput.requestBinding, bodyDigest: 'A'.repeat(64) } })), /CRM_BODY_DIGEST_INVALID/);
   assert.throws(() => prepareCrmIdentityDeliveryV1(input({ ttlSeconds: 61 })), /IDENTITY_TTL_INVALID/);
   assert.throws(() => prepareCrmIdentityDeliveryV1(input({ issuedAt: Number.MAX_SAFE_INTEGER })), /IDENTITY_EXPIRES_AT_INVALID/);
+});
+
+test('the preparation rejects hidden, symbolic, inherited and accessor input fields', () => {
+  const hidden = input();
+  Object.defineProperty(hidden, 'hidden', { value: true, enumerable: false });
+  assert.throws(() => prepareCrmIdentityDeliveryV1(hidden), /IDENTITY_CRM_DELIVERY_INPUT_INVALID/);
+
+  const symbolic = input();
+  symbolic[Symbol('hidden')] = true;
+  assert.throws(() => prepareCrmIdentityDeliveryV1(symbolic), /IDENTITY_CRM_DELIVERY_INPUT_INVALID/);
+
+  const inherited = Object.create(input());
+  assert.throws(() => prepareCrmIdentityDeliveryV1(inherited), /IDENTITY_CRM_DELIVERY_INPUT_INVALID/);
+
+  const accessor = input();
+  Object.defineProperty(accessor, 'jti', { enumerable: true, get: () => baseInput.jti });
+  assert.throws(() => prepareCrmIdentityDeliveryV1(accessor), /IDENTITY_CRM_DELIVERY_INPUT_INVALID/);
 });
 
 test('the source-only helper is not connected to the legacy public runtime or a secret', async () => {


### PR DESCRIPTION
## Summary
- add a disabled-by-default, source-only Identity helper that prepares minimized CRM delivery input
- require an opaque Identity subject and strict request/scope fields while rejecting legacy actors and extra fields
- keep the helper disconnected from routes, Workers, secrets, signing, storage, and deployment

## Deliberate limits
- this is not the canonical wire-contract implementation and does not sign or issue a JWS
- later integration requires the exact private contracts package, persistent opaque Identity subject, private service binding, CRM verifier, and replay store

## Validation
- npm --prefix identity test
- npm run domain-boundaries:validate