### PR TITLE
chore(crm): freeze legacy general Pages publisher

### DIFF
--- a/.github/governance/cloudflare-single-writer-policy.json
+++ b/.github/governance/cloudflare-single-writer-policy.json
@@ -53,7 +53,7 @@
     {
       "id": "crm-cloudflare-writer",
       "resource": "global:crm-cloudflare-writer",
-      "purpose": "Serializes CRM Pages and the coupled CRM Worker secret/deploy workflows that can mutate the same project or credentials."
+      "purpose": "Serializes the legacy composite Pages surface, including governed Ponto and coupled external secret/deploy workflows that can mutate the same project or credentials. The general CRM Pages publisher is frozen; this group is not authority for CRM Core."
     },
     {
       "id": "ponto-workers-writer",

--- a/.github/workflows/deploy-crm-pages.yml
+++ b/.github/workflows/deploy-crm-pages.yml
@@ -14,7 +14,7 @@ on:
       preview_run_id: { description: "Required for staging", required: false, type: string }
       staging_run_id: { description: "Required for production", required: false, type: string }
       release_scope:
-        description: General CRM release or the governed Ponto composite release
+        description: Legacy general CRM release (frozen) or the governed Ponto composite release
         required: true
         default: general
         type: choice
@@ -43,7 +43,22 @@ permissions:
   contents: read
 
 jobs:
+  legacy-general-publisher-freeze:
+    name: Freeze legacy general CRM Pages publisher
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject the retired general CRM release scope before coordination
+        env:
+          RELEASE_SCOPE: ${{ inputs.release_scope }}
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE_SCOPE" != "ponto" ]]; then
+            echo "::error title=Legacy CRM publisher frozen::The general CRM Pages publisher is retired and cannot acquire a lease, read deployment credentials, or mutate Cloudflare. The governed Ponto scope remains available."
+            exit 1
+          fi
+          echo "Governed Ponto scope accepted; the legacy general CRM publisher remains frozen."
   coordination:
+    needs: legacy-general-publisher-freeze
     permissions:
       actions: read
       checks: write

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -589,6 +589,22 @@ test("general CRM Pages checks out trusted local coordination actions before usi
   assert.match(workflow.slice(checkout, authorization), /inputs\.release_scope == 'general'/);
 });
 
+test("the retired general CRM publisher is rejected before it can acquire coordination or credentials", () => {
+  const workflow = read(".github/workflows/deploy-crm-pages.yml");
+  const freeze = jobBlock(workflow, "legacy-general-publisher-freeze");
+  const coordination = jobBlock(workflow, "coordination");
+
+  assert.match(freeze, /RELEASE_SCOPE: \$\{\{ inputs\.release_scope \}\}/);
+  assert.match(freeze, /\[\[ "\$RELEASE_SCOPE" != "ponto" \]\]/);
+  assert.match(freeze, /Legacy CRM publisher frozen/);
+  assert.match(freeze, /cannot acquire a lease, read deployment credentials, or mutate Cloudflare/);
+  assert.match(coordination, /needs: legacy-general-publisher-freeze/);
+  assert.ok(
+    workflow.indexOf("legacy-general-publisher-freeze:") < workflow.indexOf("  coordination:"),
+    "freeze must run before the reusable coordination job",
+  );
+});
+
 test("the reusable orchestrator gate exposes global lease outputs to callers", () => {
   const workflow = read(".github/workflows/ponto-orchestrator-gate.yml");
 


### PR DESCRIPTION
## Objective
Freeze only the legacy **general CRM Pages publisher** before it can acquire coordination, read deployment credentials, or mutate Cloudflare.

## Scope
- `release_scope: general` now fails in a credential-free job before `coordination`.
- `release_scope: ponto` remains permitted and keeps its existing guarded release path.
- The shared legacy Pages writer lock remains in place for Ponto and the external-domain secret synchronizers.

## Risk and rollback
This changes workflow control flow only; it does not run a deployment or alter a current Pages deployment. Roll back by reverting this commit, restoring the previous general publisher behavior.

## Validation
- `npm run workflow:yaml:test`
- `node --test scripts/tests/global-concurrency-governance-static.test.mjs`
- `node .github/scripts/validate-architecture.mjs`
- `node .github/scripts/validate-deploy-topology.mjs`
- `node --test .github/scripts/ponto-dispatch-workflow.test.mjs .github/scripts/ponto-orchestrator-lease.test.mjs .github/scripts/validate-cloudflare-single-writer.test.mjs`