### PR TITLE
fix(api): allowlist CRM Core request headers

### DIFF
--- a/api/src/gateway.js
+++ b/api/src/gateway.js
@@ -10,6 +10,13 @@ const FINANCE_PROBE_TIMEOUT_MS = 3_000;
 const FINANCE_READ_TIMEOUT_MS = 3_000;
 const FINANCE_WRITE_TIMEOUT_MS = 5_000;
 const CRM_CORE_STAGING_TIMEOUT_MS = 3_000;
+const CRM_CORE_REQUEST_HEADER_ALLOWLIST = Object.freeze([
+    'accept',
+    'content-type',
+    'origin',
+    'x-request-id',
+    'x-identity-delivery',
+]);
 // Inventory's authenticated routes traverse the service's rate-limiter
 // Durable Object before reaching D1. Keep the normal budget bounded, but give
 // the unified team route a separate budget because its readiness/config read
@@ -95,26 +102,20 @@ function isStagingEnvironment(env) {
 }
 
 /**
- * The independent CRM Core accepts only its own signed delivery envelope.
- * Legacy browser credentials must never cross this service boundary. The
- * `x-identity-delivery` header intentionally survives: CRM Core verifies it
- * against its pinned Identity public key and replay ledger.
+ * This is a fresh allowlist, never a mutation of public request headers.
+ * CRM Core needs only browser representation/CORS metadata, correlation and
+ * its signed Identity delivery envelope. In particular, no legacy session,
+ * service token, proxy, Cloudflare or future credential-shaped header can
+ * cross this boundary. `x-identity-delivery` intentionally survives because
+ * CRM Core verifies it against its pinned Identity public key and replay
+ * ledger.
  */
 export function prepareCrmCoreRequest(request) {
-    const headers = new Headers(request.headers);
-    for (const name of [
-        'authorization',
-        'cookie',
-        'x-csrf-token',
-        'x-skincos-actor',
-        'x-skincos-actor-sig',
-        'x-skincos-local-crm-actor',
-        'x-skincos-local-crm-csrf',
-        'x-skincos-network-context',
-        'x-skincos-network-sig',
-        'x-skincos-network-signature-version',
-        'x-skincos-network-ts',
-    ]) headers.delete(name);
+    const headers = new Headers();
+    for (const name of CRM_CORE_REQUEST_HEADER_ALLOWLIST) {
+        const value = request.headers.get(name);
+        if (value !== null) headers.set(name, value);
+    }
     return new Request(request, { headers });
 }
 

--- a/api/test/gateway.test.mjs
+++ b/api/test/gateway.test.mjs
@@ -716,13 +716,19 @@ test('Finance is reached through an explicit service binding with a short-lived 
   assert.equal((await verifySignedDomainContext(received, 'finance-secret', 'finance')).actor.username, 'pilot');
 });
 
-test('CRM Core keeps its public staging mount and removes every legacy session credential', async () => {
+test('CRM Core keeps its public staging mount with a narrow request-header allowlist', async () => {
   resetBoundServiceResilienceForTest();
   let received = null;
   const response = await handleGatewayRequest(new Request('https://api-staging.skincos.com.br/crm/ready?smoke=1', {
     headers: {
+      accept: 'application/json',
       authorization: 'Bearer legacy-session',
       cookie: 'crm_session=legacy',
+      'content-type': 'application/json',
+      'cf-connecting-ip': '203.0.113.20',
+      forwarded: 'for=203.0.113.10;proto=https',
+      origin: 'https://crm-staging.skincos.com.br',
+      'proxy-authorization': 'Basic synthetic-proxy-credential',
       'x-csrf-token': 'legacy-csrf',
       'x-identity-delivery': 'identity-crm-delivery/v1.synthetic-envelope',
       'x-request-id': 'crm-core-gateway-1',
@@ -733,6 +739,10 @@ test('CRM Core keeps its public staging mount and removes every legacy session c
       'x-skincos-network-sig': 'legacy-signature',
       'x-skincos-network-signature-version': '2',
       'x-skincos-network-ts': '1788288000000',
+      'x-skincos-service-token': 'synthetic-service-token',
+      'x-unlisted-credential': 'must-not-cross',
+      'x-forwarded-for': '203.0.113.10',
+      'x-forwarded-host': 'legacy-proxy.invalid',
     },
   }), {
     APP_VERSION: 'a'.repeat(40),
@@ -755,6 +765,9 @@ test('CRM Core keeps its public staging mount and removes every legacy session c
   assert.equal((await response.json()).reason, 'CRM_STAGING_READY');
   assert.equal(new URL(received.url).pathname, '/crm/ready');
   assert.equal(new URL(received.url).search, '?smoke=1');
+  assert.equal(received.headers.get('accept'), 'application/json');
+  assert.equal(received.headers.get('content-type'), 'application/json');
+  assert.equal(received.headers.get('origin'), 'https://crm-staging.skincos.com.br');
   assert.equal(received.headers.get('x-request-id'), 'crm-core-gateway-1');
   assert.equal(received.headers.get('x-identity-delivery'), 'identity-crm-delivery/v1.synthetic-envelope');
   for (const name of [
@@ -768,11 +781,53 @@ test('CRM Core keeps its public staging mount and removes every legacy session c
     'x-skincos-network-sig',
     'x-skincos-network-signature-version',
     'x-skincos-network-ts',
+    'x-skincos-service-token',
+    'x-unlisted-credential',
+    'proxy-authorization',
+    'forwarded',
+    'x-forwarded-for',
+    'x-forwarded-host',
+    'cf-connecting-ip',
   ]) assert.equal(received.headers.get(name), null, name);
   assert.equal(response.headers.get('set-cookie'), null);
   assert.equal(response.headers.get('x-skincos-gateway-release-sha'), 'a'.repeat(40));
   assert.equal(response.headers.get('x-skincos-gateway-environment'), 'staging');
   assert.equal(response.headers.get('x-skincos-gateway-version-id'), '22222222-2222-4222-8222-222222222222');
+  resetBoundServiceResilienceForTest();
+});
+
+test('CRM Core keeps its Core-owned CORS origin while omitting unneeded preflight negotiation headers', async () => {
+  resetBoundServiceResilienceForTest();
+  let received = null;
+  const response = await handleGatewayRequest(new Request('https://api-staging.skincos.com.br/crm', {
+    method: 'OPTIONS',
+    headers: {
+      origin: 'https://crm-staging.skincos.com.br',
+      'access-control-request-headers': 'content-type,x-identity-delivery',
+      'access-control-request-method': 'POST',
+      'x-skincos-service-token': 'synthetic-service-token',
+      'x-forwarded-for': '203.0.113.10',
+    },
+  }), {
+    ENVIRONMENT: 'staging',
+    CRM_CORE: {
+      fetch: async (request) => {
+        received = request;
+        return new Response(null, { status: 204 });
+      },
+    },
+  }, {});
+
+  assert.equal(response.status, 204);
+  assert.equal(received.method, 'OPTIONS');
+  // Core's preflight contract derives its static method/header response from
+  // Origin alone; these browser negotiation headers are not part of its
+  // service-binding contract and must not broaden the forwarding boundary.
+  assert.equal(received.headers.get('origin'), 'https://crm-staging.skincos.com.br');
+  assert.equal(received.headers.get('access-control-request-headers'), null);
+  assert.equal(received.headers.get('access-control-request-method'), null);
+  assert.equal(received.headers.get('x-skincos-service-token'), null);
+  assert.equal(received.headers.get('x-forwarded-for'), null);
   resetBoundServiceResilienceForTest();
 });
 

--- a/docs/extraction/crm-core-staging-api-gateway-mount.md
+++ b/docs/extraction/crm-core-staging-api-gateway-mount.md
@@ -21,10 +21,15 @@ binding. O Worker Core é o único componente que traduz esse caminho público
 para o alvo canônico privado `/api/crm/*`; não há redirecionamento ou fallback
 para `/inventory/*`.
 
-Antes de encaminhar, o gateway remove `Cookie`, `Authorization`, CSRF, ator e
-envelopes de sessão/rede legados. O único envelope de identidade que pode
+Antes de encaminhar, o gateway cria uma nova lista explícita de somente cinco
+cabeçalhos: `Accept`, `Content-Type`, `Origin`, `x-request-id` e
+`x-identity-delivery`. `Origin` permite a política CORS que pertence ao Core,
+`Content-Type`/`Accept` preservam a semântica HTTP do navegador e
+`x-request-id` preserva a correlação. O único envelope de identidade que pode
 prosseguir é `x-identity-delivery`; o Core continua responsável por verificar
-assinatura, alvo canônico, expiração e replay. Respostas também não encaminham
+assinatura, alvo canônico, expiração e replay. Todo outro cabeçalho — inclusive
+`Cookie`, `Authorization`, CSRF, tokens de serviço, proxy/Cloudflare e futuros
+cabeçalhos de credencial — é descartado. Respostas também não encaminham
 `Set-Cookie`.
 
 Assim, depois de uma publicação de staging explicitamente autorizada, os


### PR DESCRIPTION
## Security boundary fix

Follow-up to merged PR #1716. This contains only the remediation for the CRM Core staging service-binding header boundary.

- Replaces the public-header denylist with a fresh allowlist: `accept`, `content-type`, `origin`, `x-request-id`, and `x-identity-delivery`.
- Prevents `x-skincos-service-token`, browser sessions, proxy/forwarding/Cloudflare metadata, and future credential-shaped headers from reaching `CRM_CORE`.
- Retains Core-owned CORS behavior: its current preflight implementation evaluates `Origin` and returns its static method/header contract; browser preflight negotiation headers are intentionally not forwarded.

## Validation

- `npm test` in `api`: 45 passing tests.
- Focused request probe: allowed metadata and request body preserved; service/proxy/forwarded/CF/future credential headers absent.
- `wrangler deploy --dry-run --config wrangler.toml --env staging`: passed; no remote publish.

## Scope

No Cloudflare deployment, route change, secret, production configuration, migration, real data access, or merge is included. This branch is based on current `main` after #1716's squash merge.