### PR TITLE
Gate CRM production routing by release receipt

### DIFF
--- a/api/src/crm-core-production-receipt.js
+++ b/api/src/crm-core-production-receipt.js
@@ -1,0 +1,247 @@
+const RECEIPT_CONTRACT = 'skincos-crm/production-route-receipt/v1';
+const CRM_CORE_SERVICE = 'skincos-crm-core';
+const RECEIPT_KEY_PREFIX = 'crm-production-route-receipt-';
+const VERSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const RELEASE_RE = /^[0-9a-f]{40}$/;
+const DIGEST_RE = /^sha256:[0-9a-f]{64}$/;
+const KEY_ID_RE = /^[A-Za-z0-9._-]{3,96}$/;
+const BASE64URL_RE = /^[A-Za-z0-9_-]+$/;
+const RECEIPT_KEYS = Object.freeze([
+    'contract',
+    'receiptId',
+    'environment',
+    'gatewayVersionId',
+    'service',
+    'workerVersionId',
+    'release',
+    'artifactDigest',
+    'keyId',
+    'signature',
+]);
+const TEXT_ENCODER = new TextEncoder();
+const CRM_CORE_PROBE_TIMEOUT_MS = 3_000;
+const authorizedReceipts = new WeakMap();
+
+function exactRecord(value, keys) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)
+        || Object.keys(value).length !== keys.length || keys.some((key) => !Object.hasOwn(value, key))) {
+        return null;
+    }
+    return value;
+}
+
+function parseJson(value, maxLength = 16 * 1024) {
+    if (typeof value !== 'string' || value.length === 0 || value.length > maxLength) return null;
+    try {
+        return JSON.parse(value);
+    } catch {
+        return null;
+    }
+}
+
+function normalizedText(value) {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeReceipt(value) {
+    const record = exactRecord(value, RECEIPT_KEYS);
+    if (!record) return null;
+
+    const receiptId = normalizedText(record.receiptId);
+    const gatewayVersionId = normalizedText(record.gatewayVersionId).toLowerCase();
+    const workerVersionId = normalizedText(record.workerVersionId).toLowerCase();
+    const release = normalizedText(record.release).toLowerCase();
+    const artifactDigest = normalizedText(record.artifactDigest).toLowerCase();
+    const keyId = normalizedText(record.keyId);
+    const signature = normalizedText(record.signature);
+    if (record.contract !== RECEIPT_CONTRACT
+        || record.environment !== 'production'
+        || record.service !== CRM_CORE_SERVICE
+        || !/^[A-Za-z0-9._:-]{8,200}$/.test(receiptId)
+        || !VERSION_ID_RE.test(gatewayVersionId)
+        || !VERSION_ID_RE.test(workerVersionId)
+        || !RELEASE_RE.test(release)
+        || !DIGEST_RE.test(artifactDigest)
+        || !KEY_ID_RE.test(keyId)
+        || !keyId.startsWith(RECEIPT_KEY_PREFIX)
+        || !BASE64URL_RE.test(signature)) {
+        return null;
+    }
+    return Object.freeze({
+        contract: RECEIPT_CONTRACT,
+        receiptId,
+        environment: 'production',
+        gatewayVersionId,
+        service: CRM_CORE_SERVICE,
+        workerVersionId,
+        release,
+        artifactDigest,
+        keyId,
+        signature,
+    });
+}
+
+function normalizePublicKeys(value) {
+    const record = value && typeof value === 'object' && !Array.isArray(value) ? value : null;
+    if (!record) return null;
+    const entries = Object.entries(record);
+    if (entries.length === 0 || entries.length > 8) return null;
+    const keys = new Map();
+    for (const [keyId, key] of entries) {
+        if (!KEY_ID_RE.test(keyId) || !keyId.startsWith(RECEIPT_KEY_PREFIX)
+            || !key || typeof key !== 'object' || Array.isArray(key)
+            || Object.hasOwn(key, 'd') || key.kty !== 'OKP' || key.crv !== 'Ed25519'
+            || typeof key.x !== 'string' || !/^[A-Za-z0-9_-]{43}$/.test(key.x)) {
+            return null;
+        }
+        keys.set(keyId, Object.freeze({ ...key }));
+    }
+    return keys;
+}
+
+function signatureBytes(value) {
+    if (typeof globalThis.atob !== 'function' || !BASE64URL_RE.test(value)) return null;
+    const padded = value.replace(/-/g, '+').replace(/_/g, '/') + '='.repeat((4 - (value.length % 4)) % 4);
+    try {
+        return Uint8Array.from(globalThis.atob(padded), (character) => character.charCodeAt(0));
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * The signed receipt binds the production gateway version, exact service
+ * version and Core artifact identity. It is deliberately not a set of
+ * independently switchable regex-shaped variables.
+ */
+export function createCrmCoreProductionReceiptSigningInput(receipt) {
+    const normalized = normalizeReceipt(receipt);
+    if (!normalized) throw new TypeError('CRM_CORE_PRODUCTION_RECEIPT_INVALID');
+    return [
+        normalized.contract,
+        normalized.receiptId,
+        normalized.environment,
+        normalized.gatewayVersionId,
+        normalized.service,
+        normalized.workerVersionId,
+        normalized.release,
+        normalized.artifactDigest,
+        normalized.keyId,
+    ].join('\n');
+}
+
+async function verifiesReceiptSignature(receipt, publicKeys) {
+    const key = publicKeys.get(receipt.keyId);
+    const signature = signatureBytes(receipt.signature);
+    const subtle = globalThis.crypto?.subtle;
+    if (!key || !signature || !subtle?.importKey || !subtle?.verify) return false;
+    try {
+        const publicKey = await subtle.importKey('jwk', key, { name: 'Ed25519' }, false, ['verify']);
+        return await subtle.verify(
+            { name: 'Ed25519' },
+            publicKey,
+            signature,
+            TEXT_ENCODER.encode(createCrmCoreProductionReceiptSigningInput(receipt)),
+        ) === true;
+    } catch {
+        return false;
+    }
+}
+
+function receiptFromEnvironment(env) {
+    if (String(env?.ENVIRONMENT || '').trim().toLowerCase() !== 'production'
+        || String(env?.CRM_CORE_PRODUCTION_ENABLED || '').trim() !== 'true') {
+        return null;
+    }
+    const receipt = normalizeReceipt(parseJson(env?.CRM_CORE_PRODUCTION_RECEIPT));
+    const publicKeys = normalizePublicKeys(parseJson(env?.CRM_CORE_PRODUCTION_RECEIPT_PUBLIC_KEYS_JSON));
+    const gatewayVersionId = normalizedText(env?.CF_VERSION_METADATA?.id).toLowerCase();
+    if (!receipt || !publicKeys || !VERSION_ID_RE.test(gatewayVersionId)
+        || receipt.gatewayVersionId !== gatewayVersionId) {
+        return null;
+    }
+    return { receipt, publicKeys };
+}
+
+function probeRequest(request, receipt) {
+    const url = new URL(request.url);
+    url.pathname = '/ready';
+    url.search = '';
+    const suppliedRequestId = normalizedText(request.headers.get('x-request-id'));
+    const requestId = /^[A-Za-z0-9._:-]{1,96}$/.test(suppliedRequestId)
+        ? `${suppliedRequestId}.crm-receipt`
+        : 'crm-production-receipt-probe';
+    return new Request(url.toString(), {
+        method: 'GET',
+        headers: {
+            accept: 'application/json',
+            'x-request-id': requestId.slice(0, 120),
+            'cloudflare-workers-version-overrides': `${receipt.service}="${receipt.workerVersionId}"`,
+        },
+    });
+}
+
+async function fetchProbe(binding, request) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), CRM_CORE_PROBE_TIMEOUT_MS);
+    try {
+        return await binding.fetch(new Request(request, { signal: controller.signal }));
+    } catch {
+        return null;
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+async function provesReceiptTarget(request, env, receipt) {
+    const binding = env?.CRM_CORE;
+    if (!binding || typeof binding.fetch !== 'function') return false;
+    const response = await fetchProbe(binding, probeRequest(request, receipt));
+    if (!response || !response.ok) {
+        if (response?.body) await response.body.cancel().catch(() => {});
+        return false;
+    }
+    let body;
+    try {
+        body = await response.json();
+    } catch {
+        return false;
+    }
+    return body?.ok === true
+        && body?.ready === true
+        && body?.unit === 'crm-core'
+        && body?.environment === 'production'
+        && String(body?.release || '').trim().toLowerCase() === receipt.release
+        && String(body?.version || '').trim().toLowerCase() === receipt.release
+        && String(body?.artifact_digest || '').trim().toLowerCase() === receipt.artifactDigest
+        && String(body?.artifactDigest || '').trim().toLowerCase() === receipt.artifactDigest;
+}
+
+/**
+ * Verifies a custody-signed receipt, pins the service fetch to its immutable
+ * Cloudflare Worker version, and proves the pinned target's ready identity.
+ */
+export async function authorizeCrmCoreProductionRoute(request, env) {
+    const configured = receiptFromEnvironment(env);
+    if (!configured || !await verifiesReceiptSignature(configured.receipt, configured.publicKeys)) return null;
+    if (!await provesReceiptTarget(request, env, configured.receipt)) return null;
+    authorizedReceipts.set(configured.receipt, env);
+    return configured.receipt;
+}
+
+export function isCrmCoreStagingEnvironment(env) {
+    return String(env?.ENVIRONMENT || '').trim().toLowerCase() === 'staging';
+}
+
+export function isAuthorizedCrmCoreProductionReceipt(receipt, env) {
+    return Boolean(receipt && typeof receipt === 'object' && authorizedReceipts.get(receipt) === env);
+}
+
+/** A fresh header set ensures a browser cannot select the bound Worker version. */
+export function crmCoreVersionOverride(receipt, env) {
+    if (!isAuthorizedCrmCoreProductionReceipt(receipt, env)
+        || receipt.service !== CRM_CORE_SERVICE || !VERSION_ID_RE.test(receipt.workerVersionId)) {
+        throw new TypeError('CRM_CORE_PRODUCTION_RECEIPT_INVALID');
+    }
+    return `${receipt.service}="${receipt.workerVersionId}"`;
+}

--- a/api/src/gateway.js
+++ b/api/src/gateway.js
@@ -2,6 +2,12 @@ import { createGatewayHandler } from './router.js';
 import { csrfErrorFor, resolveCrmActor } from '../../shared/crm-auth/worker.js';
 import { fetchBoundService } from '../../shared/service-adapters/cloudflare-service-binding.js';
 import { createSignedDomainContext } from '../../shared/service-adapters/signed-domain-context.js';
+import {
+    authorizeCrmCoreProductionRoute,
+    crmCoreVersionOverride,
+    isAuthorizedCrmCoreProductionReceipt,
+    isCrmCoreStagingEnvironment,
+} from './crm-core-production-receipt.js';
 
 const gatewayError = (status, error) => new Response(JSON.stringify({ ok: false, error }), { status, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' } });
 const isOperationalProbe = (request) => request.method === 'GET' && ['/health', '/readiness'].includes(new URL(request.url).pathname);
@@ -97,28 +103,8 @@ function inventoryServiceTimeout(request) {
         : INVENTORY_READ_TIMEOUT_MS;
 }
 
-function isStagingEnvironment(env) {
-    return String(env?.ENVIRONMENT || '').trim().toLowerCase() === 'staging';
-}
-
 function isProductionEnvironment(env) {
     return String(env?.ENVIRONMENT || '').trim().toLowerCase() === 'production';
-}
-
-/**
- * Production CRM routing is an explicit, receipt-bound opt-in. Keeping the
- * release identity and artifact digest in the gateway configuration makes a
- * flag-only mistake fail closed before a service binding can receive traffic.
- * The values are identifiers, never credentials or customer data.
- */
-function isCrmCoreProductionEnabled(env) {
-    if (!isProductionEnvironment(env) || String(env?.CRM_CORE_PRODUCTION_ENABLED || '').trim() !== 'true') return false;
-    const release = String(env?.CRM_CORE_PRODUCTION_RELEASE_SHA || '').trim().toLowerCase();
-    const digest = String(env?.CRM_CORE_PRODUCTION_ARTIFACT_DIGEST || '').trim().toLowerCase();
-    const gate = String(env?.CRM_CORE_PRODUCTION_GATE_ID || '').trim();
-    return /^[0-9a-f]{40}$/.test(release)
-        && /^sha256:[0-9a-f]{64}$/.test(digest)
-        && /^[A-Za-z0-9._:-]{8,200}$/.test(gate);
 }
 
 /**
@@ -130,20 +116,28 @@ function isCrmCoreProductionEnabled(env) {
  * CRM Core verifies it against its pinned Identity public key and replay
  * ledger.
  */
-export function prepareCrmCoreRequest(request) {
+export function prepareCrmCoreRequest(request, productionReceipt = null, env = null) {
     const headers = new Headers();
     for (const name of CRM_CORE_REQUEST_HEADER_ALLOWLIST) {
         const value = request.headers.get(name);
         if (value !== null) headers.set(name, value);
     }
+    if (productionReceipt) {
+        headers.set('cloudflare-workers-version-overrides', crmCoreVersionOverride(productionReceipt, env));
+    }
     return new Request(request, { headers });
 }
 
-export async function forwardCrmCoreToService(request, env) {
-    if (!isStagingEnvironment(env) && !isCrmCoreProductionEnabled(env)) {
+export async function forwardCrmCoreToService(request, env, ctx, authorizedProductionReceipt = null) {
+    const staging = isCrmCoreStagingEnvironment(env);
+    let productionReceipt = staging ? null : authorizedProductionReceipt;
+    if (!staging && !isAuthorizedCrmCoreProductionReceipt(productionReceipt, env)) {
+        productionReceipt = await authorizeCrmCoreProductionRoute(request, env);
+    }
+    if (!staging && !productionReceipt) {
         return gatewayError(404, isProductionEnvironment(env) ? 'CRM_CORE_PRODUCTION_NOT_AUTHORIZED' : 'CRM_CORE_STAGING_ONLY');
     }
-    return fetchBoundService(prepareCrmCoreRequest(request), env, 'CRM_CORE', {
+    return fetchBoundService(prepareCrmCoreRequest(request, productionReceipt, env), env, 'CRM_CORE', {
         timeoutMs: CRM_CORE_TIMEOUT_MS,
     });
 }

--- a/api/src/gateway.js
+++ b/api/src/gateway.js
@@ -9,7 +9,7 @@ const isPontoReadinessProbe = (request) => request.method === 'GET' && new URL(r
 const FINANCE_PROBE_TIMEOUT_MS = 3_000;
 const FINANCE_READ_TIMEOUT_MS = 3_000;
 const FINANCE_WRITE_TIMEOUT_MS = 5_000;
-const CRM_CORE_STAGING_TIMEOUT_MS = 3_000;
+const CRM_CORE_TIMEOUT_MS = 3_000;
 const CRM_CORE_REQUEST_HEADER_ALLOWLIST = Object.freeze([
     'accept',
     'content-type',
@@ -101,6 +101,26 @@ function isStagingEnvironment(env) {
     return String(env?.ENVIRONMENT || '').trim().toLowerCase() === 'staging';
 }
 
+function isProductionEnvironment(env) {
+    return String(env?.ENVIRONMENT || '').trim().toLowerCase() === 'production';
+}
+
+/**
+ * Production CRM routing is an explicit, receipt-bound opt-in. Keeping the
+ * release identity and artifact digest in the gateway configuration makes a
+ * flag-only mistake fail closed before a service binding can receive traffic.
+ * The values are identifiers, never credentials or customer data.
+ */
+function isCrmCoreProductionEnabled(env) {
+    if (!isProductionEnvironment(env) || String(env?.CRM_CORE_PRODUCTION_ENABLED || '').trim() !== 'true') return false;
+    const release = String(env?.CRM_CORE_PRODUCTION_RELEASE_SHA || '').trim().toLowerCase();
+    const digest = String(env?.CRM_CORE_PRODUCTION_ARTIFACT_DIGEST || '').trim().toLowerCase();
+    const gate = String(env?.CRM_CORE_PRODUCTION_GATE_ID || '').trim();
+    return /^[0-9a-f]{40}$/.test(release)
+        && /^sha256:[0-9a-f]{64}$/.test(digest)
+        && /^[A-Za-z0-9._:-]{8,200}$/.test(gate);
+}
+
 /**
  * This is a fresh allowlist, never a mutation of public request headers.
  * CRM Core needs only browser representation/CORS metadata, correlation and
@@ -120,9 +140,11 @@ export function prepareCrmCoreRequest(request) {
 }
 
 export async function forwardCrmCoreToService(request, env) {
-    if (!isStagingEnvironment(env)) return gatewayError(404, 'CRM_CORE_STAGING_ONLY');
+    if (!isStagingEnvironment(env) && !isCrmCoreProductionEnabled(env)) {
+        return gatewayError(404, isProductionEnvironment(env) ? 'CRM_CORE_PRODUCTION_NOT_AUTHORIZED' : 'CRM_CORE_STAGING_ONLY');
+    }
     return fetchBoundService(prepareCrmCoreRequest(request), env, 'CRM_CORE', {
-        timeoutMs: CRM_CORE_STAGING_TIMEOUT_MS,
+        timeoutMs: CRM_CORE_TIMEOUT_MS,
     });
 }
 

--- a/api/src/router.js
+++ b/api/src/router.js
@@ -1,3 +1,5 @@
+import { authorizeCrmCoreProductionRoute, isCrmCoreStagingEnvironment } from './crm-core-production-receipt.js';
+
 const json = (status, payload, requestId) =>
     new Response(JSON.stringify(payload), {
         status,
@@ -64,21 +66,6 @@ function operationalPayload(env, requestId, ready, dependencies) {
 
 function isPontoRouteOnly(env) {
     return String(env?.PONTO_ROUTE_ONLY || '').trim() === 'true';
-}
-
-function isStagingEnvironment(env) {
-    return String(env?.ENVIRONMENT || '').trim().toLowerCase() === 'staging';
-}
-
-function isCrmCoreProductionEnabled(env) {
-    if (String(env?.ENVIRONMENT || '').trim().toLowerCase() !== 'production') return false;
-    if (String(env?.CRM_CORE_PRODUCTION_ENABLED || '').trim() !== 'true') return false;
-    const release = String(env?.CRM_CORE_PRODUCTION_RELEASE_SHA || '').trim().toLowerCase();
-    const digest = String(env?.CRM_CORE_PRODUCTION_ARTIFACT_DIGEST || '').trim().toLowerCase();
-    const gate = String(env?.CRM_CORE_PRODUCTION_GATE_ID || '').trim();
-    return /^[0-9a-f]{40}$/.test(release)
-        && /^sha256:[0-9a-f]{64}$/.test(digest)
-        && /^[A-Za-z0-9._:-]{8,200}$/.test(gate);
 }
 
 function isCrmCoreRoute(pathname) {
@@ -273,10 +260,13 @@ export function createGatewayHandler({ inventoryHandler, timekeepingHandler, fin
         }
 
         // CRM Core owns the public /crm/* spelling only in staging, or after
-        // an explicit production gate binds the exact receipt-bound artifact.
+        // a custody-signed production receipt proves the exact pinned artifact.
         // Do not strip this prefix and do not fall through to Inventory.
         if (isCrmCoreRoute(url.pathname)) {
-            if (!isStagingEnvironment(env) && !isCrmCoreProductionEnabled(env)) {
+            const productionReceipt = isCrmCoreStagingEnvironment(env)
+                ? null
+                : await authorizeCrmCoreProductionRoute(request, env);
+            if (!isCrmCoreStagingEnvironment(env) && !productionReceipt) {
                 return json(404, {
                     ok: false,
                     error: String(env?.ENVIRONMENT || '').trim().toLowerCase() === 'production'
@@ -292,7 +282,7 @@ export function createGatewayHandler({ inventoryHandler, timekeepingHandler, fin
             }
             const headers = new Headers(request.headers);
             headers.set('x-request-id', requestId);
-            const response = await crmCoreHandler(new Request(request, { headers }), env, ctx);
+            const response = await crmCoreHandler(new Request(request, { headers }), env, ctx, productionReceipt);
             const responseHeaders = new Headers(response.headers);
             // CRM Core has no legacy cookie/session compatibility surface.
             responseHeaders.delete('set-cookie');

--- a/api/src/router.js
+++ b/api/src/router.js
@@ -70,6 +70,17 @@ function isStagingEnvironment(env) {
     return String(env?.ENVIRONMENT || '').trim().toLowerCase() === 'staging';
 }
 
+function isCrmCoreProductionEnabled(env) {
+    if (String(env?.ENVIRONMENT || '').trim().toLowerCase() !== 'production') return false;
+    if (String(env?.CRM_CORE_PRODUCTION_ENABLED || '').trim() !== 'true') return false;
+    const release = String(env?.CRM_CORE_PRODUCTION_RELEASE_SHA || '').trim().toLowerCase();
+    const digest = String(env?.CRM_CORE_PRODUCTION_ARTIFACT_DIGEST || '').trim().toLowerCase();
+    const gate = String(env?.CRM_CORE_PRODUCTION_GATE_ID || '').trim();
+    return /^[0-9a-f]{40}$/.test(release)
+        && /^sha256:[0-9a-f]{64}$/.test(digest)
+        && /^[A-Za-z0-9._:-]{8,200}$/.test(gate);
+}
+
 function isCrmCoreRoute(pathname) {
     return pathname === '/crm' || pathname.startsWith('/crm/');
 }
@@ -261,13 +272,18 @@ export function createGatewayHandler({ inventoryHandler, timekeepingHandler, fin
             return json(404, { ok: false, error: 'ponto_route_only', requestId }, requestId);
         }
 
-        // CRM Core has no production route or production service binding. Its
-        // independent staging Worker owns the public /crm/* spelling and maps
-        // it exactly once to the canonical private /api/crm/* target. Do not
-        // strip this prefix and do not fall through to Inventory.
+        // CRM Core owns the public /crm/* spelling only in staging, or after
+        // an explicit production gate binds the exact receipt-bound artifact.
+        // Do not strip this prefix and do not fall through to Inventory.
         if (isCrmCoreRoute(url.pathname)) {
-            if (!isStagingEnvironment(env)) {
-                return json(404, { ok: false, error: 'crm_core_staging_only', requestId }, requestId);
+            if (!isStagingEnvironment(env) && !isCrmCoreProductionEnabled(env)) {
+                return json(404, {
+                    ok: false,
+                    error: String(env?.ENVIRONMENT || '').trim().toLowerCase() === 'production'
+                        ? 'crm_core_production_not_authorized'
+                        : 'crm_core_staging_only',
+                    requestId,
+                }, requestId);
             }
             if (typeof crmCoreHandler !== 'function') {
                 const unavailable = json(503, { ok: false, error: 'crm_core_unavailable', requestId }, requestId);

--- a/api/test/gateway.test.mjs
+++ b/api/test/gateway.test.mjs
@@ -838,7 +838,56 @@ test('CRM Core never becomes a production route even if a binding is present', a
     CRM_CORE: { fetch: async () => { calls += 1; return new Response('must-not-run'); } },
   }, {});
   assert.equal(response.status, 404);
-  assert.equal((await response.json()).error, 'crm_core_staging_only');
+  assert.equal((await response.json()).error, 'crm_core_production_not_authorized');
+  assert.equal(calls, 0);
+});
+
+test('CRM Core production routing requires an exact receipt-bound opt-in', async () => {
+  let received = null;
+  const response = await handleGatewayRequest(new Request('https://api.skincos.com.br/crm/health?cutover=probe', {
+    headers: {
+      accept: 'application/json',
+      authorization: 'must-not-cross',
+      cookie: 'must-not-cross',
+      'x-request-id': 'crm-production-gate-1',
+      'x-identity-delivery': 'identity-crm-delivery/v1.synthetic-envelope',
+    },
+  }), {
+    ENVIRONMENT: 'production',
+    CRM_CORE_PRODUCTION_ENABLED: 'true',
+    CRM_CORE_PRODUCTION_RELEASE_SHA: 'a'.repeat(40),
+    CRM_CORE_PRODUCTION_ARTIFACT_DIGEST: `sha256:${'b'.repeat(64)}`,
+    CRM_CORE_PRODUCTION_GATE_ID: 'crm-production-cutover-20260907',
+    CRM_CORE: {
+      fetch: async (request) => {
+        received = request;
+        return new Response(JSON.stringify({ ok: true, unit: 'crm-core' }), {
+          headers: { 'content-type': 'application/json; charset=utf-8' },
+        });
+      },
+    },
+  }, {});
+
+  assert.equal(response.status, 200);
+  assert.equal((await response.json()).unit, 'crm-core');
+  assert.equal(new URL(received.url).pathname, '/crm/health');
+  assert.equal(new URL(received.url).search, '?cutover=probe');
+  assert.equal(received.headers.get('accept'), 'application/json');
+  assert.equal(received.headers.get('x-request-id'), 'crm-production-gate-1');
+  assert.equal(received.headers.get('x-identity-delivery'), 'identity-crm-delivery/v1.synthetic-envelope');
+  assert.equal(received.headers.get('authorization'), null);
+  assert.equal(received.headers.get('cookie'), null);
+});
+
+test('CRM Core rejects a production flag without receipt identity', async () => {
+  let calls = 0;
+  const response = await handleGatewayRequest(new Request('https://api.skincos.com.br/crm/health'), {
+    ENVIRONMENT: 'production',
+    CRM_CORE_PRODUCTION_ENABLED: 'true',
+    CRM_CORE: { fetch: async () => { calls += 1; return new Response('must-not-run'); } },
+  }, {});
+  assert.equal(response.status, 404);
+  assert.equal((await response.json()).error, 'crm_core_production_not_authorized');
   assert.equal(calls, 0);
 });
 
@@ -864,6 +913,6 @@ test('CRM Core fails closed without its staging binding and never aliases legacy
 test('general API Worker binds CRM Core only in the staging environment', async () => {
   const config = await readFile(new URL('../wrangler.toml', import.meta.url), 'utf8');
   const productionConfig = config.slice(0, config.indexOf('[env.staging]'));
-  assert.doesNotMatch(productionConfig, /CRM_CORE/);
+  assert.doesNotMatch(productionConfig, /binding\s*=\s*"CRM_CORE"/);
   assert.match(config, /\[\[env\.staging\.services\]\]\r?\nbinding = "CRM_CORE"\r?\nservice = "skincos-crm-core-staging"/);
 });

--- a/api/test/gateway.test.mjs
+++ b/api/test/gateway.test.mjs
@@ -1,13 +1,70 @@
 import assert from 'node:assert/strict';
+import { generateKeyPairSync, sign } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 import { createGatewayHandler } from '../src/router.js';
-import { createApiGateway, forwardFinanceProbe, forwardFinanceToService, handleGatewayRequest, prepareTimekeepingRequest } from '../src/gateway.js';
+import { createApiGateway, forwardCrmCoreToService, forwardFinanceProbe, forwardFinanceToService, handleGatewayRequest, prepareTimekeepingRequest } from '../src/gateway.js';
+import { createCrmCoreProductionReceiptSigningInput } from '../src/crm-core-production-receipt.js';
 import pontoCoreWorker from '../workers/ponto.js';
 import { verifySignedDomainContext } from '../../shared/service-adapters/signed-domain-context.js';
 import { resetBoundServiceResilienceForTest } from '../../shared/service-adapters/cloudflare-service-binding.js';
 
 const calls = [];
+const crmProductionGatewayVersionId = '11111111-1111-4111-8111-111111111111';
+const crmProductionWorkerVersionId = '22222222-2222-4222-8222-222222222222';
+const crmProductionReceiptKeyId = 'crm-production-route-receipt-test';
+const crmProductionReceiptKeys = generateKeyPairSync('ed25519');
+const crmProductionReceiptPublicKey = crmProductionReceiptKeys.publicKey.export({ format: 'jwk' });
+
+function signedCrmProductionReceipt(overrides = {}) {
+    const receipt = {
+        contract: 'skincos-crm/production-route-receipt/v1',
+        receiptId: 'crm-production-route-receipt-test-20260907',
+        environment: 'production',
+        gatewayVersionId: crmProductionGatewayVersionId,
+        service: 'skincos-crm-core',
+        workerVersionId: crmProductionWorkerVersionId,
+        release: 'a'.repeat(40),
+        artifactDigest: `sha256:${'b'.repeat(64)}`,
+        keyId: crmProductionReceiptKeyId,
+        signature: 'a',
+        ...overrides,
+    };
+    receipt.signature = sign(
+        null,
+        Buffer.from(createCrmCoreProductionReceiptSigningInput(receipt)),
+        crmProductionReceiptKeys.privateKey,
+    ).toString('base64url');
+    return receipt;
+}
+
+function crmProductionEnvironment(receipt = signedCrmProductionReceipt(), overrides = {}) {
+    return {
+        ENVIRONMENT: 'production',
+        APP_VERSION: 'c'.repeat(40),
+        CF_VERSION_METADATA: { id: crmProductionGatewayVersionId },
+        CRM_CORE_PRODUCTION_ENABLED: 'true',
+        CRM_CORE_PRODUCTION_RECEIPT: JSON.stringify(receipt),
+        CRM_CORE_PRODUCTION_RECEIPT_PUBLIC_KEYS_JSON: JSON.stringify({
+            [crmProductionReceiptKeyId]: crmProductionReceiptPublicKey,
+        }),
+        ...overrides,
+    };
+}
+
+function crmCoreReceiptReadyBody(receipt, overrides = {}) {
+    return {
+        ok: true,
+        ready: true,
+        unit: 'crm-core',
+        environment: 'production',
+        release: receipt.release,
+        version: receipt.release,
+        artifact_digest: receipt.artifactDigest,
+        artifactDigest: receipt.artifactDigest,
+        ...overrides,
+    };
+}
 const gateway = createGatewayHandler({
     inventoryHandler: async (request) => {
         calls.push(new URL(request.url));
@@ -842,34 +899,48 @@ test('CRM Core never becomes a production route even if a binding is present', a
   assert.equal(calls, 0);
 });
 
-test('CRM Core production routing requires an exact receipt-bound opt-in', async () => {
+test('CRM Core production routing requires a signed receipt, pinned Worker version and matching live proof', async () => {
+  resetBoundServiceResilienceForTest();
+  const receipt = signedCrmProductionReceipt();
   let received = null;
+  let probes = 0;
   const response = await handleGatewayRequest(new Request('https://api.skincos.com.br/crm/health?cutover=probe', {
     headers: {
       accept: 'application/json',
       authorization: 'must-not-cross',
       cookie: 'must-not-cross',
+      'cloudflare-workers-version-overrides': 'skincos-evil="33333333-3333-4333-8333-333333333333"',
       'x-request-id': 'crm-production-gate-1',
       'x-identity-delivery': 'identity-crm-delivery/v1.synthetic-envelope',
     },
-  }), {
-    ENVIRONMENT: 'production',
-    CRM_CORE_PRODUCTION_ENABLED: 'true',
-    CRM_CORE_PRODUCTION_RELEASE_SHA: 'a'.repeat(40),
-    CRM_CORE_PRODUCTION_ARTIFACT_DIGEST: `sha256:${'b'.repeat(64)}`,
-    CRM_CORE_PRODUCTION_GATE_ID: 'crm-production-cutover-20260907',
+  }), crmProductionEnvironment(receipt, {
     CRM_CORE: {
       fetch: async (request) => {
+        const pathname = new URL(request.url).pathname;
+        assert.equal(
+          request.headers.get('cloudflare-workers-version-overrides'),
+          `skincos-crm-core="${receipt.workerVersionId}"`,
+        );
+        if (pathname === '/ready') {
+          probes += 1;
+          assert.equal(request.headers.get('authorization'), null);
+          assert.equal(request.headers.get('cookie'), null);
+          assert.equal(request.headers.get('x-identity-delivery'), null);
+          return new Response(JSON.stringify(crmCoreReceiptReadyBody(receipt)), {
+            headers: { 'content-type': 'application/json; charset=utf-8' },
+          });
+        }
         received = request;
         return new Response(JSON.stringify({ ok: true, unit: 'crm-core' }), {
           headers: { 'content-type': 'application/json; charset=utf-8' },
         });
       },
     },
-  }, {});
+  }), {});
 
   assert.equal(response.status, 200);
   assert.equal((await response.json()).unit, 'crm-core');
+  assert.equal(probes, 1);
   assert.equal(new URL(received.url).pathname, '/crm/health');
   assert.equal(new URL(received.url).search, '?cutover=probe');
   assert.equal(received.headers.get('accept'), 'application/json');
@@ -877,6 +948,75 @@ test('CRM Core production routing requires an exact receipt-bound opt-in', async
   assert.equal(received.headers.get('x-identity-delivery'), 'identity-crm-delivery/v1.synthetic-envelope');
   assert.equal(received.headers.get('authorization'), null);
   assert.equal(received.headers.get('cookie'), null);
+  assert.equal(
+    received.headers.get('cloudflare-workers-version-overrides'),
+    `skincos-crm-core="${receipt.workerVersionId}"`,
+  );
+  resetBoundServiceResilienceForTest();
+});
+
+test('CRM Core production never probes or forwards for a format-valid but unsigned receipt', async () => {
+  const receipt = signedCrmProductionReceipt();
+  receipt.signature = 'a'.repeat(86);
+  let calls = 0;
+  const response = await handleGatewayRequest(new Request('https://api.skincos.com.br/crm/health'), crmProductionEnvironment(receipt, {
+    CRM_CORE: { fetch: async () => { calls += 1; return new Response('must-not-run'); } },
+  }), {});
+  assert.equal(response.status, 404);
+  assert.equal((await response.json()).error, 'crm_core_production_not_authorized');
+  assert.equal(calls, 0);
+});
+
+test('CRM Core production receipt must pin the executing gateway version before probing', async () => {
+  const receipt = signedCrmProductionReceipt();
+  let calls = 0;
+  const response = await handleGatewayRequest(new Request('https://api.skincos.com.br/crm/health'), crmProductionEnvironment(receipt, {
+    CF_VERSION_METADATA: { id: '33333333-3333-4333-8333-333333333333' },
+    CRM_CORE: { fetch: async () => { calls += 1; return new Response('must-not-run'); } },
+  }), {});
+  assert.equal(response.status, 404);
+  assert.equal((await response.json()).error, 'crm_core_production_not_authorized');
+  assert.equal(calls, 0);
+});
+
+test('direct CRM forwarding cannot trust a caller-supplied version-shaped receipt', async () => {
+  let calls = 0;
+  const response = await forwardCrmCoreToService(
+    new Request('https://api.skincos.com.br/crm/health'),
+    {
+      ENVIRONMENT: 'production',
+      CRM_CORE: { fetch: async () => { calls += 1; return new Response('must-not-run'); } },
+    },
+    undefined,
+    { service: 'skincos-crm-core', workerVersionId: crmProductionWorkerVersionId },
+  );
+  assert.equal(response.status, 404);
+  assert.equal((await response.json()).error, 'CRM_CORE_PRODUCTION_NOT_AUTHORIZED');
+  assert.equal(calls, 0);
+});
+
+test('CRM Core production rejects a signed receipt when the pinned Worker proof disagrees', async () => {
+  const receipt = signedCrmProductionReceipt();
+  let probes = 0;
+  let forwards = 0;
+  const response = await handleGatewayRequest(new Request('https://api.skincos.com.br/crm/health'), crmProductionEnvironment(receipt, {
+    CRM_CORE: {
+      fetch: async (request) => {
+        if (new URL(request.url).pathname === '/ready') {
+          probes += 1;
+          return new Response(JSON.stringify(crmCoreReceiptReadyBody(receipt, { artifactDigest: `sha256:${'c'.repeat(64)}` })), {
+            headers: { 'content-type': 'application/json; charset=utf-8' },
+          });
+        }
+        forwards += 1;
+        return new Response('must-not-run');
+      },
+    },
+  }), {});
+  assert.equal(response.status, 404);
+  assert.equal((await response.json()).error, 'crm_core_production_not_authorized');
+  assert.equal(probes, 1);
+  assert.equal(forwards, 0);
 });
 
 test('CRM Core rejects a production flag without receipt identity', async () => {

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -15,6 +15,10 @@ binding = "CF_VERSION_METADATA"
 [vars]
 APP_VERSION = "unreleased"
 ENVIRONMENT = "production"
+# The production CRM binding and route remain absent until the independent
+# Worker, production receipt and legacy-retirement gates are verified. This
+# explicit default keeps a future binding fail-closed if it is added later.
+CRM_CORE_PRODUCTION_ENABLED = "false"
 
 [triggers]
 crons = ["0 * * * *"]


### PR DESCRIPTION
## Summary\n- allow /crm/* production routing only with exact release SHA, artifact digest, and gate receipt identifiers\n- preserve fail-closed default and no production CRM binding\n- add focused forwarding and rejection tests\n\n## Validation\n- node --test api/test/gateway.test.mjs (40 passed)\n- git diff --check\n\nThis is a preparation gate only; it does not deploy or change production traffic.