### PR TITLE
fix(identity): preserve session epochs across restores

### DIFF
--- a/finance/scripts/write-local-fixture.mjs
+++ b/finance/scripts/write-local-fixture.mjs
@@ -37,7 +37,7 @@ const grantRows = fixture.scopes.map((scope, index) =>
 
 const sql = [
   'PRAGMA foreign_keys=ON;',
-  `INSERT OR REPLACE INTO crm_users(username,email,display_name,password_hash,role,photo_url,allowed_units_json,allowed_modules_json,ativo,created_at,updated_at) VALUES(${quote(username)},${quote(`${username}@localhost`)},'Finance Local','local-runtime-no-password','GESTOR','',${quote(units)},${quote(modules)},1,${quote(now)},${quote(now)});`,
+  `INSERT INTO crm_users(username,email,display_name,password_hash,role,photo_url,allowed_units_json,allowed_modules_json,ativo,created_at,updated_at) VALUES(${quote(username)},${quote(`${username}@localhost`)},'Finance Local','local-runtime-no-password','GESTOR','',${quote(units)},${quote(modules)},1,${quote(now)},${quote(now)}) ON CONFLICT(username) DO UPDATE SET email=excluded.email,display_name=excluded.display_name,password_hash=excluded.password_hash,role=excluded.role,photo_url=excluded.photo_url,allowed_units_json=excluded.allowed_units_json,allowed_modules_json=excluded.allowed_modules_json,ativo=excluded.ativo,updated_at=excluded.updated_at,session_version=COALESCE(crm_users.session_version,0)+1;`,
   `DELETE FROM finance_access_grants WHERE username=${quote(username)};`,
   ...grantRows,
   `UPDATE finance_settings SET value=${quote(fixture.enabled ? 'true' : 'false')},updated_at=${quote(now)} WHERE key='module_enabled';`,

--- a/finance/test/local-fixture.test.mjs
+++ b/finance/test/local-fixture.test.mjs
@@ -59,6 +59,13 @@ test('local Finance fixture supports an isolated, bounded smoke actor', async ()
   assert.equal(both.personalScopeGranted, false);
 });
 
+test('local Finance fixture preserves the durable session epoch on repeated setup', async () => {
+  const source = await readFile(script, 'utf8');
+  assert.doesNotMatch(source, /INSERT OR REPLACE INTO crm_users/);
+  assert.match(source, /ON CONFLICT\(username\) DO UPDATE SET/);
+  assert.match(source, /session_version=COALESCE\(crm_users\.session_version,0\)\+1/);
+});
+
 test('local Finance launcher preserves the module grant when exercising only the disabled flag', async () => {
   const source = await readFile(launcher, 'utf8');
   assert.match(source, /no-module\) LOCAL_MODULES='' ;;/);

--- a/inventory/migrations/0030_crm_identity_session_epochs.sql
+++ b/inventory/migrations/0030_crm_identity_session_epochs.sql
@@ -1,0 +1,128 @@
+-- Preserve session epochs when a username is removed, restored, or reused.
+-- V2 legacy cookies without a tracked sid validate against username + session_version,
+-- so the version must never be reset when the same username returns.
+
+CREATE TABLE IF NOT EXISTS crm_identity_session_epochs (
+  username TEXT COLLATE NOCASE PRIMARY KEY,
+  session_version INTEGER NOT NULL CHECK (session_version >= 0),
+  updated_at TEXT NOT NULL,
+  reason TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_crm_identity_session_epochs_updated_at
+ON crm_identity_session_epochs(updated_at DESC);
+
+INSERT INTO crm_identity_session_epochs (username, session_version, updated_at, reason)
+SELECT username, MAX(session_version), CURRENT_TIMESTAMP, 'MIGRATION_BACKFILL'
+FROM (
+  SELECT username, COALESCE(session_version, 0) AS session_version FROM crm_users
+  UNION ALL
+  SELECT username, COALESCE(session_version, 0) AS session_version FROM crm_identity_sessions
+)
+GROUP BY username
+ON CONFLICT(username) DO UPDATE SET
+  session_version = MAX(crm_identity_session_epochs.session_version, excluded.session_version),
+  updated_at = excluded.updated_at,
+  reason = excluded.reason;
+
+CREATE TRIGGER IF NOT EXISTS trg_crm_users_session_epoch_before_delete
+BEFORE DELETE ON crm_users
+FOR EACH ROW
+BEGIN
+  UPDATE crm_identity_sessions
+  SET revoked_at = CURRENT_TIMESTAMP,
+      revoke_reason = 'USERNAME_RETIRED'
+  WHERE LOWER(username) = LOWER(OLD.username)
+    AND revoked_at IS NULL;
+
+  INSERT INTO crm_identity_session_epochs (username, session_version, updated_at, reason)
+  VALUES (
+    OLD.username,
+    MAX(
+      COALESCE(OLD.session_version, 0),
+      COALESCE((SELECT MAX(session_version) FROM crm_identity_sessions WHERE LOWER(username) = LOWER(OLD.username)), 0)
+    ),
+    CURRENT_TIMESTAMP,
+    'USERNAME_RETIRED'
+  )
+  ON CONFLICT(username) DO UPDATE SET
+    session_version = MAX(crm_identity_session_epochs.session_version, excluded.session_version),
+    updated_at = excluded.updated_at,
+    reason = excluded.reason;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_crm_users_session_epoch_after_insert
+AFTER INSERT ON crm_users
+FOR EACH ROW
+BEGIN
+  UPDATE crm_users
+  SET session_version = MAX(
+    COALESCE(NEW.session_version, 0),
+    COALESCE(
+      (SELECT session_version + 1 FROM crm_identity_session_epochs WHERE username = NEW.username),
+      COALESCE(NEW.session_version, 0)
+    )
+  )
+  WHERE username = NEW.username;
+
+  INSERT INTO crm_identity_session_epochs (username, session_version, updated_at, reason)
+  SELECT username, session_version, CURRENT_TIMESTAMP, 'USERNAME_ACTIVATED'
+  FROM crm_users
+  WHERE username = NEW.username
+  ON CONFLICT(username) DO UPDATE SET
+    session_version = MAX(crm_identity_session_epochs.session_version, excluded.session_version),
+    updated_at = excluded.updated_at,
+    reason = excluded.reason;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_crm_users_session_epoch_before_username_change
+BEFORE UPDATE OF username ON crm_users
+FOR EACH ROW
+WHEN LOWER(NEW.username) <> LOWER(OLD.username)
+BEGIN
+  UPDATE crm_identity_sessions
+  SET revoked_at = CURRENT_TIMESTAMP,
+      revoke_reason = 'USERNAME_RENAMED'
+  WHERE LOWER(username) = LOWER(OLD.username)
+    AND revoked_at IS NULL;
+
+  INSERT INTO crm_identity_session_epochs (username, session_version, updated_at, reason)
+  VALUES (
+    OLD.username,
+    MAX(
+      COALESCE(OLD.session_version, 0),
+      COALESCE((SELECT MAX(session_version) FROM crm_identity_sessions WHERE LOWER(username) = LOWER(OLD.username)), 0)
+    ),
+    CURRENT_TIMESTAMP,
+    'USERNAME_RENAMED'
+  )
+  ON CONFLICT(username) DO UPDATE SET
+    session_version = MAX(crm_identity_session_epochs.session_version, excluded.session_version),
+    updated_at = excluded.updated_at,
+    reason = excluded.reason;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_crm_users_session_epoch_after_username_change
+AFTER UPDATE OF username ON crm_users
+FOR EACH ROW
+WHEN LOWER(NEW.username) <> LOWER(OLD.username)
+BEGIN
+  UPDATE crm_users
+  SET session_version = MAX(
+    COALESCE(NEW.session_version, 0),
+    COALESCE(
+      (SELECT session_version + 1 FROM crm_identity_session_epochs WHERE username = NEW.username),
+      COALESCE(NEW.session_version, 0)
+    )
+  )
+  WHERE username = NEW.username;
+
+  INSERT INTO crm_identity_session_epochs (username, session_version, updated_at, reason)
+  SELECT username, session_version, CURRENT_TIMESTAMP, 'USERNAME_RENAMED'
+  FROM crm_users
+  WHERE username = NEW.username
+  ON CONFLICT(username) DO UPDATE SET
+    session_version = MAX(crm_identity_session_epochs.session_version, excluded.session_version),
+    updated_at = excluded.updated_at,
+    reason = excluded.reason;
+END;

--- a/inventory/src/services/backup.js
+++ b/inventory/src/services/backup.js
@@ -3,6 +3,8 @@ import { safeJsonNoTruncate } from '../lib/json.js';
 import { resolveCrmTables } from '../d1Store.js';
 import { isOpaqueIdentitySubject } from '../../../shared/identity-contract/index.js';
 
+const IDENTITY_SESSION_EPOCH_TABLE = 'crm_identity_session_epochs';
+
 async function tableHasColumn(env, tableName, columnName) {
     if (!env?.DB || !tableName || !columnName) return false;
     const t = String(tableName);
@@ -11,6 +13,18 @@ async function tableHasColumn(env, tableName, columnName) {
         const res = await env.DB.prepare(`PRAGMA table_info(${t})`).all();
         const cols = (res?.results || []).map((r) => String(r?.name || '').toLowerCase());
         return cols.includes(String(columnName).toLowerCase());
+    } catch {
+        return false;
+    }
+}
+
+async function tableExists(env, tableName) {
+    if (!env?.DB || tableName !== IDENTITY_SESSION_EPOCH_TABLE) return false;
+    try {
+        const row = await env.DB.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=? LIMIT 1")
+            .bind(tableName)
+            .first();
+        return row?.name === tableName;
     } catch {
         return false;
     }
@@ -479,12 +493,26 @@ export async function restoreBackupPayload({ env, payload, strict = false }) {
                 }
             }
 
+            // Session-version schemas also require the monotonic tombstone.
+            // Refuse a destructive restore if migrations were not applied in
+            // order; otherwise a sid-less legacy V2 cookie could become valid
+            // again after the same username is restored.
+            if (usersRows.length && usersHasSessionVersion && !await tableExists(env, IDENTITY_SESSION_EPOCH_TABLE)) {
+                throw new Error('IDENTITY_SESSION_EPOCH_REQUIRED');
+            }
+
             if (Array.isArray(p.d1.insumosStocks)) await env.DB.prepare('DELETE FROM insumos_stocks').run();
             // The stock ledger is append-only. Restore may add missing evidence,
             // but it must never erase or rewrite movements already posted.
             // Items are restored by upsert. Deleting them would cascade into
             // insumos_movements through the legacy foreign key and violate the
             // append-only ledger contract.
+            const restoreAt = new Date().toISOString();
+            if (usersRows.length && usersHasSessionVersion) {
+                await env.DB.prepare(
+                    'UPDATE crm_identity_sessions SET revoked_at=?, revoke_reason=? WHERE revoked_at IS NULL'
+                ).bind(restoreAt, 'BACKUP_RESTORE').run();
+            }
             if (usersRows.length) await env.DB.prepare(`DELETE FROM ${usersTable}`).run();
             if (Array.isArray(p.d1.shareHistory)) await env.DB.prepare('DELETE FROM share_history').run();
 
@@ -507,7 +535,13 @@ export async function restoreBackupPayload({ env, payload, strict = false }) {
                 userValues.push(Number(row.ativo || 0) ? 1 : 0, row.createdAt || new Date().toISOString(), row.updatedAt || new Date().toISOString());
                 if (usersHasSessionVersion) {
                     userColumns.push('session_version');
-                    userValues.push(Number(row.sessionVersion || 0));
+                    // Restoring an account must invalidate every cookie that
+                    // existed when this snapshot was taken, including a
+                    // sid-less legacy V2 cookie restored into a clean D1
+                    // target whose epoch ledger has no local history yet.
+                    // The trigger may advance this further when the target
+                    // already has a newer tombstone for the username.
+                    userValues.push(Math.max(0, Number(row.sessionVersion) || 0) + 1);
                 }
                 if (usersHasIdentitySubject) {
                     userColumns.push('identity_subject');
@@ -516,6 +550,13 @@ export async function restoreBackupPayload({ env, payload, strict = false }) {
                 await env.DB.prepare(`INSERT INTO ${usersTable} (${userColumns.join(',')}) VALUES (${userColumns.map(() => '?').join(',')})`)
                     .bind(...userValues)
                     .run();
+            }
+            if (usersRows.length && usersHasSessionVersion) {
+                await env.DB.prepare(
+                    `UPDATE ${IDENTITY_SESSION_EPOCH_TABLE}
+                     SET updated_at=?, reason='BACKUP_RESTORE'
+                     WHERE username IN (SELECT username FROM ${usersTable})`
+                ).bind(restoreAt).run();
             }
             for (const row of (p.d1.insumosItems || []).reverse()) {
                 await env.DB.prepare(
@@ -828,10 +869,11 @@ export async function restoreBackupPayload({ env, payload, strict = false }) {
                     .run();
             }
         } catch (error) {
-            // A schema that has durable subjects must never accept a legacy
-            // account snapshot by silently reminting its audit identity. This
-            // remains fail-closed even for the historical best-effort path.
-            if (strict || String(error?.message || '').startsWith('IDENTITY_SUBJECT_BACKUP_')) throw error;
+            // Durable identity subjects and session epochs must never be
+            // bypassed by the historical best-effort restore path.
+            if (strict
+                || String(error?.message || '').startsWith('IDENTITY_SUBJECT_BACKUP_')
+                || String(error?.message || '') === 'IDENTITY_SESSION_EPOCH_REQUIRED') throw error;
             // Legacy restore is intentionally best-effort for historical backup
             // files. The private preview sets strict and fails closed instead.
         }

--- a/inventory/tests/crmIdentitySubjectMigration.test.mjs
+++ b/inventory/tests/crmIdentitySubjectMigration.test.mjs
@@ -77,6 +77,7 @@ before(async () => {
       .bind('legacy-subject-b', 'legacy-subject-b@staging.invalid', 'Legacy Subject B', 'hash', 'CONSULTOR', '["barra-shopping-sul"]', '["insumos"]', now, now, 8),
   ]);
   await applyMigration(db, '0029_crm_users_identity_subject.sql');
+  await applyMigration(db, '0030_crm_identity_session_epochs.sql');
 });
 
 after(async () => {
@@ -95,4 +96,17 @@ test('the additive migration backfills unique opaque subjects without changing l
   const subjects = rows.results.map((row) => String(row.identity_subject || ''));
   assert.ok(subjects.every((subject) => /^idn:[A-Za-z0-9_-]{16,160}$/.test(subject)));
   assert.equal(new Set(subjects).size, 2);
+});
+
+test('the session epoch migration backfills every existing username without resetting its version', async () => {
+  const rows = await db.prepare(
+    `SELECT username, session_version
+     FROM crm_identity_session_epochs
+     WHERE username IN ('legacy-subject-a', 'legacy-subject-b')
+     ORDER BY username`,
+  ).all();
+  assert.deepEqual(rows.results, [
+    { username: 'legacy-subject-a', session_version: 5 },
+    { username: 'legacy-subject-b', session_version: 8 },
+  ]);
 });

--- a/inventory/tests/identitySessionEpochMigration.test.mjs
+++ b/inventory/tests/identitySessionEpochMigration.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { DatabaseSync } from 'node:sqlite';
+import test from 'node:test';
+
+const migrations = new URL('../migrations/', import.meta.url);
+
+function applySchema(database) {
+  for (const name of readdirSync(migrations).filter((file) => /^\d{4}_.+\.sql$/.test(file)).sort()) {
+    database.exec(readFileSync(new URL(name, migrations), 'utf8'));
+  }
+}
+
+function insertUser(database, username, sessionVersion) {
+  database.prepare(`
+    INSERT INTO crm_users
+      (username, email, display_name, password_hash, role, allowed_units_json, ativo, created_at, updated_at, session_version)
+    VALUES (?, ?, ?, 'hash', 'CONSULTOR', '[]', 1, '2026-09-05T00:00:00.000Z', '2026-09-05T00:00:00.000Z', ?)
+  `).run(username, `${username}@staging.invalid`, username, sessionVersion);
+}
+
+test('session epochs survive username replacement, restore-style recreation, and rename reuse', () => {
+  const database = new DatabaseSync(':memory:');
+  try {
+    applySchema(database);
+
+    insertUser(database, 'restore-user', 7);
+    database.prepare(`
+      INSERT INTO crm_identity_sessions (id, username, session_version, created_at, last_seen_at)
+      VALUES ('restore-session', 'restore-user', 7, '2026-09-05T00:00:00.000Z', '2026-09-05T00:00:00.000Z')
+    `).run();
+    database.prepare('DELETE FROM crm_users WHERE username=?').run('restore-user');
+    const retired = database.prepare(
+      'SELECT session_version FROM crm_identity_session_epochs WHERE username=?',
+    ).get('restore-user');
+    assert.equal(retired.session_version, 7);
+    const revoked = database.prepare(
+      'SELECT revoked_at, revoke_reason FROM crm_identity_sessions WHERE id=?',
+    ).get('restore-session');
+    assert.ok(revoked.revoked_at);
+    assert.equal(revoked.revoke_reason, 'USERNAME_RETIRED');
+
+    insertUser(database, 'restore-user', 0);
+    assert.equal(database.prepare('SELECT session_version FROM crm_users WHERE username=?').get('restore-user').session_version, 8);
+
+    insertUser(database, 'rename-source', 2);
+    insertUser(database, 'rename-target', 4);
+    database.prepare('DELETE FROM crm_users WHERE username=?').run('rename-target');
+    database.prepare('UPDATE crm_users SET username=? WHERE username=?').run('rename-target', 'rename-source');
+    assert.equal(database.prepare('SELECT session_version FROM crm_users WHERE username=?').get('rename-target').session_version, 5);
+    assert.equal(database.prepare('SELECT session_version FROM crm_identity_session_epochs WHERE username=?').get('rename-source').session_version, 2);
+
+    insertUser(database, 'case-user', 3);
+    database.prepare('DELETE FROM crm_users WHERE username=?').run('case-user');
+    insertUser(database, 'CASE-USER', 0);
+    assert.equal(database.prepare('SELECT session_version FROM crm_users WHERE LOWER(username)=LOWER(?)').get('case-user').session_version, 4);
+  } finally {
+    database.close();
+  }
+});

--- a/inventory/tests/identitySessionEpochRestore.test.mjs
+++ b/inventory/tests/identitySessionEpochRestore.test.mjs
@@ -1,0 +1,181 @@
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { DatabaseSync } from 'node:sqlite';
+import test from 'node:test';
+
+import { resolveIdentityActor } from '../../shared/identity-runtime/session.js';
+import { buildBackupPayload, restoreBackupPayload } from '../src/services/backup.js';
+
+const migrations = new URL('../migrations/', import.meta.url);
+
+class D1Statement {
+  constructor(database, sql) {
+    this.database = database;
+    this.sql = sql;
+    this.values = [];
+  }
+
+  bind(...values) {
+    this.values = values;
+    return this;
+  }
+
+  async run() {
+    const result = this.database.prepare(this.sql).run(...this.values);
+    return { meta: { changes: Number(result.changes || 0) } };
+  }
+
+  async all() {
+    return { results: this.database.prepare(this.sql).all(...this.values) };
+  }
+
+  async first() {
+    return this.database.prepare(this.sql).get(...this.values) || null;
+  }
+}
+
+function environment(database) {
+  return {
+    DB: {
+      prepare(sql) {
+        return new D1Statement(database, sql);
+      },
+      async batch(statements) {
+        return Promise.all(statements.map((statement) => statement.run()));
+      },
+    },
+  };
+}
+
+function applySchema(database, through = null) {
+  for (const name of readdirSync(migrations).filter((file) => /^\d{4}_.+\.sql$/.test(file)).sort()) {
+    if (through && name > through) break;
+    database.exec(readFileSync(new URL(name, migrations), 'utf8'));
+  }
+}
+
+function seedIdentity(database) {
+  database.prepare(`
+    INSERT INTO crm_users
+      (username, email, display_name, password_hash, role, allowed_units_json, ativo, created_at, updated_at, session_version, identity_subject)
+    VALUES ('restore-user', 'restore-user@staging.invalid', 'Restore User', 'hash', 'GESTOR', '[]', 1, '2026-09-05T00:00:00.000Z', '2026-09-05T00:00:00.000Z', 7, 'idn:restore_user_00000001')
+  `).run();
+  database.prepare(`
+    INSERT INTO crm_identity_sessions (id, username, session_version, created_at, last_seen_at)
+    VALUES ('restore-session', 'restore-user', 7, '2026-09-05T00:00:00.000Z', '2026-09-05T00:00:00.000Z')
+  `).run();
+}
+
+async function sidLessSessionToken({ username, sessionVersion, secret }) {
+  const payload = Buffer.from(JSON.stringify({
+    username,
+    sv: sessionVersion,
+    csrf: 'test-csrf',
+    exp: Date.now() + 60_000,
+  })).toString('base64url');
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = Buffer.from(await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(payload))).toString('base64url');
+  return `${payload}.${signature}`;
+}
+
+async function resolveSidLessActor(env, token) {
+  return resolveIdentityActor(
+    new Request('https://identity.test/finance', { headers: { cookie: `session=${token}` } }),
+    env,
+  );
+}
+
+test('backup restore revokes tracked sessions and advances the durable sid-less epoch', async () => {
+  const database = new DatabaseSync(':memory:');
+  try {
+    applySchema(database);
+    seedIdentity(database);
+    const env = environment(database);
+    const sessionSecret = 'session-epoch-restore-test-secret';
+    const oldToken = await sidLessSessionToken({ username: 'restore-user', sessionVersion: 7, secret: sessionSecret });
+    assert.equal((await resolveSidLessActor({ ...env, SESSION_SECRET: sessionSecret }, oldToken)).actor?.username, 'restore-user');
+    const payload = await buildBackupPayload({ env });
+    await restoreBackupPayload({ env, payload });
+
+    const restored = database.prepare(
+      'SELECT session_version, identity_subject FROM crm_users WHERE username=?',
+    ).get('restore-user');
+    assert.equal(restored.session_version, 8);
+    assert.equal(restored.identity_subject, 'idn:restore_user_00000001');
+    const revoked = database.prepare(
+      'SELECT revoked_at, revoke_reason FROM crm_identity_sessions WHERE id=?',
+    ).get('restore-session');
+    assert.ok(revoked.revoked_at);
+    assert.equal(revoked.revoke_reason, 'BACKUP_RESTORE');
+    const epoch = database.prepare(
+      'SELECT session_version, reason FROM crm_identity_session_epochs WHERE username=?',
+    ).get('restore-user');
+    assert.equal(epoch.session_version, 8);
+    assert.equal(epoch.reason, 'BACKUP_RESTORE');
+    assert.equal((await resolveSidLessActor({ ...env, SESSION_SECRET: sessionSecret }, oldToken)).actor, null);
+    const freshToken = await sidLessSessionToken({ username: 'restore-user', sessionVersion: 8, secret: sessionSecret });
+    assert.equal((await resolveSidLessActor({ ...env, SESSION_SECRET: sessionSecret }, freshToken)).actor?.username, 'restore-user');
+  } finally {
+    database.close();
+  }
+});
+
+test('backup restore advances a sid-less epoch even on a clean migrated target', async () => {
+  const sourceDatabase = new DatabaseSync(':memory:');
+  const targetDatabase = new DatabaseSync(':memory:');
+  try {
+    applySchema(sourceDatabase);
+    applySchema(targetDatabase);
+    seedIdentity(sourceDatabase);
+    const sourceEnv = environment(sourceDatabase);
+    const targetEnv = environment(targetDatabase);
+    const sessionSecret = 'session-epoch-clean-target-test-secret';
+    const oldToken = await sidLessSessionToken({ username: 'restore-user', sessionVersion: 7, secret: sessionSecret });
+    const payload = await buildBackupPayload({ env: sourceEnv });
+
+    assert.equal((await resolveSidLessActor({ ...targetEnv, SESSION_SECRET: sessionSecret }, oldToken)).actor, null);
+    await restoreBackupPayload({ env: targetEnv, payload });
+
+    const restored = targetDatabase.prepare(
+      'SELECT session_version FROM crm_users WHERE username=?',
+    ).get('restore-user');
+    assert.equal(restored.session_version, 8);
+    const epoch = targetDatabase.prepare(
+      'SELECT session_version, reason FROM crm_identity_session_epochs WHERE username=?',
+    ).get('restore-user');
+    assert.equal(epoch.session_version, 8);
+    assert.equal(epoch.reason, 'BACKUP_RESTORE');
+    assert.equal((await resolveSidLessActor({ ...targetEnv, SESSION_SECRET: sessionSecret }, oldToken)).actor, null);
+    const freshToken = await sidLessSessionToken({ username: 'restore-user', sessionVersion: 8, secret: sessionSecret });
+    assert.equal((await resolveSidLessActor({ ...targetEnv, SESSION_SECRET: sessionSecret }, freshToken)).actor?.username, 'restore-user');
+  } finally {
+    sourceDatabase.close();
+    targetDatabase.close();
+  }
+});
+
+test('backup restore fails closed when the durable subject schema lacks the epoch migration', async () => {
+  const database = new DatabaseSync(':memory:');
+  try {
+    applySchema(database);
+    seedIdentity(database);
+    const env = environment(database);
+    const payload = await buildBackupPayload({ env });
+    database.exec('DROP TABLE crm_identity_session_epochs');
+    assert.equal(
+      database.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=? LIMIT 1")
+        .get('crm_identity_session_epochs'),
+      undefined,
+    );
+    await assert.rejects(() => restoreBackupPayload({ env, payload }), /IDENTITY_SESSION_EPOCH_REQUIRED/);
+    assert.equal(database.prepare('SELECT session_version FROM crm_users WHERE username=?').get('restore-user').session_version, 7);
+  } finally {
+    database.close();
+  }
+});

--- a/inventory/tests/insumosStagingRbacFixtures.test.mjs
+++ b/inventory/tests/insumosStagingRbacFixtures.test.mjs
@@ -1,12 +1,20 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
+import { DatabaseSync } from 'node:sqlite';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 const fixtureScript = fileURLToPath(new URL('../scripts/insumosStagingRbacFixtures.mjs', import.meta.url));
+const migrations = new URL('../migrations/', import.meta.url);
+
+function applySchema(database) {
+  for (const name of readdirSync(migrations).filter((file) => /^\d{4}_.+\.sql$/.test(file)).sort()) {
+    database.exec(readFileSync(new URL(name, migrations), 'utf8'));
+  }
+}
 
 test('staging RBAC fixtures are bounded, synthetic and auditable', () => {
   const dir = mkdtempSync(join(tmpdir(), 'skincos-rbac-fixtures-'));
@@ -35,6 +43,35 @@ test('staging RBAC fixtures are bounded, synthetic and auditable', () => {
     assert.doesNotMatch(statement, /\["inventory"\]/);
     assert.doesNotMatch(statement, /BEGIN TRANSACTION|COMMIT;/);
     assert.doesNotMatch(statement, /api\.skincos\.com\.br/);
+
+    const database = new DatabaseSync(':memory:');
+    try {
+      applySchema(database);
+      database.exec(statement);
+      const firstScenario = data.scenarios[0];
+      database.prepare(`
+        INSERT INTO crm_identity_sessions (id, username, session_version, created_at, last_seen_at)
+        VALUES ('fixture-session', ?, 0, '2026-09-05T00:00:00.000Z', '2026-09-05T00:00:00.000Z')
+      `).run(firstScenario.username);
+
+      const teardownSql = join(dir, 'teardown.sql');
+      const teardown = spawnSync(process.execPath, [fixtureScript, '--action', 'teardown', '--run-id', '123456', '--fixtures', fixture, '--sql', teardownSql], { encoding: 'utf8' });
+      assert.equal(teardown.status, 0, teardown.stderr);
+      database.exec(readFileSync(teardownSql, 'utf8'));
+      assert.equal(database.prepare('SELECT COUNT(*) AS count FROM crm_users WHERE username=?').get(firstScenario.username).count, 0);
+      assert.equal(database.prepare('SELECT session_version FROM crm_identity_session_epochs WHERE username=?').get(firstScenario.username).session_version, 0);
+      const revoked = database.prepare('SELECT revoked_at, revoke_reason FROM crm_identity_sessions WHERE id=?').get('fixture-session');
+      assert.ok(revoked.revoked_at);
+      assert.equal(revoked.revoke_reason, 'USERNAME_RETIRED');
+
+      const reprovisionSql = join(dir, 'reprovision.sql');
+      const reprovision = spawnSync(process.execPath, [fixtureScript, '--action', 'provision', '--run-id', '123456', '--fixtures', fixture, '--sql', reprovisionSql], { encoding: 'utf8' });
+      assert.equal(reprovision.status, 0, reprovision.stderr);
+      database.exec(readFileSync(reprovisionSql, 'utf8'));
+      assert.ok(database.prepare('SELECT session_version FROM crm_users WHERE username=?').get(firstScenario.username).session_version >= 1);
+    } finally {
+      database.close();
+    }
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/inventory/tests/unifiedTeamAccountScope.test.mjs
+++ b/inventory/tests/unifiedTeamAccountScope.test.mjs
@@ -63,6 +63,7 @@ const schemaMigrations = [
   '0025_onboarding_idempotency_fingerprint.sql', '0026_unified_invite_identity.sql',
   '0027_crm_employee_account_links.sql', '0028_unified_team_query_indexes.sql',
   '0029_crm_users_identity_subject.sql',
+  '0030_crm_identity_session_epochs.sql',
 ];
 
 let proxy;
@@ -242,6 +243,7 @@ beforeEach(async () => {
     env.DB.prepare('DELETE FROM crm_employee_onboarding'),
     env.DB.prepare('DELETE FROM crm_user_prefs'),
     env.DB.prepare('DELETE FROM crm_users'),
+    env.DB.prepare('DELETE FROM crm_identity_session_epochs'),
   ]);
   await seedFixture();
 });
@@ -351,7 +353,7 @@ test('backup and restore preserve a durable subject and reject legacy user snaps
 
   await restoreBackupPayload({ env, payload });
   const restored = await env.DB.prepare('SELECT identity_subject, session_version FROM crm_users WHERE username=?').bind('hellenmelo').first();
-  assert.deepEqual(restored, { identity_subject: 'idn:fixture_hellenmelo_0001', session_version: 7 });
+  assert.deepEqual(restored, { identity_subject: 'idn:fixture_hellenmelo_0001', session_version: 8 });
 
   const legacyPayload = JSON.parse(JSON.stringify(payload));
   delete legacyPayload.d1.crmUsers.find((row) => row.username === 'hellenmelo').identitySubject;

--- a/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.test.mjs
+++ b/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.test.mjs
@@ -196,6 +196,12 @@ test('staging fixture SQL is run-scoped, secret-free, and teardown preserves aud
       assert.match(timekeepingAttestation, /timekeeping_audit_events WHERE request_id IN \('request-incumbent-1','request-incumbent-2'\)/);
       assert.match(teardownTimekeeping, /updated_by = 'stg-ponto-123456789:presence-policy'/);
       assert.doesNotMatch(teardownTimekeeping, /DELETE FROM workforce_units/);
+
+      // The next run uses the same controlled usernames. The D1 epoch trigger
+      // must advance them instead of recreating session_version zero.
+      database.exec(provisionCore);
+      assert.ok(database.prepare('SELECT session_version FROM crm_users WHERE username=?').get(fixture.username).session_version >= 1);
+      assert.ok(database.prepare('SELECT session_version FROM crm_users WHERE username=?').get(fixture.adminUsername).session_version >= 1);
     } finally {
       database.close();
       timekeepingDatabase.close();


### PR DESCRIPTION
## Correção de segurança

Fecha a reativação de cookies V2 legados sem `sid` quando um username é removido, recriado, renomeado ou restaurado a partir de backup.

- adiciona o ledger aditivo `crm_identity_session_epochs` no D1 e triggers para delete, insert e rename de `crm_users`;
- faz o restore falhar fechado sem a migration e inserir `session_version` acima da versão do snapshot, inclusive em um alvo D1 recém-migrado;
- preserva a compatibilidade do formato V2, mas invalida o token anterior e aceita apenas a sessão recém-emitida;
- elimina o `INSERT OR REPLACE` do fixture local de Finance e cobre os teardowns sintéticos de Insumos e Ponto.

## Validação

- 33 testes focados passaram, incluindo o reprodutor de cookie V2 sem `sid` em restore origem -> alvo limpo;
- 20 cenários de integração com D1/workerd local passaram;
- montagem seca do Worker passou para a configuração principal e `staging` com Wrangler 4.107.0; nenhum upload, deploy ou migration remota foi executado.

## Rollout e rollback

Esta PR contém somente código e uma migration aditiva; não publica Worker nem aplica migration.

Para staging: aplicar a migration em um artefato de preview, executar o smoke sintético de restore e confirmar rollback do artefato sem remover ou retroceder o ledger de epochs. Uma restauração física integral de D1 deve preservar esse ledger. Contas removidas antes da migration, sem histórico atual no banco, exigem que o cutover respeite a janela máxima das sessões legadas.