### PR TITLE
fix(website): restore Roda da Beleza aliases

### DIFF
--- a/website/scripts/smoke.mjs
+++ b/website/scripts/smoke.mjs
@@ -185,6 +185,21 @@ async function run() {
         assertPublicRedirectLocation(loc, path);
     }
 
+    // Historic wheel campaign links must converge to the live entry point without losing attribution.
+    for (const path of ["/roleta", "/roda-da-beleza", "/rodadabeleza"]) {
+        const tracking = "utm_source=smoke&utm_campaign=roda-da-beleza";
+        const res = await fetchHead(`${path}?${tracking}`, { redirect: "manual" });
+        assert(res.status === 301, `${path} expected a permanent redirect, got ${res.status}`);
+
+        const loc = res.headers.get("location");
+        assert(loc, `${path} expected Location header`);
+        const destination = new URL(loc, `${baseUrl}/`);
+        assert(destination.origin === new URL(baseUrl).origin, `${path} expected a first-party destination`);
+        assert(destination.pathname === "/cadastro", `${path} expected /cadastro, got ${destination.pathname}`);
+        assert(destination.searchParams.get("utm_source") === "smoke", `${path} lost utm_source`);
+        assert(destination.searchParams.get("utm_campaign") === "roda-da-beleza", `${path} lost utm_campaign`);
+    }
+
     // Header markers (ensure we're not serving an older deployment)
     {
         const { res, text } = await fetchText("/");

--- a/website/src/middleware.ts
+++ b/website/src/middleware.ts
@@ -10,13 +10,18 @@ const CADASTRO_WHEEL_LEGACY_PATHS = new Set([
     "/rodadabeleza",
 ]);
 
+const CADASTRO_WHEEL_WORKER_HOSTS = new Set([
+    "espacofacial-site.skincos.workers.dev",
+    "espacofacial-site-staging.skincos.workers.dev",
+]);
+
 function isCadastroWheelRedirectHost(host: string, hostname: string): boolean {
     return [host, hostname]
-        .map((value) => value.toLowerCase().replace(/:\\d+$/, ""))
+        .map((value) => value.toLowerCase().replace(/:\d+$/, ""))
         .some(
             (value) =>
                 getOfficialHostFamily(value) === "espacofacial-public" ||
-                value.endsWith(".skincos.workers.dev"),
+                CADASTRO_WHEEL_WORKER_HOSTS.has(value),
         );
 }
 

--- a/website/src/middleware.ts
+++ b/website/src/middleware.ts
@@ -1,8 +1,24 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { isPathAllowedForSite } from "@/lib/site-config";
+import { getOfficialHostFamily, isPathAllowedForSite } from "@/lib/site-config";
 import { buildWhatsappRedirectHrefFromRequest, isSupportedWhatsappUrl } from "@/lib/whatsappTracking";
 import { mergeCampaignParamsIntoUrl } from "@/lib/mergeCampaignParams";
 import { ANIVERSARIO_7_LEGACY_REDIRECTS } from "@/lib/aniversario7Redirects";
+
+const CADASTRO_WHEEL_LEGACY_PATHS = new Set([
+    "/roleta",
+    "/roda-da-beleza",
+    "/rodadabeleza",
+]);
+
+function isCadastroWheelRedirectHost(host: string, hostname: string): boolean {
+    return [host, hostname]
+        .map((value) => value.toLowerCase().replace(/:\\d+$/, ""))
+        .some(
+            (value) =>
+                getOfficialHostFamily(value) === "espacofacial-public" ||
+                value.endsWith(".skincos.workers.dev"),
+        );
+}
 
 function isPublicAsset(pathname: string): boolean {
     return (
@@ -78,6 +94,16 @@ export function middleware(req: NextRequest) {
     if (!isPublicAsset(url.pathname) && !url.pathname.startsWith("/api/") && host.startsWith("www.")) {
         url.host = host.replace(/^www\./, "");
         return NextResponse.redirect(url, 308);
+    }
+
+    // Preserve historic campaign links while keeping tracking parameters and the current host.
+    if (
+        !isPublicAsset(url.pathname) &&
+        isCadastroWheelRedirectHost(host, url.hostname) &&
+        CADASTRO_WHEEL_LEGACY_PATHS.has(normalizeRedirectPath(url.pathname))
+    ) {
+        url.pathname = "/cadastro";
+        return NextResponse.redirect(url, { status: 301 });
     }
 
     if (!isPublicAsset(url.pathname)) {

--- a/website/tests/cadastroWheelAliases.test.ts
+++ b/website/tests/cadastroWheelAliases.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { NextRequest } from "next/server";
+import { middleware } from "../src/middleware";
+
+const LEGACY_WHEEL_PATHS = ["/roleta", "/roda-da-beleza", "/rodadabeleza"];
+
+function redirectFor(requestUrl: string) {
+    const response = middleware(new NextRequest(requestUrl));
+    const location = response.headers.get("location");
+
+    assert.ok(location, `${requestUrl} should include a redirect location`);
+    return { response, destination: new URL(location, requestUrl) };
+}
+
+test("legacy Roda da Beleza paths redirect to cadastro without losing campaign parameters", () => {
+    for (const path of LEGACY_WHEEL_PATHS) {
+        const source = new URL(path, "https://espacofacial.com");
+        source.searchParams.append("utm_source", "meta");
+        source.searchParams.append("utm_campaign", "roda-da-beleza");
+        source.searchParams.append("tag", "first");
+        source.searchParams.append("tag", "second");
+
+        const { response, destination } = redirectFor(source.toString());
+
+        assert.equal(response.status, 301);
+        assert.equal(destination.origin, source.origin);
+        assert.equal(destination.pathname, "/cadastro");
+        assert.deepEqual([...destination.searchParams.entries()], [...source.searchParams.entries()]);
+    }
+});
+
+test("legacy Roda da Beleza paths stay on the staging worker host", () => {
+    const source = new URL(
+        "/roda-da-beleza?utm_source=staging&utm_campaign=roda-da-beleza",
+        "https://espacofacial-site-staging.skincos.workers.dev",
+    );
+
+    const { response, destination } = redirectFor(source.toString());
+
+    assert.equal(response.status, 301);
+    assert.equal(destination.origin, source.origin);
+    assert.equal(destination.pathname, "/cadastro");
+    assert.equal(destination.search, source.search);
+});
+
+test("legacy Roda da Beleza paths recognize a public host header with a local port", () => {
+    const requestUrl = "http://127.0.0.1:3417/roleta?utm_source=local";
+    const response = middleware(
+        new NextRequest(requestUrl, {
+            headers: { host: "espacofacial.com:3417" },
+        }),
+    );
+    const location = response.headers.get("location");
+
+    assert.ok(location, "the public host header should enable the legacy redirect");
+    assert.equal(response.status, 301);
+    assert.equal(new URL(location, requestUrl).pathname, "/cadastro");
+    assert.equal(new URL(location, requestUrl).searchParams.get("utm_source"), "local");
+});
+
+test("legacy Roda da Beleza paths do not take over the esfa.co short-link domain", () => {
+    const response = middleware(new NextRequest("https://esfa.co/roleta?utm_source=meta"));
+
+    assert.equal(response.headers.get("location"), null);
+});

--- a/website/tests/cadastroWheelAliases.test.ts
+++ b/website/tests/cadastroWheelAliases.test.ts
@@ -59,8 +59,25 @@ test("legacy Roda da Beleza paths recognize a public host header with a local po
     assert.equal(new URL(location, requestUrl).searchParams.get("utm_source"), "local");
 });
 
-test("legacy Roda da Beleza paths do not take over the esfa.co short-link domain", () => {
-    const response = middleware(new NextRequest("https://esfa.co/roleta?utm_source=meta"));
+test("legacy Roda da Beleza paths recognize the staging worker host with a local port", () => {
+    const requestUrl = "http://127.0.0.1:3417/roleta?utm_source=staging-local";
+    const response = middleware(
+        new NextRequest(requestUrl, {
+            headers: { host: "espacofacial-site-staging.skincos.workers.dev:3417" },
+        }),
+    );
+    const location = response.headers.get("location");
 
-    assert.equal(response.headers.get("location"), null);
+    assert.ok(location, "the staging worker host should enable the legacy redirect");
+    assert.equal(response.status, 301);
+    assert.equal(new URL(location, requestUrl).pathname, "/cadastro");
+    assert.equal(new URL(location, requestUrl).searchParams.get("utm_source"), "staging-local");
+});
+
+test("legacy Roda da Beleza paths do not take over other site surfaces", () => {
+    for (const host of ["https://esfa.co", "https://skincos-site.skincos.workers.dev"]) {
+        const response = middleware(new NextRequest(`${host}/roleta?utm_source=meta`));
+
+        assert.equal(response.headers.get("location"), null);
+    }
 });


### PR DESCRIPTION
## Objetivo
Restaurar os aliases históricos da Roda da Beleza para a entrada pública já ativa em `/cadastro`.

## Superfícies
- Middleware do Website: `/roleta`, `/roda-da-beleza` e `/rodadabeleza`
- Smoke de Website
- Teste de contrato de redirecionamento

## Comportamento
Os aliases respondem com 301 no domínio público e no Worker de staging, preservando UTMs e outros parâmetros. `esfa.co` não é capturado. Não há alteração de prêmios, formulário, dados, segredo, binding, migration, workflow ou flag.

## Risco
É uma mudança de redirect/cache de campanha. O teste cobre as três entradas, parâmetros repetidos, host de staging, host com porta local e isolamento do domínio curto.

## Validação local
- `npm run quality:website`: lint, 199 testes, typecheck e build verdes.
- Runtime local: 301 para `/cadastro` com parâmetros preservados; `esfa.co` não redireciona.

## Rollback
Reverter este commit e promover a versão imutável anterior pela mesma sequência preview → staging → production. Não há estado de dados para desfazer; a página canônica `/cadastro` permanece uma destinação segura mesmo durante cache de 301.

## Próxima etapa de release
Depois do merge e dos checks obrigatórios: preview, staging com smoke dos aliases, e somente então produção com o mesmo SHA.