### PR TITLE
feat(website): add roda da beleza campaign foundation

### DIFF
--- a/website/docs/roda-da-beleza-campaign-foundation.md
+++ b/website/docs/roda-da-beleza-campaign-foundation.md
@@ -1,0 +1,141 @@
+# Roda da Beleza — fundação da próxima campanha
+
+## Estado atual
+
+Esta fundação cria apenas um contrato público versionado e uma rota de leitura
+desligada por padrão:
+
+`GET /api/public/campaigns/roda-da-beleza/v1`
+
+Enquanto não houver uma campanha aprovada, a rota responde `503` com
+`campaign_unavailable`. Ela não lê cookies, query strings, variáveis de
+ambiente, D1, segredos, dados pessoais ou o catálogo legado. Ela não é uma
+troca de tráfego para `/cadastro`, `/roleta`, `/roda-da-beleza` ou
+`/rodadabeleza`.
+
+O componente e as APIs atuais de cadastro são uma referência de experiência
+legada, não a fonte para uma nova campanha. Eles usam `BOOKING_DB`, persistem
+nome, telefone e e-mail, e ainda não carregam um aceite próprio versionado da
+campanha. Não reutilizá-los para a ativação nova.
+
+## Limite deste change
+
+Incluído:
+
+- contrato público `roda-da-beleza-public/v1`, sem catálogo comercial;
+- endpoint somente de leitura, privado no cache e fail-closed;
+- testes de isolamento contra dependências de cadastro, Booking, cookies,
+  D1, segredos e configuração de runtime;
+- este roteiro para transformar a fundação em campanha operacional.
+
+Excluído deliberadamente:
+
+- catálogo, preço, desconto, sorteio, estoque ou texto promocional;
+- formulário, cadastro, WhatsApp, conversão, pixel, CAPI e links de mídia;
+- binding, database ID, migration aplicada, seed, secret, workflow ou deploy
+  externo;
+- troca, remoção ou alteração do fluxo de cadastro existente.
+
+## Contrato público v1
+
+Uma futura resposta disponível terá somente dados publicáveis:
+
+```json
+{
+  "ok": true,
+  "contractVersion": "roda-da-beleza-public/v1",
+  "campaign": {
+    "id": "roda-da-beleza",
+    "title": "...",
+    "termsVersion": "...",
+    "capabilities": { "catalog": true, "enrollment": false, "award": false },
+    "offers": [{ "code": "...", "title": "...", "description": "...", "termsVersion": "..." }]
+  }
+}
+```
+
+Nunca incluir identificador de lead, nome, e-mail, telefone, prêmio individual,
+token, validade de sessão, replay ou destino individual de WhatsApp nessa
+resposta. Cadastro, autenticação de participação e atribuição de oferta são
+contratos separados e só podem existir depois dos controles abaixo.
+
+## Pré-requisitos de ativação
+
+### 1. Brief comercial e jurídico aprovado
+
+Registrar em um artefato revisável, antes de criar ofertas ou tela pública:
+
+| Tema | Definição necessária |
+| --- | --- |
+| Janela | início, fim, timezone, encerramento e unidades participantes |
+| Mecânica | elegibilidade, uma participação por campanha, aleatoriedade, disputa e auditoria |
+| Ofertas | código, texto exato, preço/condição, peso, estoque, teto por unidade, validade e exceções |
+| Atendimento | número oficial, mensagem por oferta, responsável, SLA e fluxo de contestação |
+| Regulamento | versão, URL pública, condições, restrições, eventual enquadramento promocional e responsável jurídico |
+| Dados | finalidade, base legal, retenção, descarte, canal LGPD e opt-outs independentes para operação, marketing e medição |
+| Mídia | URL canônica, UTMs obrigatórias, criativos, consentimento de marketing e eventos permitidos |
+
+Nenhum valor desta tabela pode ser inferido do catálogo legado ou de campanhas
+anteriores.
+
+### 2. Serviço de campanha separado
+
+Criar uma D1 dedicada por ambiente, fora de `BOOKING_DB`, com migration
+versionada aplicada por Wrangler antes do deploy. A migration futura deve ter,
+no mínimo:
+
+- campanhas e revisões imutáveis, com estado `draft`, `active`, `disabled` ou
+  `closed`, janela e versão de regulamento;
+- unidades e ofertas por campanha, peso, capacidade e snapshots públicos;
+- participante identificado por HMAC de contato e dados pessoais cifrados,
+  nunca em retorno público ou URL;
+- aceite append-only com finalidade, versão do aviso, data, revogação e prazo
+  de retenção;
+- sessão opaca em cookie HttpOnly, HMAC próprio e expiração curta;
+- prêmio único por campanha/participante e snapshot imutável da oferta e do
+  regulamento;
+- limitadores por identidade e IP usando valores HMAC;
+- evento/auditoria sem PII em metadata.
+
+O claim deve ocorrer integralmente no banco: sorteio feito no servidor com
+CSPRNG, capacidade reservada por update/trigger condicional e constraint de
+prêmio único. Repetições devem devolver o mesmo resultado canônico. Nunca
+aceitar um `prizeId` enviado pelo navegador, nem usar `localStorage` ou cookie
+como prova de prêmio.
+
+### 3. Segurança, consentimento e medição
+
+- Use chaves distintas para HMAC de sessão/identidade e cifra de PII; não
+  reutilize `CADASTRO_WHEEL_SECRET` ou segredos de Booking.
+- Exija origem permitida, limites de payload, rate limit e ausência de CORS
+  permissivo em toda rota de escrita.
+- Grave consentimento operacional, contato promocional/WhatsApp e medição
+  como decisões separadas, cada uma com versão e timestamp.
+- Só envie Meta/Google/CAPI após o respectivo consentimento de marketing.
+- Defina previamente se o redirector de WhatsApp pode receber cada tipo de
+  contexto; não coloque PII em URL, evento ou mensagem de tracking.
+
+### 4. Liberação
+
+1. Criar banco/binding/segredos separados para staging e produção; manter a
+   flag de campanha desligada.
+2. Aplicar migration e seed estritamente sintético em staging.
+3. Testar contrato, origem, rate limit, replay, concorrência de capacidade,
+   expiracão, revogação, consentimento e ausência de PII em logs/URLs.
+4. Fazer revisão jurídica/comercial da página renderizada, regulamento e
+   mensagens reais.
+5. Promover o mesmo SHA após evidência de staging; só então habilitar a flag
+   de produção durante a janela aprovada.
+6. Para rollback, desligar a flag, preservar ledger/snapshots para auditoria e
+   remover a rota de entrada de mídia. Não apagar participantes ou prêmios
+   enquanto houver obrigação operacional ou jurídica.
+
+## Evidência mínima para aceitar a campanha
+
+- migration registrada em D1 dedicada e sem DDL em caminho de requisição;
+- configuração da campanha e regulamento aprovados e versionados;
+- testes automatizados de contrato, segurança, concorrência e regressão da
+  roleta legada;
+- smoke sintético em staging e leitura posterior do estado;
+- captura da página final e validação de acessibilidade/movimento reduzido;
+- evidência de promoção pelo SHA imutável e plano de rollback executável.

--- a/website/src/app/api/public/campaigns/roda-da-beleza/v1/route.ts
+++ b/website/src/app/api/public/campaigns/roda-da-beleza/v1/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import {
+    RODA_DA_BELEZA_PUBLIC_CONTRACT_VERSION,
+    readRodaDaBelezaPublicCampaignV1,
+    rodaDaBelezaCampaignUnavailableV1,
+} from "@/lib/publicCampaigns/rodaDaBelezaV1";
+
+export const dynamic = "force-dynamic";
+
+const ALLOWED_METHODS = "GET, HEAD, OPTIONS";
+
+function applyPrivateNoStoreHeaders(response: NextResponse): NextResponse {
+    response.headers.set("Cache-Control", "no-store, no-cache, must-revalidate, private");
+    response.headers.set("Pragma", "no-cache");
+    response.headers.set("Expires", "0");
+    response.headers.set("X-Content-Type-Options", "nosniff");
+    return response;
+}
+
+function unavailableResponse(): NextResponse {
+    return applyPrivateNoStoreHeaders(
+        NextResponse.json(rodaDaBelezaCampaignUnavailableV1(), { status: 503 }),
+    );
+}
+
+function availableResponse(): NextResponse | null {
+    const campaign = readRodaDaBelezaPublicCampaignV1();
+    if (!campaign) return null;
+    return applyPrivateNoStoreHeaders(
+        NextResponse.json({
+            ok: true,
+            contractVersion: RODA_DA_BELEZA_PUBLIC_CONTRACT_VERSION,
+            campaign,
+        }),
+    );
+}
+
+function methodNotAllowedResponse(): NextResponse {
+    const response = applyPrivateNoStoreHeaders(new NextResponse(null, { status: 405 }));
+    response.headers.set("Allow", ALLOWED_METHODS);
+    return response;
+}
+
+function optionsResponse(): NextResponse {
+    const response = applyPrivateNoStoreHeaders(new NextResponse(null, { status: 204 }));
+    response.headers.set("Allow", ALLOWED_METHODS);
+    return response;
+}
+
+export function GET(_request: Request): NextResponse {
+    void _request;
+    return availableResponse() ?? unavailableResponse();
+}
+
+export function HEAD(_request: Request): NextResponse {
+    void _request;
+    const response = availableResponse() ?? unavailableResponse();
+    return new NextResponse(null, { status: response.status, headers: response.headers });
+}
+
+export function OPTIONS(_request: Request): NextResponse {
+    void _request;
+    return optionsResponse();
+}
+
+export function POST(_request: Request): NextResponse {
+    void _request;
+    return methodNotAllowedResponse();
+}
+
+export function PUT(_request: Request): NextResponse {
+    void _request;
+    return methodNotAllowedResponse();
+}
+
+export function PATCH(_request: Request): NextResponse {
+    void _request;
+    return methodNotAllowedResponse();
+}
+
+export function DELETE(_request: Request): NextResponse {
+    void _request;
+    return methodNotAllowedResponse();
+}

--- a/website/src/lib/publicCampaigns/rodaDaBelezaV1.ts
+++ b/website/src/lib/publicCampaigns/rodaDaBelezaV1.ts
@@ -1,0 +1,61 @@
+/**
+ * Public, read-only contract for the next Roda da Beleza campaign.
+ *
+ * This module deliberately carries no commercial catalogue, personal data,
+ * runtime configuration, or infrastructure dependency. A campaign may only
+ * become available after its approved source, dedicated data store, and
+ * activation checks are introduced in a separate change.
+ */
+export const RODA_DA_BELEZA_PUBLIC_CONTRACT_VERSION = "roda-da-beleza-public/v1" as const;
+
+export type RodaDaBelezaPublicOfferV1 = {
+    code: string;
+    title: string;
+    description: string;
+    termsVersion: string;
+};
+
+export type RodaDaBelezaPublicCampaignV1 = {
+    id: "roda-da-beleza";
+    title: string;
+    termsVersion: string;
+    capabilities: {
+        catalog: true;
+        enrollment: false;
+        award: false;
+    };
+    offers: readonly RodaDaBelezaPublicOfferV1[];
+};
+
+export type RodaDaBelezaPublicCampaignUnavailableV1 = {
+    ok: false;
+    contractVersion: typeof RODA_DA_BELEZA_PUBLIC_CONTRACT_VERSION;
+    error: "campaign_unavailable";
+};
+
+export type RodaDaBelezaPublicCampaignAvailableV1 = {
+    ok: true;
+    contractVersion: typeof RODA_DA_BELEZA_PUBLIC_CONTRACT_VERSION;
+    campaign: RodaDaBelezaPublicCampaignV1;
+};
+
+export type RodaDaBelezaPublicCampaignResponseV1 =
+    | RodaDaBelezaPublicCampaignUnavailableV1
+    | RodaDaBelezaPublicCampaignAvailableV1;
+
+/**
+ * The absence of a campaign is intentional. Do not source this from an
+ * environment variable or legacy wheel data: availability must eventually be
+ * resolved from the approved, dedicated campaign service.
+ */
+export function readRodaDaBelezaPublicCampaignV1(): RodaDaBelezaPublicCampaignV1 | null {
+    return null;
+}
+
+export function rodaDaBelezaCampaignUnavailableV1(): RodaDaBelezaPublicCampaignUnavailableV1 {
+    return {
+        ok: false,
+        contractVersion: RODA_DA_BELEZA_PUBLIC_CONTRACT_VERSION,
+        error: "campaign_unavailable",
+    };
+}

--- a/website/tests/publicCampaignRodaDaBelezaV1.test.ts
+++ b/website/tests/publicCampaignRodaDaBelezaV1.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import {
+    RODA_DA_BELEZA_PUBLIC_CONTRACT_VERSION,
+    readRodaDaBelezaPublicCampaignV1,
+} from "../src/lib/publicCampaigns/rodaDaBelezaV1";
+import { DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT } from "../src/app/api/public/campaigns/roda-da-beleza/v1/route";
+
+const sourceUrl = (relativePath: string) => new URL(`../${relativePath}`, import.meta.url);
+
+function assertPrivateNoStore(response: Response) {
+    assert.equal(response.headers.get("cache-control"), "no-store, no-cache, must-revalidate, private");
+    assert.equal(response.headers.get("pragma"), "no-cache");
+    assert.equal(response.headers.get("expires"), "0");
+    assert.equal(response.headers.get("x-content-type-options"), "nosniff");
+    assert.equal(response.headers.get("set-cookie"), null);
+    assert.equal(response.headers.get("access-control-allow-origin"), null);
+}
+
+test("the public Roda da Beleza contract has no default commercial campaign", () => {
+    assert.equal(readRodaDaBelezaPublicCampaignV1(), null);
+});
+
+test("the public campaign endpoint fails closed regardless of caller input", async () => {
+    const request = new Request(
+        "https://example.com/api/public/campaigns/roda-da-beleza/v1?campaign=legacy&email=test%40example.com",
+        {
+            headers: {
+                cookie: "ef_cadastro_lead=legacy-lead; ef_cadastro_wheel=legacy-prize",
+                origin: "https://untrusted.example",
+            },
+        },
+    );
+
+    const response = GET(request);
+    assert.equal(response.status, 503);
+    assertPrivateNoStore(response);
+    assert.deepEqual(await response.json(), {
+        ok: false,
+        contractVersion: RODA_DA_BELEZA_PUBLIC_CONTRACT_VERSION,
+        error: "campaign_unavailable",
+    });
+});
+
+test("the public campaign endpoint exposes only safe read semantics", () => {
+    const request = new Request("https://example.com/api/public/campaigns/roda-da-beleza/v1");
+
+    const head = HEAD(request);
+    assert.equal(head.status, 503);
+    assertPrivateNoStore(head);
+
+    const options = OPTIONS(request);
+    assert.equal(options.status, 204);
+    assert.equal(options.headers.get("allow"), "GET, HEAD, OPTIONS");
+    assertPrivateNoStore(options);
+
+    for (const handler of [POST, PUT, PATCH, DELETE]) {
+        const response = handler(request);
+        assert.equal(response.status, 405);
+        assert.equal(response.headers.get("allow"), "GET, HEAD, OPTIONS");
+        assertPrivateNoStore(response);
+    }
+});
+
+test("the new public surface remains isolated from legacy, data, and runtime dependencies", async () => {
+    const [contract, route] = await Promise.all([
+        readFile(sourceUrl("src/lib/publicCampaigns/rodaDaBelezaV1.ts"), "utf8"),
+        readFile(sourceUrl("src/app/api/public/campaigns/roda-da-beleza/v1/route.ts"), "utf8"),
+    ]);
+    const source = `${contract}\n${route}`;
+
+    for (const forbidden of [
+        "cadastroLeadDb",
+        "cadastroWheel",
+        "bookingDb",
+        "getCloudflareContext",
+        "getRuntimeSecret",
+        "process.env",
+        "fetch(",
+        "cookies.",
+    ]) {
+        assert.equal(source.includes(forbidden), false, `public campaign foundation must not reference ${forbidden}`);
+    }
+});


### PR DESCRIPTION
## Resumo
- adiciona o contrato público versionado e inativo da próxima Roda da Beleza
- preserva o fluxo legado de cadastro/roleta e seus aliases publicados
- documenta os gates comercial, LGPD, dados e rollout antes da ativação

## Segurança e escopo
- não define ofertas, preços, regulamento, unidades, contatos ou dados pessoais
- não cria D1, secrets, bindings, workflows, migrações ou deploy
- a rota GET responde `campaign_unavailable` (503) até uma ativação futura e explícita

## Validação
- teste focal pós-rebase: 4/4 aprovado
- typecheck/build do Website pós-rebase aprovado
- validação de fronteiras de domínio aprovada
- suíte completa do Website: 214 testes aprovados antes do rebase
- security diff scan: 0 achados, cobertura completa