### PR TITLE
fix(ci): close inventory health heredoc before API deploy

### DIFF
--- a/.github/workflows/deploy-core-workers.yml
+++ b/.github/workflows/deploy-core-workers.yml
@@ -916,7 +916,7 @@ jobs:
               if (!passed) {
                 throw new Error(`Inventory health did not attest the required InventoryLegacyJobsEntrypoint release in two consecutive samples within the propagation window; attempts=${attempt}; last=${lastObservation}`);
               }
-              NODE
+          NODE
             fi
             [[ "$TIMEKEEPING_VERSION_ID" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo 'Core API deploy requires an explicit Timekeeping version UUID'; exit 1; }
             if [[ "$BOOTSTRAP_FINANCE_CONTEXT" == "true" ]]; then


### PR DESCRIPTION
Corrige o terminador do heredoc na guarda de InventoryLegacyJobsEntrypoint do deploy-core-workers.

O terminador estava com indentação adicional dentro do bloco YAML, então o shell não encerrava o `node --input-type=module` e o restante do deploy era interpretado como JavaScript. Isso bloqueava o API staging antes da publicação.

Escopo:
- uma linha em `.github/workflows/deploy-core-workers.yml`;
- nenhum Worker, D1, rota, segredo ou dado externo alterado;
- permite que a guarda de Inventory e o deploy API staging prossigam pelo workflow oficial.

Validação local: `git diff --check`.