### PR TITLE
fix(atendimento): align backfill public path

### DIFF
--- a/integration/atendimento/crm-core-projection-exporter/README.md
+++ b/integration/atendimento/crm-core-projection-exporter/README.md
@@ -29,7 +29,7 @@ exige capacidades já construídas pelo operador:
 - signer Ed25519 injetado, com key ID iniciado por
   `crm-staging-atendimento-backfill-`;
 - transporte HTTPS injetado para a rota exata
-  `/_internal/crm/backfill/atendimento`;
+  `/crm/_internal/backfill/atendimento`;
 - checkpoint privado com operações `read`, `write` e `complete`.
 
 O runner abre uma única transação `REPEATABLE READ READ ONLY`, atesta a fonte e

--- a/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionBackfillHttpTransport.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionBackfillHttpTransport.mjs
@@ -10,7 +10,7 @@ import {
   assertAtendimentoProjectionBackfillDelivery,
 } from './atendimentoProjectionBackfillDelivery.mjs'
 
-export const ATENDIMENTO_CRM_BACKFILL_HTTP_PATH = '/_internal/crm/backfill/atendimento'
+export const ATENDIMENTO_CRM_BACKFILL_HTTP_PATH = '/crm/_internal/backfill/atendimento'
 export const ATENDIMENTO_CRM_BACKFILL_HTTP_MAX_BODY_BYTES = 64 * 1024
 export const ATENDIMENTO_CRM_BACKFILL_HTTP_TIMEOUT_MS = 15_000
 export const ATENDIMENTO_CRM_BACKFILL_RECEIPT_VERSION = 'crm-core/projection-backfill-receipt/v1'

--- a/integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionBackfillDelivery.test.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionBackfillDelivery.test.mjs
@@ -68,7 +68,7 @@ test('refuses a signing key that belongs to another environment before it can si
   }), /ATENDIMENTO_CRM_BACKFILL_DELIVERY_KEY_ENVIRONMENT_MISMATCH/)
 })
 
-test('uses the internal HTTPS route with no credential, cookie, origin, or authorization forwarding', async () => {
+test('uses the CRM-scoped internal HTTPS route with no credential, cookie, origin, or authorization forwarding', async () => {
   const currentBatch = batch()
   const { signer } = signerFor()
   const delivery = await signer.signBatch(currentBatch)
@@ -101,6 +101,7 @@ test('uses the internal HTTPS route with no credential, cookie, origin, or autho
   })
 
   assert.equal(calls.length, 1)
+  assert.equal(ATENDIMENTO_CRM_BACKFILL_HTTP_PATH, '/crm/_internal/backfill/atendimento')
   assert.equal(calls[0].url, `https://crm-core-staging.example.test${ATENDIMENTO_CRM_BACKFILL_HTTP_PATH}`)
   assert.equal(calls[0].init.method, 'POST')
   assert.equal(calls[0].init.credentials, 'omit')
@@ -183,9 +184,14 @@ test('bounds a stalled receipt body with the same abort deadline', async () => {
   assert.equal(signal?.aborted, true)
 })
 
-test('refuses an arbitrary route before it can invoke fetch', () => {
-  assert.throws(() => createAtendimentoProjectionBackfillHttpTransport({
-    endpoint: 'https://crm-core-staging.example.test/crm/backfill',
-    fetch: async () => ({ status: 200, json: async () => ({}) }),
-  }), /ATENDIMENTO_CRM_BACKFILL_TRANSPORT_ENDPOINT_INVALID/)
+test('refuses the legacy or arbitrary route before it can invoke fetch', () => {
+  for (const suppliedEndpoint of [
+    'https://crm-core-staging.example.test/_internal/crm/backfill/atendimento',
+    'https://crm-core-staging.example.test/crm/backfill',
+  ]) {
+    assert.throws(() => createAtendimentoProjectionBackfillHttpTransport({
+      endpoint: suppliedEndpoint,
+      fetch: async () => ({ status: 200, json: async () => ({}) }),
+    }), /ATENDIMENTO_CRM_BACKFILL_TRANSPORT_ENDPOINT_INVALID/)
+  }
 })


### PR DESCRIPTION
## Summary
- move the Atendimento backfill producer to the CRM-scoped internal path `/crm/_internal/backfill/atendimento`
- keep Ed25519 proof, target/digest binding, header allowlist, HTTPS-only validation, timeout, and staging gates unchanged
- reject the former `/_internal/crm/backfill/atendimento` path before `fetch` and update the operator documentation

## Validation
- `node --test integration/atendimento/crm-core-projection-exporter/test/*.test.mjs` (34 passed)
- `git diff --check`
- Codex Security diff scan: 0 findings; source-only review of the signed outbound transport boundary

## Operational scope
No Cloudflare deployment, runtime configuration, secret, data access, external rehearsal, or production activation is included. Rollback is a revert of this source-only commit.