### PR TITLE
feat(atendimento): add synthetic CRM backfill preparation

### DIFF
--- a/integration/atendimento/crm-core-projection-exporter/README.md
+++ b/integration/atendimento/crm-core-projection-exporter/README.md
@@ -29,6 +29,31 @@ contagem, formato de linha ou limite não correspondem ao contrato. A primeira
 carga é propositalmente um snapshot completo e limitado; se o volume superar o
 limite, ele não pagina nem cria um backfill parcial.
 
+## Preflight reutilizável e preparação sintética
+
+`preflightAtendimentoProjectionSource(client, { maxRows })` é a parte
+reutilizável da leitura: dentro de uma transação já aberta como `REPEATABLE
+READ READ ONLY`, ela atesta o principal, captura o instante do snapshot e
+confirma a contagem antes de qualquer seleção de identidade. O teto é sempre
+10.000; não há paginação ou forma de ampliá-lo pelo runner.
+
+`prepareSyntheticAtendimentoProjectionStaging(...)` é apenas um ensaio local
+desabilitado por padrão. Ele só continua quando recebe a constante de intenção
+explícita `ATENDIMENTO_SYNTHETIC_STAGING_PREPARATION_INTENT`, um alvo `staging`,
+um pool criado por `createSyntheticAtendimentoProjectionFixturePool(...)` e um
+receptor criado por `createSyntheticAtendimentoProjectionReceiptReceiver()`.
+As duas factories registram exclusivamente estado em memória; um cliente
+PostgreSQL, pool, array, proxy ou receptor arbitrário é recusado antes de
+`connect()` ou da entrega do recibo. Um alvo de produção é recusado antes de
+ler o pool, a chave HMAC ou o receptor injetados.
+
+O runner não tem CLI, URL, transporte, cliente PostgreSQL, leitura de ambiente,
+arquivo de saída ou integração de rede. Ele aceita unicamente dependências
+injetadas pelo teste e entrega ao receptor em memória um recibo congelado com
+somente `batchId`, `count`, `release` e `digest`; os eventos, UUIDs e a chave
+HMAC nunca saem dele. Portanto, ele não é um backfill, não envia nada ao CRM
+Core e não é um caminho para produção.
+
 ## Validação local
 
 No ambiente Linux do projeto:

--- a/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionExporter.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionExporter.mjs
@@ -3,6 +3,7 @@ import { createHash, createHmac } from 'node:crypto'
 export const ATENDIMENTO_CRM_PROJECTION_EXPORTER_VERSION = 'atendimento/crm-core-projection-exporter/v1'
 export const CRM_PROJECTION_BACKFILL_BATCH_VERSION = 'skincos-crm/projection-backfill-batch/v1'
 export const ATENDIMENTO_PROJECTION_SCOPE = 'global-client-identities/v1'
+export const ATENDIMENTO_CRM_PROJECTION_MAX_ROWS = 10_000
 
 export const ATENDIMENTO_PROJECTION_EXPORTER_DATABASE = Object.freeze({
   database: 'skincos_clientes_production',
@@ -33,8 +34,6 @@ const SHA256_PATTERN = /^sha256:[a-f0-9]{64}$/
 const RELEASE_PATTERN = /^[0-9a-f]{40}$/
 const KEY_ID_PATTERN = /^[A-Za-z0-9._-]{3,96}$/
 const OPAQUE_PART_PATTERN = /^[A-Za-z0-9_-]{8,160}$/
-const MAX_ROWS = 10_000
-
 function fail(code) {
   throw new Error(code)
 }
@@ -96,14 +95,14 @@ function keyId(value) {
 }
 
 function maximumRows(value) {
-  const normalized = value === undefined ? MAX_ROWS : Number(value)
-  if (!Number.isSafeInteger(normalized) || normalized < 1 || normalized > MAX_ROWS) {
+  const normalized = value === undefined ? ATENDIMENTO_CRM_PROJECTION_MAX_ROWS : Number(value)
+  if (!Number.isSafeInteger(normalized) || normalized < 1 || normalized > ATENDIMENTO_CRM_PROJECTION_MAX_ROWS) {
     fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_MAX_ROWS_INVALID')
   }
   return normalized
 }
 
-function targetDescriptor(value) {
+export function assertAtendimentoProjectionExportTarget(value) {
   const target = object(value, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_TARGET_INVALID')
   exactKeys(target, ['environment', 'release', 'artifactDigest'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_TARGET_INVALID')
   const environment = text(target.environment, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_TARGET_INVALID')
@@ -152,6 +151,30 @@ function sourceRows(value, expectedCount) {
     identifiers.add(row.id)
   }
   return Object.freeze(rows)
+}
+
+/**
+ * Attests the already-open source transaction before any source identity row
+ * is selected. Callers must start a repeatable-read, read-only transaction
+ * first; the identity query then proves the dedicated source principal and
+ * returns only snapshot metadata needed to bound a later read.
+ */
+export async function preflightAtendimentoProjectionSource(client, { maxRows } = {}) {
+  if (!client || typeof client.query !== 'function') fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_CLIENT_INVALID')
+  const limit = maximumRows(maxRows)
+
+  const identityResult = await client.query(ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL)
+  const identity = sourceIdentity(identityResult?.rows?.[0])
+
+  const snapshotResult = await client.query(ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL)
+  const capturedAt = timestamp(snapshotResult?.rows?.[0]?.captured_at, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SNAPSHOT_INVALID')
+
+  const countResult = await client.query(ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL)
+  const rowCount = Number(countResult?.rows?.[0]?.row_count)
+  if (!Number.isSafeInteger(rowCount) || rowCount < 0) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_COUNT_INVALID')
+  if (rowCount > limit) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_LIMIT_EXCEEDED')
+
+  return Object.freeze({ identity, capturedAt, rowCount })
 }
 
 function eventFromSourceRow(row, { key, capturedAt }) {
@@ -243,7 +266,7 @@ export function assertAtendimentoProjectionBackfillBatch(value) {
     fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
   }
   const capturedAt = timestamp(sourceSnapshot.capturedAt, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
-  const target = targetDescriptor(batch.target)
+  const target = assertAtendimentoProjectionExportTarget(batch.target)
   if (!Array.isArray(batch.events) || batch.events.length !== sourceSnapshot.rowCount || batch.events.length !== integrity.eventCount) {
     fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
   }
@@ -286,7 +309,7 @@ export async function exportAtendimentoClientProjectionBatch({
   if (!pool || typeof pool.connect !== 'function') fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_POOL_REQUIRED')
   const key = hmacKey(suppliedHmacKey)
   const keyIdentifier = keyId(suppliedKeyId)
-  const targetValue = targetDescriptor(target)
+  const targetValue = assertAtendimentoProjectionExportTarget(target)
   const limit = maximumRows(maxRows)
   let client
   let transactionOpen = false
@@ -297,16 +320,7 @@ export async function exportAtendimentoClientProjectionBatch({
     await client.query('BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY')
     transactionOpen = true
 
-    const identityResult = await client.query(ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL)
-    sourceIdentity(identityResult?.rows?.[0])
-
-    const snapshotResult = await client.query(ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL)
-    const capturedAt = timestamp(snapshotResult?.rows?.[0]?.captured_at, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SNAPSHOT_INVALID')
-
-    const countResult = await client.query(ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL)
-    const rowCount = Number(countResult?.rows?.[0]?.row_count)
-    if (!Number.isSafeInteger(rowCount) || rowCount < 0) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_COUNT_INVALID')
-    if (rowCount > limit) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_LIMIT_EXCEEDED')
+    const { capturedAt, rowCount } = await preflightAtendimentoProjectionSource(client, { maxRows: limit })
 
     const rowsResult = await client.query(ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL, [rowCount])
     const rows = sourceRows(rowsResult?.rows, rowCount)

--- a/integration/atendimento/crm-core-projection-exporter/src/syntheticStagingPreparationRunner.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/syntheticStagingPreparationRunner.mjs
@@ -1,0 +1,183 @@
+import {
+  ATENDIMENTO_CRM_PROJECTION_MAX_ROWS,
+  ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL,
+  assertAtendimentoProjectionExportTarget,
+  exportAtendimentoClientProjectionBatch,
+} from './atendimentoProjectionExporter.mjs'
+
+export const ATENDIMENTO_SYNTHETIC_STAGING_PREPARATION_INTENT = 'atendimento/crm-core/synthetic-staging-preparation/v1'
+
+const INPUT_KEYS = Object.freeze(['syntheticIntent', 'target', 'fixturePool', 'hmacKey', 'keyId', 'receiver', 'maxRows'])
+const SYNTHETIC_FIXTURE_POOLS = new WeakSet()
+const SYNTHETIC_FIXTURE_RECEIVERS = new WeakSet()
+const SYNTHETIC_FIXTURE_RECEIPTS = new WeakMap()
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function fail(code) {
+  throw new Error(code)
+}
+
+function object(value, code) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(code)
+  return value
+}
+
+function exactKeys(value, keys, code) {
+  if (Object.keys(value).length !== keys.length || keys.some((key) => !Object.hasOwn(value, key))) fail(code)
+}
+
+function onlyKnownKeys(value, keys, code) {
+  if (Object.keys(value).some((key) => !keys.includes(key))) fail(code)
+}
+
+function timestamp(value, code) {
+  const parsed = value instanceof Date ? value : new Date(String(value || '').trim())
+  if (Number.isNaN(parsed.getTime())) fail(code)
+  return parsed.toISOString()
+}
+
+function explicitSyntheticIntent(value) {
+  if (value !== ATENDIMENTO_SYNTHETIC_STAGING_PREPARATION_INTENT) {
+    fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_INTENT_REQUIRED')
+  }
+}
+
+function stagingTarget(value) {
+  const target = assertAtendimentoProjectionExportTarget(value)
+  if (target.environment === 'production') fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_PRODUCTION_FORBIDDEN')
+  if (target.environment !== 'staging') fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_STAGING_TARGET_REQUIRED')
+  return target
+}
+
+function boundedCount(value) {
+  const count = value === undefined ? ATENDIMENTO_CRM_PROJECTION_MAX_ROWS : Number(value)
+  if (!Number.isSafeInteger(count) || count < 1 || count > ATENDIMENTO_CRM_PROJECTION_MAX_ROWS) {
+    fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_COUNT_INVALID')
+  }
+  return count
+}
+
+function fixturePool(value) {
+  if (!value || typeof value !== 'object' || !SYNTHETIC_FIXTURE_POOLS.has(value)) {
+    fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_POOL_REQUIRED')
+  }
+  return value
+}
+
+function fixtureReceiver(value) {
+  if (!value || typeof value !== 'object' || !SYNTHETIC_FIXTURE_RECEIVERS.has(value)) {
+    fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_RECEIVER_INVALID')
+  }
+  return SYNTHETIC_FIXTURE_RECEIPTS.get(value)
+}
+
+function sanitizedReceipt(batch) {
+  return Object.freeze({
+    batchId: batch.batchId,
+    count: batch.events.length,
+    release: batch.target.release,
+    digest: batch.target.artifactDigest,
+  })
+}
+
+function syntheticSourceRows(value) {
+  if (!Array.isArray(value)) fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_INVALID')
+  const identifiers = new Set()
+  const rows = value.map((item) => {
+    const row = object(item, 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_INVALID')
+    exactKeys(row, ['id', 'updated_at'], 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_INVALID')
+    const id = String(row.id || '').trim().toLowerCase()
+    if (!UUID_PATTERN.test(id) || identifiers.has(id)) fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_INVALID')
+    identifiers.add(id)
+    return Object.freeze({ id, updated_at: timestamp(row.updated_at, 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_INVALID') })
+  })
+  return Object.freeze(rows.sort((left, right) => left.updated_at.localeCompare(right.updated_at) || left.id.localeCompare(right.id)))
+}
+
+/**
+ * Creates the only pool shape the synthetic runner accepts. This factory holds
+ * source-shaped fixture rows in memory and registers the resulting pool in a
+ * module-private WeakSet, so an arbitrary database client cannot be passed to
+ * the runner as a fixture.
+ */
+export function createSyntheticAtendimentoProjectionFixturePool(value) {
+  const fixture = object(value, 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_INVALID')
+  exactKeys(fixture, ['capturedAt', 'rows'], 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_INVALID')
+  const capturedAt = timestamp(fixture.capturedAt, 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_INVALID')
+  const rows = syntheticSourceRows(fixture.rows)
+  const identity = Object.freeze({
+    database_name: 'skincos_clientes_production',
+    current_user: 'crm_core_projection_exporter',
+    session_user: 'crm_core_projection_exporter',
+    transaction_read_only: 'on',
+  })
+  const client = Object.freeze({
+    async query(sql, params = []) {
+      if (sql === 'BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY' || sql === 'ROLLBACK') return { rows: [] }
+      if (sql === ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL) return { rows: [identity] }
+      if (sql === ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL) return { rows: [{ captured_at: capturedAt }] }
+      if (sql === ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL) return { rows: [{ row_count: rows.length }] }
+      if (sql === ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL) {
+        if (!Array.isArray(params) || params.length !== 1 || params[0] !== rows.length) {
+          fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID')
+        }
+        return { rows }
+      }
+      fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID')
+    },
+    release() {},
+  })
+  const pool = Object.freeze({ async connect() { return client } })
+  SYNTHETIC_FIXTURE_POOLS.add(pool)
+  return pool
+}
+
+/**
+ * Creates an opaque, in-memory receipt receiver. The runner accepts only this
+ * capability and keeps its mutable receipt collection module-private, so an
+ * injected array, proxy, callback, or transport cannot run at delivery time.
+ */
+export function createSyntheticAtendimentoProjectionReceiptReceiver() {
+  const receiver = Object.freeze({})
+  SYNTHETIC_FIXTURE_RECEIVERS.add(receiver)
+  SYNTHETIC_FIXTURE_RECEIPTS.set(receiver, [])
+  return receiver
+}
+
+export function readSyntheticAtendimentoProjectionReceipts(receiver) {
+  const receipts = fixtureReceiver(receiver)
+  return Object.freeze([...receipts])
+}
+
+/**
+ * Prepare one synthetic, staging-only projection batch. This is intentionally
+ * disabled until the caller supplies the exact synthetic intent. It has no
+ * transport configuration: the only receiver is an injected in-memory fixture
+ * that receives the sanitized receipt, never the event batch.
+ */
+export async function prepareSyntheticAtendimentoProjectionStaging(options = {}) {
+  const input = object(options, 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_OPTIONS_INVALID')
+
+  // This must be the first injected value read. A production target is refused
+  // before a pool, HMAC value, or receiver fixture can be touched.
+  const target = stagingTarget(input.target)
+  onlyKnownKeys(input, INPUT_KEYS, 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_OPTIONS_INVALID')
+  explicitSyntheticIntent(input.syntheticIntent)
+  const maxRows = boundedCount(input.maxRows)
+  const pool = fixturePool(input.fixturePool)
+  const receipts = fixtureReceiver(input.receiver)
+
+  const batch = await exportAtendimentoClientProjectionBatch({
+    pool,
+    hmacKey: input.hmacKey,
+    keyId: input.keyId,
+    target,
+    maxRows,
+  })
+  const receipt = sanitizedReceipt(batch)
+  receipts[receipts.length] = receipt
+  return receipt
+}

--- a/integration/atendimento/crm-core-projection-exporter/test/syntheticStagingPreparationRunner.test.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/test/syntheticStagingPreparationRunner.test.mjs
@@ -1,0 +1,200 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+import {
+  ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL,
+  preflightAtendimentoProjectionSource,
+} from '../src/atendimentoProjectionExporter.mjs'
+import {
+  ATENDIMENTO_SYNTHETIC_STAGING_PREPARATION_INTENT,
+  createSyntheticAtendimentoProjectionFixturePool,
+  createSyntheticAtendimentoProjectionReceiptReceiver,
+  prepareSyntheticAtendimentoProjectionStaging,
+  readSyntheticAtendimentoProjectionReceipts,
+} from '../src/syntheticStagingPreparationRunner.mjs'
+
+const HMAC_KEY = 'synthetic-atendimento-staging-preparation-key-at-least-32-bytes'
+const TARGET = Object.freeze({
+  environment: 'staging',
+  release: 'a'.repeat(40),
+  artifactDigest: `sha256:${'b'.repeat(64)}`,
+})
+const PRODUCTION_TARGET = Object.freeze({ ...TARGET, environment: 'production' })
+const SOURCE_ID = '123e4567-e89b-42d3-a456-426614174000'
+const CAPTURED_AT = '2026-09-07T00:00:00.000Z'
+
+function sourceRow(index = 0) {
+  const suffix = index.toString(16).padStart(12, '0')
+  return { id: `123e4567-e89b-42d3-a456-${suffix}`, updated_at: CAPTURED_AT }
+}
+
+function syntheticFixturePool(rows = [sourceRow()]) {
+  return createSyntheticAtendimentoProjectionFixturePool({ capturedAt: CAPTURED_AT, rows })
+}
+
+function fakeClient({
+  rows = [{ id: SOURCE_ID, updated_at: CAPTURED_AT }],
+  rowCount = rows.length,
+} = {}) {
+  const calls = []
+  return {
+    calls,
+    client: {
+      async query(sql, params = []) {
+        calls.push({ sql, params })
+        if (sql === ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL) return { rows: [{
+          database_name: 'skincos_clientes_production',
+          current_user: 'crm_core_projection_exporter',
+          session_user: 'crm_core_projection_exporter',
+          transaction_read_only: 'on',
+        }] }
+        if (sql === ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL) return { rows: [{ captured_at: CAPTURED_AT }] }
+        if (sql === ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL) return { rows: [{ row_count: rowCount }] }
+        if (sql === ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL) return { rows }
+        throw new Error('unexpected query')
+      },
+    },
+  }
+}
+
+function input(overrides = {}) {
+  return {
+    syntheticIntent: ATENDIMENTO_SYNTHETIC_STAGING_PREPARATION_INTENT,
+    target: TARGET,
+    fixturePool: syntheticFixturePool(),
+    hmacKey: HMAC_KEY,
+    keyId: 'atendimento-projection-key-v1',
+    receiver: createSyntheticAtendimentoProjectionReceiptReceiver(),
+    ...overrides,
+  }
+}
+
+test('exports a reusable source preflight that only attests identity, snapshot, and bounded count', async () => {
+  const fixture = fakeClient({ rowCount: 1 })
+  const result = await preflightAtendimentoProjectionSource(fixture.client, { maxRows: 10_000 })
+
+  assert.deepEqual(result, {
+    identity: {
+      database: 'skincos_clientes_production',
+      currentUser: 'crm_core_projection_exporter',
+      sessionUser: 'crm_core_projection_exporter',
+      readOnly: 'on',
+    },
+    capturedAt: CAPTURED_AT,
+    rowCount: 1,
+  })
+  assert.equal(fixture.calls.some((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL), false)
+})
+
+test('prepares only a synthetic staging batch and returns a receipt without events, HMAC material, or UUIDs', async () => {
+  const receiver = createSyntheticAtendimentoProjectionReceiptReceiver()
+  const receipt = await prepareSyntheticAtendimentoProjectionStaging(input({ receiver }))
+  const serialized = JSON.stringify(receipt)
+
+  assert.deepEqual(Object.keys(receipt).sort(), ['batchId', 'count', 'digest', 'release'])
+  assert.match(receipt.batchId, /^backfill:atendimento:[A-Za-z0-9_-]+$/)
+  assert.equal(receipt.count, 1)
+  assert.equal(receipt.release, TARGET.release)
+  assert.equal(receipt.digest, TARGET.artifactDigest)
+  assert.deepEqual(readSyntheticAtendimentoProjectionReceipts(receiver), [receipt])
+  assert.doesNotMatch(serialized, new RegExp(SOURCE_ID, 'i'))
+  assert.doesNotMatch(serialized, /event|hmac|synthetic-atendimento/i)
+})
+
+test('is disabled by default and does not request the fixture pool without explicit synthetic intent', async () => {
+  let providerRead = false
+  const disabledInput = {
+    target: TARGET,
+    get fixturePool() { providerRead = true; throw new Error('fixture pool must not be read') },
+  }
+
+  await assert.rejects(() => prepareSyntheticAtendimentoProjectionStaging(disabledInput), {
+    message: 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_INTENT_REQUIRED',
+  })
+  assert.equal(providerRead, false)
+})
+
+test('refuses a production target before reading any injected provider', async () => {
+  let providerRead = false
+  const productionInput = {
+    get target() { return PRODUCTION_TARGET },
+    get fixturePool() { providerRead = true; throw new Error('fixture pool must not be read') },
+    get hmacKey() { providerRead = true; throw new Error('HMAC must not be read') },
+    get receiver() { providerRead = true; throw new Error('receiver must not be read') },
+  }
+
+  await assert.rejects(() => prepareSyntheticAtendimentoProjectionStaging(productionInput), {
+    message: 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_PRODUCTION_FORBIDDEN',
+  })
+  assert.equal(providerRead, false)
+})
+
+test('enforces the 10,000-count hard limit before requesting the fixture pool', async () => {
+  let providerRead = false
+  const excessiveInput = {
+    syntheticIntent: ATENDIMENTO_SYNTHETIC_STAGING_PREPARATION_INTENT,
+    target: TARGET,
+    maxRows: 10_001,
+    get fixturePool() { providerRead = true; throw new Error('fixture pool must not be read') },
+  }
+
+  await assert.rejects(() => prepareSyntheticAtendimentoProjectionStaging(excessiveInput), {
+    message: 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_COUNT_INVALID',
+  })
+  assert.equal(providerRead, false)
+})
+
+test('does not create a receipt when the in-memory source preflight reports more than 10,000 rows', async () => {
+  const rows = Array.from({ length: 10_001 }, (_, index) => sourceRow(index))
+  const receiver = createSyntheticAtendimentoProjectionReceiptReceiver()
+
+  await assert.rejects(() => prepareSyntheticAtendimentoProjectionStaging(input({
+    fixturePool: syntheticFixturePool(rows),
+    receiver,
+  })), { message: 'ATENDIMENTO_CRM_PROJECTION_EXPORT_LIMIT_EXCEEDED' })
+  assert.deepEqual(readSyntheticAtendimentoProjectionReceipts(receiver), [])
+})
+
+test('rejects an arbitrary pool before it can connect, including one shaped like a database client', async () => {
+  let connectRequested = false
+  const forgedPool = {
+    async connect() {
+      connectRequested = true
+      throw new Error('must never connect')
+    },
+  }
+
+  await assert.rejects(() => prepareSyntheticAtendimentoProjectionStaging(input({ fixturePool: forgedPool })), {
+    message: 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_POOL_REQUIRED',
+  })
+  assert.equal(connectRequested, false)
+})
+
+test('accepts no endpoint-shaped configuration or forged receiver and the runner source has no environment, network, disk, or database-client import', async () => {
+  await assert.rejects(() => prepareSyntheticAtendimentoProjectionStaging(input({
+    endpoint: 'https://example.test/receiver',
+  })), { message: 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_OPTIONS_INVALID' })
+
+  await assert.rejects(() => prepareSyntheticAtendimentoProjectionStaging(input({
+    receiver: { endpoint: 'https://example.test/receiver' },
+  })), { message: 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_RECEIVER_INVALID' })
+
+  let pushRequested = false
+  const forgedReceiver = []
+  Object.defineProperty(forgedReceiver, 'push', {
+    value() { pushRequested = true; throw new Error('must never run') },
+  })
+  await assert.rejects(() => prepareSyntheticAtendimentoProjectionStaging(input({ receiver: forgedReceiver })), {
+    message: 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_RECEIVER_INVALID',
+  })
+  assert.equal(pushRequested, false)
+
+  const source = await readFile(new URL('../src/syntheticStagingPreparationRunner.mjs', import.meta.url), 'utf8')
+  assert.doesNotMatch(source, /node:(?:fs|http|https|net|tls|child_process)/)
+  assert.doesNotMatch(source, /\bfrom ['"]pg['"]|\brequire\(['"]pg['"]\)/)
+  assert.doesNotMatch(source, /process\.env|\bfetch\s*\(/)
+})


### PR DESCRIPTION
Adds a disabled-by-default, in-memory synthetic staging preparation runner for the Atendimento CRM projection exporter, plus reusable read-only source preflight. It refuses production before touching injected dependencies and creates no network, credential, database client, or actual delivery path.\n\nValidation: node --test integration/atendimento/crm-core-projection-exporter/test/*.test.mjs.