### PR TITLE
feat(atendimento): prepare unit-scoped projection backfill v2

### DIFF
--- a/integration/atendimento/crm-core-projection-exporter/README.md
+++ b/integration/atendimento/crm-core-projection-exporter/README.md
@@ -1,9 +1,11 @@
 # Exportador de projeções opacas de Atendimento para CRM Core
 
 Este adaptador prepara lotes de backfill v2 para o CRM independente, em uma
-transação PostgreSQL `REPEATABLE READ READ ONLY`. Ele não escolhe nem inventa
-a relação entre identidade global e unidade: a tabela de identidades globais
-não possui `unit_slug` canônico. Portanto não há SQL padrão para dados reais.
+transação PostgreSQL `REPEATABLE READ ONLY`. A tabela de identidades globais não
+possui `unit_slug` por si só; a fonte padrão para dados reais é a associação
+confirmada de Atendimento em
+`src/atendimentoConfirmedUnitScopedProjectionSource.mjs`, que resolve o slug
+somente pelas evidências e unidades canônicas do owner.
 
 Toda execução exige uma fonte injetada e atestada pelo owner de Atendimento,
 com uma linha estrita por vínculo identidade/unidade:
@@ -45,6 +47,9 @@ exige capacidades já construídas pelo operador:
   `crm-staging-atendimento-backfill-`;
 - transporte HTTPS injetado para a rota exata
   `/crm/_internal/backfill/atendimento`;
+- recibo HTTP estrito `crm-core/projection-backfill-receipt/v2`, vinculado ao
+  lote, request ID e artefato alvo; o envelope assinado de entrega continua em
+  `skincos-crm/projection-backfill-delivery/v1`;
 - checkpoint privado com operações `read`, `write` e `complete`.
 
 O runner abre uma única transação `REPEATABLE READ READ ONLY`, atesta a fonte e
@@ -73,19 +78,39 @@ contagem, formato de linha, lote, prova, endpoint, resposta ou limite não
 correspondem ao contrato. O teto da fonte continua sendo 10.000 linhas; se a
 carga exceder isso, ele não cria um backfill parcial.
 
-## Contrato que o owner de Atendimento ainda precisa fornecer
+## Fonte canônica confirmada pelo owner de Atendimento
 
-Antes de qualquer backfill real, o owner deve fornecer o descritor injetado da
-fonte canônica. O adaptador valida que as consultas sejam somente-leitura, sem
-`OFFSET` ou DDL/DML, que as páginas sejam ordenadas e que o cursor seguinte use
-exatamente quatro parâmetros: `updated_at`, `id`, `unit_slug` e `limit`. A
-consulta de página seguinte deve ter `WHERE`, `ORDER BY` e aliases explícitos.
+`src/atendimentoConfirmedUnitScopedProjectionSource.mjs` fornece o descritor
+canônico `ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE`. Ele reproduz a
+mesma regra já usada pelo runtime comercial de Atendimento: uma identidade tem
+escopo em cada unidade comprovada por um dos quatro canais abaixo, e o slug só
+é aceito após resolver contra `crm_atendimento.units`.
 
-O descritor não decide a semântica da associação. Essa decisão continua com
-Atendimento: deve definir qual membership confirmado projeta uma linha e qual
-fonte vence quando dados heterogêneos divergem. Até essa regra existir em
-código proprietário, o exportador recusa a consulta legada de duas colunas e
-não acessa nenhuma linha de domínio.
+- atendimento ativo: `global_client_identity_members` →
+  `attendance_client_links` → `attendances` não deletado;
+- venda Caixa: `global_client_identity_members` → `crm_caixa.sales`;
+- cadastro de app: `global_client_identity_members` →
+  `app_client_registrations.unit_slugs`;
+- lead suplementar: `global_client_identity_members` →
+  `supplemental_lead_profiles.unit_slugs`.
+
+Evidências repetidas para a mesma identidade/unidade são reduzidas a uma única
+linha; evidências em unidades diferentes constituem uma associação multiunidade
+válida, sem uma regra arbitrária de precedência. Uma identidade sem evidência
+canônica não gera linha alguma: não há fallback global, `all` ou `unknown`.
+
+As consultas continuam somente leitura, sem `OFFSET` ou DDL/DML, e usam a chave
+`(updated_at, id, unit_slug)`. `updated_at` é o carimbo observável usado pelo
+snapshot/cursor; não é uma revisão monotônica do CRM Core. O evento emitido tem
+`revision: 1`, portanto este caminho é exclusivamente para o backfill inicial e
+o replay exato do mesmo pacote. Remoções de vínculo ou sincronização incremental
+exigem um contrato posterior com tombstone e revisão monotônica; não devem ser
+simuladas reenviando esta fonte com revisão 1.
+
+Ainda é necessário que o operador provisione externamente o principal
+`crm_core_projection_exporter` com `SELECT` somente nas relações e colunas que
+essa consulta usa. Este repositório não cria usuário, senha, grant, conexão ou
+qualquer acesso ao banco de produção.
 
 ## Preflight reutilizável e preparação sintética
 

--- a/integration/atendimento/crm-core-projection-exporter/README.md
+++ b/integration/atendimento/crm-core-projection-exporter/README.md
@@ -1,15 +1,27 @@
 # Exportador de projeções opacas de Atendimento para CRM Core
 
-Este adaptador prepara lotes de backfill para o CRM independente.
-Ele lê exclusivamente `id` e `updated_at` de
-`crm_atendimento.global_client_identities`, em uma transação PostgreSQL
-`REPEATABLE READ READ ONLY`.
+Este adaptador prepara lotes de backfill v2 para o CRM independente, em uma
+transação PostgreSQL `REPEATABLE READ READ ONLY`. Ele não escolhe nem inventa
+a relação entre identidade global e unidade: a tabela de identidades globais
+não possui `unit_slug` canônico. Portanto não há SQL padrão para dados reais.
+
+Toda execução exige uma fonte injetada e atestada pelo owner de Atendimento,
+com uma linha estrita por vínculo identidade/unidade:
+
+```text
+{ id, updated_at, unit_slug }
+```
+
+`unit_slug` deve ser o slug canônico, minúsculo, sem curingas (`all`) ou
+sentinelas (`unknown`). A mesma identidade pode aparecer em mais de uma
+unidade, uma vez por unidade; ela vira eventos opacos distintos.
 
 Antes de o lote sair do adaptador, cada UUID vira uma referência HMAC opaca:
 
 - `source:` identifica a origem sem expor o UUID;
 - `projection:` identifica a projeção CRM sem copiar o registro do cliente;
-- `event:` torna o replay idempotente.
+- `event:` torna o replay idempotente e inclui o `unit_slug`, evitando colisão
+  de uma identidade legítima multiunidade.
 
 O lote não contém nomes, e-mails, telefones, contato, sessões, cookies,
 credenciais, dados de venda ou qualquer outra coluna da origem. A chave HMAC
@@ -23,8 +35,11 @@ staging explícito. Ele só aceita o intent
 `ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT`, rejeita alvo `production` e
 exige capacidades já construídas pelo operador:
 
-- pool PostgreSQL autenticado como `crm_core_projection_exporter`, limitado a
-  `CONNECT`, `USAGE` no schema `crm_atendimento` e `SELECT (id, updated_at)`;
+- pool PostgreSQL autenticado como `crm_core_projection_exporter`, com acesso
+  somente leitura à fonte explicitamente aprovada pelo owner;
+- descritor de fonte `atendimento/crm-core/unit-scoped-projection-source/v1`,
+  com `countSql`, `rowsSql`, `firstPageSql` e `nextPageSql`; as páginas devem
+  expor somente `id`, `updated_at` e `unit_slug` com aliases explícitos;
 - chave HMAC sob custódia externa para transformar UUIDs em referências opacas;
 - signer Ed25519 injetado, com key ID iniciado por
   `crm-staging-atendimento-backfill-`;
@@ -33,7 +48,7 @@ exige capacidades já construídas pelo operador:
 - checkpoint privado com operações `read`, `write` e `complete`.
 
 O runner abre uma única transação `REPEATABLE READ READ ONLY`, atesta a fonte e
-usa paginação por chave `(updated_at, id)`, nunca `OFFSET`. Cada lote contém no
+usa paginação por chave `(updated_at, id, unit_slug)`, nunca `OFFSET`. Cada lote contém no
 máximo 20 eventos. A consulta converte `updated_at` para UTC com seis dígitos
 de microssegundo, e o cursor privado preserva essa precisão; a data pública do
 evento continua no formato do contrato CRM. O transporte limita o corpo a 64
@@ -46,7 +61,7 @@ Antes de qualquer entrega, o checkpoint privado recebe o pacote opaco completo
 e a prova detached Ed25519. Se a entrega falhar sem recibo, a próxima execução
 repete esse mesmo pacote antes de abrir uma nova transação. Ela só pode
 continuar a paginação se o novo preflight confirmar a mesma contagem e o mesmo
-HMAC do conjunto ordenado de pares `(updated_at, id)`. O HMAC não contém a
+HMAC do conjunto ordenado de triplas `(updated_at, id, unit_slug)`. O HMAC não contém a
 origem em claro e torna a retomada independente do novo `transaction_timestamp`;
 caso a entrada do backfill tenha mudado, o runner falha fechado depois do replay,
 sem substituir o checkpoint. Antes até do replay, ele compara o alvo gravado ao
@@ -58,18 +73,33 @@ contagem, formato de linha, lote, prova, endpoint, resposta ou limite não
 correspondem ao contrato. O teto da fonte continua sendo 10.000 linhas; se a
 carga exceder isso, ele não cria um backfill parcial.
 
+## Contrato que o owner de Atendimento ainda precisa fornecer
+
+Antes de qualquer backfill real, o owner deve fornecer o descritor injetado da
+fonte canônica. O adaptador valida que as consultas sejam somente-leitura, sem
+`OFFSET` ou DDL/DML, que as páginas sejam ordenadas e que o cursor seguinte use
+exatamente quatro parâmetros: `updated_at`, `id`, `unit_slug` e `limit`. A
+consulta de página seguinte deve ter `WHERE`, `ORDER BY` e aliases explícitos.
+
+O descritor não decide a semântica da associação. Essa decisão continua com
+Atendimento: deve definir qual membership confirmado projeta uma linha e qual
+fonte vence quando dados heterogêneos divergem. Até essa regra existir em
+código proprietário, o exportador recusa a consulta legada de duas colunas e
+não acessa nenhuma linha de domínio.
+
 ## Preflight reutilizável e preparação sintética
 
-`preflightAtendimentoProjectionSource(client, { maxRows })` é a parte
+`preflightAtendimentoProjectionSource(client, { maxRows, source })` é a parte
 reutilizável da leitura: dentro de uma transação já aberta como `REPEATABLE
-READ READ ONLY`, ela atesta o principal, captura o instante do snapshot e
-confirma a contagem antes de qualquer seleção de identidade. O teto é sempre
+READ ONLY`, ela atesta o principal, captura o instante do snapshot e confirma
+a contagem antes de qualquer seleção de identidade. O teto da fonte é sempre
 10.000; o runner paginado mantém esse teto e não oferece forma de ampliá-lo.
 
 `prepareSyntheticAtendimentoProjectionStaging(...)` é apenas um ensaio local
 desabilitado por padrão. Ele só continua quando recebe a constante de intenção
 explícita `ATENDIMENTO_SYNTHETIC_STAGING_PREPARATION_INTENT`, um alvo `staging`,
-um pool criado por `createSyntheticAtendimentoProjectionFixturePool(...)` e um
+um pool criado por `createSyntheticAtendimentoProjectionFixturePool(...)` com
+linhas sintéticas `{ id, updated_at, unit_slug }` e um
 receptor criado por `createSyntheticAtendimentoProjectionReceiptReceiver()`.
 As duas factories registram exclusivamente estado em memória; um cliente
 PostgreSQL, pool, array, proxy ou receptor arbitrário é recusado antes de
@@ -106,7 +136,7 @@ pública e essa allowlist finita, `rehearse(...)` exige a intenção explícita
 função de reconciliação D1. Ele passa pela mesma fonte paginada, assinatura e
 transporte HTTPS do produtor real, exige a primeira resposta `accepted`, repete
 o pacote exato e exige `idempotent`, e só emite o recibo sanitizado após a
-reconciliação confirmar o digest, alvo, cursor e evento persistidos. O adaptador
+reconciliação confirmar o digest, alvo, cursor, unidades e evento persistidos. O adaptador
 não lê ambiente, não possui URL de Worker embutida, não faz deploy e não é um
 mecanismo de ativação de produção.
 

--- a/integration/atendimento/crm-core-projection-exporter/src/atendimentoConfirmedUnitScopedProjectionSource.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/atendimentoConfirmedUnitScopedProjectionSource.mjs
@@ -1,0 +1,124 @@
+import {
+  ATENDIMENTO_UNIT_SCOPED_PROJECTION_SOURCE_CONTRACT,
+  createAtendimentoUnitScopedProjectionSource,
+} from './atendimentoProjectionExporter.mjs'
+
+export const ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE_VERSION = 'atendimento/crm-core/confirmed-unit-membership-source/v1'
+
+// This is the same four-channel membership rule already enforced by Atendimento
+// commercial operations. A unit only becomes exportable after it resolves to a
+// canonical `crm_atendimento.units` row; an identity without such evidence has
+// no output row and can never fall back to a global/wildcard scope.
+export const ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE_SEMANTICS = Object.freeze({
+  version: ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE_VERSION,
+  membership: 'union of active attendance, Caixa sale, app registration, and supplemental lead evidence resolved through canonical units',
+  duplicateEvidence: 'one identity/unit row, with the latest observed source timestamp',
+  divergentUnits: 'valid multi-unit membership; emit one row for each canonical unit slug',
+  missingEvidence: 'no projection row; there is no global or wildcard fallback',
+  revision: 'snapshot-only: updated_at is cursor material, while CRM Core event revision remains 1 for the initial backfill and exact replay',
+})
+
+// This validates the UUID separators as well as the hexadecimal groups before
+// the source text is cast. A permissive "36 hex-or-dash characters" predicate
+// could still let an invalid legacy source_id abort an otherwise read-only
+// snapshot at PostgreSQL cast time.
+const UUID_TEXT_PATTERN = '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+
+// Keep every source branch data-minimal. The final projection only selects the
+// opaque identity UUID, a timestamp, and the canonical unit slug; names,
+// phones, email, and sale/attendance payloads never cross this boundary.
+const MEMBERSHIP_CTE = `WITH unit_membership_evidence AS (
+  SELECT member.identity_id,
+    unit.slug AS unit_slug,
+    GREATEST(
+      member.updated_at,
+      COALESCE(attendance_link.updated_at, attendance_link.created_at, member.updated_at),
+      COALESCE(attendance.updated_at, attendance.created_at, member.updated_at)
+    ) AS observed_at
+  FROM crm_atendimento.global_client_identity_members member
+  JOIN crm_atendimento.attendance_client_links attendance_link
+    ON attendance_link.client_id = CASE
+      WHEN member.source_id ~ '${UUID_TEXT_PATTERN}' THEN member.source_id::uuid
+      ELSE NULL
+    END
+  JOIN crm_atendimento.attendances attendance
+    ON attendance.id = attendance_link.attendance_id
+  JOIN crm_atendimento.units unit ON unit.id = attendance.unit_id
+  WHERE member.source_type = 'attendance_client'
+    AND member.source_id ~ '${UUID_TEXT_PATTERN}'
+    AND attendance.deleted_at IS NULL
+
+  UNION ALL
+
+  SELECT member.identity_id,
+    unit.slug AS unit_slug,
+    GREATEST(member.updated_at, COALESCE(sale.updated_at, sale.created_at, member.updated_at)) AS observed_at
+  FROM crm_atendimento.global_client_identity_members member
+  JOIN crm_caixa.sales sale ON sale.customer_id = CASE
+    WHEN member.source_id ~ '${UUID_TEXT_PATTERN}' THEN member.source_id::uuid
+    ELSE NULL
+  END
+  JOIN crm_atendimento.units unit ON unit.id = sale.unit_id
+  WHERE member.source_type = 'caixa_customer'
+    AND member.source_id ~ '${UUID_TEXT_PATTERN}'
+
+  UNION ALL
+
+  SELECT member.identity_id,
+    unit.slug AS unit_slug,
+    GREATEST(member.updated_at, registration.updated_at) AS observed_at
+  FROM crm_atendimento.global_client_identity_members member
+  JOIN crm_atendimento.app_client_registrations registration
+    ON registration.source_client_id = member.source_id
+  JOIN LATERAL jsonb_array_elements_text(COALESCE(registration.unit_slugs, '[]'::jsonb)) scope(slug)
+    ON TRUE
+  JOIN crm_atendimento.units unit ON unit.slug = scope.slug
+  WHERE member.source_type = 'app_registration'
+
+  UNION ALL
+
+  SELECT member.identity_id,
+    unit.slug AS unit_slug,
+    GREATEST(member.updated_at, lead.updated_at) AS observed_at
+  FROM crm_atendimento.global_client_identity_members member
+  JOIN crm_atendimento.supplemental_lead_profiles lead
+    ON lead.source_profile_id = member.source_id
+  JOIN LATERAL jsonb_array_elements_text(COALESCE(lead.unit_slugs, '[]'::jsonb)) scope(slug)
+    ON TRUE
+  JOIN crm_atendimento.units unit ON unit.slug = scope.slug
+  WHERE member.source_type = 'lead_profile'
+), unit_memberships AS (
+  SELECT identity_id, unit_slug, max(observed_at) AS observed_at
+  FROM unit_membership_evidence
+  GROUP BY identity_id, unit_slug
+), projection_rows AS (
+  SELECT identity_id,
+    observed_at,
+    identity_id::text AS id,
+    to_char(observed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS updated_at,
+    unit_slug
+  FROM unit_memberships
+)`
+
+const ROWS_SELECT = `SELECT id, updated_at, unit_slug
+FROM projection_rows`
+
+export const ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE = createAtendimentoUnitScopedProjectionSource({
+  contract: ATENDIMENTO_UNIT_SCOPED_PROJECTION_SOURCE_CONTRACT,
+  countSql: `${MEMBERSHIP_CTE}
+SELECT count(*)::int AS row_count
+FROM projection_rows`,
+  rowsSql: `${MEMBERSHIP_CTE}
+${ROWS_SELECT}
+ORDER BY updated_at ASC, id ASC, unit_slug ASC
+LIMIT $1`,
+  firstPageSql: `${MEMBERSHIP_CTE}
+${ROWS_SELECT}
+ORDER BY updated_at ASC, id ASC, unit_slug ASC
+LIMIT $1`,
+  nextPageSql: `${MEMBERSHIP_CTE}
+${ROWS_SELECT}
+WHERE (observed_at, identity_id, unit_slug) > ($1::timestamptz, $2::uuid, $3::text)
+ORDER BY updated_at ASC, id ASC, unit_slug ASC
+LIMIT $4`,
+})

--- a/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionBackfillHttpTransport.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionBackfillHttpTransport.mjs
@@ -13,7 +13,7 @@ import {
 export const ATENDIMENTO_CRM_BACKFILL_HTTP_PATH = '/crm/_internal/backfill/atendimento'
 export const ATENDIMENTO_CRM_BACKFILL_HTTP_MAX_BODY_BYTES = 64 * 1024
 export const ATENDIMENTO_CRM_BACKFILL_HTTP_TIMEOUT_MS = 15_000
-export const ATENDIMENTO_CRM_BACKFILL_RECEIPT_VERSION = 'crm-core/projection-backfill-receipt/v1'
+export const ATENDIMENTO_CRM_BACKFILL_RECEIPT_VERSION = 'crm-core/projection-backfill-receipt/v2'
 
 const REQUEST_ID_PATTERN = /^[A-Za-z0-9._:-]{1,120}$/
 const OUTCOMES = new Set(['accepted', 'idempotent'])

--- a/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionExporter.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionExporter.mjs
@@ -1,9 +1,11 @@
 import { createHash, createHmac } from 'node:crypto'
 
-export const ATENDIMENTO_CRM_PROJECTION_EXPORTER_VERSION = 'atendimento/crm-core-projection-exporter/v1'
-export const CRM_PROJECTION_BACKFILL_BATCH_VERSION = 'skincos-crm/projection-backfill-batch/v1'
+export const ATENDIMENTO_CRM_PROJECTION_EXPORTER_VERSION = 'atendimento/crm-core-projection-exporter/v2'
+export const CRM_PROJECTION_BACKFILL_BATCH_VERSION = 'skincos-crm/projection-backfill-batch/v2'
 export const ATENDIMENTO_PROJECTION_SCOPE = 'global-client-identities/v1'
 export const ATENDIMENTO_CRM_PROJECTION_MAX_ROWS = 10_000
+export const ATENDIMENTO_CRM_PROJECTION_BACKFILL_MAX_EVENTS = 20
+export const ATENDIMENTO_UNIT_SCOPED_PROJECTION_SOURCE_CONTRACT = 'atendimento/crm-core/unit-scoped-projection-source/v1'
 
 export const ATENDIMENTO_PROJECTION_EXPORTER_DATABASE = Object.freeze({
   database: 'skincos_clientes_production',
@@ -18,28 +20,22 @@ export const ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL = `SELECT
 
 export const ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL = 'SELECT transaction_timestamp()::timestamptz AS captured_at'
 
-export const ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL = `SELECT count(*)::int AS row_count
+// These retired v1 queries deliberately remain named as legacy evidence only.
+// They are never selected by this exporter: a v2 caller must inject an owner
+// source contract with an explicit canonical `unit_slug` for every emitted row.
+export const ATENDIMENTO_PROJECTION_EXPORT_LEGACY_COUNT_SQL = `SELECT count(*)::int AS row_count
 FROM crm_atendimento.global_client_identities`
-
-// This source query deliberately has no join and no selectable field beyond the
-// stable identity UUID and its revision timestamp. The UUID is converted to an
-// HMAC reference in memory before anything leaves this adapter.
-export const ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL = `/* bounded source-input fingerprint */
-SELECT id::text AS id,
+export const ATENDIMENTO_PROJECTION_EXPORT_LEGACY_ROWS_SQL = `SELECT id::text AS id,
   to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS updated_at
 FROM crm_atendimento.global_client_identities
 ORDER BY updated_at ASC, id ASC
 LIMIT $1`
-
-// The paginated runner uses keyset pagination, never OFFSET. Both queries keep
-// the source shape deliberately limited to the stable UUID and revision time.
-export const ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL = `SELECT id::text AS id,
+export const ATENDIMENTO_PROJECTION_EXPORT_LEGACY_FIRST_PAGE_SQL = `SELECT id::text AS id,
   to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS updated_at
 FROM crm_atendimento.global_client_identities
 ORDER BY updated_at ASC, id ASC
 LIMIT $1`
-
-export const ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL = `SELECT id::text AS id,
+export const ATENDIMENTO_PROJECTION_EXPORT_LEGACY_NEXT_PAGE_SQL = `SELECT id::text AS id,
   to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS updated_at
 FROM crm_atendimento.global_client_identities
 WHERE (updated_at, id) > ($1::timestamptz, $2::uuid)
@@ -51,6 +47,10 @@ const SHA256_PATTERN = /^sha256:[a-f0-9]{64}$/
 const RELEASE_PATTERN = /^[0-9a-f]{40}$/
 const KEY_ID_PATTERN = /^[A-Za-z0-9._-]{3,96}$/
 const OPAQUE_PART_PATTERN = /^[A-Za-z0-9_-]{8,160}$/
+const UNIT_SLUG_PATTERN = /^(?!all$|unknown$)[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?$/
+const SOURCE_TIMESTAMP_PATTERN = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})\.(\d{1,6})Z$/
+const SOURCE_QUERY_FORBIDDEN = /\b(?:alter|call|copy|create|delete|drop|grant|insert|merge|offset|revoke|truncate|update|vacuum)\b/i
+
 function fail(code) {
   throw new Error(code)
 }
@@ -74,6 +74,13 @@ function timestamp(value, code) {
   const parsed = value instanceof Date ? value : new Date(String(value || '').trim())
   if (Number.isNaN(parsed.getTime())) fail(code)
   return parsed.toISOString()
+}
+
+function sourceTimestamp(value, code) {
+  const raw = value instanceof Date ? value.toISOString() : text(value, code)
+  const match = SOURCE_TIMESTAMP_PATTERN.exec(raw)
+  if (!match || Number.isNaN(new Date(raw).getTime())) fail(code)
+  return `${match[1]}.${match[2].padEnd(6, '0')}Z`
 }
 
 function canonicalize(value) {
@@ -119,6 +126,79 @@ function maximumRows(value) {
   return normalized
 }
 
+function maximumBatchRows(value) {
+  const normalized = value === undefined ? ATENDIMENTO_CRM_PROJECTION_BACKFILL_MAX_EVENTS : Number(value)
+  if (!Number.isSafeInteger(normalized) || normalized < 1 || normalized > ATENDIMENTO_CRM_PROJECTION_BACKFILL_MAX_EVENTS) {
+    fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_SIZE_INVALID')
+  }
+  return normalized
+}
+
+function unitSlug(value, code) {
+  const normalized = text(value, code)
+  if (normalized !== normalized.toLowerCase() || !UNIT_SLUG_PATTERN.test(normalized)) fail(code)
+  return normalized
+}
+
+function sourceQuery(value, code, requiredAliases = []) {
+  const sql = text(value, code)
+  if (
+    sql.length > 32_768
+    || sql.includes(';')
+    || SOURCE_QUERY_FORBIDDEN.test(sql)
+    || !/^\s*(?:(?:\/\*[\s\S]*?\*\/)\s*)*(?:select|with)\b/i.test(sql)
+  ) fail(code)
+  for (const alias of requiredAliases) {
+    const expression = new RegExp(`\\bas\\s+(?:"${alias}"|${alias})\\b`, 'i')
+    if (!expression.test(sql)) fail(code)
+  }
+  return sql
+}
+
+function sourcePageQuery(value, code, { parameters, keyset = false } = {}) {
+  const sql = sourceQuery(value, code, ['id', 'updated_at', 'unit_slug'])
+  const actualParameters = [...sql.matchAll(/\$(\d+)\b/g)].map((match) => Number(match[1]))
+  const orderedTuple = /\border\s+by\s+(?:[A-Za-z_][A-Za-z0-9_]*\.)?updated_at\s+asc\s*,\s*(?:[A-Za-z_][A-Za-z0-9_]*\.)?id\s+asc\s*,\s*(?:[A-Za-z_][A-Za-z0-9_]*\.)?unit_slug\s+asc\s*\blimit\b/i
+  const keysetTuple = /\bwhere\b[\s\S]*?\bupdated_at\b[\s\S]*?\bid\b[\s\S]*?\bunit_slug\b/i
+  if (
+    !orderedTuple.test(sql)
+    || actualParameters.length === 0
+    || new Set(actualParameters).size !== actualParameters.length
+    || actualParameters.some((parameter) => !parameters.includes(parameter))
+    || parameters.some((parameter) => !actualParameters.includes(parameter))
+    || (keyset && !keysetTuple.test(sql))
+  ) fail(code)
+  return sql
+}
+
+/**
+ * Validates a source owned by Atendimento. The export adapter does not know
+ * how a global identity maps to units and intentionally offers no default SQL.
+ * The owner must attest an immutable read-only query family that emits exactly
+ * one row per canonical identity/unit membership.
+ */
+export function assertAtendimentoUnitScopedProjectionSource(value) {
+  const source = object(value, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_REQUIRED')
+  exactKeys(source, ['contract', 'countSql', 'rowsSql', 'firstPageSql', 'nextPageSql'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_INVALID')
+  if (source.contract !== ATENDIMENTO_UNIT_SCOPED_PROJECTION_SOURCE_CONTRACT) {
+    fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_INVALID')
+  }
+  return Object.freeze({
+    contract: ATENDIMENTO_UNIT_SCOPED_PROJECTION_SOURCE_CONTRACT,
+    countSql: sourceQuery(source.countSql, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_INVALID', ['row_count']),
+    rowsSql: sourcePageQuery(source.rowsSql, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_INVALID', { parameters: [1] }),
+    firstPageSql: sourcePageQuery(source.firstPageSql, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_INVALID', { parameters: [1] }),
+    nextPageSql: sourcePageQuery(source.nextPageSql, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_INVALID', {
+      parameters: [1, 2, 3, 4],
+      keyset: true,
+    }),
+  })
+}
+
+export function createAtendimentoUnitScopedProjectionSource(value) {
+  return assertAtendimentoUnitScopedProjectionSource(value)
+}
+
 export function assertAtendimentoProjectionExportTarget(value) {
   const target = object(value, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_TARGET_INVALID')
   exactKeys(target, ['environment', 'release', 'artifactDigest'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_TARGET_INVALID')
@@ -150,47 +230,68 @@ function sourceIdentity(value) {
 
 export function assertAtendimentoProjectionSourceRow(value) {
   const row = object(value, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID')
-  exactKeys(row, ['id', 'updated_at'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID')
+  exactKeys(row, ['id', 'updated_at', 'unit_slug'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID')
   const id = text(row.id, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID').toLowerCase()
   if (!UUID_PATTERN.test(id)) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID')
   return Object.freeze({
     id,
     updatedAt: timestamp(row.updated_at, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID'),
+    sourceUpdatedAt: sourceTimestamp(row.updated_at, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID'),
+    unitSlug: unitSlug(row.unit_slug, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID'),
   })
 }
 
 function normalizedSourceRow(value) {
   const row = object(value, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID')
   if (
-    Object.keys(row).length === 2
+    Object.keys(row).length === 4
     && Object.hasOwn(row, 'id')
     && Object.hasOwn(row, 'updatedAt')
+    && Object.hasOwn(row, 'sourceUpdatedAt')
+    && Object.hasOwn(row, 'unitSlug')
   ) {
-    return assertAtendimentoProjectionSourceRow({ id: row.id, updated_at: row.updatedAt })
+    const normalized = assertAtendimentoProjectionSourceRow({
+      id: row.id,
+      updated_at: row.sourceUpdatedAt,
+      unit_slug: row.unitSlug,
+    })
+    if (timestamp(row.updatedAt, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID') !== normalized.updatedAt) {
+      fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_ROW_INVALID')
+    }
+    return normalized
   }
   return assertAtendimentoProjectionSourceRow(row)
 }
 
+function compareSourceRows(left, right) {
+  return left.sourceUpdatedAt.localeCompare(right.sourceUpdatedAt)
+    || left.id.localeCompare(right.id)
+    || left.unitSlug.localeCompare(right.unitSlug)
+}
+
 function sourceRows(value, expectedCount) {
-  if (!Array.isArray(value) || value.length !== expectedCount) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_READBACK_INVALID')
-  const identifiers = new Set()
-  const rows = value.map(normalizedSourceRow)
+  if (!Array.isArray(value) || value.length !== expectedCount || value.length > ATENDIMENTO_CRM_PROJECTION_BACKFILL_MAX_EVENTS) {
+    fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_READBACK_INVALID')
+  }
+  const rows = value.map(normalizedSourceRow).sort(compareSourceRows)
+  const identities = new Set()
   for (const row of rows) {
-    if (identifiers.has(row.id)) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_READBACK_INVALID')
-    identifiers.add(row.id)
+    const key = `${row.id}\u0000${row.unitSlug}`
+    if (identities.has(key)) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_READBACK_INVALID')
+    identities.add(key)
   }
   return Object.freeze(rows)
 }
 
 /**
- * Attests the already-open source transaction before any source identity row
- * is selected. Callers must start a repeatable-read, read-only transaction
- * first; the identity query then proves the dedicated source principal and
- * returns only snapshot metadata needed to bound a later read.
+ * Attests an already-open source transaction before the owner-defined unit
+ * mapping is selected. A missing source or a legacy two-column query fails
+ * closed before any domain row is requested.
  */
-export async function preflightAtendimentoProjectionSource(client, { maxRows } = {}) {
+export async function preflightAtendimentoProjectionSource(client, { maxRows, source } = {}) {
   if (!client || typeof client.query !== 'function') fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_CLIENT_INVALID')
   const limit = maximumRows(maxRows)
+  const sourceDefinition = assertAtendimentoUnitScopedProjectionSource(source)
 
   const identityResult = await client.query(ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL)
   const identity = sourceIdentity(identityResult?.rows?.[0])
@@ -198,45 +299,49 @@ export async function preflightAtendimentoProjectionSource(client, { maxRows } =
   const snapshotResult = await client.query(ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL)
   const capturedAt = timestamp(snapshotResult?.rows?.[0]?.captured_at, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SNAPSHOT_INVALID')
 
-  const countResult = await client.query(ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL)
+  const countResult = await client.query(sourceDefinition.countSql)
   const rowCount = Number(countResult?.rows?.[0]?.row_count)
   if (!Number.isSafeInteger(rowCount) || rowCount < 0) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_COUNT_INVALID')
   if (rowCount > limit) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_LIMIT_EXCEEDED')
 
-  return Object.freeze({ identity, capturedAt, rowCount })
+  return Object.freeze({ identity, capturedAt, rowCount, source: sourceDefinition })
 }
 
-function eventFromSourceRow(row, { key, capturedAt }) {
-  const sourceReference = hmacReference(key, 'source-reference/v1', row.id, 'source')
-  const projectionReference = hmacReference(key, 'projection-reference/v1', row.id, 'projection')
+function eventFromSourceRow(row, { key }) {
+  // Source/projection references preserve one opaque global identity across
+  // units. Only the event identity incorporates unit and microsecond cursor
+  // material, so a legitimate multi-unit identity cannot collide in v2.
+  const sourceReference = hmacReference(key, 'source-reference/v2', row.id, 'source')
+  const projectionReference = hmacReference(key, 'projection-reference/v2', row.id, 'projection')
   const eventId = hmacReference(
     key,
-    'projection-event/v1',
-    `${sourceReference}\u0000${projectionReference}\u0000${row.updatedAt}\u00001\u0000upsert`,
+    'projection-event/v2',
+    `${sourceReference}\u0000${projectionReference}\u0000${row.unitSlug}\u0000${row.sourceUpdatedAt}\u00001\u0000upsert`,
     'event',
   )
   return Object.freeze({
-    contractVersion: 'crm-projection-event/v1',
+    contractVersion: 'crm-projection-event/v2',
     id: eventId,
     projection: Object.freeze({ reference: projectionReference, kind: 'client-reference' }),
     source: Object.freeze({ owner: 'atendimento', reference: sourceReference }),
+    unitScope: Object.freeze({ unitSlug: row.unitSlug }),
     revision: 1,
     operation: 'upsert',
     occurredAt: row.updatedAt,
-    // Deliberately do not include source UUID, snapshot timestamp, or any
-    // contact field in the event. `capturedAt` participates only in batch ID.
   })
 }
 
 function assertProjectionEvent(value) {
   const event = object(value, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
-  exactKeys(event, ['contractVersion', 'id', 'projection', 'source', 'revision', 'operation', 'occurredAt'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  exactKeys(event, ['contractVersion', 'id', 'projection', 'source', 'unitScope', 'revision', 'operation', 'occurredAt'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
   const projection = object(event.projection, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
   const source = object(event.source, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  const scope = object(event.unitScope, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
   exactKeys(projection, ['reference', 'kind'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
   exactKeys(source, ['owner', 'reference'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  exactKeys(scope, ['unitSlug'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
   if (
-    event.contractVersion !== 'crm-projection-event/v1'
+    event.contractVersion !== 'crm-projection-event/v2'
     || !/^event:[A-Za-z0-9_-]{8,160}$/.test(text(event.id, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID'))
     || !/^projection:[A-Za-z0-9_-]{8,160}$/.test(text(projection.reference, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID'))
     || projection.kind !== 'client-reference'
@@ -248,10 +353,11 @@ function assertProjectionEvent(value) {
     fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
   }
   return Object.freeze({
-    contractVersion: event.contractVersion,
+    contractVersion: 'crm-projection-event/v2',
     id: event.id,
     projection: Object.freeze({ reference: projection.reference, kind: projection.kind }),
     source: Object.freeze({ owner: source.owner, reference: source.reference }),
+    unitScope: Object.freeze({ unitSlug: unitSlug(scope.unitSlug, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID') }),
     revision: event.revision,
     operation: event.operation,
     occurredAt: timestamp(event.occurredAt, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID'),
@@ -259,7 +365,7 @@ function assertProjectionEvent(value) {
 }
 
 function batchId(key, keyIdentifier, capturedAt, eventsDigest) {
-  return `backfill:atendimento:${hmacPart(key, 'projection-backfill-batch/v1', `${keyIdentifier}\u0000${capturedAt}\u0000${eventsDigest}`)}`
+  return `backfill:atendimento:${hmacPart(key, 'projection-backfill-batch/v2', `${keyIdentifier}\u0000${capturedAt}\u0000${eventsDigest}`)}`
 }
 
 function batchCursorDigest(capturedAt, events) {
@@ -268,13 +374,17 @@ function batchCursorDigest(capturedAt, events) {
     scope: ATENDIMENTO_PROJECTION_SCOPE,
     capturedAt,
     sourceReferences: events.map((event) => event.source.reference),
+    unitSlugs: events.map((event) => event.unitScope.unitSlug),
   })
 }
 
+function uniqueUnitSlugs(events) {
+  return Object.freeze([...new Set(events.map((event) => event.unitScope.unitSlug))].sort())
+}
+
 /**
- * Builds one opaque CRM batch from an already-bounded source page. This has no
- * transport or database side effect; callers that paginate must keep the raw
- * source cursor private and send only the returned opaque batch.
+ * Builds one bounded opaque CRM v2 batch from a unit-scoped owner page. This
+ * function has no transport or source database side effect.
  */
 export function createAtendimentoProjectionBackfillBatch({
   rows,
@@ -288,14 +398,20 @@ export function createAtendimentoProjectionBackfillBatch({
   const targetValue = assertAtendimentoProjectionExportTarget(target)
   const normalizedCapturedAt = timestamp(capturedAt, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SNAPSHOT_INVALID')
   const normalizedRows = sourceRows(rows, Array.isArray(rows) ? rows.length : -1)
-  const events = Object.freeze(normalizedRows.map((row) => eventFromSourceRow(row, { key, capturedAt: normalizedCapturedAt })))
+  if (normalizedRows.length === 0) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  const events = Object.freeze(normalizedRows.map((row) => eventFromSourceRow(row, { key })))
   const eventsDigest = sha256(events)
   const cursorDigest = batchCursorDigest(normalizedCapturedAt, events)
   return assertAtendimentoProjectionBackfillBatch({
     contract: CRM_PROJECTION_BACKFILL_BATCH_VERSION,
     batchId: batchId(key, keyIdentifier, normalizedCapturedAt, eventsDigest),
     producer: { owner: 'atendimento', scope: ATENDIMENTO_PROJECTION_SCOPE, keyId: keyIdentifier },
-    sourceSnapshot: { capturedAt: normalizedCapturedAt, cursorDigest, rowCount: normalizedRows.length },
+    sourceSnapshot: {
+      capturedAt: normalizedCapturedAt,
+      cursorDigest,
+      rowCount: normalizedRows.length,
+      unitSlugs: uniqueUnitSlugs(events),
+    },
     target: targetValue,
     events,
     integrity: { algorithm: 'sha256', eventCount: events.length, eventsDigest },
@@ -309,7 +425,7 @@ export function assertAtendimentoProjectionBackfillBatch(value) {
   const sourceSnapshot = object(batch.sourceSnapshot, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
   const integrity = object(batch.integrity, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
   exactKeys(producer, ['owner', 'scope', 'keyId'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
-  exactKeys(sourceSnapshot, ['capturedAt', 'cursorDigest', 'rowCount'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+  exactKeys(sourceSnapshot, ['capturedAt', 'cursorDigest', 'rowCount', 'unitSlugs'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
   exactKeys(integrity, ['algorithm', 'eventCount', 'eventsDigest'], 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
   if (
     batch.contract !== CRM_PROJECTION_BACKFILL_BATCH_VERSION
@@ -318,9 +434,16 @@ export function assertAtendimentoProjectionBackfillBatch(value) {
     || producer.scope !== ATENDIMENTO_PROJECTION_SCOPE
     || !KEY_ID_PATTERN.test(text(producer.keyId, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID'))
     || !SHA256_PATTERN.test(text(sourceSnapshot.cursorDigest, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID'))
-    || !Number.isSafeInteger(sourceSnapshot.rowCount) || sourceSnapshot.rowCount < 0
+    || !Number.isSafeInteger(sourceSnapshot.rowCount)
+    || sourceSnapshot.rowCount < 1
+    || sourceSnapshot.rowCount > ATENDIMENTO_CRM_PROJECTION_BACKFILL_MAX_EVENTS
+    || !Array.isArray(sourceSnapshot.unitSlugs)
+    || sourceSnapshot.unitSlugs.length < 1
+    || sourceSnapshot.unitSlugs.length > ATENDIMENTO_CRM_PROJECTION_BACKFILL_MAX_EVENTS
     || integrity.algorithm !== 'sha256'
-    || !Number.isSafeInteger(integrity.eventCount) || integrity.eventCount < 0
+    || !Number.isSafeInteger(integrity.eventCount)
+    || integrity.eventCount < 1
+    || integrity.eventCount > ATENDIMENTO_CRM_PROJECTION_BACKFILL_MAX_EVENTS
     || !SHA256_PATTERN.test(text(integrity.eventsDigest, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID'))
   ) {
     fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
@@ -332,28 +455,37 @@ export function assertAtendimentoProjectionBackfillBatch(value) {
   }
   const events = Object.freeze(batch.events.map(assertProjectionEvent))
   const identifiers = new Set()
+  const projectionKeys = new Set()
   for (const event of events) {
-    if (identifiers.has(event.id)) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
+    const projectionKey = `${event.unitScope.unitSlug}:${event.projection.reference}`
+    if (identifiers.has(event.id) || projectionKeys.has(projectionKey)) fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
     identifiers.add(event.id)
+    projectionKeys.add(projectionKey)
+  }
+  const unitSlugs = sourceSnapshot.unitSlugs.map((value) => unitSlug(value, 'ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')).sort()
+  if (new Set(unitSlugs).size !== unitSlugs.length || JSON.stringify(unitSlugs) !== JSON.stringify(uniqueUnitSlugs(events))) {
+    fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
   }
   if (integrity.eventsDigest !== sha256(events) || sourceSnapshot.cursorDigest !== batchCursorDigest(capturedAt, events)) {
     fail('ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID')
   }
   return Object.freeze({
-    contract: batch.contract,
+    contract: CRM_PROJECTION_BACKFILL_BATCH_VERSION,
     batchId: batch.batchId,
     producer: Object.freeze({ owner: producer.owner, scope: producer.scope, keyId: producer.keyId }),
-    sourceSnapshot: Object.freeze({ capturedAt, cursorDigest: sourceSnapshot.cursorDigest, rowCount: sourceSnapshot.rowCount }),
+    sourceSnapshot: Object.freeze({
+      capturedAt,
+      cursorDigest: sourceSnapshot.cursorDigest,
+      rowCount: sourceSnapshot.rowCount,
+      unitSlugs: Object.freeze(unitSlugs),
+    }),
     target,
     events,
     integrity: Object.freeze({ algorithm: integrity.algorithm, eventCount: integrity.eventCount, eventsDigest: integrity.eventsDigest }),
   })
 }
 
-/**
- * Matches the CRM Core's canonical batch digest without importing its source
- * tree. It is intentionally over the validated opaque batch only.
- */
+/** Matches the CRM Core v2 canonical digest without importing its source tree. */
 export function digestAtendimentoProjectionBackfillBatch(value) {
   return sha256(assertAtendimentoProjectionBackfillBatch(value))
 }
@@ -363,12 +495,13 @@ function knownError(error) {
 }
 
 /**
- * Export exactly one bounded, repeatable-read snapshot of Atendimento global
- * identities. It never writes to the source, never returns source UUIDs, and
- * fails rather than silently paginating an incomplete historical backfill.
+ * Exports exactly one bounded unit-scoped snapshot. This compatibility helper
+ * is intentionally capped to the CRM receiver batch maximum; larger work uses
+ * the paginated runner and a private checkpoint.
  */
 export async function exportAtendimentoClientProjectionBatch({
   pool,
+  source,
   hmacKey: suppliedHmacKey,
   keyId: suppliedKeyId,
   target,
@@ -378,7 +511,8 @@ export async function exportAtendimentoClientProjectionBatch({
   const key = hmacKey(suppliedHmacKey)
   const keyIdentifier = keyId(suppliedKeyId)
   const targetValue = assertAtendimentoProjectionExportTarget(target)
-  const limit = maximumRows(maxRows)
+  const sourceDefinition = assertAtendimentoUnitScopedProjectionSource(source)
+  const limit = maximumBatchRows(maxRows)
   let client
   let transactionOpen = false
 
@@ -388,9 +522,8 @@ export async function exportAtendimentoClientProjectionBatch({
     await client.query('BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY')
     transactionOpen = true
 
-    const { capturedAt, rowCount } = await preflightAtendimentoProjectionSource(client, { maxRows: limit })
-
-    const rowsResult = await client.query(ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL, [rowCount])
+    const { capturedAt, rowCount } = await preflightAtendimentoProjectionSource(client, { maxRows: limit, source: sourceDefinition })
+    const rowsResult = await client.query(sourceDefinition.rowsSql, [rowCount])
     const rows = sourceRows(rowsResult?.rows, rowCount)
     const batch = createAtendimentoProjectionBackfillBatch({
       rows,

--- a/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionExporter.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionExporter.mjs
@@ -140,13 +140,25 @@ function unitSlug(value, code) {
   return normalized
 }
 
+function startsReadOnlyQuery(sql) {
+  let cursor = 0
+  while (cursor < sql.length) {
+    while (cursor < sql.length && /\s/.test(sql[cursor])) cursor += 1
+    if (!sql.startsWith('/*', cursor)) break
+    const commentEnd = sql.indexOf('*/', cursor + 2)
+    if (commentEnd < 0) return false
+    cursor = commentEnd + 2
+  }
+  return /^(?:select|with)\b/i.test(sql.slice(cursor))
+}
+
 function sourceQuery(value, code, requiredAliases = []) {
   const sql = text(value, code)
   if (
     sql.length > 32_768
     || sql.includes(';')
     || SOURCE_QUERY_FORBIDDEN.test(sql)
-    || !/^\s*(?:(?:\/\*[\s\S]*?\*\/)\s*)*(?:select|with)\b/i.test(sql)
+    || !startsReadOnlyQuery(sql)
   ) fail(code)
   for (const alias of requiredAliases) {
     const expression = new RegExp(`\\bas\\s+(?:"${alias}"|${alias})\\b`, 'i')

--- a/integration/atendimento/crm-core-projection-exporter/src/paginatedAtendimentoProjectionBackfillRunner.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/paginatedAtendimentoProjectionBackfillRunner.mjs
@@ -2,12 +2,10 @@ import { createHash, createHmac } from 'node:crypto'
 
 import {
   ATENDIMENTO_CRM_PROJECTION_MAX_ROWS,
-  ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL,
-  ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL,
-  ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL,
   assertAtendimentoProjectionBackfillBatch,
   assertAtendimentoProjectionExportTarget,
   assertAtendimentoProjectionSourceRow,
+  assertAtendimentoUnitScopedProjectionSource,
   createAtendimentoProjectionBackfillBatch,
   digestAtendimentoProjectionBackfillBatch,
   preflightAtendimentoProjectionSource,
@@ -16,11 +14,11 @@ import {
   assertAtendimentoProjectionBackfillDelivery,
 } from './atendimentoProjectionBackfillDelivery.mjs'
 
-export const ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUNNER_VERSION = 'atendimento/crm-core-projection-backfill-runner/v1'
-export const ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT = 'atendimento/crm-core/staging-projection-backfill/v1'
+export const ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUNNER_VERSION = 'atendimento/crm-core-projection-backfill-runner/v2'
+export const ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT = 'atendimento/crm-core/staging-projection-backfill/v2'
 export const ATENDIMENTO_CRM_PROJECTION_BACKFILL_MAX_EVENTS_PER_BATCH = 20
 
-const CHECKPOINT_VERSION = 'atendimento/crm-core/projection-backfill-checkpoint/v2'
+const CHECKPOINT_VERSION = 'atendimento/crm-core/projection-backfill-checkpoint/v3'
 const REQUEST_ID_PREFIX = 'crm-atendimento-backfill-'
 const SOURCE_CURSOR_TIMESTAMP = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})\.(\d{1,6})Z$/
 
@@ -84,17 +82,21 @@ function sameTarget(left, right) {
 function sourceCursor(row) {
   const raw = object(row, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CURSOR_INVALID')
   const updatedAt = Object.hasOwn(raw, 'updated_at') ? raw.updated_at : raw.updatedAt
-  const normalized = assertAtendimentoProjectionSourceRow({ id: raw.id, updated_at: updatedAt })
+  const unitSlug = Object.hasOwn(raw, 'unit_slug') ? raw.unit_slug : raw.unitSlug
+  const normalized = assertAtendimentoProjectionSourceRow({ id: raw.id, updated_at: updatedAt, unit_slug: unitSlug })
   return Object.freeze({
     updatedAt: sourceCursorTimestamp(updatedAt, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_CURSOR_INVALID'),
     id: normalized.id,
+    unitSlug: normalized.unitSlug,
   })
 }
 
 function compareCursor(left, right) {
   const timestampOrder = left.updatedAt.localeCompare(right.updatedAt)
   if (timestampOrder !== 0) return timestampOrder
-  return left.id.localeCompare(right.id)
+  const idOrder = left.id.localeCompare(right.id)
+  if (idOrder !== 0) return idOrder
+  return left.unitSlug.localeCompare(right.unitSlug)
 }
 
 function pageRows(value, { limit, after } = {}) {
@@ -104,7 +106,12 @@ function pageRows(value, { limit, after } = {}) {
   const rows = []
   let previous = after || null
   for (const valueRow of value) {
-    const row = assertAtendimentoProjectionSourceRow(valueRow)
+    const raw = object(valueRow, 'ATENDIMENTO_CRM_BACKFILL_RUNNER_PAGE_INVALID')
+    const row = assertAtendimentoProjectionSourceRow({
+      id: raw.id,
+      updated_at: Object.hasOwn(raw, 'updated_at') ? raw.updated_at : raw.updatedAt,
+      unit_slug: Object.hasOwn(raw, 'unit_slug') ? raw.unit_slug : raw.unitSlug,
+    })
     const cursor = sourceCursor(valueRow)
     if (previous && compareCursor(cursor, previous) <= 0) {
       fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_CURSOR_INVALID')
@@ -117,16 +124,16 @@ function pageRows(value, { limit, after } = {}) {
 
 function sourceInputDigest(rows, hmacKey) {
   const digest = createHmac('sha256', hmacKey)
-  digest.update('atendimento/crm-core/projection-backfill-source-input/v1\u0000')
+  digest.update('atendimento/crm-core/projection-backfill-source-input/v2\u0000')
   for (const { cursor } of rows) {
-    digest.update(cursor.updatedAt).update('\u0000').update(cursor.id).update('\n')
+    digest.update(cursor.updatedAt).update('\u0000').update(cursor.id).update('\u0000').update(cursor.unitSlug).update('\n')
   }
   return `sha256:${digest.digest('hex')}`
 }
 
-async function preflightSourceInputDigest(client, { rowCount, hmacKey }) {
+async function preflightSourceInputDigest(client, { rowCount, hmacKey, source }) {
   if (rowCount === 0) return sourceInputDigest([], hmacKey)
-  const result = await client.query(ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL, [rowCount])
+  const result = await client.query(source.rowsSql, [rowCount])
   const rows = pageRows(result?.rows, { limit: rowCount })
   if (rows.length !== rowCount) fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_SOURCE_INPUT_INVALID')
   return sourceInputDigest(rows, hmacKey)
@@ -172,8 +179,8 @@ function nextReconciliationDigest(previous, record) {
 function storedCursor(value, code) {
   if (value === null) return null
   const cursor = object(value, code)
-  exactKeys(cursor, ['updatedAt', 'id'], code)
-  return sourceCursor({ updatedAt: cursor.updatedAt, id: cursor.id })
+  exactKeys(cursor, ['updatedAt', 'id', 'unitSlug'], code)
+  return sourceCursor({ updatedAt: cursor.updatedAt, id: cursor.id, unitSlug: cursor.unitSlug })
 }
 
 function storedPending(value, { target, capturedAt, code }) {
@@ -345,6 +352,7 @@ function knownError(error) {
  */
 export function createPaginatedAtendimentoProjectionBackfillRunner({
   pool,
+  source,
   hmacKey,
   keyId,
   target,
@@ -357,6 +365,9 @@ export function createPaginatedAtendimentoProjectionBackfillRunner({
   if (!pool || typeof pool.connect !== 'function') fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_POOL_REQUIRED')
   const pageSize = normalizedBatchSize(batchSize)
   const maximumRows = normalizedMaximumRows(maxRows)
+  // The owner-defined query family is verified before the pool is connected,
+  // so the historic two-column identity query cannot be selected by a caller.
+  const sourceDefinition = assertAtendimentoUnitScopedProjectionSource(source)
   const targetValue = assertAtendimentoProjectionExportTarget(target)
   if (targetValue.environment !== 'staging') fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_STAGING_ONLY')
   const deliverySigner = signer(suppliedSigner)
@@ -405,12 +416,16 @@ export function createPaginatedAtendimentoProjectionBackfillRunner({
         await client.query('BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY')
         transactionOpen = true
 
-        const source = await preflightAtendimentoProjectionSource(client, { maxRows: maximumRows })
-        const capturedAt = source.capturedAt
-        const sourceRowCount = source.rowCount
+        const sourceSnapshot = await preflightAtendimentoProjectionSource(client, {
+          maxRows: maximumRows,
+          source: sourceDefinition,
+        })
+        const capturedAt = sourceSnapshot.capturedAt
+        const sourceRowCount = sourceSnapshot.rowCount
         const currentSourceInputDigest = await preflightSourceInputDigest(client, {
           rowCount: sourceRowCount,
           hmacKey,
+          source: sourceDefinition,
         })
         let state
         if (restored) {
@@ -440,8 +455,13 @@ export function createPaginatedAtendimentoProjectionBackfillRunner({
           const remaining = sourceRowCount - state.deliveredCount
           const limit = Math.min(pageSize, remaining)
           const result = state.cursor
-            ? await client.query(ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL, [state.cursor.updatedAt, state.cursor.id, limit])
-            : await client.query(ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL, [limit])
+            ? await client.query(sourceDefinition.nextPageSql, [
+              state.cursor.updatedAt,
+              state.cursor.id,
+              state.cursor.unitSlug,
+              limit,
+            ])
+            : await client.query(sourceDefinition.firstPageSql, [limit])
           const page = pageRows(result?.rows, { limit, after: state.cursor })
           const rows = page.map(({ row }) => row)
           if (rows.length > remaining) fail('ATENDIMENTO_CRM_BACKFILL_RUNNER_RECONCILIATION_FAILED')

--- a/integration/atendimento/crm-core-projection-exporter/src/syntheticAtendimentoProjectionRemoteRehearsal.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/syntheticAtendimentoProjectionRemoteRehearsal.mjs
@@ -16,19 +16,21 @@ import {
   createPaginatedAtendimentoProjectionBackfillRunner,
 } from './paginatedAtendimentoProjectionBackfillRunner.mjs'
 import {
+  ATENDIMENTO_SYNTHETIC_UNIT_SCOPED_PROJECTION_SOURCE,
   createSyntheticAtendimentoProjectionFixturePool,
 } from './syntheticStagingPreparationRunner.mjs'
 
-export const ATENDIMENTO_SYNTHETIC_REMOTE_REHEARSAL_VERSION = 'atendimento/crm-core/synthetic-remote-backfill-rehearsal/v1'
-export const ATENDIMENTO_SYNTHETIC_REMOTE_REHEARSAL_INTENT = 'atendimento/crm-core/synthetic-remote-backfill-rehearsal-delivery/v1'
+export const ATENDIMENTO_SYNTHETIC_REMOTE_REHEARSAL_VERSION = 'atendimento/crm-core/synthetic-remote-backfill-rehearsal/v2'
+export const ATENDIMENTO_SYNTHETIC_REMOTE_REHEARSAL_INTENT = 'atendimento/crm-core/synthetic-remote-backfill-rehearsal-delivery/v2'
 
 const SYNTHETIC_CAPTURED_AT = '2026-09-07T00:00:00.000Z'
 const SYNTHETIC_SOURCE_ROW = Object.freeze({
   id: '123e4567-e89b-42d3-a456-426614174001',
   updated_at: SYNTHETIC_CAPTURED_AT,
+  unit_slug: 'novo-hamburgo',
 })
 const DELIVERY_KEY_ID = 'crm-staging-atendimento-backfill-remote-rehearsal'
-const SOURCE_KEY_ID = 'atendimento-synthetic-remote-rehearsal-v1'
+const SOURCE_KEY_ID = 'atendimento-synthetic-remote-rehearsal-v2'
 const LEGACY_FIXTURE_BATCH_ID = 'backfill:atendimento:fixture-batch-0001'
 
 function fail(code) {
@@ -94,13 +96,14 @@ function expectedReconciliation(batch, batchDigest) {
     eventCount: batch.events.length,
     eventsDigest: batch.integrity.eventsDigest,
     cursorDigest: batch.sourceSnapshot.cursorDigest,
+    unitSlugs: batch.sourceSnapshot.unitSlugs,
     eventIds: Object.freeze(batch.events.map((event) => event.id)),
   })
 }
 
 function assertReconciliation(value, expected) {
   const reconciliation = object(value, 'ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_RECONCILIATION_INVALID')
-  exactKeys(reconciliation, ['batchId', 'target', 'eventCount', 'eventsDigest', 'cursorDigest', 'eventIds'], 'ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_RECONCILIATION_INVALID')
+  exactKeys(reconciliation, ['batchId', 'target', 'eventCount', 'eventsDigest', 'cursorDigest', 'unitSlugs', 'eventIds'], 'ATENDIMENTO_CRM_SYNTHETIC_REMOTE_REHEARSAL_RECONCILIATION_INVALID')
   const target = assertAtendimentoProjectionExportTarget(reconciliation.target)
   if (
     reconciliation.batchId !== expected.batchId
@@ -108,6 +111,8 @@ function assertReconciliation(value, expected) {
     || reconciliation.eventCount !== expected.eventCount
     || reconciliation.eventsDigest !== expected.eventsDigest
     || reconciliation.cursorDigest !== expected.cursorDigest
+    || !Array.isArray(reconciliation.unitSlugs)
+    || JSON.stringify(reconciliation.unitSlugs) !== JSON.stringify(expected.unitSlugs)
     || !Array.isArray(reconciliation.eventIds)
     || reconciliation.eventIds.length !== expected.eventIds.length
     || reconciliation.eventIds.some((eventId, index) => eventId !== expected.eventIds[index])
@@ -118,6 +123,7 @@ function assertReconciliation(value, expected) {
     eventCount: expected.eventCount,
     eventsDigest: expected.eventsDigest,
     cursorDigest: expected.cursorDigest,
+    unitSlugs: Object.freeze([...expected.unitSlugs]),
   })
 }
 
@@ -209,6 +215,7 @@ export function createSyntheticAtendimentoProjectionRemoteRehearsal(options = {}
         capturedAt: SYNTHETIC_CAPTURED_AT,
         rows: [SYNTHETIC_SOURCE_ROW],
       }),
+      source: ATENDIMENTO_SYNTHETIC_UNIT_SCOPED_PROJECTION_SOURCE,
       hmacKey,
       keyId: SOURCE_KEY_ID,
       target,
@@ -246,7 +253,7 @@ export function createSyntheticAtendimentoProjectionRemoteRehearsal(options = {}
       }
       const verified = assertReconciliation(reconciliation, expected)
       return Object.freeze({
-        contractVersion: 'atendimento/crm-core/synthetic-remote-backfill-rehearsal-receipt/v1',
+        contractVersion: 'atendimento/crm-core/synthetic-remote-backfill-rehearsal-receipt/v2',
         status: 'reconciled',
         target: Object.freeze({ ...target }),
         batchId: batch.batchId,

--- a/integration/atendimento/crm-core-projection-exporter/src/syntheticStagingPreparationRunner.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/syntheticStagingPreparationRunner.mjs
@@ -1,22 +1,50 @@
 import {
-  ATENDIMENTO_CRM_PROJECTION_MAX_ROWS,
-  ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL,
-  ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL,
+  ATENDIMENTO_CRM_PROJECTION_BACKFILL_MAX_EVENTS,
   ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL,
-  ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL,
-  ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL,
   ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL,
+  ATENDIMENTO_UNIT_SCOPED_PROJECTION_SOURCE_CONTRACT,
+  assertAtendimentoProjectionSourceRow,
   assertAtendimentoProjectionExportTarget,
+  createAtendimentoUnitScopedProjectionSource,
   exportAtendimentoClientProjectionBatch,
 } from './atendimentoProjectionExporter.mjs'
 
-export const ATENDIMENTO_SYNTHETIC_STAGING_PREPARATION_INTENT = 'atendimento/crm-core/synthetic-staging-preparation/v1'
+export const ATENDIMENTO_SYNTHETIC_STAGING_PREPARATION_INTENT = 'atendimento/crm-core/synthetic-staging-preparation/v2'
+
+// This descriptor is deliberately synthetic. A production caller must inject
+// an Atendimento-owned source contract rather than repurposing this fixture.
+export const ATENDIMENTO_SYNTHETIC_UNIT_SCOPED_PROJECTION_SOURCE = createAtendimentoUnitScopedProjectionSource({
+  contract: ATENDIMENTO_UNIT_SCOPED_PROJECTION_SOURCE_CONTRACT,
+  countSql: `SELECT count(*)::int AS row_count
+FROM synthetic_atendimento_unit_projection_source`,
+  rowsSql: `/* bounded source-input fingerprint */
+SELECT id::text AS id,
+  to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS updated_at,
+  unit_slug AS unit_slug
+FROM synthetic_atendimento_unit_projection_source
+ORDER BY updated_at ASC, id ASC, unit_slug ASC
+LIMIT $1`,
+  firstPageSql: `/* first keyset page */
+SELECT id::text AS id,
+  to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS updated_at,
+  unit_slug AS unit_slug
+FROM synthetic_atendimento_unit_projection_source
+ORDER BY updated_at ASC, id ASC, unit_slug ASC
+LIMIT $1`,
+  nextPageSql: `SELECT id::text AS id,
+  to_char(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS updated_at,
+  unit_slug AS unit_slug
+FROM synthetic_atendimento_unit_projection_source
+WHERE (updated_at, id, unit_slug) > ($1::timestamptz, $2::uuid, $3::text)
+ORDER BY updated_at ASC, id ASC, unit_slug ASC
+LIMIT $4`,
+})
 
 const INPUT_KEYS = Object.freeze(['syntheticIntent', 'target', 'fixturePool', 'hmacKey', 'keyId', 'receiver', 'maxRows'])
 const SYNTHETIC_FIXTURE_POOLS = new WeakSet()
 const SYNTHETIC_FIXTURE_RECEIVERS = new WeakSet()
 const SYNTHETIC_FIXTURE_RECEIPTS = new WeakMap()
-const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const SOURCE_CURSOR_TIMESTAMP = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})\.(\d{1,6})Z$/
 
 function fail(code) {
   throw new Error(code)
@@ -42,7 +70,10 @@ function timestamp(value, code) {
 }
 
 function cursorTimestamp(value, code) {
-  return timestamp(value, code).replace(/\.(\d{3})Z$/, (_match, milliseconds) => `.${milliseconds}000Z`)
+  const raw = String(value || '').trim()
+  const match = SOURCE_CURSOR_TIMESTAMP.exec(raw)
+  if (!match || Number.isNaN(new Date(raw).getTime())) fail(code)
+  return `${match[1]}.${match[2].padEnd(6, '0')}Z`
 }
 
 function explicitSyntheticIntent(value) {
@@ -59,8 +90,8 @@ function stagingTarget(value) {
 }
 
 function boundedCount(value) {
-  const count = value === undefined ? ATENDIMENTO_CRM_PROJECTION_MAX_ROWS : Number(value)
-  if (!Number.isSafeInteger(count) || count < 1 || count > ATENDIMENTO_CRM_PROJECTION_MAX_ROWS) {
+  const count = value === undefined ? ATENDIMENTO_CRM_PROJECTION_BACKFILL_MAX_EVENTS : Number(value)
+  if (!Number.isSafeInteger(count) || count < 1 || count > ATENDIMENTO_CRM_PROJECTION_BACKFILL_MAX_EVENTS) {
     fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_COUNT_INVALID')
   }
   return count
@@ -91,16 +122,30 @@ function sanitizedReceipt(batch) {
 
 function syntheticSourceRows(value) {
   if (!Array.isArray(value)) fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_INVALID')
-  const identifiers = new Set()
+  const identities = new Set()
   const rows = value.map((item) => {
     const row = object(item, 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_INVALID')
-    exactKeys(row, ['id', 'updated_at'], 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_INVALID')
-    const id = String(row.id || '').trim().toLowerCase()
-    if (!UUID_PATTERN.test(id) || identifiers.has(id)) fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_INVALID')
-    identifiers.add(id)
-    return Object.freeze({ id, updated_at: timestamp(row.updated_at, 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_INVALID') })
+    exactKeys(row, ['id', 'updated_at', 'unit_slug'], 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_INVALID')
+    let normalized
+    try {
+      normalized = assertAtendimentoProjectionSourceRow(row)
+    } catch {
+      fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_INVALID')
+    }
+    const identity = `${normalized.id}\u0000${normalized.unitSlug}`
+    if (identities.has(identity)) fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_INVALID')
+    identities.add(identity)
+    return Object.freeze({
+      id: normalized.id,
+      updated_at: normalized.sourceUpdatedAt,
+      unit_slug: normalized.unitSlug,
+    })
   })
-  return Object.freeze(rows.sort((left, right) => left.updated_at.localeCompare(right.updated_at) || left.id.localeCompare(right.id)))
+  return Object.freeze(rows.sort((left, right) => (
+    left.updated_at.localeCompare(right.updated_at)
+    || left.id.localeCompare(right.id)
+    || left.unit_slug.localeCompare(right.unit_slug)
+  )))
 }
 
 /**
@@ -125,33 +170,41 @@ export function createSyntheticAtendimentoProjectionFixturePool(value) {
       if (sql === 'BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY' || sql === 'ROLLBACK') return { rows: [] }
       if (sql === ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL) return { rows: [identity] }
       if (sql === ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL) return { rows: [{ captured_at: capturedAt }] }
-      if (sql === ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL) return { rows: [{ row_count: rows.length }] }
-      if (sql === ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL) {
+      if (sql === ATENDIMENTO_SYNTHETIC_UNIT_SCOPED_PROJECTION_SOURCE.countSql) return { rows: [{ row_count: rows.length }] }
+      if (sql === ATENDIMENTO_SYNTHETIC_UNIT_SCOPED_PROJECTION_SOURCE.rowsSql) {
         if (!Array.isArray(params) || params.length !== 1 || params[0] !== rows.length) {
           fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID')
         }
         return { rows }
       }
-      if (sql === ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL) {
+      if (sql === ATENDIMENTO_SYNTHETIC_UNIT_SCOPED_PROJECTION_SOURCE.firstPageSql) {
         const [limit] = params
         if (!Number.isSafeInteger(limit) || limit < 1 || limit > rows.length) {
           fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID')
         }
         return { rows: rows.slice(0, limit) }
       }
-      if (sql === ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL) {
-        const [updatedAt, id, limit] = params
-        if (
-          !Number.isSafeInteger(limit)
-          || limit < 1
-          || typeof updatedAt !== 'string'
-          || !UUID_PATTERN.test(String(id || ''))
-        ) fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID')
-        const cursorUpdatedAt = cursorTimestamp(updatedAt, 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID')
+      if (sql === ATENDIMENTO_SYNTHETIC_UNIT_SCOPED_PROJECTION_SOURCE.nextPageSql) {
+        const [updatedAt, id, unitSlug, limit] = params
+        if (!Number.isSafeInteger(limit) || limit < 1) fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID')
+        let cursor
+        try {
+          const normalized = assertAtendimentoProjectionSourceRow({ id, updated_at: updatedAt, unit_slug: unitSlug })
+          cursor = Object.freeze({
+            updatedAt: cursorTimestamp(updatedAt, 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID'),
+            id: normalized.id,
+            unitSlug: normalized.unitSlug,
+          })
+        } catch {
+          fail('ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID')
+        }
         return {
           rows: rows.filter((row) => (
-            cursorTimestamp(row.updated_at, 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID').localeCompare(cursorUpdatedAt) > 0
-            || (cursorTimestamp(row.updated_at, 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID') === cursorUpdatedAt && row.id.localeCompare(id) > 0)
+            cursorTimestamp(row.updated_at, 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID').localeCompare(cursor.updatedAt) > 0
+            || (cursorTimestamp(row.updated_at, 'ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_QUERY_INVALID') === cursor.updatedAt && (
+              row.id.localeCompare(cursor.id) > 0
+              || (row.id === cursor.id && row.unit_slug.localeCompare(cursor.unitSlug) > 0)
+            ))
           )).slice(0, limit),
         }
       }
@@ -201,6 +254,7 @@ export async function prepareSyntheticAtendimentoProjectionStaging(options = {})
 
   const batch = await exportAtendimentoClientProjectionBatch({
     pool,
+    source: ATENDIMENTO_SYNTHETIC_UNIT_SCOPED_PROJECTION_SOURCE,
     hmacKey: input.hmacKey,
     keyId: input.keyId,
     target,

--- a/integration/atendimento/crm-core-projection-exporter/test/atendimentoConfirmedUnitScopedProjectionSource.test.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/test/atendimentoConfirmedUnitScopedProjectionSource.test.mjs
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE,
+  ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE_SEMANTICS,
+} from '../src/atendimentoConfirmedUnitScopedProjectionSource.mjs'
+import {
+  ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL,
+  ATENDIMENTO_UNIT_SCOPED_PROJECTION_SOURCE_CONTRACT,
+  createAtendimentoUnitScopedProjectionSource,
+  exportAtendimentoClientProjectionBatch,
+} from '../src/atendimentoProjectionExporter.mjs'
+
+const HMAC_KEY = 'synthetic-atendimento-confirmed-unit-source-key-at-least-32-bytes'
+const TARGET = Object.freeze({
+  environment: 'staging',
+  release: 'a'.repeat(40),
+  artifactDigest: `sha256:${'b'.repeat(64)}`,
+})
+const IDENTITY_ID = '123e4567-e89b-42d3-a456-426614174000'
+
+function sourceRow({
+  id = IDENTITY_ID,
+  updated_at = '2026-09-07T00:00:00.000000Z',
+  unit_slug = 'novo-hamburgo',
+} = {}) {
+  return { id, updated_at, unit_slug }
+}
+
+function fixturePool(rows) {
+  const calls = []
+  const client = {
+    async query(sql, params = []) {
+      calls.push({ sql, params })
+      if (sql === 'BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY' || sql === 'ROLLBACK') return { rows: [] }
+      if (sql === ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL) {
+        return { rows: [{
+          database_name: 'skincos_clientes_production',
+          current_user: 'crm_core_projection_exporter',
+          session_user: 'crm_core_projection_exporter',
+          transaction_read_only: 'on',
+        }] }
+      }
+      if (sql === ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL) return { rows: [{ captured_at: '2026-09-07T00:00:00.000Z' }] }
+      if (sql === ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE.countSql) return { rows: [{ row_count: rows.length }] }
+      if (sql === ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE.rowsSql) return { rows }
+      throw new Error('unexpected query')
+    },
+    release() {},
+  }
+  return { calls, pool: { async connect() { return client } } }
+}
+
+async function exportConfirmed(rows) {
+  return exportAtendimentoClientProjectionBatch({
+    pool: fixturePool(rows).pool,
+    source: ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE,
+    hmacKey: HMAC_KEY,
+    keyId: 'atendimento-confirmed-unit-source-v1',
+    target: TARGET,
+  })
+}
+
+function sourceWithLeadingComment(prefix) {
+  return createAtendimentoUnitScopedProjectionSource({
+    contract: ATENDIMENTO_UNIT_SCOPED_PROJECTION_SOURCE_CONTRACT,
+    countSql: 'SELECT count(*)::int AS row_count FROM test_source',
+    rowsSql: `${prefix} SELECT id::text AS id, updated_at AS updated_at, unit_slug AS unit_slug FROM test_source ORDER BY updated_at ASC, id ASC, unit_slug ASC LIMIT $1`,
+    firstPageSql: `${prefix} SELECT id::text AS id, updated_at AS updated_at, unit_slug AS unit_slug FROM test_source ORDER BY updated_at ASC, id ASC, unit_slug ASC LIMIT $1`,
+    nextPageSql: `${prefix} SELECT id::text AS id, updated_at AS updated_at, unit_slug AS unit_slug FROM test_source WHERE (updated_at, id, unit_slug) > ($1::timestamptz, $2::uuid, $3::text) ORDER BY updated_at ASC, id ASC, unit_slug ASC LIMIT $4`,
+  })
+}
+
+test('expresses the proven four-channel unit membership without a global fallback or source PII', () => {
+  const { countSql, rowsSql, firstPageSql, nextPageSql } = ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE
+  const queries = [countSql, rowsSql, firstPageSql, nextPageSql]
+
+  for (const query of queries) {
+    assert.match(query, /crm_atendimento\.global_client_identity_members/i)
+    assert.match(query, /crm_atendimento\.units/i)
+    assert.doesNotMatch(query, /\b(?:canonical_name|phone_key|email_keys|cpf_keys|client_name|raw_service)\b/i)
+  }
+  for (const sourceType of ['attendance_client', 'caixa_customer', 'app_registration', 'lead_profile']) {
+    assert.match(rowsSql, new RegExp(`source_type = '${sourceType}'`))
+  }
+  assert.match(rowsSql, /attendance\.deleted_at IS NULL/)
+  assert.match(rowsSql, /GROUP BY identity_id, unit_slug/)
+  assert.match(nextPageSql, /projection_rows AS \(\s*SELECT identity_id,\s*observed_at,/)
+  assert.match(rowsSql, /SELECT id, updated_at, unit_slug/)
+  assert.match(nextPageSql, /WHERE \(observed_at, identity_id, unit_slug\) > \(\$1::timestamptz, \$2::uuid, \$3::text\)/)
+  assert.doesNotMatch(nextPageSql, /\bOFFSET\b/i)
+  assert.equal(ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE_SEMANTICS.missingEvidence, 'no projection row; there is no global or wildcard fallback')
+})
+
+test('emits one opaque event per canonical unit for an identity with multi-unit evidence', async () => {
+  const batch = await exportConfirmed([
+    sourceRow({ unit_slug: 'barra-shopping-sul' }),
+    sourceRow({ unit_slug: 'novo-hamburgo' }),
+  ])
+
+  assert.deepEqual(batch.sourceSnapshot.unitSlugs, ['barra-shopping-sul', 'novo-hamburgo'])
+  assert.equal(batch.events.length, 2)
+  assert.equal(batch.events[0].projection.reference, batch.events[1].projection.reference)
+  assert.notEqual(batch.events[0].id, batch.events[1].id)
+  assert.deepEqual(batch.events.map((event) => event.revision), [1, 1])
+  assert.equal(JSON.stringify(batch).includes(IDENTITY_ID), false)
+})
+
+test('rejects a source result with duplicate identity/unit output instead of silently choosing a conflicting membership', async () => {
+  await assert.rejects(() => exportConfirmed([
+    sourceRow(),
+    sourceRow(),
+  ]), /ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_READBACK_INVALID/)
+})
+
+test('does not manufacture a global projection when the proven membership source is empty', async () => {
+  await assert.rejects(() => exportConfirmed([]), /ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID/)
+})
+
+test('parses bounded leading SQL comments without nested-regex backtracking', () => {
+  const commentPrefix = Array.from({ length: 200 }, () => '/* source contract */').join(' ')
+  assert.equal(sourceWithLeadingComment(commentPrefix).contract, ATENDIMENTO_UNIT_SCOPED_PROJECTION_SOURCE_CONTRACT)
+  assert.throws(() => sourceWithLeadingComment('/* unterminated'), /ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_INVALID/)
+})

--- a/integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionBackfillDelivery.test.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionBackfillDelivery.test.mjs
@@ -82,7 +82,7 @@ test('uses the CRM-scoped internal HTTPS route with no credential, cookie, origi
         async json() {
           return {
             ok: true,
-            contractVersion: 'crm-core/projection-backfill-receipt/v1',
+            contractVersion: 'crm-core/projection-backfill-receipt/v2',
             status: 'accepted',
             batchId: currentBatch.batchId,
             eventCount: currentBatch.events.length,
@@ -122,9 +122,38 @@ test('fails closed when the receiver response does not bind the batch and reques
       async json() {
         return {
           ok: true,
-          contractVersion: 'crm-core/projection-backfill-receipt/v1',
+          contractVersion: 'crm-core/projection-backfill-receipt/v2',
           status: 'accepted',
           batchId: 'backfill:atendimento:wrong-batch',
+          eventCount: currentBatch.events.length,
+          target: TARGET,
+          requestId: 'crm-atendimento-backfill-000001',
+        }
+      },
+    }),
+  })
+
+  await assert.rejects(() => transport.deliver({
+    batch: currentBatch,
+    delivery,
+    requestId: 'crm-atendimento-backfill-000001',
+  }), /ATENDIMENTO_CRM_BACKFILL_TRANSPORT_RESPONSE_INVALID/)
+})
+
+test('rejects a legacy receipt version even when every other receipt field matches', async () => {
+  const currentBatch = batch()
+  const { signer } = signerFor()
+  const delivery = await signer.signBatch(currentBatch)
+  const transport = createAtendimentoProjectionBackfillHttpTransport({
+    endpoint: `https://crm-core-staging.example.test${ATENDIMENTO_CRM_BACKFILL_HTTP_PATH}`,
+    fetch: async () => ({
+      status: 200,
+      async json() {
+        return {
+          ok: true,
+          contractVersion: 'crm-core/projection-backfill-receipt/v1',
+          status: 'accepted',
+          batchId: currentBatch.batchId,
           eventCount: currentBatch.events.length,
           target: TARGET,
           requestId: 'crm-atendimento-backfill-000001',

--- a/integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionBackfillDelivery.test.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionBackfillDelivery.test.mjs
@@ -22,12 +22,12 @@ const TARGET = Object.freeze({
 })
 const SOURCE_ID = '123e4567-e89b-42d3-a456-426614174000'
 
-function batch(rows = [{ id: SOURCE_ID, updated_at: '2026-09-07T00:00:00.000Z' }]) {
+function batch(rows = [{ id: SOURCE_ID, updated_at: '2026-09-07T00:00:00.000Z', unit_slug: 'novo-hamburgo' }]) {
   return createAtendimentoProjectionBackfillBatch({
     rows,
     capturedAt: '2026-09-07T00:00:00.000Z',
     hmacKey: HMAC_KEY,
-    keyId: 'atendimento-projection-key-v1',
+    keyId: 'atendimento-projection-key-v2',
     target: TARGET,
   })
 }

--- a/integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionExporter.test.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionExporter.test.mjs
@@ -2,11 +2,16 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
-  ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL,
   ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL,
-  ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_LEGACY_COUNT_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_LEGACY_FIRST_PAGE_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_LEGACY_NEXT_PAGE_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_LEGACY_ROWS_SQL,
   ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL,
+  ATENDIMENTO_UNIT_SCOPED_PROJECTION_SOURCE_CONTRACT,
   assertAtendimentoProjectionBackfillBatch,
+  createAtendimentoProjectionBackfillBatch,
+  createAtendimentoUnitScopedProjectionSource,
   exportAtendimentoClientProjectionBatch,
 } from '../src/atendimentoProjectionExporter.mjs'
 
@@ -17,9 +22,36 @@ const TARGET = Object.freeze({
   artifactDigest: `sha256:${'b'.repeat(64)}`,
 })
 const SOURCE_ID = '123e4567-e89b-42d3-a456-426614174000'
+const SOURCE = createAtendimentoUnitScopedProjectionSource({
+  contract: ATENDIMENTO_UNIT_SCOPED_PROJECTION_SOURCE_CONTRACT,
+  countSql: 'SELECT count(*)::int AS row_count FROM test_atendimento_unit_projection_source',
+  rowsSql: `/* bounded source-input fingerprint */
+SELECT id::text AS id, updated_at AS updated_at, unit_slug AS unit_slug
+FROM test_atendimento_unit_projection_source
+ORDER BY updated_at ASC, id ASC, unit_slug ASC
+LIMIT $1`,
+  firstPageSql: `/* first keyset page */
+SELECT id::text AS id, updated_at AS updated_at, unit_slug AS unit_slug
+FROM test_atendimento_unit_projection_source
+ORDER BY updated_at ASC, id ASC, unit_slug ASC
+LIMIT $1`,
+  nextPageSql: `SELECT id::text AS id, updated_at AS updated_at, unit_slug AS unit_slug
+FROM test_atendimento_unit_projection_source
+WHERE (updated_at, id, unit_slug) > ($1::timestamptz, $2::uuid, $3::text)
+ORDER BY updated_at ASC, id ASC, unit_slug ASC
+LIMIT $4`,
+})
+
+function sourceRow({
+  id = SOURCE_ID,
+  updated_at = '2026-09-07T00:00:00.000Z',
+  unit_slug = 'novo-hamburgo',
+} = {}) {
+  return { id, updated_at, unit_slug }
+}
 
 function fakePool({
-  rows = [{ id: SOURCE_ID, updated_at: '2026-09-07T00:00:00.000Z' }],
+  rows = [sourceRow()],
   rowCount = rows.length,
   identity = {
     database_name: 'skincos_clientes_production',
@@ -36,8 +68,8 @@ function fakePool({
       if (sql === 'BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY') return { rows: [] }
       if (sql === ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL) return { rows: [identity] }
       if (sql === ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL) return { rows: [{ captured_at: '2026-09-07T00:00:00.000Z' }] }
-      if (sql === ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL) return { rows: [{ row_count: rowCount }] }
-      if (sql === ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL) return { rows }
+      if (sql === SOURCE.countSql) return { rows: [{ row_count: rowCount }] }
+      if (sql === SOURCE.rowsSql) return { rows }
       if (sql === 'ROLLBACK') return { rows: [] }
       throw new Error('unexpected query')
     },
@@ -49,24 +81,27 @@ function fakePool({
 async function exportBatch(options = {}) {
   return exportAtendimentoClientProjectionBatch({
     pool: options.pool,
+    source: SOURCE,
     hmacKey: HMAC_KEY,
-    keyId: 'atendimento-projection-key-v1',
+    keyId: 'atendimento-projection-key-v2',
     target: TARGET,
     ...options,
   })
 }
 
-test('exports a repeatable-read, opaque batch without serializing a source UUID or customer data', async () => {
+test('exports a repeatable-read, unit-scoped opaque v2 batch without serializing a source UUID or customer data', async () => {
   const fixture = fakePool()
   const batch = await exportBatch({ pool: fixture.pool })
   const serialized = JSON.stringify(batch)
 
-  assert.equal(batch.contract, 'skincos-crm/projection-backfill-batch/v1')
+  assert.equal(batch.contract, 'skincos-crm/projection-backfill-batch/v2')
   assert.match(batch.batchId, /^backfill:atendimento:[A-Za-z0-9_-]+$/)
   assert.deepEqual(batch.producer, {
-    owner: 'atendimento', scope: 'global-client-identities/v1', keyId: 'atendimento-projection-key-v1',
+    owner: 'atendimento', scope: 'global-client-identities/v1', keyId: 'atendimento-projection-key-v2',
   })
   assert.equal(batch.events.length, 1)
+  assert.deepEqual(batch.events[0].unitScope, { unitSlug: 'novo-hamburgo' })
+  assert.deepEqual(batch.sourceSnapshot.unitSlugs, ['novo-hamburgo'])
   assert.match(batch.events[0].id, /^event:/)
   assert.match(batch.events[0].projection.reference, /^projection:/)
   assert.match(batch.events[0].source.reference, /^source:/)
@@ -76,10 +111,29 @@ test('exports a repeatable-read, opaque batch without serializing a source UUID 
   assert.equal(fixture.calls.at(-1).sql, 'ROLLBACK')
   assert.equal(fixture.released(), true)
 
-  const sourceRead = fixture.calls.find((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL)
+  const sourceRead = fixture.calls.find((call) => call.sql === SOURCE.rowsSql)
   assert.deepEqual(sourceRead.params, [1])
-  assert.match(sourceRead.sql, /SELECT id::text AS id,\s+to_char\(updated_at AT TIME ZONE 'UTC'/)
+  assert.match(sourceRead.sql, /unit_slug AS unit_slug/i)
   assert.doesNotMatch(sourceRead.sql, /canonical_name|email|phone|member|contact/i)
+})
+
+test('allows one global identity in multiple explicit unit scopes without an event HMAC collision', () => {
+  const batch = createAtendimentoProjectionBackfillBatch({
+    rows: [
+      sourceRow({ unit_slug: 'novo-hamburgo' }),
+      sourceRow({ unit_slug: 'barra-shopping-sul' }),
+    ],
+    capturedAt: '2026-09-07T00:00:00.000Z',
+    hmacKey: HMAC_KEY,
+    keyId: 'atendimento-projection-key-v2',
+    target: TARGET,
+  })
+
+  assert.deepEqual(batch.events.map((event) => event.unitScope.unitSlug), ['barra-shopping-sul', 'novo-hamburgo'])
+  assert.equal(batch.events[0].source.reference, batch.events[1].source.reference)
+  assert.equal(batch.events[0].projection.reference, batch.events[1].projection.reference)
+  assert.notEqual(batch.events[0].id, batch.events[1].id)
+  assert.deepEqual(batch.sourceSnapshot.unitSlugs, ['barra-shopping-sul', 'novo-hamburgo'])
 })
 
 test('batch output is deterministic for the same immutable source snapshot and HMAC key', async () => {
@@ -88,6 +142,26 @@ test('batch output is deterministic for the same immutable source snapshot and H
 
   assert.deepEqual(second, first)
   assert.equal(assertAtendimentoProjectionBackfillBatch(first).integrity.eventsDigest, first.integrity.eventsDigest)
+})
+
+test('requires an explicit owner source and rejects the retired two-column query family before any pool connection', async () => {
+  let connectCount = 0
+  const pool = { async connect() { connectCount += 1; throw new Error('must not connect') } }
+  await assert.rejects(() => exportAtendimentoClientProjectionBatch({
+    pool,
+    hmacKey: HMAC_KEY,
+    keyId: 'atendimento-projection-key-v2',
+    target: TARGET,
+  }), /ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_REQUIRED/)
+  assert.equal(connectCount, 0)
+
+  assert.throws(() => createAtendimentoUnitScopedProjectionSource({
+    contract: ATENDIMENTO_UNIT_SCOPED_PROJECTION_SOURCE_CONTRACT,
+    countSql: ATENDIMENTO_PROJECTION_EXPORT_LEGACY_COUNT_SQL,
+    rowsSql: ATENDIMENTO_PROJECTION_EXPORT_LEGACY_ROWS_SQL,
+    firstPageSql: ATENDIMENTO_PROJECTION_EXPORT_LEGACY_FIRST_PAGE_SQL,
+    nextPageSql: ATENDIMENTO_PROJECTION_EXPORT_LEGACY_NEXT_PAGE_SQL,
+  }), /ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_INVALID/)
 })
 
 test('fails before source-row selection when the principal is not dedicated and read-only', async () => {
@@ -101,7 +175,7 @@ test('fails before source-row selection when the principal is not dedicated and 
   await assert.rejects(() => exportBatch({ pool: fixture.pool }), {
     message: 'ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_IDENTITY_UNSAFE',
   })
-  assert.equal(fixture.calls.some((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL), false)
+  assert.equal(fixture.calls.some((call) => call.sql === SOURCE.rowsSql), false)
   assert.equal(fixture.calls.at(-1).sql, 'ROLLBACK')
 })
 
@@ -111,13 +185,12 @@ test('fails closed rather than creating a partial historical batch beyond the bo
   await assert.rejects(() => exportBatch({ pool: fixture.pool, maxRows: 2 }), {
     message: 'ATENDIMENTO_CRM_PROJECTION_EXPORT_LIMIT_EXCEEDED',
   })
-  assert.equal(fixture.calls.some((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL), false)
+  assert.equal(fixture.calls.some((call) => call.sql === SOURCE.rowsSql), false)
 })
 
-test('rejects a source query result that expands beyond id and updated_at', async () => {
+test('rejects a source query result that expands beyond id, updated_at, and unit_slug', async () => {
   const fixture = fakePool({ rows: [{
-    id: SOURCE_ID,
-    updated_at: '2026-09-07T00:00:00.000Z',
+    ...sourceRow(),
     canonical_name: 'must-never-leave-atendimento',
   }] })
 

--- a/integration/atendimento/crm-core-projection-exporter/test/paginatedAtendimentoProjectionBackfillRunner.test.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/test/paginatedAtendimentoProjectionBackfillRunner.test.mjs
@@ -3,12 +3,10 @@ import crypto from 'node:crypto'
 import test from 'node:test'
 
 import {
-  ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL,
-  ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL,
   ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL,
-  ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL,
-  ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL,
   ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL,
+  ATENDIMENTO_UNIT_SCOPED_PROJECTION_SOURCE_CONTRACT,
+  createAtendimentoUnitScopedProjectionSource,
 } from '../src/atendimentoProjectionExporter.mjs'
 import {
   createAtendimentoProjectionBackfillDeliverySigner,
@@ -29,10 +27,29 @@ const OTHER_TARGET = Object.freeze({
   release: 'c'.repeat(40),
 })
 const CAPTURED_AT = '2026-09-07T00:00:00.000Z'
+const SOURCE = createAtendimentoUnitScopedProjectionSource({
+  contract: ATENDIMENTO_UNIT_SCOPED_PROJECTION_SOURCE_CONTRACT,
+  countSql: 'SELECT count(*)::int AS row_count FROM test_atendimento_unit_projection_source',
+  rowsSql: `/* bounded source-input fingerprint */
+SELECT id::text AS id, updated_at AS updated_at, unit_slug AS unit_slug
+FROM test_atendimento_unit_projection_source
+ORDER BY updated_at ASC, id ASC, unit_slug ASC
+LIMIT $1`,
+  firstPageSql: `/* first keyset page */
+SELECT id::text AS id, updated_at AS updated_at, unit_slug AS unit_slug
+FROM test_atendimento_unit_projection_source
+ORDER BY updated_at ASC, id ASC, unit_slug ASC
+LIMIT $1`,
+  nextPageSql: `SELECT id::text AS id, updated_at AS updated_at, unit_slug AS unit_slug
+FROM test_atendimento_unit_projection_source
+WHERE (updated_at, id, unit_slug) > ($1::timestamptz, $2::uuid, $3::text)
+ORDER BY updated_at ASC, id ASC, unit_slug ASC
+LIMIT $4`,
+})
 
-function sourceRowAt(index, timestamp) {
+function sourceRowAt(index, timestamp, unit_slug = index % 2 === 0 ? 'barra-shopping-sul' : 'novo-hamburgo') {
   const suffix = index.toString(16).padStart(12, '0')
-  return Object.freeze({ id: `123e4567-e89b-42d3-a456-${suffix}`, updated_at: timestamp })
+  return Object.freeze({ id: `123e4567-e89b-42d3-a456-${suffix}`, updated_at: timestamp, unit_slug })
 }
 
 function sourceRow(index) {
@@ -41,7 +58,9 @@ function sourceRow(index) {
 }
 
 function compareRows(left, right) {
-  return left.updated_at.localeCompare(right.updated_at) || left.id.localeCompare(right.id)
+  return left.updated_at.localeCompare(right.updated_at)
+    || left.id.localeCompare(right.id)
+    || left.unit_slug.localeCompare(right.unit_slug)
 }
 
 function fakePool({
@@ -65,20 +84,23 @@ function fakePool({
         transaction_read_only: 'on',
       }] }
       if (sql === ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL) return { rows: [{ captured_at: capturedAt }] }
-      if (sql === ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL) return { rows: [{ row_count: rowCount }] }
-      if (sql === ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL) {
+      if (sql === SOURCE.countSql) return { rows: [{ row_count: rowCount }] }
+      if (sql === SOURCE.rowsSql) {
         if (params.length !== 1 || params[0] !== rowCount) throw new Error('unexpected source-input query parameters')
         return { rows: sourceRows.slice(0, params[0]) }
       }
-      if (sql === ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL) {
+      if (sql === SOURCE.firstPageSql) {
         return { rows: sourceRows.slice(0, params[0]) }
       }
-      if (sql === ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL) {
-        const [updatedAt, id, limit] = params
+      if (sql === SOURCE.nextPageSql) {
+        const [updatedAt, id, unitSlug, limit] = params
         return {
           rows: sourceRows.filter((row) => (
             row.updated_at.localeCompare(updatedAt) > 0
-            || (row.updated_at === updatedAt && row.id.localeCompare(id) > 0)
+            || (row.updated_at === updatedAt && (
+              row.id.localeCompare(id) > 0
+              || (row.id === id && row.unit_slug.localeCompare(unitSlug) > 0)
+            ))
           )).slice(0, limit),
         }
       }
@@ -147,6 +169,7 @@ function transportFixture({ statuses = ['accepted'], failure } = {}) {
 function runner({ pool, checkpointStore, transport, target = TARGET, batchSize = 20, maxRows = 10_000 } = {}) {
   return createPaginatedAtendimentoProjectionBackfillRunner({
     pool,
+    source: SOURCE,
     hmacKey: HMAC_KEY,
     keyId: 'atendimento-projection-key-v1',
     target,
@@ -186,12 +209,12 @@ test('delivers deterministic keyset pages, stores private checkpoints, and recon
   assert.deepEqual(deliveries.deliveries().map(({ batch }) => batch.events.length), [20, 20, 5])
   assert.equal(deliveries.deliveries().every(({ batch }) => !JSON.stringify(batch).includes(sourceRow(0).id)), true)
   assert.equal(JSON.stringify(summary).includes(sourceRow(0).id), false)
-  assert.equal(source.calls.filter((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL).length, 1)
-  assert.equal(source.calls.filter((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL).length, 2)
-  assert.equal(source.calls.filter((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL).length, 1)
+  assert.equal(source.calls.filter((call) => call.sql === SOURCE.firstPageSql).length, 1)
+  assert.equal(source.calls.filter((call) => call.sql === SOURCE.nextPageSql).length, 2)
+  assert.equal(source.calls.filter((call) => call.sql === SOURCE.rowsSql).length, 1)
   assert.equal(source.calls.some((call) => /\bOFFSET\b/i.test(call.sql)), false)
-  assert.deepEqual(source.calls.find((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL).params, [20])
-  assert.deepEqual(source.calls.filter((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL).map((call) => call.params.at(-1)), [20, 5])
+  assert.deepEqual(source.calls.find((call) => call.sql === SOURCE.firstPageSql).params, [20])
+  assert.deepEqual(source.calls.filter((call) => call.sql === SOURCE.nextPageSql).map((call) => call.params.at(-1)), [20, 5])
   assert.equal(source.calls.at(-1).sql, 'ROLLBACK')
   assert.equal(source.released(), true)
   assert.equal(checkpoints.active(), null)
@@ -272,7 +295,7 @@ test('replays the exact private pending packet and resumes when a new transactio
   assert.equal(summary.batchCount, 1)
   assert.equal(summary.acceptedCount, 0)
   assert.equal(summary.idempotentCount, 1)
-  assert.equal(resumedSource.calls.some((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_FIRST_PAGE_SQL), false)
+  assert.equal(resumedSource.calls.some((call) => call.sql === SOURCE.firstPageSql), false)
   assert.equal(checkpoints.active(), null)
 })
 
@@ -346,10 +369,10 @@ test('refuses a checkpoint for another CRM target before replaying its pending p
   assert.ok(checkpoints.active()?.pending)
 })
 
-test('keeps the exact PostgreSQL microsecond cursor for keyset pagination', async () => {
+test('keeps the exact PostgreSQL microsecond and unit cursor for three-column keyset pagination', async () => {
   const rows = [
-    sourceRowAt(1, '2026-09-07T00:00:00.123001Z'),
-    sourceRowAt(2, '2026-09-07T00:00:00.123456Z'),
+    sourceRowAt(1, '2026-09-07T00:00:00.123001Z', 'barra-shopping-sul'),
+    sourceRowAt(1, '2026-09-07T00:00:00.123001Z', 'novo-hamburgo'),
     sourceRowAt(3, '2026-09-07T00:00:00.124000Z'),
   ]
   const source = fakePool({ rows })
@@ -363,14 +386,14 @@ test('keeps the exact PostgreSQL microsecond cursor for keyset pagination', asyn
   })
   const summary = await currentRunner.run({ intent: ATENDIMENTO_CRM_PROJECTION_BACKFILL_RUN_INTENT })
   const cursorParameters = source.calls
-    .filter((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_NEXT_PAGE_SQL)
-    .map((call) => call.params[0])
+    .filter((call) => call.sql === SOURCE.nextPageSql)
+    .map((call) => call.params.slice(0, 3))
 
   assert.equal(summary.deliveredCount, 3)
   assert.equal(deliveries.deliveries().length, 3)
   assert.deepEqual(cursorParameters, [
-    '2026-09-07T00:00:00.123001Z',
-    '2026-09-07T00:00:00.123456Z',
+    ['2026-09-07T00:00:00.123001Z', '123e4567-e89b-42d3-a456-000000000001', 'barra-shopping-sul'],
+    ['2026-09-07T00:00:00.123001Z', '123e4567-e89b-42d3-a456-000000000001', 'novo-hamburgo'],
   ])
 })
 

--- a/integration/atendimento/crm-core-projection-exporter/test/syntheticAtendimentoProjectionRemoteRehearsal.test.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/test/syntheticAtendimentoProjectionRemoteRehearsal.test.mjs
@@ -30,7 +30,7 @@ function acceptedThenIdempotentFetch(calls) {
       async json() {
         return {
           ok: true,
-          contractVersion: 'crm-core/projection-backfill-receipt/v1',
+          contractVersion: 'crm-core/projection-backfill-receipt/v2',
           status: calls.length === 1 ? 'accepted' : 'idempotent',
           batchId: input.batch.batchId,
           eventCount: input.batch.events.length,

--- a/integration/atendimento/crm-core-projection-exporter/test/syntheticAtendimentoProjectionRemoteRehearsal.test.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/test/syntheticAtendimentoProjectionRemoteRehearsal.test.mjs
@@ -76,6 +76,7 @@ test('delivers the real paginated producer packet twice and requires a D1-style 
         eventCount: expected.eventCount,
         eventsDigest: expected.eventsDigest,
         cursorDigest: expected.cursorDigest,
+        unitSlugs: expected.unitSlugs,
         eventIds: expected.eventIds,
       }
     },
@@ -91,11 +92,12 @@ test('delivers the real paginated producer packet twice and requires a D1-style 
   assert.equal(calls.every((call) => call.body.delivery.batchDigest === receipt.batchDigest), true)
   assert.equal(calls.every((call) => !JSON.stringify(call.body).includes(SOURCE_UUID)), true)
   assert.equal(calls[0].body.batch.events.length, 1)
+  assert.deepEqual(calls[0].body.batch.events[0].unitScope, { unitSlug: 'novo-hamburgo' })
   assert.equal(reconcileCalls.length, 1)
   assert.equal(reconcileCalls[0].batchId, receipt.batchId)
   assert.equal(reconcileCalls[0].batchDigest, receipt.batchDigest)
   assert.deepEqual(receipt, {
-    contractVersion: 'atendimento/crm-core/synthetic-remote-backfill-rehearsal-receipt/v1',
+    contractVersion: 'atendimento/crm-core/synthetic-remote-backfill-rehearsal-receipt/v2',
     status: 'reconciled',
     target: TARGET,
     batchId: receipt.batchId,
@@ -108,6 +110,7 @@ test('delivers the real paginated producer packet twice and requires a D1-style 
       eventCount: 1,
       eventsDigest: reconcileCalls[0].eventsDigest,
       cursorDigest: reconcileCalls[0].cursorDigest,
+      unitSlugs: ['novo-hamburgo'],
     },
   })
   assert.doesNotMatch(JSON.stringify(receipt), new RegExp(SOURCE_UUID, 'i'))
@@ -126,6 +129,7 @@ test('refuses a mismatched D1 reconciliation after delivery', async () => {
         eventCount: expected.eventCount,
         eventsDigest: expected.eventsDigest,
         cursorDigest: `sha256:${'f'.repeat(64)}`,
+        unitSlugs: expected.unitSlugs,
         eventIds: expected.eventIds,
       }
     },

--- a/integration/atendimento/crm-core-projection-exporter/test/syntheticStagingPreparationRunner.test.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/test/syntheticStagingPreparationRunner.test.mjs
@@ -3,14 +3,13 @@ import { readFile } from 'node:fs/promises'
 import test from 'node:test'
 
 import {
-  ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL,
   ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL,
-  ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL,
   ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL,
   preflightAtendimentoProjectionSource,
 } from '../src/atendimentoProjectionExporter.mjs'
 import {
   ATENDIMENTO_SYNTHETIC_STAGING_PREPARATION_INTENT,
+  ATENDIMENTO_SYNTHETIC_UNIT_SCOPED_PROJECTION_SOURCE,
   createSyntheticAtendimentoProjectionFixturePool,
   createSyntheticAtendimentoProjectionReceiptReceiver,
   prepareSyntheticAtendimentoProjectionStaging,
@@ -27,9 +26,9 @@ const PRODUCTION_TARGET = Object.freeze({ ...TARGET, environment: 'production' }
 const SOURCE_ID = '123e4567-e89b-42d3-a456-426614174000'
 const CAPTURED_AT = '2026-09-07T00:00:00.000Z'
 
-function sourceRow(index = 0) {
+function sourceRow(index = 0, unit_slug = 'novo-hamburgo') {
   const suffix = index.toString(16).padStart(12, '0')
-  return { id: `123e4567-e89b-42d3-a456-${suffix}`, updated_at: CAPTURED_AT }
+  return { id: `123e4567-e89b-42d3-a456-${suffix}`, updated_at: CAPTURED_AT, unit_slug }
 }
 
 function syntheticFixturePool(rows = [sourceRow()]) {
@@ -37,7 +36,7 @@ function syntheticFixturePool(rows = [sourceRow()]) {
 }
 
 function fakeClient({
-  rows = [{ id: SOURCE_ID, updated_at: CAPTURED_AT }],
+  rows = [{ id: SOURCE_ID, updated_at: CAPTURED_AT, unit_slug: 'novo-hamburgo' }],
   rowCount = rows.length,
 } = {}) {
   const calls = []
@@ -53,8 +52,8 @@ function fakeClient({
           transaction_read_only: 'on',
         }] }
         if (sql === ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL) return { rows: [{ captured_at: CAPTURED_AT }] }
-        if (sql === ATENDIMENTO_PROJECTION_EXPORT_COUNT_SQL) return { rows: [{ row_count: rowCount }] }
-        if (sql === ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL) return { rows }
+        if (sql === ATENDIMENTO_SYNTHETIC_UNIT_SCOPED_PROJECTION_SOURCE.countSql) return { rows: [{ row_count: rowCount }] }
+        if (sql === ATENDIMENTO_SYNTHETIC_UNIT_SCOPED_PROJECTION_SOURCE.rowsSql) return { rows }
         throw new Error('unexpected query')
       },
     },
@@ -67,15 +66,18 @@ function input(overrides = {}) {
     target: TARGET,
     fixturePool: syntheticFixturePool(),
     hmacKey: HMAC_KEY,
-    keyId: 'atendimento-projection-key-v1',
+    keyId: 'atendimento-projection-key-v2',
     receiver: createSyntheticAtendimentoProjectionReceiptReceiver(),
     ...overrides,
   }
 }
 
-test('exports a reusable source preflight that only attests identity, snapshot, and bounded count', async () => {
+test('exports a reusable preflight only for an explicit unit-scoped owner source', async () => {
   const fixture = fakeClient({ rowCount: 1 })
-  const result = await preflightAtendimentoProjectionSource(fixture.client, { maxRows: 10_000 })
+  const result = await preflightAtendimentoProjectionSource(fixture.client, {
+    maxRows: 20,
+    source: ATENDIMENTO_SYNTHETIC_UNIT_SCOPED_PROJECTION_SOURCE,
+  })
 
   assert.deepEqual(result, {
     identity: {
@@ -86,11 +88,12 @@ test('exports a reusable source preflight that only attests identity, snapshot, 
     },
     capturedAt: CAPTURED_AT,
     rowCount: 1,
+    source: ATENDIMENTO_SYNTHETIC_UNIT_SCOPED_PROJECTION_SOURCE,
   })
-  assert.equal(fixture.calls.some((call) => call.sql === ATENDIMENTO_PROJECTION_EXPORT_ROWS_SQL), false)
+  assert.equal(fixture.calls.some((call) => call.sql === ATENDIMENTO_SYNTHETIC_UNIT_SCOPED_PROJECTION_SOURCE.rowsSql), false)
 })
 
-test('prepares only a synthetic staging batch and returns a receipt without events, HMAC material, or UUIDs', async () => {
+test('prepares only a synthetic unit-scoped staging batch and returns a receipt without events, HMAC material, or UUIDs', async () => {
   const receiver = createSyntheticAtendimentoProjectionReceiptReceiver()
   const receipt = await prepareSyntheticAtendimentoProjectionStaging(input({ receiver }))
   const serialized = JSON.stringify(receipt)
@@ -103,6 +106,22 @@ test('prepares only a synthetic staging batch and returns a receipt without even
   assert.deepEqual(readSyntheticAtendimentoProjectionReceipts(receiver), [receipt])
   assert.doesNotMatch(serialized, new RegExp(SOURCE_ID, 'i'))
   assert.doesNotMatch(serialized, /event|hmac|synthetic-atendimento/i)
+})
+
+test('permits a synthetic multi-unit identity while retaining separate opaque events', async () => {
+  const receiver = createSyntheticAtendimentoProjectionReceiptReceiver()
+  const rows = [
+    sourceRow(0, 'barra-shopping-sul'),
+    sourceRow(0, 'novo-hamburgo'),
+  ]
+  const receipt = await prepareSyntheticAtendimentoProjectionStaging(input({
+    fixturePool: syntheticFixturePool(rows),
+    receiver,
+    maxRows: 2,
+  }))
+
+  assert.equal(receipt.count, 2)
+  assert.deepEqual(readSyntheticAtendimentoProjectionReceipts(receiver), [receipt])
 })
 
 test('is disabled by default and does not request the fixture pool without explicit synthetic intent', async () => {
@@ -133,12 +152,12 @@ test('refuses a production target before reading any injected provider', async (
   assert.equal(providerRead, false)
 })
 
-test('enforces the 10,000-count hard limit before requesting the fixture pool', async () => {
+test('enforces the 20-event batch ceiling before requesting the fixture pool', async () => {
   let providerRead = false
   const excessiveInput = {
     syntheticIntent: ATENDIMENTO_SYNTHETIC_STAGING_PREPARATION_INTENT,
     target: TARGET,
-    maxRows: 10_001,
+    maxRows: 21,
     get fixturePool() { providerRead = true; throw new Error('fixture pool must not be read') },
   }
 
@@ -148,8 +167,8 @@ test('enforces the 10,000-count hard limit before requesting the fixture pool', 
   assert.equal(providerRead, false)
 })
 
-test('does not create a receipt when the in-memory source preflight reports more than 10,000 rows', async () => {
-  const rows = Array.from({ length: 10_001 }, (_, index) => sourceRow(index))
+test('does not create a receipt when the in-memory source preflight reports more than 20 rows', async () => {
+  const rows = Array.from({ length: 21 }, (_, index) => sourceRow(index))
   const receiver = createSyntheticAtendimentoProjectionReceiptReceiver()
 
   await assert.rejects(() => prepareSyntheticAtendimentoProjectionStaging(input({
@@ -157,6 +176,13 @@ test('does not create a receipt when the in-memory source preflight reports more
     receiver,
   })), { message: 'ATENDIMENTO_CRM_PROJECTION_EXPORT_LIMIT_EXCEEDED' })
   assert.deepEqual(readSyntheticAtendimentoProjectionReceipts(receiver), [])
+})
+
+test('rejects a synthetic fixture row with no canonical unit slug', () => {
+  assert.throws(() => createSyntheticAtendimentoProjectionFixturePool({
+    capturedAt: CAPTURED_AT,
+    rows: [{ id: SOURCE_ID, updated_at: CAPTURED_AT }],
+  }), /ATENDIMENTO_CRM_SYNTHETIC_PREPARATION_FIXTURE_INVALID/)
 })
 
 test('rejects an arbitrary pool before it can connect, including one shaped like a database client', async () => {


### PR DESCRIPTION
## Summary

- Prepare the Atendimento producer for CRM scoped-projection batch/event v2.
- Require an owner-injected, read-only source shape: `id`, `updated_at`, and canonical `unit_slug`.
- Use a three-column keyset cursor, v2 HMAC/event identity, private checkpoint v3, and synthetic v2 fixtures.

## Explicitly pending

- No canonical production membership SQL is included. `crm_atendimento.global_client_identities` has no canonical `unit_slug`; the Atendimento owner must implement and attest the identity-to-unit membership rule and source descriptor.
- Receiver/store v2 integration remains a separate CRM Core task. This PR does not activate receiver opt-in, staging configuration, deploy, backfill, or production.

## Validation

- `node --test integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionExporter.test.mjs integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionBackfillDelivery.test.mjs integration/atendimento/crm-core-projection-exporter/test/paginatedAtendimentoProjectionBackfillRunner.test.mjs integration/atendimento/crm-core-projection-exporter/test/syntheticStagingPreparationRunner.test.mjs integration/atendimento/crm-core-projection-exporter/test/syntheticAtendimentoProjectionRemoteRehearsal.test.mjs`
- 38/38 focused tests passed through the project WSL gateway.
- `git diff --check` passed.