### PR TITLE
fix(agent-zero): remove expired security exceptions

### DIFF
--- a/.github/security/bandit-exceptions.csv
+++ b/.github/security/bandit-exceptions.csv
@@ -1,4 +1,1 @@
 # filename,test_id,expires_on,reason
-backend/apps/agent-zero/apps/agent_zero_core/python/helpers/files.py,B103,2026-08-31,Upstream agent-zero core uses chmod 0777 in helper utility; pending upstream hardening
-backend/apps/agent-zero/apps/agent_zero_core/python/helpers/knowledge_import.py,B324,2026-08-31,Upstream agent-zero helper uses md5 for content fingerprinting; pending upstream replacement
-backend/apps/agent-zero/apps/agent_zero_core/python/helpers/shell_ssh.py,B507,2026-08-31,Upstream helper auto-adds SSH host key; pending strict host key validation

--- a/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/files.py
+++ b/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/files.py
@@ -293,26 +293,9 @@ def delete_dir(relative_path: str):
     # ensure deletion of directory without propagating errors
     abs_path = get_abs_path(relative_path)
     if os.path.exists(abs_path):
-        # first try with ignore_errors=True which is the safest option
+        # Do not widen permissions just to remove files that cannot be deleted
+        # through the normal filesystem policy.
         shutil.rmtree(abs_path, ignore_errors=True)
-
-        # if directory still exists, try more aggressive methods
-        if os.path.exists(abs_path):
-            try:
-                # try to change permissions and delete again
-                for root, dirs, files in os.walk(abs_path, topdown=False):
-                    for name in files:
-                        file_path = os.path.join(root, name)
-                        os.chmod(file_path, 0o777)
-                    for name in dirs:
-                        dir_path = os.path.join(root, name)
-                        os.chmod(dir_path, 0o777)
-
-                # try again after changing permissions
-                shutil.rmtree(abs_path, ignore_errors=True)
-            except:
-                # suppress all errors - we're ensuring no errors propagate
-                pass
 
 
 def list_files(relative_path: str, filter: str = "*"):

--- a/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/knowledge_import.py
+++ b/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/knowledge_import.py
@@ -23,10 +23,10 @@ class KnowledgeImport(TypedDict):
 
 
 def calculate_checksum(file_path: str) -> str:
-    hasher = hashlib.md5()
+    hasher = hashlib.sha256()
     with open(file_path, "rb") as f:
-        buf = f.read()
-        hasher.update(buf)
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            hasher.update(chunk)
     return hasher.hexdigest()
 
 

--- a/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/shell_ssh.py
+++ b/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/shell_ssh.py
@@ -22,7 +22,9 @@ class SSHInteractiveSession:
         self.username = username
         self.password = password
         self.client = paramiko.SSHClient()
-        self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        # SSH execution is opt-in; operators must provision the target key.
+        self.client.load_system_host_keys()
+        self.client.set_missing_host_key_policy(paramiko.RejectPolicy())
         self.shell = None
         self.full_output = b""
         self.last_command = b""

--- a/backend/apps/agent-zero/tests/test_security_baseline.py
+++ b/backend/apps/agent-zero/tests/test_security_baseline.py
@@ -1,0 +1,117 @@
+import hashlib
+import importlib.util
+import sys
+import tempfile
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+
+AGENT_ZERO_ROOT = Path(__file__).resolve().parents[1]
+CORE_ROOT = AGENT_ZERO_ROOT / "apps" / "agent_zero_core"
+
+
+def _module_from_path(name: str, path: Path, modules: dict[str, types.ModuleType]):
+    with patch.dict(sys.modules, modules):
+        spec = importlib.util.spec_from_file_location(name, path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader
+        spec.loader.exec_module(module)
+        return module
+
+
+def _knowledge_import_module():
+    document_loaders = types.ModuleType("langchain_community.document_loaders")
+    for name in ("CSVLoader", "PyPDFLoader", "TextLoader", "UnstructuredHTMLLoader"):
+        setattr(document_loaders, name, object)
+
+    langchain_community = types.ModuleType("langchain_community")
+    langchain_community.document_loaders = document_loaders
+    helpers = types.ModuleType("python.helpers")
+    log = types.ModuleType("python.helpers.log")
+    log.LogItem = object
+    print_style = types.ModuleType("python.helpers.print_style")
+    print_style.PrintStyle = object
+    python = types.ModuleType("python")
+    python.helpers = helpers
+    helpers.log = log
+    helpers.print_style = print_style
+
+    return _module_from_path(
+        "security_baseline_knowledge_import",
+        CORE_ROOT / "python" / "helpers" / "knowledge_import.py",
+        {
+            "langchain_community": langchain_community,
+            "langchain_community.document_loaders": document_loaders,
+            "python": python,
+            "python.helpers": helpers,
+            "python.helpers.log": log,
+            "python.helpers.print_style": print_style,
+        },
+    )
+
+
+def _shell_ssh_module(events: list[object]):
+    paramiko = types.ModuleType("paramiko")
+
+    class RejectPolicy:
+        pass
+
+    class SSHClient:
+        def __init__(self):
+            events.append("created")
+
+        def load_system_host_keys(self):
+            events.append("system-host-keys")
+
+        def set_missing_host_key_policy(self, policy):
+            events.append(policy)
+
+    paramiko.SSHClient = SSHClient
+    paramiko.RejectPolicy = RejectPolicy
+
+    helpers = types.ModuleType("python.helpers")
+    log = types.ModuleType("python.helpers.log")
+    log.Log = object
+    print_style = types.ModuleType("python.helpers.print_style")
+    print_style.PrintStyle = object
+    strings = types.ModuleType("python.helpers.strings")
+    strings.calculate_valid_match_lengths = lambda *args, **kwargs: (0, 0)
+    python = types.ModuleType("python")
+    python.helpers = helpers
+    helpers.log = log
+    helpers.print_style = print_style
+    helpers.strings = strings
+
+    return _module_from_path(
+        "security_baseline_shell_ssh",
+        CORE_ROOT / "python" / "helpers" / "shell_ssh.py",
+        {
+            "paramiko": paramiko,
+            "python": python,
+            "python.helpers": helpers,
+            "python.helpers.log": log,
+            "python.helpers.print_style": print_style,
+            "python.helpers.strings": strings,
+        },
+    ), RejectPolicy
+
+
+def test_knowledge_checksum_uses_sha256():
+    knowledge_import = _knowledge_import_module()
+    content = b"security baseline"
+
+    with tempfile.NamedTemporaryFile() as handle:
+        handle.write(content)
+        handle.flush()
+        assert knowledge_import.calculate_checksum(handle.name) == hashlib.sha256(content).hexdigest()
+
+
+def test_ssh_session_requires_a_known_host_key():
+    events: list[object] = []
+    shell_ssh, reject_policy = _shell_ssh_module(events)
+
+    shell_ssh.SSHInteractiveSession(object(), "host.example", 22, "user", "password")
+
+    assert events[0:2] == ["created", "system-host-keys"]
+    assert isinstance(events[2], reject_policy)


### PR DESCRIPTION
## Summary

Removes the three expired Agent Zero Bandit exceptions by correcting the source rather than renewing policy waivers:

- stops widening filesystem permissions during best-effort directory removal;
- uses chunked SHA-256 for knowledge-import change detection;
- loads the system known-hosts store and rejects unrecognized SSH host keys.

## Operational impact

This is source-only; it does not deploy, change credentials, or activate a service. Existing knowledge indexes using MD5 will be treated as changed on their next import and reprocessed. SSH execution remains opt-in, but its target host key must be pre-provisioned in the runtime known-hosts store; unknown hosts are intentionally rejected.

## Validation

- focused standard-library tests for SHA-256 output and strict SSH policy;
- `python3 -m compileall` for the changed Python sources and test;
- isolated Bandit high/high scan: no findings;
- whitespace validation.

## Rollback

Revert `fdc5bf0a5` to restore the prior source behavior. No data migration or deployed artifact is involved.