### PR TITLE
feat(atendimento): add staged CRM backfill delivery producer

### DIFF
--- a/integration/atendimento/crm-core-projection-exporter/README.md
+++ b/integration/atendimento/crm-core-projection-exporter/README.md
@@ -34,18 +34,24 @@ exige capacidades já construídas pelo operador:
 
 O runner abre uma única transação `REPEATABLE READ READ ONLY`, atesta a fonte e
 usa paginação por chave `(updated_at, id)`, nunca `OFFSET`. Cada lote contém no
-máximo 20 eventos. O transporte limita o corpo a 64 KiB, envia apenas
-`content-type` e `x-request-id`, omite credenciais e rejeita redirects,
-cookies, `Origin` e `Authorization`. A resposta precisa vincular exatamente o
-lote, o request ID e o release/digest do artefato CRM Core esperado.
+máximo 20 eventos. A consulta converte `updated_at` para UTC com seis dígitos
+de microssegundo, e o cursor privado preserva essa precisão; a data pública do
+evento continua no formato do contrato CRM. O transporte limita o corpo a 64
+KiB, tem deadline padrão de 15 segundos (máximo configurável de 60 segundos),
+envia apenas `content-type` e `x-request-id`, omite credenciais e rejeita
+redirects, cookies, `Origin` e `Authorization`. A resposta precisa vincular
+exatamente o lote, o request ID e o release/digest do artefato CRM Core esperado.
 
 Antes de qualquer entrega, o checkpoint privado recebe o pacote opaco completo
 e a prova detached Ed25519. Se a entrega falhar sem recibo, a próxima execução
 repete esse mesmo pacote antes de abrir uma nova transação. Ela só pode
-continuar a paginação se o novo preflight confirmar o mesmo `capturedAt` e a
-mesma contagem de linhas; caso contrário, falha fechado depois do replay, sem
-substituir o snapshot. O cursor UUID e o pacote pendente nunca aparecem na
-resposta do runner, em logs ou no Git.
+continuar a paginação se o novo preflight confirmar a mesma contagem e o mesmo
+HMAC do conjunto ordenado de pares `(updated_at, id)`. O HMAC não contém a
+origem em claro e torna a retomada independente do novo `transaction_timestamp`;
+caso a entrada do backfill tenha mudado, o runner falha fechado depois do replay,
+sem substituir o checkpoint. Antes até do replay, ele compara o alvo gravado ao
+alvo configurado e recusa um artefato CRM diferente. O cursor UUID e o pacote
+pendente nunca aparecem na resposta do runner, em logs ou no Git.
 
 O exportador falha fechado quando o principal, banco, transação somente-leitura,
 contagem, formato de linha, lote, prova, endpoint, resposta ou limite não

--- a/integration/atendimento/crm-core-projection-exporter/README.md
+++ b/integration/atendimento/crm-core-projection-exporter/README.md
@@ -77,6 +77,33 @@ embutidos. Uma entrega real de staging requer que o operador injete essas
 capacidades e que o Worker CRM Core tenha o opt-in e a allowlist de digests
 aprovados. Nada neste diretório autoriza produção.
 
+## Ensaio remoto sintético fechado
+
+`createSyntheticAtendimentoProjectionRemoteRehearsal({ target, endpoint })`
+prepara, mas não ativa, um único ensaio remoto de `staging`. A factory gera em
+memória uma chave HMAC de origem e uma chave Ed25519 efêmera, monta um lote
+determinístico de um evento sintético e devolve somente o material público que
+o operador externo precisa revisar:
+
+- um `keyId` iniciado por `crm-staging-atendimento-backfill-` e sua JWK pública;
+- uma allowlist com exatamente um `batchDigest`;
+- identidade do alvo, `batchId`, contagem e `configurationDigest`.
+
+Ela nunca devolve a chave privada, a chave HMAC, o UUID sintético ou os eventos.
+O `batchId` é diferente de `backfill:atendimento:fixture-batch-0001`; portanto
+o ensaio não reaproveita a allowlist de outro exercício. Preparar esse objeto
+não abre conexão nem faz requisição HTTP.
+
+Depois que um operador configurar externamente o opt-in de staging, a chave
+pública e essa allowlist finita, `rehearse(...)` exige a intenção explícita
+`ATENDIMENTO_SYNTHETIC_REMOTE_REHEARSAL_INTENT`, um `fetch` injetado e uma
+função de reconciliação D1. Ele passa pela mesma fonte paginada, assinatura e
+transporte HTTPS do produtor real, exige a primeira resposta `accepted`, repete
+o pacote exato e exige `idempotent`, e só emite o recibo sanitizado após a
+reconciliação confirmar o digest, alvo, cursor e evento persistidos. O adaptador
+não lê ambiente, não possui URL de Worker embutida, não faz deploy e não é um
+mecanismo de ativação de produção.
+
 ## Validação local
 
 No ambiente Linux do projeto:

--- a/integration/atendimento/crm-core-projection-exporter/README.md
+++ b/integration/atendimento/crm-core-projection-exporter/README.md
@@ -1,6 +1,6 @@
 # Exportador de projeções opacas de Atendimento para CRM Core
 
-Este adaptador prepara o primeiro lote de backfill para o CRM independente.
+Este adaptador prepara lotes de backfill para o CRM independente.
 Ele lê exclusivamente `id` e `updated_at` de
 `crm_atendimento.global_client_identities`, em uma transação PostgreSQL
 `REPEATABLE READ READ ONLY`.
@@ -16,18 +16,41 @@ credenciais, dados de venda ou qualquer outra coluna da origem. A chave HMAC
 fica somente na custódia operacional privada; ela nunca é escrita neste
 repositório, em logs ou em recibos Git.
 
-## O que este adaptador ainda não faz
+## Entrega paginada para o Worker isolado
 
-Ele não abre uma conexão por conta própria, não cria usuário PostgreSQL, não
-aplica grant, não grava no CRM Core, não cria rota, e não faz deploy. Um runner
-operacional futuro deve injetar um pool já autenticado com o principal dedicado
-`crm_core_projection_exporter`, limitado a `CONNECT`, `USAGE` no schema
-`crm_atendimento` e `SELECT (id, updated_at)` na tabela indicada.
+`createPaginatedAtendimentoProjectionBackfillRunner(...)` é o runner de
+staging explícito. Ele só aceita o intent
+`ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT`, rejeita alvo `production` e
+exige capacidades já construídas pelo operador:
+
+- pool PostgreSQL autenticado como `crm_core_projection_exporter`, limitado a
+  `CONNECT`, `USAGE` no schema `crm_atendimento` e `SELECT (id, updated_at)`;
+- chave HMAC sob custódia externa para transformar UUIDs em referências opacas;
+- signer Ed25519 injetado, com key ID iniciado por
+  `crm-staging-atendimento-backfill-`;
+- transporte HTTPS injetado para a rota exata
+  `/_internal/crm/backfill/atendimento`;
+- checkpoint privado com operações `read`, `write` e `complete`.
+
+O runner abre uma única transação `REPEATABLE READ READ ONLY`, atesta a fonte e
+usa paginação por chave `(updated_at, id)`, nunca `OFFSET`. Cada lote contém no
+máximo 20 eventos. O transporte limita o corpo a 64 KiB, envia apenas
+`content-type` e `x-request-id`, omite credenciais e rejeita redirects,
+cookies, `Origin` e `Authorization`. A resposta precisa vincular exatamente o
+lote, o request ID e o release/digest do artefato CRM Core esperado.
+
+Antes de qualquer entrega, o checkpoint privado recebe o pacote opaco completo
+e a prova detached Ed25519. Se a entrega falhar sem recibo, a próxima execução
+repete esse mesmo pacote antes de abrir uma nova transação. Ela só pode
+continuar a paginação se o novo preflight confirmar o mesmo `capturedAt` e a
+mesma contagem de linhas; caso contrário, falha fechado depois do replay, sem
+substituir o snapshot. O cursor UUID e o pacote pendente nunca aparecem na
+resposta do runner, em logs ou no Git.
 
 O exportador falha fechado quando o principal, banco, transação somente-leitura,
-contagem, formato de linha ou limite não correspondem ao contrato. A primeira
-carga é propositalmente um snapshot completo e limitado; se o volume superar o
-limite, ele não pagina nem cria um backfill parcial.
+contagem, formato de linha, lote, prova, endpoint, resposta ou limite não
+correspondem ao contrato. O teto da fonte continua sendo 10.000 linhas; se a
+carga exceder isso, ele não cria um backfill parcial.
 
 ## Preflight reutilizável e preparação sintética
 
@@ -35,7 +58,7 @@ limite, ele não pagina nem cria um backfill parcial.
 reutilizável da leitura: dentro de uma transação já aberta como `REPEATABLE
 READ READ ONLY`, ela atesta o principal, captura o instante do snapshot e
 confirma a contagem antes de qualquer seleção de identidade. O teto é sempre
-10.000; não há paginação ou forma de ampliá-lo pelo runner.
+10.000; o runner paginado mantém esse teto e não oferece forma de ampliá-lo.
 
 `prepareSyntheticAtendimentoProjectionStaging(...)` é apenas um ensaio local
 desabilitado por padrão. Ele só continua quando recebe a constante de intenção
@@ -47,12 +70,12 @@ PostgreSQL, pool, array, proxy ou receptor arbitrário é recusado antes de
 `connect()` ou da entrega do recibo. Um alvo de produção é recusado antes de
 ler o pool, a chave HMAC ou o receptor injetados.
 
-O runner não tem CLI, URL, transporte, cliente PostgreSQL, leitura de ambiente,
-arquivo de saída ou integração de rede. Ele aceita unicamente dependências
-injetadas pelo teste e entrega ao receptor em memória um recibo congelado com
-somente `batchId`, `count`, `release` e `digest`; os eventos, UUIDs e a chave
-HMAC nunca saem dele. Portanto, ele não é um backfill, não envia nada ao CRM
-Core e não é um caminho para produção.
+O ensaio sintético anterior continua isolado: ele não compartilha cliente,
+transporte, checkpoint ou configuração com o runner paginado. O novo runner
+também não tem CLI, leitura de ambiente, arquivo de saída, banco, URL ou chave
+embutidos. Uma entrega real de staging requer que o operador injete essas
+capacidades e que o Worker CRM Core tenha o opt-in e a allowlist de digests
+aprovados. Nada neste diretório autoriza produção.
 
 ## Validação local
 

--- a/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionBackfillDelivery.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionBackfillDelivery.mjs
@@ -1,0 +1,148 @@
+import { Buffer } from 'node:buffer'
+
+import {
+  assertAtendimentoProjectionBackfillBatch,
+  assertAtendimentoProjectionExportTarget,
+  digestAtendimentoProjectionBackfillBatch,
+} from './atendimentoProjectionExporter.mjs'
+
+export const ATENDIMENTO_CRM_PROJECTION_BACKFILL_DELIVERY_VERSION = 'skincos-crm/projection-backfill-delivery/v1'
+export const ATENDIMENTO_CRM_PROJECTION_BACKFILL_DELIVERY_ALGORITHM = 'Ed25519'
+
+const KEY_ID_PATTERN = /^[A-Za-z0-9._-]{3,96}$/
+const SHA256_PATTERN = /^sha256:[a-f0-9]{64}$/
+const SIGNATURE_PATTERN = /^[A-Za-z0-9_-]{80,512}$/
+
+function fail(code) {
+  throw new Error(code)
+}
+
+function object(value, code) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(code)
+  return value
+}
+
+function exactKeys(value, keys, code) {
+  if (Object.keys(value).length !== keys.length || keys.some((key) => !Object.hasOwn(value, key))) fail(code)
+}
+
+function text(value, code) {
+  const normalized = String(value || '').trim()
+  if (!normalized) fail(code)
+  return normalized
+}
+
+function deliveryKeyId(value) {
+  const normalized = text(value, 'ATENDIMENTO_CRM_BACKFILL_DELIVERY_KEY_ID_INVALID')
+  if (!KEY_ID_PATTERN.test(normalized)) fail('ATENDIMENTO_CRM_BACKFILL_DELIVERY_KEY_ID_INVALID')
+  return normalized
+}
+
+function batchDigest(value) {
+  const normalized = text(value, 'ATENDIMENTO_CRM_BACKFILL_DELIVERY_BATCH_DIGEST_INVALID').toLowerCase()
+  if (!SHA256_PATTERN.test(normalized)) fail('ATENDIMENTO_CRM_BACKFILL_DELIVERY_BATCH_DIGEST_INVALID')
+  return normalized
+}
+
+function signature(value) {
+  const normalized = text(value, 'ATENDIMENTO_CRM_BACKFILL_DELIVERY_SIGNATURE_INVALID')
+  if (!SIGNATURE_PATTERN.test(normalized)) fail('ATENDIMENTO_CRM_BACKFILL_DELIVERY_SIGNATURE_INVALID')
+  return normalized
+}
+
+function sameTarget(left, right) {
+  return left.environment === right.environment
+    && left.release === right.release
+    && left.artifactDigest === right.artifactDigest
+}
+
+function encodeSignature(value) {
+  if (value instanceof Uint8Array || Buffer.isBuffer(value)) return Buffer.from(value).toString('base64url')
+  if (value instanceof ArrayBuffer) return Buffer.from(value).toString('base64url')
+  return String(value || '').trim()
+}
+
+/**
+ * Exact detached-signature input accepted by CRM Core. No private key is read
+ * or retained here; production callers must inject a custody-backed signer.
+ */
+export function createAtendimentoProjectionBackfillDeliverySigningInput({
+  keyId,
+  batchDigest: suppliedBatchDigest,
+  target,
+} = {}) {
+  const normalizedKeyId = deliveryKeyId(keyId)
+  const normalizedBatchDigest = batchDigest(suppliedBatchDigest)
+  const normalizedTarget = assertAtendimentoProjectionExportTarget(target)
+  return [
+    ATENDIMENTO_CRM_PROJECTION_BACKFILL_DELIVERY_VERSION,
+    normalizedKeyId,
+    ATENDIMENTO_CRM_PROJECTION_BACKFILL_DELIVERY_ALGORITHM,
+    normalizedBatchDigest,
+    normalizedTarget.environment,
+    normalizedTarget.release,
+    normalizedTarget.artifactDigest,
+  ].join('\n')
+}
+
+export function assertAtendimentoProjectionBackfillDelivery(value) {
+  const delivery = object(value, 'ATENDIMENTO_CRM_BACKFILL_DELIVERY_INVALID')
+  exactKeys(delivery, ['contract', 'keyId', 'algorithm', 'batchDigest', 'signature'], 'ATENDIMENTO_CRM_BACKFILL_DELIVERY_INVALID')
+  if (
+    delivery.contract !== ATENDIMENTO_CRM_PROJECTION_BACKFILL_DELIVERY_VERSION
+    || delivery.algorithm !== ATENDIMENTO_CRM_PROJECTION_BACKFILL_DELIVERY_ALGORITHM
+  ) fail('ATENDIMENTO_CRM_BACKFILL_DELIVERY_INVALID')
+  return Object.freeze({
+    contract: ATENDIMENTO_CRM_PROJECTION_BACKFILL_DELIVERY_VERSION,
+    keyId: deliveryKeyId(delivery.keyId),
+    algorithm: ATENDIMENTO_CRM_PROJECTION_BACKFILL_DELIVERY_ALGORITHM,
+    batchDigest: batchDigest(delivery.batchDigest),
+    signature: signature(delivery.signature),
+  })
+}
+
+/**
+ * Returns a signer for one exact target artifact. The callback is the only
+ * component allowed to touch a private key, so this module cannot load a key
+ * from the repository, environment, command line or log output.
+ */
+export function createAtendimentoProjectionBackfillDeliverySigner({
+  target,
+  keyId,
+  sign,
+} = {}) {
+  const configuredTarget = assertAtendimentoProjectionExportTarget(target)
+  const configuredKeyId = deliveryKeyId(keyId)
+  const requiredPrefix = `crm-${configuredTarget.environment}-atendimento-backfill-`
+  if (!configuredKeyId.startsWith(requiredPrefix)) fail('ATENDIMENTO_CRM_BACKFILL_DELIVERY_KEY_ENVIRONMENT_MISMATCH')
+  if (typeof sign !== 'function') fail('ATENDIMENTO_CRM_BACKFILL_DELIVERY_SIGNER_REQUIRED')
+
+  return Object.freeze({
+    version: 'atendimento/crm-core-projection-backfill-delivery-signer/v1',
+    target: configuredTarget,
+    keyId: configuredKeyId,
+    async signBatch(value) {
+      const batch = assertAtendimentoProjectionBackfillBatch(value)
+      if (!sameTarget(batch.target, configuredTarget)) fail('ATENDIMENTO_CRM_BACKFILL_DELIVERY_TARGET_MISMATCH')
+      const digest = digestAtendimentoProjectionBackfillBatch(batch)
+      const signingInput = createAtendimentoProjectionBackfillDeliverySigningInput({
+        keyId: configuredKeyId,
+        batchDigest: digest,
+        target: configuredTarget,
+      })
+      let rawSignature
+      try {
+        rawSignature = await sign(Buffer.from(signingInput, 'utf8'))
+      } catch {
+        fail('ATENDIMENTO_CRM_BACKFILL_DELIVERY_SIGNING_UNAVAILABLE')
+      }
+      return assertAtendimentoProjectionBackfillDelivery({
+        contract: ATENDIMENTO_CRM_PROJECTION_BACKFILL_DELIVERY_VERSION,
+        keyId: configuredKeyId,
+        algorithm: ATENDIMENTO_CRM_PROJECTION_BACKFILL_DELIVERY_ALGORITHM,
+        batchDigest: digest,
+        signature: encodeSignature(rawSignature),
+      })
+    },
+  })
+}

--- a/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionBackfillHttpTransport.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionBackfillHttpTransport.mjs
@@ -12,10 +12,13 @@ import {
 
 export const ATENDIMENTO_CRM_BACKFILL_HTTP_PATH = '/_internal/crm/backfill/atendimento'
 export const ATENDIMENTO_CRM_BACKFILL_HTTP_MAX_BODY_BYTES = 64 * 1024
+export const ATENDIMENTO_CRM_BACKFILL_HTTP_TIMEOUT_MS = 15_000
 export const ATENDIMENTO_CRM_BACKFILL_RECEIPT_VERSION = 'crm-core/projection-backfill-receipt/v1'
 
 const REQUEST_ID_PATTERN = /^[A-Za-z0-9._:-]{1,120}$/
 const OUTCOMES = new Set(['accepted', 'idempotent'])
+const MAX_TIMEOUT_MS = 60_000
+const TRANSPORT_TIMEOUT = Symbol('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_TIMEOUT')
 
 function fail(code) {
   throw new Error(code)
@@ -34,6 +37,39 @@ function requestId(value) {
   const normalized = String(value || '').trim()
   if (!REQUEST_ID_PATTERN.test(normalized)) fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_REQUEST_ID_INVALID')
   return normalized
+}
+
+function timeout(value) {
+  const normalized = value === undefined ? ATENDIMENTO_CRM_BACKFILL_HTTP_TIMEOUT_MS : Number(value)
+  if (!Number.isSafeInteger(normalized) || normalized < 1 || normalized > MAX_TIMEOUT_MS) {
+    fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_TIMEOUT_INVALID')
+  }
+  return normalized
+}
+
+function withAbortDeadline(value, signal) {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(TRANSPORT_TIMEOUT)
+      return
+    }
+    const abort = () => {
+      cleanup()
+      reject(TRANSPORT_TIMEOUT)
+    }
+    const cleanup = () => signal.removeEventListener('abort', abort)
+    signal.addEventListener('abort', abort, { once: true })
+    Promise.resolve(value).then(
+      (result) => {
+        cleanup()
+        resolve(result)
+      },
+      (error) => {
+        cleanup()
+        reject(error)
+      },
+    )
+  })
 }
 
 function endpoint(value) {
@@ -93,9 +129,11 @@ function responseReceipt(value, { batch, requestId: expectedRequestId }) {
 export function createAtendimentoProjectionBackfillHttpTransport({
   endpoint: suppliedEndpoint,
   fetch: fetchImpl,
+  timeoutMs: suppliedTimeoutMs,
 } = {}) {
   const targetEndpoint = endpoint(suppliedEndpoint)
   if (typeof fetchImpl !== 'function') fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_FETCH_REQUIRED')
+  const timeoutMs = timeout(suppliedTimeoutMs)
 
   return Object.freeze({
     version: 'atendimento/crm-core-projection-backfill-http-transport/v1',
@@ -120,32 +158,40 @@ export function createAtendimentoProjectionBackfillHttpTransport({
         fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_BODY_TOO_LARGE')
       }
 
-      let response
+      const controller = new AbortController()
+      const deadline = setTimeout(() => controller.abort(), timeoutMs)
       try {
-        response = await fetchImpl(targetEndpoint, {
-          method: 'POST',
-          credentials: 'omit',
-          redirect: 'error',
-          cache: 'no-store',
-          headers: Object.freeze({
-            'content-type': 'application/json',
-            'x-request-id': id,
-          }),
-          body,
-        })
-      } catch {
-        fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_UNAVAILABLE')
+        let response
+        try {
+          response = await withAbortDeadline(fetchImpl(targetEndpoint, {
+            method: 'POST',
+            credentials: 'omit',
+            redirect: 'error',
+            cache: 'no-store',
+            headers: Object.freeze({
+              'content-type': 'application/json',
+              'x-request-id': id,
+            }),
+            body,
+            signal: controller.signal,
+          }), controller.signal)
+        } catch {
+          fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_UNAVAILABLE')
+        }
+        if (!response || response.status !== 200 || typeof response.json !== 'function') {
+          fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_REJECTED')
+        }
+        let payload
+        try {
+          payload = await withAbortDeadline(response.json(), controller.signal)
+        } catch (error) {
+          if (error === TRANSPORT_TIMEOUT) fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_UNAVAILABLE')
+          fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_RESPONSE_INVALID')
+        }
+        return responseReceipt(payload, { batch, requestId: id })
+      } finally {
+        clearTimeout(deadline)
       }
-      if (!response || response.status !== 200 || typeof response.json !== 'function') {
-        fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_REJECTED')
-      }
-      let payload
-      try {
-        payload = await response.json()
-      } catch {
-        fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_RESPONSE_INVALID')
-      }
-      return responseReceipt(payload, { batch, requestId: id })
     },
   })
 }

--- a/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionBackfillHttpTransport.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionBackfillHttpTransport.mjs
@@ -1,0 +1,151 @@
+import { Buffer } from 'node:buffer'
+
+import {
+  assertAtendimentoProjectionBackfillBatch,
+  assertAtendimentoProjectionExportTarget,
+  digestAtendimentoProjectionBackfillBatch,
+} from './atendimentoProjectionExporter.mjs'
+import {
+  ATENDIMENTO_CRM_PROJECTION_BACKFILL_DELIVERY_VERSION,
+  assertAtendimentoProjectionBackfillDelivery,
+} from './atendimentoProjectionBackfillDelivery.mjs'
+
+export const ATENDIMENTO_CRM_BACKFILL_HTTP_PATH = '/_internal/crm/backfill/atendimento'
+export const ATENDIMENTO_CRM_BACKFILL_HTTP_MAX_BODY_BYTES = 64 * 1024
+export const ATENDIMENTO_CRM_BACKFILL_RECEIPT_VERSION = 'crm-core/projection-backfill-receipt/v1'
+
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9._:-]{1,120}$/
+const OUTCOMES = new Set(['accepted', 'idempotent'])
+
+function fail(code) {
+  throw new Error(code)
+}
+
+function object(value, code) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(code)
+  return value
+}
+
+function exactKeys(value, keys, code) {
+  if (Object.keys(value).length !== keys.length || keys.some((key) => !Object.hasOwn(value, key))) fail(code)
+}
+
+function requestId(value) {
+  const normalized = String(value || '').trim()
+  if (!REQUEST_ID_PATTERN.test(normalized)) fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_REQUEST_ID_INVALID')
+  return normalized
+}
+
+function endpoint(value) {
+  let parsed
+  try {
+    parsed = new URL(String(value || '').trim())
+  } catch {
+    fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_ENDPOINT_INVALID')
+  }
+  if (
+    parsed.protocol !== 'https:'
+    || parsed.username
+    || parsed.password
+    || parsed.pathname !== ATENDIMENTO_CRM_BACKFILL_HTTP_PATH
+    || parsed.search
+    || parsed.hash
+  ) fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_ENDPOINT_INVALID')
+  return parsed.toString()
+}
+
+function sameTarget(left, right) {
+  return left.environment === right.environment
+    && left.release === right.release
+    && left.artifactDigest === right.artifactDigest
+}
+
+function responseReceipt(value, { batch, requestId: expectedRequestId }) {
+  const receipt = object(value, 'ATENDIMENTO_CRM_BACKFILL_TRANSPORT_RESPONSE_INVALID')
+  exactKeys(receipt, ['ok', 'contractVersion', 'status', 'batchId', 'eventCount', 'target', 'requestId'], 'ATENDIMENTO_CRM_BACKFILL_TRANSPORT_RESPONSE_INVALID')
+  const target = assertAtendimentoProjectionExportTarget(receipt.target)
+  if (
+    receipt.ok !== true
+    || receipt.contractVersion !== ATENDIMENTO_CRM_BACKFILL_RECEIPT_VERSION
+    || !OUTCOMES.has(receipt.status)
+    || receipt.batchId !== batch.batchId
+    || receipt.eventCount !== batch.events.length
+    || receipt.requestId !== expectedRequestId
+    || !sameTarget(target, batch.target)
+  ) fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_RESPONSE_INVALID')
+  return Object.freeze({
+    ok: true,
+    contractVersion: ATENDIMENTO_CRM_BACKFILL_RECEIPT_VERSION,
+    status: receipt.status,
+    batchId: batch.batchId,
+    eventCount: batch.events.length,
+    target,
+    requestId: expectedRequestId,
+  })
+}
+
+/**
+ * Creates an opt-in HTTP transport for the private Worker route. It receives a
+ * configured HTTPS endpoint and a caller-supplied fetch implementation; it
+ * never reads environment variables, follows redirects, forwards browser
+ * credentials, or creates an Authorization/Cookie/Origin header.
+ */
+export function createAtendimentoProjectionBackfillHttpTransport({
+  endpoint: suppliedEndpoint,
+  fetch: fetchImpl,
+} = {}) {
+  const targetEndpoint = endpoint(suppliedEndpoint)
+  if (typeof fetchImpl !== 'function') fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_FETCH_REQUIRED')
+
+  return Object.freeze({
+    version: 'atendimento/crm-core-projection-backfill-http-transport/v1',
+    endpoint: targetEndpoint,
+    async deliver(value) {
+      const input = object(value, 'ATENDIMENTO_CRM_BACKFILL_TRANSPORT_INPUT_INVALID')
+      exactKeys(input, ['batch', 'delivery', 'requestId'], 'ATENDIMENTO_CRM_BACKFILL_TRANSPORT_INPUT_INVALID')
+      const batch = assertAtendimentoProjectionBackfillBatch(input.batch)
+      const delivery = assertAtendimentoProjectionBackfillDelivery(input.delivery)
+      const id = requestId(input.requestId)
+      if (
+        delivery.contract !== ATENDIMENTO_CRM_PROJECTION_BACKFILL_DELIVERY_VERSION
+        || delivery.batchDigest !== digestAtendimentoProjectionBackfillBatch(batch)
+      ) {
+        // The Core validates the canonical batch digest rather than eventsDigest;
+        // this guard only ensures the caller cannot substitute a different proof.
+        fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_DELIVERY_MISMATCH')
+      }
+
+      const body = JSON.stringify({ batch, delivery })
+      if (Buffer.byteLength(body, 'utf8') > ATENDIMENTO_CRM_BACKFILL_HTTP_MAX_BODY_BYTES) {
+        fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_BODY_TOO_LARGE')
+      }
+
+      let response
+      try {
+        response = await fetchImpl(targetEndpoint, {
+          method: 'POST',
+          credentials: 'omit',
+          redirect: 'error',
+          cache: 'no-store',
+          headers: Object.freeze({
+            'content-type': 'application/json',
+            'x-request-id': id,
+          }),
+          body,
+        })
+      } catch {
+        fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_UNAVAILABLE')
+      }
+      if (!response || response.status !== 200 || typeof response.json !== 'function') {
+        fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_REJECTED')
+      }
+      let payload
+      try {
+        payload = await response.json()
+      } catch {
+        fail('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_RESPONSE_INVALID')
+      }
+      return responseReceipt(payload, { batch, requestId: id })
+    },
+  })
+}

--- a/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionExporter.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionExporter.mjs
@@ -29,6 +29,19 @@ FROM crm_atendimento.global_client_identities
 ORDER BY updated_at ASC, id ASC
 LIMIT $1`
 
+// The paginated runner uses keyset pagination, never OFFSET. Both queries keep
+// the source shape deliberately limited to the stable UUID and revision time.
+export const ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL = `SELECT id::text AS id, updated_at
+FROM crm_atendimento.global_client_identities
+ORDER BY updated_at ASC, id ASC
+LIMIT $1`
+
+export const ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL = `SELECT id::text AS id, updated_at
+FROM crm_atendimento.global_client_identities
+WHERE (updated_at, id) > ($1::timestamptz, $2::uuid)
+ORDER BY updated_at ASC, id ASC
+LIMIT $3`
+
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const SHA256_PATTERN = /^sha256:[a-f0-9]{64}$/
 const RELEASE_PATTERN = /^[0-9a-f]{40}$/
@@ -131,7 +144,7 @@ function sourceIdentity(value) {
   return Object.freeze({ database, currentUser, sessionUser, readOnly })
 }
 
-function sourceRow(value) {
+export function assertAtendimentoProjectionSourceRow(value) {
   const row = object(value, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID')
   exactKeys(row, ['id', 'updated_at'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID')
   const id = text(row.id, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID').toLowerCase()
@@ -142,10 +155,22 @@ function sourceRow(value) {
   })
 }
 
+function normalizedSourceRow(value) {
+  const row = object(value, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID')
+  if (
+    Object.keys(row).length === 2
+    && Object.hasOwn(row, 'id')
+    && Object.hasOwn(row, 'updatedAt')
+  ) {
+    return assertAtendimentoProjectionSourceRow({ id: row.id, updated_at: row.updatedAt })
+  }
+  return assertAtendimentoProjectionSourceRow(row)
+}
+
 function sourceRows(value, expectedCount) {
   if (!Array.isArray(value) || value.length !== expectedCount) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_READBACK_INVALID')
   const identifiers = new Set()
-  const rows = value.map(sourceRow)
+  const rows = value.map(normalizedSourceRow)
   for (const row of rows) {
     if (identifiers.has(row.id)) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_READBACK_INVALID')
     identifiers.add(row.id)
@@ -242,6 +267,37 @@ function batchCursorDigest(capturedAt, events) {
   })
 }
 
+/**
+ * Builds one opaque CRM batch from an already-bounded source page. This has no
+ * transport or database side effect; callers that paginate must keep the raw
+ * source cursor private and send only the returned opaque batch.
+ */
+export function createAtendimentoProjectionBackfillBatch({
+  rows,
+  capturedAt,
+  hmacKey: suppliedHmacKey,
+  keyId: suppliedKeyId,
+  target,
+} = {}) {
+  const key = hmacKey(suppliedHmacKey)
+  const keyIdentifier = keyId(suppliedKeyId)
+  const targetValue = assertAtendimentoProjectionExportTarget(target)
+  const normalizedCapturedAt = timestamp(capturedAt, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SNAPSHOT_INVALID')
+  const normalizedRows = sourceRows(rows, Array.isArray(rows) ? rows.length : -1)
+  const events = Object.freeze(normalizedRows.map((row) => eventFromSourceRow(row, { key, capturedAt: normalizedCapturedAt })))
+  const eventsDigest = sha256(events)
+  const cursorDigest = batchCursorDigest(normalizedCapturedAt, events)
+  return assertAtendimentoProjectionBackfillBatch({
+    contract: CRM_PROJECTION_BACKFILL_BATCH_VERSION,
+    batchId: batchId(key, keyIdentifier, normalizedCapturedAt, eventsDigest),
+    producer: { owner: 'atendimento', scope: ATENDIMENTO_PROJECTION_SCOPE, keyId: keyIdentifier },
+    sourceSnapshot: { capturedAt: normalizedCapturedAt, cursorDigest, rowCount: normalizedRows.length },
+    target: targetValue,
+    events,
+    integrity: { algorithm: 'sha256', eventCount: events.length, eventsDigest },
+  })
+}
+
 export function assertAtendimentoProjectionBackfillBatch(value) {
   const batch = object(value, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
   exactKeys(batch, ['contract', 'batchId', 'producer', 'sourceSnapshot', 'target', 'events', 'integrity'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
@@ -290,6 +346,14 @@ export function assertAtendimentoProjectionBackfillBatch(value) {
   })
 }
 
+/**
+ * Matches the CRM Core's canonical batch digest without importing its source
+ * tree. It is intentionally over the validated opaque batch only.
+ */
+export function digestAtendimentoProjectionBackfillBatch(value) {
+  return sha256(assertAtendimentoProjectionBackfillBatch(value))
+}
+
 function knownError(error) {
   return error instanceof Error && /^ATENDIMENTO_CRM_PROJECTION_EXPORT_[A-Z_]+$/.test(error.message)
 }
@@ -324,17 +388,12 @@ export async function exportAtendimentoClientProjectionBatch({
 
     const rowsResult = await client.query(ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL, [rowCount])
     const rows = sourceRows(rowsResult?.rows, rowCount)
-    const events = Object.freeze(rows.map((row) => eventFromSourceRow(row, { key, capturedAt })))
-    const eventsDigest = sha256(events)
-    const cursorDigest = batchCursorDigest(capturedAt, events)
-    const batch = assertAtendimentoProjectionBackfillBatch({
-      contract: CRM_PROJECTION_BACKFILL_BATCH_VERSION,
-      batchId: batchId(key, keyIdentifier, capturedAt, eventsDigest),
-      producer: { owner: 'atendimento', scope: ATENDIMENTO_PROJECTION_SCOPE, keyId: keyIdentifier },
-      sourceSnapshot: { capturedAt, cursorDigest, rowCount },
+    const batch = createAtendimentoProjectionBackfillBatch({
+      rows,
+      capturedAt,
+      hmacKey: key,
+      keyId: keyIdentifier,
       target: targetValue,
-      events,
-      integrity: { algorithm: 'sha256', eventCount: events.length, eventsDigest },
     })
 
     await client.query('ROLLBACK')

--- a/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionExporter.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionExporter.mjs
@@ -24,19 +24,23 @@ FROM crm_atendimento.global_client_identities`
 // This source query deliberately has no join and no selectable field beyond the
 // stable identity UUID and its revision timestamp. The UUID is converted to an
 // HMAC reference in memory before anything leaves this adapter.
-export const ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL = `SELECT id::text AS id, updated_at
+export const ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL = `/* bounded source-input fingerprint */
+SELECT id::text AS id,
+  to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS updated_at
 FROM crm_atendimento.global_client_identities
 ORDER BY updated_at ASC, id ASC
 LIMIT $1`
 
 // The paginated runner uses keyset pagination, never OFFSET. Both queries keep
 // the source shape deliberately limited to the stable UUID and revision time.
-export const ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL = `SELECT id::text AS id, updated_at
+export const ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL = `SELECT id::text AS id,
+  to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS updated_at
 FROM crm_atendimento.global_client_identities
 ORDER BY updated_at ASC, id ASC
 LIMIT $1`
 
-export const ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL = `SELECT id::text AS id, updated_at
+export const ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL = `SELECT id::text AS id,
+  to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS updated_at
 FROM crm_atendimento.global_client_identities
 WHERE (updated_at, id) > ($1::timestamptz, $2::uuid)
 ORDER BY updated_at ASC, id ASC

--- a/integration/atendimento/crm-core-projection-exporter/src/paginatedAtendimentoProjectionBackfillRunner.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/paginatedAtendimentoProjectionBackfillRunner.mjs
@@ -1,9 +1,10 @@
-import { createHash } from 'node:crypto'
+import { createHash, createHmac } from 'node:crypto'
 
 import {
   ATENDIMENTO_CRM_PROJECTION_MAX_ROWS,
   ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL,
   ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL,
   assertAtendimentoProjectionBackfillBatch,
   assertAtendimentoProjectionExportTarget,
   assertAtendimentoProjectionSourceRow,
@@ -19,8 +20,9 @@ export const ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUNNER_VERSION = 'atendimento/c
 export const ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT = 'atendimento/crm-core/staging-projection-backfill/v1'
 export const ATENDIMENTO_CRM_PROJECTION_BACKFILL_MAX_EVENTS_PER_BATCH = 20
 
-const CHECKPOINT_VERSION = 'atendimento/crm-core/projection-backfill-checkpoint/v1'
+const CHECKPOINT_VERSION = 'atendimento/crm-core/projection-backfill-checkpoint/v2'
 const REQUEST_ID_PREFIX = 'crm-atendimento-backfill-'
+const SOURCE_CURSOR_TIMESTAMP = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})\.(\d{1,6})Z$/
 
 function fail(code) {
   throw new Error(code)
@@ -62,6 +64,17 @@ function normalizedTimestamp(value, code) {
   return parsed.toISOString()
 }
 
+// The source query deliberately emits a UTC, fixed-width microsecond string.
+// JavaScript Date is used only for public event timestamps; this private
+// cursor must retain all six digits so PostgreSQL keyset comparisons cannot
+// fetch the final row of a page a second time.
+function sourceCursorTimestamp(value, code) {
+  const raw = String(value || '').trim()
+  const match = SOURCE_CURSOR_TIMESTAMP.exec(raw)
+  if (!match || Number.isNaN(new Date(raw).getTime())) fail(code)
+  return `${match[1]}.${match[2].padEnd(6, '0')}Z`
+}
+
 function sameTarget(left, right) {
   return left.environment === right.environment
     && left.release === right.release
@@ -69,8 +82,13 @@ function sameTarget(left, right) {
 }
 
 function sourceCursor(row) {
-  const normalized = assertAtendimentoProjectionSourceRow({ id: row.id, updated_at: row.updatedAt })
-  return Object.freeze({ updatedAt: normalized.updatedAt, id: normalized.id })
+  const raw = object(row, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CURSOR_INVALID')
+  const updatedAt = Object.hasOwn(raw, 'updated_at') ? raw.updated_at : raw.updatedAt
+  const normalized = assertAtendimentoProjectionSourceRow({ id: raw.id, updated_at: updatedAt })
+  return Object.freeze({
+    updatedAt: sourceCursorTimestamp(updatedAt, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CURSOR_INVALID'),
+    id: normalized.id,
+  })
 }
 
 function compareCursor(left, right) {
@@ -87,14 +105,31 @@ function pageRows(value, { limit, after } = {}) {
   let previous = after || null
   for (const valueRow of value) {
     const row = assertAtendimentoProjectionSourceRow(valueRow)
-    const cursor = sourceCursor(row)
+    const cursor = sourceCursor(valueRow)
     if (previous && compareCursor(cursor, previous) <= 0) {
       fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_CURSOR_INVALID')
     }
-    rows.push(row)
+    rows.push(Object.freeze({ row, cursor }))
     previous = cursor
   }
   return Object.freeze(rows)
+}
+
+function sourceInputDigest(rows, hmacKey) {
+  const digest = createHmac('sha256', hmacKey)
+  digest.update('atendimento/crm-core/projection-backfill-source-input/v1\u0000')
+  for (const { cursor } of rows) {
+    digest.update(cursor.updatedAt).update('\u0000').update(cursor.id).update('\n')
+  }
+  return `sha256:${digest.digest('hex')}`
+}
+
+async function preflightSourceInputDigest(client, { rowCount, hmacKey }) {
+  if (rowCount === 0) return sourceInputDigest([], hmacKey)
+  const result = await client.query(ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL, [rowCount])
+  const rows = pageRows(result?.rows, { limit: rowCount })
+  if (rows.length !== rowCount) fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_SOURCE_INPUT_INVALID')
+  return sourceInputDigest(rows, hmacKey)
 }
 
 function checkpointStore(value) {
@@ -171,7 +206,7 @@ function storedCheckpoint(value) {
   exactKeys(checkpointValue, ['contractVersion', 'state', 'target', 'sourceSnapshot', 'progress', 'cursor', 'pending'], 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
   const sourceSnapshot = object(checkpointValue.sourceSnapshot, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
   const progress = object(checkpointValue.progress, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
-  exactKeys(sourceSnapshot, ['capturedAt', 'rowCount'], 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
+  exactKeys(sourceSnapshot, ['capturedAt', 'rowCount', 'inputDigest'], 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
   exactKeys(progress, ['deliveredCount', 'batchCount', 'acceptedCount', 'idempotentCount', 'reconciliationDigest'], 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
   if (
     checkpointValue.contractVersion !== CHECKPOINT_VERSION
@@ -180,6 +215,9 @@ function storedCheckpoint(value) {
   ) fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
   const target = assertAtendimentoProjectionExportTarget(checkpointValue.target)
   const rowCount = normalizedInteger(sourceSnapshot.rowCount, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
+  if (!/^sha256:[a-f0-9]{64}$/.test(String(sourceSnapshot.inputDigest || ''))) {
+    fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
+  }
   const deliveredCount = normalizedInteger(progress.deliveredCount, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID', { maximum: rowCount })
   const batchCount = normalizedInteger(progress.batchCount, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
   const acceptedCount = normalizedInteger(progress.acceptedCount, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
@@ -203,6 +241,7 @@ function storedCheckpoint(value) {
     target,
     capturedAt,
     sourceRowCount: rowCount,
+    sourceInputDigest: sourceSnapshot.inputDigest,
     deliveredCount,
     batchCount,
     acceptedCount,
@@ -213,12 +252,12 @@ function storedCheckpoint(value) {
   })
 }
 
-function checkpoint({ target, capturedAt, sourceRowCount, deliveredCount, batchCount, acceptedCount, idempotentCount, reconciliationDigest, cursor, pending }) {
+function checkpoint({ target, capturedAt, sourceRowCount, sourceInputDigest, deliveredCount, batchCount, acceptedCount, idempotentCount, reconciliationDigest, cursor, pending }) {
   return Object.freeze({
     contractVersion: CHECKPOINT_VERSION,
     state: 'running',
     target: Object.freeze({ ...target }),
-    sourceSnapshot: Object.freeze({ capturedAt, rowCount: sourceRowCount }),
+    sourceSnapshot: Object.freeze({ capturedAt, rowCount: sourceRowCount, inputDigest: sourceInputDigest }),
     progress: Object.freeze({ deliveredCount, batchCount, acceptedCount, idempotentCount, reconciliationDigest }),
     // This cursor contains the source UUID and is deliberately supplied only to
     // the private checkpoint capability. It never appears in HTTP or results.
@@ -301,7 +340,8 @@ function knownError(error) {
  * database construction or network default: all capabilities are injected by
  * an operator-owned caller. A pending opaque packet can be replayed before a
  * new source transaction opens. Further pagination is allowed only when the
- * new transaction attests the exact capturedAt and rowCount in its checkpoint.
+ * new repeatable-read snapshot has the same bounded source-input HMAC digest
+ * and row count; transaction_timestamp itself is not resumable across runs.
  */
 export function createPaginatedAtendimentoProjectionBackfillRunner({
   pool,
@@ -340,6 +380,13 @@ export function createPaginatedAtendimentoProjectionBackfillRunner({
         }
       }
 
+      // Never replay a signed packet through a transport configured for a
+      // different CRM artifact. This comparison deliberately precedes both
+      // the pending delivery and any source connection.
+      if (restored && !sameTarget(restored.target, targetValue)) {
+        fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_TARGET_MISMATCH')
+      }
+
       let client
       let transactionOpen = false
       try {
@@ -361,12 +408,15 @@ export function createPaginatedAtendimentoProjectionBackfillRunner({
         const source = await preflightAtendimentoProjectionSource(client, { maxRows: maximumRows })
         const capturedAt = source.capturedAt
         const sourceRowCount = source.rowCount
+        const currentSourceInputDigest = await preflightSourceInputDigest(client, {
+          rowCount: sourceRowCount,
+          hmacKey,
+        })
         let state
         if (restored) {
           if (
-            !sameTarget(restored.target, targetValue)
-            || restored.capturedAt !== capturedAt
-            || restored.sourceRowCount !== sourceRowCount
+            restored.sourceRowCount !== sourceRowCount
+            || restored.sourceInputDigest !== currentSourceInputDigest
           ) fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_SNAPSHOT_MISMATCH')
           state = restored
         } else {
@@ -374,6 +424,7 @@ export function createPaginatedAtendimentoProjectionBackfillRunner({
             target: targetValue,
             capturedAt,
             sourceRowCount,
+            sourceInputDigest: currentSourceInputDigest,
             deliveredCount: 0,
             batchCount: 0,
             acceptedCount: 0,
@@ -391,7 +442,8 @@ export function createPaginatedAtendimentoProjectionBackfillRunner({
           const result = state.cursor
             ? await client.query(ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL, [state.cursor.updatedAt, state.cursor.id, limit])
             : await client.query(ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL, [limit])
-          const rows = pageRows(result?.rows, { limit, after: state.cursor })
+          const page = pageRows(result?.rows, { limit, after: state.cursor })
+          const rows = page.map(({ row }) => row)
           if (rows.length > remaining) fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_RECONCILIATION_FAILED')
 
           const batch = createAtendimentoProjectionBackfillBatch({
@@ -408,7 +460,7 @@ export function createPaginatedAtendimentoProjectionBackfillRunner({
           if (delivery.batchDigest !== digestAtendimentoProjectionBackfillBatch(batch)) {
             fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_DELIVERY_MISMATCH')
           }
-          const cursorAfter = sourceCursor(rows.at(-1))
+          const cursorAfter = page.at(-1).cursor
           const requestId = `${REQUEST_ID_PREFIX}${String(state.batchCount + 1).padStart(6, '0')}`
           const pending = Object.freeze({
             batch,

--- a/integration/atendimento/crm-core-projection-exporter/src/paginatedAtendimentoProjectionBackfillRunner.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/paginatedAtendimentoProjectionBackfillRunner.mjs
@@ -1,0 +1,457 @@
+import { createHash } from 'node:crypto'
+
+import {
+  ATENDIMENTO_CRM_PROJECTION_MAX_ROWS,
+  ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL,
+  assertAtendimentoProjectionBackfillBatch,
+  assertAtendimentoProjectionExportTarget,
+  assertAtendimentoProjectionSourceRow,
+  createAtendimentoProjectionBackfillBatch,
+  digestAtendimentoProjectionBackfillBatch,
+  preflightAtendimentoProjectionSource,
+} from './atendimentoProjectionExporter.mjs'
+import {
+  assertAtendimentoProjectionBackfillDelivery,
+} from './atendimentoProjectionBackfillDelivery.mjs'
+
+export const ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUNNER_VERSION = 'atendimento/crm-core-projection-backfill-runner/v1'
+export const ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT = 'atendimento/crm-core/staging-projection-backfill/v1'
+export const ATENDIMENTO_CRM_PROJECTION_BACKFILL_MAX_EVENTS_PER_BATCH = 20
+
+const CHECKPOINT_VERSION = 'atendimento/crm-core/projection-backfill-checkpoint/v1'
+const REQUEST_ID_PREFIX = 'crm-atendimento-backfill-'
+
+function fail(code) {
+  throw new Error(code)
+}
+
+function object(value, code) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(code)
+  return value
+}
+
+function exactKeys(value, keys, code) {
+  if (Object.keys(value).length !== keys.length || keys.some((key) => !Object.hasOwn(value, key))) fail(code)
+}
+
+function normalizedBatchSize(value) {
+  const batchSize = value === undefined ? ATENDIMENTO_CRM_PROJECTION_BACKFILL_MAX_EVENTS_PER_BATCH : Number(value)
+  if (!Number.isSafeInteger(batchSize) || batchSize < 1 || batchSize > ATENDIMENTO_CRM_PROJECTION_BACKFILL_MAX_EVENTS_PER_BATCH) {
+    fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_BATCH_SIZE_INVALID')
+  }
+  return batchSize
+}
+
+function normalizedMaximumRows(value) {
+  const maximumRows = value === undefined ? ATENDIMENTO_CRM_PROJECTION_MAX_ROWS : Number(value)
+  if (!Number.isSafeInteger(maximumRows) || maximumRows < 1 || maximumRows > ATENDIMENTO_CRM_PROJECTION_MAX_ROWS) {
+    fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_MAX_ROWS_INVALID')
+  }
+  return maximumRows
+}
+
+function normalizedInteger(value, code, { minimum = 0, maximum = Number.MAX_SAFE_INTEGER } = {}) {
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) fail(code)
+  return value
+}
+
+function normalizedTimestamp(value, code) {
+  const parsed = new Date(String(value || '').trim())
+  if (Number.isNaN(parsed.getTime())) fail(code)
+  return parsed.toISOString()
+}
+
+function sameTarget(left, right) {
+  return left.environment === right.environment
+    && left.release === right.release
+    && left.artifactDigest === right.artifactDigest
+}
+
+function sourceCursor(row) {
+  const normalized = assertAtendimentoProjectionSourceRow({ id: row.id, updated_at: row.updatedAt })
+  return Object.freeze({ updatedAt: normalized.updatedAt, id: normalized.id })
+}
+
+function compareCursor(left, right) {
+  const timestampOrder = left.updatedAt.localeCompare(right.updatedAt)
+  if (timestampOrder !== 0) return timestampOrder
+  return left.id.localeCompare(right.id)
+}
+
+function pageRows(value, { limit, after } = {}) {
+  if (!Array.isArray(value) || value.length === 0 || value.length > limit) {
+    fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_PAGE_INVALID')
+  }
+  const rows = []
+  let previous = after || null
+  for (const valueRow of value) {
+    const row = assertAtendimentoProjectionSourceRow(valueRow)
+    const cursor = sourceCursor(row)
+    if (previous && compareCursor(cursor, previous) <= 0) {
+      fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_CURSOR_INVALID')
+    }
+    rows.push(row)
+    previous = cursor
+  }
+  return Object.freeze(rows)
+}
+
+function checkpointStore(value) {
+  const store = object(value, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_STORE_REQUIRED')
+  exactKeys(store, ['read', 'write', 'complete'], 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_STORE_REQUIRED')
+  if (typeof store.read !== 'function' || typeof store.write !== 'function' || typeof store.complete !== 'function') {
+    fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_STORE_REQUIRED')
+  }
+  return store
+}
+
+function signer(value) {
+  const normalized = object(value, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_SIGNER_REQUIRED')
+  if (typeof normalized.signBatch !== 'function') fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_SIGNER_REQUIRED')
+  return normalized
+}
+
+function transport(value) {
+  const normalized = object(value, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_TRANSPORT_REQUIRED')
+  if (typeof normalized.deliver !== 'function') fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_TRANSPORT_REQUIRED')
+  return normalized
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, canonicalize(value[key])]))
+  }
+  return value
+}
+
+function digest(value) {
+  return `sha256:${createHash('sha256').update(JSON.stringify(canonicalize(value))).digest('hex')}`
+}
+
+function nextReconciliationDigest(previous, record) {
+  return digest({ previous, record })
+}
+
+function storedCursor(value, code) {
+  if (value === null) return null
+  const cursor = object(value, code)
+  exactKeys(cursor, ['updatedAt', 'id'], code)
+  return sourceCursor({ updatedAt: cursor.updatedAt, id: cursor.id })
+}
+
+function storedPending(value, { target, capturedAt, code }) {
+  if (value === null) return null
+  const pending = object(value, code)
+  exactKeys(pending, ['batch', 'delivery', 'requestId', 'cursorAfter'], code)
+  if (!/^crm-atendimento-backfill-\d{6}$/.test(String(pending.requestId || ''))) fail(code)
+  const batch = assertAtendimentoProjectionBackfillBatch(pending.batch)
+  const delivery = assertAtendimentoProjectionBackfillDelivery(pending.delivery)
+  const cursorAfter = storedCursor(pending.cursorAfter, code)
+  if (
+    batch.events.length < 1
+    || batch.events.length > ATENDIMENTO_CRM_PROJECTION_BACKFILL_MAX_EVENTS_PER_BATCH
+    || !cursorAfter
+    || !sameTarget(batch.target, target)
+    || batch.sourceSnapshot.capturedAt !== capturedAt
+    || delivery.batchDigest !== digestAtendimentoProjectionBackfillBatch(batch)
+    || !delivery.keyId.startsWith(`crm-${target.environment}-atendimento-backfill-`)
+  ) fail(code)
+  return Object.freeze({
+    batch,
+    delivery,
+    requestId: pending.requestId,
+    cursorAfter,
+  })
+}
+
+function storedCheckpoint(value) {
+  const checkpointValue = object(value, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
+  exactKeys(checkpointValue, ['contractVersion', 'state', 'target', 'sourceSnapshot', 'progress', 'cursor', 'pending'], 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
+  const sourceSnapshot = object(checkpointValue.sourceSnapshot, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
+  const progress = object(checkpointValue.progress, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
+  exactKeys(sourceSnapshot, ['capturedAt', 'rowCount'], 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
+  exactKeys(progress, ['deliveredCount', 'batchCount', 'acceptedCount', 'idempotentCount', 'reconciliationDigest'], 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
+  if (
+    checkpointValue.contractVersion !== CHECKPOINT_VERSION
+    || checkpointValue.state !== 'running'
+    || !/^sha256:[a-f0-9]{64}$/.test(String(progress.reconciliationDigest || ''))
+  ) fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
+  const target = assertAtendimentoProjectionExportTarget(checkpointValue.target)
+  const rowCount = normalizedInteger(sourceSnapshot.rowCount, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
+  const deliveredCount = normalizedInteger(progress.deliveredCount, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID', { maximum: rowCount })
+  const batchCount = normalizedInteger(progress.batchCount, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
+  const acceptedCount = normalizedInteger(progress.acceptedCount, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
+  const idempotentCount = normalizedInteger(progress.idempotentCount, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
+  if (
+    acceptedCount + idempotentCount !== batchCount
+    || (deliveredCount === 0 && batchCount !== 0)
+    || (deliveredCount > 0 && (batchCount === 0 || batchCount > deliveredCount))
+  ) fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
+  const cursor = storedCursor(checkpointValue.cursor, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
+  const capturedAt = normalizedTimestamp(sourceSnapshot.capturedAt, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
+  const pending = storedPending(checkpointValue.pending, {
+    target,
+    capturedAt,
+    code: 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID',
+  })
+  if ((deliveredCount === 0) !== (cursor === null)) fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
+  if (pending && cursor && compareCursor(pending.cursorAfter, cursor) <= 0) fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
+  if (pending && deliveredCount + pending.batch.events.length > rowCount) fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_INVALID')
+  return Object.freeze({
+    target,
+    capturedAt,
+    sourceRowCount: rowCount,
+    deliveredCount,
+    batchCount,
+    acceptedCount,
+    idempotentCount,
+    reconciliationDigest: progress.reconciliationDigest,
+    cursor,
+    pending,
+  })
+}
+
+function checkpoint({ target, capturedAt, sourceRowCount, deliveredCount, batchCount, acceptedCount, idempotentCount, reconciliationDigest, cursor, pending }) {
+  return Object.freeze({
+    contractVersion: CHECKPOINT_VERSION,
+    state: 'running',
+    target: Object.freeze({ ...target }),
+    sourceSnapshot: Object.freeze({ capturedAt, rowCount: sourceRowCount }),
+    progress: Object.freeze({ deliveredCount, batchCount, acceptedCount, idempotentCount, reconciliationDigest }),
+    // This cursor contains the source UUID and is deliberately supplied only to
+    // the private checkpoint capability. It never appears in HTTP or results.
+    cursor: cursor ? Object.freeze({ ...cursor }) : null,
+    pending: pending ? Object.freeze({
+      batch: pending.batch,
+      delivery: pending.delivery,
+      requestId: pending.requestId,
+      cursorAfter: Object.freeze({ ...pending.cursorAfter }),
+    }) : null,
+  })
+}
+
+function completedSummary({ target, capturedAt, sourceRowCount, deliveredCount, batchCount, acceptedCount, idempotentCount, reconciliationDigest }) {
+  return Object.freeze({
+    contractVersion: 'atendimento/crm-core/projection-backfill-reconciliation/v1',
+    status: 'reconciled',
+    target: Object.freeze({ ...target }),
+    sourceSnapshot: Object.freeze({ capturedAt, rowCount: sourceRowCount }),
+    deliveredCount,
+    batchCount,
+    acceptedCount,
+    idempotentCount,
+    reconciliationDigest,
+  })
+}
+
+async function readCheckpoint(store) {
+  try {
+    return await store.read()
+  } catch {
+    fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_UNAVAILABLE')
+  }
+}
+
+async function writeCheckpoint(store, value) {
+  try {
+    await store.write(value)
+  } catch {
+    fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_UNAVAILABLE')
+  }
+}
+
+async function completeCheckpoint(store, value) {
+  try {
+    await store.complete(value)
+  } catch {
+    fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_UNAVAILABLE')
+  }
+}
+
+function confirmedCheckpointState(state, pending, receipt) {
+  if (!receipt || !['accepted', 'idempotent'].includes(receipt.status)) {
+    fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_RECONCILIATION_FAILED')
+  }
+  const record = Object.freeze({
+    batchId: pending.batch.batchId,
+    batchDigest: pending.delivery.batchDigest,
+    eventCount: pending.batch.events.length,
+    status: receipt.status,
+  })
+  return Object.freeze({
+    ...state,
+    deliveredCount: state.deliveredCount + pending.batch.events.length,
+    batchCount: state.batchCount + 1,
+    acceptedCount: state.acceptedCount + (receipt.status === 'accepted' ? 1 : 0),
+    idempotentCount: state.idempotentCount + (receipt.status === 'idempotent' ? 1 : 0),
+    reconciliationDigest: nextReconciliationDigest(state.reconciliationDigest, record),
+    cursor: pending.cursorAfter,
+    pending: null,
+  })
+}
+
+function knownError(error) {
+  return error instanceof Error && /^ATENDIMENTO_CRM_(?:PROJECTION_EXPORT|BACKFILL)_[A-Z_]+$/.test(error.message)
+}
+
+/**
+ * Creates an explicit staging-only runner. It has no CLI, environment lookup,
+ * database construction or network default: all capabilities are injected by
+ * an operator-owned caller. A pending opaque packet can be replayed before a
+ * new source transaction opens. Further pagination is allowed only when the
+ * new transaction attests the exact capturedAt and rowCount in its checkpoint.
+ */
+export function createPaginatedAtendimentoProjectionBackfillRunner({
+  pool,
+  hmacKey,
+  keyId,
+  target,
+  signer: suppliedSigner,
+  transport: suppliedTransport,
+  checkpointStore: suppliedCheckpointStore,
+  batchSize,
+  maxRows,
+} = {}) {
+  if (!pool || typeof pool.connect !== 'function') fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_POOL_REQUIRED')
+  const pageSize = normalizedBatchSize(batchSize)
+  const maximumRows = normalizedMaximumRows(maxRows)
+  const targetValue = assertAtendimentoProjectionExportTarget(target)
+  if (targetValue.environment !== 'staging') fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_STAGING_ONLY')
+  const deliverySigner = signer(suppliedSigner)
+  const deliveryTransport = transport(suppliedTransport)
+  const privateCheckpointStore = checkpointStore(suppliedCheckpointStore)
+
+  return Object.freeze({
+    version: ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUNNER_VERSION,
+    target: targetValue,
+    async run({ intent } = {}) {
+      if (intent !== ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT) {
+        fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_INTENT_REQUIRED')
+      }
+      const existing = await readCheckpoint(privateCheckpointStore)
+      let restored = null
+      if (existing !== null && existing !== undefined) {
+        try {
+          restored = storedCheckpoint(existing)
+        } catch {
+          fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_RECOVERY_REQUIRED')
+        }
+      }
+
+      let client
+      let transactionOpen = false
+      try {
+        if (restored?.pending) {
+          const receipt = await deliveryTransport.deliver({
+            batch: restored.pending.batch,
+            delivery: restored.pending.delivery,
+            requestId: restored.pending.requestId,
+          })
+          restored = confirmedCheckpointState(restored, restored.pending, receipt)
+          await writeCheckpoint(privateCheckpointStore, checkpoint(restored))
+        }
+
+        client = await pool.connect()
+        if (!client || typeof client.query !== 'function') fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_CLIENT_INVALID')
+        await client.query('BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY')
+        transactionOpen = true
+
+        const source = await preflightAtendimentoProjectionSource(client, { maxRows: maximumRows })
+        const capturedAt = source.capturedAt
+        const sourceRowCount = source.rowCount
+        let state
+        if (restored) {
+          if (
+            !sameTarget(restored.target, targetValue)
+            || restored.capturedAt !== capturedAt
+            || restored.sourceRowCount !== sourceRowCount
+          ) fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_SNAPSHOT_MISMATCH')
+          state = restored
+        } else {
+          state = Object.freeze({
+            target: targetValue,
+            capturedAt,
+            sourceRowCount,
+            deliveredCount: 0,
+            batchCount: 0,
+            acceptedCount: 0,
+            idempotentCount: 0,
+            reconciliationDigest: digest([]),
+            cursor: null,
+            pending: null,
+          })
+          await writeCheckpoint(privateCheckpointStore, checkpoint(state))
+        }
+
+        while (state.deliveredCount < sourceRowCount) {
+          const remaining = sourceRowCount - state.deliveredCount
+          const limit = Math.min(pageSize, remaining)
+          const result = state.cursor
+            ? await client.query(ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL, [state.cursor.updatedAt, state.cursor.id, limit])
+            : await client.query(ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL, [limit])
+          const rows = pageRows(result?.rows, { limit, after: state.cursor })
+          if (rows.length > remaining) fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_RECONCILIATION_FAILED')
+
+          const batch = createAtendimentoProjectionBackfillBatch({
+            rows,
+            capturedAt,
+            hmacKey,
+            keyId,
+            target: targetValue,
+          })
+          if (batch.events.length > ATENDIMENTO_CRM_PROJECTION_BACKFILL_MAX_EVENTS_PER_BATCH) {
+            fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_BATCH_SIZE_INVALID')
+          }
+          const delivery = assertAtendimentoProjectionBackfillDelivery(await deliverySigner.signBatch(batch))
+          if (delivery.batchDigest !== digestAtendimentoProjectionBackfillBatch(batch)) {
+            fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_DELIVERY_MISMATCH')
+          }
+          const cursorAfter = sourceCursor(rows.at(-1))
+          const requestId = `${REQUEST_ID_PREFIX}${String(state.batchCount + 1).padStart(6, '0')}`
+          const pending = Object.freeze({
+            batch,
+            delivery,
+            requestId,
+            cursorAfter,
+          })
+          state = Object.freeze({ ...state, pending })
+          await writeCheckpoint(privateCheckpointStore, checkpoint(state))
+
+          const receipt = await deliveryTransport.deliver({ batch, delivery, requestId })
+          state = confirmedCheckpointState(state, pending, receipt)
+          await writeCheckpoint(privateCheckpointStore, checkpoint(state))
+        }
+
+        if (state.deliveredCount !== sourceRowCount) fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_RECONCILIATION_FAILED')
+        const summary = completedSummary({
+          target: targetValue,
+          capturedAt,
+          sourceRowCount,
+          deliveredCount: state.deliveredCount,
+          batchCount: state.batchCount,
+          acceptedCount: state.acceptedCount,
+          idempotentCount: state.idempotentCount,
+          reconciliationDigest: state.reconciliationDigest,
+        })
+        await completeCheckpoint(privateCheckpointStore, summary)
+        await client.query('ROLLBACK')
+        transactionOpen = false
+        return summary
+      } catch (error) {
+        if (transactionOpen) {
+          try {
+            await client?.query('ROLLBACK')
+          } catch {
+            // The original fail-closed error remains the observable outcome.
+          }
+        }
+        if (knownError(error)) throw error
+        fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_UNAVAILABLE')
+      } finally {
+        if (client && typeof client.release === 'function') client.release()
+      }
+    },
+  })
+}

--- a/integration/atendimento/crm-core-projection-exporter/src/syntheticAtendimentoProjectionRemoteRehearsal.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/syntheticAtendimentoProjectionRemoteRehearsal.mjs
@@ -1,0 +1,260 @@
+import { createHash, generateKeyPairSync, randomBytes, sign } from 'node:crypto'
+
+import {
+  assertAtendimentoProjectionExportTarget,
+  createAtendimentoProjectionBackfillBatch,
+  digestAtendimentoProjectionBackfillBatch,
+} from './atendimentoProjectionExporter.mjs'
+import {
+  createAtendimentoProjectionBackfillDeliverySigner,
+} from './atendimentoProjectionBackfillDelivery.mjs'
+import {
+  createAtendimentoProjectionBackfillHttpTransport,
+} from './atendimentoProjectionBackfillHttpTransport.mjs'
+import {
+  ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT,
+  createPaginatedAtendimentoProjectionBackfillRunner,
+} from './paginatedAtendimentoProjectionBackfillRunner.mjs'
+import {
+  createSyntheticAtendimentoProjectionFixturePool,
+} from './syntheticStagingPreparationRunner.mjs'
+
+export const ATENDIMENTO_SYNTHETIC_REMOTE_REHEARSAL_VERSION = 'atendimento/crm-core/synthetic-remote-backfill-rehearsal/v1'
+export const ATENDIMENTO_SYNTHETIC_REMOTE_REHEARSAL_INTENT = 'atendimento/crm-core/synthetic-remote-backfill-rehearsal-delivery/v1'
+
+const SYNTHETIC_CAPTURED_AT = '2026-09-07T00:00:00.000Z'
+const SYNTHETIC_SOURCE_ROW = Object.freeze({
+  id: '123e4567-e89b-42d3-a456-426614174001',
+  updated_at: SYNTHETIC_CAPTURED_AT,
+})
+const DELIVERY_KEY_ID = 'crm-staging-atendimento-backfill-remote-rehearsal'
+const SOURCE_KEY_ID = 'atendimento-synthetic-remote-rehearsal-v1'
+const LEGACY_FIXTURE_BATCH_ID = 'backfill:atendimento:fixture-batch-0001'
+
+function fail(code) {
+  throw new Error(code)
+}
+
+function object(value, code) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(code)
+  return value
+}
+
+function exactKeys(value, keys, code) {
+  if (Object.keys(value).length !== keys.length || keys.some((key) => !Object.hasOwn(value, key))) fail(code)
+}
+
+function sameTarget(left, right) {
+  return left.environment === right.environment
+    && left.release === right.release
+    && left.artifactDigest === right.artifactDigest
+}
+
+function stagingTarget(value) {
+  const target = assertAtendimentoProjectionExportTarget(value)
+  if (target.environment !== 'staging') fail('ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_STAGING_ONLY')
+  return target
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, canonicalize(value[key])]))
+  }
+  return value
+}
+
+function digest(value) {
+  return `sha256:${createHash('sha256').update(JSON.stringify(canonicalize(value))).digest('hex')}`
+}
+
+function publicJwk(value) {
+  const key = object(value, 'ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_PUBLIC_KEY_INVALID')
+  exactKeys(key, ['crv', 'kty', 'x'], 'ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_PUBLIC_KEY_INVALID')
+  if (key.kty !== 'OKP' || key.crv !== 'Ed25519' || typeof key.x !== 'string' || !key.x) {
+    fail('ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_PUBLIC_KEY_INVALID')
+  }
+  return Object.freeze({ crv: key.crv, kty: key.kty, x: key.x })
+}
+
+function memoryCheckpointStore() {
+  let current = null
+  return Object.freeze({
+    async read() { return current },
+    async write(value) { current = value },
+    async complete() { current = null },
+  })
+}
+
+function expectedReconciliation(batch, batchDigest) {
+  return Object.freeze({
+    batchId: batch.batchId,
+    batchDigest,
+    target: Object.freeze({ ...batch.target }),
+    eventCount: batch.events.length,
+    eventsDigest: batch.integrity.eventsDigest,
+    cursorDigest: batch.sourceSnapshot.cursorDigest,
+    eventIds: Object.freeze(batch.events.map((event) => event.id)),
+  })
+}
+
+function assertReconciliation(value, expected) {
+  const reconciliation = object(value, 'ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_RECONCILIATION_INVALID')
+  exactKeys(reconciliation, ['batchId', 'target', 'eventCount', 'eventsDigest', 'cursorDigest', 'eventIds'], 'ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_RECONCILIATION_INVALID')
+  const target = assertAtendimentoProjectionExportTarget(reconciliation.target)
+  if (
+    reconciliation.batchId !== expected.batchId
+    || !sameTarget(target, expected.target)
+    || reconciliation.eventCount !== expected.eventCount
+    || reconciliation.eventsDigest !== expected.eventsDigest
+    || reconciliation.cursorDigest !== expected.cursorDigest
+    || !Array.isArray(reconciliation.eventIds)
+    || reconciliation.eventIds.length !== expected.eventIds.length
+    || reconciliation.eventIds.some((eventId, index) => eventId !== expected.eventIds[index])
+  ) fail('ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_RECONCILIATION_INVALID')
+  return Object.freeze({
+    batchId: expected.batchId,
+    target: Object.freeze({ ...expected.target }),
+    eventCount: expected.eventCount,
+    eventsDigest: expected.eventsDigest,
+    cursorDigest: expected.cursorDigest,
+  })
+}
+
+function assertRunSummary(value, status) {
+  if (
+    !value
+    || value.status !== 'reconciled'
+    || value.deliveredCount !== 1
+    || value.batchCount !== 1
+    || value.acceptedCount !== (status === 'accepted' ? 1 : 0)
+    || value.idempotentCount !== (status === 'idempotent' ? 1 : 0)
+  ) fail('ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_RECEIPT_INVALID')
+}
+
+/**
+ * Prepares a single, finite, synthetic staging rehearsal. The source HMAC and
+ * Ed25519 private key are generated in-memory and retained only by the closed
+ * `rehearse` function. Calling this factory performs no network or deployment
+ * action; it returns the public key and one approved canonical batch digest
+ * that an external staging operator may configure only for this rehearsal.
+ */
+export function createSyntheticAtendimentoProjectionRemoteRehearsal(options = {}) {
+  const input = object(options, 'ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_OPTIONS_INVALID')
+  const target = stagingTarget(input.target)
+  exactKeys(input, ['target', 'endpoint'], 'ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_OPTIONS_INVALID')
+
+  // Reuse the strict transport constructor to validate the exact HTTPS route,
+  // while its inert injected function ensures preparation never opens a network
+  // connection.
+  const endpoint = createAtendimentoProjectionBackfillHttpTransport({
+    endpoint: input.endpoint,
+    fetch: async () => fail('ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_NETWORK_NOT_PERMITTED'),
+  }).endpoint
+
+  let keyPair
+  try {
+    keyPair = generateKeyPairSync('ed25519')
+  } catch {
+    fail('ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_KEY_GENERATION_UNAVAILABLE')
+  }
+  const publicKey = publicJwk(keyPair.publicKey.export({ format: 'jwk' }))
+  const hmacKey = randomBytes(48).toString('base64url')
+  const batch = createAtendimentoProjectionBackfillBatch({
+    rows: [SYNTHETIC_SOURCE_ROW],
+    capturedAt: SYNTHETIC_CAPTURED_AT,
+    hmacKey,
+    keyId: SOURCE_KEY_ID,
+    target,
+  })
+  if (batch.batchId === LEGACY_FIXTURE_BATCH_ID) fail('ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_BATCH_COLLISION')
+  const batchDigest = digestAtendimentoProjectionBackfillBatch(batch)
+  const signer = createAtendimentoProjectionBackfillDeliverySigner({
+    target,
+    keyId: DELIVERY_KEY_ID,
+    sign: (inputToSign) => sign(null, inputToSign, keyPair.privateKey),
+  })
+  const expected = expectedReconciliation(batch, batchDigest)
+  const publicKeysJson = JSON.stringify({ [DELIVERY_KEY_ID]: publicKey })
+  const batchDigestsJson = JSON.stringify([batchDigest])
+  const activation = Object.freeze({
+    contractVersion: 'atendimento/crm-core/synthetic-remote-backfill-activation/v1',
+    environment: 'staging',
+    keyId: DELIVERY_KEY_ID,
+    publicKeysJson,
+    batchDigestsJson,
+    configurationDigest: digest({ target, publicKey, batchDigest }),
+    batch: Object.freeze({
+      batchId: batch.batchId,
+      batchDigest,
+      eventCount: batch.events.length,
+      capturedAt: batch.sourceSnapshot.capturedAt,
+    }),
+  })
+
+  async function deliverOnce(fetchImpl) {
+    const httpTransport = createAtendimentoProjectionBackfillHttpTransport({ endpoint, fetch: fetchImpl })
+    const transport = Object.freeze({
+      async deliver(value) {
+        if (
+          value?.batch?.batchId !== batch.batchId
+          || value?.delivery?.batchDigest !== batchDigest
+          || value?.batch?.integrity?.eventsDigest !== expected.eventsDigest
+        ) fail('ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_PACKET_MISMATCH')
+        return httpTransport.deliver(value)
+      },
+    })
+    const runner = createPaginatedAtendimentoProjectionBackfillRunner({
+      pool: createSyntheticAtendimentoProjectionFixturePool({
+        capturedAt: SYNTHETIC_CAPTURED_AT,
+        rows: [SYNTHETIC_SOURCE_ROW],
+      }),
+      hmacKey,
+      keyId: SOURCE_KEY_ID,
+      target,
+      signer,
+      transport,
+      checkpointStore: memoryCheckpointStore(),
+      batchSize: 1,
+      maxRows: 1,
+    })
+    return runner.run({ intent: ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT })
+  }
+
+  return Object.freeze({
+    version: ATENDIMENTO_SYNTHETIC_REMOTE_REHEARSAL_VERSION,
+    activation,
+    async rehearse(value = {}) {
+      const input = object(value, 'ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_INPUT_INVALID')
+      if (input.intent !== ATENDIMENTO_SYNTHETIC_REMOTE_REHEARSAL_INTENT) {
+        fail('ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_INTENT_REQUIRED')
+      }
+      exactKeys(input, ['intent', 'fetch', 'reconcile'], 'ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_INPUT_INVALID')
+      if (typeof input.fetch !== 'function') fail('ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_FETCH_REQUIRED')
+      if (typeof input.reconcile !== 'function') fail('ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_RECONCILER_REQUIRED')
+
+      const accepted = await deliverOnce(input.fetch)
+      assertRunSummary(accepted, 'accepted')
+      const idempotent = await deliverOnce(input.fetch)
+      assertRunSummary(idempotent, 'idempotent')
+
+      let reconciliation
+      try {
+        reconciliation = await input.reconcile(expected)
+      } catch {
+        fail('ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_RECONCILIATION_UNAVAILABLE')
+      }
+      const verified = assertReconciliation(reconciliation, expected)
+      return Object.freeze({
+        contractVersion: 'atendimento/crm-core/synthetic-remote-backfill-rehearsal-receipt/v1',
+        status: 'reconciled',
+        target: Object.freeze({ ...target }),
+        batchId: batch.batchId,
+        batchDigest,
+        accepted: 'accepted',
+        retry: 'idempotent',
+        reconciliation: verified,
+      })
+    },
+  })
+}

--- a/integration/atendimento/crm-core-projection-exporter/src/syntheticStagingPreparationRunner.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/syntheticStagingPreparationRunner.mjs
@@ -1,7 +1,9 @@
 import {
   ATENDIMENTO_CRM_PROJECTION_MAX_ROWS,
   ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL,
   ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL,
   ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL,
   ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL,
   assertAtendimentoProjectionExportTarget,
@@ -125,6 +127,28 @@ export function createSyntheticAtendimentoProjectionFixturePool(value) {
           fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID')
         }
         return { rows }
+      }
+      if (sql === ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL) {
+        const [limit] = params
+        if (!Number.isSafeInteger(limit) || limit < 1 || limit > rows.length) {
+          fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID')
+        }
+        return { rows: rows.slice(0, limit) }
+      }
+      if (sql === ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL) {
+        const [updatedAt, id, limit] = params
+        if (
+          !Number.isSafeInteger(limit)
+          || limit < 1
+          || typeof updatedAt !== 'string'
+          || !UUID_PATTERN.test(String(id || ''))
+        ) fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID')
+        return {
+          rows: rows.filter((row) => (
+            row.updated_at.localeCompare(updatedAt) > 0
+            || (row.updated_at === updatedAt && row.id.localeCompare(id) > 0)
+          )).slice(0, limit),
+        }
       }
       fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID')
     },

--- a/integration/atendimento/crm-core-projection-exporter/src/syntheticStagingPreparationRunner.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/syntheticStagingPreparationRunner.mjs
@@ -41,6 +41,10 @@ function timestamp(value, code) {
   return parsed.toISOString()
 }
 
+function cursorTimestamp(value, code) {
+  return timestamp(value, code).replace(/\.(\d{3})Z$/, (_match, milliseconds) => `.${milliseconds}000Z`)
+}
+
 function explicitSyntheticIntent(value) {
   if (value !== ATENDIMENTO_SYNTHETIC_STAGING_PREPARATION_INTENT) {
     fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_INTENT_REQUIRED')
@@ -143,10 +147,11 @@ export function createSyntheticAtendimentoProjectionFixturePool(value) {
           || typeof updatedAt !== 'string'
           || !UUID_PATTERN.test(String(id || ''))
         ) fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID')
+        const cursorUpdatedAt = cursorTimestamp(updatedAt, 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID')
         return {
           rows: rows.filter((row) => (
-            row.updated_at.localeCompare(updatedAt) > 0
-            || (row.updated_at === updatedAt && row.id.localeCompare(id) > 0)
+            cursorTimestamp(row.updated_at, 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID').localeCompare(cursorUpdatedAt) > 0
+            || (cursorTimestamp(row.updated_at, 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID') === cursorUpdatedAt && row.id.localeCompare(id) > 0)
           )).slice(0, limit),
         }
       }

--- a/integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionBackfillDelivery.test.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionBackfillDelivery.test.mjs
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict'
+import crypto from 'node:crypto'
+import test from 'node:test'
+
+import {
+  createAtendimentoProjectionBackfillBatch,
+} from '../src/atendimentoProjectionExporter.mjs'
+import {
+  createAtendimentoProjectionBackfillDeliverySigner,
+  createAtendimentoProjectionBackfillDeliverySigningInput,
+} from '../src/atendimentoProjectionBackfillDelivery.mjs'
+import {
+  ATENDIMENTO_CRM_BACKFILL_HTTP_PATH,
+  createAtendimentoProjectionBackfillHttpTransport,
+} from '../src/atendimentoProjectionBackfillHttpTransport.mjs'
+
+const HMAC_KEY = 'synthetic-atendimento-projection-export-key-at-least-32-bytes'
+const TARGET = Object.freeze({
+  environment: 'staging',
+  release: 'a'.repeat(40),
+  artifactDigest: `sha256:${'b'.repeat(64)}`,
+})
+const SOURCE_ID = '123e4567-e89b-42d3-a456-426614174000'
+
+function batch(rows = [{ id: SOURCE_ID, updated_at: '2026-09-07T00:00:00.000Z' }]) {
+  return createAtendimentoProjectionBackfillBatch({
+    rows,
+    capturedAt: '2026-09-07T00:00:00.000Z',
+    hmacKey: HMAC_KEY,
+    keyId: 'atendimento-projection-key-v1',
+    target: TARGET,
+  })
+}
+
+function signerFor(target = TARGET) {
+  const keys = crypto.generateKeyPairSync('ed25519')
+  const signer = createAtendimentoProjectionBackfillDeliverySigner({
+    target,
+    keyId: `crm-${target.environment}-atendimento-backfill-v1`,
+    sign: (input) => crypto.sign(null, input, keys.privateKey),
+  })
+  return { signer, publicKey: keys.publicKey }
+}
+
+test('signs the exact detached proof CRM Core verifies without retaining a private key', async () => {
+  const currentBatch = batch()
+  const { signer, publicKey } = signerFor()
+  const delivery = await signer.signBatch(currentBatch)
+  const signingInput = createAtendimentoProjectionBackfillDeliverySigningInput({
+    keyId: delivery.keyId,
+    batchDigest: delivery.batchDigest,
+    target: TARGET,
+  })
+
+  assert.equal(delivery.contract, 'skincos-crm/projection-backfill-delivery/v1')
+  assert.equal(delivery.algorithm, 'Ed25519')
+  assert.match(delivery.keyId, /^crm-staging-atendimento-backfill-/)
+  assert.equal(crypto.verify(null, Buffer.from(signingInput, 'utf8'), publicKey, Buffer.from(delivery.signature, 'base64url')), true)
+  assert.doesNotMatch(JSON.stringify(delivery), /private|hmac|123e4567/i)
+})
+
+test('refuses a signing key that belongs to another environment before it can sign', () => {
+  const keys = crypto.generateKeyPairSync('ed25519')
+  assert.throws(() => createAtendimentoProjectionBackfillDeliverySigner({
+    target: TARGET,
+    keyId: 'crm-production-atendimento-backfill-v1',
+    sign: (input) => crypto.sign(null, input, keys.privateKey),
+  }), /ATENDIMENTO_CRM_BACKFILL_DELIVERY_KEY_ENVIRONMENT_MISMATCH/)
+})
+
+test('uses the internal HTTPS route with no credential, cookie, origin, or authorization forwarding', async () => {
+  const currentBatch = batch()
+  const { signer } = signerFor()
+  const delivery = await signer.signBatch(currentBatch)
+  const calls = []
+  const transport = createAtendimentoProjectionBackfillHttpTransport({
+    endpoint: `https://crm-core-staging.example.test${ATENDIMENTO_CRM_BACKFILL_HTTP_PATH}`,
+    fetch: async (url, init) => {
+      calls.push({ url, init })
+      return {
+        status: 200,
+        async json() {
+          return {
+            ok: true,
+            contractVersion: 'crm-core/projection-backfill-receipt/v1',
+            status: 'accepted',
+            batchId: currentBatch.batchId,
+            eventCount: currentBatch.events.length,
+            target: TARGET,
+            requestId: 'crm-atendimento-backfill-000001',
+          }
+        },
+      }
+    },
+  })
+
+  const receipt = await transport.deliver({
+    batch: currentBatch,
+    delivery,
+    requestId: 'crm-atendimento-backfill-000001',
+  })
+
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].url, `https://crm-core-staging.example.test${ATENDIMENTO_CRM_BACKFILL_HTTP_PATH}`)
+  assert.equal(calls[0].init.method, 'POST')
+  assert.equal(calls[0].init.credentials, 'omit')
+  assert.equal(calls[0].init.redirect, 'error')
+  assert.deepEqual(Object.keys(calls[0].init.headers).sort(), ['content-type', 'x-request-id'])
+  assert.equal(JSON.stringify(calls[0].init.headers).match(/authorization|cookie|origin/i), null)
+  assert.equal(receipt.status, 'accepted')
+})
+
+test('fails closed when the receiver response does not bind the batch and request id', async () => {
+  const currentBatch = batch()
+  const { signer } = signerFor()
+  const delivery = await signer.signBatch(currentBatch)
+  const transport = createAtendimentoProjectionBackfillHttpTransport({
+    endpoint: `https://crm-core-staging.example.test${ATENDIMENTO_CRM_BACKFILL_HTTP_PATH}`,
+    fetch: async () => ({
+      status: 200,
+      async json() {
+        return {
+          ok: true,
+          contractVersion: 'crm-core/projection-backfill-receipt/v1',
+          status: 'accepted',
+          batchId: 'backfill:atendimento:wrong-batch',
+          eventCount: currentBatch.events.length,
+          target: TARGET,
+          requestId: 'crm-atendimento-backfill-000001',
+        }
+      },
+    }),
+  })
+
+  await assert.rejects(() => transport.deliver({
+    batch: currentBatch,
+    delivery,
+    requestId: 'crm-atendimento-backfill-000001',
+  }), /ATENDIMENTO_CRM_BACKFILL_TRANSPORT_RESPONSE_INVALID/)
+})
+
+test('refuses an arbitrary route before it can invoke fetch', () => {
+  assert.throws(() => createAtendimentoProjectionBackfillHttpTransport({
+    endpoint: 'https://crm-core-staging.example.test/crm/backfill',
+    fetch: async () => ({ status: 200, json: async () => ({}) }),
+  }), /ATENDIMENTO_CRM_BACKFILL_TRANSPORT_ENDPOINT_INVALID/)
+})

--- a/integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionBackfillDelivery.test.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionBackfillDelivery.test.mjs
@@ -139,6 +139,50 @@ test('fails closed when the receiver response does not bind the batch and reques
   }), /ATENDIMENTO_CRM_BACKFILL_TRANSPORT_RESPONSE_INVALID/)
 })
 
+test('bounds a stalled HTTP connection and aborts the injected request', async () => {
+  const currentBatch = batch()
+  const { signer } = signerFor()
+  const delivery = await signer.signBatch(currentBatch)
+  let signal
+  const transport = createAtendimentoProjectionBackfillHttpTransport({
+    endpoint: `https://crm-core-staging.example.test${ATENDIMENTO_CRM_BACKFILL_HTTP_PATH}`,
+    timeoutMs: 1,
+    fetch: (_url, init) => {
+      signal = init.signal
+      return new Promise(() => {})
+    },
+  })
+
+  await assert.rejects(() => transport.deliver({
+    batch: currentBatch,
+    delivery,
+    requestId: 'crm-atendimento-backfill-000001',
+  }), /ATENDIMENTO_CRM_BACKFILL_TRANSPORT_UNAVAILABLE/)
+  assert.equal(signal?.aborted, true)
+})
+
+test('bounds a stalled receipt body with the same abort deadline', async () => {
+  const currentBatch = batch()
+  const { signer } = signerFor()
+  const delivery = await signer.signBatch(currentBatch)
+  let signal
+  const transport = createAtendimentoProjectionBackfillHttpTransport({
+    endpoint: `https://crm-core-staging.example.test${ATENDIMENTO_CRM_BACKFILL_HTTP_PATH}`,
+    timeoutMs: 1,
+    fetch: async (_url, init) => {
+      signal = init.signal
+      return { status: 200, json: () => new Promise(() => {}) }
+    },
+  })
+
+  await assert.rejects(() => transport.deliver({
+    batch: currentBatch,
+    delivery,
+    requestId: 'crm-atendimento-backfill-000001',
+  }), /ATENDIMENTO_CRM_BACKFILL_TRANSPORT_UNAVAILABLE/)
+  assert.equal(signal?.aborted, true)
+})
+
 test('refuses an arbitrary route before it can invoke fetch', () => {
   assert.throws(() => createAtendimentoProjectionBackfillHttpTransport({
     endpoint: 'https://crm-core-staging.example.test/crm/backfill',

--- a/integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionExporter.test.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionExporter.test.mjs
@@ -78,7 +78,7 @@ test('exports a repeatable-read, opaque batch without serializing a source UUID 
 
   const sourceRead = fixture.calls.find((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL)
   assert.deepEqual(sourceRead.params, [1])
-  assert.match(sourceRead.sql, /SELECT id::text AS id, updated_at/)
+  assert.match(sourceRead.sql, /SELECT id::text AS id,\s+to_char\(updated_at AT TIME ZONE 'UTC'/)
   assert.doesNotMatch(sourceRead.sql, /canonical_name|email|phone|member|contact/i)
 })
 

--- a/integration/atendimento/crm-core-projection-exporter/test/paginatedAtendimentoProjectionBackfillRunner.test.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/test/paginatedAtendimentoProjectionBackfillRunner.test.mjs
@@ -1,0 +1,333 @@
+import assert from 'node:assert/strict'
+import crypto from 'node:crypto'
+import test from 'node:test'
+
+import {
+  ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL,
+} from '../src/atendimentoProjectionExporter.mjs'
+import {
+  createAtendimentoProjectionBackfillDeliverySigner,
+} from '../src/atendimentoProjectionBackfillDelivery.mjs'
+import {
+  ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT,
+  createPaginatedAtendimentoProjectionBackfillRunner,
+} from '../src/paginatedAtendimentoProjectionBackfillRunner.mjs'
+
+const HMAC_KEY = 'synthetic-atendimento-paginated-export-key-at-least-32-bytes'
+const TARGET = Object.freeze({
+  environment: 'staging',
+  release: 'a'.repeat(40),
+  artifactDigest: `sha256:${'b'.repeat(64)}`,
+})
+const CAPTURED_AT = '2026-09-07T00:00:00.000Z'
+
+function sourceRow(index) {
+  const suffix = index.toString(16).padStart(12, '0')
+  const timestamp = new Date(Date.parse(CAPTURED_AT) + (Math.floor(index / 2) * 1000)).toISOString()
+  return Object.freeze({ id: `123e4567-e89b-42d3-a456-${suffix}`, updated_at: timestamp })
+}
+
+function compareRows(left, right) {
+  return left.updated_at.localeCompare(right.updated_at) || left.id.localeCompare(right.id)
+}
+
+function fakePool({
+  rows = [sourceRow(0)],
+  rowCount = rows.length,
+  capturedAt = CAPTURED_AT,
+  preserveSourceOrder = false,
+} = {}) {
+  const sourceRows = preserveSourceOrder ? [...rows] : [...rows].sort(compareRows)
+  const calls = []
+  let released = false
+  let connectCount = 0
+  const client = {
+    async query(sql, params = []) {
+      calls.push({ sql, params })
+      if (sql === 'BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY' || sql === 'ROLLBACK') return { rows: [] }
+      if (sql === ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL) return { rows: [{
+        database_name: 'skincos_clientes_production',
+        current_user: 'crm_core_projection_exporter',
+        session_user: 'crm_core_projection_exporter',
+        transaction_read_only: 'on',
+      }] }
+      if (sql === ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL) return { rows: [{ captured_at: capturedAt }] }
+      if (sql === ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL) return { rows: [{ row_count: rowCount }] }
+      if (sql === ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL) {
+        return { rows: sourceRows.slice(0, params[0]) }
+      }
+      if (sql === ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL) {
+        const [updatedAt, id, limit] = params
+        return {
+          rows: sourceRows.filter((row) => (
+            row.updated_at.localeCompare(updatedAt) > 0
+            || (row.updated_at === updatedAt && row.id.localeCompare(id) > 0)
+          )).slice(0, limit),
+        }
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    },
+    release() { released = true },
+  }
+  return {
+    calls,
+    released: () => released,
+    connectCount: () => connectCount,
+    pool: {
+      async connect() {
+        connectCount += 1
+        return client
+      },
+    },
+  }
+}
+
+function checkpointFixture({ initial = null } = {}) {
+  let active = initial
+  const writes = []
+  const completions = []
+  return {
+    store: Object.freeze({
+      async read() { return active },
+      async write(value) {
+        active = structuredClone(value)
+        writes.push(active)
+      },
+      async complete(value) {
+        completions.push(structuredClone(value))
+        active = null
+      },
+    }),
+    writes: () => writes,
+    completions: () => completions,
+    active: () => active,
+  }
+}
+
+function signingFixture() {
+  const { privateKey } = crypto.generateKeyPairSync('ed25519')
+  return createAtendimentoProjectionBackfillDeliverySigner({
+    target: TARGET,
+    keyId: 'crm-staging-atendimento-backfill-v1',
+    sign: (input) => crypto.sign(null, input, privateKey),
+  })
+}
+
+function transportFixture({ statuses = ['accepted'], failure } = {}) {
+  const deliveries = []
+  return {
+    transport: Object.freeze({
+      async deliver({ batch, delivery, requestId }) {
+        deliveries.push(Object.freeze({ batch, delivery, requestId }))
+        if (failure) throw failure
+        return Object.freeze({ status: statuses[Math.min(deliveries.length - 1, statuses.length - 1)] })
+      },
+    }),
+    deliveries: () => deliveries,
+  }
+}
+
+function runner({ pool, checkpointStore, transport, target = TARGET, batchSize = 20, maxRows = 10_000 } = {}) {
+  return createPaginatedAtendimentoProjectionBackfillRunner({
+    pool,
+    hmacKey: HMAC_KEY,
+    keyId: 'atendimento-projection-key-v1',
+    target,
+    signer: signingFixture(),
+    transport,
+    checkpointStore,
+    batchSize,
+    maxRows,
+  })
+}
+
+test('delivers deterministic keyset pages, stores private checkpoints, and reconciles only confirmed receipts', async () => {
+  const source = fakePool({ rows: Array.from({ length: 45 }, (_, index) => sourceRow(index)) })
+  const checkpoints = checkpointFixture()
+  const deliveries = transportFixture({ statuses: ['accepted', 'idempotent', 'accepted'] })
+  const currentRunner = runner({
+    pool: source.pool,
+    checkpointStore: checkpoints.store,
+    transport: deliveries.transport,
+  })
+
+  const summary = await currentRunner.run({ intent: ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT })
+
+  assert.deepEqual(summary, {
+    contractVersion: 'atendimento/crm-core/projection-backfill-reconciliation/v1',
+    status: 'reconciled',
+    target: TARGET,
+    sourceSnapshot: { capturedAt: CAPTURED_AT, rowCount: 45 },
+    deliveredCount: 45,
+    batchCount: 3,
+    acceptedCount: 2,
+    idempotentCount: 1,
+    reconciliationDigest: summary.reconciliationDigest,
+  })
+  assert.match(summary.reconciliationDigest, /^sha256:[a-f0-9]{64}$/)
+  assert.equal(deliveries.deliveries().length, 3)
+  assert.deepEqual(deliveries.deliveries().map(({ batch }) => batch.events.length), [20, 20, 5])
+  assert.equal(deliveries.deliveries().every(({ batch }) => !JSON.stringify(batch).includes(sourceRow(0).id)), true)
+  assert.equal(JSON.stringify(summary).includes(sourceRow(0).id), false)
+  assert.equal(source.calls.filter((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL).length, 1)
+  assert.equal(source.calls.filter((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL).length, 2)
+  assert.equal(source.calls.some((call) => /\bOFFSET\b/i.test(call.sql)), false)
+  assert.deepEqual(source.calls.find((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL).params, [20])
+  assert.deepEqual(source.calls.filter((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL).map((call) => call.params.at(-1)), [20, 5])
+  assert.equal(source.calls.at(-1).sql, 'ROLLBACK')
+  assert.equal(source.released(), true)
+  assert.equal(checkpoints.active(), null)
+  assert.equal(checkpoints.completions().length, 1)
+  assert.equal(checkpoints.writes().at(-1).pending, null)
+})
+
+test('refuses to replace an outstanding private checkpoint with a different source snapshot', async () => {
+  const source = fakePool()
+  const checkpoints = checkpointFixture({ initial: Object.freeze({ pending: 'operator-reconciliation-required' }) })
+  const deliveries = transportFixture()
+  const currentRunner = runner({
+    pool: source.pool,
+    checkpointStore: checkpoints.store,
+    transport: deliveries.transport,
+  })
+
+  await assert.rejects(
+    () => currentRunner.run({ intent: ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT }),
+    /ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_RECOVERY_REQUIRED/,
+  )
+  assert.equal(source.connectCount(), 0)
+  assert.equal(deliveries.deliveries().length, 0)
+})
+
+test('retains a pending checkpoint and rolls back the read-only transaction when delivery cannot be confirmed', async () => {
+  const source = fakePool({ rows: Array.from({ length: 2 }, (_, index) => sourceRow(index)) })
+  const checkpoints = checkpointFixture()
+  const deliveries = transportFixture({ failure: new Error('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_UNAVAILABLE') })
+  const currentRunner = runner({
+    pool: source.pool,
+    checkpointStore: checkpoints.store,
+    transport: deliveries.transport,
+  })
+
+  await assert.rejects(
+    () => currentRunner.run({ intent: ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT }),
+    /ATENDIMENTO_CRM_BACKFILL_TRANSPORT_UNAVAILABLE/,
+  )
+  assert.equal(source.calls.at(-1).sql, 'ROLLBACK')
+  assert.equal(checkpoints.completions().length, 0)
+  assert.ok(checkpoints.active()?.pending)
+  assert.equal(checkpoints.active().progress.deliveredCount, 0)
+})
+
+test('replays the exact private pending packet before paginating a matching synthetic snapshot', async () => {
+  const firstSource = fakePool({ rows: Array.from({ length: 2 }, (_, index) => sourceRow(index)) })
+  const checkpoints = checkpointFixture()
+  const failedDelivery = transportFixture({ failure: new Error('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_UNAVAILABLE') })
+  const firstRunner = runner({
+    pool: firstSource.pool,
+    checkpointStore: checkpoints.store,
+    transport: failedDelivery.transport,
+  })
+
+  await assert.rejects(
+    () => firstRunner.run({ intent: ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT }),
+    /ATENDIMENTO_CRM_BACKFILL_TRANSPORT_UNAVAILABLE/,
+  )
+  const pending = structuredClone(checkpoints.active().pending)
+
+  const resumedSource = fakePool({ rows: Array.from({ length: 2 }, (_, index) => sourceRow(index)) })
+  const replayDelivery = transportFixture({ statuses: ['idempotent'] })
+  const resumedRunner = runner({
+    pool: resumedSource.pool,
+    checkpointStore: checkpoints.store,
+    transport: replayDelivery.transport,
+  })
+  const summary = await resumedRunner.run({ intent: ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT })
+
+  assert.equal(replayDelivery.deliveries().length, 1)
+  assert.equal(replayDelivery.deliveries()[0].batch.batchId, pending.batch.batchId)
+  assert.deepEqual(replayDelivery.deliveries()[0].delivery, pending.delivery)
+  assert.equal(summary.deliveredCount, 2)
+  assert.equal(summary.batchCount, 1)
+  assert.equal(summary.acceptedCount, 0)
+  assert.equal(summary.idempotentCount, 1)
+  assert.equal(resumedSource.calls.some((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL), false)
+  assert.equal(checkpoints.active(), null)
+})
+
+test('replays a pending packet before failing a new source transaction with a mismatched snapshot', async () => {
+  const firstSource = fakePool({ rows: Array.from({ length: 2 }, (_, index) => sourceRow(index)) })
+  const checkpoints = checkpointFixture()
+  const failedDelivery = transportFixture({ failure: new Error('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_UNAVAILABLE') })
+  const firstRunner = runner({
+    pool: firstSource.pool,
+    checkpointStore: checkpoints.store,
+    transport: failedDelivery.transport,
+  })
+  await assert.rejects(
+    () => firstRunner.run({ intent: ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT }),
+    /ATENDIMENTO_CRM_BACKFILL_TRANSPORT_UNAVAILABLE/,
+  )
+
+  const changedSnapshotSource = fakePool({
+    rows: Array.from({ length: 2 }, (_, index) => sourceRow(index)),
+    capturedAt: '2026-09-07T00:00:01.000Z',
+  })
+  const replayDelivery = transportFixture({ statuses: ['idempotent'] })
+  const resumedRunner = runner({
+    pool: changedSnapshotSource.pool,
+    checkpointStore: checkpoints.store,
+    transport: replayDelivery.transport,
+  })
+
+  await assert.rejects(
+    () => resumedRunner.run({ intent: ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT }),
+    /ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_SNAPSHOT_MISMATCH/,
+  )
+  assert.equal(replayDelivery.deliveries().length, 1)
+  assert.equal(changedSnapshotSource.calls.at(-1).sql, 'ROLLBACK')
+  assert.equal(checkpoints.active().pending, null)
+  assert.equal(checkpoints.active().progress.deliveredCount, 2)
+})
+
+test('fails closed on non-monotonic source pages before the page is signed or delivered', async () => {
+  const source = fakePool({ rows: [sourceRow(1), sourceRow(0)], preserveSourceOrder: true })
+  const checkpoints = checkpointFixture()
+  const deliveries = transportFixture()
+  const currentRunner = runner({
+    pool: source.pool,
+    checkpointStore: checkpoints.store,
+    transport: deliveries.transport,
+  })
+
+  await assert.rejects(
+    () => currentRunner.run({ intent: ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT }),
+    /ATENDIMENTO_CRM_BACKFILL_RUNNER_CURSOR_INVALID/,
+  )
+  assert.equal(deliveries.deliveries().length, 0)
+  assert.equal(source.calls.at(-1).sql, 'ROLLBACK')
+})
+
+test('requires explicit intent and is staging-only by construction', async () => {
+  const source = fakePool()
+  const checkpoints = checkpointFixture()
+  const deliveries = transportFixture()
+  const currentRunner = runner({
+    pool: source.pool,
+    checkpointStore: checkpoints.store,
+    transport: deliveries.transport,
+  })
+
+  await assert.rejects(() => currentRunner.run(), /ATENDIMENTO_CRM_BACKFILL_RUNNER_INTENT_REQUIRED/)
+  assert.equal(source.connectCount(), 0)
+  assert.throws(() => runner({
+    pool: source.pool,
+    checkpointStore: checkpoints.store,
+    transport: deliveries.transport,
+    target: { ...TARGET, environment: 'production' },
+  }), /ATENDIMENTO_CRM_BACKFILL_RUNNER_STAGING_ONLY/)
+})

--- a/integration/atendimento/crm-core-projection-exporter/test/paginatedAtendimentoProjectionBackfillRunner.test.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/test/paginatedAtendimentoProjectionBackfillRunner.test.mjs
@@ -7,6 +7,7 @@ import {
   ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL,
   ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL,
   ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL,
   ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL,
 } from '../src/atendimentoProjectionExporter.mjs'
 import {
@@ -23,12 +24,20 @@ const TARGET = Object.freeze({
   release: 'a'.repeat(40),
   artifactDigest: `sha256:${'b'.repeat(64)}`,
 })
+const OTHER_TARGET = Object.freeze({
+  ...TARGET,
+  release: 'c'.repeat(40),
+})
 const CAPTURED_AT = '2026-09-07T00:00:00.000Z'
 
-function sourceRow(index) {
+function sourceRowAt(index, timestamp) {
   const suffix = index.toString(16).padStart(12, '0')
-  const timestamp = new Date(Date.parse(CAPTURED_AT) + (Math.floor(index / 2) * 1000)).toISOString()
   return Object.freeze({ id: `123e4567-e89b-42d3-a456-${suffix}`, updated_at: timestamp })
+}
+
+function sourceRow(index) {
+  const milliseconds = new Date(Date.parse(CAPTURED_AT) + (Math.floor(index / 2) * 1000)).toISOString()
+  return sourceRowAt(index, milliseconds.replace(/\.(\d{3})Z$/, (_match, value) => `.${value}000Z`))
 }
 
 function compareRows(left, right) {
@@ -57,6 +66,10 @@ function fakePool({
       }] }
       if (sql === ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL) return { rows: [{ captured_at: capturedAt }] }
       if (sql === ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL) return { rows: [{ row_count: rowCount }] }
+      if (sql === ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL) {
+        if (params.length !== 1 || params[0] !== rowCount) throw new Error('unexpected source-input query parameters')
+        return { rows: sourceRows.slice(0, params[0]) }
+      }
       if (sql === ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL) {
         return { rows: sourceRows.slice(0, params[0]) }
       }
@@ -137,7 +150,7 @@ function runner({ pool, checkpointStore, transport, target = TARGET, batchSize =
     hmacKey: HMAC_KEY,
     keyId: 'atendimento-projection-key-v1',
     target,
-    signer: signingFixture(),
+    signer: signingFixture(target),
     transport,
     checkpointStore,
     batchSize,
@@ -175,6 +188,7 @@ test('delivers deterministic keyset pages, stores private checkpoints, and recon
   assert.equal(JSON.stringify(summary).includes(sourceRow(0).id), false)
   assert.equal(source.calls.filter((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL).length, 1)
   assert.equal(source.calls.filter((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL).length, 2)
+  assert.equal(source.calls.filter((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL).length, 1)
   assert.equal(source.calls.some((call) => /\bOFFSET\b/i.test(call.sql)), false)
   assert.deepEqual(source.calls.find((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL).params, [20])
   assert.deepEqual(source.calls.filter((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL).map((call) => call.params.at(-1)), [20, 5])
@@ -223,7 +237,7 @@ test('retains a pending checkpoint and rolls back the read-only transaction when
   assert.equal(checkpoints.active().progress.deliveredCount, 0)
 })
 
-test('replays the exact private pending packet before paginating a matching synthetic snapshot', async () => {
+test('replays the exact private pending packet and resumes when a new transaction has the same bounded source input', async () => {
   const firstSource = fakePool({ rows: Array.from({ length: 2 }, (_, index) => sourceRow(index)) })
   const checkpoints = checkpointFixture()
   const failedDelivery = transportFixture({ failure: new Error('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_UNAVAILABLE') })
@@ -239,7 +253,10 @@ test('replays the exact private pending packet before paginating a matching synt
   )
   const pending = structuredClone(checkpoints.active().pending)
 
-  const resumedSource = fakePool({ rows: Array.from({ length: 2 }, (_, index) => sourceRow(index)) })
+  const resumedSource = fakePool({
+    rows: Array.from({ length: 2 }, (_, index) => sourceRow(index)),
+    capturedAt: '2026-09-07T00:00:01.000Z',
+  })
   const replayDelivery = transportFixture({ statuses: ['idempotent'] })
   const resumedRunner = runner({
     pool: resumedSource.pool,
@@ -259,7 +276,7 @@ test('replays the exact private pending packet before paginating a matching synt
   assert.equal(checkpoints.active(), null)
 })
 
-test('replays a pending packet before failing a new source transaction with a mismatched snapshot', async () => {
+test('replays a pending packet before failing a new transaction whose bounded source input changed', async () => {
   const firstSource = fakePool({ rows: Array.from({ length: 2 }, (_, index) => sourceRow(index)) })
   const checkpoints = checkpointFixture()
   const failedDelivery = transportFixture({ failure: new Error('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_UNAVAILABLE') })
@@ -273,8 +290,12 @@ test('replays a pending packet before failing a new source transaction with a mi
     /ATENDIMENTO_CRM_BACKFILL_TRANSPORT_UNAVAILABLE/,
   )
 
+  const changedSourceInput = [
+    sourceRow(0),
+    sourceRowAt(1, '2026-09-07T00:00:00.999999Z'),
+  ]
   const changedSnapshotSource = fakePool({
-    rows: Array.from({ length: 2 }, (_, index) => sourceRow(index)),
+    rows: changedSourceInput,
     capturedAt: '2026-09-07T00:00:01.000Z',
   })
   const replayDelivery = transportFixture({ statuses: ['idempotent'] })
@@ -292,6 +313,65 @@ test('replays a pending packet before failing a new source transaction with a mi
   assert.equal(changedSnapshotSource.calls.at(-1).sql, 'ROLLBACK')
   assert.equal(checkpoints.active().pending, null)
   assert.equal(checkpoints.active().progress.deliveredCount, 2)
+})
+
+test('refuses a checkpoint for another CRM target before replaying its pending packet', async () => {
+  const firstSource = fakePool({ rows: Array.from({ length: 2 }, (_, index) => sourceRow(index)) })
+  const checkpoints = checkpointFixture()
+  const failedDelivery = transportFixture({ failure: new Error('ATENDIMENTO_CRM_BACKFILL_TRANSPORT_UNAVAILABLE') })
+  const firstRunner = runner({
+    pool: firstSource.pool,
+    checkpointStore: checkpoints.store,
+    transport: failedDelivery.transport,
+  })
+  await assert.rejects(
+    () => firstRunner.run({ intent: ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT }),
+    /ATENDIMENTO_CRM_BACKFILL_TRANSPORT_UNAVAILABLE/,
+  )
+
+  const resumedSource = fakePool({ rows: Array.from({ length: 2 }, (_, index) => sourceRow(index)) })
+  const otherTransport = transportFixture()
+  const resumedRunner = runner({
+    pool: resumedSource.pool,
+    checkpointStore: checkpoints.store,
+    transport: otherTransport.transport,
+    target: OTHER_TARGET,
+  })
+  await assert.rejects(
+    () => resumedRunner.run({ intent: ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT }),
+    /ATENDIMENTO_CRM_BACKFILL_RUNNER_CHECKPOINT_TARGET_MISMATCH/,
+  )
+  assert.equal(otherTransport.deliveries().length, 0)
+  assert.equal(resumedSource.connectCount(), 0)
+  assert.ok(checkpoints.active()?.pending)
+})
+
+test('keeps the exact PostgreSQL microsecond cursor for keyset pagination', async () => {
+  const rows = [
+    sourceRowAt(1, '2026-09-07T00:00:00.123001Z'),
+    sourceRowAt(2, '2026-09-07T00:00:00.123456Z'),
+    sourceRowAt(3, '2026-09-07T00:00:00.124000Z'),
+  ]
+  const source = fakePool({ rows })
+  const checkpoints = checkpointFixture()
+  const deliveries = transportFixture({ statuses: ['accepted'] })
+  const currentRunner = runner({
+    pool: source.pool,
+    checkpointStore: checkpoints.store,
+    transport: deliveries.transport,
+    batchSize: 1,
+  })
+  const summary = await currentRunner.run({ intent: ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT })
+  const cursorParameters = source.calls
+    .filter((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL)
+    .map((call) => call.params[0])
+
+  assert.equal(summary.deliveredCount, 3)
+  assert.equal(deliveries.deliveries().length, 3)
+  assert.deepEqual(cursorParameters, [
+    '2026-09-07T00:00:00.123001Z',
+    '2026-09-07T00:00:00.123456Z',
+  ])
 })
 
 test('fails closed on non-monotonic source pages before the page is signed or delivered', async () => {

--- a/integration/atendimento/crm-core-projection-exporter/test/syntheticAtendimentoProjectionRemoteRehearsal.test.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/test/syntheticAtendimentoProjectionRemoteRehearsal.test.mjs
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  ATENDIMENTO_CRM_BACKFILL_HTTP_PATH,
+} from '../src/atendimentoProjectionBackfillHttpTransport.mjs'
+import {
+  ATENDIMENTO_SYNTHETIC_REMOTE_REHEARSAL_INTENT,
+  createSyntheticAtendimentoProjectionRemoteRehearsal,
+} from '../src/syntheticAtendimentoProjectionRemoteRehearsal.mjs'
+
+const TARGET = Object.freeze({
+  environment: 'staging',
+  release: 'a'.repeat(40),
+  artifactDigest: `sha256:${'b'.repeat(64)}`,
+})
+const SOURCE_UUID = '123e4567-e89b-42d3-a456-426614174001'
+const ENDPOINT = `https://crm-core-staging.example.test${ATENDIMENTO_CRM_BACKFILL_HTTP_PATH}`
+
+function remoteRehearsal() {
+  return createSyntheticAtendimentoProjectionRemoteRehearsal({ target: TARGET, endpoint: ENDPOINT })
+}
+
+function acceptedThenIdempotentFetch(calls) {
+  return async (url, init) => {
+    calls.push({ url, init, body: JSON.parse(init.body) })
+    const input = calls.at(-1).body
+    return {
+      status: 200,
+      async json() {
+        return {
+          ok: true,
+          contractVersion: 'crm-core/projection-backfill-receipt/v1',
+          status: calls.length === 1 ? 'accepted' : 'idempotent',
+          batchId: input.batch.batchId,
+          eventCount: input.batch.events.length,
+          target: input.batch.target,
+          requestId: init.headers['x-request-id'],
+        }
+      },
+    }
+  }
+}
+
+test('prepares one public finite allowlist without a source UUID, HMAC, or private Ed25519 material', () => {
+  const rehearsal = remoteRehearsal()
+  const { activation } = rehearsal
+  const publicKeys = JSON.parse(activation.publicKeysJson)
+  const allowedDigests = JSON.parse(activation.batchDigestsJson)
+  const serialized = JSON.stringify(activation)
+
+  assert.equal(activation.environment, 'staging')
+  assert.match(activation.keyId, /^crm-staging-atendimento-backfill-/)
+  assert.equal(allowedDigests.length, 1)
+  assert.equal(allowedDigests[0], activation.batch.batchDigest)
+  assert.notEqual(activation.batch.batchId, 'backfill:atendimento:fixture-batch-0001')
+  assert.deepEqual(Object.keys(publicKeys), [activation.keyId])
+  assert.deepEqual(Object.keys(publicKeys[activation.keyId]).sort(), ['crv', 'kty', 'x'])
+  assert.equal(publicKeys[activation.keyId].d, undefined)
+  assert.doesNotMatch(serialized, new RegExp(SOURCE_UUID, 'i'))
+  assert.doesNotMatch(serialized, /hmac|privateKey|"d"\s*:/i)
+})
+
+test('delivers the real paginated producer packet twice and requires a D1-style digest reconciliation', async () => {
+  const rehearsal = remoteRehearsal()
+  const calls = []
+  const reconcileCalls = []
+  const receipt = await rehearsal.rehearse({
+    intent: ATENDIMENTO_SYNTHETIC_REMOTE_REHEARSAL_INTENT,
+    fetch: acceptedThenIdempotentFetch(calls),
+    async reconcile(expected) {
+      reconcileCalls.push(expected)
+      return {
+        batchId: expected.batchId,
+        target: expected.target,
+        eventCount: expected.eventCount,
+        eventsDigest: expected.eventsDigest,
+        cursorDigest: expected.cursorDigest,
+        eventIds: expected.eventIds,
+      }
+    },
+  })
+
+  assert.equal(calls.length, 2)
+  assert.equal(calls.every((call) => call.url === ENDPOINT), true)
+  assert.equal(calls.every((call) => call.init.method === 'POST'), true)
+  assert.equal(calls.every((call) => call.init.credentials === 'omit'), true)
+  assert.equal(calls.every((call) => call.init.redirect === 'error'), true)
+  assert.equal(calls.every((call) => Object.keys(call.init.headers).sort().join(',') === 'content-type,x-request-id'), true)
+  assert.equal(calls.every((call) => call.body.batch.batchId === receipt.batchId), true)
+  assert.equal(calls.every((call) => call.body.delivery.batchDigest === receipt.batchDigest), true)
+  assert.equal(calls.every((call) => !JSON.stringify(call.body).includes(SOURCE_UUID)), true)
+  assert.equal(calls[0].body.batch.events.length, 1)
+  assert.equal(reconcileCalls.length, 1)
+  assert.equal(reconcileCalls[0].batchId, receipt.batchId)
+  assert.equal(reconcileCalls[0].batchDigest, receipt.batchDigest)
+  assert.deepEqual(receipt, {
+    contractVersion: 'atendimento/crm-core/synthetic-remote-backfill-rehearsal-receipt/v1',
+    status: 'reconciled',
+    target: TARGET,
+    batchId: receipt.batchId,
+    batchDigest: receipt.batchDigest,
+    accepted: 'accepted',
+    retry: 'idempotent',
+    reconciliation: {
+      batchId: receipt.batchId,
+      target: TARGET,
+      eventCount: 1,
+      eventsDigest: reconcileCalls[0].eventsDigest,
+      cursorDigest: reconcileCalls[0].cursorDigest,
+    },
+  })
+  assert.doesNotMatch(JSON.stringify(receipt), new RegExp(SOURCE_UUID, 'i'))
+})
+
+test('refuses a mismatched D1 reconciliation after delivery', async () => {
+  const rehearsal = remoteRehearsal()
+  const calls = []
+  await assert.rejects(() => rehearsal.rehearse({
+    intent: ATENDIMENTO_SYNTHETIC_REMOTE_REHEARSAL_INTENT,
+    fetch: acceptedThenIdempotentFetch(calls),
+    async reconcile(expected) {
+      return {
+        batchId: expected.batchId,
+        target: expected.target,
+        eventCount: expected.eventCount,
+        eventsDigest: expected.eventsDigest,
+        cursorDigest: `sha256:${'f'.repeat(64)}`,
+        eventIds: expected.eventIds,
+      }
+    },
+  }), /ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_RECONCILIATION_INVALID/)
+  assert.equal(calls.length, 2)
+})
+
+test('is inert without explicit delivery intent and refuses production before reading the endpoint', async () => {
+  const rehearsal = remoteRehearsal()
+  let fetchRead = false
+  await assert.rejects(() => rehearsal.rehearse({
+    intent: 'not-authorized',
+    get fetch() { fetchRead = true; throw new Error('must not read fetch') },
+    get reconcile() { fetchRead = true; throw new Error('must not read reconciler') },
+  }), /ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_INTENT_REQUIRED/)
+  assert.equal(fetchRead, false)
+
+  let endpointRead = false
+  assert.throws(() => createSyntheticAtendimentoProjectionRemoteRehearsal({
+    get target() { return { ...TARGET, environment: 'production' } },
+    get endpoint() { endpointRead = true; throw new Error('must not read endpoint') },
+  }), /ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_STAGING_ONLY/)
+  assert.equal(endpointRead, false)
+})


### PR DESCRIPTION
## Summary
- Adds deterministic keyset production-owner batches capped at 20 events for the CRM Core staging backfill route.
- Adds detached Ed25519 signing, exact HTTPS transport/receipt binding, and private checkpoint replay/reconciliation.
- Keeps the path staging-only, capability-injected, and free of source UUIDs, customer data, embedded URLs, or secrets.

## Validation
- 
ode --test integration/atendimento/crm-core-projection-exporter/test/*.test.mjs (26 passing)
- Synthetic source -> signed HTTP transport -> actual CRM Core handler rehearsal: accepted, then idempotent replay.
- Cross-repository canonical digest and Ed25519 verifier interoperability check passed.
- Focused Codex Security diff scan: 0 findings.

## Operational boundary
No production deploy, source grant, secret, or real data delivery is included. Remote staging rehearsal must use the receiver's published artifact and its finite synthetic digest allowlist.