### PR TITLE
fix(security): pin document fetch DNS resolution

### DIFF
--- a/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/document_query.py
+++ b/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/document_query.py
@@ -25,7 +25,6 @@ from python.helpers.network_policy import (
     PinnedResolver,
     RemoteDocumentTarget,
     resolve_remote_document_target,
-    validate_remote_document_url,
 )
 from agent import Agent
 
@@ -91,9 +90,15 @@ async def _request_remote_document(
         await connector.close()
 
 
-async def fetch_remote_document(document_uri: str) -> tuple[bytes, int, dict[str, str]]:
+async def fetch_remote_document(
+    document_uri: str,
+    target: RemoteDocumentTarget | None = None,
+) -> tuple[bytes, int, dict[str, str]]:
     """Fetch content through a DNS-pinned, non-redirecting transport."""
-    target = resolve_remote_document_target(document_uri)
+    if target is None:
+        target = resolve_remote_document_target(document_uri)
+    elif target.uri != document_uri:
+        raise ValueError("Remote document target does not match the requested URI")
     status, headers, body = await _request_remote_document(target, "GET")
     if 300 <= status < 400:
         raise ValueError("Remote document redirects must be resolved before download")
@@ -102,18 +107,21 @@ async def fetch_remote_document(document_uri: str) -> tuple[bytes, int, dict[str
 
 async def resolve_remote_document_url(
     document_uri: str,
-) -> tuple[str, int, dict[str, str]]:
+) -> tuple[str, int, dict[str, str], RemoteDocumentTarget]:
     """Resolve a short redirect chain while validating every destination."""
-    current = validate_remote_document_url(document_uri)
+    current = document_uri
     for _ in range(5):
         target = resolve_remote_document_target(current)
         status, headers, _body = await _request_remote_document(target, "HEAD")
         if status not in {301, 302, 303, 307, 308}:
-            return current, status, headers
+            # Return the exact target whose addresses passed the preflight. The
+            # subsequent GET must reuse it instead of resolving the hostname
+            # again, otherwise DNS rebinding can bypass this boundary.
+            return current, status, headers, target
         location = headers.get("location")
         if not location:
             raise ValueError("Remote document redirect has no location")
-        current = validate_remote_document_url(urljoin(current, location))
+        current = urljoin(current, location)
     raise ValueError("Remote document redirect chain is too long")
 
 
@@ -528,13 +536,19 @@ class DocumentQueryHelper:
         mimetype = mimetype or "application/octet-stream"
         fetch_document_uri = original_document_uri
         index_document_uri = original_document_uri
+        fetch_target: RemoteDocumentTarget | None = None
 
         if scheme in {"http", "https"}:
             # Validate before handing the URL to any loader. The resolved
             # public URL is used only for fetching; the caller's URI remains
             # the stable index key after a legitimate cross-host redirect.
             try:
-                fetch_document_uri, response_status, response_headers = (
+                (
+                    fetch_document_uri,
+                    response_status,
+                    response_headers,
+                    fetch_target,
+                ) = (
                     await resolve_remote_document_url(original_document_uri)
                 )
             except Exception as exc:
@@ -586,23 +600,23 @@ class DocumentQueryHelper:
         if not exists:
             if mimetype.startswith("image/"):
                 document_content = await self.handle_image_document(
-                    fetch_document_uri, scheme
+                    fetch_document_uri, scheme, fetch_target
                 )
             elif mimetype == "text/html":
                 document_content = await self.handle_html_document(
-                    fetch_document_uri, scheme
+                    fetch_document_uri, scheme, fetch_target
                 )
             elif mimetype.startswith("text/") or mimetype == "application/json":
                 document_content = await self.handle_text_document(
-                    fetch_document_uri, scheme
+                    fetch_document_uri, scheme, fetch_target
                 )
             elif mimetype == "application/pdf":
                 document_content = await self.handle_pdf_document(
-                    fetch_document_uri, scheme
+                    fetch_document_uri, scheme, fetch_target
                 )
             else:
                 document_content = await self.handle_unstructured_document(
-                    fetch_document_uri, scheme
+                    fetch_document_uri, scheme, fetch_target
                 )
             if add_to_db:
                 self.progress_callback(f"Indexing document")
@@ -625,12 +639,22 @@ class DocumentQueryHelper:
                 )
         return document_content
 
-    async def handle_image_document(self, document: str, scheme: str) -> str:
-        return await self.handle_unstructured_document(document, scheme)
+    async def handle_image_document(
+        self,
+        document: str,
+        scheme: str,
+        target: RemoteDocumentTarget | None = None,
+    ) -> str:
+        return await self.handle_unstructured_document(document, scheme, target)
 
-    async def handle_html_document(self, document: str, scheme: str) -> str:
+    async def handle_html_document(
+        self,
+        document: str,
+        scheme: str,
+        target: RemoteDocumentTarget | None = None,
+    ) -> str:
         if scheme in ["http", "https"]:
-            body, status, headers = await fetch_remote_document(document)
+            body, status, headers = await fetch_remote_document(document, target)
             if status != 200:
                 raise ValueError(
                     f"DocumentQueryHelper::handle_html_document: Failed to download document from {document}: {status}"
@@ -665,9 +689,14 @@ class DocumentQueryHelper:
             ]
         )
 
-    async def handle_text_document(self, document: str, scheme: str) -> str:
+    async def handle_text_document(
+        self,
+        document: str,
+        scheme: str,
+        target: RemoteDocumentTarget | None = None,
+    ) -> str:
         if scheme in ["http", "https"]:
-            body, status, headers = await fetch_remote_document(document)
+            body, status, headers = await fetch_remote_document(document, target)
             if status != 200:
                 raise ValueError(
                     f"DocumentQueryHelper::handle_text_document: Failed to download document from {document}: {status}"
@@ -699,7 +728,12 @@ class DocumentQueryHelper:
 
         return "\n".join([element.page_content for element in elements])
 
-    async def handle_pdf_document(self, document: str, scheme: str) -> str:
+    async def handle_pdf_document(
+        self,
+        document: str,
+        scheme: str,
+        target: RemoteDocumentTarget | None = None,
+    ) -> str:
         temp_file_path = ""
         if scheme == "file":
             # Use RFC file operations to read the PDF file as binary
@@ -711,7 +745,7 @@ class DocumentQueryHelper:
                 temp_file.write(file_content_bytes)
                 temp_file_path = temp_file.name
         elif scheme in ["http", "https"]:
-            body, status, _headers = await fetch_remote_document(document)
+            body, status, _headers = await fetch_remote_document(document, target)
             if status != 200:
                 raise ValueError(
                     f"DocumentQueryHelper::handle_pdf_document: Failed to download PDF from {document}: {status}"
@@ -765,10 +799,15 @@ class DocumentQueryHelper:
         finally:
             os.unlink(temp_file_path)
 
-    async def handle_unstructured_document(self, document: str, scheme: str) -> str:
+    async def handle_unstructured_document(
+        self,
+        document: str,
+        scheme: str,
+        target: RemoteDocumentTarget | None = None,
+    ) -> str:
         elements: list[Document] = []
         if scheme in ["http", "https"]:
-            body, status, headers = await fetch_remote_document(document)
+            body, status, headers = await fetch_remote_document(document, target)
             if status != 200:
                 raise ValueError(
                     f"DocumentQueryHelper::handle_unstructured_document: Failed to download document from {document}: {status}"

--- a/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/document_query.py
+++ b/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/document_query.py
@@ -1,20 +1,17 @@
+import json
 import mimetypes
 import os
-import asyncio
+from datetime import datetime
+from typing import Callable, List, Optional, Sequence, Tuple
+from urllib.parse import urljoin, urlparse
+
 import aiohttp
-import json
 
 from python.helpers.vector_db import VectorDB
 
 os.environ["USER_AGENT"] = "@mixedbread-ai/unstructured"  # noqa E402
 from langchain_unstructured import UnstructuredLoader  # noqa E402
 
-from urllib.parse import urljoin, urlparse
-from typing import Callable, Sequence, List, Optional, Tuple
-from datetime import datetime
-
-from langchain_community.document_loaders import AsyncHtmlLoader
-from langchain_community.document_loaders.text import TextLoader
 from langchain_community.document_loaders.pdf import PyMuPDFLoader
 from langchain_community.document_transformers import MarkdownifyTransformer
 from langchain_community.document_loaders.parsers.images import TesseractBlobParser
@@ -24,13 +21,83 @@ from langchain.schema import SystemMessage, HumanMessage
 
 from python.helpers.print_style import PrintStyle
 from python.helpers import files, errors
-from python.helpers.network_policy import validate_remote_document_url
+from python.helpers.network_policy import (
+    PinnedResolver,
+    RemoteDocumentTarget,
+    resolve_remote_document_target,
+    validate_remote_document_url,
+)
 from agent import Agent
 
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 
 
 DEFAULT_SEARCH_THRESHOLD = 0.5
+MAX_REMOTE_DOCUMENT_BYTES = 50 * 1024 * 1024
+
+
+def _response_headers(response: aiohttp.ClientResponse) -> dict[str, str]:
+    return {str(key).lower(): str(value) for key, value in response.headers.items()}
+
+
+async def _read_remote_body(
+    response: aiohttp.ClientResponse,
+    max_bytes: int = MAX_REMOTE_DOCUMENT_BYTES,
+) -> bytes:
+    content_length = response.headers.get("content-length")
+    if content_length:
+        try:
+            if int(content_length) > max_bytes:
+                raise ValueError("Remote document content exceeds 50MB")
+        except ValueError as exc:
+            if "exceeds 50MB" in str(exc):
+                raise
+            raise ValueError("Remote document content-length is invalid") from exc
+
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in response.content.iter_chunked(64 * 1024):
+        total += len(chunk)
+        if total > max_bytes:
+            raise ValueError("Remote document content exceeds 50MB")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+async def _request_remote_document(
+    target: RemoteDocumentTarget,
+    method: str,
+) -> tuple[int, dict[str, str], bytes]:
+    """Perform one request through the addresses approved for ``target``."""
+    connector = aiohttp.TCPConnector(
+        resolver=PinnedResolver(target),
+        use_dns_cache=False,
+    )
+    try:
+        async with aiohttp.ClientSession(
+            connector=connector,
+            timeout=aiohttp.ClientTimeout(total=10.0),
+            raise_for_status=False,
+        ) as session:
+            async with session.request(
+                method,
+                target.uri,
+                allow_redirects=False,
+            ) as response:
+                headers = _response_headers(response)
+                body = b"" if method == "HEAD" else await _read_remote_body(response)
+                return response.status, headers, body
+    finally:
+        await connector.close()
+
+
+async def fetch_remote_document(document_uri: str) -> tuple[bytes, int, dict[str, str]]:
+    """Fetch content through a DNS-pinned, non-redirecting transport."""
+    target = resolve_remote_document_target(document_uri)
+    status, headers, body = await _request_remote_document(target, "GET")
+    if 300 <= status < 400:
+        raise ValueError("Remote document redirects must be resolved before download")
+    return body, status, headers
 
 
 async def resolve_remote_document_url(
@@ -38,21 +105,16 @@ async def resolve_remote_document_url(
 ) -> tuple[str, int, dict[str, str]]:
     """Resolve a short redirect chain while validating every destination."""
     current = validate_remote_document_url(document_uri)
-    timeout = aiohttp.ClientTimeout(total=2.0)
-    async with aiohttp.ClientSession() as session:
-        for _ in range(5):
-            response = await session.head(
-                current,
-                timeout=timeout,
-                allow_redirects=False,
-            )
-            if response.status not in {301, 302, 303, 307, 308}:
-                return current, response.status, dict(response.headers)
-            location = response.headers.get("location")
-            if not location:
-                raise ValueError("Remote document redirect has no location")
-            current = validate_remote_document_url(urljoin(current, location))
-        raise ValueError("Remote document redirect chain is too long")
+    for _ in range(5):
+        target = resolve_remote_document_target(current)
+        status, headers, _body = await _request_remote_document(target, "HEAD")
+        if status not in {301, 302, 303, 307, 308}:
+            return current, status, headers
+        location = headers.get("location")
+        if not location:
+            raise ValueError("Remote document redirect has no location")
+        current = validate_remote_document_url(urljoin(current, location))
+    raise ValueError("Remote document redirect chain is too long")
 
 
 class DocumentQueryStore:
@@ -459,27 +521,30 @@ class DocumentQueryHelper:
         self, document_uri: str, add_to_db: bool = False
     ) -> str:
         self.progress_callback(f"Fetching document content")
-        url = urlparse(document_uri)
+        original_document_uri = document_uri
+        url = urlparse(original_document_uri)
         scheme = url.scheme or "file"
-        mimetype, encoding = mimetypes.guess_type(document_uri)
+        mimetype, encoding = mimetypes.guess_type(original_document_uri)
         mimetype = mimetype or "application/octet-stream"
+        fetch_document_uri = original_document_uri
+        index_document_uri = original_document_uri
 
         if scheme in {"http", "https"}:
             # Validate before handing the URL to any loader. The resolved
-            # public URL is reused so an HTTP->HTTPS redirect cannot bypass
-            # the network boundary checked here.
+            # public URL is used only for fetching; the caller's URI remains
+            # the stable index key after a legitimate cross-host redirect.
             try:
-                document_uri, response_status, response_headers = (
-                    await resolve_remote_document_url(document_uri)
+                fetch_document_uri, response_status, response_headers = (
+                    await resolve_remote_document_url(original_document_uri)
                 )
             except Exception as exc:
                 raise ValueError(
-                    f"DocumentQueryHelper::document_get_content: Document fetch error: {document_uri} ({exc})"
+                    f"DocumentQueryHelper::document_get_content: Document fetch error: {original_document_uri} ({exc})"
                 ) from exc
 
             if response_status > 399:
                 raise ValueError(
-                    f"DocumentQueryHelper::document_get_content: Document fetch error: {document_uri} ({response_status})"
+                    f"DocumentQueryHelper::document_get_content: Document fetch error: {fetch_document_uri} ({response_status})"
                 )
 
             if mimetype == "application/octet-stream":
@@ -490,7 +555,7 @@ class DocumentQueryHelper:
                 )  # MB
                 if content_length > 50.0:
                     raise ValueError(
-                        f"Document content length exceeds max. 50MB: {content_length} MB ({document_uri})"
+                        f"Document content length exceeds max. 50MB: {content_length} MB ({fetch_document_uri})"
                     )
             if mimetype and "; charset=" in mimetype:
                 mimetype = mimetype.split("; charset=")[0]
@@ -498,6 +563,8 @@ class DocumentQueryHelper:
         if scheme == "file":
             try:
                 document_uri = files.fix_dev_path(url.path)
+                fetch_document_uri = document_uri
+                index_document_uri = document_uri
             except Exception as e:
                 raise ValueError(f"Invalid document path '{url.path}'") from e
 
@@ -512,22 +579,30 @@ class DocumentQueryHelper:
             )
 
         # Use the store's normalization method
-        document_uri_norm = self.store.normalize_uri(document_uri)
+        document_uri_norm = self.store.normalize_uri(index_document_uri)
 
         exists = await self.store.document_exists(document_uri_norm)
         document_content = ""
         if not exists:
             if mimetype.startswith("image/"):
-                document_content = self.handle_image_document(document_uri, scheme)
+                document_content = await self.handle_image_document(
+                    fetch_document_uri, scheme
+                )
             elif mimetype == "text/html":
-                document_content = self.handle_html_document(document_uri, scheme)
+                document_content = await self.handle_html_document(
+                    fetch_document_uri, scheme
+                )
             elif mimetype.startswith("text/") or mimetype == "application/json":
-                document_content = self.handle_text_document(document_uri, scheme)
+                document_content = await self.handle_text_document(
+                    fetch_document_uri, scheme
+                )
             elif mimetype == "application/pdf":
-                document_content = self.handle_pdf_document(document_uri, scheme)
+                document_content = await self.handle_pdf_document(
+                    fetch_document_uri, scheme
+                )
             else:
-                document_content = self.handle_unstructured_document(
-                    document_uri, scheme
+                document_content = await self.handle_unstructured_document(
+                    fetch_document_uri, scheme
                 )
             if add_to_db:
                 self.progress_callback(f"Indexing document")
@@ -550,14 +625,30 @@ class DocumentQueryHelper:
                 )
         return document_content
 
-    def handle_image_document(self, document: str, scheme: str) -> str:
-        return self.handle_unstructured_document(document, scheme)
+    async def handle_image_document(self, document: str, scheme: str) -> str:
+        return await self.handle_unstructured_document(document, scheme)
 
-    def handle_html_document(self, document: str, scheme: str) -> str:
+    async def handle_html_document(self, document: str, scheme: str) -> str:
         if scheme in ["http", "https"]:
-            validate_remote_document_url(document)
-            loader = AsyncHtmlLoader(web_path=document)
-            parts: list[Document] = loader.load()
+            body, status, headers = await fetch_remote_document(document)
+            if status != 200:
+                raise ValueError(
+                    f"DocumentQueryHelper::handle_html_document: Failed to download document from {document}: {status}"
+                )
+            charset = "utf-8"
+            content_type = headers.get("content-type", "")
+            if "charset=" in content_type:
+                charset = (
+                    content_type.split("charset=", 1)[1]
+                    .split(";", 1)[0]
+                    .strip()
+                    or charset
+                )
+            try:
+                decoded = body.decode(charset, errors="replace")
+            except LookupError:
+                decoded = body.decode("utf-8", errors="replace")
+            parts = [Document(page_content=decoded, metadata={"source": document})]
         elif scheme == "file":
             # Use RFC file operations instead of TextLoader
             file_content_bytes = files.read_file_bin(document)
@@ -574,11 +665,27 @@ class DocumentQueryHelper:
             ]
         )
 
-    def handle_text_document(self, document: str, scheme: str) -> str:
+    async def handle_text_document(self, document: str, scheme: str) -> str:
         if scheme in ["http", "https"]:
-            validate_remote_document_url(document)
-            loader = AsyncHtmlLoader(web_path=document)
-            elements: list[Document] = loader.load()
+            body, status, headers = await fetch_remote_document(document)
+            if status != 200:
+                raise ValueError(
+                    f"DocumentQueryHelper::handle_text_document: Failed to download document from {document}: {status}"
+                )
+            charset = "utf-8"
+            content_type = headers.get("content-type", "")
+            if "charset=" in content_type:
+                charset = (
+                    content_type.split("charset=", 1)[1]
+                    .split(";", 1)[0]
+                    .strip()
+                    or charset
+                )
+            try:
+                decoded = body.decode(charset, errors="replace")
+            except LookupError:
+                decoded = body.decode("utf-8", errors="replace")
+            elements = [Document(page_content=decoded, metadata={"source": document})]
         elif scheme == "file":
             # Use RFC file operations instead of TextLoader
             file_content_bytes = files.read_file_bin(document)
@@ -592,7 +699,7 @@ class DocumentQueryHelper:
 
         return "\n".join([element.page_content for element in elements])
 
-    def handle_pdf_document(self, document: str, scheme: str) -> str:
+    async def handle_pdf_document(self, document: str, scheme: str) -> str:
         temp_file_path = ""
         if scheme == "file":
             # Use RFC file operations to read the PDF file as binary
@@ -604,26 +711,15 @@ class DocumentQueryHelper:
                 temp_file.write(file_content_bytes)
                 temp_file_path = temp_file.name
         elif scheme in ["http", "https"]:
-            validate_remote_document_url(document)
-            # download the file from the web url to a temporary file using python libraries for downloading
-            import requests
+            body, status, _headers = await fetch_remote_document(document)
+            if status != 200:
+                raise ValueError(
+                    f"DocumentQueryHelper::handle_pdf_document: Failed to download PDF from {document}: {status}"
+                )
             import tempfile
 
             with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as temp_file:
-                response = requests.get(
-                    document,
-                    timeout=10.0,
-                    allow_redirects=False,
-                )
-                if 300 <= response.status_code < 400:
-                    raise ValueError(
-                        "Remote PDF redirects must be resolved by document_get_content"
-                    )
-                if response.status_code != 200:
-                    raise ValueError(
-                        f"DocumentQueryHelper::handle_pdf_document: Failed to download PDF from {document}: {response.status_code}"
-                    )
-                temp_file.write(response.content)
+                temp_file.write(body)
                 temp_file_path = temp_file.name
         else:
             raise ValueError(f"Unsupported scheme: {scheme}")
@@ -669,19 +765,34 @@ class DocumentQueryHelper:
         finally:
             os.unlink(temp_file_path)
 
-    def handle_unstructured_document(self, document: str, scheme: str) -> str:
+    async def handle_unstructured_document(self, document: str, scheme: str) -> str:
         elements: list[Document] = []
         if scheme in ["http", "https"]:
-            validate_remote_document_url(document)
-            # loader = UnstructuredURLLoader(urls=[document], mode="single")
-            loader = UnstructuredLoader(
-                web_url=document,
-                mode="single",
-                partition_via_api=False,
-                # chunking_strategy="by_page",
-                strategy="hi_res",
-            )
-            elements = loader.load()
+            body, status, headers = await fetch_remote_document(document)
+            if status != 200:
+                raise ValueError(
+                    f"DocumentQueryHelper::handle_unstructured_document: Failed to download document from {document}: {status}"
+                )
+            import tempfile
+
+            content_type = headers.get("content-type", "").split(";", 1)[0].strip()
+            suffix = os.path.splitext(urlparse(document).path)[1]
+            if not suffix:
+                suffix = mimetypes.guess_extension(content_type) or ".bin"
+            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as temp_file:
+                temp_file.write(body)
+                temp_file_path = temp_file.name
+            try:
+                loader = UnstructuredLoader(
+                    file_path=temp_file_path,
+                    mode="single",
+                    partition_via_api=False,
+                    # chunking_strategy="by_page",
+                    strategy="hi_res",
+                )
+                elements = loader.load()
+            finally:
+                os.unlink(temp_file_path)
         elif scheme == "file":
             # Use RFC file operations to read the file as binary
             file_content_bytes = files.read_file_bin(document)

--- a/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/network_policy.py
+++ b/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/network_policy.py
@@ -3,15 +3,53 @@
 import ipaddress
 import os
 import socket
+from dataclasses import dataclass
 from urllib.parse import urlparse
 
 
-def validate_remote_document_url(document_uri: str) -> str:
-    """Reject local-network targets before any document loader performs I/O.
+@dataclass(frozen=True)
+class RemoteDocumentTarget:
+    """A URL together with the public addresses approved for one request."""
 
-    Every resolved address must be globally routable. An optional host
-    allowlist can further narrow egress for deployments that do not need
-    arbitrary public documents.
+    uri: str
+    hostname: str
+    port: int
+    addresses: tuple[str, ...]
+
+
+def _normalized_hostname(hostname: str) -> str:
+    return hostname.rstrip(".").lower()
+
+
+def _resolve_public_addresses(hostname: str, port: int) -> tuple[str, ...]:
+    try:
+        addresses = tuple(
+            dict.fromkeys(
+                result[4][0]
+                for result in socket.getaddrinfo(
+                    hostname,
+                    port,
+                    type=socket.SOCK_STREAM,
+                )
+            )
+        )
+    except OSError as exc:
+        raise ValueError("Remote document host could not be resolved") from exc
+
+    if not addresses or any(
+        not ipaddress.ip_address(address.split("%", 1)[0]).is_global
+        for address in addresses
+    ):
+        raise ValueError("Remote document host resolves to a non-public address")
+    return addresses
+
+
+def resolve_remote_document_target(document_uri: str) -> RemoteDocumentTarget:
+    """Validate a URL and capture the public addresses used by its transport.
+
+    The returned address set is intentionally immutable. Callers must pass it
+    to :class:`PinnedResolver` instead of handing the original hostname to a
+    second DNS lookup, which would re-open a DNS-rebinding window.
     """
     parsed = urlparse(document_uri)
     if parsed.scheme not in {"http", "https"} or not parsed.hostname:
@@ -19,7 +57,14 @@ def validate_remote_document_url(document_uri: str) -> str:
     if parsed.username or parsed.password:
         raise ValueError("Remote document URL must not contain credentials")
 
-    hostname = parsed.hostname.rstrip(".").lower()
+    try:
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    except ValueError as exc:
+        raise ValueError("Remote document URL has an invalid port") from exc
+    if not 1 <= port <= 65535:
+        raise ValueError("Remote document URL has an invalid port")
+
+    hostname = _normalized_hostname(parsed.hostname)
     blocked_suffixes = (".localhost", ".local", ".internal", ".intranet")
     if hostname in {"localhost", "localhost.localdomain"} or hostname.endswith(
         blocked_suffixes
@@ -34,21 +79,56 @@ def validate_remote_document_url(document_uri: str) -> str:
     if allowlist and hostname not in allowlist:
         raise ValueError("Remote document host is not in AGZ_DOCUMENT_ALLOWED_HOSTS")
 
-    try:
-        addresses = {
-            result[4][0]
-            for result in socket.getaddrinfo(
-                hostname,
-                parsed.port or (443 if parsed.scheme == "https" else 80),
-                type=socket.SOCK_STREAM,
-            )
-        }
-    except OSError as exc:
-        raise ValueError("Remote document host could not be resolved") from exc
+    return RemoteDocumentTarget(
+        uri=document_uri,
+        hostname=hostname,
+        port=port,
+        addresses=_resolve_public_addresses(hostname, port),
+    )
 
-    if not addresses or any(
-        not ipaddress.ip_address(address).is_global for address in addresses
+
+class PinnedResolver:
+    """aiohttp resolver that never performs a second DNS lookup."""
+
+    def __init__(self, target: RemoteDocumentTarget):
+        self._hostname = target.hostname
+        self._port = target.port
+        self._addresses = target.addresses
+
+    async def resolve(
+        self,
+        host: str,
+        port: int = 0,
+        family: int = socket.AF_UNSPEC,
     ):
-        raise ValueError("Remote document host resolves to a non-public address")
+        if _normalized_hostname(host) != self._hostname or int(port) != self._port:
+            raise OSError("Remote document resolver target changed")
 
+        resolved = []
+        for address in self._addresses:
+            ip = ipaddress.ip_address(address.split("%", 1)[0])
+            address_family = socket.AF_INET if ip.version == 4 else socket.AF_INET6
+            if family not in {socket.AF_UNSPEC, address_family}:
+                continue
+            resolved.append(
+                {
+                    "hostname": self._hostname,
+                    "host": address,
+                    "port": self._port,
+                    "family": address_family,
+                    "proto": socket.IPPROTO_TCP,
+                    "flags": socket.AI_NUMERICHOST,
+                }
+            )
+        if not resolved:
+            raise OSError("Remote document host has no compatible public address")
+        return resolved
+
+    async def close(self):
+        return None
+
+
+def validate_remote_document_url(document_uri: str) -> str:
+    """Validate a URL while preserving the public compatibility API."""
+    resolve_remote_document_target(document_uri)
     return document_uri

--- a/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/network_policy.py
+++ b/backend/apps/agent-zero/apps/agent_zero_core/python/helpers/network_policy.py
@@ -18,7 +18,11 @@ class RemoteDocumentTarget:
 
 
 def _normalized_hostname(hostname: str) -> str:
-    return hostname.rstrip(".").lower()
+    """Return the canonical DNS form used by URL parsers and aiohttp."""
+    try:
+        return hostname.rstrip(".").encode("idna").decode("ascii").lower()
+    except UnicodeError as exc:
+        raise ValueError("Remote document host is not a valid hostname") from exc
 
 
 def _resolve_public_addresses(hostname: str, port: int) -> tuple[str, ...]:
@@ -72,7 +76,7 @@ def resolve_remote_document_target(document_uri: str) -> RemoteDocumentTarget:
         raise ValueError("Remote document host is not publicly routable")
 
     allowlist = {
-        item.strip().lower().rstrip(".")
+        _normalized_hostname(item.strip())
         for item in os.getenv("AGZ_DOCUMENT_ALLOWED_HOSTS", "").split(",")
         if item.strip()
     }

--- a/backend/apps/agent-zero/tests/test_document_network_policy.py
+++ b/backend/apps/agent-zero/tests/test_document_network_policy.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import sys
 from pathlib import Path
@@ -7,7 +8,11 @@ from unittest.mock import patch
 CORE_ROOT = Path(__file__).resolve().parents[1] / "apps" / "agent_zero_core"
 sys.path.insert(0, str(CORE_ROOT))
 
-from python.helpers.network_policy import validate_remote_document_url
+from python.helpers.network_policy import (
+    PinnedResolver,
+    resolve_remote_document_target,
+    validate_remote_document_url,
+)
 
 
 def _dns_result(address: str):
@@ -53,3 +58,34 @@ def test_remote_document_policy_rejects_credentials_and_local_names():
             pass
         else:
             raise AssertionError(f"unsafe URL was accepted: {url}")
+
+
+def test_pinned_resolver_does_not_re_resolve_after_public_preflight():
+    """A DNS answer cannot change between validation and the socket connect."""
+    with patch(
+        "python.helpers.network_policy.socket.getaddrinfo",
+        side_effect=[_dns_result("93.184.216.34"), _dns_result("10.0.0.8")],
+    ) as getaddrinfo:
+        target = resolve_remote_document_target("https://public.example/document")
+        resolved = asyncio.run(PinnedResolver(target).resolve("public.example", 443))
+
+    assert resolved[0]["host"] == "93.184.216.34"
+    assert getaddrinfo.call_count == 1
+
+
+def test_pinned_resolver_rejects_host_or_port_changes():
+    with patch(
+        "python.helpers.network_policy.socket.getaddrinfo",
+        return_value=_dns_result("93.184.216.34"),
+    ):
+        resolver = PinnedResolver(
+            resolve_remote_document_target("https://public.example/document")
+        )
+
+    for host, port in (("attacker.example", 443), ("public.example", 8443)):
+        try:
+            asyncio.run(resolver.resolve(host, port))
+        except OSError as exc:
+            assert "target changed" in str(exc)
+        else:
+            raise AssertionError("resolver accepted a changed destination")

--- a/backend/apps/agent-zero/tests/test_document_network_policy.py
+++ b/backend/apps/agent-zero/tests/test_document_network_policy.py
@@ -89,3 +89,17 @@ def test_pinned_resolver_rejects_host_or_port_changes():
             assert "target changed" in str(exc)
         else:
             raise AssertionError("resolver accepted a changed destination")
+
+
+def test_remote_document_policy_normalizes_idn_for_transport_host():
+    with patch(
+        "python.helpers.network_policy.socket.getaddrinfo",
+        return_value=_dns_result("93.184.216.34"),
+    ):
+        target = resolve_remote_document_target("https://münich.example/document")
+
+    assert target.hostname == "xn--mnich-kva.example"
+    resolved = asyncio.run(
+        PinnedResolver(target).resolve("xn--mnich-kva.example", 443)
+    )
+    assert resolved[0]["host"] == "93.184.216.34"


### PR DESCRIPTION
## Objetivo

Fechar o SSRF por DNS rebinding identificado na cadeia de documentos remotos do Agent Zero.

## Correção

- captura e valida todos os endereços públicos no preflight;
- usa um `PinnedResolver` imutável para que HEAD e GET não façam nova resolução DNS;
- bloqueia redirects no transporte e revalida cada destino antes de reconectar;
- baixa HTML, texto, PDF e conteúdo unstructured pelo mesmo transporte fixado;
- preserva a URI original como chave do índice após redirect cross-host, evitando regressão no Q&A;
- mantém limite de 50 MB e cabeçalhos normalizados.

## Validação

- `python -m pytest backend/apps/agent-zero/tests/test_document_network_policy.py -q` — 5 passando;
- `python -m py_compile ...` — passou;
- `git diff --check` — passou;
- reprodutor DNS: resolução pública foi chamada uma vez e o resolver reutilizou o IP aprovado.

Nenhum deploy, dado real ou automação do site foi acionado.