### PR TITLE
feat(identity): add controlled CRM session staging delivery

### DIFF
--- a/.github/governance/cloudflare-single-writer-policy.json
+++ b/.github/governance/cloudflare-single-writer-policy.json
@@ -147,7 +147,17 @@
         ".github/workflows/deploy-core-workers.yml",
         ".github/workflows/ponto-staging-core-provenance-recovery.yml",
         ".github/workflows/cloudflare-workers-sync-ponto-secrets.yml",
-        ".github/workflows/insumos-production-smoke-identity.yml"
+        ".github/workflows/insumos-production-smoke-identity.yml",
+        ".github/workflows/identity-crm-delivery.yml"
+      ]
+    },
+    {
+      "id": "identity-crm-delivery-staging-worker",
+      "platform": "cloudflare-worker",
+      "canonicalDeployWorkflow": ".github/workflows/identity-crm-delivery.yml",
+      "coordinationGroup": "ponto-workers-writer",
+      "mutationWorkflows": [
+        ".github/workflows/identity-crm-delivery.yml"
       ]
     },
     {
@@ -271,7 +281,8 @@
       "mutationWorkflows": [
         ".github/workflows/insumos-staging-rbac-smoke.yml",
         ".github/workflows/timekeeping-staging-journey.yml",
-        ".github/workflows/beauty-movement-staging-smoke.yml"
+        ".github/workflows/beauty-movement-staging-smoke.yml",
+        ".github/workflows/identity-crm-delivery.yml"
       ]
     },
     {

--- a/.github/scripts/validate-deploy-topology.mjs
+++ b/.github/scripts/validate-deploy-topology.mjs
@@ -48,7 +48,22 @@ for (const unit of catalog.units ?? []) {
   }
   const source = read(unit.workflow);
   if (!/^\s*workflow_dispatch:/m.test(source)) fail(`${unit.id} must be manually dispatched`);
-  if (/^\s{2}(push|schedule|pull_request_target|workflow_run|repository_dispatch):/m.test(source)) fail(`${unit.id} has an automatic publish trigger`);
+  const restrictedStagingIdentityDelivery = unit.promotion.publisherType === 'restricted-staging-identity-delivery'
+    && unit.promotion.stagingOnly === true;
+  const restrictedStagingJob = restrictedStagingIdentityDelivery ? jobSource(source, 'staging') : '';
+  const restrictedTestJob = restrictedStagingIdentityDelivery ? jobSource(source, 'test') : '';
+  const restrictedStagingStart = source.indexOf('\n  staging:\n');
+  const restrictedStagingHasLaterJob = restrictedStagingStart >= 0
+    && /\n  [a-zA-Z0-9_-]+:\n/.test(source.slice(restrictedStagingStart + '\n  staging:\n'.length));
+  if (
+    /^\s{2}(push|schedule|pull_request_target|workflow_run|repository_dispatch):/m.test(source)
+    && (
+      !restrictedStagingIdentityDelivery
+      || !restrictedStagingJob.includes("github.event_name == 'workflow_dispatch' && inputs.operation != 'test'")
+      || publishPattern.test(restrictedTestJob)
+      || restrictedStagingHasLaterJob
+    )
+  ) fail(`${unit.id} has an automatic publish trigger`);
   if (!/^concurrency:/m.test(source) || !source.includes(unit.concurrencyPrefix)) fail(`${unit.id} must serialize by unit and environment`);
   if (!/^\s+environment:/m.test(source)) fail(`${unit.id} must select a GitHub environment`);
   if (!/^permissions:\r?\n\s+actions:\s+read\r?\n\s+contents:\s+read/m.test(source)) fail(`${unit.id} must grant the promotion gate actions: read and contents: read`);
@@ -90,6 +105,28 @@ for (const unit of catalog.units ?? []) {
     }
     if (/environment:\s*production|--env\s+production|BEAUTY_MOVEMENT_ENABLED:false/i.test(source)) {
       fail(`${unit.id} must not target production or enable a production path`);
+    }
+  } else if (unit.promotion.publisherType === 'restricted-staging-identity-delivery' && unit.promotion.stagingOnly === true) {
+    if (unit.environments.length !== 1 || unit.environments[0] !== 'staging') fail(`${unit.id} must be staging-only`);
+    for (const required of [
+      'environment: staging',
+      'release_sha',
+      'bootstrap',
+      'activate',
+      'session-smoke',
+      'disable',
+      'global-coordination-acquire',
+      'IDENTITY_CRM_DELIVERY_CALLER_ENABLED:true',
+      'CRM_IDENTITY_ISSUER_CALLER_ENABLED:true',
+      'IDENTITY_CRM_DELIVERY_CALLER_ENABLED:false',
+      'CRM_IDENTITY_ISSUER_CALLER_ENABLED:false',
+      'rollback',
+      'CLOUDFLARE_API_TOKEN',
+    ]) {
+      if (!source.includes(required)) fail(`${unit.id} restricted staging publisher is missing: ${required}`);
+    }
+    if (/environment:\s*production|--env\s+production|CRM_IDENTITY_ISSUER_CALLER_ENABLED:true[^\n]*production|IDENTITY_CRM_DELIVERY_CALLER_ENABLED:true[^\n]*production/i.test(source)) {
+      fail(`${unit.id} must not target or enable a production path`);
     }
   } else if (!source.includes("promotion-gate.yml") || !source.includes("release_sha") || !source.includes("staging_run_id")) {
     fail(`${unit.id} must use the immutable promotion gate`);

--- a/.github/workflows/identity-crm-delivery.yml
+++ b/.github/workflows/identity-crm-delivery.yml
@@ -8,7 +8,10 @@ on:
       - 'api/src/crm-identity-issuer-client.js'
       - 'api/test/gateway.test.mjs'
       - 'api/wrangler.toml'
+      - 'scripts/crm-identity-staging-session-smoke.mjs'
+      - 'scripts/tests/crm-identity-staging-session-smoke.test.mjs'
       - 'shared/identity-contract/**'
+      - '.github/governance/cloudflare-single-writer-policy.json'
       - '.github/workflows/identity-crm-delivery.yml'
   push:
     branches: [main]
@@ -18,20 +21,52 @@ on:
       - 'api/src/crm-identity-issuer-client.js'
       - 'api/test/gateway.test.mjs'
       - 'api/wrangler.toml'
+      - 'scripts/crm-identity-staging-session-smoke.mjs'
+      - 'scripts/tests/crm-identity-staging-session-smoke.test.mjs'
       - 'shared/identity-contract/**'
+      - '.github/governance/cloudflare-single-writer-policy.json'
       - '.github/workflows/identity-crm-delivery.yml'
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: "Read-only test, disabled HMAC bootstrap, staging activation, synthetic session smoke, or staging disable"
+        required: true
+        default: test
+        type: choice
+        options: [test, bootstrap, activate, session-smoke, disable]
+      release_sha:
+        description: "Exact current main SHA for every non-test operation"
+        required: false
+        type: string
+      confirmation:
+        description: "Exact operation confirmation; never a secret"
+        required: false
+        type: string
+      bootstrap_run_id:
+        description: "Successful bootstrap run for the same SHA; required only for activate"
+        required: false
+        type: string
+      crm_core_release_sha:
+        description: "Exact already-live CRM Core staging release; required for activate and session-smoke"
+        required: false
+        type: string
+      crm_core_artifact_digest:
+        description: "Exact already-live CRM Core staging sha256 digest; required for activate and session-smoke"
+        required: false
+        type: string
 
 permissions:
+  actions: read
   contents: read
   packages: read
 
 concurrency:
-  group: identity-crm-delivery-${{ github.ref }}
-  cancel-in-progress: true
+  group: identity-crm-delivery-${{ github.event_name == 'workflow_dispatch' && inputs.operation || github.ref }}
+  cancel-in-progress: false
 
 jobs:
   test:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.operation == 'test' }}
     name: Test the pinned Identity issuer and staging caller
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -55,4 +90,637 @@ jobs:
           } > "$npmrc"
           NPM_CONFIG_USERCONFIG="$npmrc" npm --prefix identity ci --ignore-scripts --no-audit --fund=false
           NPM_CONFIG_USERCONFIG="$npmrc" npm --prefix identity test
+          npm --prefix api ci --ignore-scripts --no-audit --fund=false
           npm --prefix api test
+          node --test scripts/tests/crm-identity-staging-session-smoke.test.mjs
+
+  staging:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.operation != 'test' }}
+    name: Controlled CRM Identity staging ${{ inputs.operation }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    environment: staging
+    env:
+      RELEASE_SHA: ${{ inputs.release_sha }}
+      OPERATION: ${{ inputs.operation }}
+      CONFIRMATION: ${{ inputs.confirmation }}
+      BOOTSTRAP_RUN_ID: ${{ inputs.bootstrap_run_id }}
+      CRM_CORE_RELEASE_SHA: ${{ inputs.crm_core_release_sha }}
+      CRM_CORE_ARTIFACT_DIGEST: ${{ inputs.crm_core_artifact_digest }}
+      WORKER_LEASE_PROOF: ${{ runner.temp }}/crm-identity-workers-lease.json
+      D1_LEASE_PROOF: ${{ runner.temp }}/crm-identity-smoke-d1-lease.json
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: '22.12.0'
+
+      - name: Pin the restricted staging operation to current protected main
+        run: |
+          set -euo pipefail
+          case "$OPERATION" in
+            bootstrap) expected_confirmation='bootstrap-crm-identity-staging' ;;
+            activate) expected_confirmation='activate-crm-identity-staging' ;;
+            session-smoke) expected_confirmation='smoke-crm-identity-staging' ;;
+            disable) expected_confirmation='disable-crm-identity-staging' ;;
+            *) echo 'Unsupported controlled operation'; exit 1 ;;
+          esac
+          [[ "$CONFIRMATION" == "$expected_confirmation" ]] || { echo 'Explicit non-secret operation confirmation is invalid'; exit 1; }
+          [[ "$GITHUB_REF" == 'refs/heads/main' ]] || { echo 'Controlled CRM Identity staging operations run only from main'; exit 1; }
+          [[ "$GITHUB_RUN_ATTEMPT" == '1' ]] || { echo 'Reruns are refused after a potentially mutating operation'; exit 1; }
+          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'release_sha must be a full SHA'; exit 1; }
+          [[ "$GITHUB_SHA" == "$RELEASE_SHA" && "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]] || { echo 'Dispatch source differs from release_sha'; exit 1; }
+          git fetch --no-tags --force origin main:refs/remotes/origin/main
+          [[ "$(git rev-parse refs/remotes/origin/main)" == "$RELEASE_SHA" ]] || { echo 'main advanced; dispatch the current source again'; exit 1; }
+          for file in identity/wrangler.staging.toml identity/delivery/crm-issuer-staging-worker.js api/wrangler.toml api/src/crm-identity-issuer-client.js scripts/crm-identity-staging-session-smoke.mjs; do
+            git cat-file -e "$RELEASE_SHA:$file" || { echo "Missing required source: $file"; exit 1; }
+          done
+
+      - name: Test the exact staging source before any external operation
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          npmrc="$RUNNER_TEMP/skincos-identity-npmrc"
+          trap 'rm -f "$npmrc"' EXIT
+          umask 077
+          {
+            printf '%s\n' '@jubenitogarcia:registry=https://npm.pkg.github.com'
+            printf '%s\n' '//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}'
+            printf '%s\n' 'always-auth=true'
+          } > "$npmrc"
+          NPM_CONFIG_USERCONFIG="$npmrc" npm --prefix identity ci --ignore-scripts --no-audit --fund=false
+          NPM_CONFIG_USERCONFIG="$npmrc" npm --prefix identity test
+          npm --prefix api ci --ignore-scripts --no-audit --fund=false
+          npm --prefix api test
+          node --test scripts/tests/crm-identity-staging-session-smoke.test.mjs
+          npx --yes wrangler@4.112.0 deploy --dry-run --config identity/wrangler.staging.toml --env staging --outdir "$RUNNER_TEMP/identity-crm-delivery-dry-run" >/dev/null
+          npx --yes wrangler@4.112.0 deploy --dry-run --config api/wrangler.toml --env staging --outdir "$RUNNER_TEMP/api-crm-session-dry-run" >/dev/null
+
+      - name: Attest the externally published CRM Core before activation or synthetic session smoke
+        if: ${{ inputs.operation == 'activate' || inputs.operation == 'session-smoke' }}
+        run: |
+          set -euo pipefail
+          [[ "$CRM_CORE_RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'crm_core_release_sha must be a full SHA'; exit 1; }
+          [[ "$CRM_CORE_ARTIFACT_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo 'crm_core_artifact_digest must be a SHA-256 digest'; exit 1; }
+          CRM_CORE_RELEASE_SHA="$CRM_CORE_RELEASE_SHA" CRM_CORE_ARTIFACT_DIGEST="$CRM_CORE_ARTIFACT_DIGEST" node --input-type=module <<'NODE'
+          const response = await fetch('https://api-staging.skincos.com.br/crm/ready', {
+            headers: { accept: 'application/json', 'cache-control': 'no-store' },
+            redirect: 'manual', signal: AbortSignal.timeout(15_000),
+          });
+          if (response.headers.has('set-cookie')) throw new Error('CRM Core ready readback unexpectedly returned a cookie');
+          const payload = await response.json().catch(() => null);
+          const release = String(payload?.release || payload?.version || '');
+          const digest = String(payload?.artifactDigest || payload?.artifact_digest || '');
+          if (
+            response.status !== 200 || payload?.ok !== true || payload?.environment !== 'staging'
+            || payload?.reason !== 'CRM_STAGING_READY' || release !== process.env.CRM_CORE_RELEASE_SHA
+            || digest !== process.env.CRM_CORE_ARTIFACT_DIGEST
+          ) throw new Error('CRM Core staging source/digest/readiness attestation is not current');
+          process.stdout.write('CRM Core staging source and artifact are current.\n');
+          NODE
+
+      - name: Acquire canonical Core and Identity Worker custody lease
+        id: worker_lease
+        if: ${{ inputs.operation == 'bootstrap' || inputs.operation == 'activate' || inputs.operation == 'disable' }}
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          resource: global:ponto-workers-writer
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+          proof_file: ${{ runner.temp }}/crm-identity-workers-lease.json
+          inputs_json: '{"target":"staging","surface":"identity-crm-delivery"}'
+
+      - name: Check custody before reading bootstrap secret names
+        if: ${{ inputs.operation == 'bootstrap' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          proof_file: ${{ runner.temp }}/crm-identity-workers-lease.json
+          resource: global:ponto-workers-writer
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+
+      - name: Refuse partial caller HMAC custody and attest existing signer custody
+        id: bootstrap_preflight
+        if: ${{ inputs.operation == 'bootstrap' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID; do [[ -n "${!name:-}" ]] || { echo "Missing staging custody: $name"; exit 1; }; done
+          api_names="$RUNNER_TEMP/crm-identity-api-secret-names.json"
+          issuer_names="$RUNNER_TEMP/crm-identity-issuer-secret-names.json"
+          trap 'rm -f "$api_names" "$issuer_names"' EXIT
+          npx --yes wrangler@4.112.0 secret list --config api/wrangler.toml --env staging > "$api_names"
+          npx --yes wrangler@4.112.0 secret list --config identity/wrangler.staging.toml --env staging > "$issuer_names"
+          node - "$api_names" "$issuer_names" <<'NODE'
+          const fs = require('node:fs');
+          const names = (file) => new Set(JSON.parse(fs.readFileSync(file, 'utf8')).map((entry) => String(entry?.name || entry || '')));
+          const api = names(process.argv[2]);
+          const issuer = names(process.argv[3]);
+          for (const required of ['IDENTITY_CRM_DELIVERY_KID', 'IDENTITY_CRM_DELIVERY_PRIVATE_JWK', 'IDENTITY_CRM_DELIVERY_PUBLIC_JWK', 'IDENTITY_CRM_DELIVERY_REQUEST_HMAC']) {
+            if (!issuer.has(required)) throw new Error(`existing staging issuer custody is incomplete: ${required}`);
+          }
+          const apiPresent = api.has('CRM_IDENTITY_ISSUER_CALLER_HMAC');
+          const issuerPresent = issuer.has('IDENTITY_CRM_DELIVERY_CALLER_HMAC');
+          if (apiPresent !== issuerPresent) throw new Error('caller HMAC custody is partial; refusing to generate, rotate, or overwrite either side');
+          process.stdout.write(`state=${apiPresent ? 'already-provisioned' : 'missing'}\n`);
+          NODE
+          node - "$api_names" "$issuer_names" <<'NODE' >> "$GITHUB_OUTPUT"
+          const fs = require('node:fs');
+          const names = (file) => new Set(JSON.parse(fs.readFileSync(file, 'utf8')).map((entry) => String(entry?.name || entry || '')));
+          const api = names(process.argv[2]); const issuer = names(process.argv[3]);
+          process.stdout.write(`state=${api.has('CRM_IDENTITY_ISSUER_CALLER_HMAC') ? 'already-provisioned' : 'missing'}\n`);
+          NODE
+
+      - name: Provision one generated HMAC into both disabled staging runtimes
+        id: bootstrap_provision
+        if: ${{ inputs.operation == 'bootstrap' && steps.bootstrap_preflight.outputs.state == 'missing' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          SKINCOS_GLOBAL_COORDINATOR_URL: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          SKINCOS_GLOBAL_COORDINATION_KEY_ID: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+        run: |
+          set -euo pipefail
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID SKINCOS_GLOBAL_COORDINATOR_URL SKINCOS_GLOBAL_COORDINATION_SHARED_SECRET; do [[ -n "${!name:-}" ]] || { echo "Missing protected staging custody: $name"; exit 1; }; done
+          revalidate_lease() {
+            git fetch --no-tags --force origin main:refs/remotes/origin/main >/dev/null
+            observed="$(git rev-parse refs/remotes/origin/main)"
+            [[ "$observed" == "$RELEASE_SHA" ]] || { echo 'main advanced before a caller HMAC mutation'; return 1; }
+            node scripts/codex-global-coordination-workflow.mjs check \
+              --proof-file "$WORKER_LEASE_PROOF" \
+              --resource global:ponto-workers-writer \
+              --module core \
+              --source "$observed" \
+              --candidate-source "$RELEASE_SHA" \
+              --result-file "$RUNNER_TEMP/crm-identity-worker-custody-check.json" >/dev/null
+            rm -f "$RUNNER_TEMP/crm-identity-worker-custody-check.json"
+          }
+          caller_hmac="$(node --input-type=module -e \"import { randomBytes } from 'node:crypto'; process.stdout.write(randomBytes(48).toString('base64url'));\")"
+          [[ "$caller_hmac" =~ ^[A-Za-z0-9_-]{64,}$ ]] || { echo 'Internal caller HMAC generation failed'; exit 1; }
+          issuer_written=false
+          api_written=false
+          cleanup_partial() {
+            status=$?
+            trap - EXIT
+            unset caller_hmac
+            if [[ "$status" != 0 && "$issuer_written" == true && "$api_written" != true ]]; then
+              set +e
+              if revalidate_lease; then
+                npx --yes wrangler@4.112.0 secret delete IDENTITY_CRM_DELIVERY_CALLER_HMAC --config identity/wrangler.staging.toml --env staging >/dev/null
+              fi
+              set -e
+            fi
+            exit "$status"
+          }
+          trap cleanup_partial EXIT
+          revalidate_lease
+          printf '%s' "$caller_hmac" | npx --yes wrangler@4.112.0 secret put IDENTITY_CRM_DELIVERY_CALLER_HMAC --config identity/wrangler.staging.toml --env staging >/dev/null
+          issuer_written=true
+          revalidate_lease
+          printf '%s' "$caller_hmac" | npx --yes wrangler@4.112.0 secret put CRM_IDENTITY_ISSUER_CALLER_HMAC --config api/wrangler.toml --env staging >/dev/null
+          api_written=true
+          unset caller_hmac
+          trap - EXIT
+          echo 'state=provisioned' >> "$GITHUB_OUTPUT"
+
+      - name: Read back caller HMAC names without reading values
+        id: bootstrap_readback
+        if: ${{ inputs.operation == 'bootstrap' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          api_names="$RUNNER_TEMP/crm-identity-api-secret-readback.json"
+          issuer_names="$RUNNER_TEMP/crm-identity-issuer-secret-readback.json"
+          trap 'rm -f "$api_names" "$issuer_names"' EXIT
+          npx --yes wrangler@4.112.0 secret list --config api/wrangler.toml --env staging > "$api_names"
+          npx --yes wrangler@4.112.0 secret list --config identity/wrangler.staging.toml --env staging > "$issuer_names"
+          node - "$api_names" "$issuer_names" <<'NODE'
+          const fs = require('node:fs');
+          const names = (file) => new Set(JSON.parse(fs.readFileSync(file, 'utf8')).map((entry) => String(entry?.name || entry || '')));
+          const api = names(process.argv[2]); const issuer = names(process.argv[3]);
+          if (!api.has('CRM_IDENTITY_ISSUER_CALLER_HMAC') || !issuer.has('IDENTITY_CRM_DELIVERY_CALLER_HMAC')) {
+            throw new Error('caller HMAC name readback is incomplete');
+          }
+          NODE
+          echo 'state=both-present' >> "$GITHUB_OUTPUT"
+
+      - name: Write sanitised disabled bootstrap evidence
+        if: ${{ inputs.operation == 'bootstrap' && steps.bootstrap_readback.outputs.state == 'both-present' }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/crm-identity-bootstrap"
+          RELEASE_SHA="$RELEASE_SHA" BOOTSTRAP_STATE="${{ steps.bootstrap_provision.outputs.state || steps.bootstrap_preflight.outputs.state }}" node - "$RUNNER_TEMP/crm-identity-bootstrap/evidence.json" <<'NODE'
+          const fs = require('node:fs');
+          fs.writeFileSync(process.argv[2], `${JSON.stringify({
+            schemaVersion: 1,
+            operation: 'bootstrap',
+            environment: 'staging',
+            sourceSha: process.env.RELEASE_SHA,
+            state: process.env.BOOTSTRAP_STATE || 'already-provisioned',
+            callerId: 'crm-api-staging-v1',
+            apiSecretName: 'CRM_IDENTITY_ISSUER_CALLER_HMAC',
+            issuerSecretName: 'IDENTITY_CRM_DELIVERY_CALLER_HMAC',
+            callerEnabled: false,
+            secretValuesIncluded: false,
+          }, null, 2)}\n`, { mode: 0o600 });
+          NODE
+      - name: Upload sanitised disabled bootstrap evidence
+        if: ${{ inputs.operation == 'bootstrap' && steps.bootstrap_readback.outputs.state == 'both-present' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: crm-identity-caller-bootstrap-${{ inputs.release_sha }}
+          path: ${{ runner.temp }}/crm-identity-bootstrap/evidence.json
+          retention-days: 90
+          if-no-files-found: error
+
+      - name: Verify bootstrap evidence and both caller HMAC names before activation
+        if: ${{ inputs.operation == 'activate' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          [[ "$BOOTSTRAP_RUN_ID" =~ ^[0-9]+$ ]] || { echo 'activate requires a numeric successful bootstrap_run_id'; exit 1; }
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$BOOTSTRAP_RUN_ID" > "$RUNNER_TEMP/crm-identity-bootstrap-run.json"
+          node - "$RUNNER_TEMP/crm-identity-bootstrap-run.json" <<'NODE'
+          const fs = require('node:fs'); const run = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          if (
+            run.status !== 'completed' || run.conclusion !== 'success' || run.event !== 'workflow_dispatch'
+            || run.head_branch !== 'main' || run.head_sha !== process.env.RELEASE_SHA || run.run_attempt !== 1
+            || run.path !== '.github/workflows/identity-crm-delivery.yml'
+          ) {
+            throw new Error('bootstrap run is not a successful first-attempt main dispatch');
+          }
+          NODE
+          mkdir -p "$RUNNER_TEMP/crm-identity-bootstrap-evidence"
+          gh run download "$BOOTSTRAP_RUN_ID" --repo "$GITHUB_REPOSITORY" --name "crm-identity-caller-bootstrap-$RELEASE_SHA" --dir "$RUNNER_TEMP/crm-identity-bootstrap-evidence"
+          RELEASE_SHA="$RELEASE_SHA" node - "$RUNNER_TEMP/crm-identity-bootstrap-evidence/evidence.json" <<'NODE'
+          const fs = require('node:fs'); const evidence = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          if (evidence?.schemaVersion !== 1 || evidence.operation !== 'bootstrap' || evidence.environment !== 'staging' || evidence.sourceSha !== process.env.RELEASE_SHA || evidence.callerEnabled !== false || evidence.secretValuesIncluded !== false) {
+            throw new Error('bootstrap evidence does not bind the current disabled staging source');
+          }
+          NODE
+          api_names="$RUNNER_TEMP/crm-identity-api-activation-names.json"
+          issuer_names="$RUNNER_TEMP/crm-identity-issuer-activation-names.json"
+          trap 'rm -f "$api_names" "$issuer_names" "$RUNNER_TEMP/crm-identity-bootstrap-run.json"' EXIT
+          npx --yes wrangler@4.112.0 secret list --config api/wrangler.toml --env staging > "$api_names"
+          npx --yes wrangler@4.112.0 secret list --config identity/wrangler.staging.toml --env staging > "$issuer_names"
+          node - "$api_names" "$issuer_names" <<'NODE'
+          const fs = require('node:fs'); const names = (file) => new Set(JSON.parse(fs.readFileSync(file, 'utf8')).map((entry) => String(entry?.name || entry || '')));
+          if (!names(process.argv[2]).has('CRM_IDENTITY_ISSUER_CALLER_HMAC') || !names(process.argv[3]).has('IDENTITY_CRM_DELIVERY_CALLER_HMAC')) throw new Error('caller HMAC custody disappeared after bootstrap');
+          NODE
+
+      - name: Capture exact active staging Worker versions for activation rollback
+        id: activation_checkpoint
+        if: ${{ inputs.operation == 'activate' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4.112.0 deployments status --json --config identity/wrangler.staging.toml --env staging > "$RUNNER_TEMP/crm-identity-issuer-incumbent.json"
+          npx --yes wrangler@4.112.0 deployments status --json --config api/wrangler.toml --env staging > "$RUNNER_TEMP/crm-identity-api-incumbent.json"
+          node - "$RUNNER_TEMP/crm-identity-issuer-incumbent.json" "$RUNNER_TEMP/crm-identity-api-incumbent.json" <<'NODE' >> "$GITHUB_OUTPUT"
+          const fs = require('node:fs');
+          const active = (file) => {
+            const payload = JSON.parse(fs.readFileSync(file, 'utf8')); const versions = payload?.versions || [];
+            if (versions.length !== 1 || Number(versions[0]?.percentage) !== 100) throw new Error('staging Worker lacks one exact incumbent');
+            const id = String(versions[0]?.version_id || ''); if (!/^[0-9a-f-]{36}$/i.test(id)) throw new Error('staging incumbent version is invalid');
+            return id;
+          };
+          process.stdout.write(`issuer_incumbent=${active(process.argv[2])}\napi_incumbent=${active(process.argv[3])}\n`);
+          NODE
+
+      - name: Check custody before enabling the isolated Identity issuer
+        if: ${{ inputs.operation == 'activate' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          proof_file: ${{ runner.temp }}/crm-identity-workers-lease.json
+          resource: global:ponto-workers-writer
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+      - name: Enable the isolated staging Identity issuer only
+        id: activate_issuer
+        if: ${{ inputs.operation == 'activate' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4.112.0 deploy --config identity/wrangler.staging.toml --env staging --keep-vars \
+            --var 'IDENTITY_CRM_DELIVERY_ENABLED:true' \
+            --var 'IDENTITY_CRM_DELIVERY_ENVIRONMENT:staging' \
+            --var 'IDENTITY_CRM_DELIVERY_CALLER_ENABLED:true' \
+            --var 'IDENTITY_CRM_DELIVERY_CALLER_ID:crm-api-staging-v1' >/dev/null
+          npx --yes wrangler@4.112.0 deployments status --json --config identity/wrangler.staging.toml --env staging > "$RUNNER_TEMP/crm-identity-issuer-active.json"
+          node - "$RUNNER_TEMP/crm-identity-issuer-active.json" <<'NODE' >> "$GITHUB_OUTPUT"
+          const fs = require('node:fs'); const versions = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'))?.versions || [];
+          const id = String(versions?.[0]?.version_id || ''); if (versions.length !== 1 || Number(versions[0]?.percentage) !== 100 || !/^[0-9a-f-]{36}$/i.test(id)) throw new Error('enabled issuer has no exact active version');
+          process.stdout.write(`active=${id}\n`);
+          NODE
+
+      - name: Check custody before enabling the API caller
+        if: ${{ inputs.operation == 'activate' && steps.activate_issuer.outcome == 'success' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          proof_file: ${{ runner.temp }}/crm-identity-workers-lease.json
+          resource: global:ponto-workers-writer
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+      - name: Enable the staging API caller only after the issuer is active
+        id: activate_api
+        if: ${{ inputs.operation == 'activate' && steps.activate_issuer.outcome == 'success' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4.112.0 deploy --config api/wrangler.toml --env staging --keep-vars \
+            --var "APP_VERSION:$RELEASE_SHA" \
+            --var 'ENVIRONMENT:staging' \
+            --var 'CRM_IDENTITY_ISSUER_CALLER_ENABLED:true' \
+            --var 'CRM_IDENTITY_ISSUER_CALLER_ID:crm-api-staging-v1' >/dev/null
+          npx --yes wrangler@4.112.0 deployments status --json --config api/wrangler.toml --env staging > "$RUNNER_TEMP/crm-identity-api-active.json"
+          node - "$RUNNER_TEMP/crm-identity-api-active.json" <<'NODE' >> "$GITHUB_OUTPUT"
+          const fs = require('node:fs'); const versions = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'))?.versions || [];
+          const id = String(versions?.[0]?.version_id || ''); if (versions.length !== 1 || Number(versions[0]?.percentage) !== 100 || !/^[0-9a-f-]{36}$/i.test(id)) throw new Error('enabled API has no exact active version');
+          process.stdout.write(`active=${id}\n`);
+          NODE
+
+      - name: Prove the activated public session route rejects anonymous callers without emitting a cookie
+        if: ${{ inputs.operation == 'activate' && steps.activate_api.outcome == 'success' }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          const response = await fetch('https://api-staging.skincos.com.br/crm/session', {
+            headers: { accept: 'application/json', 'cache-control': 'no-store' }, redirect: 'manual', signal: AbortSignal.timeout(15_000),
+          });
+          if (response.status !== 401 || response.headers.has('set-cookie')) throw new Error('activated CRM session anonymous boundary is invalid');
+          const payload = await response.json().catch(() => null);
+          if (payload?.ok !== false || payload?.error !== 'CRM_IDENTITY_REQUIRED') throw new Error('activated CRM session anonymous response is invalid');
+          process.stdout.write('Activated session route rejects anonymous callers without a cookie.\n');
+          NODE
+
+      - name: Check custody before rollback of a failed API activation
+        if: ${{ failure() && inputs.operation == 'activate' && steps.activate_api.outputs.active != '' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          proof_file: ${{ runner.temp }}/crm-identity-workers-lease.json
+          resource: global:ponto-workers-writer
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+      - name: Restore the exact API incumbent only if this activation still owns traffic
+        if: ${{ failure() && inputs.operation == 'activate' && steps.activate_api.outputs.active != '' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ACTIVE: ${{ steps.activate_api.outputs.active }}
+          INCUMBENT: ${{ steps.activation_checkpoint.outputs.api_incumbent }}
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4.112.0 deployments status --json --config api/wrangler.toml --env staging > "$RUNNER_TEMP/crm-identity-api-rollback-status.json"
+          ACTIVE="$ACTIVE" INCUMBENT="$INCUMBENT" node - "$RUNNER_TEMP/crm-identity-api-rollback-status.json" <<'NODE'
+          const fs = require('node:fs'); const versions = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'))?.versions || [];
+          const current = String(versions?.[0]?.version_id || '').toLowerCase();
+          if (versions.length !== 1 || Number(versions[0]?.percentage) !== 100) throw new Error('API rollback ownership is ambiguous');
+          if (current === process.env.INCUMBENT.toLowerCase()) process.exit(0);
+          if (current !== process.env.ACTIVE.toLowerCase()) throw new Error('API rollback ownership conflict');
+          NODE
+          current="$(node -e "const p=require(process.argv[1]);process.stdout.write(String(p?.versions?.[0]?.version_id||''))" "$RUNNER_TEMP/crm-identity-api-rollback-status.json")"
+          if [[ "$current" != "${INCUMBENT}" ]]; then npx --yes wrangler@4.112.0 rollback "$INCUMBENT" --yes --config api/wrangler.toml --env staging >/dev/null; fi
+
+      - name: Check custody before rollback of a failed issuer activation
+        if: ${{ failure() && inputs.operation == 'activate' && steps.activate_issuer.outputs.active != '' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          proof_file: ${{ runner.temp }}/crm-identity-workers-lease.json
+          resource: global:ponto-workers-writer
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+      - name: Restore the exact issuer incumbent only if this activation still owns traffic
+        if: ${{ failure() && inputs.operation == 'activate' && steps.activate_issuer.outputs.active != '' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ACTIVE: ${{ steps.activate_issuer.outputs.active }}
+          INCUMBENT: ${{ steps.activation_checkpoint.outputs.issuer_incumbent }}
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4.112.0 deployments status --json --config identity/wrangler.staging.toml --env staging > "$RUNNER_TEMP/crm-identity-issuer-rollback-status.json"
+          ACTIVE="$ACTIVE" INCUMBENT="$INCUMBENT" node - "$RUNNER_TEMP/crm-identity-issuer-rollback-status.json" <<'NODE'
+          const fs = require('node:fs'); const versions = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'))?.versions || [];
+          const current = String(versions?.[0]?.version_id || '').toLowerCase();
+          if (versions.length !== 1 || Number(versions[0]?.percentage) !== 100) throw new Error('issuer rollback ownership is ambiguous');
+          if (current === process.env.INCUMBENT.toLowerCase()) process.exit(0);
+          if (current !== process.env.ACTIVE.toLowerCase()) throw new Error('issuer rollback ownership conflict');
+          NODE
+          current="$(node -e "const p=require(process.argv[1]);process.stdout.write(String(p?.versions?.[0]?.version_id||''))" "$RUNNER_TEMP/crm-identity-issuer-rollback-status.json")"
+          if [[ "$current" != "${INCUMBENT}" ]]; then npx --yes wrangler@4.112.0 rollback "$INCUMBENT" --yes --config identity/wrangler.staging.toml --env staging >/dev/null; fi
+
+      - name: Check custody before explicitly disabling the API caller
+        if: ${{ inputs.operation == 'disable' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          proof_file: ${{ runner.temp }}/crm-identity-workers-lease.json
+          resource: global:ponto-workers-writer
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+      - name: Disable only the staging API caller while retaining its HMAC for recovery
+        if: ${{ inputs.operation == 'disable' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4.112.0 deploy --config api/wrangler.toml --env staging --keep-vars \
+            --var "APP_VERSION:$RELEASE_SHA" --var 'ENVIRONMENT:staging' \
+            --var 'CRM_IDENTITY_ISSUER_CALLER_ENABLED:false' --var 'CRM_IDENTITY_ISSUER_CALLER_ID:crm-api-staging-v1' >/dev/null
+      - name: Check custody before explicitly disabling the Identity issuer caller
+        if: ${{ inputs.operation == 'disable' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          proof_file: ${{ runner.temp }}/crm-identity-workers-lease.json
+          resource: global:ponto-workers-writer
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+      - name: Disable only the staging Identity issuer caller while retaining its HMAC for recovery
+        if: ${{ inputs.operation == 'disable' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4.112.0 deploy --config identity/wrangler.staging.toml --env staging --keep-vars \
+            --var 'IDENTITY_CRM_DELIVERY_ENABLED:false' \
+            --var 'IDENTITY_CRM_DELIVERY_ENVIRONMENT:staging' \
+            --var 'IDENTITY_CRM_DELIVERY_CALLER_ENABLED:false' \
+            --var 'IDENTITY_CRM_DELIVERY_CALLER_ID:crm-api-staging-v1' >/dev/null
+
+      - name: Acquire staging D1 custody for one synthetic session proof
+        id: d1_lease
+        if: ${{ inputs.operation == 'session-smoke' }}
+        uses: ./.github/actions/global-coordination-acquire
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          resource: global:staging-d1
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+          proof_file: ${{ runner.temp }}/crm-identity-smoke-d1-lease.json
+          inputs_json: '{"target":"staging","surface":"crm-identity-session-smoke"}'
+      - name: Check D1 custody before creating synthetic Identity fixtures
+        if: ${{ inputs.operation == 'session-smoke' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          proof_file: ${{ runner.temp }}/crm-identity-smoke-d1-lease.json
+          resource: global:staging-d1
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+      - name: Generate runner-private synthetic Identity fixtures
+        id: synthetic_fixture
+        if: ${{ inputs.operation == 'session-smoke' }}
+        run: |
+          set -euo pipefail
+          node inventory/scripts/insumosStagingRbacFixtures.mjs --action provision --run-id "$GITHUB_RUN_ID" --fixtures "$RUNNER_TEMP/crm-identity-smoke-fixtures.json" --sql "$RUNNER_TEMP/crm-identity-smoke-provision.sql" >/dev/null
+          echo 'created=true' >> "$GITHUB_OUTPUT"
+      - name: Provision only this run's synthetic staging Identity fixture
+        if: ${{ inputs.operation == 'session-smoke' && steps.synthetic_fixture.outcome == 'success' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          [[ -n "${CLOUDFLARE_API_TOKEN:-}" && -n "${CLOUDFLARE_ACCOUNT_ID:-}" ]] || { echo 'Staging D1 custody is unavailable'; exit 1; }
+          npx --yes wrangler@4.112.0 d1 execute skincos-db-staging --config inventory/wrangler.toml --env staging --remote --file "$RUNNER_TEMP/crm-identity-smoke-provision.sql" >/dev/null
+      - name: Check D1 custody before the synthetic authenticated session proof
+        if: ${{ inputs.operation == 'session-smoke' && steps.synthetic_fixture.outcome == 'success' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          proof_file: ${{ runner.temp }}/crm-identity-smoke-d1-lease.json
+          resource: global:staging-d1
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+      - name: Prove a real synthetic login reaches the CRM session without forwarding its cookie
+        if: ${{ inputs.operation == 'session-smoke' && steps.synthetic_fixture.outcome == 'success' }}
+        env:
+          CRM_IDENTITY_SMOKE_FIXTURES: ${{ runner.temp }}/crm-identity-smoke-fixtures.json
+          CRM_IDENTITY_SMOKE_REPORT: ${{ runner.temp }}/crm-identity-smoke-report.json
+          CRM_IDENTITY_SMOKE_API_ORIGIN: https://api-staging.skincos.com.br
+        run: node scripts/crm-identity-staging-session-smoke.mjs
+      - name: Check D1 custody before synthetic fixture teardown
+        id: synthetic_teardown_lease
+        if: ${{ always() && inputs.operation == 'session-smoke' && steps.synthetic_fixture.outcome == 'success' }}
+        uses: ./.github/actions/global-coordination-check
+        with:
+          required: 'true'
+          enabled: ${{ vars.SKINCOS_GLOBAL_COORDINATION_REQUIRED }}
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          proof_file: ${{ runner.temp }}/crm-identity-smoke-d1-lease.json
+          resource: global:staging-d1
+          module: core
+          source_sha: ${{ inputs.release_sha }}
+      - name: Tear down only this run's synthetic staging Identity fixture
+        id: synthetic_teardown
+        if: ${{ always() && inputs.operation == 'session-smoke' && steps.synthetic_teardown_lease.outcome == 'success' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          fixtures="$RUNNER_TEMP/crm-identity-smoke-fixtures.json"
+          [[ -f "$fixtures" ]] || exit 0
+          node inventory/scripts/insumosStagingRbacFixtures.mjs --action teardown --run-id "$GITHUB_RUN_ID" --fixtures "$fixtures" --sql "$RUNNER_TEMP/crm-identity-smoke-teardown.sql" >/dev/null
+          npx --yes wrangler@4.112.0 d1 execute skincos-db-staging --config inventory/wrangler.toml --env staging --remote --file "$RUNNER_TEMP/crm-identity-smoke-teardown.sql" >/dev/null
+          rm -f "$fixtures" "$RUNNER_TEMP/crm-identity-smoke-provision.sql" "$RUNNER_TEMP/crm-identity-smoke-teardown.sql"
+      - name: Upload only the sanitised synthetic session proof
+        if: ${{ always() && inputs.operation == 'session-smoke' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: crm-identity-session-smoke-${{ inputs.release_sha }}
+          path: ${{ runner.temp }}/crm-identity-smoke-report.json
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Release canonical Core and Identity Worker custody lease
+        if: ${{ always() && steps.worker_lease.outcome == 'success' }}
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: 'true'
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          proof_file: ${{ runner.temp }}/crm-identity-workers-lease.json
+      - name: Release staging D1 custody lease
+        if: ${{ always() && steps.d1_lease.outcome == 'success' }}
+        uses: ./.github/actions/global-coordination-release
+        with:
+          required: 'true'
+          coordinator_url: ${{ vars.SKINCOS_GLOBAL_COORDINATOR_URL }}
+          shared_secret: ${{ secrets.SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY }}
+          key_id: ${{ vars.SKINCOS_GLOBAL_COORDINATION_KEY_ID }}
+          proof_file: ${{ runner.temp }}/crm-identity-smoke-d1-lease.json

--- a/.github/workflows/identity-crm-delivery.yml
+++ b/.github/workflows/identity-crm-delivery.yml
@@ -4,11 +4,21 @@ on:
   pull_request:
     paths:
       - 'identity/**'
+      - 'api/src/gateway.js'
+      - 'api/src/crm-identity-issuer-client.js'
+      - 'api/test/gateway.test.mjs'
+      - 'api/wrangler.toml'
+      - 'shared/identity-contract/**'
       - '.github/workflows/identity-crm-delivery.yml'
   push:
     branches: [main]
     paths:
       - 'identity/**'
+      - 'api/src/gateway.js'
+      - 'api/src/crm-identity-issuer-client.js'
+      - 'api/test/gateway.test.mjs'
+      - 'api/wrangler.toml'
+      - 'shared/identity-contract/**'
       - '.github/workflows/identity-crm-delivery.yml'
   workflow_dispatch: {}
 
@@ -22,7 +32,7 @@ concurrency:
 
 jobs:
   test:
-    name: Install pinned contract and test issuer
+    name: Test the pinned Identity issuer and staging caller
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -45,3 +55,4 @@ jobs:
           } > "$npmrc"
           NPM_CONFIG_USERCONFIG="$npmrc" npm --prefix identity ci --ignore-scripts --no-audit --fund=false
           NPM_CONFIG_USERCONFIG="$npmrc" npm --prefix identity test
+          npm --prefix api test

--- a/.github/workflows/identity-crm-delivery.yml
+++ b/.github/workflows/identity-crm-delivery.yml
@@ -8,7 +8,9 @@ on:
       - 'api/src/crm-identity-issuer-client.js'
       - 'api/test/gateway.test.mjs'
       - 'api/wrangler.toml'
+      - 'scripts/crm-identity-staging-caller-runtime-readback.mjs'
       - 'scripts/crm-identity-staging-session-smoke.mjs'
+      - 'scripts/tests/crm-identity-staging-caller-runtime-readback.test.mjs'
       - 'scripts/tests/crm-identity-staging-session-smoke.test.mjs'
       - 'shared/identity-contract/**'
       - '.github/governance/cloudflare-single-writer-policy.json'
@@ -21,7 +23,9 @@ on:
       - 'api/src/crm-identity-issuer-client.js'
       - 'api/test/gateway.test.mjs'
       - 'api/wrangler.toml'
+      - 'scripts/crm-identity-staging-caller-runtime-readback.mjs'
       - 'scripts/crm-identity-staging-session-smoke.mjs'
+      - 'scripts/tests/crm-identity-staging-caller-runtime-readback.test.mjs'
       - 'scripts/tests/crm-identity-staging-session-smoke.test.mjs'
       - 'shared/identity-contract/**'
       - '.github/governance/cloudflare-single-writer-policy.json'
@@ -92,6 +96,7 @@ jobs:
           NPM_CONFIG_USERCONFIG="$npmrc" npm --prefix identity test
           npm --prefix api ci --ignore-scripts --no-audit --fund=false
           npm --prefix api test
+          node --test scripts/tests/crm-identity-staging-caller-runtime-readback.test.mjs
           node --test scripts/tests/crm-identity-staging-session-smoke.test.mjs
 
   staging:
@@ -135,7 +140,7 @@ jobs:
           [[ "$GITHUB_SHA" == "$RELEASE_SHA" && "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]] || { echo 'Dispatch source differs from release_sha'; exit 1; }
           git fetch --no-tags --force origin main:refs/remotes/origin/main
           [[ "$(git rev-parse refs/remotes/origin/main)" == "$RELEASE_SHA" ]] || { echo 'main advanced; dispatch the current source again'; exit 1; }
-          for file in identity/wrangler.staging.toml identity/delivery/crm-issuer-staging-worker.js api/wrangler.toml api/src/crm-identity-issuer-client.js scripts/crm-identity-staging-session-smoke.mjs; do
+          for file in identity/wrangler.staging.toml identity/delivery/crm-issuer-staging-worker.js api/wrangler.toml api/src/crm-identity-issuer-client.js scripts/crm-identity-staging-caller-runtime-readback.mjs scripts/crm-identity-staging-session-smoke.mjs; do
             git cat-file -e "$RELEASE_SHA:$file" || { echo "Missing required source: $file"; exit 1; }
           done
 
@@ -156,6 +161,7 @@ jobs:
           NPM_CONFIG_USERCONFIG="$npmrc" npm --prefix identity test
           npm --prefix api ci --ignore-scripts --no-audit --fund=false
           npm --prefix api test
+          node --test scripts/tests/crm-identity-staging-caller-runtime-readback.test.mjs
           node --test scripts/tests/crm-identity-staging-session-smoke.test.mjs
           npx --yes wrangler@4.112.0 deploy --dry-run --config identity/wrangler.staging.toml --env staging --outdir "$RUNNER_TEMP/identity-crm-delivery-dry-run" >/dev/null
           npx --yes wrangler@4.112.0 deploy --dry-run --config api/wrangler.toml --env staging --outdir "$RUNNER_TEMP/api-crm-session-dry-run" >/dev/null
@@ -212,6 +218,34 @@ jobs:
           resource: global:ponto-workers-writer
           module: core
           source_sha: ${{ inputs.release_sha }}
+
+      - name: Read back exact active staging Worker bindings and require the caller disabled before bootstrap
+        id: bootstrap_runtime_preflight
+        if: ${{ inputs.operation == 'bootstrap' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID; do [[ -n "${!name:-}" ]] || { echo "Missing staging custody: $name"; exit 1; }; done
+          api_deployment="$RUNNER_TEMP/crm-identity-api-disabled-preflight-deployment.json"
+          issuer_deployment="$RUNNER_TEMP/crm-identity-issuer-disabled-preflight-deployment.json"
+          runtime_report="$RUNNER_TEMP/crm-identity-disabled-preflight.json"
+          trap 'rm -f "$api_deployment" "$issuer_deployment" "$runtime_report"' EXIT
+          npx --yes wrangler@4.112.0 deployments status --json --config api/wrangler.toml --env staging > "$api_deployment"
+          npx --yes wrangler@4.112.0 deployments status --json --config identity/wrangler.staging.toml --env staging > "$issuer_deployment"
+          node scripts/crm-identity-staging-caller-runtime-readback.mjs "$api_deployment" "$issuer_deployment" > "$runtime_report"
+          node - "$runtime_report" <<'NODE' >> "$GITHUB_OUTPUT"
+          const fs = require('node:fs');
+          const report = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          const version = (value) => typeof value === 'string' && /^[0-9a-f-]{36}$/i.test(value);
+          if (
+            report?.schemaVersion !== 1 || report.state !== 'disabled' || report.observation !== 'exact-active-worker-version-bindings'
+            || report?.api?.script !== 'skincos-api-staging' || report.api.callerEnabled !== false || report.api.callerId !== 'crm-api-staging-v1' || !version(report.api.activeVersion)
+            || report?.issuer?.script !== 'skincos-identity-crm-delivery-staging' || report.issuer.deliveryEnabled !== false || report.issuer.callerEnabled !== false || report.issuer.callerId !== 'crm-api-staging-v1' || !version(report.issuer.activeVersion)
+          ) throw new Error('active staging caller flags are not proven disabled');
+          process.stdout.write(`state=disabled\napi_version=${report.api.activeVersion}\nissuer_version=${report.issuer.activeVersion}\n`);
+          NODE
 
       - name: Refuse partial caller HMAC custody and attest existing signer custody
         id: bootstrap_preflight
@@ -323,19 +357,52 @@ jobs:
           NODE
           echo 'state=both-present' >> "$GITHUB_OUTPUT"
 
+      - name: Read back exact active staging Worker bindings after caller HMAC custody
+        id: bootstrap_runtime_readback
+        if: ${{ inputs.operation == 'bootstrap' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID; do [[ -n "${!name:-}" ]] || { echo "Missing staging custody: $name"; exit 1; }; done
+          api_deployment="$RUNNER_TEMP/crm-identity-api-disabled-readback-deployment.json"
+          issuer_deployment="$RUNNER_TEMP/crm-identity-issuer-disabled-readback-deployment.json"
+          runtime_report="$RUNNER_TEMP/crm-identity-disabled-readback.json"
+          trap 'rm -f "$api_deployment" "$issuer_deployment" "$runtime_report"' EXIT
+          npx --yes wrangler@4.112.0 deployments status --json --config api/wrangler.toml --env staging > "$api_deployment"
+          npx --yes wrangler@4.112.0 deployments status --json --config identity/wrangler.staging.toml --env staging > "$issuer_deployment"
+          node scripts/crm-identity-staging-caller-runtime-readback.mjs "$api_deployment" "$issuer_deployment" > "$runtime_report"
+          node - "$runtime_report" <<'NODE' >> "$GITHUB_OUTPUT"
+          const fs = require('node:fs');
+          const report = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          const version = (value) => typeof value === 'string' && /^[0-9a-f-]{36}$/i.test(value);
+          if (
+            report?.schemaVersion !== 1 || report.state !== 'disabled' || report.observation !== 'exact-active-worker-version-bindings'
+            || report?.api?.script !== 'skincos-api-staging' || report.api.callerEnabled !== false || report.api.callerId !== 'crm-api-staging-v1' || !version(report.api.activeVersion)
+            || report?.issuer?.script !== 'skincos-identity-crm-delivery-staging' || report.issuer.deliveryEnabled !== false || report.issuer.callerEnabled !== false || report.issuer.callerId !== 'crm-api-staging-v1' || !version(report.issuer.activeVersion)
+          ) throw new Error('active staging caller flags changed or are not proven disabled');
+          process.stdout.write(`state=disabled\napi_version=${report.api.activeVersion}\nissuer_version=${report.issuer.activeVersion}\n`);
+          NODE
+
       - name: Write sanitised disabled bootstrap evidence
-        if: ${{ inputs.operation == 'bootstrap' && steps.bootstrap_readback.outputs.state == 'both-present' }}
+        if: ${{ inputs.operation == 'bootstrap' && steps.bootstrap_runtime_preflight.outputs.state == 'disabled' && steps.bootstrap_readback.outputs.state == 'both-present' && steps.bootstrap_runtime_readback.outputs.state == 'disabled' }}
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/crm-identity-bootstrap"
-          RELEASE_SHA="$RELEASE_SHA" BOOTSTRAP_STATE="${{ steps.bootstrap_provision.outputs.state || steps.bootstrap_preflight.outputs.state }}" node - "$RUNNER_TEMP/crm-identity-bootstrap/evidence.json" <<'NODE'
+          RELEASE_SHA="$RELEASE_SHA" BOOTSTRAP_STATE="${{ steps.bootstrap_provision.outputs.state || steps.bootstrap_preflight.outputs.state }}" API_VERSION="${{ steps.bootstrap_runtime_readback.outputs.api_version }}" ISSUER_VERSION="${{ steps.bootstrap_runtime_readback.outputs.issuer_version }}" node - "$RUNNER_TEMP/crm-identity-bootstrap/evidence.json" <<'NODE'
           const fs = require('node:fs');
+          const version = (value) => typeof value === 'string' && /^[0-9a-f-]{36}$/i.test(value);
+          if (!version(process.env.API_VERSION) || !version(process.env.ISSUER_VERSION)) throw new Error('disabled active version evidence is missing');
           fs.writeFileSync(process.argv[2], `${JSON.stringify({
-            schemaVersion: 1,
+            schemaVersion: 2,
             operation: 'bootstrap',
             environment: 'staging',
             sourceSha: process.env.RELEASE_SHA,
             state: process.env.BOOTSTRAP_STATE || 'already-provisioned',
+            runtimeReadback: 'exact-active-worker-version-bindings',
+            apiActiveVersion: process.env.API_VERSION,
+            issuerActiveVersion: process.env.ISSUER_VERSION,
             callerId: 'crm-api-staging-v1',
             apiSecretName: 'CRM_IDENTITY_ISSUER_CALLER_HMAC',
             issuerSecretName: 'IDENTITY_CRM_DELIVERY_CALLER_HMAC',
@@ -344,7 +411,7 @@ jobs:
           }, null, 2)}\n`, { mode: 0o600 });
           NODE
       - name: Upload sanitised disabled bootstrap evidence
-        if: ${{ inputs.operation == 'bootstrap' && steps.bootstrap_readback.outputs.state == 'both-present' }}
+        if: ${{ inputs.operation == 'bootstrap' && steps.bootstrap_runtime_preflight.outputs.state == 'disabled' && steps.bootstrap_readback.outputs.state == 'both-present' && steps.bootstrap_runtime_readback.outputs.state == 'disabled' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: crm-identity-caller-bootstrap-${{ inputs.release_sha }}
@@ -376,7 +443,12 @@ jobs:
           gh run download "$BOOTSTRAP_RUN_ID" --repo "$GITHUB_REPOSITORY" --name "crm-identity-caller-bootstrap-$RELEASE_SHA" --dir "$RUNNER_TEMP/crm-identity-bootstrap-evidence"
           RELEASE_SHA="$RELEASE_SHA" node - "$RUNNER_TEMP/crm-identity-bootstrap-evidence/evidence.json" <<'NODE'
           const fs = require('node:fs'); const evidence = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
-          if (evidence?.schemaVersion !== 1 || evidence.operation !== 'bootstrap' || evidence.environment !== 'staging' || evidence.sourceSha !== process.env.RELEASE_SHA || evidence.callerEnabled !== false || evidence.secretValuesIncluded !== false) {
+          const version = (value) => typeof value === 'string' && /^[0-9a-f-]{36}$/i.test(value);
+          if (
+            evidence?.schemaVersion !== 2 || evidence.operation !== 'bootstrap' || evidence.environment !== 'staging' || evidence.sourceSha !== process.env.RELEASE_SHA
+            || evidence.runtimeReadback !== 'exact-active-worker-version-bindings' || !version(evidence.apiActiveVersion) || !version(evidence.issuerActiveVersion)
+            || evidence.callerEnabled !== false || evidence.secretValuesIncluded !== false
+          ) {
             throw new Error('bootstrap evidence does not bind the current disabled staging source');
           }
           NODE

--- a/api/src/crm-identity-issuer-client.js
+++ b/api/src/crm-identity-issuer-client.js
@@ -1,0 +1,179 @@
+import { isCanonicalUnitScope, isOpaqueIdentitySubject } from '../../shared/identity-contract/index.js';
+import { fetchBoundService } from '../../shared/service-adapters/cloudflare-service-binding.js';
+
+const IDENTITY_ISSUER_BINDING = 'IDENTITY_CRM_ISSUER';
+const IDENTITY_ISSUER_PATH = '/internal/identity-crm-delivery/v1/issue';
+const IDENTITY_ISSUER_ORIGIN = 'https://identity-crm-issuer.internal';
+const IDENTITY_ISSUER_CALLER_ID = 'crm-api-staging-v1';
+const IDENTITY_ISSUER_CALLER_HEADER = 'x-skincos-identity-issuer-caller';
+const IDENTITY_ISSUER_AUTH_HEADER = 'x-skincos-identity-issuer-auth';
+const CRM_SESSION_PATH = '/crm/session';
+const CRM_SESSION_TARGET = '/api/crm/session';
+const TEXT_ENCODER = new TextEncoder();
+const ROLE_PATTERN = /^[A-Z][A-Z0-9_]{0,63}$/;
+const SCOPE_ITEM_PATTERN = /^[a-z][a-z0-9:-]{0,159}$/;
+const JTI_PATTERN = /^[A-Za-z0-9_-]{16,160}$/;
+const KEY_ID_PATTERN = /^crm-staging-[A-Za-z0-9._-]{1,148}$/;
+const COMPACT_JWS_PATTERN = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+const MAX_COMPACT_JWS_LENGTH = 16_384;
+const ISSUE_TIMEOUT_MS = 3_000;
+
+function fail(code) {
+    throw new TypeError(code);
+}
+function assertPlainObject(value, code) {
+    if (!value || typeof value !== 'object' || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) fail(code);
+    return value;
+}
+
+function assertExactKeys(value, allowed, code) {
+    assertPlainObject(value, code);
+    const keys = Reflect.ownKeys(value);
+    if (keys.length !== allowed.length || keys.some((key) => typeof key !== 'string' || !allowed.includes(key))) fail(code);
+    for (const key of allowed) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, key);
+        if (!descriptor || !descriptor.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) fail(code);
+    }
+    return value;
+}
+
+function ownData(value, key, code) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor || !descriptor.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) fail(code);
+    return descriptor.value;
+}
+
+function strictScopeItems(value, code, pattern, additionalValidation = null) {
+    if (!Array.isArray(value) || Object.getPrototypeOf(value) !== Array.prototype || value.length > 64) fail(code);
+    const expectedKeys = new Set(Array.from({ length: value.length }, (_, index) => String(index)));
+    const keys = Reflect.ownKeys(value);
+    if (keys.length !== value.length + 1 || keys.some((key) => key !== 'length' && (typeof key !== 'string' || !expectedKeys.has(key)))) fail(code);
+
+    const items = [];
+    for (let index = 0; index < value.length; index += 1) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+        if (!descriptor || !descriptor.enumerable || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) fail(code);
+        const item = descriptor.value;
+        if (typeof item !== 'string' || !item || !pattern.test(item) || (additionalValidation && !additionalValidation(item))) fail(code);
+        items.push(item);
+    }
+    if (new Set(items).size !== items.length) fail(code);
+    return Object.freeze(items.sort());
+}
+
+function trustedIdentityProjection(actor) {
+    assertPlainObject(actor, 'CRM_IDENTITY_REQUIRED');
+    const identitySubject = ownData(actor, 'identitySubject', 'CRM_IDENTITY_SUBJECT_REQUIRED');
+    const role = ownData(actor, 'role', 'CRM_IDENTITY_ROLE_INVALID');
+    const scopes = ownData(actor, 'scopes', 'CRM_IDENTITY_SCOPES_INVALID');
+    if (!isOpaqueIdentitySubject(identitySubject)) fail('CRM_IDENTITY_SUBJECT_REQUIRED');
+    if (typeof role !== 'string' || !ROLE_PATTERN.test(role)) fail('CRM_IDENTITY_ROLE_INVALID');
+    assertExactKeys(scopes, ['units', 'modules', 'permissions'], 'CRM_IDENTITY_SCOPES_INVALID');
+
+    return Object.freeze({
+        identitySubject,
+        role,
+        scopes: Object.freeze({
+            units: strictScopeItems(ownData(scopes, 'units', 'CRM_IDENTITY_SCOPES_INVALID'), 'CRM_IDENTITY_SCOPE_UNITS_INVALID', /^[a-z][a-z0-9-]{0,159}$/, isCanonicalUnitScope),
+            modules: strictScopeItems(ownData(scopes, 'modules', 'CRM_IDENTITY_SCOPES_INVALID'), 'CRM_IDENTITY_SCOPE_MODULES_INVALID', SCOPE_ITEM_PATTERN),
+            permissions: strictScopeItems(ownData(scopes, 'permissions', 'CRM_IDENTITY_SCOPES_INVALID'), 'CRM_IDENTITY_SCOPE_PERMISSIONS_INVALID', SCOPE_ITEM_PATTERN),
+        }),
+    });
+}
+
+function loadCallerConfiguration(env) {
+    if (String(env?.ENVIRONMENT || '').trim().toLowerCase() !== 'staging'
+        || env?.CRM_IDENTITY_ISSUER_CALLER_ENABLED !== 'true') {
+        fail('CRM_IDENTITY_DELIVERY_UNAVAILABLE');
+    }
+    const callerId = String(env?.CRM_IDENTITY_ISSUER_CALLER_ID || '').trim();
+    const secret = env?.CRM_IDENTITY_ISSUER_CALLER_HMAC;
+    if (callerId !== IDENTITY_ISSUER_CALLER_ID
+        || typeof secret !== 'string'
+        || secret.trim() !== secret
+        || TEXT_ENCODER.encode(secret).byteLength < 32) {
+        fail('CRM_IDENTITY_DELIVERY_UNAVAILABLE');
+    }
+    return Object.freeze({ callerId, secret });
+}
+
+function createJti() {
+    const randomUuid = globalThis.crypto?.randomUUID;
+    if (typeof randomUuid !== 'function') fail('CRM_IDENTITY_DELIVERY_UNAVAILABLE');
+    const jti = String(randomUuid.call(globalThis.crypto)).replaceAll('-', '');
+    if (!JTI_PATTERN.test(jti)) fail('CRM_IDENTITY_DELIVERY_UNAVAILABLE');
+    return jti;
+}
+
+function encodeBase64Url(bytes) {
+    let binary = '';
+    for (const byte of bytes) binary += String.fromCharCode(byte);
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+async function requestAuthentication(secret, rawBody) {
+    const subtle = globalThis.crypto?.subtle;
+    if (!subtle || typeof subtle.importKey !== 'function' || typeof subtle.sign !== 'function') fail('CRM_IDENTITY_DELIVERY_UNAVAILABLE');
+    const key = await subtle.importKey('raw', TEXT_ENCODER.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+    const signature = await subtle.sign('HMAC', key, TEXT_ENCODER.encode(rawBody));
+    return encodeBase64Url(new Uint8Array(signature));
+}
+
+function parseIssuerResponse(value) {
+    assertExactKeys(value, ['ok', 'version', 'keyId', 'compact'], 'CRM_IDENTITY_DELIVERY_UNAVAILABLE');
+    if (value.ok !== true
+        || value.version !== 'identity-crm-delivery/v1'
+        || typeof value.keyId !== 'string'
+        || !KEY_ID_PATTERN.test(value.keyId)
+        || typeof value.compact !== 'string'
+        || value.compact.length > MAX_COMPACT_JWS_LENGTH
+        || !COMPACT_JWS_PATTERN.test(value.compact)) {
+        fail('CRM_IDENTITY_DELIVERY_UNAVAILABLE');
+    }
+    return value.compact;
+}
+
+export function isCrmSessionPath(request) {
+    return new URL(request.url).pathname === CRM_SESSION_PATH;
+}
+
+export function isCrmSessionRequest(request) {
+    const url = new URL(request.url);
+    return request.method === 'GET' && url.pathname === CRM_SESSION_PATH && !url.search;
+}
+
+/**
+ * The public gateway is the only component that may resolve a browser
+ * session. It turns the resulting server-owned actor into a minimal, signed
+ * delivery envelope, then discards the browser credential before CRM Core is
+ * called. This route is intentionally a GET-only session capability.
+ */
+export async function issueCrmSessionIdentityDelivery(request, env, actor) {
+    if (!isCrmSessionRequest(request)) fail('CRM_SESSION_REQUEST_INVALID');
+    const caller = loadCallerConfiguration(env);
+    const identity = trustedIdentityProjection(actor);
+    const rawBody = JSON.stringify({
+        identity,
+        request: { method: 'GET', target: CRM_SESSION_TARGET, bodyBase64: '' },
+        jti: createJti(),
+    });
+    const authorization = await requestAuthentication(caller.secret, rawBody);
+    const issuerRequest = new Request(`${IDENTITY_ISSUER_ORIGIN}${IDENTITY_ISSUER_PATH}`, {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/json; charset=utf-8',
+            [IDENTITY_ISSUER_CALLER_HEADER]: caller.callerId,
+            [IDENTITY_ISSUER_AUTH_HEADER]: authorization,
+        },
+        body: rawBody,
+    });
+
+    const response = await fetchBoundService(issuerRequest, env, IDENTITY_ISSUER_BINDING, { timeoutMs: ISSUE_TIMEOUT_MS });
+    if (response.status !== 200) fail('CRM_IDENTITY_DELIVERY_UNAVAILABLE');
+    try {
+        return parseIssuerResponse(await response.json());
+    } catch (error) {
+        if (error instanceof TypeError && error.message === 'CRM_IDENTITY_DELIVERY_UNAVAILABLE') throw error;
+        fail('CRM_IDENTITY_DELIVERY_UNAVAILABLE');
+    }
+}

--- a/api/src/gateway.js
+++ b/api/src/gateway.js
@@ -8,6 +8,7 @@ import {
     isAuthorizedCrmCoreProductionReceipt,
     isCrmCoreStagingEnvironment,
 } from './crm-core-production-receipt.js';
+import { isCrmSessionPath, isCrmSessionRequest, issueCrmSessionIdentityDelivery } from './crm-identity-issuer-client.js';
 
 const gatewayError = (status, error) => new Response(JSON.stringify({ ok: false, error }), { status, headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' } });
 const isOperationalProbe = (request) => request.method === 'GET' && ['/health', '/readiness'].includes(new URL(request.url).pathname);
@@ -16,6 +17,8 @@ const FINANCE_PROBE_TIMEOUT_MS = 3_000;
 const FINANCE_READ_TIMEOUT_MS = 3_000;
 const FINANCE_WRITE_TIMEOUT_MS = 5_000;
 const CRM_CORE_TIMEOUT_MS = 3_000;
+const CRM_IDENTITY_DELIVERY_HEADER_PATTERN = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+const CRM_IDENTITY_DELIVERY_HEADER_MAX_LENGTH = 16_384;
 const CRM_CORE_REQUEST_HEADER_ALLOWLIST = Object.freeze([
     'accept',
     'content-type',
@@ -110,34 +113,50 @@ function isProductionEnvironment(env) {
 /**
  * This is a fresh allowlist, never a mutation of public request headers.
  * CRM Core needs only browser representation/CORS metadata, correlation and
- * its signed Identity delivery envelope. In particular, no legacy session,
- * service token, proxy, Cloudflare or future credential-shaped header can
- * cross this boundary. `x-identity-delivery` intentionally survives because
- * CRM Core verifies it against its pinned Identity public key and replay
- * ledger.
+ * a delivery envelope that the gateway itself obtained over its private
+ * Identity binding. In particular, no browser-supplied envelope, legacy
+ * session, service token, proxy, Cloudflare or future credential-shaped header
+ * can cross this boundary. For the staging session capability, a fresh
+ * internally issued envelope replaces any browser-supplied value.
  */
-export function prepareCrmCoreRequest(request, productionReceipt = null, env = null) {
+export function prepareCrmCoreRequest(request, productionReceipt = null, env = null, identityDelivery = null) {
     const headers = new Headers();
     for (const name of CRM_CORE_REQUEST_HEADER_ALLOWLIST) {
         const value = request.headers.get(name);
         if (value !== null) headers.set(name, value);
     }
+    if (isCrmCoreStagingEnvironment(env) || identityDelivery !== null) headers.delete('x-identity-delivery');
     if (productionReceipt) {
         headers.set('cloudflare-workers-version-overrides', crmCoreVersionOverride(productionReceipt, env));
+    }
+    if (typeof identityDelivery === 'string'
+        && identityDelivery.length <= CRM_IDENTITY_DELIVERY_HEADER_MAX_LENGTH
+        && CRM_IDENTITY_DELIVERY_HEADER_PATTERN.test(identityDelivery)) {
+        headers.set('x-identity-delivery', identityDelivery);
     }
     return new Request(request, { headers });
 }
 
+function crmCoreForwardContext(value) {
+    if (value && typeof value === 'object' && !Array.isArray(value)
+        && Object.prototype.hasOwnProperty.call(value, 'identityDelivery')) {
+        return { productionReceipt: null, identityDelivery: value.identityDelivery };
+    }
+    return { productionReceipt: value, identityDelivery: null };
+}
+
 export async function forwardCrmCoreToService(request, env, ctx, authorizedProductionReceipt = null) {
+    const { productionReceipt: suppliedProductionReceipt, identityDelivery } = crmCoreForwardContext(authorizedProductionReceipt);
     const staging = isCrmCoreStagingEnvironment(env);
-    let productionReceipt = staging ? null : authorizedProductionReceipt;
+    if (!staging && identityDelivery !== null) return gatewayError(404, 'CRM_CORE_STAGING_ONLY');
+    let productionReceipt = staging ? null : suppliedProductionReceipt;
     if (!staging && !isAuthorizedCrmCoreProductionReceipt(productionReceipt, env)) {
         productionReceipt = await authorizeCrmCoreProductionRoute(request, env);
     }
     if (!staging && !productionReceipt) {
         return gatewayError(404, isProductionEnvironment(env) ? 'CRM_CORE_PRODUCTION_NOT_AUTHORIZED' : 'CRM_CORE_STAGING_ONLY');
     }
-    return fetchBoundService(prepareCrmCoreRequest(request, productionReceipt, env), env, 'CRM_CORE', {
+    return fetchBoundService(prepareCrmCoreRequest(request, productionReceipt, env, identityDelivery), env, 'CRM_CORE', {
         timeoutMs: CRM_CORE_TIMEOUT_MS,
     });
 }
@@ -201,7 +220,34 @@ export function createApiGateway({
             if (csrfError) return csrfError;
             return financeDomainHandler(request, env, ctx, auth);
         },
-        crmCoreHandler: typeof crmCoreHandler === 'function' ? crmCoreHandler : undefined,
+        crmCoreHandler: typeof crmCoreHandler === 'function'
+            ? async (request, env, ctx, productionReceipt = null) => {
+                if (!isCrmSessionPath(request)) return crmCoreHandler(request, env, ctx, productionReceipt);
+                if (!isCrmCoreStagingEnvironment(env)) return gatewayError(404, 'CRM_CORE_STAGING_ONLY');
+                if (!isCrmSessionRequest(request)) {
+                    return request.method === 'GET'
+                        ? gatewayError(400, 'CRM_SESSION_QUERY_NOT_ALLOWED')
+                        : gatewayError(405, 'CRM_SESSION_METHOD_NOT_ALLOWED');
+                }
+                let auth;
+                try {
+                    auth = await resolveActor(request, env);
+                } catch {
+                    return gatewayError(503, 'IDENTITY_UNAVAILABLE');
+                }
+                if (auth?.unavailable) return gatewayError(503, 'IDENTITY_UNAVAILABLE');
+                if (!auth?.actor) return gatewayError(401, 'CRM_IDENTITY_REQUIRED');
+                try {
+                    const identityDelivery = await issueCrmSessionIdentityDelivery(request, env, auth.actor);
+                    return crmCoreHandler(request, env, ctx, { identityDelivery });
+                } catch (error) {
+                    if (error instanceof TypeError && error.message === 'CRM_IDENTITY_SUBJECT_REQUIRED') {
+                        return gatewayError(403, 'CRM_IDENTITY_SUBJECT_REQUIRED');
+                    }
+                    return gatewayError(503, 'CRM_IDENTITY_DELIVERY_UNAVAILABLE');
+                }
+            }
+            : undefined,
     });
 }
 

--- a/api/src/gateway.js
+++ b/api/src/gateway.js
@@ -19,6 +19,8 @@ const FINANCE_WRITE_TIMEOUT_MS = 5_000;
 const CRM_CORE_TIMEOUT_MS = 3_000;
 const CRM_IDENTITY_DELIVERY_HEADER_PATTERN = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
 const CRM_IDENTITY_DELIVERY_HEADER_MAX_LENGTH = 16_384;
+const CRM_SESSION_STAGING_ORIGIN = 'https://crm-staging.skincos.com.br';
+const CRM_SESSION_CORS_REQUEST_HEADERS = new Set(['accept', 'cache-control']);
 const CRM_CORE_REQUEST_HEADER_ALLOWLIST = Object.freeze([
     'accept',
     'content-type',
@@ -35,6 +37,67 @@ const INVENTORY_TEAM_TIMEOUT_MS = 8_000;
 const CLOUDFLARE_VERSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const NETWORK_CONTEXT_RE = /^v1:[A-Za-z0-9_-]{43}$/;
 const B64URL_SHA256_RE = /^[A-Za-z0-9_-]{43}$/;
+
+function crmSessionCorsHeaders(request, env) {
+    if (!isCrmCoreStagingEnvironment(env)) return null;
+    if (String(request.headers.get('origin') || '').trim() !== CRM_SESSION_STAGING_ORIGIN) return null;
+    return {
+        'access-control-allow-origin': CRM_SESSION_STAGING_ORIGIN,
+        'access-control-allow-credentials': 'true',
+        vary: 'Origin',
+    };
+}
+
+function crmSessionOriginAllowed(request) {
+    const origin = String(request.headers.get('origin') || '').trim();
+    return !origin || origin === CRM_SESSION_STAGING_ORIGIN;
+}
+
+function withCrmSessionCors(response, request, env) {
+    const cors = crmSessionCorsHeaders(request, env);
+    if (!cors) return response;
+    const headers = new Headers(response.headers);
+    for (const [name, value] of Object.entries(cors)) {
+        if (name !== 'vary') headers.set(name, value);
+    }
+    const vary = headers.get('vary');
+    if (!vary) headers.set('vary', 'Origin');
+    else if (!vary.split(',').some((value) => value.trim().toLowerCase() === 'origin')) {
+        headers.set('vary', `${vary}, Origin`);
+    }
+    return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
+}
+
+function crmSessionError(request, env, status, error) {
+    return withCrmSessionCors(gatewayError(status, error), request, env);
+}
+
+function crmSessionCorsPreflightAllowed(request) {
+    const url = new URL(request.url);
+    if (request.method !== 'OPTIONS' || url.pathname !== '/crm/session' || url.search) return false;
+    if (String(request.headers.get('access-control-request-method') || '').trim().toUpperCase() !== 'GET') return false;
+    const requestedHeaders = String(request.headers.get('access-control-request-headers') || '')
+        .split(',')
+        .map((value) => value.trim().toLowerCase())
+        .filter(Boolean);
+    return requestedHeaders.every((name) => CRM_SESSION_CORS_REQUEST_HEADERS.has(name));
+}
+
+function crmSessionPreflight(request, env) {
+    const cors = crmSessionCorsHeaders(request, env);
+    if (!cors) return gatewayError(403, 'CRM_SESSION_CORS_ORIGIN_NOT_ALLOWED');
+    if (!crmSessionCorsPreflightAllowed(request)) return crmSessionError(request, env, 400, 'CRM_SESSION_CORS_PREFLIGHT_INVALID');
+    return new Response(null, {
+        status: 204,
+        headers: {
+            ...cors,
+            'access-control-allow-methods': 'GET',
+            'access-control-allow-headers': 'accept, cache-control',
+            'access-control-max-age': '300',
+            'cache-control': 'no-store',
+        },
+    });
+}
 
 function timekeepingServiceName(env) {
     return String(env?.ENVIRONMENT || '').trim().toLowerCase() === 'staging'
@@ -224,27 +287,29 @@ export function createApiGateway({
             ? async (request, env, ctx, productionReceipt = null) => {
                 if (!isCrmSessionPath(request)) return crmCoreHandler(request, env, ctx, productionReceipt);
                 if (!isCrmCoreStagingEnvironment(env)) return gatewayError(404, 'CRM_CORE_STAGING_ONLY');
+                if (!crmSessionOriginAllowed(request)) return gatewayError(403, 'CRM_SESSION_CORS_ORIGIN_NOT_ALLOWED');
+                if (request.method === 'OPTIONS') return crmSessionPreflight(request, env);
                 if (!isCrmSessionRequest(request)) {
                     return request.method === 'GET'
-                        ? gatewayError(400, 'CRM_SESSION_QUERY_NOT_ALLOWED')
-                        : gatewayError(405, 'CRM_SESSION_METHOD_NOT_ALLOWED');
+                        ? crmSessionError(request, env, 400, 'CRM_SESSION_QUERY_NOT_ALLOWED')
+                        : crmSessionError(request, env, 405, 'CRM_SESSION_METHOD_NOT_ALLOWED');
                 }
                 let auth;
                 try {
                     auth = await resolveActor(request, env);
                 } catch {
-                    return gatewayError(503, 'IDENTITY_UNAVAILABLE');
+                    return crmSessionError(request, env, 503, 'IDENTITY_UNAVAILABLE');
                 }
-                if (auth?.unavailable) return gatewayError(503, 'IDENTITY_UNAVAILABLE');
-                if (!auth?.actor) return gatewayError(401, 'CRM_IDENTITY_REQUIRED');
+                if (auth?.unavailable) return crmSessionError(request, env, 503, 'IDENTITY_UNAVAILABLE');
+                if (!auth?.actor) return crmSessionError(request, env, 401, 'CRM_IDENTITY_REQUIRED');
                 try {
                     const identityDelivery = await issueCrmSessionIdentityDelivery(request, env, auth.actor);
-                    return crmCoreHandler(request, env, ctx, { identityDelivery });
+                    return withCrmSessionCors(await crmCoreHandler(request, env, ctx, { identityDelivery }), request, env);
                 } catch (error) {
                     if (error instanceof TypeError && error.message === 'CRM_IDENTITY_SUBJECT_REQUIRED') {
-                        return gatewayError(403, 'CRM_IDENTITY_SUBJECT_REQUIRED');
+                        return crmSessionError(request, env, 403, 'CRM_IDENTITY_SUBJECT_REQUIRED');
                     }
-                    return gatewayError(503, 'CRM_IDENTITY_DELIVERY_UNAVAILABLE');
+                    return crmSessionError(request, env, 503, 'CRM_IDENTITY_DELIVERY_UNAVAILABLE');
                 }
             }
             : undefined,

--- a/api/test/gateway.test.mjs
+++ b/api/test/gateway.test.mjs
@@ -1011,6 +1011,67 @@ test('CRM session rejects query strings and non-GET requests before Identity or 
   assert.equal(resolverCalls, 0);
 });
 
+test('CRM session has an exact staging CORS preflight and never resolves Identity for it', async () => {
+  let resolverCalls = 0;
+  let coreCalls = 0;
+  const sessionGateway = createApiGateway({
+    inventoryHandler: async () => new Response('inventory-not-used'),
+    resolveActor: async () => { resolverCalls += 1; return { actor: null, csrf: null }; },
+    crmCoreHandler: async () => { coreCalls += 1; return new Response('must-not-run'); },
+  });
+  const preflight = await sessionGateway(new Request('https://api-staging.skincos.com.br/crm/session', {
+    method: 'OPTIONS',
+    headers: {
+      origin: 'https://crm-staging.skincos.com.br',
+      'access-control-request-method': 'GET',
+      'access-control-request-headers': 'cache-control',
+    },
+  }), { ENVIRONMENT: 'staging' }, {});
+  assert.equal(preflight.status, 204);
+  assert.equal(preflight.headers.get('access-control-allow-origin'), 'https://crm-staging.skincos.com.br');
+  assert.equal(preflight.headers.get('access-control-allow-credentials'), 'true');
+  assert.equal(preflight.headers.get('access-control-allow-methods'), 'GET');
+  assert.equal(preflight.headers.get('access-control-allow-headers'), 'accept, cache-control');
+  assert.equal(resolverCalls, 0);
+  assert.equal(coreCalls, 0);
+
+  const deniedHeader = await sessionGateway(new Request('https://api-staging.skincos.com.br/crm/session', {
+    method: 'OPTIONS',
+    headers: {
+      origin: 'https://crm-staging.skincos.com.br',
+      'access-control-request-method': 'GET',
+      'access-control-request-headers': 'authorization',
+    },
+  }), { ENVIRONMENT: 'staging' }, {});
+  assert.equal(deniedHeader.status, 400);
+  assert.equal((await deniedHeader.json()).error, 'CRM_SESSION_CORS_PREFLIGHT_INVALID');
+  assert.equal(deniedHeader.headers.get('access-control-allow-origin'), 'https://crm-staging.skincos.com.br');
+  assert.equal(resolverCalls, 0);
+  assert.equal(coreCalls, 0);
+});
+
+test('CRM session supplies credentialed CORS only to its exact staging origin', async () => {
+  let resolverCalls = 0;
+  const sessionGateway = createApiGateway({
+    inventoryHandler: async () => new Response('inventory-not-used'),
+    resolveActor: async () => { resolverCalls += 1; return { actor: null, csrf: null }; },
+  });
+  const allowed = await sessionGateway(new Request('https://api-staging.skincos.com.br/crm/session', {
+    headers: { origin: 'https://crm-staging.skincos.com.br' },
+  }), { ENVIRONMENT: 'staging' }, {});
+  assert.equal(allowed.status, 401);
+  assert.equal(allowed.headers.get('access-control-allow-origin'), 'https://crm-staging.skincos.com.br');
+  assert.equal(allowed.headers.get('access-control-allow-credentials'), 'true');
+
+  const denied = await sessionGateway(new Request('https://api-staging.skincos.com.br/crm/session', {
+    headers: { origin: 'https://untrusted.example' },
+  }), { ENVIRONMENT: 'staging' }, {});
+  assert.equal(denied.status, 403);
+  assert.equal((await denied.json()).error, 'CRM_SESSION_CORS_ORIGIN_NOT_ALLOWED');
+  assert.equal(denied.headers.get('access-control-allow-origin'), null);
+  assert.equal(resolverCalls, 1);
+});
+
 test('CRM session remains staging-only even when a production Core route is receipt-authorized', async () => {
   let resolverCalls = 0;
   let issuerCalls = 0;

--- a/api/test/gateway.test.mjs
+++ b/api/test/gateway.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { generateKeyPairSync, sign } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
+import { webcrypto } from 'node:crypto';
 import test from 'node:test';
 import { createGatewayHandler } from '../src/router.js';
 import { createApiGateway, forwardCrmCoreToService, forwardFinanceProbe, forwardFinanceToService, handleGatewayRequest, prepareTimekeepingRequest } from '../src/gateway.js';
@@ -8,6 +9,8 @@ import { createCrmCoreProductionReceiptSigningInput } from '../src/crm-core-prod
 import pontoCoreWorker from '../workers/ponto.js';
 import { verifySignedDomainContext } from '../../shared/service-adapters/signed-domain-context.js';
 import { resetBoundServiceResilienceForTest } from '../../shared/service-adapters/cloudflare-service-binding.js';
+
+if (!globalThis.crypto) Object.defineProperty(globalThis, 'crypto', { value: webcrypto, configurable: true });
 
 const calls = [];
 const crmProductionGatewayVersionId = '11111111-1111-4111-8111-111111111111';
@@ -826,7 +829,7 @@ test('CRM Core keeps its public staging mount with a narrow request-header allow
   assert.equal(received.headers.get('content-type'), 'application/json');
   assert.equal(received.headers.get('origin'), 'https://crm-staging.skincos.com.br');
   assert.equal(received.headers.get('x-request-id'), 'crm-core-gateway-1');
-  assert.equal(received.headers.get('x-identity-delivery'), 'identity-crm-delivery/v1.synthetic-envelope');
+  assert.equal(received.headers.get('x-identity-delivery'), null);
   for (const name of [
     'authorization',
     'cookie',
@@ -851,6 +854,190 @@ test('CRM Core keeps its public staging mount with a narrow request-header allow
   assert.equal(response.headers.get('x-skincos-gateway-environment'), 'staging');
   assert.equal(response.headers.get('x-skincos-gateway-version-id'), '22222222-2222-4222-8222-222222222222');
   resetBoundServiceResilienceForTest();
+});
+
+test('CRM session resolves Identity only at the staging gateway and forwards its minimal signed envelope', async () => {
+  resetBoundServiceResilienceForTest();
+  let issuerRequest = null;
+  let coreRequest = null;
+  let resolverCalls = 0;
+  const callerSecret = 'synthetic-crm-identity-caller-hmac-secret-2026';
+  const sessionGateway = createApiGateway({
+    inventoryHandler: async () => new Response('inventory-not-used'),
+    resolveActor: async (request) => {
+      resolverCalls += 1;
+      assert.equal(request.headers.get('cookie'), 'session=browser-only');
+      return {
+        actor: {
+          identitySubject: 'idn:session_identity_actor_0001',
+          username: 'must-not-cross',
+          email: 'private@example.invalid',
+          displayName: 'Private Identity',
+          role: 'GESTOR',
+          scopes: {
+            units: ['novo-hamburgo'],
+            modules: ['overview', 'clients'],
+            permissions: ['clients:read', 'overview:read'],
+          },
+        },
+        csrf: 'browser-csrf-not-forwarded',
+      };
+    },
+  });
+  const response = await sessionGateway(new Request('https://api-staging.skincos.com.br/crm/session', {
+    headers: {
+      accept: 'application/json',
+      authorization: 'Bearer browser-credential',
+      cookie: 'session=browser-only',
+      origin: 'https://crm-staging.skincos.com.br',
+      'x-csrf-token': 'browser-csrf-not-forwarded',
+      'x-identity-delivery': 'forged.browser.envelope',
+      'x-request-id': 'crm-session-gateway-1',
+    },
+  }), {
+    ENVIRONMENT: 'staging',
+    CRM_IDENTITY_ISSUER_CALLER_ENABLED: 'true',
+    CRM_IDENTITY_ISSUER_CALLER_ID: 'crm-api-staging-v1',
+    CRM_IDENTITY_ISSUER_CALLER_HMAC: callerSecret,
+    IDENTITY_CRM_ISSUER: {
+      fetch: async (request) => {
+        issuerRequest = request;
+        return new Response(JSON.stringify({
+          ok: true,
+          version: 'identity-crm-delivery/v1',
+          keyId: 'crm-staging-identity-2026-09',
+          compact: 'test.header.signature',
+        }), { headers: { 'content-type': 'application/json' } });
+      },
+    },
+    CRM_CORE: {
+      fetch: async (request) => {
+        coreRequest = request;
+        return new Response(JSON.stringify({ ok: true, identity: { identitySubject: 'idn:session_identity_actor_0001', role: 'GESTOR', scopes: {} }, requestId: 'crm-session-gateway-1' }), {
+          headers: { 'content-type': 'application/json' },
+        });
+      },
+    },
+  }, {});
+
+  assert.equal(response.status, 200);
+  assert.equal(resolverCalls, 1);
+  assert.ok(issuerRequest);
+  assert.ok(coreRequest);
+  assert.equal(new URL(issuerRequest.url).pathname, '/internal/identity-crm-delivery/v1/issue');
+  assert.equal(issuerRequest.headers.get('x-skincos-identity-issuer-caller'), 'crm-api-staging-v1');
+  assert.equal(issuerRequest.headers.get('cookie'), null);
+  assert.equal(issuerRequest.headers.get('authorization'), null);
+  assert.equal(issuerRequest.headers.get('x-identity-delivery'), null);
+  const rawIssuerBody = await issuerRequest.text();
+  const issuerPayload = JSON.parse(rawIssuerBody);
+  assert.deepEqual(issuerPayload.identity, {
+    identitySubject: 'idn:session_identity_actor_0001',
+    role: 'GESTOR',
+    scopes: {
+      units: ['novo-hamburgo'],
+      modules: ['clients', 'overview'],
+      permissions: ['clients:read', 'overview:read'],
+    },
+  });
+  assert.deepEqual(issuerPayload.request, { method: 'GET', target: '/api/crm/session', bodyBase64: '' });
+  assert.match(issuerPayload.jti, /^[A-Za-z0-9_-]{16,160}$/);
+  assert.doesNotMatch(rawIssuerBody, /must-not-cross|private@example|Private Identity|browser-csrf/i);
+  const hmacKey = await webcrypto.subtle.importKey('raw', new TextEncoder().encode(callerSecret), { name: 'HMAC', hash: 'SHA-256' }, false, ['verify']);
+  assert.equal(await webcrypto.subtle.verify(
+    'HMAC',
+    hmacKey,
+    Buffer.from(issuerRequest.headers.get('x-skincos-identity-issuer-auth'), 'base64url'),
+    new TextEncoder().encode(rawIssuerBody),
+  ), true);
+
+  assert.equal(new URL(coreRequest.url).pathname, '/crm/session');
+  assert.equal(coreRequest.headers.get('x-identity-delivery'), 'test.header.signature');
+  for (const name of ['cookie', 'authorization', 'x-csrf-token']) assert.equal(coreRequest.headers.get(name), null, name);
+  assert.equal(coreRequest.headers.get('x-request-id'), 'crm-session-gateway-1');
+  resetBoundServiceResilienceForTest();
+});
+
+test('CRM session remains unavailable by default and rejects an Identity actor without an opaque subject', async () => {
+  resetBoundServiceResilienceForTest();
+  let issuerCalls = 0;
+  let coreCalls = 0;
+  let actor = {
+    identitySubject: null,
+    role: 'GESTOR',
+    scopes: { units: ['novo-hamburgo'], modules: ['clients'], permissions: ['clients:read'] },
+  };
+  const sessionGateway = createApiGateway({
+    inventoryHandler: async () => new Response('inventory-not-used'),
+    resolveActor: async () => ({ actor, csrf: '' }),
+  });
+  const env = {
+    ENVIRONMENT: 'staging',
+    CRM_IDENTITY_ISSUER_CALLER_ENABLED: 'false',
+    CRM_IDENTITY_ISSUER_CALLER_ID: 'crm-api-staging-v1',
+    CRM_IDENTITY_ISSUER_CALLER_HMAC: 'synthetic-crm-identity-caller-hmac-secret-2026',
+    IDENTITY_CRM_ISSUER: { fetch: async () => { issuerCalls += 1; return new Response('must-not-run'); } },
+    CRM_CORE: { fetch: async () => { coreCalls += 1; return new Response('must-not-run'); } },
+  };
+
+  const subjectMissing = await sessionGateway(new Request('https://api-staging.skincos.com.br/crm/session'), { ...env, CRM_IDENTITY_ISSUER_CALLER_ENABLED: 'true' }, {});
+  assert.equal(subjectMissing.status, 403);
+  assert.equal((await subjectMissing.json()).error, 'CRM_IDENTITY_SUBJECT_REQUIRED');
+  assert.equal(issuerCalls, 0);
+  assert.equal(coreCalls, 0);
+
+  actor = { ...actor, identitySubject: 'idn:session_identity_actor_0001' };
+  const defaultOff = await sessionGateway(new Request('https://api-staging.skincos.com.br/crm/session'), env, {});
+  assert.equal(defaultOff.status, 503);
+  assert.equal((await defaultOff.json()).error, 'CRM_IDENTITY_DELIVERY_UNAVAILABLE');
+  assert.equal(issuerCalls, 0);
+  assert.equal(coreCalls, 0);
+  resetBoundServiceResilienceForTest();
+});
+
+test('CRM session rejects query strings and non-GET requests before Identity or Core is called', async () => {
+  let resolverCalls = 0;
+  const sessionGateway = createApiGateway({
+    inventoryHandler: async () => new Response('inventory-not-used'),
+    resolveActor: async () => { resolverCalls += 1; return { actor: null, csrf: null }; },
+    crmCoreHandler: async () => new Response('must-not-run'),
+  });
+  const query = await sessionGateway(new Request('https://api-staging.skincos.com.br/crm/session?unexpected=true'), { ENVIRONMENT: 'staging' }, {});
+  assert.equal(query.status, 400);
+  assert.equal((await query.json()).error, 'CRM_SESSION_QUERY_NOT_ALLOWED');
+  const post = await sessionGateway(new Request('https://api-staging.skincos.com.br/crm/session', { method: 'POST' }), { ENVIRONMENT: 'staging' }, {});
+  assert.equal(post.status, 405);
+  assert.equal((await post.json()).error, 'CRM_SESSION_METHOD_NOT_ALLOWED');
+  assert.equal(resolverCalls, 0);
+});
+
+test('CRM session remains staging-only even when a production Core route is receipt-authorized', async () => {
+  let resolverCalls = 0;
+  let issuerCalls = 0;
+  let receiptProbes = 0;
+  let coreForwards = 0;
+  const receipt = signedCrmProductionReceipt();
+  const response = await handleGatewayRequest(new Request('https://api.skincos.com.br/crm/session'), crmProductionEnvironment(receipt, {
+    CRM_IDENTITY_ISSUER_CALLER_ENABLED: 'true',
+    CRM_IDENTITY_ISSUER_CALLER_HMAC: 'synthetic-crm-identity-caller-hmac-secret-2026',
+    IDENTITY_CRM_ISSUER: { fetch: async () => { issuerCalls += 1; return new Response('must-not-run'); } },
+    CRM_CORE: {
+      fetch: async (request) => {
+        if (new URL(request.url).pathname === '/ready') {
+          receiptProbes += 1;
+          return new Response(JSON.stringify(crmCoreReceiptReadyBody(receipt)), { headers: { 'content-type': 'application/json' } });
+        }
+        coreForwards += 1;
+        return new Response('must-not-run');
+      },
+    },
+  }), {});
+  assert.equal(response.status, 404);
+  assert.equal((await response.json()).error, 'CRM_CORE_STAGING_ONLY');
+  assert.equal(receiptProbes, 1);
+  assert.equal(issuerCalls, 0);
+  assert.equal(coreForwards, 0);
+  assert.equal(resolverCalls, 0);
 });
 
 test('CRM Core keeps its Core-owned CORS origin while omitting unneeded preflight negotiation headers', async () => {
@@ -1054,5 +1241,8 @@ test('general API Worker binds CRM Core only in the staging environment', async 
   const config = await readFile(new URL('../wrangler.toml', import.meta.url), 'utf8');
   const productionConfig = config.slice(0, config.indexOf('[env.staging]'));
   assert.doesNotMatch(productionConfig, /binding\s*=\s*"CRM_CORE"/);
+  assert.doesNotMatch(productionConfig, /IDENTITY_CRM_ISSUER|CRM_IDENTITY_ISSUER_CALLER/);
   assert.match(config, /\[\[env\.staging\.services\]\]\r?\nbinding = "CRM_CORE"\r?\nservice = "skincos-crm-core-staging"/);
+  assert.match(config, /CRM_IDENTITY_ISSUER_CALLER_ENABLED\s*=\s*"false"/);
+  assert.match(config, /\[\[env\.staging\.services\]\]\r?\nbinding = "IDENTITY_CRM_ISSUER"\r?\nservice = "skincos-identity-crm-delivery-staging"/);
 });

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -81,6 +81,11 @@ binding = "CF_VERSION_METADATA"
 [env.staging.vars]
 APP_VERSION = "unreleased"
 ENVIRONMENT = "staging"
+# The persistent Identity caller remains off until a source-pinned staging
+# release enables both sides and provisions its separate HMAC through the
+# protected bootstrap. No production counterpart exists in this manifest.
+CRM_IDENTITY_ISSUER_CALLER_ENABLED = "false"
+CRM_IDENTITY_ISSUER_CALLER_ID = "crm-api-staging-v1"
 
 [[env.staging.durable_objects.bindings]]
 name = "RATE_LIMITER"
@@ -118,6 +123,14 @@ service = "skincos-finance-staging"
 [[env.staging.services]]
 binding = "CRM_CORE"
 service = "skincos-crm-core-staging"
+
+# Identity signs the one GET /crm/session capability through a private staging
+# binding. The browser never supplies an envelope and no production API worker
+# gets this binding. Provision CRM_IDENTITY_ISSUER_CALLER_HMAC only through the
+# protected staging secret bootstrap; it is intentionally absent from Git.
+[[env.staging.services]]
+binding = "IDENTITY_CRM_ISSUER"
+service = "skincos-identity-crm-delivery-staging"
 
 [[env.staging.r2_buckets]]
 binding = "BACKUP_BUCKET"

--- a/docs/extraction/crm-core-staging-api-gateway-mount.md
+++ b/docs/extraction/crm-core-staging-api-gateway-mount.md
@@ -22,16 +22,25 @@ binding. O Worker Core é o único componente que traduz esse caminho público
 para o alvo canônico privado `/api/crm/*`; não há redirecionamento ou fallback
 para `/inventory/*`.
 
-Antes de encaminhar, o gateway cria uma nova lista explícita de somente cinco
-cabeçalhos: `Accept`, `Content-Type`, `Origin`, `x-request-id` e
-`x-identity-delivery`. `Origin` permite a política CORS que pertence ao Core,
-`Content-Type`/`Accept` preservam a semântica HTTP do navegador e
-`x-request-id` preserva a correlação. O único envelope de identidade que pode
-prosseguir é `x-identity-delivery`; o Core continua responsável por verificar
-assinatura, alvo canônico, expiração e replay. Todo outro cabeçalho — inclusive
-`Cookie`, `Authorization`, CSRF, tokens de serviço, proxy/Cloudflare e futuros
-cabeçalhos de credencial — é descartado. Respostas também não encaminham
-`Set-Cookie`.
+Antes de encaminhar, o gateway cria uma nova lista explícita de somente quatro
+cabeçalhos públicos: `Accept`, `Content-Type`, `Origin` e `x-request-id`.
+`Origin` permite a política CORS que pertence ao Core, `Content-Type`/`Accept`
+preservam a semântica HTTP do navegador e `x-request-id` preserva a correlação.
+Um `x-identity-delivery` recebido do navegador nunca prossegue. Todo outro
+cabeçalho — inclusive `Cookie`, `Authorization`, CSRF, tokens de serviço,
+proxy/Cloudflare e futuros cabeçalhos de credencial — também é descartado.
+Respostas não encaminham `Set-Cookie`.
+
+`GET /crm/session` é a única capacidade de sessão adicionada a esse mount. O
+gateway central resolve a sessão Identity ainda dentro do seu limite privado,
+extrai somente `identitySubject` opaco, `role` e `scopes`, e pede ao emissor
+Identity de staging um envelope novo, via service binding e HMAC exclusivo do
+caller `crm-api-staging-v1`. O envelope emitido é então o único valor interno
+adicionado como `x-identity-delivery` para o Core. Ele é vinculado ao alvo
+exato `GET /api/crm/session`, sem query e sem corpo; o Core continua
+responsável pela assinatura, alvo canônico, expiração e proteção contra replay.
+Não há cookie, perfil, nome de usuário, e-mail ou envelope fornecido pelo
+navegador nesse tráfego.
 
 Assim, depois de uma publicação de staging explicitamente autorizada, os
 smokes sem identidade são:
@@ -44,6 +53,12 @@ GET https://api-staging.skincos.com.br/crm/ready
 Eles devem refletir o artefato e o D1 dedicados do CRM Core. A rota não ativa
 módulos, leituras de domínio ou escritas: o Core mantém esses caminhos fechados
 até que seus contratos e gates próprios estejam completos.
+
+Quando os três artefatos de staging estiverem no SHA liberado (gateway, emissor
+Identity e Core), a prova adicional é `GET /crm/session`: ela deve responder
+somente a projeção verificada `{ ok, identity, requestId }`, sem PII e sem
+cookie. Um caller ausente, uma sessão sem subject opaco, query, método diferente
+de `GET`, binding indisponível ou assinatura inválida devem falhar fechados.
 
 ## Readback da publicação de staging (2026-09-07)
 
@@ -74,15 +89,26 @@ gates/credenciais Cloudflare já custodidos pelo ambiente. Nenhum segredo novo
 do CRM Core é necessário para o service binding, mas a mudança não deve ser
 publicada fora desse fluxo.
 
+O caller persistente acrescenta dois segredos de staging com o mesmo valor
+interno gerado uma única vez: `CRM_IDENTITY_ISSUER_CALLER_HMAC` no gateway e
+`IDENTITY_CRM_DELIVERY_CALLER_HMAC` no emissor. Eles pertencem ao runtime
+Cloudflare, nunca ao Git, ao navegador ou ao Core. O HMAC de smoke já existente
+(`IDENTITY_CRM_DELIVERY_REQUEST_HMAC`) não é girado nem substituído. Ambos os
+manifestos mantêm o caller desligado por padrão; uma ativação exige deploy de
+staging no SHA exato, custódia confirmada nos dois Workers e readback da sessão
+autenticada e negada. Não existe flag, binding ou rota de produção para essa
+capacidade.
+
 Para próximas publicações, registrar a versão ativa de `skincos-api-staging` e
 o rollback correspondente; depois, conferir os dois smokes acima, a rejeição
 de `/api/crm/*`, a ausência de `Set-Cookie` e a preservação de todas as rotas
 Inventory, Finance e Ponto. A rota do shell `crm-staging.skincos.com.br`
 continua deliberadamente fora deste PR.
 
-## Pendência conhecida
+## Estado do caller persistente
 
-O emissor Identity de staging ainda não tem caller persistente sob custódia do
-CRM para emitir envelopes de navegação/negócio. Portanto este mount permite
-health/readiness sem credencial de identidade, mas não é uma ativação de UI,
-backfill, leitura de domínio, escrita ou cutover de produção.
+O contrato de caller persistente está implementado e coberto por testes no
+owner correto: o monorepo Identity/gateway. Ele permanece propositalmente
+desligado até a publicação coordenada dos três artefatos e a provisão de seus
+segredos internos. Mesmo depois do smoke de sessão, isto não ativa UI de
+negócio, backfill, leitura de domínio, escrita ou cutover de produção.

--- a/docs/extraction/crm-core-staging-api-gateway-mount.md
+++ b/docs/extraction/crm-core-staging-api-gateway-mount.md
@@ -42,6 +42,17 @@ responsável pela assinatura, alvo canônico, expiração e proteção contra re
 Não há cookie, perfil, nome de usuário, e-mail ou envelope fornecido pelo
 navegador nesse tráfego.
 
+O único navegador autorizado para essa capacidade de staging é
+`https://crm-staging.skincos.com.br`. O gateway responde CORS com credenciais
+somente para essa origem e inclui as falhas de sessão nessa mesma política, para
+que o Console possa distinguir uma sessão ausente de uma falha de rede. O
+preflight é limitado a `GET` e aos cabeçalhos `Accept` e `Cache-Control`; ele
+não resolve Identity, não emite envelope e não chama o Core. Qualquer outra
+origem, método ou cabeçalho é recusado sem ampliar a superfície CORS. Quando
+um pedido de navegador traz uma origem diferente, ele também é recusado antes
+de consultar Identity ou o Core; pedidos internos sem `Origin` preservam a
+capacidade de smoke sintético autenticado por serviço.
+
 Assim, depois de uma publicação de staging explicitamente autorizada, os
 smokes sem identidade são:
 
@@ -112,3 +123,27 @@ owner correto: o monorepo Identity/gateway. Ele permanece propositalmente
 desligado até a publicação coordenada dos três artefatos e a provisão de seus
 segredos internos. Mesmo depois do smoke de sessão, isto não ativa UI de
 negócio, backfill, leitura de domínio, escrita ou cutover de produção.
+
+O workflow canônico `.github/workflows/identity-crm-delivery.yml` torna essa
+prova repetível sem adicionar autoridade de produção. Ele aceita apenas um SHA
+que já seja `main` e separa as operações em quatro etapas deliberadas:
+
+- `bootstrap` gera uma única chave HMAC interna somente quando os dois nomes de
+  segredo ainda não existem, grava-a nos dois Workers de staging sob a custódia
+  global existente e deixa ambos os callers desativados;
+- `activate` exige o SHA e o digest do Core que já estejam visíveis no readback
+  externo, captura as versões incumbentes, habilita primeiro o emissor e depois
+  o gateway, e restaura apenas uma versão que ainda esteja sob sua posse caso a
+  ativação falhe;
+- `session-smoke` cria uma identidade estritamente sintética no D1 de staging,
+  comprova login e `GET /crm/session` sem cookie ou PII no relatório, e remove
+  a fixture no mesmo run mesmo se o smoke falhar;
+- `disable` desativa primeiro o caller do gateway e depois o emissor, sem
+  apagar a chave necessária para uma recuperação controlada.
+
+Cada mutação revalida o lease `global:ponto-workers-writer` ou
+`global:staging-d1` imediatamente antes de ocorrer. A automação está pronta
+como código, mas não é uma autorização para executá-la: enquanto o Core de
+staging estiver em reconciliação concorrente, nenhum bootstrap, ativação ou
+smoke autenticado deve ser despachado. Não há operação, segredo ou alvo de
+produção nesse fluxo.

--- a/identity/delivery/crm-issuer-staging-worker.js
+++ b/identity/delivery/crm-issuer-staging-worker.js
@@ -19,6 +19,13 @@ const stagingWorker = createIdentityCrmIssuerWorker({
     auth: 'IDENTITY_STAGING_REQUEST_AUTH_INVALID',
     crypto: 'IDENTITY_STAGING_CRYPTO_UNAVAILABLE',
   },
+  caller: {
+    enabled: 'IDENTITY_CRM_DELIVERY_CALLER_ENABLED',
+    id: 'IDENTITY_CRM_DELIVERY_CALLER_ID',
+    hmac: 'IDENTITY_CRM_DELIVERY_CALLER_HMAC',
+    expectedId: 'crm-api-staging-v1',
+    header: 'x-skincos-identity-issuer-caller',
+  },
 });
 
 export default { fetch: stagingWorker };

--- a/identity/delivery/crm-issuer-worker-runtime.js
+++ b/identity/delivery/crm-issuer-worker-runtime.js
@@ -200,6 +200,22 @@ function assertSecretNames(secretNames) {
   return secretNames;
 }
 
+function assertCallerConfig(caller) {
+  if (caller === undefined || caller === null) return null;
+  const required = ['enabled', 'id', 'hmac', 'expectedId', 'header'];
+  if (!caller || typeof caller !== 'object'
+    || required.some((name) => typeof caller[name] !== 'string' || !caller[name])) {
+    throw new TypeError('IDENTITY_CALLER_CONFIG_INVALID');
+  }
+  return Object.freeze({
+    enabled: caller.enabled,
+    id: caller.id,
+    hmac: caller.hmac,
+    expectedId: caller.expectedId,
+    header: caller.header,
+  });
+}
+
 /**
  * Creates an isolated Identity CRM delivery Worker handler. The profile is
  * deliberately explicit: a Worker can enable signing only when both its
@@ -221,11 +237,13 @@ export function createIdentityCrmIssuerWorker({
     publicJwk: 'IDENTITY_CRM_DELIVERY_PUBLIC_JWK',
     requestHmac: 'IDENTITY_CRM_DELIVERY_REQUEST_HMAC',
   },
+  caller = null,
 } = {}) {
   if (typeof environment !== 'string' || !environment) throw new TypeError('IDENTITY_WORKER_ENVIRONMENT_INVALID');
   if (typeof keyIdPrefix !== 'string' || !keyIdPrefix) throw new TypeError('IDENTITY_KEY_PREFIX_INVALID');
   if (!['single', 'production-ring'].includes(publicKeyMode)) throw new TypeError('IDENTITY_PUBLIC_KEY_MODE_INVALID');
   const names = assertSecretNames(secretNames);
+  const callerConfig = assertCallerConfig(caller);
 
   function enabled(env) {
     return env?.IDENTITY_CRM_DELIVERY_ENABLED === 'true'
@@ -249,11 +267,24 @@ export function createIdentityCrmIssuerWorker({
       })();
     if (privateJwk.x !== publicKeyRing.activeJwk.x) fail('IDENTITY_PUBLIC_KEY_MISMATCH');
     if (TEXT_ENCODER.encode(env[names.requestHmac]).byteLength < 32) fail(errorCodes.auth);
+    let callerMaterial = null;
+    if (callerConfig && env[callerConfig.enabled] === 'true') {
+      const callerId = String(env[callerConfig.id] || '').trim();
+      const callerHmac = env[callerConfig.hmac];
+      if (callerId !== callerConfig.expectedId
+        || typeof callerHmac !== 'string'
+        || callerHmac.trim() !== callerHmac
+        || TEXT_ENCODER.encode(callerHmac).byteLength < 32) {
+        fail(errorCodes.custody);
+      }
+      callerMaterial = Object.freeze({ id: callerId, hmac: callerHmac, header: callerConfig.header });
+    }
     return Object.freeze({
       kid,
       privateJwk,
       publicKeys: publicKeyRing.keys,
       requestHmac: env[names.requestHmac],
+      caller: callerMaterial,
     });
   }
 
@@ -303,7 +334,13 @@ export function createIdentityCrmIssuerWorker({
     const rawBody = await request.text();
     if (TEXT_ENCODER.encode(rawBody).byteLength > MAX_REQUEST_BYTES) return json({ ok: false, error: 'REQUEST_TOO_LARGE' }, 413);
     try {
-      if (!await isAuthorizedIssueRequest(request, rawBody, material.requestHmac, errorCodes.auth, errorCodes.crypto)) return json({ ok: false, error: 'UNAUTHORIZED' }, 401);
+      const requestedCallerId = callerConfig ? request.headers.get(callerConfig.header) : null;
+      const requestHmac = requestedCallerId === null
+        ? material.requestHmac
+        : material.caller?.id === requestedCallerId
+          ? material.caller.hmac
+          : null;
+      if (!requestHmac || !await isAuthorizedIssueRequest(request, rawBody, requestHmac, errorCodes.auth, errorCodes.crypto)) return json({ ok: false, error: 'UNAUTHORIZED' }, 401);
     } catch {
       return json({ ok: false, error: 'UNAUTHORIZED' }, 401);
     }

--- a/identity/test/crm-issuer-staging-worker.test.mjs
+++ b/identity/test/crm-issuer-staging-worker.test.mjs
@@ -11,6 +11,7 @@ if (!globalThis.crypto) Object.defineProperty(globalThis, 'crypto', { value: web
 const issueUrl = 'https://identity-crm-delivery-staging.example/internal/identity-crm-delivery/v1/issue';
 const keysUrl = 'https://identity-crm-delivery-staging.example/.well-known/identity-crm-delivery/v1/keys';
 const secret = 'synthetic-staging-request-hmac-secret-2026';
+const callerSecret = 'synthetic-crm-api-staging-caller-hmac-secret-2026';
 
 function encodeBase64Url(bytes) {
   let binary = '';
@@ -18,10 +19,10 @@ function encodeBase64Url(bytes) {
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 }
 
-async function authHeader(body) {
+async function authHeader(body, signingSecret = secret) {
   const key = await webcrypto.subtle.importKey(
     'raw',
-    new TextEncoder().encode(secret),
+    new TextEncoder().encode(signingSecret),
     { name: 'HMAC', hash: 'SHA-256' },
     false,
     ['sign'],
@@ -92,6 +93,8 @@ test('staging issuer rejects a key id from another environment', async () => {
 test('staging manifest has no production route or data binding and keeps signing disabled', async () => {
   const manifest = await readFile(new URL('../wrangler.staging.toml', import.meta.url), 'utf8');
   assert.match(manifest, /IDENTITY_CRM_DELIVERY_ENABLED\s*=\s*"false"/);
+  assert.match(manifest, /IDENTITY_CRM_DELIVERY_CALLER_ENABLED\s*=\s*"false"/);
+  assert.match(manifest, /IDENTITY_CRM_DELIVERY_CALLER_ID\s*=\s*"crm-api-staging-v1"/);
   assert.doesNotMatch(manifest, /^routes\s*=/m);
   assert.doesNotMatch(manifest, /^\[\[d1_databases\]\]/m);
   assert.doesNotMatch(manifest, /^\[\[kv_namespaces\]\]/m);
@@ -154,4 +157,77 @@ test('staging issue endpoint rejects unauthenticated callers and unknown routes'
 
   const unknown = await handleIdentityCrmIssuerStagingRequest(new Request('https://identity-crm-delivery-staging.example/internal/other', { method: 'POST' }), env);
   assert.equal(unknown.status, 404);
+});
+
+test('staging issuer accepts the dedicated CRM API caller without rotating the existing smoke HMAC', async () => {
+  const { env } = await stagingEnv();
+  const callerEnv = {
+    ...env,
+    IDENTITY_CRM_DELIVERY_CALLER_ENABLED: 'true',
+    IDENTITY_CRM_DELIVERY_CALLER_ID: 'crm-api-staging-v1',
+    IDENTITY_CRM_DELIVERY_CALLER_HMAC: callerSecret,
+  };
+  const payload = JSON.stringify(issuePayload());
+  const callerAuth = await authHeader(payload, callerSecret);
+  const callerResponse = await handleIdentityCrmIssuerStagingRequest(new Request(issueUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-skincos-identity-issuer-caller': 'crm-api-staging-v1',
+      'x-skincos-identity-issuer-auth': callerAuth,
+    },
+    body: payload,
+  }), callerEnv);
+  assert.equal(callerResponse.status, 200);
+  const callerResult = await callerResponse.json();
+  assert.equal(callerResult.ok, true);
+  assert.equal(JSON.stringify(callerResult).includes(callerSecret), false);
+
+  const legacyAuth = await authHeader(payload);
+  const legacyResponse = await handleIdentityCrmIssuerStagingRequest(new Request(issueUrl, {
+    method: 'POST',
+    headers: { 'x-skincos-identity-issuer-auth': legacyAuth },
+    body: payload,
+  }), callerEnv);
+  assert.equal(legacyResponse.status, 200);
+});
+
+test('staging issuer fails closed for a caller id or caller HMAC outside its explicit custody', async () => {
+  const { env } = await stagingEnv();
+  const payload = JSON.stringify(issuePayload());
+  const enabled = {
+    ...env,
+    IDENTITY_CRM_DELIVERY_CALLER_ENABLED: 'true',
+    IDENTITY_CRM_DELIVERY_CALLER_ID: 'crm-api-staging-v1',
+    IDENTITY_CRM_DELIVERY_CALLER_HMAC: callerSecret,
+  };
+  const wrongCaller = await handleIdentityCrmIssuerStagingRequest(new Request(issueUrl, {
+    method: 'POST',
+    headers: {
+      'x-skincos-identity-issuer-caller': 'other-worker-v1',
+      'x-skincos-identity-issuer-auth': await authHeader(payload, callerSecret),
+    },
+    body: payload,
+  }), enabled);
+  assert.equal(wrongCaller.status, 401);
+
+  const wrongHmac = await handleIdentityCrmIssuerStagingRequest(new Request(issueUrl, {
+    method: 'POST',
+    headers: {
+      'x-skincos-identity-issuer-caller': 'crm-api-staging-v1',
+      'x-skincos-identity-issuer-auth': await authHeader(payload),
+    },
+    body: payload,
+  }), enabled);
+  assert.equal(wrongHmac.status, 401);
+
+  const callerDisabled = await handleIdentityCrmIssuerStagingRequest(new Request(issueUrl, {
+    method: 'POST',
+    headers: {
+      'x-skincos-identity-issuer-caller': 'crm-api-staging-v1',
+      'x-skincos-identity-issuer-auth': await authHeader(payload, callerSecret),
+    },
+    body: payload,
+  }), env);
+  assert.equal(callerDisabled.status, 401);
 });

--- a/identity/wrangler.staging.toml
+++ b/identity/wrangler.staging.toml
@@ -11,6 +11,8 @@ preview_urls = false
 [vars]
 IDENTITY_CRM_DELIVERY_ENABLED = "false"
 IDENTITY_CRM_DELIVERY_ENVIRONMENT = "staging"
+IDENTITY_CRM_DELIVERY_CALLER_ENABLED = "false"
+IDENTITY_CRM_DELIVERY_CALLER_ID = "crm-api-staging-v1"
 
 [env.staging]
 name = "skincos-identity-crm-delivery-staging"
@@ -24,6 +26,8 @@ preview_urls = false
 [env.staging.vars]
 IDENTITY_CRM_DELIVERY_ENABLED = "false"
 IDENTITY_CRM_DELIVERY_ENVIRONMENT = "staging"
+IDENTITY_CRM_DELIVERY_CALLER_ENABLED = "false"
+IDENTITY_CRM_DELIVERY_CALLER_ID = "crm-api-staging-v1"
 
 # Before any staging enablement, provision these values through the protected
 # secret manager, never through this file or Git:
@@ -31,3 +35,4 @@ IDENTITY_CRM_DELIVERY_ENVIRONMENT = "staging"
 #   wrangler secret put IDENTITY_CRM_DELIVERY_PRIVATE_JWK --env staging
 #   wrangler secret put IDENTITY_CRM_DELIVERY_PUBLIC_JWK --env staging
 #   wrangler secret put IDENTITY_CRM_DELIVERY_REQUEST_HMAC --env staging
+#   wrangler secret put IDENTITY_CRM_DELIVERY_CALLER_HMAC --env staging

--- a/platform/deploy/operational-units.json
+++ b/platform/deploy/operational-units.json
@@ -20,6 +20,23 @@
       }
     },
     {
+      "id": "identity-crm-delivery-staging",
+      "workflow": ".github/workflows/identity-crm-delivery.yml",
+      "concurrencyPrefix": "identity-crm-delivery-",
+      "publishes": ["Worker:skincos-identity-crm-delivery-staging"],
+      "resources": ["Identity CRM delivery staging signer", "restricted CRM session caller configuration on the staging API Worker", "synthetic Identity session smoke fixture"],
+      "secrets": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "SKINCOS_GLOBAL_COORDINATION_ACTIVE_KEY", "CRM_IDENTITY_ISSUER_CALLER_HMAC", "IDENTITY_CRM_DELIVERY_CALLER_HMAC"],
+      "migrationPaths": [],
+      "environments": ["staging"],
+      "promotion": {
+        "stagingSupported": true,
+        "publisherType": "restricted-staging-identity-delivery",
+        "stagingOnly": true,
+        "featureFlagDefault": "disabled",
+        "rollback": "Disable the API caller and Identity issuer caller while retaining the internally generated HMAC only for controlled recovery."
+      }
+    },
+    {
       "id": "ponto-core-baseline",
       "workflow": ".github/workflows/ponto-core-baseline-publisher.yml",
       "concurrencyPrefix": "ponto-surface-mutation",

--- a/scripts/crm-identity-staging-caller-runtime-readback.mjs
+++ b/scripts/crm-identity-staging-caller-runtime-readback.mjs
@@ -1,0 +1,152 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const VERSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const ACCOUNT_ID_PATTERN = /^[0-9a-f]{32}$/i;
+const REQUEST_TIMEOUT_MS = 15_000;
+
+const API_RUNTIME = Object.freeze({
+    label: 'api',
+    script: 'skincos-api-staging',
+    expectedPlainTextBindings: Object.freeze({
+        ENVIRONMENT: 'staging',
+        CRM_IDENTITY_ISSUER_CALLER_ENABLED: 'false',
+        CRM_IDENTITY_ISSUER_CALLER_ID: 'crm-api-staging-v1',
+    }),
+});
+
+const ISSUER_RUNTIME = Object.freeze({
+    label: 'issuer',
+    script: 'skincos-identity-crm-delivery-staging',
+    expectedPlainTextBindings: Object.freeze({
+        IDENTITY_CRM_DELIVERY_ENABLED: 'false',
+        IDENTITY_CRM_DELIVERY_ENVIRONMENT: 'staging',
+        IDENTITY_CRM_DELIVERY_CALLER_ENABLED: 'false',
+        IDENTITY_CRM_DELIVERY_CALLER_ID: 'crm-api-staging-v1',
+    }),
+});
+
+function fail(code) {
+    throw new Error(code);
+}
+
+function activeVersion(deployment, runtime) {
+    const versions = Array.isArray(deployment?.versions) ? deployment.versions : [];
+    if (versions.length !== 1 || Number(versions[0]?.percentage) !== 100) {
+        fail(`${runtime.label}_ACTIVE_DEPLOYMENT_INVALID`);
+    }
+    const version = String(versions[0]?.version_id || '').toLowerCase();
+    if (!VERSION_ID_PATTERN.test(version)) fail(`${runtime.label}_ACTIVE_VERSION_INVALID`);
+    return version;
+}
+
+function exactPlainTextBinding(versionDetail, runtime, activeVersionId, name, expected) {
+    if (versionDetail?.success !== true || String(versionDetail?.result?.id || '').toLowerCase() !== activeVersionId) {
+        fail(`${runtime.label}_VERSION_DETAIL_INVALID`);
+    }
+    const bindings = versionDetail?.result?.resources?.bindings;
+    if (!Array.isArray(bindings)) fail(`${runtime.label}_VERSION_BINDINGS_INVALID`);
+    const matches = bindings.filter((binding) => binding?.name === name);
+    if (matches.length !== 1 || matches[0]?.type !== 'plain_text' || String(matches[0]?.text) !== expected) {
+        fail(`${runtime.label}_${name}_MISMATCH`);
+    }
+}
+
+function verifyRuntime(deployment, versionDetail, runtime) {
+    const version = activeVersion(deployment, runtime);
+    for (const [name, expected] of Object.entries(runtime.expectedPlainTextBindings)) {
+        exactPlainTextBinding(versionDetail, runtime, version, name, expected);
+    }
+    return Object.freeze({
+        script: runtime.script,
+        activeVersion: version,
+    });
+}
+
+/**
+ * Verify public plain-text bindings on the exact active versions. Secret-text
+ * bindings are never returned or written by this helper.
+ */
+export function verifyActiveRuntimeState({ apiDeployment, issuerDeployment, apiVersionDetail, issuerVersionDetail }) {
+    const api = verifyRuntime(apiDeployment, apiVersionDetail, API_RUNTIME);
+    const issuer = verifyRuntime(issuerDeployment, issuerVersionDetail, ISSUER_RUNTIME);
+    return Object.freeze({
+        schemaVersion: 1,
+        state: 'disabled',
+        observation: 'exact-active-worker-version-bindings',
+        api: Object.freeze({
+            ...api,
+            callerEnabled: false,
+            callerId: 'crm-api-staging-v1',
+        }),
+        issuer: Object.freeze({
+            ...issuer,
+            deliveryEnabled: false,
+            callerEnabled: false,
+            callerId: 'crm-api-staging-v1',
+        }),
+    });
+}
+
+async function fetchVersionDetail(fetchImpl, accountId, token, runtime, version) {
+    const response = await fetchImpl(
+        `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/workers/scripts/${encodeURIComponent(runtime.script)}/versions/${encodeURIComponent(version)}`,
+        {
+            headers: {
+                accept: 'application/json',
+                authorization: `Bearer ${token}`,
+            },
+            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        },
+    );
+    if (!response.ok) fail(`${runtime.label}_VERSION_READBACK_FAILED`);
+    try {
+        return await response.json();
+    } catch {
+        fail(`${runtime.label}_VERSION_READBACK_INVALID`);
+    }
+}
+
+export async function readActiveRuntimeState({ apiDeployment, issuerDeployment, accountId, token, fetchImpl = globalThis.fetch }) {
+    if (!ACCOUNT_ID_PATTERN.test(String(accountId || ''))) fail('CLOUDFLARE_ACCOUNT_ID_INVALID');
+    if (typeof token !== 'string' || token.length === 0) fail('CLOUDFLARE_API_TOKEN_MISSING');
+    if (typeof fetchImpl !== 'function') fail('CLOUDFLARE_FETCH_UNAVAILABLE');
+
+    const apiVersion = activeVersion(apiDeployment, API_RUNTIME);
+    const issuerVersion = activeVersion(issuerDeployment, ISSUER_RUNTIME);
+    const [apiVersionDetail, issuerVersionDetail] = await Promise.all([
+        fetchVersionDetail(fetchImpl, accountId, token, API_RUNTIME, apiVersion),
+        fetchVersionDetail(fetchImpl, accountId, token, ISSUER_RUNTIME, issuerVersion),
+    ]);
+    return verifyActiveRuntimeState({ apiDeployment, issuerDeployment, apiVersionDetail, issuerVersionDetail });
+}
+
+async function readJson(path) {
+    return JSON.parse(await readFile(path, 'utf8'));
+}
+
+const invokedDirectly = process.argv[1]
+    && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+
+if (invokedDirectly) {
+    const [apiDeploymentPath, issuerDeploymentPath] = process.argv.slice(2);
+    try {
+        if (!apiDeploymentPath || !issuerDeploymentPath || process.argv.length !== 4) fail('USAGE');
+        const [apiDeployment, issuerDeployment] = await Promise.all([
+            readJson(apiDeploymentPath),
+            readJson(issuerDeploymentPath),
+        ]);
+        const report = await readActiveRuntimeState({
+            apiDeployment,
+            issuerDeployment,
+            accountId: process.env.CLOUDFLARE_ACCOUNT_ID,
+            token: process.env.CLOUDFLARE_API_TOKEN,
+        });
+        process.stdout.write(`${JSON.stringify(report)}\n`);
+    } catch (error) {
+        const code = error instanceof Error && /^[A-Z0-9_]+$/.test(error.message) ? error.message : 'READBACK_FAILED';
+        process.stderr.write(`CRM Identity staging runtime readback failed: ${code}\n`);
+        process.exitCode = 1;
+    }
+}

--- a/scripts/crm-identity-staging-session-smoke.mjs
+++ b/scripts/crm-identity-staging-session-smoke.mjs
@@ -1,0 +1,215 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const EXPECTED_ORIGIN = 'https://api-staging.skincos.com.br';
+const ERROR_PATTERN = /^[A-Z0-9_]{3,120}$/;
+
+function fail(code) {
+  throw new Error(code);
+}
+
+function plainObject(value, code) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) fail(code);
+  return value;
+}
+
+function exactKeys(value, keys, code) {
+  plainObject(value, code);
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) fail(code);
+  return value;
+}
+
+function parseJson(text, code) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    fail(code);
+  }
+}
+
+function assertStagingOrigin(value) {
+  let url;
+  try {
+    url = new URL(String(value || ''));
+  } catch {
+    fail('CRM_SESSION_SMOKE_ORIGIN_INVALID');
+  }
+  if (url.origin !== EXPECTED_ORIGIN || url.pathname !== '/' || url.search || url.hash) fail('CRM_SESSION_SMOKE_ORIGIN_INVALID');
+  return url.origin;
+}
+
+function loadScenario(fixturesPath) {
+  if (typeof fixturesPath !== 'string' || !fixturesPath) fail('CRM_SESSION_SMOKE_FIXTURES_REQUIRED');
+  const fixtures = parseJson(fs.readFileSync(fixturesPath, 'utf8'), 'CRM_SESSION_SMOKE_FIXTURES_INVALID');
+  plainObject(fixtures, 'CRM_SESSION_SMOKE_FIXTURES_INVALID');
+  if (fixtures.environment !== 'staging' || !Array.isArray(fixtures.scenarios)) fail('CRM_SESSION_SMOKE_FIXTURES_INVALID');
+  const scenario = fixtures.scenarios.find((candidate) => candidate?.id === 'nh');
+  exactKeys(scenario, ['allowedUnits', 'email', 'expectedUnits', 'id', 'identitySubject', 'password', 'role', 'username'], 'CRM_SESSION_SMOKE_FIXTURES_INVALID');
+  if (
+    typeof scenario.email !== 'string'
+    || typeof scenario.password !== 'string'
+    || typeof scenario.username !== 'string'
+    || typeof scenario.identitySubject !== 'string'
+    || !/^idn:[A-Za-z0-9_-]{16,160}$/.test(scenario.identitySubject)
+    || typeof scenario.role !== 'string'
+    || !Array.isArray(scenario.expectedUnits)
+  ) fail('CRM_SESSION_SMOKE_FIXTURES_INVALID');
+  return scenario;
+}
+
+function setCookies(response) {
+  if (typeof response?.headers?.getSetCookie === 'function') return response.headers.getSetCookie();
+  const fallback = response?.headers?.get('set-cookie');
+  return fallback ? [fallback] : [];
+}
+
+function cookieHeader(response) {
+  const pairs = setCookies(response).map((line) => String(line).split(';', 1)[0]).filter(Boolean);
+  if (!pairs.length || pairs.some((pair) => !/^[^=;\s]+=[^;\s]+$/.test(pair))) fail('CRM_SESSION_SMOKE_LOGIN_COOKIE_MISSING');
+  return pairs.join('; ');
+}
+
+function assertNoCookie(response, code) {
+  if (setCookies(response).length || response.headers.get('set-cookie')) fail(code);
+}
+
+async function jsonResponse(response, code) {
+  if (!response || typeof response.status !== 'number') fail(code);
+  return parseJson(await response.text(), code);
+}
+
+function assertGatewayError(payload, expected) {
+  exactKeys(payload, ['error', 'ok'], 'CRM_SESSION_SMOKE_GATEWAY_RESPONSE_INVALID');
+  if (payload.ok !== false || payload.error !== expected) fail('CRM_SESSION_SMOKE_GATEWAY_RESPONSE_INVALID');
+}
+
+function assertVerifiedSession(payload, scenario) {
+  exactKeys(payload, ['identity', 'ok', 'requestId'], 'CRM_SESSION_SMOKE_RESPONSE_INVALID');
+  if (payload.ok !== true || typeof payload.requestId !== 'string' || !payload.requestId) fail('CRM_SESSION_SMOKE_RESPONSE_INVALID');
+  exactKeys(payload.identity, ['identitySubject', 'role', 'scopes'], 'CRM_SESSION_SMOKE_RESPONSE_INVALID');
+  const { identity } = payload;
+  if (identity.identitySubject !== scenario.identitySubject || identity.role !== scenario.role) fail('CRM_SESSION_SMOKE_ACTOR_MISMATCH');
+  exactKeys(identity.scopes, ['modules', 'permissions', 'units'], 'CRM_SESSION_SMOKE_RESPONSE_INVALID');
+  for (const scope of Object.values(identity.scopes)) {
+    if (!Array.isArray(scope) || scope.some((item) => typeof item !== 'string')) fail('CRM_SESSION_SMOKE_RESPONSE_INVALID');
+  }
+  if (JSON.stringify(identity.scopes.units) !== JSON.stringify(scenario.expectedUnits)) fail('CRM_SESSION_SMOKE_SCOPE_MISMATCH');
+  return identity;
+}
+
+function safeFailureCode(error) {
+  const candidate = error instanceof Error ? error.message : '';
+  return ERROR_PATTERN.test(candidate) ? candidate : 'CRM_SESSION_SMOKE_FAILED';
+}
+
+function writeReport(reportPath, report) {
+  if (typeof reportPath !== 'string' || !reportPath) return;
+  fs.mkdirSync(path.dirname(path.resolve(reportPath)), { recursive: true });
+  fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 });
+}
+
+/**
+ * Runs a staging-only, synthetic end-to-end check. The ephemeral session cookie
+ * remains only in this process and is deliberately never saved, logged, passed
+ * to CRM Core, or represented in the sanitised report.
+ */
+export async function runCrmIdentityStagingSessionSmoke({
+  fetchImpl = globalThis.fetch,
+  fixturesPath = process.env.CRM_IDENTITY_SMOKE_FIXTURES,
+  reportPath = process.env.CRM_IDENTITY_SMOKE_REPORT,
+  apiOrigin = process.env.CRM_IDENTITY_SMOKE_API_ORIGIN || EXPECTED_ORIGIN,
+  now = () => new Date().toISOString(),
+} = {}) {
+  if (typeof fetchImpl !== 'function') fail('CRM_SESSION_SMOKE_FETCH_UNAVAILABLE');
+  const origin = assertStagingOrigin(apiOrigin);
+  const scenario = loadScenario(fixturesPath);
+  const report = {
+    schemaVersion: 1,
+    environment: 'staging',
+    apiOrigin: origin,
+    at: now(),
+    credentialMaterialIncluded: false,
+    piiIncluded: false,
+  };
+
+  try {
+    const anonymous = await fetchImpl(`${origin}/crm/session`, {
+      method: 'GET', headers: { accept: 'application/json', 'cache-control': 'no-store' }, redirect: 'manual',
+    });
+    assertNoCookie(anonymous, 'CRM_SESSION_SMOKE_ANONYMOUS_SET_COOKIE');
+    if (anonymous.status !== 401) fail('CRM_SESSION_SMOKE_ANONYMOUS_STATUS_INVALID');
+    assertGatewayError(await jsonResponse(anonymous, 'CRM_SESSION_SMOKE_ANONYMOUS_RESPONSE_INVALID'), 'CRM_IDENTITY_REQUIRED');
+
+    const query = await fetchImpl(`${origin}/crm/session?unexpected=1`, {
+      method: 'GET', headers: { accept: 'application/json', 'cache-control': 'no-store' }, redirect: 'manual',
+    });
+    assertNoCookie(query, 'CRM_SESSION_SMOKE_QUERY_SET_COOKIE');
+    if (query.status !== 400) fail('CRM_SESSION_SMOKE_QUERY_STATUS_INVALID');
+    assertGatewayError(await jsonResponse(query, 'CRM_SESSION_SMOKE_QUERY_RESPONSE_INVALID'), 'CRM_SESSION_QUERY_NOT_ALLOWED');
+
+    const method = await fetchImpl(`${origin}/crm/session`, {
+      method: 'POST', headers: { accept: 'application/json', 'content-type': 'application/json', 'cache-control': 'no-store' }, body: '{}', redirect: 'manual',
+    });
+    assertNoCookie(method, 'CRM_SESSION_SMOKE_METHOD_SET_COOKIE');
+    if (method.status !== 405) fail('CRM_SESSION_SMOKE_METHOD_STATUS_INVALID');
+    assertGatewayError(await jsonResponse(method, 'CRM_SESSION_SMOKE_METHOD_RESPONSE_INVALID'), 'CRM_SESSION_METHOD_NOT_ALLOWED');
+
+    const login = await fetchImpl(`${origin}/auth/login`, {
+      method: 'POST',
+      headers: { accept: 'application/json', 'content-type': 'application/json', 'cache-control': 'no-store' },
+      body: JSON.stringify({ email: scenario.email, password: scenario.password }),
+      redirect: 'manual',
+    });
+    if (login.status !== 200) fail('CRM_SESSION_SMOKE_LOGIN_STATUS_INVALID');
+    const loginPayload = await jsonResponse(login, 'CRM_SESSION_SMOKE_LOGIN_RESPONSE_INVALID');
+    if (!loginPayload || typeof loginPayload !== 'object' || loginPayload.success === false) fail('CRM_SESSION_SMOKE_LOGIN_RESPONSE_INVALID');
+    const cookie = cookieHeader(login);
+
+    const session = await fetchImpl(`${origin}/crm/session`, {
+      method: 'GET', headers: { accept: 'application/json', cookie, 'cache-control': 'no-store' }, redirect: 'manual',
+    });
+    assertNoCookie(session, 'CRM_SESSION_SMOKE_SESSION_SET_COOKIE');
+    if (session.status !== 200) fail('CRM_SESSION_SMOKE_SESSION_STATUS_INVALID');
+    const identity = assertVerifiedSession(await jsonResponse(session, 'CRM_SESSION_SMOKE_RESPONSE_INVALID'), scenario);
+
+    const repeated = await fetchImpl(`${origin}/crm/session`, {
+      method: 'GET', headers: { accept: 'application/json', cookie, 'cache-control': 'no-store' }, redirect: 'manual',
+    });
+    assertNoCookie(repeated, 'CRM_SESSION_SMOKE_REPEATED_SET_COOKIE');
+    if (repeated.status !== 200) fail('CRM_SESSION_SMOKE_REPEATED_STATUS_INVALID');
+    assertVerifiedSession(await jsonResponse(repeated, 'CRM_SESSION_SMOKE_REPEATED_RESPONSE_INVALID'), scenario);
+
+    Object.assign(report, {
+      result: 'verified',
+      anonymousStatus: anonymous.status,
+      queryStatus: query.status,
+      methodStatus: method.status,
+      authenticatedStatus: session.status,
+      repeatedStatus: repeated.status,
+      identity: {
+        opaqueSubject: true,
+        unitCount: identity.scopes.units.length,
+        moduleCount: identity.scopes.modules.length,
+        permissionCount: identity.scopes.permissions.length,
+      },
+    });
+    writeReport(reportPath, report);
+    return report;
+  } catch (error) {
+    const failed = { ...report, result: 'failed', failure: safeFailureCode(error) };
+    writeReport(reportPath, failed);
+    throw error;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  runCrmIdentityStagingSessionSmoke()
+    .then((report) => process.stdout.write(`${JSON.stringify(report)}\n`))
+    .catch((error) => {
+      process.stderr.write(`[crm-identity-staging-session-smoke] ${safeFailureCode(error)}\n`);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/tests/crm-identity-staging-caller-runtime-readback.test.mjs
+++ b/scripts/tests/crm-identity-staging-caller-runtime-readback.test.mjs
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { verifyActiveRuntimeState } from '../crm-identity-staging-caller-runtime-readback.mjs';
+
+const apiVersion = '11111111-1111-4111-8111-111111111111';
+const issuerVersion = '22222222-2222-4222-8222-222222222222';
+
+function deployment(version) {
+    return { versions: [{ version_id: version, percentage: 100 }] };
+}
+
+function plainText(name, text) {
+    return { name, type: 'plain_text', text };
+}
+
+function versionDetail(id, bindings) {
+    return { success: true, result: { id, resources: { bindings } } };
+}
+
+function disabledState(overrides = {}) {
+    const apiBindings = [
+        plainText('ENVIRONMENT', 'staging'),
+        plainText('CRM_IDENTITY_ISSUER_CALLER_ENABLED', 'false'),
+        plainText('CRM_IDENTITY_ISSUER_CALLER_ID', 'crm-api-staging-v1'),
+    ];
+    const issuerBindings = [
+        plainText('IDENTITY_CRM_DELIVERY_ENABLED', 'false'),
+        plainText('IDENTITY_CRM_DELIVERY_ENVIRONMENT', 'staging'),
+        plainText('IDENTITY_CRM_DELIVERY_CALLER_ENABLED', 'false'),
+        plainText('IDENTITY_CRM_DELIVERY_CALLER_ID', 'crm-api-staging-v1'),
+    ];
+    return {
+        apiDeployment: deployment(apiVersion),
+        issuerDeployment: deployment(issuerVersion),
+        apiVersionDetail: versionDetail(apiVersion, apiBindings),
+        issuerVersionDetail: versionDetail(issuerVersion, issuerBindings),
+        ...overrides,
+    };
+}
+
+test('accepts only the exact active disabled public caller bindings', () => {
+    const report = verifyActiveRuntimeState(disabledState());
+
+    assert.deepEqual(report, {
+        schemaVersion: 1,
+        state: 'disabled',
+        observation: 'exact-active-worker-version-bindings',
+        api: {
+            script: 'skincos-api-staging',
+            activeVersion: apiVersion,
+            callerEnabled: false,
+            callerId: 'crm-api-staging-v1',
+        },
+        issuer: {
+            script: 'skincos-identity-crm-delivery-staging',
+            activeVersion: issuerVersion,
+            deliveryEnabled: false,
+            callerEnabled: false,
+            callerId: 'crm-api-staging-v1',
+        },
+    });
+});
+
+test('rejects an active API version with an enabled caller before any bootstrap receipt can be written', () => {
+    const state = disabledState();
+    state.apiVersionDetail.result.resources.bindings[1].text = 'true';
+
+    assert.throws(() => verifyActiveRuntimeState(state), /api_CRM_IDENTITY_ISSUER_CALLER_ENABLED_MISMATCH/);
+});
+
+test('rejects a caller flag that is missing, secret, or bound to another active version', () => {
+  const missing = disabledState();
+  missing.issuerVersionDetail.result.resources.bindings = missing.issuerVersionDetail.result.resources.bindings
+    .filter((binding) => binding.name !== 'IDENTITY_CRM_DELIVERY_CALLER_ENABLED');
+  assert.throws(() => verifyActiveRuntimeState(missing), /issuer_IDENTITY_CRM_DELIVERY_CALLER_ENABLED_MISMATCH/);
+
+  const secret = disabledState();
+  secret.apiVersionDetail.result.resources.bindings[1] = { name: 'CRM_IDENTITY_ISSUER_CALLER_ENABLED', type: 'secret_text' };
+  assert.throws(() => verifyActiveRuntimeState(secret), /api_CRM_IDENTITY_ISSUER_CALLER_ENABLED_MISMATCH/);
+
+  const wrongVersion = disabledState();
+    wrongVersion.apiVersionDetail.result.id = issuerVersion;
+    assert.throws(() => verifyActiveRuntimeState(wrongVersion), /api_VERSION_DETAIL_INVALID/);
+});

--- a/scripts/tests/crm-identity-staging-session-smoke.test.mjs
+++ b/scripts/tests/crm-identity-staging-session-smoke.test.mjs
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { runCrmIdentityStagingSessionSmoke } from '../crm-identity-staging-session-smoke.mjs';
+
+function fixtures(directory) {
+  const fixturePath = join(directory, 'fixtures.json');
+  writeFileSync(fixturePath, JSON.stringify({
+    environment: 'staging',
+    scenarios: [{
+      id: 'nh', username: 'synthetic-user', email: 'synthetic@example.invalid', password: 'synthetic-password',
+      identitySubject: 'idn:synthetic_identity_subject_0001', role: 'GESTOR', allowedUnits: ['novo-hamburgo'], expectedUnits: ['novo-hamburgo'],
+    }],
+  }));
+  return fixturePath;
+}
+
+function response(payload, status, headers = {}) {
+  return new Response(JSON.stringify(payload), { status, headers: { 'content-type': 'application/json', ...headers } });
+}
+
+test('staging session smoke uses a synthetic cookie only at the gateway and writes a sanitised proof', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'crm-identity-smoke-'));
+  try {
+    const fixturePath = fixtures(directory);
+    const reportPath = join(directory, 'report.json');
+    const calls = [];
+    const fetchImpl = async (url, init) => {
+      calls.push({ url, method: init.method, hasCookie: Boolean(init.headers?.cookie) });
+      const path = new URL(url).pathname;
+      if (path === '/auth/login') return response({ success: true }, 200, { 'set-cookie': 'session=synthetic-cookie; HttpOnly; Secure' });
+      if (url.endsWith('/crm/session?unexpected=1')) return response({ ok: false, error: 'CRM_SESSION_QUERY_NOT_ALLOWED' }, 400);
+      if (init.method === 'POST' && path === '/crm/session') return response({ ok: false, error: 'CRM_SESSION_METHOD_NOT_ALLOWED' }, 405);
+      if (!init.headers?.cookie) return response({ ok: false, error: 'CRM_IDENTITY_REQUIRED' }, 401);
+      return response({
+        ok: true,
+        identity: {
+          identitySubject: 'idn:synthetic_identity_subject_0001', role: 'GESTOR',
+          scopes: { units: ['novo-hamburgo'], modules: ['insumos'], permissions: ['insumos:read'] },
+        },
+        requestId: 'synthetic-request-id',
+      }, 200);
+    };
+    const report = await runCrmIdentityStagingSessionSmoke({ fetchImpl, fixturesPath: fixturePath, reportPath, now: () => '2026-09-07T00:00:00.000Z' });
+    assert.equal(report.result, 'verified');
+    assert.equal(report.authenticatedStatus, 200);
+    assert.deepEqual(calls.map((call) => [new URL(call.url).pathname, call.method, call.hasCookie]), [
+      ['/crm/session', 'GET', false], ['/crm/session', 'GET', false], ['/crm/session', 'POST', false], ['/auth/login', 'POST', false], ['/crm/session', 'GET', true], ['/crm/session', 'GET', true],
+    ]);
+    const persisted = readFileSync(reportPath, 'utf8');
+    assert.doesNotMatch(persisted, /synthetic@example\.invalid|synthetic-password|synthetic-cookie|idn:/);
+    assert.match(persisted, /"credentialMaterialIncluded": false/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('staging session smoke refuses a session response that tries to return a cookie', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'crm-identity-smoke-'));
+  try {
+    const fixturePath = fixtures(directory);
+    const reportPath = join(directory, 'report.json');
+    const fetchImpl = async (url, init) => {
+      const path = new URL(url).pathname;
+      if (path === '/auth/login') return response({ success: true }, 200, { 'set-cookie': 'session=synthetic-cookie; HttpOnly; Secure' });
+      if (url.endsWith('/crm/session?unexpected=1')) return response({ ok: false, error: 'CRM_SESSION_QUERY_NOT_ALLOWED' }, 400);
+      if (init.method === 'POST' && path === '/crm/session') return response({ ok: false, error: 'CRM_SESSION_METHOD_NOT_ALLOWED' }, 405);
+      if (!init.headers?.cookie) return response({ ok: false, error: 'CRM_IDENTITY_REQUIRED' }, 401);
+      return response({ ok: true, identity: {}, requestId: 'unexpected' }, 200, { 'set-cookie': 'unexpected=value' });
+    };
+    await assert.rejects(
+      runCrmIdentityStagingSessionSmoke({ fetchImpl, fixturesPath: fixturePath, reportPath }),
+      /CRM_SESSION_SMOKE_SESSION_SET_COOKIE/,
+    );
+    const persisted = JSON.parse(readFileSync(reportPath, 'utf8'));
+    assert.equal(persisted.result, 'failed');
+    assert.equal(persisted.failure, 'CRM_SESSION_SMOKE_SESSION_SET_COOKIE');
+    assert.equal(persisted.credentialMaterialIncluded, false);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -578,6 +578,29 @@ test("shared staging D1 custody serializes synthetic mutators before every write
   assert.match(timekeepingJourney, /steps\.check_staging_d1_teardown\.outcome == 'success'/);
 });
 
+test("Identity CRM delivery is a restricted staging-only canonical publisher", () => {
+  const catalog = JSON.parse(read("platform/deploy/operational-units.json"));
+  const unit = catalog.units.find((entry) => entry.id === "identity-crm-delivery-staging");
+  assert.ok(unit);
+  assert.equal(unit.workflow, ".github/workflows/identity-crm-delivery.yml");
+  assert.deepEqual(unit.environments, ["staging"]);
+  assert.equal(unit.promotion.publisherType, "restricted-staging-identity-delivery");
+  assert.equal(unit.promotion.stagingOnly, true);
+  assert.equal(unit.promotion.featureFlagDefault, "disabled");
+  assert.ok(unit.publishes.includes("Worker:skincos-identity-crm-delivery-staging"));
+  assert.equal(unit.publishes.includes("Worker:skincos-api-staging"), false);
+
+  const workflow = read(unit.workflow);
+  assert.match(workflow, /github\.event_name == 'workflow_dispatch' && inputs\.operation != 'test'/);
+  assert.match(workflow, /environment: staging/);
+  assert.match(workflow, /global-coordination-acquire/);
+  assert.match(workflow, /IDENTITY_CRM_DELIVERY_CALLER_ENABLED:true/);
+  assert.match(workflow, /CRM_IDENTITY_ISSUER_CALLER_ENABLED:true/);
+  assert.match(workflow, /IDENTITY_CRM_DELIVERY_CALLER_ENABLED:false/);
+  assert.match(workflow, /CRM_IDENTITY_ISSUER_CALLER_ENABLED:false/);
+  assert.doesNotMatch(workflow, /environment:\s*production|--env\s+production/i);
+});
+
 test("general CRM Pages checks out trusted local coordination actions before using them", () => {
   const workflow = read(".github/workflows/deploy-crm-pages.yml");
   const checkout = workflow.indexOf("Checkout trusted general coordination actions");

--- a/scripts/tests/global-concurrency-governance-static.test.mjs
+++ b/scripts/tests/global-concurrency-governance-static.test.mjs
@@ -599,6 +599,18 @@ test("Identity CRM delivery is a restricted staging-only canonical publisher", (
   assert.match(workflow, /IDENTITY_CRM_DELIVERY_CALLER_ENABLED:false/);
   assert.match(workflow, /CRM_IDENTITY_ISSUER_CALLER_ENABLED:false/);
   assert.doesNotMatch(workflow, /environment:\s*production|--env\s+production/i);
+
+  const disabledPreflight = workflow.indexOf("Read back exact active staging Worker bindings and require the caller disabled before bootstrap");
+  const secretPreflight = workflow.indexOf("Refuse partial caller HMAC custody and attest existing signer custody");
+  const provision = workflow.indexOf("Provision one generated HMAC into both disabled staging runtimes");
+  const disabledReadback = workflow.indexOf("Read back exact active staging Worker bindings after caller HMAC custody");
+  const evidence = workflow.indexOf("Write sanitised disabled bootstrap evidence");
+  assert.ok(disabledPreflight >= 0 && secretPreflight > disabledPreflight && provision > secretPreflight && disabledReadback > provision && evidence > disabledReadback);
+  assert.match(workflow, /scripts\/crm-identity-staging-caller-runtime-readback\.mjs/);
+  assert.match(workflow, /steps\.bootstrap_runtime_preflight\.outputs\.state == 'disabled'/);
+  assert.match(workflow, /steps\.bootstrap_runtime_readback\.outputs\.state == 'disabled'/);
+  assert.match(workflow, /schemaVersion: 2/);
+  assert.match(workflow, /runtimeReadback: 'exact-active-worker-version-bindings'/);
 });
 
 test("general CRM Pages checks out trusted local coordination actions before using them", () => {


### PR DESCRIPTION
## What this changes

- Adds the persistent, staging-only Identity caller for `GET /crm/session`.
- Resolves the browser session only at the API gateway, projects only opaque subject, role and scopes, then delivers a fresh HMAC-authenticated JWS request through the private Identity binding.
- Keeps the caller disabled by default and preserves production without an Identity caller binding or route.
- Adds strict credentialed CORS only for `https://crm-staging.skincos.com.br`; an untrusted browser origin is rejected before Identity or CRM Core.
- Adds the protected, SHA-pinned staging workflow for bootstrap, activation, synthetic session smoke, disable, readback, rollback and teardown. No workflow was dispatched by this PR.
- Before bootstrap can write a caller HMAC, reads the exact 100%-active API and Identity Worker versions and accepts only their public disabled caller bindings; repeats that proof after custody and binds both version IDs into the sanitized bootstrap receipt.
- Rebases cleanly onto the shared Identity issuer runtime, with the restricted caller configured only by the staging wrapper.
- Registers the workflow as a canonical, staging-only publisher and proves that automatic push/pull-request triggers can only run tests; mutation remains manual and guarded.
- Replaces a JWT-shaped synthetic test fixture that Gitleaks correctly rejected; no secret was present.

## Validation

- API tests: 57 passed
- Identity tests: 38 passed
- Runtime readback tests: 3 passed
- Session smoke tests: 2 passed
- Workflow YAML tests: 103 passed
- Cloudflare single-writer tests: 7 passed
- Global coordination tests: 208 passed
- Deployment topology and architecture/dependency-closure validation passed
- Final security diff scan of `126ba586..bf54bc24`: 0 findings
- GitHub CI, including Gitleaks, CodeQL, Semgrep, and scoped E2E, passed.

## Deliberate limits

This source PR does not deploy Cloudflare, create or rotate secrets, write D1, activate CRM modules, change production routing, or modify the independent CRM Core.