### PR TITLE
feat(atendimento): define confirmed unit projection source

### DIFF
--- a/integration/atendimento/crm-core-projection-exporter/README.md
+++ b/integration/atendimento/crm-core-projection-exporter/README.md
@@ -1,9 +1,11 @@
 # Exportador de projeções opacas de Atendimento para CRM Core
 
 Este adaptador prepara lotes de backfill v2 para o CRM independente, em uma
-transação PostgreSQL `REPEATABLE READ READ ONLY`. Ele não escolhe nem inventa
-a relação entre identidade global e unidade: a tabela de identidades globais
-não possui `unit_slug` canônico. Portanto não há SQL padrão para dados reais.
+transação PostgreSQL `REPEATABLE READ ONLY`. A tabela de identidades globais não
+possui `unit_slug` por si só; a fonte padrão para dados reais é a associação
+confirmada de Atendimento em
+`src/atendimentoConfirmedUnitScopedProjectionSource.mjs`, que resolve o slug
+somente pelas evidências e unidades canônicas do owner.
 
 Toda execução exige uma fonte injetada e atestada pelo owner de Atendimento,
 com uma linha estrita por vínculo identidade/unidade:
@@ -45,6 +47,9 @@ exige capacidades já construídas pelo operador:
   `crm-staging-atendimento-backfill-`;
 - transporte HTTPS injetado para a rota exata
   `/crm/_internal/backfill/atendimento`;
+- recibo HTTP estrito `crm-core/projection-backfill-receipt/v2`, vinculado ao
+  lote, request ID e artefato alvo; o envelope assinado de entrega continua em
+  `skincos-crm/projection-backfill-delivery/v1`;
 - checkpoint privado com operações `read`, `write` e `complete`.
 
 O runner abre uma única transação `REPEATABLE READ READ ONLY`, atesta a fonte e
@@ -73,19 +78,39 @@ contagem, formato de linha, lote, prova, endpoint, resposta ou limite não
 correspondem ao contrato. O teto da fonte continua sendo 10.000 linhas; se a
 carga exceder isso, ele não cria um backfill parcial.
 
-## Contrato que o owner de Atendimento ainda precisa fornecer
+## Fonte canônica confirmada pelo owner de Atendimento
 
-Antes de qualquer backfill real, o owner deve fornecer o descritor injetado da
-fonte canônica. O adaptador valida que as consultas sejam somente-leitura, sem
-`OFFSET` ou DDL/DML, que as páginas sejam ordenadas e que o cursor seguinte use
-exatamente quatro parâmetros: `updated_at`, `id`, `unit_slug` e `limit`. A
-consulta de página seguinte deve ter `WHERE`, `ORDER BY` e aliases explícitos.
+`src/atendimentoConfirmedUnitScopedProjectionSource.mjs` fornece o descritor
+canônico `ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE`. Ele reproduz a
+mesma regra já usada pelo runtime comercial de Atendimento: uma identidade tem
+escopo em cada unidade comprovada por um dos quatro canais abaixo, e o slug só
+é aceito após resolver contra `crm_atendimento.units`.
 
-O descritor não decide a semântica da associação. Essa decisão continua com
-Atendimento: deve definir qual membership confirmado projeta uma linha e qual
-fonte vence quando dados heterogêneos divergem. Até essa regra existir em
-código proprietário, o exportador recusa a consulta legada de duas colunas e
-não acessa nenhuma linha de domínio.
+- atendimento ativo: `global_client_identity_members` →
+  `attendance_client_links` → `attendances` não deletado;
+- venda Caixa: `global_client_identity_members` → `crm_caixa.sales`;
+- cadastro de app: `global_client_identity_members` →
+  `app_client_registrations.unit_slugs`;
+- lead suplementar: `global_client_identity_members` →
+  `supplemental_lead_profiles.unit_slugs`.
+
+Evidências repetidas para a mesma identidade/unidade são reduzidas a uma única
+linha; evidências em unidades diferentes constituem uma associação multiunidade
+válida, sem uma regra arbitrária de precedência. Uma identidade sem evidência
+canônica não gera linha alguma: não há fallback global, `all` ou `unknown`.
+
+As consultas continuam somente leitura, sem `OFFSET` ou DDL/DML, e usam a chave
+`(updated_at, id, unit_slug)`. `updated_at` é o carimbo observável usado pelo
+snapshot/cursor; não é uma revisão monotônica do CRM Core. O evento emitido tem
+`revision: 1`, portanto este caminho é exclusivamente para o backfill inicial e
+o replay exato do mesmo pacote. Remoções de vínculo ou sincronização incremental
+exigem um contrato posterior com tombstone e revisão monotônica; não devem ser
+simuladas reenviando esta fonte com revisão 1.
+
+Ainda é necessário que o operador provisione externamente o principal
+`crm_core_projection_exporter` com `SELECT` somente nas relações e colunas que
+essa consulta usa. Este repositório não cria usuário, senha, grant, conexão ou
+qualquer acesso ao banco de produção.
 
 ## Preflight reutilizável e preparação sintética
 

--- a/integration/atendimento/crm-core-projection-exporter/src/atendimentoConfirmedUnitScopedProjectionSource.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/atendimentoConfirmedUnitScopedProjectionSource.mjs
@@ -1,0 +1,124 @@
+import {
+  ATENDIMENTO_UNIT_SCOPED_PROJECTION_SOURCE_CONTRACT,
+  createAtendimentoUnitScopedProjectionSource,
+} from './atendimentoProjectionExporter.mjs'
+
+export const ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE_VERSION = 'atendimento/crm-core/confirmed-unit-membership-source/v1'
+
+// This is the same four-channel membership rule already enforced by Atendimento
+// commercial operations. A unit only becomes exportable after it resolves to a
+// canonical `crm_atendimento.units` row; an identity without such evidence has
+// no output row and can never fall back to a global/wildcard scope.
+export const ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE_SEMANTICS = Object.freeze({
+  version: ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE_VERSION,
+  membership: 'union of active attendance, Caixa sale, app registration, and supplemental lead evidence resolved through canonical units',
+  duplicateEvidence: 'one identity/unit row, with the latest observed source timestamp',
+  divergentUnits: 'valid multi-unit membership; emit one row for each canonical unit slug',
+  missingEvidence: 'no projection row; there is no global or wildcard fallback',
+  revision: 'snapshot-only: updated_at is cursor material, while CRM Core event revision remains 1 for the initial backfill and exact replay',
+})
+
+// This validates the UUID separators as well as the hexadecimal groups before
+// the source text is cast. A permissive "36 hex-or-dash characters" predicate
+// could still let an invalid legacy source_id abort an otherwise read-only
+// snapshot at PostgreSQL cast time.
+const UUID_TEXT_PATTERN = '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+
+// Keep every source branch data-minimal. The final projection only selects the
+// opaque identity UUID, a timestamp, and the canonical unit slug; names,
+// phones, email, and sale/attendance payloads never cross this boundary.
+const MEMBERSHIP_CTE = `WITH unit_membership_evidence AS (
+  SELECT member.identity_id,
+    unit.slug AS unit_slug,
+    GREATEST(
+      member.updated_at,
+      COALESCE(attendance_link.updated_at, attendance_link.created_at, member.updated_at),
+      COALESCE(attendance.updated_at, attendance.created_at, member.updated_at)
+    ) AS observed_at
+  FROM crm_atendimento.global_client_identity_members member
+  JOIN crm_atendimento.attendance_client_links attendance_link
+    ON attendance_link.client_id = CASE
+      WHEN member.source_id ~ '${UUID_TEXT_PATTERN}' THEN member.source_id::uuid
+      ELSE NULL
+    END
+  JOIN crm_atendimento.attendances attendance
+    ON attendance.id = attendance_link.attendance_id
+  JOIN crm_atendimento.units unit ON unit.id = attendance.unit_id
+  WHERE member.source_type = 'attendance_client'
+    AND member.source_id ~ '${UUID_TEXT_PATTERN}'
+    AND attendance.deleted_at IS NULL
+
+  UNION ALL
+
+  SELECT member.identity_id,
+    unit.slug AS unit_slug,
+    GREATEST(member.updated_at, COALESCE(sale.updated_at, sale.created_at, member.updated_at)) AS observed_at
+  FROM crm_atendimento.global_client_identity_members member
+  JOIN crm_caixa.sales sale ON sale.customer_id = CASE
+    WHEN member.source_id ~ '${UUID_TEXT_PATTERN}' THEN member.source_id::uuid
+    ELSE NULL
+  END
+  JOIN crm_atendimento.units unit ON unit.id = sale.unit_id
+  WHERE member.source_type = 'caixa_customer'
+    AND member.source_id ~ '${UUID_TEXT_PATTERN}'
+
+  UNION ALL
+
+  SELECT member.identity_id,
+    unit.slug AS unit_slug,
+    GREATEST(member.updated_at, registration.updated_at) AS observed_at
+  FROM crm_atendimento.global_client_identity_members member
+  JOIN crm_atendimento.app_client_registrations registration
+    ON registration.source_client_id = member.source_id
+  JOIN LATERAL jsonb_array_elements_text(COALESCE(registration.unit_slugs, '[]'::jsonb)) scope(slug)
+    ON TRUE
+  JOIN crm_atendimento.units unit ON unit.slug = scope.slug
+  WHERE member.source_type = 'app_registration'
+
+  UNION ALL
+
+  SELECT member.identity_id,
+    unit.slug AS unit_slug,
+    GREATEST(member.updated_at, lead.updated_at) AS observed_at
+  FROM crm_atendimento.global_client_identity_members member
+  JOIN crm_atendimento.supplemental_lead_profiles lead
+    ON lead.source_profile_id = member.source_id
+  JOIN LATERAL jsonb_array_elements_text(COALESCE(lead.unit_slugs, '[]'::jsonb)) scope(slug)
+    ON TRUE
+  JOIN crm_atendimento.units unit ON unit.slug = scope.slug
+  WHERE member.source_type = 'lead_profile'
+), unit_memberships AS (
+  SELECT identity_id, unit_slug, max(observed_at) AS observed_at
+  FROM unit_membership_evidence
+  GROUP BY identity_id, unit_slug
+), projection_rows AS (
+  SELECT identity_id,
+    observed_at,
+    identity_id::text AS id,
+    to_char(observed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS updated_at,
+    unit_slug
+  FROM unit_memberships
+)`
+
+const ROWS_SELECT = `SELECT id, updated_at, unit_slug
+FROM projection_rows`
+
+export const ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE = createAtendimentoUnitScopedProjectionSource({
+  contract: ATENDIMENTO_UNIT_SCOPED_PROJECTION_SOURCE_CONTRACT,
+  countSql: `${MEMBERSHIP_CTE}
+SELECT count(*)::int AS row_count
+FROM projection_rows`,
+  rowsSql: `${MEMBERSHIP_CTE}
+${ROWS_SELECT}
+ORDER BY updated_at ASC, id ASC, unit_slug ASC
+LIMIT $1`,
+  firstPageSql: `${MEMBERSHIP_CTE}
+${ROWS_SELECT}
+ORDER BY updated_at ASC, id ASC, unit_slug ASC
+LIMIT $1`,
+  nextPageSql: `${MEMBERSHIP_CTE}
+${ROWS_SELECT}
+WHERE (observed_at, identity_id, unit_slug) > ($1::timestamptz, $2::uuid, $3::text)
+ORDER BY updated_at ASC, id ASC, unit_slug ASC
+LIMIT $4`,
+})

--- a/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionBackfillHttpTransport.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionBackfillHttpTransport.mjs
@@ -13,7 +13,7 @@ import {
 export const ATENDIMENTO_CRM_BACKFILL_HTTP_PATH = '/crm/_internal/backfill/atendimento'
 export const ATENDIMENTO_CRM_BACKFILL_HTTP_MAX_BODY_BYTES = 64 * 1024
 export const ATENDIMENTO_CRM_BACKFILL_HTTP_TIMEOUT_MS = 15_000
-export const ATENDIMENTO_CRM_BACKFILL_RECEIPT_VERSION = 'crm-core/projection-backfill-receipt/v1'
+export const ATENDIMENTO_CRM_BACKFILL_RECEIPT_VERSION = 'crm-core/projection-backfill-receipt/v2'
 
 const REQUEST_ID_PATTERN = /^[A-Za-z0-9._:-]{1,120}$/
 const OUTCOMES = new Set(['accepted', 'idempotent'])

--- a/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionExporter.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/src/atendimentoProjectionExporter.mjs
@@ -140,13 +140,25 @@ function unitSlug(value, code) {
   return normalized
 }
 
+function startsReadOnlyQuery(sql) {
+  let cursor = 0
+  while (cursor < sql.length) {
+    while (cursor < sql.length && /\s/.test(sql[cursor])) cursor += 1
+    if (!sql.startsWith('/*', cursor)) break
+    const commentEnd = sql.indexOf('*/', cursor + 2)
+    if (commentEnd < 0) return false
+    cursor = commentEnd + 2
+  }
+  return /^(?:select|with)\b/i.test(sql.slice(cursor))
+}
+
 function sourceQuery(value, code, requiredAliases = []) {
   const sql = text(value, code)
   if (
     sql.length > 32_768
     || sql.includes(';')
     || SOURCE_QUERY_FORBIDDEN.test(sql)
-    || !/^\s*(?:(?:\/\*[\s\S]*?\*\/)\s*)*(?:select|with)\b/i.test(sql)
+    || !startsReadOnlyQuery(sql)
   ) fail(code)
   for (const alias of requiredAliases) {
     const expression = new RegExp(`\\bas\\s+(?:"${alias}"|${alias})\\b`, 'i')

--- a/integration/atendimento/crm-core-projection-exporter/test/atendimentoConfirmedUnitScopedProjectionSource.test.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/test/atendimentoConfirmedUnitScopedProjectionSource.test.mjs
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE,
+  ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE_SEMANTICS,
+} from '../src/atendimentoConfirmedUnitScopedProjectionSource.mjs'
+import {
+  ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL,
+  ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL,
+  ATENDIMENTO_UNIT_SCOPED_PROJECTION_SOURCE_CONTRACT,
+  createAtendimentoUnitScopedProjectionSource,
+  exportAtendimentoClientProjectionBatch,
+} from '../src/atendimentoProjectionExporter.mjs'
+
+const HMAC_KEY = 'synthetic-atendimento-confirmed-unit-source-key-at-least-32-bytes'
+const TARGET = Object.freeze({
+  environment: 'staging',
+  release: 'a'.repeat(40),
+  artifactDigest: `sha256:${'b'.repeat(64)}`,
+})
+const IDENTITY_ID = '123e4567-e89b-42d3-a456-426614174000'
+
+function sourceRow({
+  id = IDENTITY_ID,
+  updated_at = '2026-09-07T00:00:00.000000Z',
+  unit_slug = 'novo-hamburgo',
+} = {}) {
+  return { id, updated_at, unit_slug }
+}
+
+function fixturePool(rows) {
+  const calls = []
+  const client = {
+    async query(sql, params = []) {
+      calls.push({ sql, params })
+      if (sql === 'BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY' || sql === 'ROLLBACK') return { rows: [] }
+      if (sql === ATENDIMENTO_PROJECTION_EXPORT_IDENTITY_SQL) {
+        return { rows: [{
+          database_name: 'skincos_clientes_production',
+          current_user: 'crm_core_projection_exporter',
+          session_user: 'crm_core_projection_exporter',
+          transaction_read_only: 'on',
+        }] }
+      }
+      if (sql === ATENDIMENTO_PROJECTION_EXPORT_SNAPSHOT_SQL) return { rows: [{ captured_at: '2026-09-07T00:00:00.000Z' }] }
+      if (sql === ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE.countSql) return { rows: [{ row_count: rows.length }] }
+      if (sql === ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE.rowsSql) return { rows }
+      throw new Error('unexpected query')
+    },
+    release() {},
+  }
+  return { calls, pool: { async connect() { return client } } }
+}
+
+async function exportConfirmed(rows) {
+  return exportAtendimentoClientProjectionBatch({
+    pool: fixturePool(rows).pool,
+    source: ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE,
+    hmacKey: HMAC_KEY,
+    keyId: 'atendimento-confirmed-unit-source-v1',
+    target: TARGET,
+  })
+}
+
+function sourceWithLeadingComment(prefix) {
+  return createAtendimentoUnitScopedProjectionSource({
+    contract: ATENDIMENTO_UNIT_SCOPED_PROJECTION_SOURCE_CONTRACT,
+    countSql: 'SELECT count(*)::int AS row_count FROM test_source',
+    rowsSql: `${prefix} SELECT id::text AS id, updated_at AS updated_at, unit_slug AS unit_slug FROM test_source ORDER BY updated_at ASC, id ASC, unit_slug ASC LIMIT $1`,
+    firstPageSql: `${prefix} SELECT id::text AS id, updated_at AS updated_at, unit_slug AS unit_slug FROM test_source ORDER BY updated_at ASC, id ASC, unit_slug ASC LIMIT $1`,
+    nextPageSql: `${prefix} SELECT id::text AS id, updated_at AS updated_at, unit_slug AS unit_slug FROM test_source WHERE (updated_at, id, unit_slug) > ($1::timestamptz, $2::uuid, $3::text) ORDER BY updated_at ASC, id ASC, unit_slug ASC LIMIT $4`,
+  })
+}
+
+test('expresses the proven four-channel unit membership without a global fallback or source PII', () => {
+  const { countSql, rowsSql, firstPageSql, nextPageSql } = ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE
+  const queries = [countSql, rowsSql, firstPageSql, nextPageSql]
+
+  for (const query of queries) {
+    assert.match(query, /crm_atendimento\.global_client_identity_members/i)
+    assert.match(query, /crm_atendimento\.units/i)
+    assert.doesNotMatch(query, /\b(?:canonical_name|phone_key|email_keys|cpf_keys|client_name|raw_service)\b/i)
+  }
+  for (const sourceType of ['attendance_client', 'caixa_customer', 'app_registration', 'lead_profile']) {
+    assert.match(rowsSql, new RegExp(`source_type = '${sourceType}'`))
+  }
+  assert.match(rowsSql, /attendance\.deleted_at IS NULL/)
+  assert.match(rowsSql, /GROUP BY identity_id, unit_slug/)
+  assert.match(nextPageSql, /projection_rows AS \(\s*SELECT identity_id,\s*observed_at,/)
+  assert.match(rowsSql, /SELECT id, updated_at, unit_slug/)
+  assert.match(nextPageSql, /WHERE \(observed_at, identity_id, unit_slug\) > \(\$1::timestamptz, \$2::uuid, \$3::text\)/)
+  assert.doesNotMatch(nextPageSql, /\bOFFSET\b/i)
+  assert.equal(ATENDIMENTO_CONFIRMED_UNIT_SCOPED_PROJECTION_SOURCE_SEMANTICS.missingEvidence, 'no projection row; there is no global or wildcard fallback')
+})
+
+test('emits one opaque event per canonical unit for an identity with multi-unit evidence', async () => {
+  const batch = await exportConfirmed([
+    sourceRow({ unit_slug: 'barra-shopping-sul' }),
+    sourceRow({ unit_slug: 'novo-hamburgo' }),
+  ])
+
+  assert.deepEqual(batch.sourceSnapshot.unitSlugs, ['barra-shopping-sul', 'novo-hamburgo'])
+  assert.equal(batch.events.length, 2)
+  assert.equal(batch.events[0].projection.reference, batch.events[1].projection.reference)
+  assert.notEqual(batch.events[0].id, batch.events[1].id)
+  assert.deepEqual(batch.events.map((event) => event.revision), [1, 1])
+  assert.equal(JSON.stringify(batch).includes(IDENTITY_ID), false)
+})
+
+test('rejects a source result with duplicate identity/unit output instead of silently choosing a conflicting membership', async () => {
+  await assert.rejects(() => exportConfirmed([
+    sourceRow(),
+    sourceRow(),
+  ]), /ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_READBACK_INVALID/)
+})
+
+test('does not manufacture a global projection when the proven membership source is empty', async () => {
+  await assert.rejects(() => exportConfirmed([]), /ATENDIMENTO_CRM_PROJECTION_EXPORT_BATCH_INVALID/)
+})
+
+test('parses bounded leading SQL comments without nested-regex backtracking', () => {
+  const commentPrefix = Array.from({ length: 200 }, () => '/* source contract */').join(' ')
+  assert.equal(sourceWithLeadingComment(commentPrefix).contract, ATENDIMENTO_UNIT_SCOPED_PROJECTION_SOURCE_CONTRACT)
+  assert.throws(() => sourceWithLeadingComment('/* unterminated'), /ATENDIMENTO_CRM_PROJECTION_EXPORT_SOURCE_INVALID/)
+})

--- a/integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionBackfillDelivery.test.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/test/atendimentoProjectionBackfillDelivery.test.mjs
@@ -82,7 +82,7 @@ test('uses the CRM-scoped internal HTTPS route with no credential, cookie, origi
         async json() {
           return {
             ok: true,
-            contractVersion: 'crm-core/projection-backfill-receipt/v1',
+            contractVersion: 'crm-core/projection-backfill-receipt/v2',
             status: 'accepted',
             batchId: currentBatch.batchId,
             eventCount: currentBatch.events.length,
@@ -122,9 +122,38 @@ test('fails closed when the receiver response does not bind the batch and reques
       async json() {
         return {
           ok: true,
-          contractVersion: 'crm-core/projection-backfill-receipt/v1',
+          contractVersion: 'crm-core/projection-backfill-receipt/v2',
           status: 'accepted',
           batchId: 'backfill:atendimento:wrong-batch',
+          eventCount: currentBatch.events.length,
+          target: TARGET,
+          requestId: 'crm-atendimento-backfill-000001',
+        }
+      },
+    }),
+  })
+
+  await assert.rejects(() => transport.deliver({
+    batch: currentBatch,
+    delivery,
+    requestId: 'crm-atendimento-backfill-000001',
+  }), /ATENDIMENTO_CRM_BACKFILL_TRANSPORT_RESPONSE_INVALID/)
+})
+
+test('rejects a legacy receipt version even when every other receipt field matches', async () => {
+  const currentBatch = batch()
+  const { signer } = signerFor()
+  const delivery = await signer.signBatch(currentBatch)
+  const transport = createAtendimentoProjectionBackfillHttpTransport({
+    endpoint: `https://crm-core-staging.example.test${ATENDIMENTO_CRM_BACKFILL_HTTP_PATH}`,
+    fetch: async () => ({
+      status: 200,
+      async json() {
+        return {
+          ok: true,
+          contractVersion: 'crm-core/projection-backfill-receipt/v1',
+          status: 'accepted',
+          batchId: currentBatch.batchId,
           eventCount: currentBatch.events.length,
           target: TARGET,
           requestId: 'crm-atendimento-backfill-000001',

--- a/integration/atendimento/crm-core-projection-exporter/test/syntheticAtendimentoProjectionRemoteRehearsal.test.mjs
+++ b/integration/atendimento/crm-core-projection-exporter/test/syntheticAtendimentoProjectionRemoteRehearsal.test.mjs
@@ -30,7 +30,7 @@ function acceptedThenIdempotentFetch(calls) {
       async json() {
         return {
           ok: true,
-          contractVersion: 'crm-core/projection-backfill-receipt/v1',
+          contractVersion: 'crm-core/projection-backfill-receipt/v2',
           status: calls.length === 1 ? 'accepted' : 'idempotent',
           batchId: input.batch.batchId,
           eventCount: input.batch.events.length,


### PR DESCRIPTION
## Contexto

Complemento empilhado sobre #1725. Nao fazer merge isoladamente: primeiro integrar/rebasear #1725 ou atualizar a base.

## Alteracoes

- adiciona o descritor owner de leitura para a associacao canonica identidade -> unit_slug;
- usa exatamente as quatro provas ja aplicadas pelo runtime Comercial: atendimento ativo, venda Caixa, cadastro app e lead suplementar, sempre resolvidas por crm_atendimento.units;
- agrega duplicatas por identidade/unidade e preserva multiunidade sem escolher uma unidade vencedora;
- recusa ausencia de prova (sem fallback global/wildcard), UUID de origem malformado e consultas SQL inseguras;
- corrige a validacao SQL apontada pelo CodeQL sem regex de backtracking aninhado;
- alinha o transporte ao recibo estrito crm-core/projection-backfill-receipt/v2, mantendo o envelope assinado delivery/v1.

## Semantica

updated_at e somente material de snapshot/cursor. O evento Core continua revision: 1, portanto este caminho permite o backfill inicial e o replay exato; mudanca/remocao incremental exige contrato posterior de revisao monotona e tombstone.

## Validacao

- 44 testes focais passaram pelo runtime Linux do projeto;
- git diff --check passou;
- nenhum banco, dado real, segredo, deploy ou backfill remoto foi acessado.

## Gates restantes

- provisionar e verificar externamente o principal read-only crm_core_projection_exporter nas relacoes/colunas minimas;
- revisar a integracao do receiver/store CRM Core v2 com release/digest exatos;
- executar somente o ensaio sintetico de staging aprovado antes de qualquer dado real;
- definir revisao/tombstone antes de sincronizacao incremental.