### PR TITLE
docs(crm): record staging gateway readback and rollback

### DIFF
--- a/docs/extraction/crm-core-staging-api-gateway-mount.md
+++ b/docs/extraction/crm-core-staging-api-gateway-mount.md
@@ -4,9 +4,10 @@
 
 Esta mudança prepara somente o gateway Worker de staging `skincos-api-staging`
 para encaminhar o prefixo público `https://api-staging.skincos.com.br/crm/*`
-ao Worker independente `skincos-crm-core-staging`. Ela não publica nada por si
-só: não houve deploy, mudança de rota Cloudflare, migração, segredo, dado de
-cliente ou alteração de produção.
+ao Worker independente `skincos-crm-core-staging`. O PR não publica nada por si
+só; a publicação foi feita depois, exclusivamente pelo workflow oficial de
+staging. Na mudança do PR não houve deploy, mudança de rota, migração, segredo,
+dado de cliente ou alteração de produção.
 
 O binding está declarado exclusivamente em
 [`api/wrangler.toml`](../../api/wrangler.toml) como `CRM_CORE` dentro de
@@ -44,7 +45,27 @@ Eles devem refletir o artefato e o D1 dedicados do CRM Core. A rota não ativa
 módulos, leituras de domínio ou escritas: o Core mantém esses caminhos fechados
 até que seus contratos e gates próprios estejam completos.
 
-## Publicação futura de staging
+## Readback da publicação de staging (2026-09-07)
+
+O gateway foi publicado pelo workflow oficial com `unit=api`, usando o SHA
+canônico `15c0f2f0bf45530f5f7ebb15b0a3e91cefc74aff` e o preview imutável
+`34164739551`. A execução de staging foi `34165396727`; o lease global foi
+liberado com sucesso. O readback externo final observou:
+
+- `/crm/health`: `200`, `ok=true`, CRM Core `def3d5c8f714ff30e223c052e759f0d00cb97054`, digest `sha256:0d13042c00f00354497c6a64707211d6f7622dc3d8f7abfa97d6a055c456562e`;
+- `/crm/ready`: `200`, `ok=true`, `reason=CRM_STAGING_READY`;
+- `/crm/modules`: `200`, estado `pre-cut`, todos os módulos ainda indisponíveis;
+- `/api/crm/health`: `404`, mantendo o prefixo legado fechado;
+- cabeçalhos do gateway: ambiente `staging`, release `15c0f2f0bf45530f5f7ebb15b0a3e91cefc74aff`, sincronização `current`, sem `Set-Cookie`.
+
+O rollback de staging foi ensaiado reimplantando o incumbente
+`8126987694a2096cb1a5a3142939dd227132adc9` no workflow `34165274174`: as
+rotas `/crm/health` e `/crm/ready` retornaram `404`, e `/api/crm/health`
+continuou `404`. O candidato foi restaurado no workflow `34165396727`, com
+gateway version id `2a6b9014-834c-45d4-8fd8-c4a3f0ace6a1`. Nenhuma dessas
+execuções alterou produção, Site, Booking ou dados reais.
+
+## Publicação de staging e owner operacional
 
 O owner continua sendo o monorepo, pelo workflow
 `.github/workflows/deploy-core-workers.yml`, com `unit=api` e `target=staging`.
@@ -53,7 +74,7 @@ gates/credenciais Cloudflare já custodidos pelo ambiente. Nenhum segredo novo
 do CRM Core é necessário para o service binding, mas a mudança não deve ser
 publicada fora desse fluxo.
 
-Antes de qualquer deploy, registrar a versão ativa de `skincos-api-staging` e
+Para próximas publicações, registrar a versão ativa de `skincos-api-staging` e
 o rollback correspondente; depois, conferir os dois smokes acima, a rejeição
 de `/api/crm/*`, a ausência de `Set-Cookie` e a preservação de todas as rotas
 Inventory, Finance e Ponto. A rota do shell `crm-staging.skincos.com.br`


### PR DESCRIPTION
## Objetivo\nRegistrar o readback externo e o ensaio de rollback do mount do CRM Core no gateway de staging.\n\n## Escopo\n- documenta os workflows 34164739551, 34165396727 e 34165274174;\n- fixa o SHA do gateway e o digest do Worker CRM Core observados;\n- registra /crm/health, /crm/ready, /crm/modules e a rejeição de /api/crm/health;\n- mantém explícito que não houve produção, dados reais, Site ou Booking.\n\n## Validação\n- git diff --check;\n- readback externo após restore do candidato;\n- nenhuma alteração em bindings/segredos/rotas de produção.\n\nA publicação e o rollback continuam dependentes do workflow oficial; este PR é somente documental.