### PR TITLE
feat(identity): preserve opaque CRM identity subject

### DIFF
--- a/.github/workflows/insumos-production-smoke-identity.yml
+++ b/.github/workflows/insumos-production-smoke-identity.yml
@@ -129,21 +129,38 @@ jobs:
 
           const identityWhere = `(lower(username) = lower(${sql(username)}) OR lower(email) = lower(${sql(email)}))`
           const exactWhere = `(username = ${sql(username)} AND lower(email) = lower(${sql(email)}) AND display_name = 'Codex production smoke' AND role = 'ADMIN')`
+          const identitySubject = `idn:${crypto.randomBytes(16).toString('hex')}`
           let statements
           if (action === 'provision') {
             const passwordHash = hashPassword()
-            statements = `INSERT INTO crm_users (username, email, display_name, password_hash, role, photo_url, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at)\nSELECT ${sql(username)}, ${sql(email)}, 'Codex production smoke', ${sql(passwordHash)}, 'ADMIN', NULL, '[]', '[]', 1, ${sql(now)}, ${sql(now)}\nWHERE NOT EXISTS (SELECT 1 FROM crm_users WHERE ${identityWhere});\n`
+            statements = `INSERT INTO crm_users (username, email, display_name, password_hash, role, photo_url, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at, identity_subject)\nSELECT ${sql(username)}, ${sql(email)}, 'Codex production smoke', ${sql(passwordHash)}, 'ADMIN', NULL, '[]', '[]', 1, ${sql(now)}, ${sql(now)}, ${sql(identitySubject)}\nWHERE NOT EXISTS (SELECT 1 FROM crm_users WHERE ${identityWhere});\n`
           } else if (action === 'cleanup') {
             statements = `DELETE FROM crm_identity_sessions WHERE username = ${sql(username)};\nDELETE FROM auth_attempts WHERE username = ${sql(username)} OR username = ${sql(email)};\nDELETE FROM crm_user_prefs WHERE username = ${sql(username)};\nDELETE FROM crm_users WHERE ${exactWhere};\n`
           } else {
             throw new Error('ACTION_CONTRACT')
           }
 
-          const verify = `SELECT COUNT(*) AS c FROM crm_users WHERE ${identityWhere};\n`
+          // This no-row query resolves identity_subject without reading a user.
+          // It makes a pre-migration run fail before any production mutation.
+          const schema = `SELECT identity_subject FROM crm_users WHERE 1 = 0;\n`
+          // Referencing identity_subject makes a pre-migration run fail during
+          // the read-only collision check, before any production mutation.
+          const verify = `SELECT COUNT(*) AS c, COALESCE(SUM(CASE WHEN identity_subject LIKE 'idn:%' AND length(identity_subject) BETWEEN 20 AND 164 THEN 1 ELSE 0 END), 0) AS opaque_subjects FROM crm_users WHERE ${identityWhere};\n`
           fs.writeFileSync(path.join(dir, 'mutation.sql'), statements, { encoding: 'utf8', mode: 0o600 })
+          fs.writeFileSync(path.join(dir, 'schema.sql'), schema, { encoding: 'utf8', mode: 0o600 })
           fs.writeFileSync(path.join(dir, 'verify.sql'), verify, { encoding: 'utf8', mode: 0o600 })
           fs.writeFileSync(path.join(dir, 'manifest.json'), JSON.stringify({ action, synthetic: true, piiFree: true, database: 'skincos-db' }) + '\n', { encoding: 'utf8', mode: 0o600 })
           NODE
+
+      - name: Verify CRM identity subject schema before mutation
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          RUNNER_TEMP_DIR: ${{ runner.temp }}/insumos-production-smoke-identity
+        run: |
+          set -euo pipefail
+          schema_command="$(<"${RUNNER_TEMP_DIR}/schema.sql")"
+          npx --yes wrangler@4.119.0 d1 execute skincos-db --remote --config inventory/wrangler.toml --command "$schema_command" --json > "${RUNNER_TEMP_DIR}/schema.json"
 
       - name: Check synthetic identity collision
         if: ${{ inputs.action == 'provision' }}
@@ -286,9 +303,11 @@ jobs:
           const count = Number(row.c)
           const expected = action === 'provision' ? 1 : 0
           if (!Number.isInteger(count) || count !== expected) throw new Error(`SMOKE_IDENTITY_FINAL_STATE:${Number.isInteger(count) ? count : 'unknown'}:expected:${expected}`)
+          const opaqueSubjects = Number(row.opaque_subjects)
+          if (!Number.isInteger(opaqueSubjects) || opaqueSubjects !== expected) throw new Error(`SMOKE_IDENTITY_OPAQUE_SUBJECT_COUNT:${Number.isInteger(opaqueSubjects) ? opaqueSubjects : 'unknown'}:expected:${expected}`)
           const beforePath = path.join(dir, 'before-count.json')
           const before = fs.existsSync(beforePath) ? JSON.parse(fs.readFileSync(beforePath, 'utf8')) : {}
-          fs.writeFileSync(path.join(dir, 'evidence.json'), JSON.stringify({ action, database: 'skincos-db', synthetic: true, piiFree: true, collisionCountBefore: before.collisionCountBefore ?? null, finalCount: count, auditHistoryDeleted: false }) + '\n')
+          fs.writeFileSync(path.join(dir, 'evidence.json'), JSON.stringify({ action, database: 'skincos-db', synthetic: true, piiFree: true, collisionCountBefore: before.collisionCountBefore ?? null, finalCount: count, opaqueSubjectCount: opaqueSubjects, auditHistoryDeleted: false }) + '\n')
           NODE
 
       - name: Release production Identity/D1 coordination lease

--- a/finance/scripts/staging-smoke-identity-sql.mjs
+++ b/finance/scripts/staging-smoke-identity-sql.mjs
@@ -34,6 +34,7 @@ const passwordHash = () => {
   const derived = pbkdf2Sync(password, salt, 100_000, 32, 'sha256');
   return `pbkdf2_sha256$100000$${base64url(salt)}$${base64url(derived)}`;
 };
+const identitySubject = `idn:${randomBytes(16).toString('hex')}`;
 const audit = (actionName, before, after) => `INSERT INTO audit_log(ts,actor,role,action,entity,entity_id,unidade,idempotency_key,before_json,after_json) VALUES(${quote(now)},${quote(technicalActor)},'SYSTEM',${quote(actionName)},'crm_users',${quote(username)},'novo-hamburgo',${quote(`finance-smoke:${action}:${now}`)},${json(before)},${json(after)});`;
 const financeAudit = (actionName, before, after) => `INSERT INTO finance_audit_events(id,scope_id,actor,action,entity_type,entity_id,request_id,before_json,after_json,created_at) VALUES(${quote(`finance-smoke-${action}-${randomBytes(8).toString('hex')}`)},${quote(scopeId)},${quote(technicalActor)},${quote(actionName)},'finance_access_grant',${quote(username)},${quote(`finance-smoke:${action}:${now}`)},${json(before)},${json(after)},${quote(now)});`;
 
@@ -50,8 +51,9 @@ if (action === 'provision') {
     // workflow, so leave transaction ownership to the D1 service. Provision is
     // safe for the one known synthetic username even when a previous revoke
     // left its inactive row behind: reactivate that row, otherwise insert it.
-    `UPDATE crm_users SET email=${quote('finance-staging-smoke@staging.invalid')},display_name=${quote('Finance staging smoke (synthetic)')},password_hash=${quote(passwordHash())},role='INJETOR',photo_url='',allowed_units_json=${quote(JSON.stringify(['novo-hamburgo']))},allowed_modules_json=${quote(JSON.stringify(['finance']))},ativo=1,updated_at=${quote(now)},session_version=COALESCE(session_version,0)+1 WHERE username=${quote(username)} AND ativo=0;`,
-    `INSERT INTO crm_users(username,email,display_name,password_hash,role,photo_url,allowed_units_json,allowed_modules_json,ativo,created_at,updated_at,session_version) SELECT ${quote(username)},${quote('finance-staging-smoke@staging.invalid')},${quote('Finance staging smoke (synthetic)')},${quote(passwordHash())},'INJETOR','',${quote(JSON.stringify(['novo-hamburgo']))},${quote(JSON.stringify(['finance']))},1,${quote(now)},${quote(now)},1 WHERE NOT EXISTS (SELECT 1 FROM crm_users WHERE username=${quote(username)});`,
+    `UPDATE crm_users SET email=${quote('finance-staging-smoke@staging.invalid')},display_name=${quote('Finance staging smoke (synthetic)')},password_hash=${quote(passwordHash())},role='INJETOR',photo_url='',allowed_units_json=${quote(JSON.stringify(['novo-hamburgo']))},allowed_modules_json=${quote(JSON.stringify(['finance']))},identity_subject=CASE WHEN identity_subject IS NULL OR trim(identity_subject) = '' THEN ${quote(identitySubject)} ELSE identity_subject END,ativo=1,updated_at=${quote(now)},session_version=COALESCE(session_version,0)+1 WHERE username=${quote(username)} AND ativo=0;`,
+    `UPDATE crm_users SET identity_subject=${quote(identitySubject)} WHERE username=${quote(username)} AND (identity_subject IS NULL OR trim(identity_subject) = '');`,
+    `INSERT INTO crm_users(username,email,display_name,password_hash,role,photo_url,allowed_units_json,allowed_modules_json,ativo,created_at,updated_at,session_version,identity_subject) SELECT ${quote(username)},${quote('finance-staging-smoke@staging.invalid')},${quote('Finance staging smoke (synthetic)')},${quote(passwordHash())},'INJETOR','',${quote(JSON.stringify(['novo-hamburgo']))},${quote(JSON.stringify(['finance']))},1,${quote(now)},${quote(now)},1,${quote(identitySubject)} WHERE NOT EXISTS (SELECT 1 FROM crm_users WHERE username=${quote(username)});`,
     audit('FINANCE_SMOKE_IDENTITY_PROVISIONED_OR_REACTIVATED', null, { ...baseline, active: true }),
   ].join('\n');
   financeSql = [
@@ -60,7 +62,7 @@ if (action === 'provision') {
   ].join('\n');
 } else if (action === 'rotate') {
   coreSql = [
-    `UPDATE crm_users SET password_hash=${quote(passwordHash())},role='INJETOR',allowed_units_json=${quote(JSON.stringify(['novo-hamburgo']))},allowed_modules_json=${quote(JSON.stringify(['finance']))},session_version=COALESCE(session_version,0)+1,updated_at=${quote(now)} WHERE username=${quote(username)} AND ativo=1;`,
+    `UPDATE crm_users SET password_hash=${quote(passwordHash())},role='INJETOR',allowed_units_json=${quote(JSON.stringify(['novo-hamburgo']))},allowed_modules_json=${quote(JSON.stringify(['finance']))},identity_subject=CASE WHEN identity_subject IS NULL OR trim(identity_subject) = '' THEN ${quote(identitySubject)} ELSE identity_subject END,session_version=COALESCE(session_version,0)+1,updated_at=${quote(now)} WHERE username=${quote(username)} AND ativo=1;`,
     audit('FINANCE_SMOKE_IDENTITY_ROTATED', { active: true }, { ...baseline, active: true }),
   ].join('\n');
   financeSql = [

--- a/finance/scripts/staging-test-identity-sql.mjs
+++ b/finance/scripts/staging-test-identity-sql.mjs
@@ -26,15 +26,16 @@ const passwordHash = () => {
   const derived = pbkdf2Sync(password, salt, 100_000, 32, 'sha256');
   return `pbkdf2_sha256$100000$${base64url(salt)}$${base64url(derived)}`;
 };
+const identitySubject = `idn:${randomBytes(16).toString('hex')}`;
 
 let sql;
 if (action === 'create') {
   sql = [
-    `INSERT INTO crm_users(username,email,display_name,password_hash,role,photo_url,allowed_units_json,allowed_modules_json,ativo,created_at,updated_at,session_version) VALUES(${quote(username)},${quote('finance-staging-monitor@staging.invalid')},${quote('Finance staging monitor (synthetic)')},${quote(passwordHash())},'CONSULTOR','',${quote(JSON.stringify(['novo-hamburgo']))},${quote(JSON.stringify(['finance']))},1,${quote(now)},${quote(now)},0);`,
+    `INSERT INTO crm_users(username,email,display_name,password_hash,role,photo_url,allowed_units_json,allowed_modules_json,ativo,created_at,updated_at,session_version,identity_subject) VALUES(${quote(username)},${quote('finance-staging-monitor@staging.invalid')},${quote('Finance staging monitor (synthetic)')},${quote(passwordHash())},'CONSULTOR','',${quote(JSON.stringify(['novo-hamburgo']))},${quote(JSON.stringify(['finance']))},1,${quote(now)},${quote(now)},0,${quote(identitySubject)});`,
     `INSERT INTO finance_access_grants(id,username,scope_id,permission,created_at,created_by) VALUES(${quote('finance-staging-monitor-viewer-nh')},${quote(username)},${quote(scopeId)},'viewer',${quote(now)},${quote('@skincos/finance')});`,
   ].join('\n');
 } else if (action === 'rotate') {
-  sql = `UPDATE crm_users SET password_hash=${quote(passwordHash())},session_version=COALESCE(session_version,0)+1,updated_at=${quote(now)} WHERE username=${quote(username)} AND ativo=1;`;
+  sql = `UPDATE crm_users SET password_hash=${quote(passwordHash())},identity_subject=CASE WHEN identity_subject IS NULL OR trim(identity_subject) = '' THEN ${quote(identitySubject)} ELSE identity_subject END,session_version=COALESCE(session_version,0)+1,updated_at=${quote(now)} WHERE username=${quote(username)} AND ativo=1;`;
 } else {
   // Invalidate the session before removing the grant. Either completed statement denies Finance access.
   sql = [

--- a/finance/scripts/write-local-fixture.mjs
+++ b/finance/scripts/write-local-fixture.mjs
@@ -37,7 +37,7 @@ const grantRows = fixture.scopes.map((scope, index) =>
 
 const sql = [
   'PRAGMA foreign_keys=ON;',
-  `INSERT OR REPLACE INTO crm_users(username,email,display_name,password_hash,role,photo_url,allowed_units_json,allowed_modules_json,ativo,created_at,updated_at) VALUES(${quote(username)},${quote(`${username}@localhost`)},'Finance Local','local-runtime-no-password','GESTOR','',${quote(units)},${quote(modules)},1,${quote(now)},${quote(now)});`,
+  `INSERT INTO crm_users(username,email,display_name,password_hash,role,photo_url,allowed_units_json,allowed_modules_json,ativo,created_at,updated_at) VALUES(${quote(username)},${quote(`${username}@localhost`)},'Finance Local','local-runtime-no-password','GESTOR','',${quote(units)},${quote(modules)},1,${quote(now)},${quote(now)}) ON CONFLICT(username) DO UPDATE SET email=excluded.email,display_name=excluded.display_name,password_hash=excluded.password_hash,role=excluded.role,photo_url=excluded.photo_url,allowed_units_json=excluded.allowed_units_json,allowed_modules_json=excluded.allowed_modules_json,ativo=excluded.ativo,updated_at=excluded.updated_at,session_version=COALESCE(crm_users.session_version,0)+1;`,
   `DELETE FROM finance_access_grants WHERE username=${quote(username)};`,
   ...grantRows,
   `UPDATE finance_settings SET value=${quote(fixture.enabled ? 'true' : 'false')},updated_at=${quote(now)} WHERE key='module_enabled';`,

--- a/finance/test/local-fixture.test.mjs
+++ b/finance/test/local-fixture.test.mjs
@@ -59,6 +59,13 @@ test('local Finance fixture supports an isolated, bounded smoke actor', async ()
   assert.equal(both.personalScopeGranted, false);
 });
 
+test('local Finance fixture preserves the durable session epoch on repeated setup', async () => {
+  const source = await readFile(script, 'utf8');
+  assert.doesNotMatch(source, /INSERT OR REPLACE INTO crm_users/);
+  assert.match(source, /ON CONFLICT\(username\) DO UPDATE SET/);
+  assert.match(source, /session_version=COALESCE\(crm_users\.session_version,0\)\+1/);
+});
+
 test('local Finance launcher preserves the module grant when exercising only the disabled flag', async () => {
   const source = await readFile(launcher, 'utf8');
   assert.match(source, /no-module\) LOCAL_MODULES='' ;;/);

--- a/finance/test/staging-smoke-identity-scope.test.mjs
+++ b/finance/test/staging-smoke-identity-scope.test.mjs
@@ -6,6 +6,7 @@ import { spawnSync } from 'node:child_process';
 import test from 'node:test';
 
 const script = new URL('../scripts/staging-smoke-identity-sql.mjs', import.meta.url);
+const monitorScript = new URL('../scripts/staging-test-identity-sql.mjs', import.meta.url);
 const password = 'synthetic-test-password-with-at-least-24-characters';
 
 function generate(action) {
@@ -33,10 +34,36 @@ test('synthetic Finance identity preserves only the explicit Finance module in t
   assert.match(provision.core, /UPDATE crm_users SET/);
   assert.match(provision.core, /WHERE username='finance-staging-smoke' AND ativo=0/);
   assert.match(provision.core, /WHERE NOT EXISTS \(SELECT 1 FROM crm_users/);
+  assert.match(provision.core, /identity_subject=CASE WHEN identity_subject IS NULL OR trim\(identity_subject\) = '' THEN 'idn:[0-9a-f]{32}' ELSE identity_subject END/);
+  assert.match(provision.core, /identity_subject\) SELECT/);
   assert.doesNotMatch(provision.core, /'CONSULTOR'/);
   assert.match(rotation.core, /role='INJETOR'/);
   assert.match(rotation.core, /allowed_modules_json='\["finance"\]'/);
+  assert.match(rotation.core, /identity_subject=CASE WHEN identity_subject IS NULL OR trim\(identity_subject\) = '' THEN 'idn:[0-9a-f]{32}' ELSE identity_subject END/);
   assert.match(provision.finance, /ON CONFLICT\(username,scope_id\) DO UPDATE/);
   assert.match(rotation.finance, /ON CONFLICT\(username,scope_id\) DO UPDATE/);
   assert.match(rotation.finance, /finance_access_grant/);
+});
+
+test('the independent Finance monitor fixture creates an opaque subject and repairs only an absent legacy subject', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'skincos-finance-monitor-'));
+  const output = join(directory, 'monitor.sql');
+  try {
+    const env = {
+      ...process.env,
+      FINANCE_STAGING_IDENTITY_ACK: '1',
+      FINANCE_STAGING_TEST_PASSWORD: password,
+    };
+    const create = spawnSync(process.execPath, [monitorScript.pathname, 'create', '--output', output], { env, encoding: 'utf8' });
+    assert.equal(create.status, 0, create.stderr);
+    const createdSql = readFileSync(output, 'utf8');
+    assert.match(createdSql, /identity_subject\) VALUES\([^\n]*'idn:[0-9a-f]{32}'\)/);
+
+    const rotate = spawnSync(process.execPath, [monitorScript.pathname, 'rotate', '--output', output], { env, encoding: 'utf8' });
+    assert.equal(rotate.status, 0, rotate.stderr);
+    const rotateSql = readFileSync(output, 'utf8');
+    assert.match(rotateSql, /identity_subject=CASE WHEN identity_subject IS NULL OR trim\(identity_subject\) = '' THEN 'idn:[0-9a-f]{32}' ELSE identity_subject END/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
 });

--- a/identity/README.md
+++ b/identity/README.md
@@ -18,9 +18,11 @@ stable `shared/crm-auth` facade, which now delegates to the same Identity actor
 resolver. The independent Worker cutover requires a disabled-by-default
 binding/flag, staging session and recovery smoke, and a rollback to this mount.
 
-This PR intentionally does not include or execute an Identity D1 migration. An
-adoption migration may only be introduced with a separately approved staging
-data-migration plan.
+This preparation includes an additive, unapplied Identity subject migration for
+the shared `crm_users` table. It does not execute the migration, alter a live
+D1 database, or activate delivery. Applying it still requires a separately
+approved staging data-migration plan, a synthetic smoke and a tested rollback
+decision before any production consideration.
 
 The legacy `/admin/users` and `/admin/invites` handlers also remain on the
 Inventory Worker as an HTTP compatibility host. Invitation policy and mail are

--- a/identity/routes/auth.js
+++ b/identity/routes/auth.js
@@ -5,7 +5,7 @@ import { resolveIdentityTables } from '../store/d1.js';
 import { hasPasswordResetMailerConfig, sendPasswordResetEmail } from '../notifications/smtpMailer.js';
 import { hasRequiredInviteScope, normalizeInviteEmail } from '../policy/invitePolicy.js';
 import { normalizeCorporateEmail, normalizeEmployeeUsername } from '../policy/employeeOnboarding.js';
-import { normalizeAllowedUnits } from '../../shared/identity-contract/index.js';
+import { createOpaqueIdentitySubject, normalizeAllowedUnits } from '../../shared/identity-contract/index.js';
 import { syncIdentityWorkforceStatus } from '../../shared/identity-runtime/workforce-onboarding.js';
 
 function b64UrlBytes(value) {
@@ -275,6 +275,7 @@ export async function handleAuthRoutes({
 
         const { usersTable, invitesTable, passwordResetsTable } = await resolveIdentityTables(env);
 	        const usersHasModules = await tableHasColumn(usersTable, 'allowed_modules_json');
+	        const usersHasIdentitySubject = await tableHasColumn(usersTable, 'identity_subject');
 	        const invitesHasModules = await tableHasColumn(invitesTable, 'allowed_modules_json');
 	        const invitesHasInviteeEmail = await tableHasColumn(invitesTable, 'invitee_email');
 	        const invitesHasCorporateEmail = await tableHasColumn(invitesTable, 'corporate_email');
@@ -691,10 +692,13 @@ export async function handleAuthRoutes({
                 }
                 const hash = await hashPassword(password);
                 const currentTime = new Date().toISOString();
+                const identitySubject = usersHasIdentitySubject ? createOpaqueIdentitySubject() : null;
+                const identitySubjectColumn = usersHasIdentitySubject ? ', identity_subject' : '';
+                const identitySubjectValue = usersHasIdentitySubject ? ', ?' : '';
                 const registration = env.DB.prepare(
                     `INSERT INTO ${usersTable}
-                     (username, email, display_name, password_hash, role, photo_url, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at)
-                     SELECT ?, ?, ?, ?, role, '', ?, ?, 0, ?, ?
+                     (username, email, display_name, password_hash, role, photo_url, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at${identitySubjectColumn})
+                     SELECT ?, ?, ?, ?, role, '', ?, ?, 0, ?, ?${identitySubjectValue}
                      FROM ${invitesTable}
                      WHERE token_hash = ?
                        AND invitee_email = ?
@@ -702,7 +706,7 @@ export async function handleAuthRoutes({
                        AND max_uses = 1
                        AND uses_count = 0
                        AND expires_at > ?`
-                ).bind(candidate, loginEmail, name, hash, JSON.stringify(allowedUnits), JSON.stringify(allowedModules), now, now, inviteHash, email, currentTime);
+                ).bind(candidate, loginEmail, name, hash, JSON.stringify(allowedUnits), JSON.stringify(allowedModules), now, now, ...(usersHasIdentitySubject ? [identitySubject] : []), inviteHash, email, currentTime);
                 const consume = env.DB.prepare(
                     `UPDATE ${invitesTable}
                      SET uses_count = 1

--- a/identity/store/d1.js
+++ b/identity/store/d1.js
@@ -1,4 +1,4 @@
-import { normalizeAllowedUnits, toAuthenticatedActor } from '../../shared/identity-contract/index.js';
+import { isOpaqueIdentitySubject, normalizeAllowedUnits, toAuthenticatedActor } from '../../shared/identity-contract/index.js';
 
 const toInt = (value, fallback = 0) => {
   const parsed = typeof value === 'number' ? value : Number.parseInt(String(value ?? ''), 10);
@@ -58,6 +58,7 @@ function toIdentityUser(row) {
     email: row.email || '',
     role: row.role || 'CONSULTOR',
     photoUrl: row.photo_url || '',
+    identitySubject: isOpaqueIdentitySubject(row.identity_subject) ? row.identity_subject : null,
     allowedUnits: normalizeAllowedUnits(row.allowed_units_json),
     allowedModules: parseScopes(row.allowed_modules_json),
     ativo: toInt(row.ativo, 1) === 1,
@@ -72,8 +73,9 @@ async function readUser(env, where, values) {
   if (!env?.DB) return null;
   const { usersTable } = await resolveIdentityTables(env);
   const modulesColumn = await hasColumn(env, usersTable, 'allowed_modules_json') ? ', allowed_modules_json' : '';
+  const identitySubjectColumn = await hasColumn(env, usersTable, 'identity_subject') ? ', identity_subject' : '';
   const row = await env.DB.prepare(
-    `SELECT username, email, display_name, password_hash, role, photo_url, allowed_units_json, ativo, created_at, updated_at, session_version${modulesColumn}
+    `SELECT username, email, display_name, password_hash, role, photo_url, allowed_units_json, ativo, created_at, updated_at, session_version${modulesColumn}${identitySubjectColumn}
      FROM ${usersTable} WHERE ${where} LIMIT 1`,
   ).bind(...values).first();
   return toIdentityUser(row);
@@ -97,7 +99,7 @@ export async function updateIdentityProfile(env, username, updates) {
   if (!env?.DB) return { ok: false, status: 500, error: 'DB_NOT_CONFIGURED' };
   const current = await getIdentityUserByUsername(env, username);
   if (!current) return { ok: false, status: 404, error: 'USER_NOT_FOUND' };
-  const { usersTable } = await resolveIdentityTables(env);
+  const { usersTable, userPrefsTable } = await resolveIdentityTables(env);
   const nextUsername = updates?.newUsername ? String(updates.newUsername).trim() : current.username;
   const now = new Date().toISOString();
   if (nextUsername.toLowerCase() !== current.username.toLowerCase()) {
@@ -112,16 +114,42 @@ export async function updateIdentityProfile(env, username, updates) {
     passwordHash: updates?.passwordHash ? String(updates.passwordHash) : current.passwordHash,
   };
   if (nextUsername !== current.username) {
-    const modulesColumn = await hasColumn(env, usersTable, 'allowed_modules_json');
-    const columns = modulesColumn
-      ? 'username,email,display_name,password_hash,role,photo_url,allowed_units_json,allowed_modules_json,ativo,created_at,updated_at,session_version'
-      : 'username,email,display_name,password_hash,role,photo_url,allowed_units_json,ativo,created_at,updated_at,session_version';
-    const placeholders = modulesColumn ? '?,?,?,?,?,?,?,?,?,?,?,?' : '?,?,?,?,?,?,?,?,?,?,?';
-    const values = modulesColumn
-      ? [next.username, next.email, next.displayName, next.passwordHash, current.role, next.photoUrl, JSON.stringify(current.allowedUnits), JSON.stringify(current.allowedModules), current.ativo ? 1 : 0, current.createdAt || now, now, current.sessionVersion]
-      : [next.username, next.email, next.displayName, next.passwordHash, current.role, next.photoUrl, JSON.stringify(current.allowedUnits), current.ativo ? 1 : 0, current.createdAt || now, now, current.sessionVersion];
-    await env.DB.prepare(`INSERT INTO ${usersTable} (${columns}) VALUES (${placeholders})`).bind(...values).run();
-    await env.DB.prepare(`DELETE FROM ${usersTable} WHERE LOWER(username)=LOWER(?)`).bind(current.username).run();
+    const identitySubjectColumn = await hasColumn(env, usersTable, 'identity_subject');
+    if (identitySubjectColumn && !current.identitySubject) {
+      return { ok: false, status: 503, error: 'IDENTITY_SUBJECT_REQUIRED' };
+    }
+    const [accountLinksType, userPrefsType] = await Promise.all([
+      objectType(env, 'crm_employee_account_links'),
+      objectType(env, userPrefsTable),
+    ]);
+    if (typeof env.DB.batch !== 'function') {
+      return { ok: false, status: 500, error: 'DB_BATCH_UNSUPPORTED' };
+    }
+    // Change the primary-key value and its live references together. Re-inserting
+    // first would briefly duplicate the durable subject and violate its unique
+    // index; sequential updates could leave the confirmed team link stale.
+    const changes = [
+      env.DB.prepare(
+        `UPDATE ${usersTable}
+         SET username=?, email=?, display_name=?, photo_url=?, password_hash=?, updated_at=?
+         WHERE LOWER(username)=LOWER(?)`,
+      ).bind(next.username, next.email, next.displayName, next.photoUrl, next.passwordHash, now, current.username),
+    ];
+    if (accountLinksType === 'table') {
+      changes.push(
+        env.DB.prepare(
+          'UPDATE crm_employee_account_links SET crm_username=?, updated_at=? WHERE LOWER(crm_username)=LOWER(?)',
+        ).bind(next.username, now, current.username),
+      );
+    }
+    if (userPrefsType === 'table') {
+      changes.push(
+        env.DB.prepare(
+          `UPDATE ${userPrefsTable} SET username=?, updated_at=? WHERE LOWER(username)=LOWER(?)`,
+        ).bind(next.username, now, current.username),
+      );
+    }
+    await env.DB.batch(changes);
     // Compatibility bridge: preserve references owned by older domains until their migrations consume subject aliases.
     for (const tableColumn of ['insumos_movements:usuario', 'share_history:user', 'audit_log:actor']) {
       const [table, column] = tableColumn.split(':');

--- a/identity/test/actor-contract.test.mjs
+++ b/identity/test/actor-contract.test.mjs
@@ -1,19 +1,31 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { hasUnitScopeAccess, normalizeAllowedUnits, normalizeUnitScope, toAuthenticatedActor } from '../../shared/identity-contract/index.js';
+import { createOpaqueIdentitySubject, hasUnitScopeAccess, isOpaqueIdentitySubject, normalizeAllowedUnits, normalizeUnitScope, toAuthenticatedActor } from '../../shared/identity-contract/index.js';
 import { isCurrentSessionVersion, resolveIdentityActor } from '../session/actor.js';
 
 test('Identity publishes a stable actor with scoped permissions and compatibility aliases', () => {
   const actor = toAuthenticatedActor({
     username: 'pilot', displayName: 'Pilot User', role: 'gestor',
+    identitySubject: 'idn:fixture_identity_actor_0001',
     allowedUnits: ['novo-hamburgo'], allowedModules: ['finance'], permissions: ['finance:read'],
   });
   assert.equal(actor.subject, 'pilot');
+  assert.equal(actor.identitySubject, 'idn:fixture_identity_actor_0001');
   assert.equal(actor.role, 'GESTOR');
   assert.deepEqual(actor.scopes, { units: ['novo-hamburgo'], modules: ['finance'], permissions: ['finance:read'] });
   assert.deepEqual(actor.allowedModules, ['finance']);
   assert.equal(isCurrentSessionVersion({ sv: 4 }, { sessionVersion: 4 }), true);
   assert.equal(isCurrentSessionVersion({ sv: 3 }, { sessionVersion: 4 }), false);
+});
+
+test('Identity subjects are opaque and server-generated without changing the v1 username alias', () => {
+  const generated = createOpaqueIdentitySubject();
+  assert.equal(isOpaqueIdentitySubject(generated), true);
+  assert.equal(generated.startsWith('idn:'), true);
+  const actor = toAuthenticatedActor({ username: 'pilot', identitySubject: generated });
+  assert.equal(actor.subject, 'pilot');
+  assert.equal(actor.identitySubject, generated);
+  assert.equal(toAuthenticatedActor({ username: 'pilot', identitySubject: 'pilot' }).identitySubject, null);
 });
 
 test('Identity canonicalizes known unit aliases and keeps unknown or empty scopes fail-closed', () => {
@@ -49,10 +61,11 @@ test('Identity accepts the existing signed session payload without changing its 
             if (sql.includes('FROM crm_users')) return {
               username: 'pilot', display_name: 'Pilot User', role: 'GESTOR', ativo: 1,
               allowed_units_json: '["novo-hamburgo"]', allowed_modules_json: '["finance"]', session_version: 4,
+              identity_subject: 'idn:fixture_identity_actor_0001',
             };
             return null;
           },
-          async all() { return { results: [{ name: 'allowed_modules_json' }] }; },
+          async all() { return { results: [{ name: 'allowed_modules_json' }, { name: 'identity_subject' }] }; },
         };
       },
     },
@@ -62,5 +75,6 @@ test('Identity accepts the existing signed session payload without changing its 
 
   assert.equal(result.csrf, 'csrf-existing');
   assert.equal(result.actor.subject, 'pilot');
+  assert.equal(result.actor.identitySubject, 'idn:fixture_identity_actor_0001');
   assert.deepEqual(result.actor.scopes.modules, ['finance']);
 });

--- a/identity/test/crm-envelope-v1.test.mjs
+++ b/identity/test/crm-envelope-v1.test.mjs
@@ -154,4 +154,9 @@ test('the source-only helper is not connected to the legacy public runtime or a 
   assert.doesNotMatch(helper, /from ['"]cloudflare:workers['"]/i);
   assert.doesNotMatch(authRoutes, /crm-envelope-v1/);
   assert.doesNotMatch(inventoryWorker, /crm-envelope-v1/);
+
+  const authMeStart = authRoutes.indexOf('// GET /auth/me');
+  const authRefreshStart = authRoutes.indexOf('// POST /auth/refresh', authMeStart);
+  assert.ok(authMeStart >= 0 && authRefreshStart > authMeStart, 'expected the legacy /auth/me boundary');
+  assert.doesNotMatch(authRoutes.slice(authMeStart, authRefreshStart), /\bidentitySubject\b/);
 });

--- a/identity/test/onboarding-security.test.mjs
+++ b/identity/test/onboarding-security.test.mjs
@@ -19,7 +19,10 @@ test('team accounts accept both the unique username and corporate email at login
   assert.match(auth, /SELECT \?, \?, \?, \?, role/);
   assert.match(auth, /INVITE_IDENTITY_MIGRATION_REQUIRED/);
   assert.match(auth, /AUTH_INVITE_ACCOUNT_LINKED/);
+  assert.match(auth, /createOpaqueIdentitySubject/);
+  assert.match(auth, /identity_subject/);
   assert.match(store, /LOWER\(username\) = LOWER\(\?\) OR \(email IS NOT NULL AND email != '' AND LOWER\(email\) = LOWER\(\?\)\)/);
+  assert.match(store, /IDENTITY_SUBJECT_REQUIRED/);
 });
 
 test('authentication failures do not disclose inactive or passwordless account state', async () => {

--- a/identity/test/opaque-subject-migration.test.mjs
+++ b/identity/test/opaque-subject-migration.test.mjs
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+import { updateIdentityProfile } from '../store/d1.js';
+
+const migrationUrl = new URL('../../inventory/migrations/0029_crm_users_identity_subject.sql', import.meta.url);
+const identityStoreUrl = new URL('../store/d1.js', import.meta.url);
+const actorContractUrl = new URL('../../shared/identity-contract/index.js', import.meta.url);
+
+function createRenameEnvironment() {
+  const state = {
+    user: {
+      username: 'identity-legacy',
+      email: 'identity-legacy@staging.invalid',
+      display_name: 'Identity Legacy',
+      password_hash: 'hash',
+      role: 'GESTOR',
+      photo_url: '',
+      allowed_units_json: '["novo-hamburgo"]',
+      allowed_modules_json: '["finance"]',
+      ativo: 1,
+      created_at: '2026-09-02T00:00:00.000Z',
+      updated_at: '2026-09-02T00:00:00.000Z',
+      session_version: 6,
+      identity_subject: 'idn:identity_legacy_0001',
+    },
+    accountLinkUsername: 'identity-legacy',
+    prefsUsername: 'identity-legacy',
+  };
+
+  const statement = (sql, params = []) => ({
+    sql,
+    params,
+    bind(...values) { return statement(sql, values); },
+    async first() {
+      if (sql.includes('sqlite_master')) {
+        const name = String(params[0] || '');
+        return ['crm_users', 'crm_invites', 'crm_password_resets', 'crm_user_prefs', 'crm_employee_account_links'].includes(name)
+          ? { type: 'table' }
+          : null;
+      }
+      if (sql.includes('FROM crm_users')) {
+        const requested = String(params[0] || '').toLowerCase();
+        return state.user.username.toLowerCase() === requested ? { ...state.user } : null;
+      }
+      return null;
+    },
+    async all() {
+      if (sql.startsWith('PRAGMA table_info(crm_users)')) {
+        return { results: [{ name: 'allowed_modules_json' }, { name: 'identity_subject' }] };
+      }
+      return { results: [] };
+    },
+    async run() {
+      if (sql.includes('UPDATE crm_users')) {
+        state.user = {
+          ...state.user,
+          username: params[0],
+          email: params[1],
+          display_name: params[2],
+          photo_url: params[3],
+          password_hash: params[4],
+          updated_at: params[5],
+        };
+      } else if (sql.includes('UPDATE crm_employee_account_links')) {
+        state.accountLinkUsername = params[0];
+      } else if (sql.includes('UPDATE crm_user_prefs')) {
+        state.prefsUsername = params[0];
+      }
+      return { meta: { changes: 1 } };
+    },
+  });
+
+  const DB = {
+    prepare(sql) { return statement(sql); },
+    async batch(statements) {
+      for (const item of statements) await item.run();
+    },
+  };
+  return { env: { DB }, state };
+}
+
+test('the CRM identity subject migration is additive, opaque, and uniquely indexed', async () => {
+  const migration = await readFile(migrationUrl, 'utf8');
+
+  assert.match(migration, /ALTER TABLE crm_users ADD COLUMN identity_subject TEXT;/);
+  assert.match(migration, /SET identity_subject = 'idn:' \|\| lower\(hex\(randomblob\(16\)\)\)/);
+  assert.match(migration, /CREATE UNIQUE INDEX IF NOT EXISTS idx_crm_users_identity_subject/);
+  assert.match(migration, /ON crm_users\(identity_subject\)\s+WHERE identity_subject IS NOT NULL;/);
+  assert.doesNotMatch(migration, /\b(?:DROP|RENAME)\s+(?:TABLE|COLUMN)\b/i);
+  assert.doesNotMatch(migration, /identity_subject\s+TEXT\s+NOT\s+NULL/i);
+});
+
+test('identity persistence renames in place while v1 actor.subject remains username-based', async () => {
+  const [store, contract] = await Promise.all([
+    readFile(identityStoreUrl, 'utf8'),
+    readFile(actorContractUrl, 'utf8'),
+  ]);
+
+  assert.match(store, /identitySubjectColumn && !current\.identitySubject/);
+  assert.match(store, /error: 'IDENTITY_SUBJECT_REQUIRED'/);
+  const renameBlock = store.match(/if \(nextUsername !== current\.username\) \{([\s\S]*?)\n  \} else \{/);
+  assert.ok(renameBlock, 'expected a dedicated username rename branch');
+  assert.match(renameBlock[1], /UPDATE \$\{usersTable\}[\s\S]*SET username=\?/);
+  assert.doesNotMatch(renameBlock[1], /\b(?:INSERT|DELETE)\b/i);
+  assert.match(contract, /identitySubject: isOpaqueIdentitySubject\(user\.identitySubject\) \? user\.identitySubject : null/);
+  assert.match(contract, /subject: String\(user\.username\)/);
+});
+
+test('the mounted Identity store preserves the opaque subject, team link, and preferences through an in-place rename', async () => {
+  const { env, state } = createRenameEnvironment();
+  const renamed = await updateIdentityProfile(env, 'identity-legacy', {
+    newUsername: 'identity-renamed',
+    displayName: 'Identity Renamed',
+  });
+
+  assert.equal(renamed.ok, true);
+  assert.equal(renamed.user.username, 'identity-renamed');
+  assert.equal(renamed.user.identitySubject, 'idn:identity_legacy_0001');
+  assert.equal(renamed.user.sessionVersion, 6);
+  assert.equal(state.accountLinkUsername, 'identity-renamed');
+  assert.equal(state.prefsUsername, 'identity-renamed');
+});

--- a/inventory/migrations/0029_crm_users_identity_subject.sql
+++ b/inventory/migrations/0029_crm_users_identity_subject.sql
@@ -1,0 +1,14 @@
+-- Add an opaque, durable identity alias without changing the username primary
+-- key or existing session semantics. The later CRM delivery contract may use
+-- only this value; legacy actor.subject remains username-based in v1.
+ALTER TABLE crm_users ADD COLUMN identity_subject TEXT;
+
+-- Backfill once in the same additive migration. The value contains no profile
+-- data and does not derive from the username or e-mail address.
+UPDATE crm_users
+SET identity_subject = 'idn:' || lower(hex(randomblob(16)))
+WHERE identity_subject IS NULL OR trim(identity_subject) = '';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_crm_users_identity_subject
+ON crm_users(identity_subject)
+WHERE identity_subject IS NOT NULL;

--- a/inventory/migrations/0030_crm_identity_session_epochs.sql
+++ b/inventory/migrations/0030_crm_identity_session_epochs.sql
@@ -1,0 +1,128 @@
+-- Preserve session epochs when a username is removed, restored, or reused.
+-- V2 legacy cookies without a tracked sid validate against username + session_version,
+-- so the version must never be reset when the same username returns.
+
+CREATE TABLE IF NOT EXISTS crm_identity_session_epochs (
+  username TEXT COLLATE NOCASE PRIMARY KEY,
+  session_version INTEGER NOT NULL CHECK (session_version >= 0),
+  updated_at TEXT NOT NULL,
+  reason TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_crm_identity_session_epochs_updated_at
+ON crm_identity_session_epochs(updated_at DESC);
+
+INSERT INTO crm_identity_session_epochs (username, session_version, updated_at, reason)
+SELECT username, MAX(session_version), CURRENT_TIMESTAMP, 'MIGRATION_BACKFILL'
+FROM (
+  SELECT username, COALESCE(session_version, 0) AS session_version FROM crm_users
+  UNION ALL
+  SELECT username, COALESCE(session_version, 0) AS session_version FROM crm_identity_sessions
+)
+GROUP BY username
+ON CONFLICT(username) DO UPDATE SET
+  session_version = MAX(crm_identity_session_epochs.session_version, excluded.session_version),
+  updated_at = excluded.updated_at,
+  reason = excluded.reason;
+
+CREATE TRIGGER IF NOT EXISTS trg_crm_users_session_epoch_before_delete
+BEFORE DELETE ON crm_users
+FOR EACH ROW
+BEGIN
+  UPDATE crm_identity_sessions
+  SET revoked_at = CURRENT_TIMESTAMP,
+      revoke_reason = 'USERNAME_RETIRED'
+  WHERE LOWER(username) = LOWER(OLD.username)
+    AND revoked_at IS NULL;
+
+  INSERT INTO crm_identity_session_epochs (username, session_version, updated_at, reason)
+  VALUES (
+    OLD.username,
+    MAX(
+      COALESCE(OLD.session_version, 0),
+      COALESCE((SELECT MAX(session_version) FROM crm_identity_sessions WHERE LOWER(username) = LOWER(OLD.username)), 0)
+    ),
+    CURRENT_TIMESTAMP,
+    'USERNAME_RETIRED'
+  )
+  ON CONFLICT(username) DO UPDATE SET
+    session_version = MAX(crm_identity_session_epochs.session_version, excluded.session_version),
+    updated_at = excluded.updated_at,
+    reason = excluded.reason;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_crm_users_session_epoch_after_insert
+AFTER INSERT ON crm_users
+FOR EACH ROW
+BEGIN
+  UPDATE crm_users
+  SET session_version = MAX(
+    COALESCE(NEW.session_version, 0),
+    COALESCE(
+      (SELECT session_version + 1 FROM crm_identity_session_epochs WHERE username = NEW.username),
+      COALESCE(NEW.session_version, 0)
+    )
+  )
+  WHERE username = NEW.username;
+
+  INSERT INTO crm_identity_session_epochs (username, session_version, updated_at, reason)
+  SELECT username, session_version, CURRENT_TIMESTAMP, 'USERNAME_ACTIVATED'
+  FROM crm_users
+  WHERE username = NEW.username
+  ON CONFLICT(username) DO UPDATE SET
+    session_version = MAX(crm_identity_session_epochs.session_version, excluded.session_version),
+    updated_at = excluded.updated_at,
+    reason = excluded.reason;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_crm_users_session_epoch_before_username_change
+BEFORE UPDATE OF username ON crm_users
+FOR EACH ROW
+WHEN LOWER(NEW.username) <> LOWER(OLD.username)
+BEGIN
+  UPDATE crm_identity_sessions
+  SET revoked_at = CURRENT_TIMESTAMP,
+      revoke_reason = 'USERNAME_RENAMED'
+  WHERE LOWER(username) = LOWER(OLD.username)
+    AND revoked_at IS NULL;
+
+  INSERT INTO crm_identity_session_epochs (username, session_version, updated_at, reason)
+  VALUES (
+    OLD.username,
+    MAX(
+      COALESCE(OLD.session_version, 0),
+      COALESCE((SELECT MAX(session_version) FROM crm_identity_sessions WHERE LOWER(username) = LOWER(OLD.username)), 0)
+    ),
+    CURRENT_TIMESTAMP,
+    'USERNAME_RENAMED'
+  )
+  ON CONFLICT(username) DO UPDATE SET
+    session_version = MAX(crm_identity_session_epochs.session_version, excluded.session_version),
+    updated_at = excluded.updated_at,
+    reason = excluded.reason;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_crm_users_session_epoch_after_username_change
+AFTER UPDATE OF username ON crm_users
+FOR EACH ROW
+WHEN LOWER(NEW.username) <> LOWER(OLD.username)
+BEGIN
+  UPDATE crm_users
+  SET session_version = MAX(
+    COALESCE(NEW.session_version, 0),
+    COALESCE(
+      (SELECT session_version + 1 FROM crm_identity_session_epochs WHERE username = NEW.username),
+      COALESCE(NEW.session_version, 0)
+    )
+  )
+  WHERE username = NEW.username;
+
+  INSERT INTO crm_identity_session_epochs (username, session_version, updated_at, reason)
+  SELECT username, session_version, CURRENT_TIMESTAMP, 'USERNAME_RENAMED'
+  FROM crm_users
+  WHERE username = NEW.username
+  ON CONFLICT(username) DO UPDATE SET
+    session_version = MAX(crm_identity_session_epochs.session_version, excluded.session_version),
+    updated_at = excluded.updated_at,
+    reason = excluded.reason;
+END;

--- a/inventory/scripts/insumosStagingRbacFixtures.mjs
+++ b/inventory/scripts/insumosStagingRbacFixtures.mjs
@@ -18,6 +18,7 @@ const sql = (value) => `'${String(value).replaceAll("'", "''")}'`;
 const prefix = `stg-rbac-${runId}`;
 const now = new Date().toISOString();
 const password = () => `StgRbac-${randomBytes(18).toString('base64url')}`;
+const opaqueIdentitySubject = () => `idn:${randomBytes(16).toString('hex')}`;
 const passwordHash = (value) => {
   const salt = randomBytes(16);
   const digest = pbkdf2Sync(value, salt, 100_000, 32, 'sha256');
@@ -62,6 +63,7 @@ function privateFixtures() {
       username: `${prefix}-${definition.id}`,
       email: `${prefix}-${definition.id}@staging.invalid`,
       password: password(),
+      identitySubject: opaqueIdentitySubject(),
     })),
     teamMembers: syntheticTeamMembers(),
   };
@@ -82,7 +84,7 @@ if (action === 'provision') {
     statements.push(`DELETE FROM crm_users WHERE username = ${sql(scenario.username)};`);
     // `insumos` is the runtime module permission enforced by the Inventory
     // Worker. `inventory` is a domain label, not an authorization scope.
-    statements.push(`INSERT INTO crm_users (username, email, display_name, password_hash, role, photo_url, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at, session_version) VALUES (${sql(scenario.username)}, ${sql(scenario.email)}, ${sql(`Synthetic Insumos RBAC ${scenario.id}`)}, ${sql(passwordHash(scenario.password))}, ${sql(scenario.role)}, '', ${sql(JSON.stringify(scenario.allowedUnits))}, ${sql(JSON.stringify(['insumos']))}, 1, ${sql(now)}, ${sql(now)}, 0);`);
+    statements.push(`INSERT INTO crm_users (username, email, display_name, password_hash, role, photo_url, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at, session_version, identity_subject) VALUES (${sql(scenario.username)}, ${sql(scenario.email)}, ${sql(`Synthetic Insumos RBAC ${scenario.id}`)}, ${sql(passwordHash(scenario.password))}, ${sql(scenario.role)}, '', ${sql(JSON.stringify(scenario.allowedUnits))}, ${sql(JSON.stringify(['insumos']))}, 1, ${sql(now)}, ${sql(now)}, 0, ${sql(scenario.identitySubject)});`);
     statements.push(audit('STAGING_SYNTHETIC_IDENTITY_PROVISIONED', scenario.username, { runId, scope: scenario.allowedUnits, role: scenario.role }));
   }
   for (const member of fixtures.teamMembers || []) {

--- a/inventory/src/d1Store.js
+++ b/inventory/src/d1Store.js
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import {
   hasUnitScopeAccess,
+  isOpaqueIdentitySubject,
   normalizeAllowedUnits as normalizeCanonicalAllowedUnits,
   normalizeUnitScope,
 } from '../../shared/identity-contract/index.js';
@@ -4331,6 +4332,7 @@ export function d1UserRowToUser(row) {
     email: row.email || '',
     role: row.role || 'CONSULTOR',
     photoUrl: row.photo_url || '',
+    identitySubject: isOpaqueIdentitySubject(row.identity_subject) ? row.identity_subject : null,
     allowedUnits: normalizeAllowedUnits(row.allowed_units_json),
     allowedModules: normalizeAllowedModules(row.allowed_modules_json),
     ativo: toInt(row.ativo, 1) ? true : false,
@@ -4347,7 +4349,8 @@ export async function d1GetUserByUsername(env, username) {
   if (!u) return null;
   const { usersTable } = await resolveCrmTables(env);
   const hasModules = await tableHasColumn(env, usersTable, 'allowed_modules_json');
-  const extra = hasModules ? ', allowed_modules_json' : '';
+  const hasIdentitySubject = await tableHasColumn(env, usersTable, 'identity_subject');
+  const extra = `${hasModules ? ', allowed_modules_json' : ''}${hasIdentitySubject ? ', identity_subject' : ''}`;
   const row = await env.DB.prepare(
     `SELECT username, email, display_name, password_hash, role, photo_url, allowed_units_json, ativo, created_at, updated_at, session_version${extra}
      FROM ${usersTable}
@@ -4365,7 +4368,8 @@ export async function d1GetUserByIdentifier(env, identifier) {
   if (!id) return null;
   const { usersTable } = await resolveCrmTables(env);
   const hasModules = await tableHasColumn(env, usersTable, 'allowed_modules_json');
-  const extra = hasModules ? ', allowed_modules_json' : '';
+  const hasIdentitySubject = await tableHasColumn(env, usersTable, 'identity_subject');
+  const extra = `${hasModules ? ', allowed_modules_json' : ''}${hasIdentitySubject ? ', identity_subject' : ''}`;
   const row = await env.DB.prepare(
     `SELECT username, email, display_name, password_hash, role, photo_url, allowed_units_json, ativo, created_at, updated_at, session_version${extra}
      FROM ${usersTable}
@@ -4382,11 +4386,12 @@ export async function d1UpdateUserProfile(env, username, updates) {
   const u = String(username || '').trim();
   if (!u) return { ok: false, status: 400, error: 'USERNAME_REQUIRED' };
 
-  const { usersTable } = await resolveCrmTables(env);
+  const { usersTable, userPrefsTable } = await resolveCrmTables(env);
   const hasModules = await tableHasColumn(env, usersTable, 'allowed_modules_json');
-  const extra = hasModules ? ', allowed_modules_json' : '';
+  const hasIdentitySubject = await tableHasColumn(env, usersTable, 'identity_subject');
+  const extra = `${hasModules ? ', allowed_modules_json' : ''}${hasIdentitySubject ? ', identity_subject' : ''}`;
   const existing = await env.DB.prepare(
-    `SELECT username, email, display_name, password_hash, role, photo_url, allowed_units_json, ativo, created_at, updated_at${extra}
+    `SELECT username, email, display_name, password_hash, role, photo_url, allowed_units_json, ativo, created_at, updated_at, session_version${extra}
      FROM ${usersTable}
      WHERE LOWER(username) = LOWER(?)
      LIMIT 1`
@@ -4410,47 +4415,51 @@ export async function d1UpdateUserProfile(env, username, updates) {
       .first();
     if (taken) return { ok: false, status: 409, error: 'USERNAME_TAKEN' };
 
-    // Move user PK (best-effort) and keep references consistent.
-    if (hasModules) {
-      await env.DB.prepare(
-        `INSERT INTO ${usersTable} (username, email, display_name, password_hash, role, photo_url, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-      )
-        .bind(
-          nextUsername,
-          nextEmail ?? existing.email ?? '',
-          nextDisplayName ?? existing.display_name ?? '',
-          nextPasswordHash ?? existing.password_hash ?? '',
-          existing.role ?? 'CONSULTOR',
-          nextPhotoUrl ?? existing.photo_url ?? '',
-          existing.allowed_units_json ?? null,
-          existing.allowed_modules_json ?? null,
-          toInt(existing.ativo, 1),
-          existing.created_at || now,
-          now
-        )
-        .run();
-    } else {
-      await env.DB.prepare(
-        `INSERT INTO ${usersTable} (username, email, display_name, password_hash, role, photo_url, allowed_units_json, ativo, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-      )
-        .bind(
-          nextUsername,
-          nextEmail ?? existing.email ?? '',
-          nextDisplayName ?? existing.display_name ?? '',
-          nextPasswordHash ?? existing.password_hash ?? '',
-          existing.role ?? 'CONSULTOR',
-          nextPhotoUrl ?? existing.photo_url ?? '',
-          existing.allowed_units_json ?? null,
-          toInt(existing.ativo, 1),
-          existing.created_at || now,
-          now
-        )
-        .run();
+    // Rename through one D1 batch and preserve live references.
+    if (hasIdentitySubject && !isOpaqueIdentitySubject(existing.identity_subject)) {
+      return { ok: false, status: 503, error: 'IDENTITY_SUBJECT_REQUIRED' };
     }
-
-    await env.DB.prepare(`DELETE FROM ${usersTable} WHERE LOWER(username) = LOWER(?)`).bind(u).run();
+    const [accountLinksType, userPrefsType] = await Promise.all([
+      sqliteObjectType(env, 'crm_employee_account_links'),
+      sqliteObjectType(env, userPrefsTable),
+    ]);
+    if (typeof env.DB.batch !== 'function') {
+      return { ok: false, status: 500, error: 'DB_BATCH_UNSUPPORTED' };
+    }
+    // Update the primary key and its live references together. An
+    // insert-before-delete strategy would temporarily duplicate
+    // identity_subject; separate writes could orphan a confirmed team link.
+    const changes = [
+      env.DB.prepare(
+        `UPDATE ${usersTable}
+         SET username=?, email=?, display_name=?, photo_url=?, password_hash=?, updated_at=?
+         WHERE LOWER(username) = LOWER(?)`,
+      )
+        .bind(
+          nextUsername,
+          nextEmail ?? existing.email ?? '',
+          nextDisplayName ?? existing.display_name ?? '',
+          nextPhotoUrl ?? existing.photo_url ?? '',
+          nextPasswordHash ?? existing.password_hash ?? '',
+          now,
+          u,
+        ),
+    ];
+    if (accountLinksType === 'table') {
+      changes.push(
+        env.DB.prepare(
+          'UPDATE crm_employee_account_links SET crm_username=?, updated_at=? WHERE LOWER(crm_username)=LOWER(?)',
+        ).bind(nextUsername, now, existing.username),
+      );
+    }
+    if (userPrefsType === 'table') {
+      changes.push(
+        env.DB.prepare(
+          `UPDATE ${userPrefsTable} SET username=?, updated_at=? WHERE LOWER(username)=LOWER(?)`,
+        ).bind(nextUsername, now, existing.username),
+      );
+    }
+    await env.DB.batch(changes);
     // Best-effort propagate to other tables where we store username as text.
     // Ledger rows retain the backend actor captured at posting time. User
     // profile changes must never rewrite historical responsibility.

--- a/inventory/src/routes/admin.js
+++ b/inventory/src/routes/admin.js
@@ -10,7 +10,7 @@ import { isAuthorizedDevSeedRequest } from '../lib/devSeed.js';
 import { resolveCrmTables } from '../d1Store.js';
 import { hasAuthMailerConfig, sendAccountInviteEmail } from '../smtpMailer.js';
 import { normalizeInviteEmail, normalizeInviteScope, validateInviteDelegation } from '../invitePolicy.js';
-import { normalizeAllowedUnits as normalizeCanonicalAllowedUnits, unknownUnitScopes } from '../../../shared/identity-contract/index.js';
+import { createOpaqueIdentitySubject, normalizeAllowedUnits as normalizeCanonicalAllowedUnits, unknownUnitScopes } from '../../../shared/identity-contract/index.js';
 import { buildEmployeeOnboardingFingerprintPayload, canCreateEmployee, displayJobTitle, publicOnboarding, resolveEmployeeProfile, suggestEmployeeUsername, validateOnboardingInput } from '../../../shared/identity-runtime/inventory-compat.js';
 import { syncIdentityWorkforceOnboarding, syncIdentityWorkforceStatus } from '../../../shared/identity-runtime/workforce-onboarding.js';
 import { isValidAccountTransition, normalizeAccountState, shouldIssueInvite } from '../../../shared/identity-runtime/onboarding-state.js';
@@ -708,6 +708,7 @@ export async function handleAdminRoutes({
 
   const { usersTable, invitesTable } = await resolveCrmTables(env);
   const usersHasModules = await tableHasColumn(env, usersTable, 'allowed_modules_json');
+  const usersHasIdentitySubject = await tableHasColumn(env, usersTable, 'identity_subject');
   const invitesHasModules = await tableHasColumn(env, invitesTable, 'allowed_modules_json');
   const invitesHasInviteeEmail = await tableHasColumn(env, invitesTable, 'invitee_email');
   const invitesHasCorporateEmail = await tableHasColumn(env, invitesTable, 'corporate_email');
@@ -2599,46 +2600,21 @@ export async function handleAdminRoutes({
 
       const now = new Date().toISOString();
       const hash = await hashPasswordPBKDF2(env, password);
+      const insertColumns = ['username', 'email', 'display_name', 'password_hash', 'role', 'photo_url', 'allowed_units_json'];
+      const insertValues = [username, email, displayName, hash, role, String(body.photoUrl || ''), JSON.stringify(allowedUnits)];
       if (usersHasModules) {
-        await env.DB.prepare(
-          `INSERT INTO ${usersTable}
-           (username, email, display_name, password_hash, role, photo_url, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-        )
-          .bind(
-            username,
-            email,
-            displayName,
-            hash,
-            role,
-            String(body.photoUrl || ''),
-            JSON.stringify(allowedUnits),
-            JSON.stringify(allowedModules),
-            ativo,
-            now,
-            now
-          )
-          .run();
-      } else {
-        await env.DB.prepare(
-          `INSERT INTO ${usersTable}
-           (username, email, display_name, password_hash, role, photo_url, allowed_units_json, ativo, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-        )
-          .bind(
-            username,
-            email,
-            displayName,
-            hash,
-            role,
-            String(body.photoUrl || ''),
-            JSON.stringify(allowedUnits),
-            ativo,
-            now,
-            now
-          )
-          .run();
+        insertColumns.push('allowed_modules_json');
+        insertValues.push(JSON.stringify(allowedModules));
       }
+      insertColumns.push('ativo', 'created_at', 'updated_at');
+      insertValues.push(ativo, now, now);
+      if (usersHasIdentitySubject) {
+        insertColumns.push('identity_subject');
+        insertValues.push(createOpaqueIdentitySubject());
+      }
+      await env.DB.prepare(`INSERT INTO ${usersTable} (${insertColumns.join(',')}) VALUES (${insertColumns.map(() => '?').join(',')})`)
+        .bind(...insertValues)
+        .run();
 
       const user = publicUser({ username, displayName, email, role, allowedUnits, allowedModules, ativo: !!ativo, createdAt: now, updatedAt: now, photoUrl: String(body.photoUrl || '') });
       try {

--- a/inventory/src/services/backup.js
+++ b/inventory/src/services/backup.js
@@ -3,6 +3,8 @@ import { safeJsonNoTruncate } from '../lib/json.js';
 import { resolveCrmTables } from '../d1Store.js';
 import { isOpaqueIdentitySubject } from '../../../shared/identity-contract/index.js';
 
+const IDENTITY_SESSION_EPOCH_TABLE = 'crm_identity_session_epochs';
+
 async function tableHasColumn(env, tableName, columnName) {
     if (!env?.DB || !tableName || !columnName) return false;
     const t = String(tableName);
@@ -11,6 +13,18 @@ async function tableHasColumn(env, tableName, columnName) {
         const res = await env.DB.prepare(`PRAGMA table_info(${t})`).all();
         const cols = (res?.results || []).map((r) => String(r?.name || '').toLowerCase());
         return cols.includes(String(columnName).toLowerCase());
+    } catch {
+        return false;
+    }
+}
+
+async function tableExists(env, tableName) {
+    if (!env?.DB || tableName !== IDENTITY_SESSION_EPOCH_TABLE) return false;
+    try {
+        const row = await env.DB.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=? LIMIT 1")
+            .bind(tableName)
+            .first();
+        return row?.name === tableName;
     } catch {
         return false;
     }
@@ -479,12 +493,26 @@ export async function restoreBackupPayload({ env, payload, strict = false }) {
                 }
             }
 
+            // Session-version schemas also require the monotonic tombstone.
+            // Refuse a destructive restore if migrations were not applied in
+            // order; otherwise a sid-less legacy V2 cookie could become valid
+            // again after the same username is restored.
+            if (usersRows.length && usersHasSessionVersion && !await tableExists(env, IDENTITY_SESSION_EPOCH_TABLE)) {
+                throw new Error('IDENTITY_SESSION_EPOCH_REQUIRED');
+            }
+
             if (Array.isArray(p.d1.insumosStocks)) await env.DB.prepare('DELETE FROM insumos_stocks').run();
             // The stock ledger is append-only. Restore may add missing evidence,
             // but it must never erase or rewrite movements already posted.
             // Items are restored by upsert. Deleting them would cascade into
             // insumos_movements through the legacy foreign key and violate the
             // append-only ledger contract.
+            const restoreAt = new Date().toISOString();
+            if (usersRows.length && usersHasSessionVersion) {
+                await env.DB.prepare(
+                    'UPDATE crm_identity_sessions SET revoked_at=?, revoke_reason=? WHERE revoked_at IS NULL'
+                ).bind(restoreAt, 'BACKUP_RESTORE').run();
+            }
             if (usersRows.length) await env.DB.prepare(`DELETE FROM ${usersTable}`).run();
             if (Array.isArray(p.d1.shareHistory)) await env.DB.prepare('DELETE FROM share_history').run();
 
@@ -507,7 +535,13 @@ export async function restoreBackupPayload({ env, payload, strict = false }) {
                 userValues.push(Number(row.ativo || 0) ? 1 : 0, row.createdAt || new Date().toISOString(), row.updatedAt || new Date().toISOString());
                 if (usersHasSessionVersion) {
                     userColumns.push('session_version');
-                    userValues.push(Number(row.sessionVersion || 0));
+                    // Restoring an account must invalidate every cookie that
+                    // existed when this snapshot was taken, including a
+                    // sid-less legacy V2 cookie restored into a clean D1
+                    // target whose epoch ledger has no local history yet.
+                    // The trigger may advance this further when the target
+                    // already has a newer tombstone for the username.
+                    userValues.push(Math.max(0, Number(row.sessionVersion) || 0) + 1);
                 }
                 if (usersHasIdentitySubject) {
                     userColumns.push('identity_subject');
@@ -516,6 +550,13 @@ export async function restoreBackupPayload({ env, payload, strict = false }) {
                 await env.DB.prepare(`INSERT INTO ${usersTable} (${userColumns.join(',')}) VALUES (${userColumns.map(() => '?').join(',')})`)
                     .bind(...userValues)
                     .run();
+            }
+            if (usersRows.length && usersHasSessionVersion) {
+                await env.DB.prepare(
+                    `UPDATE ${IDENTITY_SESSION_EPOCH_TABLE}
+                     SET updated_at=?, reason='BACKUP_RESTORE'
+                     WHERE username IN (SELECT username FROM ${usersTable})`
+                ).bind(restoreAt).run();
             }
             for (const row of (p.d1.insumosItems || []).reverse()) {
                 await env.DB.prepare(
@@ -828,10 +869,11 @@ export async function restoreBackupPayload({ env, payload, strict = false }) {
                     .run();
             }
         } catch (error) {
-            // A schema that has durable subjects must never accept a legacy
-            // account snapshot by silently reminting its audit identity. This
-            // remains fail-closed even for the historical best-effort path.
-            if (strict || String(error?.message || '').startsWith('IDENTITY_SUBJECT_BACKUP_')) throw error;
+            // Durable identity subjects and session epochs must never be
+            // bypassed by the historical best-effort restore path.
+            if (strict
+                || String(error?.message || '').startsWith('IDENTITY_SUBJECT_BACKUP_')
+                || String(error?.message || '') === 'IDENTITY_SESSION_EPOCH_REQUIRED') throw error;
             // Legacy restore is intentionally best-effort for historical backup
             // files. The private preview sets strict and fails closed instead.
         }

--- a/inventory/src/services/backup.js
+++ b/inventory/src/services/backup.js
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { safeJsonNoTruncate } from '../lib/json.js';
 import { resolveCrmTables } from '../d1Store.js';
+import { isOpaqueIdentitySubject } from '../../../shared/identity-contract/index.js';
 
 async function tableHasColumn(env, tableName, columnName) {
     if (!env?.DB || !tableName || !columnName) return false;
@@ -229,10 +230,12 @@ export async function buildBackupPayload({ env }) {
         try {
             const { usersTable } = await resolveCrmTables(env);
             const hasModules = await tableHasColumn(env, usersTable, 'allowed_modules_json');
+            const hasIdentitySubject = await tableHasColumn(env, usersTable, 'identity_subject');
+            const hasSessionVersion = await tableHasColumn(env, usersTable, 'session_version');
             const u = await env.DB.prepare(
                 `SELECT username, email, display_name as displayName, password_hash as passwordHash, role, photo_url as photoUrl,
                         allowed_units_json as allowedUnitsJson${hasModules ? ', allowed_modules_json as allowedModulesJson' : ''},
-                        ativo, created_at as createdAt, updated_at as updatedAt
+                        ativo, created_at as createdAt, updated_at as updatedAt${hasSessionVersion ? ', session_version as sessionVersion' : ''}${hasIdentitySubject ? ', identity_subject as identitySubject' : ''}
                  FROM ${usersTable}`
             ).all();
             d1Dump.insumosUsers = u?.results || [];
@@ -453,9 +456,28 @@ export async function restoreBackupPayload({ env, payload, strict = false }) {
         try {
             const { usersTable } = await resolveCrmTables(env);
             const usersHasModules = await tableHasColumn(env, usersTable, 'allowed_modules_json');
+            const usersHasIdentitySubject = await tableHasColumn(env, usersTable, 'identity_subject');
+            const usersHasSessionVersion = await tableHasColumn(env, usersTable, 'session_version');
             const usersRows = Array.isArray(p.d1.crmUsers)
                 ? p.d1.crmUsers
                 : (Array.isArray(p.d1.insumosUsers) ? p.d1.insumosUsers : []);
+
+            // Once the durable subject schema exists, a restore must preserve
+            // the original audit identity. A legacy backup is not allowed to
+            // silently remint subjects for already-known accounts.
+            if (usersHasIdentitySubject) {
+                const seenIdentitySubjects = new Set();
+                for (const row of usersRows) {
+                    const subject = row?.identitySubject;
+                    if (!isOpaqueIdentitySubject(subject)) {
+                        throw new Error('IDENTITY_SUBJECT_BACKUP_REQUIRED');
+                    }
+                    if (seenIdentitySubjects.has(subject)) {
+                        throw new Error('IDENTITY_SUBJECT_BACKUP_DUPLICATE');
+                    }
+                    seenIdentitySubjects.add(subject);
+                }
+            }
 
             if (Array.isArray(p.d1.insumosStocks)) await env.DB.prepare('DELETE FROM insumos_stocks').run();
             // The stock ledger is append-only. Restore may add missing evidence,
@@ -467,44 +489,33 @@ export async function restoreBackupPayload({ env, payload, strict = false }) {
             if (Array.isArray(p.d1.shareHistory)) await env.DB.prepare('DELETE FROM share_history').run();
 
             for (const row of (usersRows || []).reverse()) {
+                const userColumns = ['username', 'email', 'display_name', 'password_hash', 'role', 'photo_url', 'allowed_units_json'];
+                const userValues = [
+                    row.username || '',
+                    row.email || '',
+                    row.displayName || '',
+                    row.passwordHash || '',
+                    row.role || 'CONSULTOR',
+                    row.photoUrl || '',
+                    row.allowedUnitsJson || null,
+                ];
                 if (usersHasModules) {
-                    await env.DB.prepare(
-                        `INSERT INTO ${usersTable} (username, email, display_name, password_hash, role, photo_url, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at)
-                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-                    )
-                        .bind(
-                            row.username || '',
-                            row.email || '',
-                            row.displayName || '',
-                            row.passwordHash || '',
-                            row.role || 'CONSULTOR',
-                            row.photoUrl || '',
-                            row.allowedUnitsJson || null,
-                            row.allowedModulesJson || null,
-                            Number(row.ativo || 0) ? 1 : 0,
-                            row.createdAt || new Date().toISOString(),
-                            row.updatedAt || new Date().toISOString()
-                        )
-                        .run();
-                } else {
-                    await env.DB.prepare(
-                        `INSERT INTO ${usersTable} (username, email, display_name, password_hash, role, photo_url, allowed_units_json, ativo, created_at, updated_at)
-                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-                    )
-                        .bind(
-                            row.username || '',
-                            row.email || '',
-                            row.displayName || '',
-                            row.passwordHash || '',
-                            row.role || 'CONSULTOR',
-                            row.photoUrl || '',
-                            row.allowedUnitsJson || null,
-                            Number(row.ativo || 0) ? 1 : 0,
-                            row.createdAt || new Date().toISOString(),
-                            row.updatedAt || new Date().toISOString()
-                        )
-                        .run();
+                    userColumns.push('allowed_modules_json');
+                    userValues.push(row.allowedModulesJson || null);
                 }
+                userColumns.push('ativo', 'created_at', 'updated_at');
+                userValues.push(Number(row.ativo || 0) ? 1 : 0, row.createdAt || new Date().toISOString(), row.updatedAt || new Date().toISOString());
+                if (usersHasSessionVersion) {
+                    userColumns.push('session_version');
+                    userValues.push(Number(row.sessionVersion || 0));
+                }
+                if (usersHasIdentitySubject) {
+                    userColumns.push('identity_subject');
+                    userValues.push(row.identitySubject);
+                }
+                await env.DB.prepare(`INSERT INTO ${usersTable} (${userColumns.join(',')}) VALUES (${userColumns.map(() => '?').join(',')})`)
+                    .bind(...userValues)
+                    .run();
             }
             for (const row of (p.d1.insumosItems || []).reverse()) {
                 await env.DB.prepare(
@@ -817,7 +828,10 @@ export async function restoreBackupPayload({ env, payload, strict = false }) {
                     .run();
             }
         } catch (error) {
-            if (strict) throw error;
+            // A schema that has durable subjects must never accept a legacy
+            // account snapshot by silently reminting its audit identity. This
+            // remains fail-closed even for the historical best-effort path.
+            if (strict || String(error?.message || '').startsWith('IDENTITY_SUBJECT_BACKUP_')) throw error;
             // Legacy restore is intentionally best-effort for historical backup
             // files. The private preview sets strict and fails closed instead.
         }

--- a/inventory/tests/crmIdentitySubjectMigration.test.mjs
+++ b/inventory/tests/crmIdentitySubjectMigration.test.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import { readFile, readdir } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import test, { after, before } from 'node:test';
+import wrangler from 'wrangler';
+
+const { getPlatformProxy } = wrangler;
+const migrationsUrl = new URL('../migrations/', import.meta.url);
+
+function splitMigrationSql(sql) {
+  const statements = [];
+  let buffer = '';
+  let quote = null;
+  let lineComment = false;
+  let blockComment = false;
+  let compound = false;
+  for (let index = 0; index < sql.length; index += 1) {
+    const char = sql[index];
+    const next = sql[index + 1] || '';
+    if (lineComment) {
+      if (char === '\n') { buffer += char; lineComment = false; }
+      continue;
+    }
+    if (blockComment) {
+      if (char === '*' && next === '/') { blockComment = false; index += 1; }
+      continue;
+    }
+    if (!quote && char === '-' && next === '-') { lineComment = true; buffer += '\n'; index += 1; continue; }
+    if (!quote && char === '/' && next === '*') { blockComment = true; index += 1; continue; }
+    if (quote) {
+      buffer += char;
+      if (char === quote && sql[index - 1] !== '\\') quote = null;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === '`') { quote = char; buffer += char; continue; }
+    buffer += char;
+    if (!compound && /CREATE\s+TRIGGER[\s\S]*\bBEGIN\s*$/i.test(buffer)) compound = true;
+    if (char === ';' && (!compound || /\bEND\s*;\s*$/i.test(buffer))) {
+      const statement = buffer.slice(0, -1).trim();
+      if (statement) statements.push(statement);
+      buffer = '';
+      compound = false;
+    }
+  }
+  if (buffer.trim()) statements.push(buffer.trim());
+  return statements;
+}
+
+async function applyMigration(db, name) {
+  const sql = await readFile(new URL(name, migrationsUrl), 'utf8');
+  for (const statement of splitMigrationSql(sql)) await db.prepare(statement).run();
+}
+
+let proxy;
+let db;
+
+before(async () => {
+  proxy = await getPlatformProxy({
+    configPath: fileURLToPath(new URL('../wrangler.toml', import.meta.url)),
+    persist: false,
+    remoteBindings: false,
+  });
+  db = proxy.env.DB;
+  const names = (await readdir(migrationsUrl))
+    .filter((name) => /^\d{4}_.+\.sql$/.test(name) && name < '0029_crm_users_identity_subject.sql')
+    .sort();
+  for (const name of names) await applyMigration(db, name);
+  const now = '2026-09-02T00:00:00.000Z';
+  await db.batch([
+    db.prepare(`INSERT INTO crm_users
+      (username, email, display_name, password_hash, role, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at, session_version)
+      VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)`)
+      .bind('legacy-subject-a', 'legacy-subject-a@staging.invalid', 'Legacy Subject A', 'hash', 'GESTOR', '["novo-hamburgo"]', '["finance"]', now, now, 5),
+    db.prepare(`INSERT INTO crm_users
+      (username, email, display_name, password_hash, role, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at, session_version)
+      VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)`)
+      .bind('legacy-subject-b', 'legacy-subject-b@staging.invalid', 'Legacy Subject B', 'hash', 'CONSULTOR', '["barra-shopping-sul"]', '["insumos"]', now, now, 8),
+  ]);
+  await applyMigration(db, '0029_crm_users_identity_subject.sql');
+});
+
+after(async () => {
+  await proxy?.dispose?.();
+});
+
+test('the additive migration backfills unique opaque subjects without changing legacy usernames or session versions', async () => {
+  const rows = await db.prepare(
+    `SELECT username, identity_subject, session_version
+     FROM crm_users
+     WHERE username IN ('legacy-subject-a', 'legacy-subject-b')
+     ORDER BY username`,
+  ).all();
+  assert.deepEqual(rows.results.map((row) => row.username), ['legacy-subject-a', 'legacy-subject-b']);
+  assert.deepEqual(rows.results.map((row) => Number(row.session_version)), [5, 8]);
+  const subjects = rows.results.map((row) => String(row.identity_subject || ''));
+  assert.ok(subjects.every((subject) => /^idn:[A-Za-z0-9_-]{16,160}$/.test(subject)));
+  assert.equal(new Set(subjects).size, 2);
+});

--- a/inventory/tests/crmIdentitySubjectMigration.test.mjs
+++ b/inventory/tests/crmIdentitySubjectMigration.test.mjs
@@ -77,6 +77,7 @@ before(async () => {
       .bind('legacy-subject-b', 'legacy-subject-b@staging.invalid', 'Legacy Subject B', 'hash', 'CONSULTOR', '["barra-shopping-sul"]', '["insumos"]', now, now, 8),
   ]);
   await applyMigration(db, '0029_crm_users_identity_subject.sql');
+  await applyMigration(db, '0030_crm_identity_session_epochs.sql');
 });
 
 after(async () => {
@@ -95,4 +96,17 @@ test('the additive migration backfills unique opaque subjects without changing l
   const subjects = rows.results.map((row) => String(row.identity_subject || ''));
   assert.ok(subjects.every((subject) => /^idn:[A-Za-z0-9_-]{16,160}$/.test(subject)));
   assert.equal(new Set(subjects).size, 2);
+});
+
+test('the session epoch migration backfills every existing username without resetting its version', async () => {
+  const rows = await db.prepare(
+    `SELECT username, session_version
+     FROM crm_identity_session_epochs
+     WHERE username IN ('legacy-subject-a', 'legacy-subject-b')
+     ORDER BY username`,
+  ).all();
+  assert.deepEqual(rows.results, [
+    { username: 'legacy-subject-a', session_version: 5 },
+    { username: 'legacy-subject-b', session_version: 8 },
+  ]);
 });

--- a/inventory/tests/identitySessionEpochMigration.test.mjs
+++ b/inventory/tests/identitySessionEpochMigration.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { DatabaseSync } from 'node:sqlite';
+import test from 'node:test';
+
+const migrations = new URL('../migrations/', import.meta.url);
+
+function applySchema(database) {
+  for (const name of readdirSync(migrations).filter((file) => /^\d{4}_.+\.sql$/.test(file)).sort()) {
+    database.exec(readFileSync(new URL(name, migrations), 'utf8'));
+  }
+}
+
+function insertUser(database, username, sessionVersion) {
+  database.prepare(`
+    INSERT INTO crm_users
+      (username, email, display_name, password_hash, role, allowed_units_json, ativo, created_at, updated_at, session_version)
+    VALUES (?, ?, ?, 'hash', 'CONSULTOR', '[]', 1, '2026-09-05T00:00:00.000Z', '2026-09-05T00:00:00.000Z', ?)
+  `).run(username, `${username}@staging.invalid`, username, sessionVersion);
+}
+
+test('session epochs survive username replacement, restore-style recreation, and rename reuse', () => {
+  const database = new DatabaseSync(':memory:');
+  try {
+    applySchema(database);
+
+    insertUser(database, 'restore-user', 7);
+    database.prepare(`
+      INSERT INTO crm_identity_sessions (id, username, session_version, created_at, last_seen_at)
+      VALUES ('restore-session', 'restore-user', 7, '2026-09-05T00:00:00.000Z', '2026-09-05T00:00:00.000Z')
+    `).run();
+    database.prepare('DELETE FROM crm_users WHERE username=?').run('restore-user');
+    const retired = database.prepare(
+      'SELECT session_version FROM crm_identity_session_epochs WHERE username=?',
+    ).get('restore-user');
+    assert.equal(retired.session_version, 7);
+    const revoked = database.prepare(
+      'SELECT revoked_at, revoke_reason FROM crm_identity_sessions WHERE id=?',
+    ).get('restore-session');
+    assert.ok(revoked.revoked_at);
+    assert.equal(revoked.revoke_reason, 'USERNAME_RETIRED');
+
+    insertUser(database, 'restore-user', 0);
+    assert.equal(database.prepare('SELECT session_version FROM crm_users WHERE username=?').get('restore-user').session_version, 8);
+
+    insertUser(database, 'rename-source', 2);
+    insertUser(database, 'rename-target', 4);
+    database.prepare('DELETE FROM crm_users WHERE username=?').run('rename-target');
+    database.prepare('UPDATE crm_users SET username=? WHERE username=?').run('rename-target', 'rename-source');
+    assert.equal(database.prepare('SELECT session_version FROM crm_users WHERE username=?').get('rename-target').session_version, 5);
+    assert.equal(database.prepare('SELECT session_version FROM crm_identity_session_epochs WHERE username=?').get('rename-source').session_version, 2);
+
+    insertUser(database, 'case-user', 3);
+    database.prepare('DELETE FROM crm_users WHERE username=?').run('case-user');
+    insertUser(database, 'CASE-USER', 0);
+    assert.equal(database.prepare('SELECT session_version FROM crm_users WHERE LOWER(username)=LOWER(?)').get('case-user').session_version, 4);
+  } finally {
+    database.close();
+  }
+});

--- a/inventory/tests/identitySessionEpochRestore.test.mjs
+++ b/inventory/tests/identitySessionEpochRestore.test.mjs
@@ -1,0 +1,181 @@
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { DatabaseSync } from 'node:sqlite';
+import test from 'node:test';
+
+import { resolveIdentityActor } from '../../shared/identity-runtime/session.js';
+import { buildBackupPayload, restoreBackupPayload } from '../src/services/backup.js';
+
+const migrations = new URL('../migrations/', import.meta.url);
+
+class D1Statement {
+  constructor(database, sql) {
+    this.database = database;
+    this.sql = sql;
+    this.values = [];
+  }
+
+  bind(...values) {
+    this.values = values;
+    return this;
+  }
+
+  async run() {
+    const result = this.database.prepare(this.sql).run(...this.values);
+    return { meta: { changes: Number(result.changes || 0) } };
+  }
+
+  async all() {
+    return { results: this.database.prepare(this.sql).all(...this.values) };
+  }
+
+  async first() {
+    return this.database.prepare(this.sql).get(...this.values) || null;
+  }
+}
+
+function environment(database) {
+  return {
+    DB: {
+      prepare(sql) {
+        return new D1Statement(database, sql);
+      },
+      async batch(statements) {
+        return Promise.all(statements.map((statement) => statement.run()));
+      },
+    },
+  };
+}
+
+function applySchema(database, through = null) {
+  for (const name of readdirSync(migrations).filter((file) => /^\d{4}_.+\.sql$/.test(file)).sort()) {
+    if (through && name > through) break;
+    database.exec(readFileSync(new URL(name, migrations), 'utf8'));
+  }
+}
+
+function seedIdentity(database) {
+  database.prepare(`
+    INSERT INTO crm_users
+      (username, email, display_name, password_hash, role, allowed_units_json, ativo, created_at, updated_at, session_version, identity_subject)
+    VALUES ('restore-user', 'restore-user@staging.invalid', 'Restore User', 'hash', 'GESTOR', '[]', 1, '2026-09-05T00:00:00.000Z', '2026-09-05T00:00:00.000Z', 7, 'idn:restore_user_00000001')
+  `).run();
+  database.prepare(`
+    INSERT INTO crm_identity_sessions (id, username, session_version, created_at, last_seen_at)
+    VALUES ('restore-session', 'restore-user', 7, '2026-09-05T00:00:00.000Z', '2026-09-05T00:00:00.000Z')
+  `).run();
+}
+
+async function sidLessSessionToken({ username, sessionVersion, secret }) {
+  const payload = Buffer.from(JSON.stringify({
+    username,
+    sv: sessionVersion,
+    csrf: 'test-csrf',
+    exp: Date.now() + 60_000,
+  })).toString('base64url');
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = Buffer.from(await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(payload))).toString('base64url');
+  return `${payload}.${signature}`;
+}
+
+async function resolveSidLessActor(env, token) {
+  return resolveIdentityActor(
+    new Request('https://identity.test/finance', { headers: { cookie: `session=${token}` } }),
+    env,
+  );
+}
+
+test('backup restore revokes tracked sessions and advances the durable sid-less epoch', async () => {
+  const database = new DatabaseSync(':memory:');
+  try {
+    applySchema(database);
+    seedIdentity(database);
+    const env = environment(database);
+    const sessionSecret = 'session-epoch-restore-test-secret';
+    const oldToken = await sidLessSessionToken({ username: 'restore-user', sessionVersion: 7, secret: sessionSecret });
+    assert.equal((await resolveSidLessActor({ ...env, SESSION_SECRET: sessionSecret }, oldToken)).actor?.username, 'restore-user');
+    const payload = await buildBackupPayload({ env });
+    await restoreBackupPayload({ env, payload });
+
+    const restored = database.prepare(
+      'SELECT session_version, identity_subject FROM crm_users WHERE username=?',
+    ).get('restore-user');
+    assert.equal(restored.session_version, 8);
+    assert.equal(restored.identity_subject, 'idn:restore_user_00000001');
+    const revoked = database.prepare(
+      'SELECT revoked_at, revoke_reason FROM crm_identity_sessions WHERE id=?',
+    ).get('restore-session');
+    assert.ok(revoked.revoked_at);
+    assert.equal(revoked.revoke_reason, 'BACKUP_RESTORE');
+    const epoch = database.prepare(
+      'SELECT session_version, reason FROM crm_identity_session_epochs WHERE username=?',
+    ).get('restore-user');
+    assert.equal(epoch.session_version, 8);
+    assert.equal(epoch.reason, 'BACKUP_RESTORE');
+    assert.equal((await resolveSidLessActor({ ...env, SESSION_SECRET: sessionSecret }, oldToken)).actor, null);
+    const freshToken = await sidLessSessionToken({ username: 'restore-user', sessionVersion: 8, secret: sessionSecret });
+    assert.equal((await resolveSidLessActor({ ...env, SESSION_SECRET: sessionSecret }, freshToken)).actor?.username, 'restore-user');
+  } finally {
+    database.close();
+  }
+});
+
+test('backup restore advances a sid-less epoch even on a clean migrated target', async () => {
+  const sourceDatabase = new DatabaseSync(':memory:');
+  const targetDatabase = new DatabaseSync(':memory:');
+  try {
+    applySchema(sourceDatabase);
+    applySchema(targetDatabase);
+    seedIdentity(sourceDatabase);
+    const sourceEnv = environment(sourceDatabase);
+    const targetEnv = environment(targetDatabase);
+    const sessionSecret = 'session-epoch-clean-target-test-secret';
+    const oldToken = await sidLessSessionToken({ username: 'restore-user', sessionVersion: 7, secret: sessionSecret });
+    const payload = await buildBackupPayload({ env: sourceEnv });
+
+    assert.equal((await resolveSidLessActor({ ...targetEnv, SESSION_SECRET: sessionSecret }, oldToken)).actor, null);
+    await restoreBackupPayload({ env: targetEnv, payload });
+
+    const restored = targetDatabase.prepare(
+      'SELECT session_version FROM crm_users WHERE username=?',
+    ).get('restore-user');
+    assert.equal(restored.session_version, 8);
+    const epoch = targetDatabase.prepare(
+      'SELECT session_version, reason FROM crm_identity_session_epochs WHERE username=?',
+    ).get('restore-user');
+    assert.equal(epoch.session_version, 8);
+    assert.equal(epoch.reason, 'BACKUP_RESTORE');
+    assert.equal((await resolveSidLessActor({ ...targetEnv, SESSION_SECRET: sessionSecret }, oldToken)).actor, null);
+    const freshToken = await sidLessSessionToken({ username: 'restore-user', sessionVersion: 8, secret: sessionSecret });
+    assert.equal((await resolveSidLessActor({ ...targetEnv, SESSION_SECRET: sessionSecret }, freshToken)).actor?.username, 'restore-user');
+  } finally {
+    sourceDatabase.close();
+    targetDatabase.close();
+  }
+});
+
+test('backup restore fails closed when the durable subject schema lacks the epoch migration', async () => {
+  const database = new DatabaseSync(':memory:');
+  try {
+    applySchema(database);
+    seedIdentity(database);
+    const env = environment(database);
+    const payload = await buildBackupPayload({ env });
+    database.exec('DROP TABLE crm_identity_session_epochs');
+    assert.equal(
+      database.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=? LIMIT 1")
+        .get('crm_identity_session_epochs'),
+      undefined,
+    );
+    await assert.rejects(() => restoreBackupPayload({ env, payload }), /IDENTITY_SESSION_EPOCH_REQUIRED/);
+    assert.equal(database.prepare('SELECT session_version FROM crm_users WHERE username=?').get('restore-user').session_version, 7);
+  } finally {
+    database.close();
+  }
+});

--- a/inventory/tests/insumosProductionSmokeIdentityWorkflow.test.mjs
+++ b/inventory/tests/insumosProductionSmokeIdentityWorkflow.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const workflow = fileURLToPath(new URL('../../.github/workflows/insumos-production-smoke-identity.yml', import.meta.url));
+
+test('the manual production Identity smoke verifies the opaque subject schema before it can mutate a synthetic user', () => {
+  const source = readFileSync(workflow, 'utf8');
+
+  assert.match(source, /workflow_dispatch:/);
+  assert.match(source, /const identitySubject = `idn:\$\{crypto\.randomBytes\(16\)\.toString\('hex'\)\}`/);
+  assert.match(source, /const schema = `SELECT identity_subject FROM crm_users WHERE 1 = 0;\\n`/);
+  assert.match(source, /name: Verify CRM identity subject schema before mutation/);
+  assert.match(source, /identity_subject\)\\nSELECT/);
+  assert.match(source, /identity_subject LIKE 'idn:%'/);
+  assert.match(source, /opaque_subjects/);
+  assert.match(source, /SMOKE_IDENTITY_OPAQUE_SUBJECT_COUNT/);
+  assert.ok(
+    source.indexOf('Verify CRM identity subject schema before mutation') < source.indexOf('Apply exact synthetic identity mutation'),
+    'schema-sensitive preflight must remain before the production mutation',
+  );
+  assert.ok(
+    source.indexOf('Read collision state after lease check') < source.indexOf('Apply exact synthetic identity mutation'),
+    'collision read must remain before the provision mutation',
+  );
+});

--- a/inventory/tests/insumosProductionSmokeIdentityWorkflow.test.mjs
+++ b/inventory/tests/insumosProductionSmokeIdentityWorkflow.test.mjs
@@ -16,8 +16,18 @@ test('the manual production Identity smoke verifies the opaque subject schema be
   assert.match(source, /identity_subject LIKE 'idn:%'/);
   assert.match(source, /opaque_subjects/);
   assert.match(source, /SMOKE_IDENTITY_OPAQUE_SUBJECT_COUNT/);
+  const schemaStepStart = source.indexOf('name: Verify CRM identity subject schema before mutation');
+  const schemaStepEnd = source.indexOf('name: Check synthetic identity collision');
+  assert.ok(schemaStepEnd > schemaStepStart, 'schema preflight step must have a bounded workflow scope');
+  const schemaStep = source.slice(schemaStepStart, schemaStepEnd);
+  assert.match(schemaStep, /schema_command="\$\(<"\$\{RUNNER_TEMP_DIR\}\/schema\.sql"\)"/);
+  assert.doesNotMatch(
+    schemaStep,
+    /\n\s+if:/,
+    'schema preflight must run for cleanup as well as provision',
+  );
   assert.ok(
-    source.indexOf('Verify CRM identity subject schema before mutation') < source.indexOf('Apply exact synthetic identity mutation'),
+    schemaStepStart < source.indexOf('Apply exact synthetic identity mutation'),
     'schema-sensitive preflight must remain before the production mutation',
   );
   assert.ok(

--- a/inventory/tests/insumosStagingRbacFixtures.test.mjs
+++ b/inventory/tests/insumosStagingRbacFixtures.test.mjs
@@ -20,12 +20,17 @@ test('staging RBAC fixtures are bounded, synthetic and auditable', () => {
     assert.equal(data.scenarios.length, 7);
     assert.deepEqual(data.scenarios.find((item) => item.id === 'alias').allowedUnits, ['NH']);
     assert.equal(data.scenarios.find((item) => item.id === 'consultor').role, 'CONSULTOR');
+    const subjects = data.scenarios.map((item) => String(item.identitySubject || ''));
+    assert.ok(subjects.every((subject) => /^idn:[A-Za-z0-9_-]{16,160}$/.test(subject)));
+    assert.equal(new Set(subjects).size, data.scenarios.length);
     assert.deepEqual(data.teamMembers.map((item) => item.units), [['novo-hamburgo'], ['barra-shopping-sul'], ['novo-hamburgo', 'barra-shopping-sul']]);
     const statement = readFileSync(sql, 'utf8');
     assert.match(statement, /STAGING_SYNTHETIC_IDENTITY_PROVISIONED/);
     assert.match(statement, /STAGING_SYNTHETIC_TEAM_PROVISIONED/);
     assert.match(statement, /crm_employee_onboarding/);
     assert.match(statement, /crm_employee_team/);
+    assert.match(statement, /identity_subject/);
+    for (const subject of subjects) assert.match(statement, new RegExp(subject));
     assert.match(statement, /\["insumos"\]/);
     assert.doesNotMatch(statement, /\["inventory"\]/);
     assert.doesNotMatch(statement, /BEGIN TRANSACTION|COMMIT;/);

--- a/inventory/tests/insumosStagingRbacFixtures.test.mjs
+++ b/inventory/tests/insumosStagingRbacFixtures.test.mjs
@@ -1,12 +1,20 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
+import { DatabaseSync } from 'node:sqlite';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 const fixtureScript = fileURLToPath(new URL('../scripts/insumosStagingRbacFixtures.mjs', import.meta.url));
+const migrations = new URL('../migrations/', import.meta.url);
+
+function applySchema(database) {
+  for (const name of readdirSync(migrations).filter((file) => /^\d{4}_.+\.sql$/.test(file)).sort()) {
+    database.exec(readFileSync(new URL(name, migrations), 'utf8'));
+  }
+}
 
 test('staging RBAC fixtures are bounded, synthetic and auditable', () => {
   const dir = mkdtempSync(join(tmpdir(), 'skincos-rbac-fixtures-'));
@@ -35,6 +43,35 @@ test('staging RBAC fixtures are bounded, synthetic and auditable', () => {
     assert.doesNotMatch(statement, /\["inventory"\]/);
     assert.doesNotMatch(statement, /BEGIN TRANSACTION|COMMIT;/);
     assert.doesNotMatch(statement, /api\.skincos\.com\.br/);
+
+    const database = new DatabaseSync(':memory:');
+    try {
+      applySchema(database);
+      database.exec(statement);
+      const firstScenario = data.scenarios[0];
+      database.prepare(`
+        INSERT INTO crm_identity_sessions (id, username, session_version, created_at, last_seen_at)
+        VALUES ('fixture-session', ?, 0, '2026-09-05T00:00:00.000Z', '2026-09-05T00:00:00.000Z')
+      `).run(firstScenario.username);
+
+      const teardownSql = join(dir, 'teardown.sql');
+      const teardown = spawnSync(process.execPath, [fixtureScript, '--action', 'teardown', '--run-id', '123456', '--fixtures', fixture, '--sql', teardownSql], { encoding: 'utf8' });
+      assert.equal(teardown.status, 0, teardown.stderr);
+      database.exec(readFileSync(teardownSql, 'utf8'));
+      assert.equal(database.prepare('SELECT COUNT(*) AS count FROM crm_users WHERE username=?').get(firstScenario.username).count, 0);
+      assert.equal(database.prepare('SELECT session_version FROM crm_identity_session_epochs WHERE username=?').get(firstScenario.username).session_version, 0);
+      const revoked = database.prepare('SELECT revoked_at, revoke_reason FROM crm_identity_sessions WHERE id=?').get('fixture-session');
+      assert.ok(revoked.revoked_at);
+      assert.equal(revoked.revoke_reason, 'USERNAME_RETIRED');
+
+      const reprovisionSql = join(dir, 'reprovision.sql');
+      const reprovision = spawnSync(process.execPath, [fixtureScript, '--action', 'provision', '--run-id', '123456', '--fixtures', fixture, '--sql', reprovisionSql], { encoding: 'utf8' });
+      assert.equal(reprovision.status, 0, reprovision.stderr);
+      database.exec(readFileSync(reprovisionSql, 'utf8'));
+      assert.ok(database.prepare('SELECT session_version FROM crm_users WHERE username=?').get(firstScenario.username).session_version >= 1);
+    } finally {
+      database.close();
+    }
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/inventory/tests/unifiedTeamAccountScope.test.mjs
+++ b/inventory/tests/unifiedTeamAccountScope.test.mjs
@@ -4,7 +4,9 @@ import { fileURLToPath } from 'node:url';
 import test, { after, before, beforeEach } from 'node:test';
 import wrangler from 'wrangler';
 
+import { d1UpdateUserProfile } from '../src/d1Store.js';
 import { handleAdminRoutes } from '../src/routes/admin.js';
+import { buildBackupPayload, restoreBackupPayload } from '../src/services/backup.js';
 
 const { getPlatformProxy } = wrangler;
 const ROOT = fileURLToPath(new URL('..', import.meta.url));
@@ -60,6 +62,7 @@ const schemaMigrations = [
   '0018_onboarding_consistency.sql', '0024_unified_team_identity.sql',
   '0025_onboarding_idempotency_fingerprint.sql', '0026_unified_invite_identity.sql',
   '0027_crm_employee_account_links.sql', '0028_unified_team_query_indexes.sql',
+  '0029_crm_users_identity_subject.sql',
 ];
 
 let proxy;
@@ -94,9 +97,10 @@ async function encryptPii(value) {
   return `v1.${bytesToBase64Url(iv)}.${bytesToBase64Url(new Uint8Array(encrypted))}`;
 }
 
-function routeEnv({ workforce = workforceBinding(true), unifiedTeamEnabled = 'true', DB = env.DB } = {}) {
+function routeEnv({ workforce = workforceBinding(true), unifiedTeamEnabled = 'true', DB = env.DB, ...overrides } = {}) {
   return {
     ...env,
+    ...overrides,
     DB,
     WORKFORCE: workforce,
     UNIFIED_TEAM_ENABLED: unifiedTeamEnabled,
@@ -162,13 +166,13 @@ async function seedFixture() {
   const now = '2026-08-11T20:00:00.000Z';
   await env.DB.batch([
     env.DB.prepare(`INSERT INTO crm_users
-      (username, email, display_name, password_hash, role, allowed_units_json, ativo, created_at, updated_at, session_version)
-      VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, 0)`)
-      .bind('hellenmelo', 'hellenmelo@espacofacial.com', 'Hellen Gabriele Lisboa Melo', 'hash', 'INJETOR', JSON.stringify(['barra-shopping-sul']), now, now),
+      (username, email, display_name, password_hash, role, allowed_units_json, ativo, created_at, updated_at, session_version, identity_subject)
+      VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, 0, ?)`)
+      .bind('hellenmelo', 'hellenmelo@espacofacial.com', 'Hellen Gabriele Lisboa Melo', 'hash', 'INJETOR', JSON.stringify(['barra-shopping-sul']), now, now, 'idn:fixture_hellenmelo_0001'),
     env.DB.prepare(`INSERT INTO crm_users
-      (username, email, display_name, password_hash, role, allowed_units_json, ativo, created_at, updated_at, session_version)
-      VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, 0)`)
-      .bind('unlinkeduser', 'unlinkeduser@espacofacial.com', 'Usuário sem vínculo', 'hash', 'CONSULTOR', JSON.stringify(['barra-shopping-sul']), now, now),
+      (username, email, display_name, password_hash, role, allowed_units_json, ativo, created_at, updated_at, session_version, identity_subject)
+      VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, 0, ?)`)
+      .bind('unlinkeduser', 'unlinkeduser@espacofacial.com', 'Usuário sem vínculo', 'hash', 'CONSULTOR', JSON.stringify(['barra-shopping-sul']), now, now, 'idn:fixture_unlinked_user_0001'),
     env.DB.prepare(`INSERT INTO crm_employee_onboarding
       (id, full_name, corporate_email, personal_email_encrypted, personal_email_hash, mobile_phone_encrypted, mobile_phone_hash,
        profile, job_title, department_name, units_json, account_status, workforce_employee_id, created_by, created_at, updated_at,
@@ -199,12 +203,13 @@ async function seedFixture() {
 async function readMemberState(id = 'hellenmelo-employee', username = 'hellenmelo') {
   const onboarding = await env.DB.prepare('SELECT units_json, compensation_state, last_error_code FROM crm_employee_onboarding WHERE id=?').bind(id).first();
   const team = await env.DB.prepare('SELECT units_json FROM crm_employee_team WHERE onboarding_id=?').bind(id).first();
-  const user = await env.DB.prepare('SELECT allowed_units_json, session_version FROM crm_users WHERE username=?').bind(username).first();
+  const user = await env.DB.prepare('SELECT allowed_units_json, session_version, identity_subject FROM crm_users WHERE username=?').bind(username).first();
   return {
     onboardingUnits: JSON.parse(onboarding.units_json),
     teamUnits: JSON.parse(team.units_json),
     accountUnits: JSON.parse(user.allowed_units_json),
     sessionVersion: Number(user.session_version),
+    identitySubject: user.identity_subject,
     compensationState: onboarding.compensation_state || null,
     lastErrorCode: onboarding.last_error_code || null,
   };
@@ -235,6 +240,7 @@ beforeEach(async () => {
     env.DB.prepare('DELETE FROM crm_employee_account_links'),
     env.DB.prepare('DELETE FROM crm_employee_team'),
     env.DB.prepare('DELETE FROM crm_employee_onboarding'),
+    env.DB.prepare('DELETE FROM crm_user_prefs'),
     env.DB.prepare('DELETE FROM crm_users'),
   ]);
   await seedFixture();
@@ -265,6 +271,100 @@ test('team edit atomically tracks confirmed CRM account scope for one and multip
   assert.deepEqual(finalState.teamUnits, ['barra-shopping-sul']);
   assert.deepEqual(finalState.accountUnits, ['barra-shopping-sul']);
   assert.equal(finalState.sessionVersion, 3);
+});
+
+test('team status changes preserve the durable opaque identity subject', async () => {
+  const before = await readMemberState();
+  const suspended = await callRoute('/admin/team/hellenmelo-employee/status', {
+    method: 'POST',
+    body: { accountStatus: 'SUSPENDED' },
+  });
+  assert.equal(suspended.response.status, 200);
+  assert.equal((await readMemberState()).identitySubject, before.identitySubject);
+
+  const reactivated = await callRoute('/admin/team/hellenmelo-employee/status', {
+    method: 'POST',
+    body: { accountStatus: 'ACTIVE' },
+  });
+  assert.equal(reactivated.response.status, 200);
+  const after = await readMemberState();
+  assert.equal(after.identitySubject, before.identitySubject);
+  assert.equal(after.identitySubject, 'idn:fixture_hellenmelo_0001');
+});
+
+test('a username rename updates the CRM primary key in place and preserves the durable opaque subject', async () => {
+  await env.DB.prepare('UPDATE crm_users SET session_version=7 WHERE username=?').bind('hellenmelo').run();
+  await env.DB.prepare('INSERT INTO crm_user_prefs (username, prefs_json, updated_at) VALUES (?, ?, ?)')
+    .bind('hellenmelo', '{"layout":"compact"}', '2026-08-11T20:00:00.000Z')
+    .run();
+  const renamed = await d1UpdateUserProfile(env, 'hellenmelo', {
+    newUsername: 'hellenmelo-renamed',
+    displayName: 'Hellen Renamed',
+  });
+  assert.equal(renamed.ok, true);
+  assert.equal(await env.DB.prepare('SELECT username FROM crm_users WHERE username=?').bind('hellenmelo').first(), null);
+  const row = await env.DB.prepare(
+    'SELECT username, display_name, identity_subject, session_version FROM crm_users WHERE username=?',
+  ).bind('hellenmelo-renamed').first();
+  assert.deepEqual(row, {
+    username: 'hellenmelo-renamed',
+    display_name: 'Hellen Renamed',
+    identity_subject: 'idn:fixture_hellenmelo_0001',
+    session_version: 7,
+  });
+  const link = await env.DB.prepare('SELECT crm_username FROM crm_employee_account_links WHERE id=?')
+    .bind('account-link-hellenmelo')
+    .first();
+  assert.deepEqual(link, { crm_username: 'hellenmelo-renamed' });
+  const prefs = await env.DB.prepare('SELECT username, prefs_json FROM crm_user_prefs WHERE username=?')
+    .bind('hellenmelo-renamed')
+    .first();
+  assert.deepEqual(prefs, { username: 'hellenmelo-renamed', prefs_json: '{"layout":"compact"}' });
+});
+
+test('the legacy administrative user writer creates an opaque subject after the additive migration', async () => {
+  const result = await callRoute('/admin/users', {
+    method: 'POST',
+    envOverride: { unifiedTeamEnabled: 'false', ALLOW_ADMIN_USER_PROVISIONING: 'true' },
+    body: {
+      username: 'legacy-subject-user',
+      email: 'legacy-subject-user@staging.invalid',
+      displayName: 'Legacy Subject User',
+      password: 'subject-safe-password-123',
+      role: 'CONSULTOR',
+      allowedUnits: ['novo-hamburgo'],
+      allowedModules: ['insumos'],
+    },
+  });
+  assert.equal(result.response.status, 201);
+  const user = await env.DB.prepare('SELECT identity_subject FROM crm_users WHERE username=?').bind('legacy-subject-user').first();
+  assert.match(String(user?.identity_subject || ''), /^idn:[A-Za-z0-9_-]{16,160}$/);
+  assert.notEqual(user.identity_subject, 'legacy-subject-user');
+});
+
+test('backup and restore preserve a durable subject and reject legacy user snapshots', async () => {
+  await env.DB.prepare('UPDATE crm_users SET session_version=7 WHERE username=?').bind('hellenmelo').run();
+  const payload = await buildBackupPayload({ env });
+  const source = payload.d1.crmUsers.find((row) => row.username === 'hellenmelo');
+  assert.equal(source.identitySubject, 'idn:fixture_hellenmelo_0001');
+  assert.equal(Number(source.sessionVersion), 7);
+
+  await restoreBackupPayload({ env, payload });
+  const restored = await env.DB.prepare('SELECT identity_subject, session_version FROM crm_users WHERE username=?').bind('hellenmelo').first();
+  assert.deepEqual(restored, { identity_subject: 'idn:fixture_hellenmelo_0001', session_version: 7 });
+
+  const legacyPayload = JSON.parse(JSON.stringify(payload));
+  delete legacyPayload.d1.crmUsers.find((row) => row.username === 'hellenmelo').identitySubject;
+  await assert.rejects(() => restoreBackupPayload({ env, payload: legacyPayload }), /IDENTITY_SUBJECT_BACKUP_REQUIRED/);
+  const unchanged = await env.DB.prepare('SELECT identity_subject FROM crm_users WHERE username=?').bind('hellenmelo').first();
+  assert.equal(unchanged.identity_subject, 'idn:fixture_hellenmelo_0001');
+
+  const duplicatePayload = JSON.parse(JSON.stringify(payload));
+  const duplicateRows = duplicatePayload.d1.crmUsers;
+  duplicateRows.find((row) => row.username === 'unlinkeduser').identitySubject = source.identitySubject;
+  await assert.rejects(() => restoreBackupPayload({ env, payload: duplicatePayload }), /IDENTITY_SUBJECT_BACKUP_DUPLICATE/);
+  const unchangedAfterDuplicate = await env.DB.prepare('SELECT identity_subject FROM crm_users WHERE username=?').bind('hellenmelo').first();
+  assert.equal(unchangedAfterDuplicate.identity_subject, 'idn:fixture_hellenmelo_0001');
 });
 
 test('team edit does not infer or create access when no explicit CRM account link exists', async () => {

--- a/inventory/tests/unifiedTeamAccountScope.test.mjs
+++ b/inventory/tests/unifiedTeamAccountScope.test.mjs
@@ -63,6 +63,7 @@ const schemaMigrations = [
   '0025_onboarding_idempotency_fingerprint.sql', '0026_unified_invite_identity.sql',
   '0027_crm_employee_account_links.sql', '0028_unified_team_query_indexes.sql',
   '0029_crm_users_identity_subject.sql',
+  '0030_crm_identity_session_epochs.sql',
 ];
 
 let proxy;
@@ -242,6 +243,7 @@ beforeEach(async () => {
     env.DB.prepare('DELETE FROM crm_employee_onboarding'),
     env.DB.prepare('DELETE FROM crm_user_prefs'),
     env.DB.prepare('DELETE FROM crm_users'),
+    env.DB.prepare('DELETE FROM crm_identity_session_epochs'),
   ]);
   await seedFixture();
 });
@@ -351,7 +353,7 @@ test('backup and restore preserve a durable subject and reject legacy user snaps
 
   await restoreBackupPayload({ env, payload });
   const restored = await env.DB.prepare('SELECT identity_subject, session_version FROM crm_users WHERE username=?').bind('hellenmelo').first();
-  assert.deepEqual(restored, { identity_subject: 'idn:fixture_hellenmelo_0001', session_version: 7 });
+  assert.deepEqual(restored, { identity_subject: 'idn:fixture_hellenmelo_0001', session_version: 8 });
 
   const legacyPayload = JSON.parse(JSON.stringify(payload));
   delete legacyPayload.d1.crmUsers.find((row) => row.username === 'hellenmelo').identitySubject;

--- a/shared/identity-contract/index.js
+++ b/shared/identity-contract/index.js
@@ -1,4 +1,5 @@
 export const IDENTITY_ACTOR_CONTRACT_VERSION = 'identity-actor/v1';
+export const OPAQUE_IDENTITY_SUBJECT_PATTERN = /^idn:[A-Za-z0-9_-]{16,160}$/;
 
 // Unit scopes are closed: persisted and RBAC-facing values are only these slugs.
 export const CANONICAL_UNIT_SCOPES = Object.freeze(['novo-hamburgo', 'barra-shopping-sul']);
@@ -58,6 +59,22 @@ const asList = (value) => Array.isArray(value)
   ? [...new Set(value.map(String).map((item) => item.trim()).filter(Boolean))]
   : [];
 
+export function isOpaqueIdentitySubject(value) {
+  return typeof value === 'string' && OPAQUE_IDENTITY_SUBJECT_PATTERN.test(value);
+}
+
+/**
+ * Identity subjects are opaque, server-generated aliases. They are deliberately
+ * unrelated to usernames, e-mail addresses, or any other mutable profile data.
+ */
+export function createOpaqueIdentitySubject() {
+  const randomUuid = globalThis.crypto?.randomUUID;
+  if (typeof randomUuid !== 'function') throw new Error('IDENTITY_SUBJECT_RANDOM_UNAVAILABLE');
+  const subject = `idn:${String(randomUuid.call(globalThis.crypto)).toLowerCase()}`;
+  if (!isOpaqueIdentitySubject(subject)) throw new Error('IDENTITY_SUBJECT_GENERATION_FAILED');
+  return subject;
+}
+
 /**
  * The only identity shape a product receives. Legacy aliases remain while
  * callers move to scopes.units/scopes.modules without invalidating sessions.
@@ -69,6 +86,9 @@ export function toAuthenticatedActor(user) {
   const permissions = asList(user.permissions);
   return Object.freeze({
     contractVersion: IDENTITY_ACTOR_CONTRACT_VERSION,
+    // This is additive. `subject` stays the username-based v1 compatibility
+    // alias until consumers explicitly move to a versioned opaque contract.
+    identitySubject: isOpaqueIdentitySubject(user.identitySubject) ? user.identitySubject : null,
     subject: String(user.username),
     username: String(user.username),
     displayName: String(user.displayName || user.name || user.username),

--- a/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs
+++ b/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.mjs
@@ -36,6 +36,7 @@ const sql = (value) => `'${String(value).replaceAll("'", "''")}'`;
 const prefix = `stg-ponto-${runId}${fixtureId ? `-${fixtureId}` : ''}`;
 const now = new Date().toISOString();
 const password = () => `StgPonto-${randomBytes(18).toString('base64url')}`;
+const opaqueIdentitySubject = () => `idn:${randomBytes(16).toString('hex')}`;
 const pin = () => String(randomInt(100000, 1_000_000));
 const passwordHash = (value) => {
   const salt = randomBytes(16);
@@ -65,9 +66,11 @@ function privateFixture() {
     username: userName,
     email: `${userName}@staging.invalid`,
     password: userPassword,
+    identitySubject: opaqueIdentitySubject(),
     adminUsername,
     adminEmail: `${adminUsername}@staging.invalid`,
     adminPassword,
+    adminIdentitySubject: opaqueIdentitySubject(),
     pin: userPin,
     role: 'CONSULTOR',
     allowedModules: ['atendimento', 'ponto'],
@@ -104,6 +107,11 @@ function controlledFixture() {
   }
   if (fixture.unitId !== 'novo-hamburgo' || fixture.forbiddenUnitId !== 'barra-shopping-sul' || JSON.stringify(fixture.allowedUnits) !== JSON.stringify(['novo-hamburgo'])) throw new Error('fixture unit scope drifted');
   if (!/^[0-9a-f]{64}$/.test(String(fixture.onboardingId || ''))) throw new Error('fixture onboardingId is invalid');
+  for (const field of ['identitySubject', 'adminIdentitySubject']) {
+    const subject = String(fixture[field] || '');
+    if (subject && !/^idn:[A-Za-z0-9_-]{16,160}$/.test(subject)) throw new Error(`fixture ${field} is invalid`);
+  }
+  if (fixture.identitySubject && fixture.adminIdentitySubject && fixture.identitySubject === fixture.adminIdentitySubject) throw new Error('fixture identity subjects must be distinct');
   if (fixture.onboardingPhone !== '+5551999999999') throw new Error('fixture onboardingPhone is invalid');
   if (
     !Array.isArray(fixture.teardownRequestIds || [])
@@ -130,8 +138,8 @@ if (action === 'provision') {
     `DELETE FROM crm_users WHERE username = ${sql(fixture.username)};`,
     `DELETE FROM crm_users WHERE username = ${sql(fixture.adminUsername)};`,
     `DELETE FROM crm_employee_onboarding WHERE id = ${sql(fixture.onboardingId)};`,
-    `INSERT INTO crm_users (username, email, display_name, password_hash, role, photo_url, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at, session_version) VALUES (${sql(fixture.username)}, ${sql(fixture.email)}, ${sql('Synthetic Ponto CONSULTOR')}, ${sql(passwordHash(fixture.password))}, 'CONSULTOR', '', ${sql(JSON.stringify(fixture.allowedUnits))}, ${sql(JSON.stringify(fixture.allowedModules))}, 1, ${sql(now)}, ${sql(now)}, 0);`,
-    `INSERT INTO crm_users (username, email, display_name, password_hash, role, photo_url, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at, session_version) VALUES (${sql(fixture.adminUsername)}, ${sql(fixture.adminEmail)}, ${sql('Synthetic Ponto GESTOR')}, ${sql(passwordHash(fixture.adminPassword))}, 'GESTOR', '', ${sql(JSON.stringify(fixture.allowedUnits))}, ${sql(JSON.stringify(['insumos']))}, 1, ${sql(now)}, ${sql(now)}, 0);`,
+    `INSERT INTO crm_users (username, email, display_name, password_hash, role, photo_url, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at, session_version, identity_subject) VALUES (${sql(fixture.username)}, ${sql(fixture.email)}, ${sql('Synthetic Ponto CONSULTOR')}, ${sql(passwordHash(fixture.password))}, 'CONSULTOR', '', ${sql(JSON.stringify(fixture.allowedUnits))}, ${sql(JSON.stringify(fixture.allowedModules))}, 1, ${sql(now)}, ${sql(now)}, 0, ${sql(fixture.identitySubject)});`,
+    `INSERT INTO crm_users (username, email, display_name, password_hash, role, photo_url, allowed_units_json, allowed_modules_json, ativo, created_at, updated_at, session_version, identity_subject) VALUES (${sql(fixture.adminUsername)}, ${sql(fixture.adminEmail)}, ${sql('Synthetic Ponto GESTOR')}, ${sql(passwordHash(fixture.adminPassword))}, 'GESTOR', '', ${sql(JSON.stringify(fixture.allowedUnits))}, ${sql(JSON.stringify(['insumos']))}, 1, ${sql(now)}, ${sql(now)}, 0, ${sql(fixture.adminIdentitySubject)});`,
     audit('STAGING_SYNTHETIC_PONTO_PROVISIONED', fixture.username, { runId, role: fixture.role, modules: fixture.allowedModules, unitCount: 1 }),
   ];
   const timekeepingStatements = [

--- a/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.test.mjs
+++ b/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.test.mjs
@@ -48,6 +48,9 @@ test('staging fixture SQL is run-scoped, secret-free, and teardown preserves aud
     assert.equal(fixture.forbiddenUnitId, 'barra-shopping-sul');
     assert.equal(fixture.role, 'CONSULTOR');
     assert.match(fixture.onboardingId, /^[0-9a-f]{64}$/);
+    assert.match(fixture.identitySubject, /^idn:[A-Za-z0-9_-]{16,160}$/);
+    assert.match(fixture.adminIdentitySubject, /^idn:[A-Za-z0-9_-]{16,160}$/);
+    assert.notEqual(fixture.identitySubject, fixture.adminIdentitySubject);
     assert.deepEqual(validateOnboardingInput({
       fullName: 'Synthetic Ponto Supervisor',
       corporateEmail: fixture.onboardingCorporateEmail,
@@ -77,6 +80,8 @@ test('staging fixture SQL is run-scoped, secret-free, and teardown preserves aud
     }
     assert.match(provisionCore, /Synthetic Ponto CONSULTOR/);
     assert.match(provisionCore, /Synthetic Ponto GESTOR/);
+    assert.match(provisionCore, new RegExp(fixture.identitySubject));
+    assert.match(provisionCore, new RegExp(fixture.adminIdentitySubject));
     assert.match(provisionCore, /'GESTOR'.*'\["insumos"\]'/);
     assert.equal((provisionCore.match(/DELETE FROM crm_identity_sessions/g) || []).length, 2);
     assert.match(provisionTimekeeping, new RegExp(fixture.employeeId));
@@ -131,6 +136,13 @@ test('staging fixture SQL is run-scoped, secret-free, and teardown preserves aud
         fixture.username,
         fixture.adminUsername,
       ).count, 2);
+      assert.deepEqual(database.prepare('SELECT username, identity_subject FROM crm_users WHERE username IN (?, ?) ORDER BY username').all(
+        fixture.username,
+        fixture.adminUsername,
+      ).map(({ username, identity_subject }) => ({ username, identity_subject })), [
+        { username: fixture.adminUsername, identity_subject: fixture.adminIdentitySubject },
+        { username: fixture.username, identity_subject: fixture.identitySubject },
+      ]);
       assert.equal(database.prepare('SELECT COUNT(*) AS count FROM crm_identity_sessions WHERE username IN (?, ?)').get(
         fixture.username,
         fixture.adminUsername,

--- a/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.test.mjs
+++ b/workforce/timekeeping/scripts/ponto-staging-journey-fixtures.test.mjs
@@ -196,6 +196,12 @@ test('staging fixture SQL is run-scoped, secret-free, and teardown preserves aud
       assert.match(timekeepingAttestation, /timekeeping_audit_events WHERE request_id IN \('request-incumbent-1','request-incumbent-2'\)/);
       assert.match(teardownTimekeeping, /updated_by = 'stg-ponto-123456789:presence-policy'/);
       assert.doesNotMatch(teardownTimekeeping, /DELETE FROM workforce_units/);
+
+      // The next run uses the same controlled usernames. The D1 epoch trigger
+      // must advance them instead of recreating session_version zero.
+      database.exec(provisionCore);
+      assert.ok(database.prepare('SELECT session_version FROM crm_users WHERE username=?').get(fixture.username).session_version >= 1);
+      assert.ok(database.prepare('SELECT session_version FROM crm_users WHERE username=?').get(fixture.adminUsername).session_version >= 1);
     } finally {
       database.close();
       timekeepingDatabase.close();


### PR DESCRIPTION
## Objetivo

Promove para a `main` canônica a preparação do sujeito opaco do CRM e a preservação de épocas de sessão após restore, já rebaseada sobre o commit de segurança atual.

## Escopo

- adiciona `identitySubject` opaco e único de forma aditiva;
- preserva o sujeito em convite, criação administrativa, rename, backup e restore;
- mantém `identity-actor/v1` e `/auth/me` compatíveis;
- impede reuso de username de reviver cookie sid-less após restore com época monotônica;
- não publica runtime, segredo, rota, Worker, D1 remoto ou deploy.

## Validação local

- testes focados de Identity: 17 passando;
- testes de época/restore e smoke de identidade: 5 passando; o teste D1 que exige `wrangler` depende da instalação de dependências do CI;
- `npm run domain-boundaries:validate` passando;
- `node .github/scripts/validate-architecture.mjs` passando;
- `git diff --check` passando.

## Segurança

Branch rebaseada sobre `jubenitogarcia/skincos@5540299a64129dff5b8cf624610c5c9737469dbb`, que contém a remediação de dependências e hardening de segurança já validada. Nenhum dado real ou automação de site foi acionado.