### PR TITLE
fix(security): harden Agent Zero persistence boundaries

### DIFF
--- a/.github/security/bandit-exceptions.csv
+++ b/.github/security/bandit-exceptions.csv
@@ -1,4 +1,1 @@
 # filename,test_id,expires_on,reason
-backend/apps/agent-zero/apps/agent_zero_core/python/helpers/files.py,B103,2026-08-31,Upstream agent-zero core uses chmod 0777 in helper utility; pending upstream hardening
-backend/apps/agent-zero/apps/agent_zero_core/python/helpers/knowledge_import.py,B324,2026-08-31,Upstream agent-zero helper uses md5 for content fingerprinting; pending upstream replacement
-backend/apps/agent-zero/apps/agent_zero_core/python/helpers/shell_ssh.py,B507,2026-08-31,Upstream helper auto-adds SSH host key; pending strict host key validation

--- a/backend/apps/agent-zero/agent.py
+++ b/backend/apps/agent-zero/agent.py
@@ -231,6 +231,7 @@ class AgentConfig:
     code_exec_ssh_port: int = 55022
     code_exec_ssh_user: str = "root"
     code_exec_ssh_pass: str = ""
+    code_exec_ssh_known_hosts: str = ""
     additional: Dict[str, Any] = field(default_factory=dict)
 
 

--- a/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/chat_paths.py
+++ b/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/chat_paths.py
@@ -1,0 +1,314 @@
+import ntpath
+import os
+import re
+import shutil
+import stat
+from contextlib import contextmanager
+from typing import Iterator
+
+
+CHAT_FILE_NAME = "chat.json"
+
+
+def _require_secure_directory_operations() -> None:
+    required_operations = (os.open, os.mkdir, os.stat, os.unlink)
+    if (
+        os.name != "posix"
+        or not hasattr(os, "O_DIRECTORY")
+        or not hasattr(os, "O_NOFOLLOW")
+        or any(operation not in os.supports_dir_fd for operation in required_operations)
+    ):
+        raise OSError("secure persisted chats require POSIX descriptor operations")
+
+
+def _directory_flags() -> int:
+    return (
+        os.O_RDONLY
+        | os.O_DIRECTORY
+        | os.O_NOFOLLOW
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+
+
+def _file_flags(flags: int) -> int:
+    return flags | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+
+
+def _context_components(context_id: str) -> list[str]:
+    if not isinstance(context_id, str) or not context_id or "\x00" in context_id:
+        raise ValueError("invalid chat context id")
+
+    if (
+        os.path.isabs(context_id)
+        or ntpath.isabs(context_id)
+        or ntpath.splitdrive(context_id)[0]
+    ):
+        raise ValueError("chat context id must be relative")
+
+    components = re.split(r"[\\/]", context_id)
+    if any(component in {"", ".", ".."} for component in components):
+        raise ValueError("chat context id contains an unsafe path component")
+    return components
+
+
+def _absolute_components(path: str) -> list[str]:
+    if not isinstance(path, str) or not path or not os.path.isabs(path):
+        raise ValueError("chat root must be an absolute path")
+
+    normalized = os.path.normpath(path)
+    return [component for component in normalized.split(os.sep) if component]
+
+
+def _open_directory_at(parent_fd: int, component: str, create: bool) -> int:
+    try:
+        return os.open(component, _directory_flags(), dir_fd=parent_fd)
+    except FileNotFoundError:
+        if not create:
+            raise
+        try:
+            os.mkdir(component, mode=0o700, dir_fd=parent_fd)
+        except FileExistsError:
+            # A concurrent writer may have won the create race. Re-open below with
+            # O_NOFOLLOW so a replacement symlink still fails closed.
+            pass
+        return os.open(component, _directory_flags(), dir_fd=parent_fd)
+
+
+def _open_chat_root(chat_root: str, create: bool) -> int:
+    """Open every root component from / without following a symlink."""
+    _require_secure_directory_operations()
+    components = _absolute_components(chat_root)
+    root_fd = os.open(os.path.sep, _directory_flags())
+    try:
+        for component in components:
+            child_fd = _open_directory_at(root_fd, component, create=create)
+            os.close(root_fd)
+            root_fd = child_fd
+        return root_fd
+    except Exception:
+        os.close(root_fd)
+        raise
+
+
+@contextmanager
+def _open_context_from_root(
+    root_fd: int, components: list[str], create: bool
+) -> Iterator[int]:
+    context_fd = os.dup(root_fd)
+    try:
+        for component in components:
+            child_fd = _open_directory_at(context_fd, component, create=create)
+            os.close(context_fd)
+            context_fd = child_fd
+        yield context_fd
+    finally:
+        os.close(context_fd)
+
+
+@contextmanager
+def _open_chat_context(
+    chat_root: str, context_id: str, create: bool
+) -> Iterator[tuple[int, int]]:
+    components = _context_components(context_id)
+    root_fd = _open_chat_root(chat_root, create=create)
+    try:
+        with _open_context_from_root(root_fd, components, create=create) as context_fd:
+            yield root_fd, context_fd
+    finally:
+        os.close(root_fd)
+
+
+def _validate_existing_context_path(root_fd: int, components: list[str]) -> None:
+    """Reject existing symlinks while preserving path-only compatibility."""
+    context_fd = os.dup(root_fd)
+    try:
+        for component in components:
+            try:
+                child_fd = _open_directory_at(context_fd, component, create=False)
+            except FileNotFoundError:
+                return
+            os.close(context_fd)
+            context_fd = child_fd
+    finally:
+        os.close(context_fd)
+
+
+def resolve_chat_directory(chat_root: str, context_id: str) -> str:
+    """Validate a chat-directory reference without following existing links.
+
+    Persisted chat I/O must use the descriptor-backed functions below; a returned
+    string cannot remain race-safe after this function returns.
+    """
+    components = _context_components(context_id)
+    try:
+        root_fd = _open_chat_root(chat_root, create=False)
+    except FileNotFoundError:
+        return os.path.join(os.path.abspath(chat_root), *components)
+    except OSError as error:
+        raise ValueError("chat root contains an unsafe symlink") from error
+    try:
+        _validate_existing_context_path(root_fd, components)
+    except OSError as error:
+        raise ValueError("chat context directory contains an unsafe symlink") from error
+    finally:
+        os.close(root_fd)
+
+    return os.path.join(os.path.abspath(chat_root), *components)
+
+
+def _open_chat_file(context_fd: int, flags: int) -> int:
+    return os.open(CHAT_FILE_NAME, _file_flags(flags), 0o600, dir_fd=context_fd)
+
+
+def write_chat_json(chat_root: str, context_id: str, content: str) -> None:
+    if not isinstance(content, str):
+        raise TypeError("persisted chat content must be text")
+
+    with _open_chat_context(chat_root, context_id, create=True) as (_, context_fd):
+        file_fd = _open_chat_file(context_fd, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
+        try:
+            os.fchmod(file_fd, 0o600)
+            with os.fdopen(file_fd, "w", encoding="utf-8") as file:
+                file_fd = -1
+                file.write(content)
+        finally:
+            if file_fd != -1:
+                os.close(file_fd)
+
+
+def read_chat_json(chat_root: str, context_id: str) -> str:
+    with _open_chat_context(chat_root, context_id, create=False) as (_, context_fd):
+        file_fd = _open_chat_file(context_fd, os.O_RDONLY)
+        try:
+            with os.fdopen(file_fd, "r", encoding="utf-8") as file:
+                file_fd = -1
+                return file.read()
+        finally:
+            if file_fd != -1:
+                os.close(file_fd)
+
+
+def list_chat_context_ids(chat_root: str) -> list[str]:
+    try:
+        root_fd = _open_chat_root(chat_root, create=False)
+    except FileNotFoundError:
+        return []
+
+    try:
+        context_ids = []
+        for entry in os.listdir(root_fd):
+            try:
+                components = _context_components(entry)
+                with _open_context_from_root(root_fd, components, create=False):
+                    context_ids.append(entry)
+            except (FileNotFoundError, NotADirectoryError, OSError, ValueError):
+                # Existing symlinks, files, and concurrent removals are not chats.
+                continue
+        return context_ids
+    finally:
+        os.close(root_fd)
+
+
+def _legacy_context_id(filename: str) -> str:
+    if os.path.basename(filename) != filename or not filename.endswith(".json"):
+        raise ValueError("legacy chat filename must be a direct .json file")
+    context_id = filename.removesuffix(".json")
+    components = _context_components(context_id)
+    if len(components) != 1:
+        raise ValueError("legacy chat filename must name one context directory")
+    return context_id
+
+
+def list_legacy_chat_jsons(chat_root: str) -> list[str]:
+    try:
+        root_fd = _open_chat_root(chat_root, create=False)
+    except FileNotFoundError:
+        return []
+
+    try:
+        return [entry for entry in os.listdir(root_fd) if entry.endswith(".json")]
+    finally:
+        os.close(root_fd)
+
+
+def _copy_file_descriptor(source_fd: int, destination_fd: int) -> None:
+    while chunk := os.read(source_fd, 64 * 1024):
+        view = memoryview(chunk)
+        while view:
+            view = view[os.write(destination_fd, view) :]
+
+
+def migrate_legacy_chat_json(chat_root: str, filename: str) -> None:
+    """Copy one legacy direct chat file without accepting a symlink source."""
+    context_id = _legacy_context_id(filename)
+    root_fd = _open_chat_root(chat_root, create=False)
+    source_fd = -1
+    try:
+        try:
+            source_fd = os.open(filename, _file_flags(os.O_RDONLY), dir_fd=root_fd)
+        except OSError as error:
+            raise ValueError("legacy chat source is unsafe") from error
+
+        source_stat = os.fstat(source_fd)
+        if not stat.S_ISREG(source_stat.st_mode):
+            raise ValueError("legacy chat source must be a regular file")
+
+        with _open_context_from_root(
+            root_fd, _context_components(context_id), create=True
+        ) as context_fd:
+            destination_fd = _open_chat_file(
+                context_fd, os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+            )
+            try:
+                os.fchmod(destination_fd, 0o600)
+                _copy_file_descriptor(source_fd, destination_fd)
+            finally:
+                os.close(destination_fd)
+
+        try:
+            current_stat = os.stat(filename, dir_fd=root_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            return
+        if (current_stat.st_dev, current_stat.st_ino) == (
+            source_stat.st_dev,
+            source_stat.st_ino,
+        ):
+            os.unlink(filename, dir_fd=root_fd)
+    finally:
+        if source_fd != -1:
+            os.close(source_fd)
+        os.close(root_fd)
+
+
+def remove_chat_directory(chat_root: str, context_id: str) -> bool:
+    """Remove one context via a parent descriptor without following links."""
+    if not getattr(shutil.rmtree, "avoids_symlink_attacks", False):
+        raise OSError("secure chat deletion is unavailable on this platform")
+
+    components = _context_components(context_id)
+    try:
+        root_fd = _open_chat_root(chat_root, create=False)
+    except FileNotFoundError:
+        return False
+
+    parent_fd = os.dup(root_fd)
+    try:
+        for component in components[:-1]:
+            child_fd = _open_directory_at(parent_fd, component, create=False)
+            os.close(parent_fd)
+            parent_fd = child_fd
+
+        try:
+            target_stat = os.stat(
+                components[-1], dir_fd=parent_fd, follow_symlinks=False
+            )
+        except FileNotFoundError:
+            return False
+        if not stat.S_ISDIR(target_stat.st_mode):
+            raise ValueError("chat context directory is unsafe")
+
+        shutil.rmtree(components[-1], dir_fd=parent_fd)
+        return True
+    finally:
+        os.close(parent_fd)
+        os.close(root_fd)

--- a/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/checksums.py
+++ b/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/checksums.py
@@ -1,0 +1,9 @@
+import hashlib
+
+
+def calculate_sha256(file_path: str) -> str:
+    hasher = hashlib.sha256()
+    with open(file_path, "rb") as file_handle:
+        for chunk in iter(lambda: file_handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()

--- a/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/files.py
+++ b/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/files.py
@@ -13,6 +13,7 @@ import importlib
 import importlib.util
 import inspect
 import glob
+import stat
 
 
 class VariablesPlugin(ABC):
@@ -303,10 +304,12 @@ def delete_dir(relative_path: str):
                 for root, dirs, files in os.walk(abs_path, topdown=False):
                     for name in files:
                         file_path = os.path.join(root, name)
-                        os.chmod(file_path, 0o777)
+                        if not os.path.islink(file_path):
+                            os.chmod(file_path, stat.S_IRUSR | stat.S_IWUSR)
                     for name in dirs:
                         dir_path = os.path.join(root, name)
-                        os.chmod(dir_path, 0o777)
+                        if not os.path.islink(dir_path):
+                            os.chmod(dir_path, stat.S_IRWXU)
 
                 # try again after changing permissions
                 shutil.rmtree(abs_path, ignore_errors=True)

--- a/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/knowledge_import.py
+++ b/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/knowledge_import.py
@@ -1,6 +1,5 @@
 import glob
 import os
-import hashlib
 from typing import Any, Dict, Literal, TypedDict
 from langchain_community.document_loaders import (
     CSVLoader,
@@ -10,6 +9,7 @@ from langchain_community.document_loaders import (
 )
 from python.helpers.log import LogItem
 from python.helpers.print_style import PrintStyle
+from python.helpers.checksums import calculate_sha256
 
 text_loader_kwargs = {"autodetect_encoding": True}
 
@@ -23,11 +23,7 @@ class KnowledgeImport(TypedDict):
 
 
 def calculate_checksum(file_path: str) -> str:
-    hasher = hashlib.md5()
-    with open(file_path, "rb") as f:
-        buf = f.read()
-        hasher.update(buf)
-    return hasher.hexdigest()
+    return calculate_sha256(file_path)
 
 
 def load_knowledge(

--- a/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/persist_chat.py
+++ b/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/persist_chat.py
@@ -4,6 +4,15 @@ from typing import Any
 import uuid
 from agent import Agent, AgentConfig, AgentContext, AgentContextType
 from python.helpers import files, history
+from python.helpers.chat_paths import (
+    list_chat_context_ids,
+    list_legacy_chat_jsons,
+    migrate_legacy_chat_json,
+    read_chat_json,
+    remove_chat_directory,
+    resolve_chat_directory,
+    write_chat_json,
+)
 import json
 from initialize import initialize_agent
 
@@ -24,16 +33,14 @@ def get_chat_folder_path(ctxid: str):
     Returns:
         The absolute path to the context folder
     """
-    return files.get_abs_path(CHATS_FOLDER, ctxid)
+    return resolve_chat_directory(files.get_abs_path(CHATS_FOLDER), ctxid)
 
 
 def save_tmp_chat(context: AgentContext):
     """Save context to the chats folder"""
-    path = _get_chat_file_path(context.id)
-    files.make_dirs(path)
     data = _serialize_context(context)
     js = _safe_json_serialize(data, ensure_ascii=False)
-    files.write_file(path, js)
+    write_chat_json(files.get_abs_path(CHATS_FOLDER), context.id, js)
 
 
 def save_tmp_chats():
@@ -45,34 +52,30 @@ def save_tmp_chats():
 def load_tmp_chats():
     """Load all contexts from the chats folder"""
     _convert_v080_chats()
-    folders = files.list_files(CHATS_FOLDER, "*")
-    json_files = []
-    for folder_name in folders:
-        json_files.append(_get_chat_file_path(folder_name))
-
     ctxids = []
-    for file in json_files:
+    chat_root = files.get_abs_path(CHATS_FOLDER)
+    for ctxid in list_chat_context_ids(chat_root):
         try:
-            js = files.read_file(file)
+            js = read_chat_json(chat_root, ctxid)
             data = json.loads(js)
             ctx = _deserialize_context(data)
             ctxids.append(ctx.id)
         except Exception as e:
-            print(f"Error loading chat {file}: {e}")
+            print(f"Error loading chat {ctxid!r}: {e}")
     return ctxids
 
 
 def _get_chat_file_path(ctxid: str):
-    return files.get_abs_path(CHATS_FOLDER, ctxid, CHAT_FILE_NAME)
+    return f"{get_chat_folder_path(ctxid)}/{CHAT_FILE_NAME}"
 
 
 def _convert_v080_chats():
-    json_files = files.list_files(CHATS_FOLDER, "*.json")
-    for file in json_files:
-        path = files.get_abs_path(CHATS_FOLDER, file)
-        name = file.rstrip(".json")
-        new = _get_chat_file_path(name)
-        files.move_file(path, new)
+    chat_root = files.get_abs_path(CHATS_FOLDER)
+    for filename in list_legacy_chat_jsons(chat_root):
+        try:
+            migrate_legacy_chat_json(chat_root, filename)
+        except (OSError, ValueError) as error:
+            print(f"Skipping unsafe legacy chat {filename!r}: {error}")
 
 
 def load_json_chats(jsons: list[str]):
@@ -96,8 +99,7 @@ def export_json_chat(context: AgentContext):
 
 def remove_chat(ctxid):
     """Remove a chat or task context"""
-    path = get_chat_folder_path(ctxid)
-    files.delete_dir(path)
+    remove_chat_directory(files.get_abs_path(CHATS_FOLDER), ctxid)
 
 
 def _serialize_context(context: AgentContext):

--- a/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/shell_ssh.py
+++ b/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/shell_ssh.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import paramiko
 import time
 import re
@@ -14,15 +15,24 @@ class SSHInteractiveSession:
     # ps1_label = "SSHInteractiveSession CLI>"
 
     def __init__(
-        self, logger: Log, hostname: str, port: int, username: str, password: str
+        self,
+        logger: Log,
+        hostname: str,
+        port: int,
+        username: str,
+        password: str,
+        known_hosts_path: str,
     ):
+        if not known_hosts_path or not os.path.isfile(known_hosts_path):
+            raise ValueError("SSH code execution requires an explicit known_hosts file")
         self.logger = logger
         self.hostname = hostname
         self.port = port
         self.username = username
         self.password = password
         self.client = paramiko.SSHClient()
-        self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        self.client.load_host_keys(known_hosts_path)
+        self.client.set_missing_host_key_policy(paramiko.RejectPolicy())
         self.shell = None
         self.full_output = b""
         self.last_command = b""

--- a/backend/apps/agent-zero/apps/agent_zero_core/python/tools/code_execution_tool.py
+++ b/backend/apps/agent-zero/apps/agent_zero_core/python/tools/code_execution_tool.py
@@ -125,6 +125,7 @@ class CodeExecution(Tool):
                             self.agent.config.code_exec_ssh_port,
                             self.agent.config.code_exec_ssh_user,
                             pswd,
+                            self.agent.config.code_exec_ssh_known_hosts,
                         )
                         await shell.connect()
                     except Exception:
@@ -183,6 +184,7 @@ class CodeExecution(Tool):
                             self.agent.config.code_exec_ssh_port,
                             self.agent.config.code_exec_ssh_user,
                             pswd,
+                            self.agent.config.code_exec_ssh_known_hosts,
                         )
                     else:
                         shell = LocalInteractiveSession()

--- a/backend/apps/agent-zero/initialize.py
+++ b/backend/apps/agent-zero/initialize.py
@@ -103,9 +103,17 @@ def initialize_agent():
     env_flag = _os.getenv("AGZ_CODE_EXEC_SSH", "0").strip().lower()
     if env_flag in ("1", "true", "yes", "on"):
         config.code_exec_ssh_enabled = True
+    config.code_exec_ssh_known_hosts = _os.getenv(
+        "AGZ_CODE_EXEC_SSH_KNOWN_HOSTS", ""
+    ).strip()
 
     # update config with runtime args
     _args_override(config)
+    # SSH stays opt-in, but it cannot be enabled without pinned host keys.
+    if config.code_exec_ssh_enabled and not _os.path.isfile(
+        config.code_exec_ssh_known_hosts
+    ):
+        config.code_exec_ssh_enabled = False
 
     # initialize MCP in deferred task to prevent blocking the main thread
     # async def initialize_mcp_async(mcp_servers_config: str):

--- a/backend/apps/agent-zero/tests/test_security_file_boundaries.py
+++ b/backend/apps/agent-zero/tests/test_security_file_boundaries.py
@@ -1,0 +1,249 @@
+import hashlib
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+CORE_ROOT = ROOT / "apps" / "agent_zero_core"
+sys.path.insert(0, str(CORE_ROOT))
+
+from python.helpers.chat_paths import (
+    list_chat_context_ids,
+    migrate_legacy_chat_json,
+    read_chat_json,
+    remove_chat_directory,
+    resolve_chat_directory,
+    write_chat_json,
+)
+from python.helpers.checksums import calculate_sha256
+from python.helpers import files as file_helpers
+
+
+class ChatPathSafetyTests(unittest.TestCase):
+    def test_resolve_chat_directory_keeps_safe_context_within_chat_root(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            chat_root = Path(temp_dir) / "tmp" / "chats"
+            chat_root.mkdir(parents=True)
+
+            resolved = resolve_chat_directory(str(chat_root), "legacy/session-42")
+
+            self.assertEqual(resolved, str(chat_root / "legacy" / "session-42"))
+
+    def test_resolve_chat_directory_rejects_escaping_context_ids(self):
+        context_ids = [
+            "",
+            "../outside",
+            "nested/../outside",
+            "/var/tmp/outside",
+            r"C:\outside",
+            r"\\server\share",
+        ]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            chat_root = Path(temp_dir) / "tmp" / "chats"
+            chat_root.mkdir(parents=True)
+
+            for context_id in context_ids:
+                with self.subTest(context_id=context_id):
+                    with self.assertRaises(ValueError):
+                        resolve_chat_directory(str(chat_root), context_id)
+
+    def test_resolve_chat_directory_rejects_symlinked_context_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            chat_root = Path(temp_dir) / "tmp" / "chats"
+            outside = Path(temp_dir) / "outside"
+            chat_root.mkdir(parents=True)
+            outside.mkdir()
+            try:
+                os.symlink(outside, chat_root / "linked")
+            except OSError as error:
+                self.skipTest(f"symlink unavailable: {error}")
+
+            with self.assertRaises(ValueError):
+                resolve_chat_directory(str(chat_root), "linked")
+
+    def test_resolve_chat_directory_rejects_a_symlinked_root(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            outside = Path(temp_dir) / "outside"
+            root_link = Path(temp_dir) / "chats"
+            outside.mkdir()
+            try:
+                os.symlink(outside, root_link)
+            except OSError as error:
+                self.skipTest(f"symlink unavailable: {error}")
+
+            with self.assertRaises(ValueError):
+                resolve_chat_directory(str(root_link), "safe")
+
+    def test_descriptor_backed_write_never_follows_a_context_symlink(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            chat_root = Path(temp_dir) / "tmp" / "chats"
+            outside = Path(temp_dir) / "outside"
+            chat_root.mkdir(parents=True)
+            outside.mkdir()
+            try:
+                os.symlink(outside, chat_root / "race")
+            except OSError as error:
+                self.skipTest(f"symlink unavailable: {error}")
+
+            with self.assertRaises(OSError):
+                write_chat_json(str(chat_root), "race", '{"id":"race"}')
+
+            self.assertFalse((outside / "chat.json").exists())
+
+    def test_descriptor_backed_write_rechecks_after_a_path_reference(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            chat_root = Path(temp_dir) / "tmp" / "chats"
+            outside = Path(temp_dir) / "outside"
+            chat_root.mkdir(parents=True)
+            outside.mkdir()
+
+            resolve_chat_directory(str(chat_root), "race")
+            try:
+                os.symlink(outside, chat_root / "race")
+            except OSError as error:
+                self.skipTest(f"symlink unavailable: {error}")
+
+            with self.assertRaises(OSError):
+                write_chat_json(str(chat_root), "race", '{"id":"race"}')
+
+            self.assertFalse((outside / "chat.json").exists())
+
+    def test_descriptor_backed_store_reads_writes_and_removes_a_regular_chat(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            chat_root = Path(temp_dir) / "tmp" / "chats"
+            chat_root.mkdir(parents=True)
+
+            write_chat_json(str(chat_root), "session-42", '{"id":"session-42"}')
+
+            self.assertEqual(
+                read_chat_json(str(chat_root), "session-42"), '{"id":"session-42"}'
+            )
+            self.assertEqual(list_chat_context_ids(str(chat_root)), ["session-42"])
+            self.assertTrue(remove_chat_directory(str(chat_root), "session-42"))
+            self.assertFalse((chat_root / "session-42").exists())
+
+    def test_descriptor_backed_store_rejects_a_symlinked_chat_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            chat_root = Path(temp_dir) / "tmp" / "chats"
+            outside = Path(temp_dir) / "outside"
+            context_dir = chat_root / "session-42"
+            chat_root.mkdir(parents=True)
+            context_dir.mkdir()
+            outside.mkdir()
+            outside_file = outside / "chat.json"
+            outside_file.write_text("outside", encoding="utf-8")
+            try:
+                os.symlink(outside_file, context_dir / "chat.json")
+            except OSError as error:
+                self.skipTest(f"symlink unavailable: {error}")
+
+            with self.assertRaises(OSError):
+                write_chat_json(str(chat_root), "session-42", '{"id":"session-42"}')
+            with self.assertRaises(OSError):
+                read_chat_json(str(chat_root), "session-42")
+
+            self.assertEqual(outside_file.read_text(encoding="utf-8"), "outside")
+
+    def test_legacy_migration_refuses_a_symlink_source(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            chat_root = Path(temp_dir) / "tmp" / "chats"
+            outside = Path(temp_dir) / "outside"
+            chat_root.mkdir(parents=True)
+            outside.mkdir()
+            outside_file = outside / "legacy.json"
+            outside_file.write_text('{"id":"outside"}', encoding="utf-8")
+            try:
+                os.symlink(outside_file, chat_root / "legacy.json")
+            except OSError as error:
+                self.skipTest(f"symlink unavailable: {error}")
+
+            with self.assertRaises(ValueError):
+                migrate_legacy_chat_json(str(chat_root), "legacy.json")
+
+            self.assertFalse((chat_root / "legacy" / "chat.json").exists())
+            self.assertEqual(outside_file.read_text(encoding="utf-8"), '{"id":"outside"}')
+
+    def test_legacy_migration_preserves_regular_chat_content(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            chat_root = Path(temp_dir) / "tmp" / "chats"
+            chat_root.mkdir(parents=True)
+            (chat_root / "legacy.json").write_text('{"id":"legacy"}', encoding="utf-8")
+
+            migrate_legacy_chat_json(str(chat_root), "legacy.json")
+
+            self.assertFalse((chat_root / "legacy.json").exists())
+            self.assertEqual(read_chat_json(str(chat_root), "legacy"), '{"id":"legacy"}')
+
+    def test_secure_removal_refuses_a_symlinked_context(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            chat_root = Path(temp_dir) / "tmp" / "chats"
+            outside = Path(temp_dir) / "outside"
+            chat_root.mkdir(parents=True)
+            outside.mkdir()
+            try:
+                os.symlink(outside, chat_root / "linked")
+            except OSError as error:
+                self.skipTest(f"symlink unavailable: {error}")
+
+            with self.assertRaises(ValueError):
+                remove_chat_directory(str(chat_root), "linked")
+
+            self.assertTrue(outside.exists())
+
+    def test_ssh_execution_requires_pinned_host_keys(self):
+        shell_source = (
+            CORE_ROOT / "python" / "helpers" / "shell_ssh.py"
+        ).read_text(encoding="utf-8")
+        config_source = (ROOT / "agent.py").read_text(encoding="utf-8")
+        initialize_source = (ROOT / "initialize.py").read_text(encoding="utf-8")
+        tool_source = (
+            CORE_ROOT / "python" / "tools" / "code_execution_tool.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("load_host_keys(known_hosts_path)", shell_source)
+        self.assertIn("paramiko.RejectPolicy()", shell_source)
+        self.assertNotIn("AutoAddPolicy", shell_source)
+        self.assertIn('code_exec_ssh_known_hosts: str = ""', config_source)
+        self.assertIn("not _os.path.isfile(", initialize_source)
+        self.assertIn("code_exec_ssh_known_hosts", tool_source)
+
+    def test_calculate_sha256_matches_standard_library_for_binary_content(self):
+        payload = b"skincos\x00security\xff"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir) / "knowledge.bin"
+            source.write_bytes(payload)
+
+            self.assertEqual(
+                calculate_sha256(str(source)), hashlib.sha256(payload).hexdigest()
+            )
+
+    def test_delete_dir_fallback_keeps_permissions_owner_only(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "chat"
+            nested = target / "nested"
+            nested.mkdir(parents=True)
+            (nested / "message.json").write_text("{}", encoding="utf-8")
+
+            original_rmtree = file_helpers.shutil.rmtree
+            calls = 0
+
+            def fail_then_delete(path, ignore_errors=False):
+                nonlocal calls
+                calls += 1
+                if calls == 1:
+                    return None
+                return original_rmtree(path, ignore_errors=ignore_errors)
+
+            with patch.object(
+                file_helpers.shutil, "rmtree", side_effect=fail_then_delete
+            ), patch.object(file_helpers.os, "chmod", wraps=os.chmod) as chmod:
+                file_helpers.delete_dir(str(target))
+
+            self.assertFalse(target.exists())
+            self.assertEqual(
+                {call.args[1] for call in chmod.call_args_list},
+                {0o600, 0o700},
+            )


### PR DESCRIPTION
Corrige achados Bandit vencidos sem renovar excecoes: persistencia de chats usa descritores POSIX com O_NOFOLLOW, migracao legado rejeita symlinks, checksum usa SHA-256 e SSH exige known_hosts com RejectPolicy. Inclui testes focados de traversal, symlink e TOCTOU. Sem deploy, migracao ou mudanca de recurso externo.