### PR TITLE
feat(identity): add signed CRM delivery issuer boundary

### DIFF
--- a/.github/workflows/identity-crm-delivery.yml
+++ b/.github/workflows/identity-crm-delivery.yml
@@ -1,0 +1,47 @@
+name: Identity CRM delivery
+
+on:
+  pull_request:
+    paths:
+      - 'identity/**'
+      - '.github/workflows/identity-crm-delivery.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'identity/**'
+      - '.github/workflows/identity-crm-delivery.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: identity-crm-delivery-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Install pinned contract and test issuer
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: '22.12.0'
+      - name: Install the exact private Identity contract without persisting credentials
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          npmrc="$RUNNER_TEMP/skincos-identity-npmrc"
+          trap 'rm -f "$npmrc"' EXIT
+          umask 077
+          {
+            printf '%s\n' '@jubenitogarcia:registry=https://npm.pkg.github.com'
+            printf '%s\n' '//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}'
+            printf '%s\n' 'always-auth=true'
+          } > "$npmrc"
+          NPM_CONFIG_USERCONFIG="$npmrc" npm --prefix identity ci --ignore-scripts --no-audit --fund=false
+          NPM_CONFIG_USERCONFIG="$npmrc" npm --prefix identity test

--- a/identity/README.md
+++ b/identity/README.md
@@ -39,10 +39,42 @@ explicit caller opt-in. It does not resolve a session, read runtime
 configuration, use a secret, serialize or sign a JWS, register a route, add a
 Worker binding, or publish an artifact.
 
-Until a clean installation of the exact private contracts package is proven,
-this helper is only a disconnected preparation guard; it is not the canonical
-wire-contract parser, serializer or compatibility proof. The future private
-entrypoint must delegate those responsibilities to the published package.
+`identity/delivery/crm-issuer-v1.js` now provides the source-level issuer
+boundary for the future private WorkerEntrypoint. It remains disabled by
+default and has no route, binding, D1 write or secret configuration. When an
+authorized runtime eventually enables it, the exact pinned
+`@jubenitogarcia/skincos-identity-contracts/identity-crm-delivery` package is
+the default canonical owner of signing-input validation. An explicit contract
+adapter is supported only for isolated tests and must expose the same fixed
+version, issuer, audience, algorithm and validators. Identity supplies only a
+signer callback backed by a non-exportable Ed25519 key held in external
+custody; private key bytes, PEM/JWK material and secrets are rejected by the
+key-ring boundary and are never stored in the CRM repository or Git.
+
+The issuer accepts the authenticated actor plus the exact method, canonical
+target and body bytes. It computes `SHA-256(body)` itself before producing the
+claims, so a caller cannot sign a digest for a different request. The actor is
+projected to `identitySubject`, `role` and sorted scopes; username, email,
+display name, cookies, sessions and compatibility aliases never enter the
+signing input.
+
+The included key-ring state machine is for synthetic tests and local contract
+integration only. It exercises active-key selection, overlap during rotation,
+revocation and fail-closed behavior. A deployable Identity runtime still needs
+a durable key registry/custody adapter, a real Ed25519 signing key, public-key
+publication for the CRM verifier and an operational rollback/rotation window.
+An optional issuer replay reservation can reject duplicate `jti` values after a
+successful signature, but it does not replace the CRM-owned atomic replay
+ledger required before business handling.
+
+The Identity package pins the exact private contracts package version and
+integrity in `identity/package-lock.json`; its focused workflow installs that
+lockfile from GitHub Packages before running the issuer tests. A registry Read
+grant for the `jubenitogarcia/skincos` repository is required for that CI job.
+The helper is still not a deployed runtime: the future private entrypoint must
+provide a durable Identity-owned key registry/custody adapter, publish the
+matching public key to CRM, and expose a staging-only service binding before
+the enabled path can be exercised outside synthetic tests.
 
 The helper refuses the current username-based actor. A future additive Identity
 migration must first provide a stable opaque `identitySubject` and preserve it

--- a/identity/delivery/crm-envelope-v1.js
+++ b/identity/delivery/crm-envelope-v1.js
@@ -9,7 +9,10 @@ const DELIVERY_METHODS = new Set(['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE
 const OPAQUE_SUBJECT_PATTERN = /^idn:[A-Za-z0-9_-]{16,160}$/;
 const ROLE_PATTERN = /^[A-Z][A-Z0-9_]{0,63}$/;
 const SCOPE_ITEM_PATTERN = /^[a-z][a-z0-9:-]{0,159}$/;
-const PERMISSION_ITEM_PATTERN = /^[a-z][a-z0-9:.-]{0,159}$/;
+// Keep the issuer-side preparation exactly aligned with the published
+// identity-crm-delivery contract. Dots belong to module grants in the CRM
+// shell; delivery permissions use the portable colon-delimited vocabulary.
+const PERMISSION_ITEM_PATTERN = /^[a-z][a-z0-9:-]{0,159}$/;
 const JTI_PATTERN = /^[A-Za-z0-9_-]{16,160}$/;
 const KEY_ID_PATTERN = /^[A-Za-z0-9._-]{1,160}$/;
 const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/;

--- a/identity/delivery/crm-issuer-staging-worker.js
+++ b/identity/delivery/crm-issuer-staging-worker.js
@@ -1,0 +1,232 @@
+import {
+  createCrmIdentityDeliveryIssuer,
+  createCrmIdentityDeliveryKeyRing,
+  createCrmIdentityEd25519Signer,
+} from './crm-issuer-v1.js';
+
+const ISSUE_PATH = '/internal/identity-crm-delivery/v1/issue';
+const PUBLIC_KEYS_PATH = '/.well-known/identity-crm-delivery/v1/keys';
+const MAX_REQUEST_BYTES = 1_048_576;
+const BASE64_URL_PATTERN = /^[A-Za-z0-9_-]*$/;
+const TEXT_ENCODER = new TextEncoder();
+
+function fail(code) {
+  throw new TypeError(code);
+}
+
+function json(value, status = 200, extraHeaders = {}) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { 'content-type': 'application/json; charset=utf-8', ...extraHeaders },
+  });
+}
+
+function noContent(status, extraHeaders = {}) {
+  return new Response(null, { status, headers: extraHeaders });
+}
+
+function parseJson(raw, code) {
+  try {
+    const value = JSON.parse(raw);
+    if (!value || typeof value !== 'object' || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) fail(code);
+    return value;
+  } catch (error) {
+    if (error instanceof TypeError && error.message === code) throw error;
+    fail(code);
+  }
+}
+
+function exactKeys(value, allowed, code) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) fail(code);
+  const keys = Reflect.ownKeys(value);
+  if (keys.length !== allowed.length || keys.some((key) => typeof key !== 'string' || !allowed.includes(key))) fail(code);
+  return value;
+}
+
+function decodeBase64Url(value, code, expectedLength = null) {
+  if (typeof value !== 'string' || !BASE64_URL_PATTERN.test(value) || value.length % 4 === 1) fail(code);
+  if (expectedLength !== null && value.length > Math.ceil(expectedLength * 4 / 3)) fail(code);
+  const padding = '='.repeat((4 - (value.length % 4)) % 4);
+  let binary;
+  try {
+    binary = atob(value.replace(/-/g, '+').replace(/_/g, '/') + padding);
+  } catch {
+    fail(code);
+  }
+  const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  let canonicalBinary = '';
+  for (const byte of bytes) canonicalBinary += String.fromCharCode(byte);
+  const canonical = btoa(canonicalBinary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+  if (canonical !== value || (expectedLength !== null && bytes.byteLength !== expectedLength)) fail(code);
+  return bytes;
+}
+
+function parseJwkSecret(raw) {
+  const value = parseJson(raw, 'IDENTITY_PRIVATE_JWK_INVALID');
+  const allowed = ['kty', 'crv', 'x', 'd', 'alg', 'key_ops', 'ext'];
+  const keys = Reflect.ownKeys(value);
+  if (keys.some((key) => typeof key !== 'string' || !allowed.includes(key))
+    || !['kty', 'crv', 'x', 'd'].every((key) => Object.prototype.hasOwnProperty.call(value, key))) {
+    fail('IDENTITY_PRIVATE_JWK_INVALID');
+  }
+  if (value.kty !== 'OKP' || value.crv !== 'Ed25519'
+    || (value.alg !== undefined && value.alg !== 'EdDSA')
+    || (value.key_ops !== undefined && (value.key_ops.length !== 1 || value.key_ops[0] !== 'sign'))
+    || (value.ext !== undefined && value.ext !== false)) fail('IDENTITY_PRIVATE_JWK_INVALID');
+  decodeBase64Url(value.x, 'IDENTITY_PRIVATE_JWK_INVALID', 32);
+  decodeBase64Url(value.d, 'IDENTITY_PRIVATE_JWK_INVALID', 32);
+  return Object.freeze({ kty: value.kty, crv: value.crv, x: value.x, d: value.d, alg: 'EdDSA', key_ops: ['sign'], ext: false });
+}
+
+function parsePublicJwk(raw) {
+  const value = parseJson(raw, 'IDENTITY_PUBLIC_JWK_INVALID');
+  const allowed = ['kty', 'crv', 'x', 'alg', 'use', 'key_ops', 'ext'];
+  const keys = Reflect.ownKeys(value);
+  if (keys.some((key) => typeof key !== 'string' || !allowed.includes(key))
+    || !['kty', 'crv', 'x'].every((key) => Object.prototype.hasOwnProperty.call(value, key))) {
+    fail('IDENTITY_PUBLIC_JWK_INVALID');
+  }
+  if (value.kty !== 'OKP' || value.crv !== 'Ed25519'
+    || (value.alg !== undefined && value.alg !== 'EdDSA')
+    || (value.use !== undefined && value.use !== 'sig')
+    || (value.key_ops !== undefined && (value.key_ops.length !== 1 || value.key_ops[0] !== 'verify'))) {
+    fail('IDENTITY_PUBLIC_JWK_INVALID');
+  }
+  decodeBase64Url(value.x, 'IDENTITY_PUBLIC_JWK_INVALID', 32);
+  return Object.freeze({ kty: value.kty, crv: value.crv, x: value.x, alg: 'EdDSA', use: 'sig' });
+}
+
+function assertKid(value) {
+  if (typeof value !== 'string' || !/^[A-Za-z0-9._-]{1,160}$/.test(value)) fail('IDENTITY_KEY_ID_INVALID');
+  return value;
+}
+
+function stagingEnabled(env) {
+  return env?.IDENTITY_CRM_DELIVERY_ENABLED === 'true'
+    && env?.IDENTITY_CRM_DELIVERY_ENVIRONMENT === 'staging';
+}
+
+function loadStagingMaterial(env) {
+  if (!stagingEnabled(env)) return null;
+  const kid = assertKid(env.IDENTITY_CRM_DELIVERY_KID);
+  if (typeof env.IDENTITY_CRM_DELIVERY_PRIVATE_JWK !== 'string'
+    || typeof env.IDENTITY_CRM_DELIVERY_PUBLIC_JWK !== 'string'
+    || typeof env.IDENTITY_CRM_DELIVERY_REQUEST_HMAC !== 'string') {
+    fail('IDENTITY_STAGING_CUSTODY_UNAVAILABLE');
+  }
+  const privateJwk = parseJwkSecret(env.IDENTITY_CRM_DELIVERY_PRIVATE_JWK);
+  const publicJwk = parsePublicJwk(env.IDENTITY_CRM_DELIVERY_PUBLIC_JWK);
+  if (privateJwk.x !== publicJwk.x) fail('IDENTITY_PUBLIC_KEY_MISMATCH');
+  if (new TextEncoder().encode(env.IDENTITY_CRM_DELIVERY_REQUEST_HMAC).byteLength < 32) {
+    fail('IDENTITY_STAGING_REQUEST_AUTH_INVALID');
+  }
+  return Object.freeze({ kid, privateJwk, publicJwk, requestHmac: env.IDENTITY_CRM_DELIVERY_REQUEST_HMAC });
+}
+
+async function importPrivateKey(privateJwk) {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle || typeof subtle.importKey !== 'function') fail('IDENTITY_STAGING_CRYPTO_UNAVAILABLE');
+  return subtle.importKey('jwk', privateJwk, { name: 'Ed25519' }, false, ['sign']);
+}
+
+async function importRequestHmac(secret) {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle || typeof subtle.importKey !== 'function') fail('IDENTITY_STAGING_CRYPTO_UNAVAILABLE');
+  return subtle.importKey('raw', TEXT_ENCODER.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['verify']);
+}
+
+function decodeRequestBody(value) {
+  const bytes = decodeBase64Url(value, 'IDENTITY_REQUEST_BODY_INVALID');
+  if (bytes.byteLength > MAX_REQUEST_BYTES) fail('IDENTITY_REQUEST_BODY_TOO_LARGE');
+  return bytes;
+}
+
+async function isAuthorizedIssueRequest(request, rawBody, secret) {
+  const supplied = request.headers.get('x-skincos-identity-issuer-auth');
+  if (!supplied) return false;
+  const signature = decodeBase64Url(supplied, 'IDENTITY_STAGING_REQUEST_AUTH_INVALID', 32);
+  const key = await importRequestHmac(secret);
+  return globalThis.crypto.subtle.verify('HMAC', key, signature, TEXT_ENCODER.encode(rawBody));
+}
+
+async function createEnabledIssuer(material) {
+  const privateKey = await importPrivateKey(material.privateJwk);
+  const keyRing = createCrmIdentityDeliveryKeyRing({
+    active: {
+      kid: material.kid,
+      sign: createCrmIdentityEd25519Signer(privateKey),
+    },
+  });
+  return createCrmIdentityDeliveryIssuer({ enabled: true, keyRing });
+}
+
+function publicKeyResponse(material) {
+  return json({
+    version: 'identity-crm-delivery/v1',
+    keys: [{ ...material.publicJwk, kid: material.kid }],
+  }, 200, { 'cache-control': 'no-store' });
+}
+
+/**
+ * Staging-only service-binding surface. It has no production route or data
+ * binding: the config intentionally leaves routes/workers.dev disabled. The
+ * private JWK and request HMAC are supplied as staging secrets at runtime;
+ * neither is read from source control. Public-key publication is explicit and
+ * read-only so CRM can pin the `kid`/JWK out of band before accepting tokens.
+ */
+export async function handleIdentityCrmIssuerStagingRequest(request, env = {}) {
+  if (!stagingEnabled(env)) {
+    return request.method === 'HEAD' ? noContent(503) : json({ ok: false, error: 'IDENTITY_CRM_DELIVERY_DISABLED' }, 503);
+  }
+
+  let material;
+  try {
+    material = loadStagingMaterial(env);
+  } catch {
+    return request.method === 'HEAD' ? noContent(503) : json({ ok: false, error: 'IDENTITY_STAGING_CUSTODY_UNAVAILABLE' }, 503);
+  }
+
+  const url = new URL(request.url);
+  if (url.pathname === PUBLIC_KEYS_PATH && (request.method === 'GET' || request.method === 'HEAD')) {
+    if (request.method === 'HEAD') return noContent(200, { 'cache-control': 'no-store' });
+    return publicKeyResponse(material);
+  }
+  if (url.pathname !== ISSUE_PATH || request.method !== 'POST') {
+    return json({ ok: false, error: 'NOT_FOUND' }, 404);
+  }
+
+  const declaredLength = request.headers.get('content-length');
+  if (declaredLength && /^\d+$/.test(declaredLength) && Number(declaredLength) > MAX_REQUEST_BYTES) {
+    return json({ ok: false, error: 'REQUEST_TOO_LARGE' }, 413);
+  }
+  const rawBody = await request.text();
+  if (new TextEncoder().encode(rawBody).byteLength > MAX_REQUEST_BYTES) return json({ ok: false, error: 'REQUEST_TOO_LARGE' }, 413);
+  try {
+    if (!await isAuthorizedIssueRequest(request, rawBody, material.requestHmac)) return json({ ok: false, error: 'UNAUTHORIZED' }, 401);
+  } catch {
+    return json({ ok: false, error: 'UNAUTHORIZED' }, 401);
+  }
+
+  try {
+    const payload = parseJson(rawBody, 'IDENTITY_ISSUE_PAYLOAD_INVALID');
+    exactKeys(payload, ['identity', 'request', 'jti'], 'IDENTITY_ISSUE_PAYLOAD_INVALID');
+    exactKeys(payload.identity, ['identitySubject', 'role', 'scopes'], 'IDENTITY_ISSUE_ACTOR_INVALID');
+    exactKeys(payload.request, ['method', 'target', 'bodyBase64'], 'IDENTITY_ISSUE_REQUEST_INVALID');
+    const issuer = await createEnabledIssuer(material);
+    const result = await issuer.issue({
+      identity: payload.identity,
+      request: {
+        method: payload.request.method,
+        target: payload.request.target,
+        body: decodeRequestBody(payload.request.bodyBase64),
+      },
+      jti: payload.jti,
+    });
+    return json({ ok: true, version: 'identity-crm-delivery/v1', keyId: result.keyId, compact: result.compact }, 200, { 'cache-control': 'no-store' });
+  } catch (error) {
+    const code = error instanceof TypeError ? error.message : 'IDENTITY_ISSUE_FAILED';
+    return json({ ok: false, error: code }, code === 'IDENTITY_CRM_DELIVERY_DISABLED' ? 503 : 400);
+  }
+}
+
+export default { fetch: handleIdentityCrmIssuerStagingRequest };

--- a/identity/delivery/crm-issuer-v1.js
+++ b/identity/delivery/crm-issuer-v1.js
@@ -1,0 +1,424 @@
+import {
+  IDENTITY_CRM_DELIVERY_AUDIENCE,
+  IDENTITY_CRM_DELIVERY_ISSUER,
+  IDENTITY_CRM_DELIVERY_MAX_TTL_SECONDS,
+  IDENTITY_CRM_DELIVERY_VERSION,
+  prepareCrmIdentityDeliveryV1,
+} from './crm-envelope-v1.js';
+import * as publishedIdentityCrmDeliveryContract from '@jubenitogarcia/skincos-identity-contracts/identity-crm-delivery';
+
+const IDENTITY_CRM_DELIVERY_ALGORITHM = 'EdDSA';
+const IDENTITY_CRM_DELIVERY_TYPE = 'skincos-identity-delivery+jws';
+const KEY_ID_PATTERN = /^[A-Za-z0-9._-]{1,160}$/;
+const JTI_PATTERN = /^[A-Za-z0-9_-]{16,160}$/;
+const MAX_CLOCK_SKEW_SECONDS = IDENTITY_CRM_DELIVERY_MAX_TTL_SECONDS;
+const KEY_STATUSES = new Set(['active', 'overlap', 'revoked']);
+const DELIVERY_METHODS = new Set(['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE']);
+const TEXT_ENCODER = new TextEncoder();
+
+function fail(code) {
+  throw new TypeError(code);
+}
+
+function assertPlainObject(value, code) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) {
+    fail(code);
+  }
+  return value;
+}
+
+function assertEpochSeconds(value, code) {
+  if (!Number.isSafeInteger(value) || value < 0) fail(code);
+  return value;
+}
+
+function assertClockSkew(value) {
+  return assertEpochSeconds(value, 'IDENTITY_CLOCK_SKEW_INVALID') <= MAX_CLOCK_SKEW_SECONDS
+    ? value
+    : fail('IDENTITY_CLOCK_SKEW_INVALID');
+}
+
+function assertKeyId(value, code = 'IDENTITY_KEY_ID_INVALID') {
+  if (typeof value !== 'string' || !KEY_ID_PATTERN.test(value)) fail(code);
+  return value;
+}
+
+function assertJti(value) {
+  if (typeof value !== 'string' || !JTI_PATTERN.test(value)) fail('IDENTITY_JTI_INVALID');
+  return value;
+}
+
+function assertMethod(value) {
+  if (typeof value !== 'string') fail('IDENTITY_REQUEST_METHOD_INVALID');
+  const method = value.trim().toUpperCase();
+  if (!DELIVERY_METHODS.has(method)) fail('IDENTITY_REQUEST_METHOD_INVALID');
+  return method;
+}
+
+function requestBytes(value) {
+  if (value === undefined || value === null) return new Uint8Array();
+  if (typeof value === 'string') return TEXT_ENCODER.encode(value);
+  if (value instanceof Uint8Array) return new Uint8Array(value);
+  if (value instanceof ArrayBuffer) return new Uint8Array(value.slice(0));
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength));
+  }
+  fail('IDENTITY_REQUEST_BODY_INVALID');
+}
+
+async function sha256Hex(value) {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle || typeof subtle.digest !== 'function') fail('IDENTITY_REQUEST_CRYPTO_UNAVAILABLE');
+  const digest = await subtle.digest('SHA-256', requestBytes(value));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function assertRequest(value) {
+  assertPlainObject(value, 'IDENTITY_REQUEST_INVALID');
+  const keys = Reflect.ownKeys(value);
+  if (keys.length !== 3 || keys.some((key) => typeof key !== 'string' || !['method', 'target', 'body'].includes(key))) {
+    fail('IDENTITY_REQUEST_INVALID');
+  }
+  for (const key of keys) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor || !descriptor.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+      fail('IDENTITY_REQUEST_INVALID');
+    }
+  }
+  return value;
+}
+
+async function requestBindingFromRequest(value) {
+  const request = assertRequest(value);
+  return {
+    method: assertMethod(request.method),
+    target: request.target,
+    bodyDigest: await sha256Hex(request.body),
+  };
+}
+
+function normalizeKeyRecord(value, expectedStatus, code = 'IDENTITY_KEY_RECORD_INVALID') {
+  assertPlainObject(value, code);
+  const allowedKeys = ['kid', 'sign', 'status', 'notBefore', 'notAfter'];
+  const keys = Reflect.ownKeys(value);
+  if (keys.some((key) => typeof key !== 'string' || !allowedKeys.includes(key))) fail(code);
+  if (!Object.prototype.hasOwnProperty.call(value, 'kid') || !Object.prototype.hasOwnProperty.call(value, 'sign')) fail(code);
+  for (const key of keys) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor || !descriptor.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) fail(code);
+  }
+  if (typeof value.sign !== 'function') fail('IDENTITY_KEY_SIGNER_REQUIRED');
+
+  const kid = assertKeyId(value.kid, 'IDENTITY_KEY_ID_INVALID');
+  const status = value.status === undefined ? expectedStatus : value.status;
+  if (!KEY_STATUSES.has(status) || status !== expectedStatus) fail('IDENTITY_KEY_STATUS_INVALID');
+  const notBefore = value.notBefore === undefined ? null : assertEpochSeconds(value.notBefore, 'IDENTITY_KEY_NOT_BEFORE_INVALID');
+  const notAfter = value.notAfter === undefined ? null : assertEpochSeconds(value.notAfter, 'IDENTITY_KEY_NOT_AFTER_INVALID');
+  if (notBefore !== null && notAfter !== null && notAfter <= notBefore) fail('IDENTITY_KEY_WINDOW_INVALID');
+
+  return Object.freeze({ kid, sign: value.sign, status, notBefore, notAfter });
+}
+
+function publicKeyMetadata(key) {
+  return Object.freeze({
+    kid: key.kid,
+    status: key.status,
+    notBefore: key.notBefore,
+    notAfter: key.notAfter,
+  });
+}
+
+/**
+ * Creates an in-memory key lifecycle state machine for synthetic tests and
+ * local integration. Production must replace it with a durable Identity-owned
+ * registry/custody adapter. A key record carries only a signer callback; raw
+ * private key bytes, PEM/JWK material and secrets are deliberately rejected.
+ */
+export function createCrmIdentityDeliveryKeyRing({ active, overlap = [] } = {}) {
+  const activeKey = normalizeKeyRecord(active, 'active');
+  if (!Array.isArray(overlap)) fail('IDENTITY_KEY_OVERLAP_INVALID');
+
+  const records = new Map([[activeKey.kid, activeKey]]);
+  for (const candidate of overlap) {
+    const key = normalizeKeyRecord(candidate, 'overlap');
+    if (records.has(key.kid)) fail('IDENTITY_KEY_DUPLICATE');
+    records.set(key.kid, key);
+  }
+
+  let currentKid = activeKey.kid;
+
+  function current() {
+    return records.get(currentKid);
+  }
+
+  const ring = {
+    getActiveKey({ nowSeconds } = {}) {
+      const now = assertEpochSeconds(nowSeconds, 'IDENTITY_NOW_INVALID');
+      const key = current();
+      if (!key || key.status === 'revoked') fail('IDENTITY_SIGNING_KEY_REVOKED');
+      if (key.status !== 'active') fail('IDENTITY_SIGNING_KEY_UNAVAILABLE');
+      if (key.notBefore !== null && now < key.notBefore) fail('IDENTITY_SIGNING_KEY_NOT_YET_VALID');
+      if (key.notAfter !== null && now >= key.notAfter) fail('IDENTITY_SIGNING_KEY_EXPIRED');
+      return key;
+    },
+
+    isRevoked(kid) {
+      const key = records.get(assertKeyId(kid));
+      return key?.status === 'revoked';
+    },
+
+    list() {
+      return Object.freeze([...records.values()].map(publicKeyMetadata));
+    },
+
+    rotate(next) {
+      const nextKey = normalizeKeyRecord(next, 'active');
+      if (records.has(nextKey.kid)) fail('IDENTITY_KEY_DUPLICATE');
+      const previous = current();
+      records.set(previous.kid, Object.freeze({ ...previous, status: 'overlap' }));
+      records.set(nextKey.kid, nextKey);
+      currentKid = nextKey.kid;
+      return publicKeyMetadata(nextKey);
+    },
+
+    revoke(kid) {
+      const normalizedKid = assertKeyId(kid);
+      const key = records.get(normalizedKid);
+      if (!key) fail('IDENTITY_KEY_UNKNOWN');
+      if (normalizedKid === currentKid) fail('IDENTITY_KEY_ACTIVE_REQUIRES_ROTATION');
+      records.set(normalizedKid, Object.freeze({ ...key, status: 'revoked' }));
+      return publicKeyMetadata(records.get(normalizedKid));
+    },
+  };
+
+  return Object.freeze(ring);
+}
+
+function assertContractAdapter(contract) {
+  if (!contract || typeof contract !== 'object' || Array.isArray(contract)
+    || ![Object.prototype, null].includes(Object.getPrototypeOf(contract))) {
+    fail('IDENTITY_CRM_CONTRACT_UNAVAILABLE');
+  }
+  if (typeof contract.createIdentityCrmDeliverySigningInput !== 'function') {
+    fail('IDENTITY_CRM_CONTRACT_SIGNING_INPUT_UNAVAILABLE');
+  }
+  if (typeof contract.assertIdentityCrmDeliveryHeader !== 'function'
+    || typeof contract.assertIdentityCrmDeliveryClaims !== 'function') {
+    fail('IDENTITY_CRM_CONTRACT_VALIDATORS_UNAVAILABLE');
+  }
+  if (contract.IDENTITY_CRM_DELIVERY_VERSION !== IDENTITY_CRM_DELIVERY_VERSION
+    || contract.IDENTITY_CRM_DELIVERY_ISSUER !== IDENTITY_CRM_DELIVERY_ISSUER
+    || contract.IDENTITY_CRM_DELIVERY_AUDIENCE !== IDENTITY_CRM_DELIVERY_AUDIENCE
+    || contract.IDENTITY_CRM_DELIVERY_ALGORITHM !== IDENTITY_CRM_DELIVERY_ALGORITHM
+    || contract.IDENTITY_CRM_DELIVERY_TYPE !== IDENTITY_CRM_DELIVERY_TYPE) {
+    fail('IDENTITY_CRM_CONTRACT_MISMATCH');
+  }
+  return contract;
+}
+
+function nowProvider(value) {
+  if (value === undefined) return () => Math.floor(Date.now() / 1000);
+  if (typeof value === 'function') return value;
+  const fixed = assertEpochSeconds(value, 'IDENTITY_NOW_INVALID');
+  return () => fixed;
+}
+
+function defaultJti() {
+  const randomUUID = globalThis.crypto?.randomUUID;
+  if (typeof randomUUID !== 'function') fail('IDENTITY_JTI_RANDOM_UNAVAILABLE');
+  return String(randomUUID.call(globalThis.crypto)).replace(/-/g, '_');
+}
+
+function normalizeSignature(value) {
+  if (value instanceof Uint8Array) return new Uint8Array(value);
+  if (value instanceof ArrayBuffer) return new Uint8Array(value.slice(0));
+  if (ArrayBuffer.isView(value)) return new Uint8Array(value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength));
+  fail('IDENTITY_SIGNATURE_INVALID');
+}
+
+function assertEd25519PrivateKey(value) {
+  if (!value || typeof value !== 'object' || value.type !== 'private' || value.algorithm?.name !== 'Ed25519'
+    || value.extractable !== false || !Array.isArray(value.usages) || !value.usages.includes('sign')) {
+    fail('IDENTITY_ED25519_PRIVATE_KEY_INVALID');
+  }
+  return value;
+}
+
+/**
+ * Adapts a non-exportable WebCrypto Ed25519 key to the key-ring callback.
+ * The key never crosses the callback boundary as bytes, PEM or JWK.
+ */
+export function createCrmIdentityEd25519Signer(privateKey) {
+  const key = assertEd25519PrivateKey(privateKey);
+  return async (signingInput) => {
+    if (typeof signingInput !== 'string' || !signingInput) fail('IDENTITY_SIGNING_INPUT_INVALID');
+    const subtle = globalThis.crypto?.subtle;
+    if (!subtle || typeof subtle.sign !== 'function') fail('IDENTITY_SIGNING_CRYPTO_UNAVAILABLE');
+    return new Uint8Array(await subtle.sign(
+      { name: 'Ed25519' },
+      key,
+      TEXT_ENCODER.encode(signingInput),
+    ));
+  };
+}
+
+/**
+ * Projects an authenticated Identity actor into the exact minimized shape
+ * accepted by the delivery contract. PII and compatibility aliases are
+ * intentionally ignored, while a missing opaque subject fails closed.
+ */
+export function projectCrmIdentityActor(actor) {
+  assertPlainObject(actor, 'IDENTITY_ACTOR_REQUIRED');
+  if (!Object.prototype.hasOwnProperty.call(actor, 'identitySubject')
+    || !Object.prototype.hasOwnProperty.call(actor, 'role')
+    || !Object.prototype.hasOwnProperty.call(actor, 'scopes')) {
+    fail('IDENTITY_ACTOR_REQUIRED');
+  }
+  return Object.freeze({
+    identitySubject: actor.identitySubject,
+    role: actor.role,
+    scopes: actor.scopes,
+  });
+}
+
+function encodeBase64Url(bytes) {
+  if (typeof btoa !== 'function') fail('IDENTITY_BASE64URL_UNAVAILABLE');
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function assertSignerResult(value) {
+  const signature = normalizeSignature(value);
+  if (signature.byteLength !== 64) fail('IDENTITY_SIGNATURE_LENGTH_INVALID');
+  return signature;
+}
+
+function assertReplayAdapter(replay) {
+  if (replay === undefined) return null;
+  assertPlainObject(replay, 'IDENTITY_REPLAY_ADAPTER_INVALID');
+  if (typeof replay.reserve !== 'function') fail('IDENTITY_REPLAY_RESERVE_UNAVAILABLE');
+  return replay;
+}
+
+/**
+ * Builds the issuer boundary without owning routing, sessions, persistence or
+ * key custody. The exact private contracts package is the default canonical
+ * signing-input validator. An explicit adapter is accepted only for isolated
+ * contract tests and is checked against fixed identity-crm-delivery constants.
+ *
+ * `keyRing` returns a signer callback backed by an external non-exportable
+ * CryptoKey/secret manager. This module never accepts or serializes private
+ * key material. `replay.reserve`, when supplied, is an optional issuer-side
+ * uniqueness guard; CRM's durable atomic jti ledger remains mandatory for the
+ * recipient and is not replaced by this process-local boundary.
+ */
+export function createCrmIdentityDeliveryIssuer(options = {}) {
+  assertPlainObject(options, 'IDENTITY_CRM_ISSUER_OPTIONS_INVALID');
+  const allowedKeys = ['enabled', 'contracts', 'keyRing', 'nowSeconds', 'clockSkewSeconds', 'jtiFactory', 'replay'];
+  const keys = Reflect.ownKeys(options);
+  if (keys.some((key) => typeof key !== 'string' || !allowedKeys.includes(key))) fail('IDENTITY_CRM_ISSUER_OPTIONS_INVALID');
+
+  const enabled = options.enabled === true;
+  const clockSkewSeconds = assertClockSkew(options.clockSkewSeconds ?? 0);
+  const nowSeconds = nowProvider(options.nowSeconds);
+
+  if (!enabled) {
+    return Object.freeze({
+      async issue() {
+        fail('IDENTITY_CRM_DELIVERY_DISABLED');
+      },
+      status() {
+        return Object.freeze({ enabled: false, issuer: IDENTITY_CRM_DELIVERY_ISSUER, audience: IDENTITY_CRM_DELIVERY_AUDIENCE });
+      },
+    });
+  }
+
+  // The pinned published package is the default. Keeping an explicit override
+  // only for isolated tests lets a future WorkerEntrypoint inject an adapter
+  // while preventing a mutable or undeclared wire-contract implementation.
+  const contracts = assertContractAdapter(options.contracts ?? publishedIdentityCrmDeliveryContract);
+  const keyRing = options.keyRing;
+  if (!keyRing || typeof keyRing.getActiveKey !== 'function' || typeof keyRing.isRevoked !== 'function') {
+    fail('IDENTITY_KEY_RING_UNAVAILABLE');
+  }
+  const replay = assertReplayAdapter(options.replay);
+  const jtiFactory = options.jtiFactory === undefined ? defaultJti : options.jtiFactory;
+  if (typeof jtiFactory !== 'function') fail('IDENTITY_JTI_FACTORY_UNAVAILABLE');
+
+  return Object.freeze({
+    async issue(input = {}) {
+      assertPlainObject(input, 'IDENTITY_CRM_ISSUER_INPUT_INVALID');
+      const inputKeys = ['identity', 'request', 'issuedAt', 'ttlSeconds', 'jti'];
+      const ownKeys = Reflect.ownKeys(input);
+      if (ownKeys.some((key) => typeof key !== 'string' || !inputKeys.includes(key))) fail('IDENTITY_CRM_ISSUER_INPUT_INVALID');
+      if (!Object.prototype.hasOwnProperty.call(input, 'request')) fail('IDENTITY_REQUEST_REQUIRED');
+
+      const now = assertEpochSeconds(await nowSeconds(), 'IDENTITY_NOW_INVALID');
+      const issuedAt = input.issuedAt === undefined ? now : assertEpochSeconds(input.issuedAt, 'IDENTITY_ISSUED_AT_INVALID');
+      const ttlSeconds = input.ttlSeconds === undefined ? IDENTITY_CRM_DELIVERY_MAX_TTL_SECONDS : assertEpochSeconds(input.ttlSeconds, 'IDENTITY_TTL_INVALID');
+      if (ttlSeconds < 1 || ttlSeconds > IDENTITY_CRM_DELIVERY_MAX_TTL_SECONDS) fail('IDENTITY_TTL_INVALID');
+      if (issuedAt > now + clockSkewSeconds) fail('IDENTITY_ISSUED_AT_IN_FUTURE');
+      const expiresAt = issuedAt + ttlSeconds;
+      if (expiresAt <= now - clockSkewSeconds) fail('IDENTITY_DELIVERY_EXPIRED');
+
+      const jti = assertJti(input.jti === undefined ? await jtiFactory() : input.jti);
+      const key = keyRing.getActiveKey({ nowSeconds: now });
+      if (!key || typeof key !== 'object') fail('IDENTITY_SIGNING_KEY_UNAVAILABLE');
+      const keyId = assertKeyId(key.kid);
+      if (keyRing.isRevoked(keyId)) fail('IDENTITY_SIGNING_KEY_REVOKED');
+      if (typeof key.sign !== 'function') fail('IDENTITY_KEY_SIGNER_REQUIRED');
+
+      const prepared = prepareCrmIdentityDeliveryV1({
+        enabled: true,
+        identity: projectCrmIdentityActor(input.identity),
+        requestBinding: await requestBindingFromRequest(input.request),
+        issuedAt,
+        ttlSeconds,
+        jti,
+        keyId,
+      });
+
+      contracts.assertIdentityCrmDeliveryHeader(prepared.protectedHeader);
+      contracts.assertIdentityCrmDeliveryClaims(prepared.claims);
+
+      const signingInput = await contracts.createIdentityCrmDeliverySigningInput({
+        protectedHeader: prepared.protectedHeader,
+        claims: prepared.claims,
+      });
+      if (typeof signingInput !== 'string' || signingInput.length < 32) fail('IDENTITY_SIGNING_INPUT_INVALID');
+
+      const signature = assertSignerResult(await key.sign(signingInput));
+
+      if (replay) {
+        const reservation = await replay.reserve({
+          jti,
+          issuer: IDENTITY_CRM_DELIVERY_ISSUER,
+          audience: IDENTITY_CRM_DELIVERY_AUDIENCE,
+          expiresAt: new Date(expiresAt * 1000).toISOString(),
+        });
+        if (reservation !== 'reserved') fail('IDENTITY_JTI_REPLAY');
+      }
+
+      const compact = `${signingInput}.${encodeBase64Url(signature)}`;
+      return Object.freeze({
+        compact,
+        protectedHeader: prepared.protectedHeader,
+        claims: prepared.claims,
+        keyId,
+      });
+    },
+    status() {
+      return Object.freeze({ enabled: true, issuer: IDENTITY_CRM_DELIVERY_ISSUER, audience: IDENTITY_CRM_DELIVERY_AUDIENCE });
+    },
+  });
+}
+
+export {
+  IDENTITY_CRM_DELIVERY_ALGORITHM,
+  IDENTITY_CRM_DELIVERY_AUDIENCE,
+  IDENTITY_CRM_DELIVERY_ISSUER,
+  IDENTITY_CRM_DELIVERY_MAX_TTL_SECONDS,
+  IDENTITY_CRM_DELIVERY_TYPE,
+  IDENTITY_CRM_DELIVERY_VERSION,
+};

--- a/identity/package-lock.json
+++ b/identity/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "@skincos/identity",
+  "version": "0.0.0-precut",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@skincos/identity",
+      "version": "0.0.0-precut",
+      "dependencies": {
+        "@jubenitogarcia/skincos-identity-contracts": "0.2.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@jubenitogarcia/skincos-identity-contracts": {
+      "version": "0.2.2",
+      "resolved": "https://npm.pkg.github.com/download/@jubenitogarcia/skincos-identity-contracts/0.2.2/caacbec5a23bf0e6d3ec0195925f182d7d63f840",
+      "integrity": "sha512-xktTNpG+3gMum/1wpXvQSLh+7btjntlzMISShNL3+OP8agNLO5y4X3GwAZN6UixWaH428At9ZqUnmr4Qdkbo3A==",
+      "license": "UNLICENSED",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    }
+  }
+}

--- a/identity/package.json
+++ b/identity/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@skincos/identity",
   "private": true,
+  "version": "0.0.0-precut",
   "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "dependencies": {
+    "@jubenitogarcia/skincos-identity-contracts": "0.2.2"
+  },
   "scripts": {
     "test": "node --test test/*.test.mjs"
   }

--- a/identity/test/crm-envelope-v1.test.mjs
+++ b/identity/test/crm-envelope-v1.test.mjs
@@ -18,7 +18,7 @@ const baseInput = Object.freeze({
     scopes: Object.freeze({
       units: Object.freeze(['novo-hamburgo']),
       modules: Object.freeze(['clients', 'finance']),
-      permissions: Object.freeze(['module.clients.access', 'module.finance.access']),
+      permissions: Object.freeze(['module:clients:access', 'module:finance:access']),
     }),
   }),
   requestBinding: Object.freeze({
@@ -59,7 +59,7 @@ test('the preparation returns only the minimized Identity CRM delivery input', (
     scopes: {
       units: ['novo-hamburgo'],
       modules: ['clients', 'finance'],
-      permissions: ['module.clients.access', 'module.finance.access'],
+      permissions: ['module:clients:access', 'module:finance:access'],
     },
     iat: 1788292800,
     exp: 1788292860,
@@ -122,7 +122,7 @@ test('the preparation rejects hidden, symbolic, inherited and accessor input fie
 });
 
 test('the preparation snapshots scope array data before validation and output', () => {
-  const source = ['module.clients.access'];
+  const source = ['module:clients:access'];
   let indexGets = 0;
   const proxied = new Proxy(source, {
     get(target, property, receiver) {
@@ -133,11 +133,11 @@ test('the preparation snapshots scope array data before validation and output', 
   const prepared = prepareCrmIdentityDeliveryV1(input({
     identity: { ...baseInput.identity, scopes: { ...baseInput.identity.scopes, permissions: proxied } },
   }));
-  assert.deepEqual(prepared.claims.scopes.permissions, ['module.clients.access']);
+  assert.deepEqual(prepared.claims.scopes.permissions, ['module:clients:access']);
   assert.equal(indexGets, 0);
 
   const accessorScope = [];
-  Object.defineProperty(accessorScope, '0', { enumerable: true, get: () => 'module.clients.access' });
+  Object.defineProperty(accessorScope, '0', { enumerable: true, get: () => 'module:clients:access' });
   assert.throws(() => prepareCrmIdentityDeliveryV1(input({
     identity: { ...baseInput.identity, scopes: { ...baseInput.identity.scopes, permissions: accessorScope } },
   })), /IDENTITY_SCOPE_PERMISSIONS_INVALID/);

--- a/identity/test/crm-issuer-staging-worker.test.mjs
+++ b/identity/test/crm-issuer-staging-worker.test.mjs
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { webcrypto } from 'node:crypto';
+import test from 'node:test';
+
+import * as deliveryContract from '@jubenitogarcia/skincos-identity-contracts/identity-crm-delivery';
+import { handleIdentityCrmIssuerStagingRequest } from '../delivery/crm-issuer-staging-worker.js';
+
+if (!globalThis.crypto) Object.defineProperty(globalThis, 'crypto', { value: webcrypto, configurable: true });
+
+const issueUrl = 'https://identity-crm-delivery-staging.example/internal/identity-crm-delivery/v1/issue';
+const keysUrl = 'https://identity-crm-delivery-staging.example/.well-known/identity-crm-delivery/v1/keys';
+const secret = 'synthetic-staging-request-hmac-secret-2026';
+
+function encodeBase64Url(bytes) {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+async function authHeader(body) {
+  const key = await webcrypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await webcrypto.subtle.sign('HMAC', key, new TextEncoder().encode(body));
+  return encodeBase64Url(new Uint8Array(signature));
+}
+
+async function stagingEnv() {
+  const pair = await webcrypto.subtle.generateKey({ name: 'Ed25519' }, true, ['sign', 'verify']);
+  const privateJwk = await webcrypto.subtle.exportKey('jwk', pair.privateKey);
+  const publicJwk = await webcrypto.subtle.exportKey('jwk', pair.publicKey);
+  const publicKey = { kty: 'OKP', crv: 'Ed25519', x: publicJwk.x, alg: 'EdDSA', use: 'sig' };
+  const privateKey = { kty: 'OKP', crv: 'Ed25519', x: privateJwk.x, d: privateJwk.d, alg: 'EdDSA', key_ops: ['sign'], ext: false };
+  return {
+    pair,
+    env: {
+      IDENTITY_CRM_DELIVERY_ENABLED: 'true',
+      IDENTITY_CRM_DELIVERY_ENVIRONMENT: 'staging',
+      IDENTITY_CRM_DELIVERY_KID: 'identity-staging-2026-09',
+      IDENTITY_CRM_DELIVERY_PRIVATE_JWK: JSON.stringify(privateKey),
+      IDENTITY_CRM_DELIVERY_PUBLIC_JWK: JSON.stringify(publicKey),
+      IDENTITY_CRM_DELIVERY_REQUEST_HMAC: secret,
+    },
+    publicKey,
+  };
+}
+
+function issuePayload() {
+  return {
+    identity: {
+      identitySubject: 'idn:fixture_identity_actor_0001',
+      role: 'GESTOR',
+      scopes: {
+        units: ['novo-hamburgo'],
+        modules: ['clients'],
+        permissions: ['clients:read'],
+      },
+    },
+    request: {
+      method: 'POST',
+      target: '/api/crm/leads',
+      bodyBase64: encodeBase64Url(new TextEncoder().encode('{"lead":"staging"}')),
+    },
+    jti: 'staging_nonce_0000001',
+  };
+}
+
+test('staging issuer is disabled unless the explicit staging flag is enabled', async () => {
+  const response = await handleIdentityCrmIssuerStagingRequest(
+    new Request(issueUrl, { method: 'POST', body: '{}' }),
+    { IDENTITY_CRM_DELIVERY_ENABLED: 'false', IDENTITY_CRM_DELIVERY_ENVIRONMENT: 'staging' },
+  );
+  assert.equal(response.status, 503);
+  assert.match(await response.text(), /IDENTITY_CRM_DELIVERY_DISABLED/);
+});
+
+test('staging manifest has no production route or data binding and keeps signing disabled', async () => {
+  const manifest = await readFile(new URL('../wrangler.staging.toml', import.meta.url), 'utf8');
+  assert.match(manifest, /IDENTITY_CRM_DELIVERY_ENABLED\s*=\s*"false"/);
+  assert.doesNotMatch(manifest, /^routes\s*=/m);
+  assert.doesNotMatch(manifest, /^\[\[d1_databases\]\]/m);
+  assert.doesNotMatch(manifest, /^\[\[kv_namespaces\]\]/m);
+  assert.doesNotMatch(manifest, /^\[\[r2_buckets\]\]/m);
+});
+
+test('staging service surface publishes only the public key and signs an authenticated request', async () => {
+  const { env, pair, publicKey } = await stagingEnv();
+  const payload = JSON.stringify(issuePayload());
+  const auth = await authHeader(payload);
+  const response = await handleIdentityCrmIssuerStagingRequest(new Request(issueUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-skincos-identity-issuer-auth': auth },
+    body: payload,
+  }), env);
+
+  assert.equal(response.status, 200);
+  const result = await response.json();
+  assert.equal(result.ok, true);
+  assert.equal(result.version, 'identity-crm-delivery/v1');
+  assert.equal(result.keyId, env.IDENTITY_CRM_DELIVERY_KID);
+  assert.doesNotMatch(JSON.stringify(result), /private|email|username|cookie|session|"d"/i);
+
+  const keysResponse = await handleIdentityCrmIssuerStagingRequest(new Request(keysUrl), env);
+  assert.equal(keysResponse.status, 200);
+  const keyDocument = await keysResponse.json();
+  assert.deepEqual(keyDocument, {
+    version: 'identity-crm-delivery/v1',
+    keys: [{ ...publicKey, kid: env.IDENTITY_CRM_DELIVERY_KID }],
+  });
+  assert.equal(Object.hasOwn(keyDocument.keys[0], 'd'), false);
+
+  const parsed = deliveryContract.parseIdentityCrmDeliveryCompact(result.compact);
+  const importedPublic = await webcrypto.subtle.importKey('jwk', publicKey, { name: 'Ed25519' }, false, ['verify']);
+  assert.equal(await webcrypto.subtle.verify(
+    { name: 'Ed25519' },
+    importedPublic,
+    parsed.signature,
+    new TextEncoder().encode(parsed.signingInput),
+  ), true);
+
+  const head = await handleIdentityCrmIssuerStagingRequest(new Request(keysUrl, { method: 'HEAD' }), env);
+  assert.equal(head.status, 200);
+  assert.equal(await head.text(), '');
+  assert.equal(pair.publicKey.type, 'public');
+});
+
+test('staging issue endpoint rejects unauthenticated callers and unknown routes', async () => {
+  const { env } = await stagingEnv();
+  const payload = JSON.stringify(issuePayload());
+  const unauthenticated = await handleIdentityCrmIssuerStagingRequest(new Request(issueUrl, { method: 'POST', body: payload }), env);
+  assert.equal(unauthenticated.status, 401);
+
+  const wrongAuth = await handleIdentityCrmIssuerStagingRequest(new Request(issueUrl, {
+    method: 'POST',
+    headers: { 'x-skincos-identity-issuer-auth': encodeBase64Url(new Uint8Array(32)) },
+    body: payload,
+  }), env);
+  assert.equal(wrongAuth.status, 401);
+
+  const unknown = await handleIdentityCrmIssuerStagingRequest(new Request('https://identity-crm-delivery-staging.example/internal/other', { method: 'POST' }), env);
+  assert.equal(unknown.status, 404);
+});

--- a/identity/test/crm-issuer-v1.test.mjs
+++ b/identity/test/crm-issuer-v1.test.mjs
@@ -1,0 +1,241 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import * as identityDeliveryContract from '@jubenitogarcia/skincos-identity-contracts/identity-crm-delivery';
+import {
+  IDENTITY_CRM_DELIVERY_AUDIENCE,
+  IDENTITY_CRM_DELIVERY_ISSUER,
+  IDENTITY_CRM_DELIVERY_TYPE,
+  IDENTITY_CRM_DELIVERY_VERSION,
+  createCrmIdentityDeliveryIssuer,
+  createCrmIdentityDeliveryKeyRing,
+  createCrmIdentityEd25519Signer,
+  projectCrmIdentityActor,
+} from '../delivery/crm-issuer-v1.js';
+
+const nowSeconds = 1_788_292_800;
+const baseInput = Object.freeze({
+  identity: Object.freeze({
+    identitySubject: 'idn:fixture_identity_actor_0001',
+    role: 'GESTOR',
+    scopes: Object.freeze({
+      units: Object.freeze(['novo-hamburgo']),
+      modules: Object.freeze(['clients', 'finance']),
+      permissions: Object.freeze(['clients:read', 'finance:read']),
+    }),
+  }),
+  request: Object.freeze({
+    method: 'POST',
+    target: '/api/crm/leads?unit=novo-hamburgo',
+    body: 'fixture-body',
+  }),
+});
+
+async function keyPair(extractable = false) {
+  return crypto.subtle.generateKey({ name: 'Ed25519' }, extractable, ['sign', 'verify']);
+}
+
+async function keyRecord(kid, privateKey) {
+  return { kid, sign: createCrmIdentityEd25519Signer(privateKey) };
+}
+
+test('issuer is fail-closed and disabled without requiring contracts, keys or secrets', async () => {
+  const issuer = createCrmIdentityDeliveryIssuer();
+  assert.deepEqual(issuer.status(), {
+    enabled: false,
+    issuer: IDENTITY_CRM_DELIVERY_ISSUER,
+    audience: IDENTITY_CRM_DELIVERY_AUDIENCE,
+  });
+  await assert.rejects(() => issuer.issue(baseInput), /IDENTITY_CRM_DELIVERY_DISABLED/);
+});
+
+test('issuer projects only an opaque actor and emits a compact EdDSA envelope', async () => {
+  const pair = await keyPair();
+  const keyRing = createCrmIdentityDeliveryKeyRing({ active: await keyRecord('identity-test-2026-09', pair.privateKey) });
+  const issuer = createCrmIdentityDeliveryIssuer({
+    enabled: true,
+    keyRing,
+    nowSeconds,
+    jtiFactory: () => 'fixture_nonce_00000001',
+  });
+
+  assert.deepEqual(projectCrmIdentityActor({ ...baseInput.identity, username: 'pilot', email: 'pilot@example.test' }), baseInput.identity);
+  const result = await issuer.issue(baseInput);
+  const segments = result.compact.split('.');
+  assert.equal(segments.length, 3);
+  assert.equal(result.keyId, 'identity-test-2026-09');
+  assert.deepEqual(result.protectedHeader, {
+    alg: 'EdDSA',
+    kid: 'identity-test-2026-09',
+    typ: IDENTITY_CRM_DELIVERY_TYPE,
+  });
+  assert.equal(result.claims.iss, IDENTITY_CRM_DELIVERY_ISSUER);
+  assert.equal(result.claims.aud, IDENTITY_CRM_DELIVERY_AUDIENCE);
+  assert.equal(result.claims.sub, baseInput.identity.identitySubject);
+  assert.equal(result.claims.iat, nowSeconds);
+  assert.equal(result.claims.exp, nowSeconds + 60);
+  assert.equal(result.claims.bdh, 'c7183c384504fd060c8a5d4b1b6545b830716de8bffbdc2989923a2244f6697d');
+  assert.doesNotMatch(result.compact, /pilot@example|username|displayName|cookie|session/i);
+
+  const padding = '='.repeat((4 - (segments[2].length % 4)) % 4);
+  const signature = Uint8Array.from(atob(segments[2].replace(/-/g, '+').replace(/_/g, '/') + padding), (char) => char.charCodeAt(0));
+  const verified = await crypto.subtle.verify(
+    { name: 'Ed25519' },
+    pair.publicKey,
+    signature,
+    new TextEncoder().encode(`${segments[0]}.${segments[1]}`),
+  );
+  assert.equal(verified, true);
+});
+
+test('issuer binds the actual method, target and body bytes before signing', async () => {
+  const pair = await keyPair();
+  const keyRing = createCrmIdentityDeliveryKeyRing({ active: await keyRecord('identity-test-request', pair.privateKey) });
+  const issuer = createCrmIdentityDeliveryIssuer({
+    enabled: true,
+    keyRing,
+    nowSeconds,
+    jtiFactory: () => 'fixture_nonce_request_0001',
+  });
+
+  const result = await issuer.issue({
+    ...baseInput,
+    request: { method: ' post ', target: '/api/crm/leads', body: new Uint8Array([1, 2, 3]) },
+  });
+  assert.equal(result.claims.htm, 'POST');
+  assert.equal(result.claims.htu, '/api/crm/leads');
+  assert.equal(result.claims.bdh, '039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81');
+
+  await assert.rejects(() => issuer.issue({
+    ...baseInput,
+    requestBinding: { method: 'POST', target: '/api/crm/leads', bodyDigest: 'a'.repeat(64) },
+  }), /IDENTITY_CRM_ISSUER_INPUT_INVALID/);
+  await assert.rejects(() => issuer.issue({
+    ...baseInput,
+    request: { method: 'TRACE', target: '/api/crm/leads', body: '' },
+  }), /IDENTITY_REQUEST_METHOD_INVALID/);
+  await assert.rejects(() => issuer.issue({
+    ...baseInput,
+    request: { method: 'POST', target: 'https://crm.example.test/api/crm/leads', body: '' },
+  }), /CRM_TARGET_INVALID/);
+  await assert.rejects(() => issuer.issue({
+    ...baseInput,
+    request: { method: 'POST', target: '/api/crm/leads', body: { hidden: true } },
+  }), /IDENTITY_REQUEST_BODY_INVALID/);
+});
+
+test('issuer enforces clock skew, TTL and opaque identity subject before signing', async () => {
+  const pair = await keyPair();
+  const keyRing = createCrmIdentityDeliveryKeyRing({ active: await keyRecord('identity-test-2026-09', pair.privateKey) });
+  const issuer = createCrmIdentityDeliveryIssuer({
+    enabled: true,
+    keyRing,
+    nowSeconds,
+    clockSkewSeconds: 5,
+    jtiFactory: () => 'fixture_nonce_00000002',
+  });
+
+  await assert.rejects(() => issuer.issue({ ...baseInput, issuedAt: nowSeconds + 6 }), /IDENTITY_ISSUED_AT_IN_FUTURE/);
+  await assert.rejects(() => issuer.issue({ ...baseInput, issuedAt: nowSeconds - 6, ttlSeconds: 1 }), /IDENTITY_DELIVERY_EXPIRED/);
+  await assert.rejects(() => issuer.issue({ ...baseInput, identity: { ...baseInput.identity, identitySubject: 'pilot' } }), /IDENTITY_SUBJECT_REQUIRED/);
+  await assert.rejects(() => issuer.issue({ ...baseInput, ttlSeconds: 61 }), /IDENTITY_TTL_INVALID/);
+});
+
+test('key ring rotates active kid and refuses active, unknown, revoked and exportable keys', async () => {
+  const first = await keyPair();
+  const second = await keyPair();
+  const third = await keyPair();
+  const keyRing = createCrmIdentityDeliveryKeyRing({ active: await keyRecord('identity-key-a', first.privateKey) });
+  const issuer = (jti) => createCrmIdentityDeliveryIssuer({
+    enabled: true,
+    keyRing,
+    nowSeconds,
+    jtiFactory: () => jti,
+  });
+
+  assert.equal((await issuer('fixture_nonce_key_a').issue(baseInput)).keyId, 'identity-key-a');
+  assert.equal(keyRing.rotate(await keyRecord('identity-key-b', second.privateKey)).kid, 'identity-key-b');
+  assert.equal((await issuer('fixture_nonce_key_b').issue(baseInput)).keyId, 'identity-key-b');
+  assert.equal(keyRing.list().find((key) => key.kid === 'identity-key-a').status, 'overlap');
+  assert.throws(() => keyRing.revoke('identity-key-b'), /IDENTITY_KEY_ACTIVE_REQUIRES_ROTATION/);
+  assert.equal(keyRing.rotate(await keyRecord('identity-key-c', third.privateKey)).kid, 'identity-key-c');
+  assert.equal(keyRing.revoke('identity-key-b').status, 'revoked');
+  assert.equal((await issuer('fixture_nonce_key_c').issue(baseInput)).keyId, 'identity-key-c');
+  assert.throws(() => keyRing.revoke('identity-key-unknown'), /IDENTITY_KEY_UNKNOWN/);
+
+  const extractable = await keyPair(true);
+  assert.throws(() => createCrmIdentityEd25519Signer(extractable.privateKey), /IDENTITY_ED25519_PRIVATE_KEY_INVALID/);
+  assert.throws(() => createCrmIdentityDeliveryKeyRing({ active: { kid: 'identity-key-a', privateKey: 'never', sign() {} } }), /IDENTITY_KEY_RECORD_INVALID/);
+});
+
+test('issuer requires an atomic replay reservation when a replay adapter is supplied', async () => {
+  const pair = await keyPair();
+  const keyRing = createCrmIdentityDeliveryKeyRing({ active: await keyRecord('identity-test-2026-09', pair.privateKey) });
+  const calls = [];
+  const issuer = createCrmIdentityDeliveryIssuer({
+    enabled: true,
+    keyRing,
+    nowSeconds,
+    jtiFactory: () => 'fixture_nonce_replay_0001',
+    replay: { reserve: async (receipt) => { calls.push(receipt); return 'reserved'; } },
+  });
+
+  await issuer.issue(baseInput);
+  assert.deepEqual(calls, [{
+    jti: 'fixture_nonce_replay_0001',
+    issuer: IDENTITY_CRM_DELIVERY_ISSUER,
+    audience: IDENTITY_CRM_DELIVERY_AUDIENCE,
+    expiresAt: new Date((nowSeconds + 60) * 1000).toISOString(),
+  }]);
+
+  const replayed = createCrmIdentityDeliveryIssuer({
+    enabled: true,
+    keyRing,
+    nowSeconds,
+    jtiFactory: () => 'fixture_nonce_replay_0002',
+    replay: { reserve: async () => 'replayed' },
+  });
+  await assert.rejects(() => replayed.issue(baseInput), /IDENTITY_JTI_REPLAY/);
+});
+
+test('issuer refuses a contract adapter that is not the pinned identity-crm-delivery contract', () => {
+  return keyPair().then(async (pair) => {
+    const keyRing = createCrmIdentityDeliveryKeyRing({ active: await keyRecord('identity-test-2026-09', pair.privateKey) });
+    assert.throws(() => createCrmIdentityDeliveryIssuer({
+      enabled: true,
+      contracts: { ...identityDeliveryContract, IDENTITY_CRM_DELIVERY_AUDIENCE: 'wrong-audience' },
+      keyRing,
+      nowSeconds,
+    }), /IDENTITY_CRM_CONTRACT_MISMATCH/);
+  });
+});
+
+test('issuer output round-trips through the pinned published contract when installed', async (t) => {
+  let contracts;
+  try {
+    contracts = await import('@jubenitogarcia/skincos-identity-contracts/identity-crm-delivery');
+  } catch {
+    t.skip('private contract package is installed by the dedicated CI workflow');
+    return;
+  }
+
+  const pair = await keyPair();
+  const keyRing = createCrmIdentityDeliveryKeyRing({ active: await keyRecord('identity-published-2026', pair.privateKey) });
+  const issuer = createCrmIdentityDeliveryIssuer({
+    enabled: true,
+    contracts,
+    keyRing,
+    nowSeconds,
+    jtiFactory: () => 'fixture_nonce_published_01',
+  });
+  const result = await issuer.issue(baseInput);
+  const parsed = contracts.parseIdentityCrmDeliveryCompact(result.compact, { nowSeconds });
+  assert.equal(parsed.claims.iss, IDENTITY_CRM_DELIVERY_ISSUER);
+  assert.equal(parsed.claims.aud, IDENTITY_CRM_DELIVERY_AUDIENCE);
+  assert.equal(await crypto.subtle.verify(
+    { name: 'Ed25519' },
+    pair.publicKey,
+    parsed.signature,
+    new TextEncoder().encode(parsed.signingInput),
+  ), true);
+});

--- a/identity/wrangler.staging.toml
+++ b/identity/wrangler.staging.toml
@@ -1,0 +1,29 @@
+# Source-only staging manifest for the Identity-owned CRM delivery signer.
+# It intentionally has no production route, workers.dev URL, D1/KV/R2 binding,
+# or secret value. A later staging publication must use a service binding from
+# CRM and explicit environment secrets; this file alone cannot activate signing.
+name = "skincos-identity-crm-delivery"
+main = "delivery/crm-issuer-staging-worker.js"
+compatibility_date = "2026-03-02"
+workers_dev = false
+preview_urls = false
+
+[vars]
+IDENTITY_CRM_DELIVERY_ENABLED = "false"
+IDENTITY_CRM_DELIVERY_ENVIRONMENT = "staging"
+
+[env.staging]
+name = "skincos-identity-crm-delivery-staging"
+workers_dev = false
+preview_urls = false
+
+[env.staging.vars]
+IDENTITY_CRM_DELIVERY_ENABLED = "false"
+IDENTITY_CRM_DELIVERY_ENVIRONMENT = "staging"
+
+# Before any staging enablement, provision these values through the protected
+# secret manager, never through this file or Git:
+#   wrangler secret put IDENTITY_CRM_DELIVERY_KID --env staging
+#   wrangler secret put IDENTITY_CRM_DELIVERY_PRIVATE_JWK --env staging
+#   wrangler secret put IDENTITY_CRM_DELIVERY_PUBLIC_JWK --env staging
+#   wrangler secret put IDENTITY_CRM_DELIVERY_REQUEST_HMAC --env staging


### PR DESCRIPTION
## Summary
- add Identity-owned Ed25519 identity-crm-delivery/v1 issuer with exact private contract pin
- bind issuer claims to the actual method, canonical target and SHA-256 body bytes
- add opaque actor projection, kid rotation/overlap/revocation and non-exportable CryptoKey signer boundary
- add staging-only service-binding WorkerEntrypoint preparation with HMAC caller gate and public-key publication/readback
- keep staging disabled with no route or data binding; add focused CI and synthetic positive/negative coverage

## Validation
- 29 focused Identity tests pass through scripts/invoke-skincos-wsl.ps1
- wrangler 4.114.0 deploy --dry-run --env staging passes with no route/D1/KV/R2 binding
- exact private contract lock pin matches CRM Core v0.2.2 integrity

## Gates intentionally not performed
- no production deploy or cutover
- no real data
- no staging secret provisioning or deploy: requires owner-approved Cloudflare secret custody and CRM service-binding/public-key pinning