### PR TITLE
feat(api): mount CRM Core in staging gateway

### DIFF
--- a/api/src/gateway.js
+++ b/api/src/gateway.js
@@ -9,6 +9,7 @@ const isPontoReadinessProbe = (request) => request.method === 'GET' && new URL(r
 const FINANCE_PROBE_TIMEOUT_MS = 3_000;
 const FINANCE_READ_TIMEOUT_MS = 3_000;
 const FINANCE_WRITE_TIMEOUT_MS = 5_000;
+const CRM_CORE_STAGING_TIMEOUT_MS = 3_000;
 // Inventory's authenticated routes traverse the service's rate-limiter
 // Durable Object before reaching D1. Keep the normal budget bounded, but give
 // the unified team route a separate budget because its readiness/config read
@@ -89,6 +90,41 @@ function inventoryServiceTimeout(request) {
         : INVENTORY_READ_TIMEOUT_MS;
 }
 
+function isStagingEnvironment(env) {
+    return String(env?.ENVIRONMENT || '').trim().toLowerCase() === 'staging';
+}
+
+/**
+ * The independent CRM Core accepts only its own signed delivery envelope.
+ * Legacy browser credentials must never cross this service boundary. The
+ * `x-identity-delivery` header intentionally survives: CRM Core verifies it
+ * against its pinned Identity public key and replay ledger.
+ */
+export function prepareCrmCoreRequest(request) {
+    const headers = new Headers(request.headers);
+    for (const name of [
+        'authorization',
+        'cookie',
+        'x-csrf-token',
+        'x-skincos-actor',
+        'x-skincos-actor-sig',
+        'x-skincos-local-crm-actor',
+        'x-skincos-local-crm-csrf',
+        'x-skincos-network-context',
+        'x-skincos-network-sig',
+        'x-skincos-network-signature-version',
+        'x-skincos-network-ts',
+    ]) headers.delete(name);
+    return new Request(request, { headers });
+}
+
+export async function forwardCrmCoreToService(request, env) {
+    if (!isStagingEnvironment(env)) return gatewayError(404, 'CRM_CORE_STAGING_ONLY');
+    return fetchBoundService(prepareCrmCoreRequest(request), env, 'CRM_CORE', {
+        timeoutMs: CRM_CORE_STAGING_TIMEOUT_MS,
+    });
+}
+
 export async function forwardFinanceProbe(request, env) {
     // This route is read-only and is itself evaluated by the external monitor's
     // latency budget. Keep the service-binding deadline above that budget so a
@@ -116,7 +152,13 @@ export async function forwardFinanceToService(request, env, ctx, auth) {
  * CSRF, correlation and the signed service hand-off. Finance owns every
  * domain decision (including scope, availability, maintenance and throttling).
  */
-export function createApiGateway({ inventoryHandler, timekeepingHandler, financeDomainHandler = forwardFinanceToService, resolveActor = resolveCrmActor } = {}) {
+export function createApiGateway({
+    inventoryHandler,
+    timekeepingHandler,
+    financeDomainHandler = forwardFinanceToService,
+    crmCoreHandler = forwardCrmCoreToService,
+    resolveActor = resolveCrmActor,
+} = {}) {
     if (typeof inventoryHandler !== 'function') throw new TypeError('inventoryHandler is required');
     return createGatewayHandler({
         inventoryHandler,
@@ -142,6 +184,7 @@ export function createApiGateway({ inventoryHandler, timekeepingHandler, finance
             if (csrfError) return csrfError;
             return financeDomainHandler(request, env, ctx, auth);
         },
+        crmCoreHandler: typeof crmCoreHandler === 'function' ? crmCoreHandler : undefined,
     });
 }
 
@@ -157,4 +200,5 @@ export const handleGatewayRequest = createApiGateway({
         passThroughErrorStatuses: isPontoReadinessProbe(request) ? [503] : [],
     }),
     financeDomainHandler: forwardFinanceToService,
+    crmCoreHandler: forwardCrmCoreToService,
 });

--- a/api/src/router.js
+++ b/api/src/router.js
@@ -66,6 +66,14 @@ function isPontoRouteOnly(env) {
     return String(env?.PONTO_ROUTE_ONLY || '').trim() === 'true';
 }
 
+function isStagingEnvironment(env) {
+    return String(env?.ENVIRONMENT || '').trim().toLowerCase() === 'staging';
+}
+
+function isCrmCoreRoute(pathname) {
+    return pathname === '/crm' || pathname.startsWith('/crm/');
+}
+
 function hasTimekeepingBinding(env) {
     return typeof env?.TIMEKEEPING?.fetch === 'function';
 }
@@ -185,7 +193,7 @@ async function pontoReadiness(request, env, ctx, timekeepingHandler, requestId) 
  * selection, request tracing and the human/service access boundary; it must
  * not grow domain persistence or business rules.
  */
-export function createGatewayHandler({ inventoryHandler, timekeepingHandler, financeHandler }) {
+export function createGatewayHandler({ inventoryHandler, timekeepingHandler, financeHandler, crmCoreHandler }) {
     if (typeof inventoryHandler !== 'function') throw new TypeError('inventoryHandler is required');
 
     return async function handleGatewayRequest(request, env, ctx) {
@@ -251,6 +259,30 @@ export function createGatewayHandler({ inventoryHandler, timekeepingHandler, fin
         // this runtime guard is the fail-closed inner boundary.
         if (isPontoRouteOnly(env)) {
             return json(404, { ok: false, error: 'ponto_route_only', requestId }, requestId);
+        }
+
+        // CRM Core has no production route or production service binding. Its
+        // independent staging Worker owns the public /crm/* spelling and maps
+        // it exactly once to the canonical private /api/crm/* target. Do not
+        // strip this prefix and do not fall through to Inventory.
+        if (isCrmCoreRoute(url.pathname)) {
+            if (!isStagingEnvironment(env)) {
+                return json(404, { ok: false, error: 'crm_core_staging_only', requestId }, requestId);
+            }
+            if (typeof crmCoreHandler !== 'function') {
+                const unavailable = json(503, { ok: false, error: 'crm_core_unavailable', requestId }, requestId);
+                setGatewayReleaseHeaders(unavailable.headers, env);
+                return unavailable;
+            }
+            const headers = new Headers(request.headers);
+            headers.set('x-request-id', requestId);
+            const response = await crmCoreHandler(new Request(request, { headers }), env, ctx);
+            const responseHeaders = new Headers(response.headers);
+            // CRM Core has no legacy cookie/session compatibility surface.
+            responseHeaders.delete('set-cookie');
+            responseHeaders.set('x-request-id', requestId);
+            setGatewayReleaseHeaders(responseHeaders, env);
+            return new Response(response.body, { status: response.status, statusText: response.statusText, headers: responseHeaders });
         }
 
         if (url.pathname === '/inventory' || url.pathname.startsWith('/inventory/')) {

--- a/api/test/gateway.test.mjs
+++ b/api/test/gateway.test.mjs
@@ -715,3 +715,100 @@ test('Finance is reached through an explicit service binding with a short-lived 
   assert.equal(received.headers.get('x-csrf-token'), null);
   assert.equal((await verifySignedDomainContext(received, 'finance-secret', 'finance')).actor.username, 'pilot');
 });
+
+test('CRM Core keeps its public staging mount and removes every legacy session credential', async () => {
+  resetBoundServiceResilienceForTest();
+  let received = null;
+  const response = await handleGatewayRequest(new Request('https://api-staging.skincos.com.br/crm/ready?smoke=1', {
+    headers: {
+      authorization: 'Bearer legacy-session',
+      cookie: 'crm_session=legacy',
+      'x-csrf-token': 'legacy-csrf',
+      'x-identity-delivery': 'identity-crm-delivery/v1.synthetic-envelope',
+      'x-request-id': 'crm-core-gateway-1',
+      'x-skincos-actor': 'legacy-actor',
+      'x-skincos-actor-sig': 'legacy-signature',
+      'x-skincos-local-crm-actor': 'local-only',
+      'x-skincos-network-context': 'legacy-network',
+      'x-skincos-network-sig': 'legacy-signature',
+      'x-skincos-network-signature-version': '2',
+      'x-skincos-network-ts': '1788288000000',
+    },
+  }), {
+    APP_VERSION: 'a'.repeat(40),
+    ENVIRONMENT: 'staging',
+    CF_VERSION_METADATA: { id: '22222222-2222-4222-8222-222222222222', tag: 'crm-core-staging' },
+    CRM_CORE: {
+      fetch: async (request) => {
+        received = request;
+        return new Response(JSON.stringify({ ok: true, reason: 'CRM_STAGING_READY' }), {
+          headers: {
+            'content-type': 'application/json; charset=utf-8',
+            'set-cookie': 'must-not-cross-boundary=true',
+          },
+        });
+      },
+    },
+  }, {});
+
+  assert.equal(response.status, 200);
+  assert.equal((await response.json()).reason, 'CRM_STAGING_READY');
+  assert.equal(new URL(received.url).pathname, '/crm/ready');
+  assert.equal(new URL(received.url).search, '?smoke=1');
+  assert.equal(received.headers.get('x-request-id'), 'crm-core-gateway-1');
+  assert.equal(received.headers.get('x-identity-delivery'), 'identity-crm-delivery/v1.synthetic-envelope');
+  for (const name of [
+    'authorization',
+    'cookie',
+    'x-csrf-token',
+    'x-skincos-actor',
+    'x-skincos-actor-sig',
+    'x-skincos-local-crm-actor',
+    'x-skincos-network-context',
+    'x-skincos-network-sig',
+    'x-skincos-network-signature-version',
+    'x-skincos-network-ts',
+  ]) assert.equal(received.headers.get(name), null, name);
+  assert.equal(response.headers.get('set-cookie'), null);
+  assert.equal(response.headers.get('x-skincos-gateway-release-sha'), 'a'.repeat(40));
+  assert.equal(response.headers.get('x-skincos-gateway-environment'), 'staging');
+  assert.equal(response.headers.get('x-skincos-gateway-version-id'), '22222222-2222-4222-8222-222222222222');
+  resetBoundServiceResilienceForTest();
+});
+
+test('CRM Core never becomes a production route even if a binding is present', async () => {
+  let calls = 0;
+  const response = await handleGatewayRequest(new Request('https://api.skincos.com.br/crm/health'), {
+    ENVIRONMENT: 'production',
+    CRM_CORE: { fetch: async () => { calls += 1; return new Response('must-not-run'); } },
+  }, {});
+  assert.equal(response.status, 404);
+  assert.equal((await response.json()).error, 'crm_core_staging_only');
+  assert.equal(calls, 0);
+});
+
+test('CRM Core fails closed without its staging binding and never aliases legacy /api/crm', async () => {
+  resetBoundServiceResilienceForTest();
+  const unavailable = await handleGatewayRequest(new Request('https://api-staging.skincos.com.br/crm/health'), {
+    ENVIRONMENT: 'staging',
+  }, {});
+  assert.equal(unavailable.status, 503);
+  assert.equal((await unavailable.json()).dependency, 'CRM_CORE');
+
+  let calls = 0;
+  const legacyAlias = await handleGatewayRequest(new Request('https://api-staging.skincos.com.br/api/crm/health'), {
+    ENVIRONMENT: 'staging',
+    CRM_CORE: { fetch: async () => { calls += 1; return new Response('must-not-run'); } },
+  }, {});
+  assert.equal(legacyAlias.status, 404);
+  assert.equal((await legacyAlias.json()).error, 'route_not_found');
+  assert.equal(calls, 0);
+  resetBoundServiceResilienceForTest();
+});
+
+test('general API Worker binds CRM Core only in the staging environment', async () => {
+  const config = await readFile(new URL('../wrangler.toml', import.meta.url), 'utf8');
+  const productionConfig = config.slice(0, config.indexOf('[env.staging]'));
+  assert.doesNotMatch(productionConfig, /CRM_CORE/);
+  assert.match(config, /\[\[env\.staging\.services\]\]\r?\nbinding = "CRM_CORE"\r?\nservice = "skincos-crm-core-staging"/);
+});

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -108,6 +108,13 @@ service = "skincos-timekeeping-staging"
 binding = "FINANCE"
 service = "skincos-finance-staging"
 
+# CRM Core is an isolated staging-only service. There is deliberately no
+# production counterpart: the main CRM publisher remains the legacy monorepo
+# surface until its independent production cutover has its own evidence.
+[[env.staging.services]]
+binding = "CRM_CORE"
+service = "skincos-crm-core-staging"
+
 [[env.staging.r2_buckets]]
 binding = "BACKUP_BUCKET"
 bucket_name = "skincos-backups-staging"

--- a/docs/extraction/crm-core-staging-api-gateway-mount.md
+++ b/docs/extraction/crm-core-staging-api-gateway-mount.md
@@ -1,0 +1,62 @@
+# Mount central de staging do CRM Core
+
+## Objetivo e limite
+
+Esta mudança prepara somente o gateway Worker de staging `skincos-api-staging`
+para encaminhar o prefixo público `https://api-staging.skincos.com.br/crm/*`
+ao Worker independente `skincos-crm-core-staging`. Ela não publica nada por si
+só: não houve deploy, mudança de rota Cloudflare, migração, segredo, dado de
+cliente ou alteração de produção.
+
+O binding está declarado exclusivamente em
+[`api/wrangler.toml`](../../api/wrangler.toml) como `CRM_CORE` dentro de
+`[env.staging]`. O runtime também retorna `404 crm_core_staging_only` fora de
+`ENVIRONMENT=staging`, inclusive se alguém introduzir um binding indevido no
+futuro. Não existe contraparte em produção.
+
+## Contrato da rota
+
+O gateway preserva integralmente `/crm/*` e sua query ao chamar o service
+binding. O Worker Core é o único componente que traduz esse caminho público
+para o alvo canônico privado `/api/crm/*`; não há redirecionamento ou fallback
+para `/inventory/*`.
+
+Antes de encaminhar, o gateway remove `Cookie`, `Authorization`, CSRF, ator e
+envelopes de sessão/rede legados. O único envelope de identidade que pode
+prosseguir é `x-identity-delivery`; o Core continua responsável por verificar
+assinatura, alvo canônico, expiração e replay. Respostas também não encaminham
+`Set-Cookie`.
+
+Assim, depois de uma publicação de staging explicitamente autorizada, os
+smokes sem identidade são:
+
+```text
+GET https://api-staging.skincos.com.br/crm/health
+GET https://api-staging.skincos.com.br/crm/ready
+```
+
+Eles devem refletir o artefato e o D1 dedicados do CRM Core. A rota não ativa
+módulos, leituras de domínio ou escritas: o Core mantém esses caminhos fechados
+até que seus contratos e gates próprios estejam completos.
+
+## Publicação futura de staging
+
+O owner continua sendo o monorepo, pelo workflow
+`.github/workflows/deploy-core-workers.yml`, com `unit=api` e `target=staging`.
+Ele exige a promoção do SHA exato, o UUID de afinidade de Timekeeping e os
+gates/credenciais Cloudflare já custodidos pelo ambiente. Nenhum segredo novo
+do CRM Core é necessário para o service binding, mas a mudança não deve ser
+publicada fora desse fluxo.
+
+Antes de qualquer deploy, registrar a versão ativa de `skincos-api-staging` e
+o rollback correspondente; depois, conferir os dois smokes acima, a rejeição
+de `/api/crm/*`, a ausência de `Set-Cookie` e a preservação de todas as rotas
+Inventory, Finance e Ponto. A rota do shell `crm-staging.skincos.com.br`
+continua deliberadamente fora deste PR.
+
+## Pendência conhecida
+
+O emissor Identity de staging ainda não tem caller persistente sob custódia do
+CRM para emitir envelopes de navegação/negócio. Portanto este mount permite
+health/readiness sem credencial de identidade, mas não é uma ativação de UI,
+backfill, leitura de domínio, escrita ou cutover de produção.


### PR DESCRIPTION
## Summary

- Mounts the independent `skincos-crm-core-staging` Worker at the staging API gateway's public `/crm/*` prefix through a staging-only `CRM_CORE` service binding.
- Preserves the exact public path/query and permits only the Core-owned `x-identity-delivery` envelope across the boundary; legacy browser/session headers and downstream cookies are removed.
- Fails closed outside staging and if the binding is absent. `/api/crm/*` remains unmounted and no production binding or route is introduced.

## Validation

- `npm test` in `api`: 44 passing tests.
- `wrangler deploy --dry-run --config wrangler.toml --env staging`: compiled successfully and reports `CRM_CORE -> skincos-crm-core-staging`.

## Deployment gate and rollback

This PR makes no Cloudflare change. A later staging publication must use `.github/workflows/deploy-core-workers.yml` with `unit=api`, the exact reviewed SHA, existing Cloudflare custody/gates, and a recorded incumbent `skincos-api-staging` version for rollback. After publication, smoke only `GET /crm/health` and `GET /crm/ready`; do not treat this as production cutover or authorization for domain writes.