### PR TITLE
fix(agent-zero): contain chat removal paths

### DIFF
--- a/.github/security/bandit-exceptions.csv
+++ b/.github/security/bandit-exceptions.csv
@@ -1,4 +1,3 @@
 # filename,test_id,expires_on,reason
-backend/apps/agent-zero/apps/agent_zero_core/python/helpers/files.py,B103,2026-08-31,Upstream agent-zero core uses chmod 0777 in helper utility; pending upstream hardening
 backend/apps/agent-zero/apps/agent_zero_core/python/helpers/knowledge_import.py,B324,2026-08-31,Upstream agent-zero helper uses md5 for content fingerprinting; pending upstream replacement
 backend/apps/agent-zero/apps/agent_zero_core/python/helpers/shell_ssh.py,B507,2026-08-31,Upstream helper auto-adds SSH host key; pending strict host key validation

--- a/backend/apps/agent-zero/apps/agent_zero_core/python/api/chat_remove.py
+++ b/backend/apps/agent-zero/apps/agent_zero_core/python/api/chat_remove.py
@@ -7,6 +7,9 @@ from python.helpers.task_scheduler import TaskScheduler
 class RemoveChat(ApiHandler):
     async def process(self, input: Input, request: Request) -> Output:
         ctxid = input.get("context", "")
+        # Validate before changing in-memory or scheduler state. The same
+        # resolver protects persistence callers outside this HTTP route.
+        persist_chat.get_chat_folder_path(ctxid)
 
         context = AgentContext.get(ctxid)
         if context:

--- a/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/files.py
+++ b/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/files.py
@@ -290,29 +290,16 @@ def write_file_base64(relative_path: str, content: str):
 
 
 def delete_dir(relative_path: str):
-    # ensure deletion of directory without propagating errors
+    # Keep recursive deletion within the Agent Zero base directory.
     abs_path = get_abs_path(relative_path)
+    base_dir = os.path.normcase(os.path.realpath(get_base_dir()))
+    resolved_path = os.path.normcase(os.path.realpath(abs_path))
+    if not is_in_base_dir(abs_path) or resolved_path == base_dir:
+        raise ValueError("Refusing to delete a path outside the Agent Zero base directory")
     if os.path.exists(abs_path):
-        # first try with ignore_errors=True which is the safest option
+        # Best-effort deletion must not broaden permissions on data it cannot
+        # remove; callers receive no destructive fallback outside this scope.
         shutil.rmtree(abs_path, ignore_errors=True)
-
-        # if directory still exists, try more aggressive methods
-        if os.path.exists(abs_path):
-            try:
-                # try to change permissions and delete again
-                for root, dirs, files in os.walk(abs_path, topdown=False):
-                    for name in files:
-                        file_path = os.path.join(root, name)
-                        os.chmod(file_path, 0o777)
-                    for name in dirs:
-                        dir_path = os.path.join(root, name)
-                        os.chmod(dir_path, 0o777)
-
-                # try again after changing permissions
-                shutil.rmtree(abs_path, ignore_errors=True)
-            except:
-                # suppress all errors - we're ensuring no errors propagate
-                pass
 
 
 def list_files(relative_path: str, filter: str = "*"):
@@ -330,6 +317,34 @@ def make_dirs(relative_path: str):
 def get_abs_path(*relative_paths):
     "Convert relative paths to absolute paths based on the base directory."
     return os.path.join(get_base_dir(), *relative_paths)
+
+
+def get_safe_child_path(parent_path: str, component: str):
+    "Resolve one untrusted child component without permitting path traversal."
+    if (
+        not isinstance(component, str)
+        or component in ("", ".", "..")
+        or "\x00" in component
+        or "/" in component
+        or "\\" in component
+    ):
+        raise ValueError("Path component must be a non-empty single identifier")
+
+    parent = os.path.normcase(os.path.realpath(get_abs_path(parent_path)))
+    if not is_in_base_dir(parent):
+        raise ValueError("Parent path escaped the Agent Zero base directory")
+    candidate = os.path.join(parent, component)
+    resolved_candidate = os.path.normcase(os.path.realpath(candidate))
+    try:
+        is_direct_child = (
+            os.path.commonpath([resolved_candidate, parent]) == parent
+            and os.path.dirname(resolved_candidate) == parent
+        )
+    except ValueError:
+        is_direct_child = False
+    if not is_direct_child:
+        raise ValueError("Path component escaped its parent directory")
+    return candidate
 
 def deabsolute_path(path:str):
     "Convert absolute paths to relative paths based on the base directory."
@@ -365,12 +380,13 @@ def dirname(path: str):
 
 
 def is_in_base_dir(path: str):
-    # check if the given path is within the base directory
-    base_dir = get_base_dir()
-    # normalize paths to handle relative paths and symlinks
-    abs_path = os.path.abspath(path)
-    # check if the absolute path starts with the base directory
-    return os.path.commonpath([abs_path, base_dir]) == base_dir
+    "Check containment after resolving traversal and symlink aliases."
+    base_dir = os.path.normcase(os.path.realpath(get_base_dir()))
+    abs_path = os.path.normcase(os.path.realpath(path))
+    try:
+        return os.path.commonpath([abs_path, base_dir]) == base_dir
+    except ValueError:
+        return False
 
 
 def get_subdirectories(

--- a/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/persist_chat.py
+++ b/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/persist_chat.py
@@ -24,7 +24,7 @@ def get_chat_folder_path(ctxid: str):
     Returns:
         The absolute path to the context folder
     """
-    return files.get_abs_path(CHATS_FOLDER, ctxid)
+    return files.get_safe_child_path(CHATS_FOLDER, ctxid)
 
 
 def save_tmp_chat(context: AgentContext):

--- a/backend/apps/agent-zero/tests/test_files_safety.py
+++ b/backend/apps/agent-zero/tests/test_files_safety.py
@@ -1,0 +1,61 @@
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+
+AGENT_ZERO_ROOT = Path(__file__).resolve().parents[1]
+CORE_ROOT = AGENT_ZERO_ROOT / "apps" / "agent_zero_core"
+if str(CORE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CORE_ROOT))
+
+from python.helpers import files
+
+
+def test_safe_child_path_accepts_legacy_safe_identifier():
+    path = files.get_safe_child_path("tmp/chats", "legacy.chat_1-2026")
+
+    assert Path(path).parent == Path(files.get_abs_path("tmp/chats")).resolve()
+
+
+def test_safe_child_path_rejects_empty_and_traversal_identifiers():
+    for value in ("", ".", "..", "../../outside", "/tmp/outside", r"C:\\outside", "chat/name"):
+        try:
+            files.get_safe_child_path("tmp/chats", value)
+        except ValueError:
+            continue
+        raise AssertionError(f"unsafe component was accepted: {value!r}")
+
+
+def test_delete_dir_rejects_outside_base_without_touching_the_target():
+    with tempfile.TemporaryDirectory() as outside:
+        marker = Path(outside) / "keep.txt"
+        marker.write_text("keep", encoding="utf-8")
+
+        try:
+            files.delete_dir(outside)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("outside deletion was accepted")
+
+        assert marker.read_text(encoding="utf-8") == "keep"
+
+
+def test_delete_dir_removes_a_base_contained_target():
+    relative = f"tmp/files-safety-{uuid.uuid4().hex}"
+    target = Path(files.get_abs_path(relative))
+    target.mkdir(parents=True)
+    (target / "temporary.txt").write_text("temporary", encoding="utf-8")
+
+    files.delete_dir(str(target))
+
+    assert not target.exists()
+
+
+def test_chat_remove_validates_context_before_mutating_state():
+    source = (CORE_ROOT / "python" / "api" / "chat_remove.py").read_text(encoding="utf-8")
+
+    assert source.index("persist_chat.get_chat_folder_path(ctxid)") < source.index(
+        "AgentContext.get(ctxid)"
+    )


### PR DESCRIPTION
## Summary
- validate chat context identifiers before any in-memory, scheduler, or persistence mutation
- constrain chat persistence deletion to a single child beneath the Agent Zero base path
- remove the world-writable deletion fallback and its expired Bandit B103 exception trigger
- add focused regression coverage for traversal payloads and deletion containment

## Validation
- focused files safety regression tests
- Python compile check for the changed modules
- Bandit high-confidence scan of the changed Agent Zero paths

## Scope
This fixes the remotely reachable context-path traversal. Full hostile-local-filesystem hardening (race-resistant handles and platform-specific reparse-point treatment) is deliberately separate from this bounded patch.