### PR TITLE
fix(website): require server-confirmed wheel claims

### DIFF
--- a/website/src/app/api/cadastro/wheel/route.ts
+++ b/website/src/app/api/cadastro/wheel/route.ts
@@ -27,6 +27,15 @@ function clearWheelCookie(response: NextResponse) {
     });
 }
 
+function clearLeadCookie(response: NextResponse) {
+    response.cookies.set({
+        name: LEAD_COOKIE_NAME,
+        value: "",
+        maxAge: 0,
+        path: "/",
+    });
+}
+
 function resolveSecret(): string | null {
     const secret = (
         process.env.CADASTRO_WHEEL_SECRET ??
@@ -137,12 +146,18 @@ export async function POST(req: NextRequest) {
     const expMs = Date.now() + lockWindowMs;
     const leadId = req.cookies.get(LEAD_COOKIE_NAME)?.value ?? "";
     if (leadId) {
-        await assignCadastroLeadPrize({ id: leadId, prizeId });
+        const claimed = await assignCadastroLeadPrize({ id: leadId, prizeId });
+        if (!claimed) {
+            const response = withNoStore({ ok: false, error: "lead_unavailable" });
+            clearLeadCookie(response);
+            return response;
+        }
+
         return withNoStore({
             ok: true,
-            prizeId,
+            prizeId: claimed.prizeId,
             expMs,
-            replay: false,
+            replay: claimed.replay,
         });
     }
 

--- a/website/src/components/CadastroWheelExperience.tsx
+++ b/website/src/components/CadastroWheelExperience.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import TrackedWhatsappLink from "@/components/TrackedWhatsappLink";
 import { trackEvent } from "@/lib/analytics";
 import { trackLeadConversion } from "@/lib/conversions";
+import { claimCadastroWheelPrize, fetchLockedCadastroWheelPrize } from "@/lib/cadastroWheelClient";
 import { CADASTRO_WHEEL_PRIZES, type CadastroPrize } from "@/lib/cadastroWheelPrizes";
 import { buildWhatsAppUrl } from "@/lib/whatsapp";
 import { useCurrentUnit } from "@/hooks/useCurrentUnit";
@@ -16,15 +17,6 @@ type CadastroLeadForm = {
     phone: string;
     email: string;
 };
-
-type WheelStatusResponse =
-    | { ok: true; locked: true; prizeId: number; expMs?: number }
-    | { ok: true; locked: false; prizeId: null }
-    | { ok: false; error: string };
-
-type WheelSpinResponse =
-    | { ok: true; prizeId: number; replay: boolean; expMs?: number }
-    | { ok: false; error: string };
 
 type SpinSoundNodes = {
     ctx: AudioContext;
@@ -41,8 +33,6 @@ const BUTTON_FADE_OUT_MS = 1200;
 const BOOKING_EXTRA_DELAY_MS = 700;
 const RESULT_STING_MS = 2000;
 const SPIN_AUDIO_FADE_OUT_MS = 250;
-const LOCAL_LOCK_KEY = "ef_cadastro_wheel_lock";
-const LOCAL_LOCK_MS = 24 * 60 * 60 * 1000;
 const CADASTRO_LEAD_STORAGE_KEY = "ef_cadastro_lead_form";
 const CADASTRO_WHATSAPP_BY_UNIT: Record<string, string> = {
     barrashoppingsul: "5551980882293",
@@ -136,51 +126,6 @@ function findPrizeById(prizeId: number): CadastroPrize | null {
     return PRIZES.find((prize) => prize.id === prizeId) ?? null;
 }
 
-function clearLocalLock() {
-    try {
-        window.localStorage.removeItem(LOCAL_LOCK_KEY);
-    } catch {
-        // noop
-    }
-}
-
-function readLocalLockedPrize(): CadastroPrize | null {
-    try {
-        const raw = window.localStorage.getItem(LOCAL_LOCK_KEY);
-        if (!raw) return null;
-        const parsed = JSON.parse(raw) as { prizeId?: unknown; expMs?: unknown };
-        const prizeId = Number(parsed.prizeId);
-        const expMs = Number(parsed.expMs);
-        if (!Number.isInteger(prizeId) || !Number.isFinite(expMs) || expMs <= Date.now()) {
-            clearLocalLock();
-            return null;
-        }
-        const prize = findPrizeById(prizeId);
-        if (!prize) {
-            clearLocalLock();
-            return null;
-        }
-        return prize;
-    } catch {
-        clearLocalLock();
-        return null;
-    }
-}
-
-function persistLocalLockedPrize(prize: CadastroPrize, expMs = Date.now() + LOCAL_LOCK_MS) {
-    try {
-        window.localStorage.setItem(
-            LOCAL_LOCK_KEY,
-            JSON.stringify({
-                prizeId: prize.id,
-                expMs,
-            }),
-        );
-    } catch {
-        // noop
-    }
-}
-
 function createNoiseBuffer(ctx: AudioContext, durationMs = 1400) {
     const frameCount = Math.max(1, Math.floor((ctx.sampleRate * durationMs) / 1000));
     const buffer = ctx.createBuffer(1, frameCount, ctx.sampleRate);
@@ -217,6 +162,7 @@ export default function CadastroWheelExperience({ whatsappPhone }: { whatsappPho
     const [leadGateOpen, setLeadGateOpen] = useState(false);
     const [leadSubmitting, setLeadSubmitting] = useState(false);
     const [leadError, setLeadError] = useState<string | null>(null);
+    const [spinError, setSpinError] = useState<string | null>(null);
     const [duplicatePrize, setDuplicatePrize] = useState<CadastroPrize | null>(null);
     const [status, setStatus] = useState<SpinStatus>("idle");
     const [buttonPhase, setButtonPhase] = useState<ButtonPhase>("hidden");
@@ -254,7 +200,7 @@ export default function CadastroWheelExperience({ whatsappPhone }: { whatsappPho
         async function gateReady() {
             setLoaderVisible(true);
             setButtonPhase("hidden");
-            const restoredPrizePromise = fetchLockedPrize();
+            const restoredPrizePromise = fetchLockedCadastroWheelPrize();
             await wait(READY_DEADLINE_MS);
             await nextFrame();
             if (!active) return;
@@ -344,75 +290,6 @@ export default function CadastroWheelExperience({ whatsappPhone }: { whatsappPho
         const id = window.setTimeout(callback, ms);
         timeoutsRef.current.push(id);
         return id;
-    }
-
-    function resolveFallbackLocalPrize(): { prize: CadastroPrize; replay: boolean } {
-        const lockedPrize = readLocalLockedPrize();
-        if (lockedPrize) {
-            return { prize: lockedPrize, replay: true };
-        }
-        const drawnPrize = PRIZES[Math.floor(Math.random() * PRIZES.length)];
-        persistLocalLockedPrize(drawnPrize);
-        return { prize: drawnPrize, replay: false };
-    }
-
-    async function fetchLockedPrize(): Promise<CadastroPrize | null> {
-        try {
-            const response = await fetch("/api/cadastro/wheel", {
-                method: "GET",
-                cache: "no-store",
-            });
-            if (!response.ok) {
-                return readLocalLockedPrize();
-            }
-
-            const payload = (await response.json()) as WheelStatusResponse;
-            if (payload.ok && payload.locked && typeof payload.prizeId === "number") {
-                return findPrizeById(payload.prizeId);
-            }
-
-            if (payload.ok && !payload.locked) {
-                clearLocalLock();
-                return null;
-            }
-
-            if (!payload.ok && payload.error === "wheel_secret_unavailable") {
-                return readLocalLockedPrize();
-            }
-
-            return null;
-        } catch {
-            return readLocalLockedPrize();
-        }
-    }
-
-    async function claimPrize(): Promise<{ prize: CadastroPrize; replay: boolean; source: "server" | "local-lock" }> {
-        try {
-            const response = await fetch("/api/cadastro/wheel", {
-                method: "POST",
-                cache: "no-store",
-            });
-            if (response.ok) {
-                const payload = (await response.json()) as WheelSpinResponse;
-                if (payload.ok && typeof payload.prizeId === "number") {
-                    const prize = findPrizeById(payload.prizeId);
-                    if (prize) {
-                        clearLocalLock();
-                        return { prize, replay: payload.replay, source: "server" };
-                    }
-                }
-
-                if (!payload.ok && payload.error === "wheel_secret_unavailable") {
-                    const fallback = resolveFallbackLocalPrize();
-                    return { ...fallback, source: "local-lock" };
-                }
-            }
-        } catch {
-            // noop
-        }
-
-        const fallback = resolveFallbackLocalPrize();
-        return { ...fallback, source: "local-lock" };
     }
 
     async function ensureAudioContext(): Promise<AudioContext | null> {
@@ -700,13 +577,22 @@ export default function CadastroWheelExperience({ whatsappPhone }: { whatsappPho
 
         void playClickSound();
         setStatus("spinning");
+        setSpinError(null);
         setResult(null);
         setCtaVisible(false);
+
+        const claimed = await claimCadastroWheelPrize();
+        if (!claimed) {
+            setStatus("idle");
+            setButtonPhase("visible");
+            setSpinError("Não foi possível registrar o seu prêmio agora. Verifique a conexão e tente novamente.");
+            trackEvent("cadastro_wheel_spin_claim_failed", { page: "/cadastro" });
+            return;
+        }
+
+        const selectedPrize = claimed.prize;
         setButtonPhase("fading");
         trackTimeout(() => setButtonPhase("gone"), BUTTON_FADE_OUT_MS);
-
-        const claimed = await claimPrize();
-        const selectedPrize = claimed.prize;
 
         if (claimed.replay) {
             setStatus("done");
@@ -715,15 +601,11 @@ export default function CadastroWheelExperience({ whatsappPhone }: { whatsappPho
             setCtaVisible(true);
             trackEvent("cadastro_wheel_spin_replay", {
                 page: "/cadastro",
-                claimSource: claimed.source,
+                claimSource: "server",
                 prizeId: selectedPrize.id,
                 prizeName: selectedPrize.label,
             });
             return;
-        }
-
-        if (claimed.source === "local-lock") {
-            trackEvent("cadastro_wheel_spin_local_lock", { page: "/cadastro" });
         }
 
         await startSpinSound();
@@ -763,7 +645,7 @@ export default function CadastroWheelExperience({ whatsappPhone }: { whatsappPho
 
         trackEvent("cadastro_wheel_spin_complete", {
             page: "/cadastro",
-            claimSource: claimed.source,
+            claimSource: "server",
             prizeId: selectedPrize.id,
             prizeName: selectedPrize.label,
             finalAngle: current,
@@ -1119,11 +1001,16 @@ export default function CadastroWheelExperience({ whatsappPhone }: { whatsappPho
                                             </>
                                         ) : (
                                             <>
-                                                <span className={styles.resultEyebrow}>Como funciona</span>
-                                                <h2 className={styles.resultTitle}>Gire a roleta para liberar o seu atendimento</h2>
+                                                <span className={styles.resultEyebrow}>
+                                                    {spinError ? "Giro não concluído" : "Como funciona"}
+                                                </span>
+                                                <h2 className={styles.resultTitle}>
+                                                    {spinError ? "Nenhum prêmio foi atribuído" : "Gire a roleta para liberar o seu atendimento"}
+                                                </h2>
                                                 <p className={styles.resultText}>
-                                                    Assim que o carregamento inicial terminar, o botão central é liberado. O prêmio aparece
-                                                    após o giro completo e o CTA é exibido com atraso para manter a cadência da dinâmica.
+                                                    {spinError
+                                                        ? spinError
+                                                        : "Assim que o carregamento inicial terminar, o botão central é liberado. O prêmio aparece após o giro completo e o CTA é exibido com atraso para manter a cadência da dinâmica."}
                                                 </p>
                                             </>
                                         )}

--- a/website/src/components/CadastroWheelExperience.tsx
+++ b/website/src/components/CadastroWheelExperience.tsx
@@ -581,15 +581,25 @@ export default function CadastroWheelExperience({ whatsappPhone }: { whatsappPho
         setResult(null);
         setCtaVisible(false);
 
-        const claimed = await claimCadastroWheelPrize();
-        if (!claimed) {
+        const claimResult = await claimCadastroWheelPrize();
+        if (!claimResult.ok) {
             setStatus("idle");
-            setButtonPhase("visible");
-            setSpinError("Não foi possível registrar o seu prêmio agora. Verifique a conexão e tente novamente.");
-            trackEvent("cadastro_wheel_spin_claim_failed", { page: "/cadastro" });
+            if (claimResult.error === "lead_unavailable") {
+                setLeadGateOpen(false);
+                setButtonPhase("hidden");
+                setLeadError("Seu cadastro precisa ser validado novamente. Confira seus dados e tente de novo.");
+            } else {
+                setButtonPhase("visible");
+                setSpinError("Não foi possível registrar o seu prêmio agora. Verifique a conexão e tente novamente.");
+            }
+            trackEvent("cadastro_wheel_spin_claim_failed", {
+                page: "/cadastro",
+                reason: claimResult.error,
+            });
             return;
         }
 
+        const claimed = claimResult.claim;
         const selectedPrize = claimed.prize;
         setButtonPhase("fading");
         trackTimeout(() => setButtonPhase("gone"), BUTTON_FADE_OUT_MS);

--- a/website/src/lib/cadastroLeadDb.ts
+++ b/website/src/lib/cadastroLeadDb.ts
@@ -3,7 +3,7 @@ import { getBookingDb, normalizeEmail, normalizePhone, nowMs, sanitizeOneLine } 
 type D1PreparedStatement = {
     bind: (...values: unknown[]) => D1PreparedStatement;
     first: <T = unknown>() => Promise<T | null>;
-    run: () => Promise<{ success: boolean; error?: string } | unknown>;
+    run: () => Promise<unknown>;
 };
 
 type D1DatabaseLike = {
@@ -22,7 +22,27 @@ export type CadastroLeadRow = {
     awarded_at_ms: number | null;
 };
 
+export type CadastroLeadPrizeClaim = {
+    prizeId: number;
+    replay: boolean;
+};
+
+type D1RunResult = {
+    success: boolean;
+    error?: string;
+    meta?: {
+        changes?: number;
+    };
+};
+
 let ensured = false;
+
+function readD1RunResult(value: unknown): D1RunResult {
+    if (!value || typeof value !== "object" || typeof (value as { success?: unknown }).success !== "boolean") {
+        throw new Error("cadastro_wheel_prize_claim_invalid_d1_result");
+    }
+    return value as D1RunResult;
+}
 
 async function ensureCadastroLeadSchema(db: D1DatabaseLike) {
     await db
@@ -152,15 +172,57 @@ export async function touchCadastroLead(params: {
         .run();
 }
 
-export async function assignCadastroLeadPrize(params: { id: string; prizeId: number }): Promise<void> {
+export async function assignCadastroLeadPrize(params: { id: string; prizeId: number }): Promise<CadastroLeadPrizeClaim | null> {
+    const safeId = sanitizeOneLine(params.id);
+    if (!safeId || !Number.isInteger(params.prizeId) || params.prizeId < 1) {
+        return null;
+    }
+
     const db = await getCadastroLeadDb();
     const ts = nowMs();
-    await db
+    const update = readD1RunResult(
+        await db
+            .prepare(
+                `UPDATE cadastro_wheel_leads
+                 SET prize_id = ?, awarded_at_ms = COALESCE(awarded_at_ms, ?), updated_at_ms = ?
+                 WHERE id = ? AND prize_id IS NULL`,
+            )
+            .bind(params.prizeId, ts, ts, safeId)
+            .run(),
+    );
+
+    if (!update.success) {
+        throw new Error("cadastro_wheel_prize_claim_failed");
+    }
+
+    if (update.meta?.changes === 1) {
+        return {
+            prizeId: params.prizeId,
+            replay: false,
+        };
+    }
+
+    if (update.meta?.changes !== 0) {
+        throw new Error("cadastro_wheel_prize_claim_invalid_change_count");
+    }
+
+    const existing = await db
         .prepare(
-            `UPDATE cadastro_wheel_leads
-             SET prize_id = ?, awarded_at_ms = COALESCE(awarded_at_ms, ?), updated_at_ms = ?
-             WHERE id = ?`,
+            `SELECT prize_id
+             FROM cadastro_wheel_leads
+             WHERE id = ?
+             LIMIT 1`,
         )
-        .bind(params.prizeId, ts, ts, params.id)
-        .run();
+        .bind(safeId)
+        .first<Pick<CadastroLeadRow, "prize_id">>();
+
+    const existingPrizeId = existing?.prize_id;
+    if (typeof existingPrizeId !== "number" || !Number.isInteger(existingPrizeId) || existingPrizeId < 1) {
+        return null;
+    }
+
+    return {
+        prizeId: existingPrizeId,
+        replay: true,
+    };
 }

--- a/website/src/lib/cadastroWheelClient.ts
+++ b/website/src/lib/cadastroWheelClient.ts
@@ -1,0 +1,62 @@
+import { CADASTRO_WHEEL_PRIZES, type CadastroPrize } from "./cadastroWheelPrizes";
+
+type WheelStatusResponse =
+    | { ok: true; locked: true; prizeId: number; expMs?: number }
+    | { ok: true; locked: false; prizeId: null }
+    | { ok: false; error: string };
+
+type WheelSpinResponse =
+    | { ok: true; prizeId: number; replay: boolean; expMs?: number }
+    | { ok: false; error: string };
+
+type WheelFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+export type CadastroWheelClaim = {
+    prize: CadastroPrize;
+    replay: boolean;
+};
+
+function findPrizeById(prizeId: number): CadastroPrize | null {
+    return CADASTRO_WHEEL_PRIZES.find((prize) => prize.id === prizeId) ?? null;
+}
+
+export async function fetchLockedCadastroWheelPrize(fetcher: WheelFetch = fetch): Promise<CadastroPrize | null> {
+    try {
+        const response = await fetcher("/api/cadastro/wheel", {
+            method: "GET",
+            cache: "no-store",
+        });
+        if (!response.ok) return null;
+
+        const payload = (await response.json().catch(() => null)) as WheelStatusResponse | null;
+        if (payload?.ok && payload.locked && typeof payload.prizeId === "number") {
+            return findPrizeById(payload.prizeId);
+        }
+    } catch {
+        // A prize is only restored from the signed server response.
+    }
+
+    return null;
+}
+
+export async function claimCadastroWheelPrize(fetcher: WheelFetch = fetch): Promise<CadastroWheelClaim | null> {
+    try {
+        const response = await fetcher("/api/cadastro/wheel", {
+            method: "POST",
+            cache: "no-store",
+        });
+        if (!response.ok) return null;
+
+        const payload = (await response.json().catch(() => null)) as WheelSpinResponse | null;
+        if (payload?.ok && typeof payload.prizeId === "number") {
+            const prize = findPrizeById(payload.prizeId);
+            if (prize) {
+                return { prize, replay: payload.replay };
+            }
+        }
+    } catch {
+        // A prize is only awarded after a successful server response.
+    }
+
+    return null;
+}

--- a/website/src/lib/cadastroWheelClient.ts
+++ b/website/src/lib/cadastroWheelClient.ts
@@ -16,6 +16,16 @@ export type CadastroWheelClaim = {
     replay: boolean;
 };
 
+export type CadastroWheelClaimResult =
+    | {
+          ok: true;
+          claim: CadastroWheelClaim;
+      }
+    | {
+          ok: false;
+          error: "claim_unavailable" | "lead_unavailable";
+      };
+
 function findPrizeById(prizeId: number): CadastroPrize | null {
     return CADASTRO_WHEEL_PRIZES.find((prize) => prize.id === prizeId) ?? null;
 }
@@ -39,24 +49,30 @@ export async function fetchLockedCadastroWheelPrize(fetcher: WheelFetch = fetch)
     return null;
 }
 
-export async function claimCadastroWheelPrize(fetcher: WheelFetch = fetch): Promise<CadastroWheelClaim | null> {
+export async function claimCadastroWheelPrize(fetcher: WheelFetch = fetch): Promise<CadastroWheelClaimResult> {
     try {
         const response = await fetcher("/api/cadastro/wheel", {
             method: "POST",
             cache: "no-store",
         });
-        if (!response.ok) return null;
-
         const payload = (await response.json().catch(() => null)) as WheelSpinResponse | null;
+        if (payload && !payload.ok && payload.error === "lead_unavailable") {
+            return { ok: false, error: "lead_unavailable" };
+        }
+        if (!response.ok) return { ok: false, error: "claim_unavailable" };
+
         if (payload?.ok && typeof payload.prizeId === "number") {
             const prize = findPrizeById(payload.prizeId);
             if (prize) {
-                return { prize, replay: payload.replay };
+                return {
+                    ok: true,
+                    claim: { prize, replay: payload.replay },
+                };
             }
         }
     } catch {
         // A prize is only awarded after a successful server response.
     }
 
-    return null;
+    return { ok: false, error: "claim_unavailable" };
 }

--- a/website/tests/cadastroLeadDb.test.ts
+++ b/website/tests/cadastroLeadDb.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test, { mock } from "node:test";
+
+const moduleUrl = (relativePath: string) => new URL("../src/" + relativePath + ".ts", import.meta.url).href;
+let persistedPrize: number | null = null;
+let updateQuery = "";
+
+const database = {
+    prepare(query: string) {
+        let values: unknown[] = [];
+        return {
+            bind: (...nextValues: unknown[]) => {
+                values = nextValues;
+                return {
+                    bind: (...replacementValues: unknown[]) => {
+                        values = replacementValues;
+                        return this;
+                    },
+                    first: async <T>() => {
+                        if (query.includes("SELECT prize_id")) {
+                            return (persistedPrize === null ? null : { prize_id: persistedPrize }) as T | null;
+                        }
+                        return null;
+                    },
+                    run: async () => {
+                        if (query.includes("UPDATE cadastro_wheel_leads")) {
+                            updateQuery = query;
+                            if (persistedPrize === null) {
+                                persistedPrize = Number(values[0]);
+                                return { success: true, meta: { changes: 1 } };
+                            }
+                            return { success: true, meta: { changes: 0 } };
+                        }
+                        return { success: true, meta: { changes: 0 } };
+                    },
+                };
+            },
+            first: async <T>() => null as T | null,
+            run: async () => ({ success: true, meta: { changes: 0 } }),
+        };
+    },
+};
+
+mock.module(moduleUrl("lib/bookingDb"), {
+    namedExports: {
+        getBookingDb: async () => database,
+        normalizeEmail: (value: string) => value.trim().toLowerCase(),
+        normalizePhone: (value: string) => value.replace(/\D/g, ""),
+        nowMs: () => 1_000,
+        sanitizeOneLine: (value: string) => value.trim(),
+    },
+});
+
+const { assignCadastroLeadPrize } = await import("../src/lib/cadastroLeadDb");
+
+test("lead prize claim persists only the first prize and replays it for later attempts", async () => {
+    persistedPrize = null;
+    updateQuery = "";
+
+    const first = await assignCadastroLeadPrize({ id: "lead-001", prizeId: 3 });
+    const second = await assignCadastroLeadPrize({ id: "lead-001", prizeId: 9 });
+
+    assert.deepEqual(first, { prizeId: 3, replay: false });
+    assert.deepEqual(second, { prizeId: 3, replay: true });
+    assert.match(updateQuery, /WHERE id = \? AND prize_id IS NULL/);
+});

--- a/website/tests/cadastroWheelClient.test.ts
+++ b/website/tests/cadastroWheelClient.test.ts
@@ -25,24 +25,29 @@ test("wheel client never awards a local fallback when the server cannot confirm 
     const unavailable = await claimCadastroWheelPrize(async () =>
         jsonResponse({ ok: false, error: "wheel_secret_unavailable" }),
     );
-    assert.equal(unavailable, null);
+    assert.deepEqual(unavailable, { ok: false, error: "claim_unavailable" });
 
     const networkFailure = await claimCadastroWheelPrize(async () => {
         throw new Error("network unavailable");
     });
-    assert.equal(networkFailure, null);
+    assert.deepEqual(networkFailure, { ok: false, error: "claim_unavailable" });
 });
 
 test("wheel client accepts a valid server claim and preserves replay state", async () => {
-    const claim = await claimCadastroWheelPrize(async () =>
+    const result = await claimCadastroWheelPrize(async () =>
         jsonResponse({ ok: true, prizeId: 7, replay: true, expMs: Date.now() + 60_000 }),
     );
 
     assert.deepEqual(
-        claim && {
-            prizeId: claim.prize.id,
-            replay: claim.replay,
+        result.ok && {
+            prizeId: result.claim.prize.id,
+            replay: result.claim.replay,
         },
         { prizeId: 7, replay: true },
     );
+});
+
+test("wheel client requires the lead form again when the server no longer has that lead", async () => {
+    const result = await claimCadastroWheelPrize(async () => jsonResponse({ ok: false, error: "lead_unavailable" }));
+    assert.deepEqual(result, { ok: false, error: "lead_unavailable" });
 });

--- a/website/tests/cadastroWheelClient.test.ts
+++ b/website/tests/cadastroWheelClient.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { claimCadastroWheelPrize, fetchLockedCadastroWheelPrize } from "../src/lib/cadastroWheelClient";
+
+function jsonResponse(body: unknown, status = 200) {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+}
+
+test("wheel client restores only a signed server lock", async () => {
+    const restored = await fetchLockedCadastroWheelPrize(async () =>
+        jsonResponse({ ok: true, locked: true, prizeId: 4, expMs: Date.now() + 60_000 }),
+    );
+    assert.equal(restored?.id, 4);
+
+    const unavailable = await fetchLockedCadastroWheelPrize(async () =>
+        jsonResponse({ ok: false, error: "wheel_secret_unavailable" }),
+    );
+    assert.equal(unavailable, null);
+});
+
+test("wheel client never awards a local fallback when the server cannot confirm a claim", async () => {
+    const unavailable = await claimCadastroWheelPrize(async () =>
+        jsonResponse({ ok: false, error: "wheel_secret_unavailable" }),
+    );
+    assert.equal(unavailable, null);
+
+    const networkFailure = await claimCadastroWheelPrize(async () => {
+        throw new Error("network unavailable");
+    });
+    assert.equal(networkFailure, null);
+});
+
+test("wheel client accepts a valid server claim and preserves replay state", async () => {
+    const claim = await claimCadastroWheelPrize(async () =>
+        jsonResponse({ ok: true, prizeId: 7, replay: true, expMs: Date.now() + 60_000 }),
+    );
+
+    assert.deepEqual(
+        claim && {
+            prizeId: claim.prize.id,
+            replay: claim.replay,
+        },
+        { prizeId: 7, replay: true },
+    );
+});

--- a/website/tests/cadastroWheelLeadClaim.test.ts
+++ b/website/tests/cadastroWheelLeadClaim.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test, { mock } from "node:test";
+import { NextRequest } from "next/server";
+
+const moduleUrl = (relativePath: string) => new URL("../src/" + relativePath + ".ts", import.meta.url).href;
+const LEAD_ID = "lead-atomic-claim-test";
+let persistedPrize: number | null = null;
+let assignmentCalls = 0;
+
+mock.module(moduleUrl("lib/cadastroLeadDb"), {
+    namedExports: {
+        findCadastroLeadById: async (id: string) => {
+            return id === LEAD_ID
+                ? {
+                      id,
+                      full_name: "Teste Roda",
+                      email: "teste@example.com",
+                      phone: "51999999999",
+                      unit_slug: "barrashoppingsul",
+                      prize_id: persistedPrize,
+                      created_at_ms: 0,
+                      updated_at_ms: 0,
+                      awarded_at_ms: null,
+                  }
+                : null;
+        },
+        assignCadastroLeadPrize: async ({ id, prizeId }: { id: string; prizeId: number }) => {
+            assignmentCalls += 1;
+            if (id !== LEAD_ID) return null;
+            if (persistedPrize === null) {
+                persistedPrize = prizeId;
+                return { prizeId, replay: false };
+            }
+            return { prizeId: persistedPrize, replay: true };
+        },
+    },
+});
+
+const { POST } = await import("../src/app/api/cadastro/wheel/route");
+
+function request() {
+    return new NextRequest("https://example.com/api/cadastro/wheel", {
+        method: "POST",
+        headers: { cookie: "ef_cadastro_lead=" + LEAD_ID },
+    });
+}
+
+test("concurrent lead spins return the same atomic prize and mark the second result as replay", async () => {
+    const previousSecret = process.env.CADASTRO_WHEEL_SECRET;
+    process.env.CADASTRO_WHEEL_SECRET = "cadastro-wheel-atomic-test-secret";
+    persistedPrize = null;
+    assignmentCalls = 0;
+
+    try {
+        const [firstResponse, secondResponse] = await Promise.all([POST(request()), POST(request())]);
+        const first = (await firstResponse.json()) as { ok: boolean; prizeId: number; replay: boolean };
+        const second = (await secondResponse.json()) as { ok: boolean; prizeId: number; replay: boolean };
+
+        assert.equal(first.ok, true);
+        assert.equal(second.ok, true);
+        assert.equal(assignmentCalls >= 1, true);
+        assert.equal(first.prizeId, second.prizeId);
+        assert.deepEqual([first.replay, second.replay].sort(), [false, true]);
+    } finally {
+        if (previousSecret === undefined) delete process.env.CADASTRO_WHEEL_SECRET;
+        else process.env.CADASTRO_WHEEL_SECRET = previousSecret;
+    }
+});
+
+test("missing lead fails closed instead of issuing an unpersisted wheel prize", async () => {
+    const previousSecret = process.env.CADASTRO_WHEEL_SECRET;
+    process.env.CADASTRO_WHEEL_SECRET = "cadastro-wheel-atomic-test-secret";
+
+    try {
+        const response = await POST(
+            new NextRequest("https://example.com/api/cadastro/wheel", {
+                method: "POST",
+                headers: { cookie: "ef_cadastro_lead=missing-lead" },
+            }),
+        );
+        assert.deepEqual(await response.json(), { ok: false, error: "lead_unavailable" });
+        assert.match(response.headers.get("set-cookie") ?? "", /ef_cadastro_lead=;/);
+    } finally {
+        if (previousSecret === undefined) delete process.env.CADASTRO_WHEEL_SECRET;
+        else process.env.CADASTRO_WHEEL_SECRET = previousSecret;
+    }
+});


### PR DESCRIPTION
## Summary
- remove browser-local prize assignment and restoration fallback
- reveal prizes only after the signed server endpoint confirms them
- make lead-backed prize assignment an atomic D1 compare-and-set, returning the persisted prize to concurrent requests
- fail closed and return the visitor to the lead form if the server no longer has the lead

## Validation
- npm run lint
- npm run typecheck
- npm run test (207 passing)
- native in-app browser: /cadastro renders the unit-selected lead gate without a framework error overlay

No catalog, commercial conditions, or production bindings are changed.