### PR TITLE
feat(atendimento): add opaque CRM projection exporter

### DIFF
--- a/.github/workflows/atendimento-crm-core-projection-exporter.yml
+++ b/.github/workflows/atendimento-crm-core-projection-exporter.yml
@@ -1,0 +1,26 @@
+name: Atendimento CRM Core projection exporter
+
+on:
+  pull_request:
+    paths:
+      - 'integration/atendimento/crm-core-projection-exporter/**'
+      - '.github/workflows/atendimento-crm-core-projection-exporter.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'integration/atendimento/crm-core-projection-exporter/**'
+      - '.github/workflows/atendimento-crm-core-projection-exporter.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.0.0
+        with:
+          node-version: 22.23.1
+      - name: Validate opaque source projection exporter
+        run: node --test integration/atendimento/crm-core-projection-exporter/test/*.test.mjs

--- a/integration/atendimento/crm-core-projection-exporter/README.md
+++ b/integration/atendimento/crm-core-projection-exporter/README.md
@@ -1,0 +1,41 @@
+# Exportador de projeções opacas de Atendimento para CRM Core
+
+Este adaptador prepara o primeiro lote de backfill para o CRM independente.
+Ele lê exclusivamente `id` e `updated_at` de
+`crm_atendimento.global_client_identities`, em uma transação PostgreSQL
+`REPEATABLE READ READ ONLY`.
+
+Antes de o lote sair do adaptador, cada UUID vira uma referência HMAC opaca:
+
+- `source:` identifica a origem sem expor o UUID;
+- `projection:` identifica a projeção CRM sem copiar o registro do cliente;
+- `event:` torna o replay idempotente.
+
+O lote não contém nomes, e-mails, telefones, contato, sessões, cookies,
+credenciais, dados de venda ou qualquer outra coluna da origem. A chave HMAC
+fica somente na custódia operacional privada; ela nunca é escrita neste
+repositório, em logs ou em recibos Git.
+
+## O que este adaptador ainda não faz
+
+Ele não abre uma conexão por conta própria, não cria usuário PostgreSQL, não
+aplica grant, não grava no CRM Core, não cria rota, e não faz deploy. Um runner
+operacional futuro deve injetar um pool já autenticado com o principal dedicado
+`crm_core_projection_exporter`, limitado a `CONNECT`, `USAGE` no schema
+`crm_atendimento` e `SELECT (id, updated_at)` na tabela indicada.
+
+O exportador falha fechado quando o principal, banco, transação somente-leitura,
+contagem, formato de linha ou limite não correspondem ao contrato. A primeira
+carga é propositalmente um snapshot completo e limitado; se o volume superar o
+limite, ele não pagina nem cria um backfill parcial.
+
+## Validação local
+
+No ambiente Linux do projeto:
+
+```text
+node --test integration/atendimento/crm-core-projection-exporter/test/*.test.mjs
+```
+
+Essa validação usa apenas uma fonte sintética em memória. Ela não acessa banco,
+Cloudflare, dados de clientes ou segredos.

--- a/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionExporter.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionExporter.mjs
@@ -1,0 +1,342 @@
+import { createHash, createHmac } from 'node:crypto'
+
+export const ATENDIMENTO_CRM_PROJECTION_EXPORTER_VERSION = 'atendimento/crm-core-projection-exporter/v1'
+export const CRM_PROJECTION_BACKFILL_BATCH_VERSION = 'skincos-crm/projection-backfill-batch/v1'
+export const ATENDIMENTO_PROJECTION_SCOPE = 'global-client-identities/v1'
+
+export const ATENDIMENTO_PROJECTION_EXPORTER_DATABASE = Object.freeze({
+  database: 'skincos_clientes_production',
+  user: 'crm_core_projection_exporter',
+})
+
+export const ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL = `SELECT
+  current_database() AS database_name,
+  current_user AS current_user,
+  session_user AS session_user,
+  current_setting('transaction_read_only') AS transaction_read_only`
+
+export const ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL = 'SELECT transaction_timestamp()::timestamptz AS captured_at'
+
+export const ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL = `SELECT count(*)::int AS row_count
+FROM crm_atendimento.global_client_identities`
+
+// This source query deliberately has no join and no selectable field beyond the
+// stable identity UUID and its revision timestamp. The UUID is converted to an
+// HMAC reference in memory before anything leaves this adapter.
+export const ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL = `SELECT id::text AS id, updated_at
+FROM crm_atendimento.global_client_identities
+ORDER BY updated_at ASC, id ASC
+LIMIT $1`
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const SHA256_PATTERN = /^sha256:[a-f0-9]{64}$/
+const RELEASE_PATTERN = /^[0-9a-f]{40}$/
+const KEY_ID_PATTERN = /^[A-Za-z0-9._-]{3,96}$/
+const OPAQUE_PART_PATTERN = /^[A-Za-z0-9_-]{8,160}$/
+const MAX_ROWS = 10_000
+
+function fail(code) {
+  throw new Error(code)
+}
+
+function object(value, code) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(code)
+  return value
+}
+
+function exactKeys(value, keys, code) {
+  if (Object.keys(value).length !== keys.length || keys.some((key) => !Object.hasOwn(value, key))) fail(code)
+}
+
+function text(value, code) {
+  const normalized = String(value || '').trim()
+  if (!normalized) fail(code)
+  return normalized
+}
+
+function timestamp(value, code) {
+  const parsed = value instanceof Date ? value : new Date(String(value || '').trim())
+  if (Number.isNaN(parsed.getTime())) fail(code)
+  return parsed.toISOString()
+}
+
+function canonicalize(value) {
+  if (value instanceof Date) return value.toISOString()
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, canonicalize(value[key])]))
+  }
+  return value
+}
+
+function sha256(value) {
+  return `sha256:${createHash('sha256').update(JSON.stringify(canonicalize(value))).digest('hex')}`
+}
+
+function hmacPart(key, namespace, value) {
+  return createHmac('sha256', key).update(`${namespace}\u0000${value}`).digest('base64url')
+}
+
+function hmacReference(key, namespace, value, prefix) {
+  const valuePart = hmacPart(key, namespace, value)
+  if (!OPAQUE_PART_PATTERN.test(valuePart)) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_HMAC_INVALID')
+  return `${prefix}:${valuePart}`
+}
+
+function hmacKey(value) {
+  const key = text(value, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_HMAC_KEY_REQUIRED')
+  if (Buffer.byteLength(key, 'utf8') < 32) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_HMAC_KEY_UNSAFE')
+  return key
+}
+
+function keyId(value) {
+  const normalized = text(value, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_KEY_ID_INVALID')
+  if (!KEY_ID_PATTERN.test(normalized)) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_KEY_ID_INVALID')
+  return normalized
+}
+
+function maximumRows(value) {
+  const normalized = value === undefined ? MAX_ROWS : Number(value)
+  if (!Number.isSafeInteger(normalized) || normalized < 1 || normalized > MAX_ROWS) {
+    fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_MAX_ROWS_INVALID')
+  }
+  return normalized
+}
+
+function targetDescriptor(value) {
+  const target = object(value, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_TARGET_INVALID')
+  exactKeys(target, ['environment', 'release', 'artifactDigest'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_TARGET_INVALID')
+  const environment = text(target.environment, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_TARGET_INVALID')
+  const release = text(target.release, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_TARGET_INVALID').toLowerCase()
+  const artifactDigest = text(target.artifactDigest, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_TARGET_INVALID').toLowerCase()
+  if (!['staging', 'production'].includes(environment) || !RELEASE_PATTERN.test(release) || !SHA256_PATTERN.test(artifactDigest)) {
+    fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_TARGET_INVALID')
+  }
+  return Object.freeze({ environment, release, artifactDigest })
+}
+
+function sourceIdentity(value) {
+  const identity = object(value, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_IDENTITY_INVALID')
+  const database = text(identity.database_name, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_IDENTITY_INVALID')
+  const currentUser = text(identity.current_user, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_IDENTITY_INVALID')
+  const sessionUser = text(identity.session_user, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_IDENTITY_INVALID')
+  const readOnly = text(identity.transaction_read_only, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_IDENTITY_INVALID').toLowerCase()
+  if (
+    database !== ATENDIMENTO_PROJECTION_EXPORTER_DATABASE.database
+    || currentUser !== ATENDIMENTO_PROJECTION_EXPORTER_DATABASE.user
+    || sessionUser !== ATENDIMENTO_PROJECTION_EXPORTER_DATABASE.user
+    || readOnly !== 'on'
+  ) {
+    fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_IDENTITY_UNSAFE')
+  }
+  return Object.freeze({ database, currentUser, sessionUser, readOnly })
+}
+
+function sourceRow(value) {
+  const row = object(value, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID')
+  exactKeys(row, ['id', 'updated_at'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID')
+  const id = text(row.id, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID').toLowerCase()
+  if (!UUID_PATTERN.test(id)) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID')
+  return Object.freeze({
+    id,
+    updatedAt: timestamp(row.updated_at, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID'),
+  })
+}
+
+function sourceRows(value, expectedCount) {
+  if (!Array.isArray(value) || value.length !== expectedCount) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_READBACK_INVALID')
+  const identifiers = new Set()
+  const rows = value.map(sourceRow)
+  for (const row of rows) {
+    if (identifiers.has(row.id)) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_READBACK_INVALID')
+    identifiers.add(row.id)
+  }
+  return Object.freeze(rows)
+}
+
+function eventFromSourceRow(row, { key, capturedAt }) {
+  const sourceReference = hmacReference(key, 'source-reference/v1', row.id, 'source')
+  const projectionReference = hmacReference(key, 'projection-reference/v1', row.id, 'projection')
+  const eventId = hmacReference(
+    key,
+    'projection-event/v1',
+    `${sourceReference}\u0000${projectionReference}\u0000${row.updatedAt}\u00001\u0000upsert`,
+    'event',
+  )
+  return Object.freeze({
+    contractVersion: 'crm-projection-event/v1',
+    id: eventId,
+    projection: Object.freeze({ reference: projectionReference, kind: 'client-reference' }),
+    source: Object.freeze({ owner: 'atendimento', reference: sourceReference }),
+    revision: 1,
+    operation: 'upsert',
+    occurredAt: row.updatedAt,
+    // Deliberately do not include source UUID, snapshot timestamp, or any
+    // contact field in the event. `capturedAt` participates only in batch ID.
+  })
+}
+
+function assertProjectionEvent(value) {
+  const event = object(value, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  exactKeys(event, ['contractVersion', 'id', 'projection', 'source', 'revision', 'operation', 'occurredAt'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  const projection = object(event.projection, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  const source = object(event.source, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  exactKeys(projection, ['reference', 'kind'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  exactKeys(source, ['owner', 'reference'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  if (
+    event.contractVersion !== 'crm-projection-event/v1'
+    || !/^event:[A-Za-z0-9_-]{8,160}$/.test(text(event.id, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID'))
+    || !/^projection:[A-Za-z0-9_-]{8,160}$/.test(text(projection.reference, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID'))
+    || projection.kind !== 'client-reference'
+    || source.owner !== 'atendimento'
+    || !/^source:[A-Za-z0-9_-]{8,160}$/.test(text(source.reference, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID'))
+    || !Number.isSafeInteger(event.revision) || event.revision !== 1
+    || event.operation !== 'upsert'
+  ) {
+    fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  }
+  return Object.freeze({
+    contractVersion: event.contractVersion,
+    id: event.id,
+    projection: Object.freeze({ reference: projection.reference, kind: projection.kind }),
+    source: Object.freeze({ owner: source.owner, reference: source.reference }),
+    revision: event.revision,
+    operation: event.operation,
+    occurredAt: timestamp(event.occurredAt, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID'),
+  })
+}
+
+function batchId(key, keyIdentifier, capturedAt, eventsDigest) {
+  return `backfill:atendimento:${hmacPart(key, 'projection-backfill-batch/v1', `${keyIdentifier}\u0000${capturedAt}\u0000${eventsDigest}`)}`
+}
+
+function batchCursorDigest(capturedAt, events) {
+  return sha256({
+    contract: CRM_PROJECTION_BACKFILL_BATCH_VERSION,
+    scope: ATENDIMENTO_PROJECTION_SCOPE,
+    capturedAt,
+    sourceReferences: events.map((event) => event.source.reference),
+  })
+}
+
+export function assertAtendimentoProjectionBackfillBatch(value) {
+  const batch = object(value, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  exactKeys(batch, ['contract', 'batchId', 'producer', 'sourceSnapshot', 'target', 'events', 'integrity'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  const producer = object(batch.producer, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  const sourceSnapshot = object(batch.sourceSnapshot, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  const integrity = object(batch.integrity, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  exactKeys(producer, ['owner', 'scope', 'keyId'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  exactKeys(sourceSnapshot, ['capturedAt', 'cursorDigest', 'rowCount'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  exactKeys(integrity, ['algorithm', 'eventCount', 'eventsDigest'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  if (
+    batch.contract !== CRM_PROJECTION_BACKFILL_BATCH_VERSION
+    || !/^backfill:atendimento:[A-Za-z0-9_-]{8,160}$/.test(text(batch.batchId, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID'))
+    || producer.owner !== 'atendimento'
+    || producer.scope !== ATENDIMENTO_PROJECTION_SCOPE
+    || !KEY_ID_PATTERN.test(text(producer.keyId, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID'))
+    || !SHA256_PATTERN.test(text(sourceSnapshot.cursorDigest, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID'))
+    || !Number.isSafeInteger(sourceSnapshot.rowCount) || sourceSnapshot.rowCount < 0
+    || integrity.algorithm !== 'sha256'
+    || !Number.isSafeInteger(integrity.eventCount) || integrity.eventCount < 0
+    || !SHA256_PATTERN.test(text(integrity.eventsDigest, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID'))
+  ) {
+    fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  }
+  const capturedAt = timestamp(sourceSnapshot.capturedAt, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  const target = targetDescriptor(batch.target)
+  if (!Array.isArray(batch.events) || batch.events.length !== sourceSnapshot.rowCount || batch.events.length !== integrity.eventCount) {
+    fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  }
+  const events = Object.freeze(batch.events.map(assertProjectionEvent))
+  const identifiers = new Set()
+  for (const event of events) {
+    if (identifiers.has(event.id)) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+    identifiers.add(event.id)
+  }
+  if (integrity.eventsDigest !== sha256(events) || sourceSnapshot.cursorDigest !== batchCursorDigest(capturedAt, events)) {
+    fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  }
+  return Object.freeze({
+    contract: batch.contract,
+    batchId: batch.batchId,
+    producer: Object.freeze({ owner: producer.owner, scope: producer.scope, keyId: producer.keyId }),
+    sourceSnapshot: Object.freeze({ capturedAt, cursorDigest: sourceSnapshot.cursorDigest, rowCount: sourceSnapshot.rowCount }),
+    target,
+    events,
+    integrity: Object.freeze({ algorithm: integrity.algorithm, eventCount: integrity.eventCount, eventsDigest: integrity.eventsDigest }),
+  })
+}
+
+function knownError(error) {
+  return error instanceof Error && /^ATENDIMENTO_CRM_PROJECTION_EXPORT_[A-Z_]+$/.test(error.message)
+}
+
+/**
+ * Export exactly one bounded, repeatable-read snapshot of Atendimento global
+ * identities. It never writes to the source, never returns source UUIDs, and
+ * fails rather than silently paginating an incomplete historical backfill.
+ */
+export async function exportAtendimentoClientProjectionBatch({
+  pool,
+  hmacKey: suppliedHmacKey,
+  keyId: suppliedKeyId,
+  target,
+  maxRows,
+} = {}) {
+  if (!pool || typeof pool.connect !== 'function') fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_POOL_REQUIRED')
+  const key = hmacKey(suppliedHmacKey)
+  const keyIdentifier = keyId(suppliedKeyId)
+  const targetValue = targetDescriptor(target)
+  const limit = maximumRows(maxRows)
+  let client
+  let transactionOpen = false
+
+  try {
+    client = await pool.connect()
+    if (!client || typeof client.query !== 'function') fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_CLIENT_INVALID')
+    await client.query('BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY')
+    transactionOpen = true
+
+    const identityResult = await client.query(ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL)
+    sourceIdentity(identityResult?.rows?.[0])
+
+    const snapshotResult = await client.query(ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL)
+    const capturedAt = timestamp(snapshotResult?.rows?.[0]?.captured_at, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SNAPSHOT_INVALID')
+
+    const countResult = await client.query(ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL)
+    const rowCount = Number(countResult?.rows?.[0]?.row_count)
+    if (!Number.isSafeInteger(rowCount) || rowCount < 0) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_COUNT_INVALID')
+    if (rowCount > limit) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_LIMIT_EXCEEDED')
+
+    const rowsResult = await client.query(ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL, [rowCount])
+    const rows = sourceRows(rowsResult?.rows, rowCount)
+    const events = Object.freeze(rows.map((row) => eventFromSourceRow(row, { key, capturedAt })))
+    const eventsDigest = sha256(events)
+    const cursorDigest = batchCursorDigest(capturedAt, events)
+    const batch = assertAtendimentoProjectionBackfillBatch({
+      contract: CRM_PROJECTION_BACKFILL_BATCH_VERSION,
+      batchId: batchId(key, keyIdentifier, capturedAt, eventsDigest),
+      producer: { owner: 'atendimento', scope: ATENDIMENTO_PROJECTION_SCOPE, keyId: keyIdentifier },
+      sourceSnapshot: { capturedAt, cursorDigest, rowCount },
+      target: targetValue,
+      events,
+      integrity: { algorithm: 'sha256', eventCount: events.length, eventsDigest },
+    })
+
+    await client.query('ROLLBACK')
+    transactionOpen = false
+    return batch
+  } catch (error) {
+    if (transactionOpen) {
+      try {
+        await client?.query('ROLLBACK')
+      } catch {
+        // The original fail-closed code remains the only observable error.
+      }
+    }
+    if (knownError(error)) throw error
+    fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_UNAVAILABLE')
+  } finally {
+    if (client && typeof client.release === 'function') client.release()
+  }
+}

--- a/integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionExporter.test.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionExporter.test.mjs
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL,
+  assertAtendimentoProjectionBackfillBatch,
+  exportAtendimentoClientProjectionBatch,
+} from '../src/atendimentoProjectionExporter.mjs'
+
+const HMAC_KEY = 'synthetic-atendimento-projection-export-key-at-least-32-bytes'
+const TARGET = Object.freeze({
+  environment: 'staging',
+  release: 'a'.repeat(40),
+  artifactDigest: `sha256:${'b'.repeat(64)}`,
+})
+const SOURCE_ID = '123e4567-e89b-42d3-a456-426614174000'
+
+function fakePool({
+  rows = [{ id: SOURCE_ID, updated_at: '2026-09-07T00:00:00.000Z' }],
+  rowCount = rows.length,
+  identity = {
+    database_name: 'skincos_clientes_production',
+    current_user: 'crm_core_projection_exporter',
+    session_user: 'crm_core_projection_exporter',
+    transaction_read_only: 'on',
+  },
+} = {}) {
+  const calls = []
+  let released = false
+  const client = {
+    async query(sql, params = []) {
+      calls.push({ sql, params })
+      if (sql === 'BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY') return { rows: [] }
+      if (sql === ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL) return { rows: [identity] }
+      if (sql === ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL) return { rows: [{ captured_at: '2026-09-07T00:00:00.000Z' }] }
+      if (sql === ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL) return { rows: [{ row_count: rowCount }] }
+      if (sql === ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL) return { rows }
+      if (sql === 'ROLLBACK') return { rows: [] }
+      throw new Error('unexpected query')
+    },
+    release() { released = true },
+  }
+  return { calls, pool: { async connect() { return client } }, released: () => released }
+}
+
+async function exportBatch(options = {}) {
+  return exportAtendimentoClientProjectionBatch({
+    pool: options.pool,
+    hmacKey: HMAC_KEY,
+    keyId: 'atendimento-projection-key-v1',
+    target: TARGET,
+    ...options,
+  })
+}
+
+test('exports a repeatable-read, opaque batch without serializing a source UUID or customer data', async () => {
+  const fixture = fakePool()
+  const batch = await exportBatch({ pool: fixture.pool })
+  const serialized = JSON.stringify(batch)
+
+  assert.equal(batch.contract, 'skincos-crm/projection-backfill-batch/v1')
+  assert.match(batch.batchId, /^backfill:atendimento:[A-Za-z0-9_-]+$/)
+  assert.deepEqual(batch.producer, {
+    owner: 'atendimento', scope: 'global-client-identities/v1', keyId: 'atendimento-projection-key-v1',
+  })
+  assert.equal(batch.events.length, 1)
+  assert.match(batch.events[0].id, /^event:/)
+  assert.match(batch.events[0].projection.reference, /^projection:/)
+  assert.match(batch.events[0].source.reference, /^source:/)
+  assert.doesNotMatch(serialized, new RegExp(SOURCE_ID, 'i'))
+  assert.doesNotMatch(serialized, /canonical_name|email|phone|contact|password|cookie|session/i)
+  assert.equal(fixture.calls[0].sql, 'BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY')
+  assert.equal(fixture.calls.at(-1).sql, 'ROLLBACK')
+  assert.equal(fixture.released(), true)
+
+  const sourceRead = fixture.calls.find((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL)
+  assert.deepEqual(sourceRead.params, [1])
+  assert.match(sourceRead.sql, /SELECT id::text AS id, updated_at/)
+  assert.doesNotMatch(sourceRead.sql, /canonical_name|email|phone|member|contact/i)
+})
+
+test('batch output is deterministic for the same immutable source snapshot and HMAC key', async () => {
+  const first = await exportBatch({ pool: fakePool().pool })
+  const second = await exportBatch({ pool: fakePool().pool })
+
+  assert.deepEqual(second, first)
+  assert.equal(assertAtendimentoProjectionBackfillBatch(first).integrity.eventsDigest, first.integrity.eventsDigest)
+})
+
+test('fails before source-row selection when the principal is not dedicated and read-only', async () => {
+  const fixture = fakePool({ identity: {
+    database_name: 'skincos_clientes_production',
+    current_user: 'skincos_clientes_migrator_login',
+    session_user: 'skincos_clientes_migrator_login',
+    transaction_read_only: 'off',
+  } })
+
+  await assert.rejects(() => exportBatch({ pool: fixture.pool }), {
+    message: 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_IDENTITY_UNSAFE',
+  })
+  assert.equal(fixture.calls.some((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL), false)
+  assert.equal(fixture.calls.at(-1).sql, 'ROLLBACK')
+})
+
+test('fails closed rather than creating a partial historical batch beyond the bounded snapshot limit', async () => {
+  const fixture = fakePool({ rowCount: 3, rows: [] })
+
+  await assert.rejects(() => exportBatch({ pool: fixture.pool, maxRows: 2 }), {
+    message: 'ATENDIMENTO_CRM_PROJECTION_EXPORT_LIMIT_EXCEEDED',
+  })
+  assert.equal(fixture.calls.some((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL), false)
+})
+
+test('rejects a source query result that expands beyond id and updated_at', async () => {
+  const fixture = fakePool({ rows: [{
+    id: SOURCE_ID,
+    updated_at: '2026-09-07T00:00:00.000Z',
+    canonical_name: 'must-never-leave-atendimento',
+  }] })
+
+  await assert.rejects(() => exportBatch({ pool: fixture.pool }), {
+    message: 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID',
+  })
+})
+
+test('rejects a batch whose event shape or digest is expanded after export', async () => {
+  const original = await exportBatch({ pool: fakePool().pool })
+  const expanded = structuredClone(original)
+  expanded.events[0].email = 'never-allowed@example.test'
+
+  assert.throws(() => assertAtendimentoProjectionBackfillBatch(expanded), {
+    message: 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID',
+  })
+})


### PR DESCRIPTION
## Objective
Prepare the first CRM backfill source adapter for Atendimento without moving or exposing customer records.

## Scope
- Adds an independent, source-domain exporter for `crm_atendimento.global_client_identities`.
- Reads only `id` and `updated_at` inside a `REPEATABLE READ READ ONLY` transaction.
- Requires a dedicated read-only principal and a non-Git HMAC key.
- Emits a bounded `projection-backfill-batch/v1` with opaque `source:`, `projection:`, and `event:` references only.
- Rejects partial snapshots, expanded source rows, unsafe source identity, malformed targets, and expanded batch fields.
- Adds a dedicated source-only test workflow; no database, Cloudflare, route, secret, deploy, or real data mutation occurs.

## Risk and rollback
The change is not wired to a production connection or a CRM Core ingestion endpoint. Revert this commit to remove the preparatory adapter. No source data or infrastructure is changed.

## Validation
- `node --test integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionExporter.test.mjs`
- `npm run workflow:yaml:test`
- `node .github/scripts/validate-architecture.mjs`
- `node .github/scripts/validate-deploy-topology.mjs`