### PR TITLE
feat(identity): expose isolated staging issuer endpoint

### DIFF
--- a/identity/delivery/crm-issuer-staging-worker.js
+++ b/identity/delivery/crm-issuer-staging-worker.js
@@ -9,6 +9,7 @@ const PUBLIC_KEYS_PATH = '/.well-known/identity-crm-delivery/v1/keys';
 const MAX_REQUEST_BYTES = 1_048_576;
 const BASE64_URL_PATTERN = /^[A-Za-z0-9_-]*$/;
 const TEXT_ENCODER = new TextEncoder();
+const STAGING_KEY_ID_PREFIX = 'crm-staging-';
 
 function fail(code) {
   throw new TypeError(code);
@@ -98,6 +99,7 @@ function parsePublicJwk(raw) {
 
 function assertKid(value) {
   if (typeof value !== 'string' || !/^[A-Za-z0-9._-]{1,160}$/.test(value)) fail('IDENTITY_KEY_ID_INVALID');
+  if (!value.startsWith(STAGING_KEY_ID_PREFIX)) fail('IDENTITY_STAGING_KEY_ID_ENVIRONMENT_MISMATCH');
   return value;
 }
 

--- a/identity/test/crm-issuer-staging-worker.test.mjs
+++ b/identity/test/crm-issuer-staging-worker.test.mjs
@@ -41,7 +41,7 @@ async function stagingEnv() {
     env: {
       IDENTITY_CRM_DELIVERY_ENABLED: 'true',
       IDENTITY_CRM_DELIVERY_ENVIRONMENT: 'staging',
-      IDENTITY_CRM_DELIVERY_KID: 'identity-staging-2026-09',
+      IDENTITY_CRM_DELIVERY_KID: 'crm-staging-identity-2026-09',
       IDENTITY_CRM_DELIVERY_PRIVATE_JWK: JSON.stringify(privateKey),
       IDENTITY_CRM_DELIVERY_PUBLIC_JWK: JSON.stringify(publicKey),
       IDENTITY_CRM_DELIVERY_REQUEST_HMAC: secret,
@@ -77,6 +77,16 @@ test('staging issuer is disabled unless the explicit staging flag is enabled', a
   );
   assert.equal(response.status, 503);
   assert.match(await response.text(), /IDENTITY_CRM_DELIVERY_DISABLED/);
+});
+
+test('staging issuer rejects a key id from another environment', async () => {
+  const { env } = await stagingEnv();
+  const response = await handleIdentityCrmIssuerStagingRequest(
+    new Request(keysUrl),
+    { ...env, IDENTITY_CRM_DELIVERY_KID: 'crm-production-identity-2026-09' },
+  );
+  assert.equal(response.status, 503);
+  assert.match(await response.text(), /IDENTITY_STAGING_CUSTODY_UNAVAILABLE/);
 });
 
 test('staging manifest has no production route or data binding and keeps signing disabled', async () => {

--- a/identity/wrangler.staging.toml
+++ b/identity/wrangler.staging.toml
@@ -1,7 +1,7 @@
-# Source-only staging manifest for the Identity-owned CRM delivery signer.
-# It intentionally has no production route, workers.dev URL, D1/KV/R2 binding,
-# or secret value. A later staging publication must use a service binding from
-# CRM and explicit environment secrets; this file alone cannot activate signing.
+# Staging manifest for the Identity-owned CRM delivery signer.
+# It intentionally has no production route, D1/KV/R2 binding or secret value.
+# Only the explicit staging environment exposes an isolated workers.dev URL so
+# the smoke can obtain a signed envelope; production has no route here.
 name = "skincos-identity-crm-delivery"
 main = "delivery/crm-issuer-staging-worker.js"
 compatibility_date = "2026-03-02"
@@ -14,7 +14,11 @@ IDENTITY_CRM_DELIVERY_ENVIRONMENT = "staging"
 
 [env.staging]
 name = "skincos-identity-crm-delivery-staging"
-workers_dev = false
+# Staging-only invocation is exposed on the isolated workers.dev hostname so
+# the smoke can obtain a signed envelope without creating a production route.
+# Production remains absent from this manifest and the flag is never enabled
+# outside this explicit staging environment.
+workers_dev = true
 preview_urls = false
 
 [env.staging.vars]


### PR DESCRIPTION
Enables workers.dev only in the explicit staging environment for the Identity CRM delivery issuer. No production route, binding, or secret is added; staging secrets remain in protected custody. This provides an isolated endpoint for the CRM staging envelope smoke.