### PR TITLE
fix(identity): tolerate legacy staging API caller bindings

### DIFF
--- a/.github/workflows/identity-crm-delivery.yml
+++ b/.github/workflows/identity-crm-delivery.yml
@@ -238,7 +238,7 @@ jobs:
           const version = (value) => typeof value === 'string' && /^[0-9a-f-]{36}$/i.test(value);
           if (
             report?.schemaVersion !== 1 || report.state !== 'caller-disabled' || report.observation !== 'exact-active-worker-version-bindings'
-            || report?.api?.script !== 'skincos-api-staging' || report.api.callerEnabled !== false || report.api.callerId !== 'crm-api-staging-v1' || !version(report.api.activeVersion)
+            || report?.api?.script !== 'skincos-api-staging' || report.api.callerEnabled !== false || report.api.effectiveCallerEnabled !== false || report.api.expectedCallerId !== 'crm-api-staging-v1' || (report.api.callerEnabledBinding !== null && report.api.callerEnabledBinding !== false) || (report.api.callerId !== null && report.api.callerId !== 'crm-api-staging-v1') || !version(report.api.activeVersion)
             || report?.issuer?.script !== 'skincos-identity-crm-delivery-staging' || report.issuer.deliveryEnabled !== true || report.issuer.callerEnabled !== false || report.issuer.effectiveCallerEnabled !== false || report.issuer.expectedCallerId !== 'crm-api-staging-v1' || (report.issuer.callerId !== null && report.issuer.callerId !== 'crm-api-staging-v1') || !version(report.issuer.activeVersion)
           ) throw new Error('active staging caller flags are not proven disabled');
           process.stdout.write(`state=caller-disabled\napi_version=${report.api.activeVersion}\nissuer_version=${report.issuer.activeVersion}\n`);
@@ -376,7 +376,7 @@ jobs:
           const version = (value) => typeof value === 'string' && /^[0-9a-f-]{36}$/i.test(value);
           if (
             report?.schemaVersion !== 1 || report.state !== 'caller-disabled' || report.observation !== 'exact-active-worker-version-bindings'
-            || report?.api?.script !== 'skincos-api-staging' || report.api.callerEnabled !== false || report.api.callerId !== 'crm-api-staging-v1' || !version(report.api.activeVersion)
+            || report?.api?.script !== 'skincos-api-staging' || report.api.callerEnabled !== false || report.api.effectiveCallerEnabled !== false || report.api.expectedCallerId !== 'crm-api-staging-v1' || (report.api.callerEnabledBinding !== null && report.api.callerEnabledBinding !== false) || (report.api.callerId !== null && report.api.callerId !== 'crm-api-staging-v1') || !version(report.api.activeVersion)
             || report?.issuer?.script !== 'skincos-identity-crm-delivery-staging' || report.issuer.deliveryEnabled !== true || report.issuer.callerEnabled !== false || report.issuer.effectiveCallerEnabled !== false || report.issuer.expectedCallerId !== 'crm-api-staging-v1' || (report.issuer.callerId !== null && report.issuer.callerId !== 'crm-api-staging-v1') || !version(report.issuer.activeVersion)
           ) throw new Error('active staging caller flags changed or are not proven disabled');
           process.stdout.write(`state=caller-disabled\napi_version=${report.api.activeVersion}\nissuer_version=${report.issuer.activeVersion}\n`);

--- a/scripts/crm-identity-staging-caller-runtime-readback.mjs
+++ b/scripts/crm-identity-staging-caller-runtime-readback.mjs
@@ -5,14 +5,13 @@ import { pathToFileURL } from 'node:url';
 const VERSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const ACCOUNT_ID_PATTERN = /^[0-9a-f]{32}$/i;
 const REQUEST_TIMEOUT_MS = 15_000;
+const STAGING_CALLER_ID = 'crm-api-staging-v1';
 
 const API_RUNTIME = Object.freeze({
     label: 'api',
     script: 'skincos-api-staging',
     expectedPlainTextBindings: Object.freeze({
         ENVIRONMENT: 'staging',
-        CRM_IDENTITY_ISSUER_CALLER_ENABLED: 'false',
-        CRM_IDENTITY_ISSUER_CALLER_ID: 'crm-api-staging-v1',
     }),
 });
 
@@ -82,6 +81,24 @@ function verifyRuntime(deployment, versionDetail, runtime) {
 export function verifyActiveRuntimeState({ apiDeployment, issuerDeployment, apiVersionDetail, issuerVersionDetail }) {
     const api = verifyRuntime(apiDeployment, apiVersionDetail, API_RUNTIME);
     const issuer = verifyRuntime(issuerDeployment, issuerVersionDetail, ISSUER_RUNTIME);
+    const apiCallerEnabled = optionalPlainTextBinding(
+        apiVersionDetail,
+        API_RUNTIME,
+        api.activeVersion,
+        'CRM_IDENTITY_ISSUER_CALLER_ENABLED',
+    );
+    if (apiCallerEnabled !== null && apiCallerEnabled !== 'false') {
+        fail('api_CRM_IDENTITY_ISSUER_CALLER_ENABLED_MISMATCH');
+    }
+    const apiCallerId = optionalPlainTextBinding(
+        apiVersionDetail,
+        API_RUNTIME,
+        api.activeVersion,
+        'CRM_IDENTITY_ISSUER_CALLER_ID',
+    );
+    if (apiCallerId !== null && apiCallerId !== STAGING_CALLER_ID) {
+        fail('api_CRM_IDENTITY_ISSUER_CALLER_ID_MISMATCH');
+    }
     const deliveryEnabled = optionalPlainTextBinding(
         issuerVersionDetail,
         ISSUER_RUNTIME,
@@ -106,7 +123,7 @@ export function verifyActiveRuntimeState({ apiDeployment, issuerDeployment, apiV
         issuer.activeVersion,
         'IDENTITY_CRM_DELIVERY_CALLER_ID',
     );
-    if (callerId !== null && callerId !== 'crm-api-staging-v1') {
+    if (callerId !== null && callerId !== STAGING_CALLER_ID) {
         fail('issuer_IDENTITY_CRM_DELIVERY_CALLER_ID_MISMATCH');
     }
     return Object.freeze({
@@ -116,7 +133,10 @@ export function verifyActiveRuntimeState({ apiDeployment, issuerDeployment, apiV
         api: Object.freeze({
             ...api,
             callerEnabled: false,
-            callerId: 'crm-api-staging-v1',
+            callerEnabledBinding: apiCallerEnabled === null ? null : false,
+            effectiveCallerEnabled: false,
+            callerId: apiCallerId,
+            expectedCallerId: STAGING_CALLER_ID,
         }),
         issuer: Object.freeze({
             ...issuer,
@@ -125,7 +145,7 @@ export function verifyActiveRuntimeState({ apiDeployment, issuerDeployment, apiV
             callerEnabledBinding: callerEnabled === null ? null : false,
             effectiveCallerEnabled: false,
             callerId,
-            expectedCallerId: 'crm-api-staging-v1',
+            expectedCallerId: STAGING_CALLER_ID,
         }),
     });
 }

--- a/scripts/tests/crm-identity-staging-caller-runtime-readback.test.mjs
+++ b/scripts/tests/crm-identity-staging-caller-runtime-readback.test.mjs
@@ -49,7 +49,10 @@ test('accepts only the exact active caller-disabled public bindings while the is
             script: 'skincos-api-staging',
             activeVersion: apiVersion,
             callerEnabled: false,
+            callerEnabledBinding: false,
+            effectiveCallerEnabled: false,
             callerId: 'crm-api-staging-v1',
+            expectedCallerId: 'crm-api-staging-v1',
         },
         issuer: {
             script: 'skincos-identity-crm-delivery-staging',
@@ -81,6 +84,20 @@ test('preserves an already-enabled delivery issuer while the isolated caller is 
     assert.equal(report.issuer.expectedCallerId, 'crm-api-staging-v1');
 });
 
+test('treats absent API caller bindings as disabled and reports null observations', () => {
+    const state = callerDisabledState();
+    state.apiVersionDetail.result.resources.bindings = state.apiVersionDetail.result.resources.bindings
+        .filter((binding) => !binding.name.startsWith('CRM_IDENTITY_ISSUER_CALLER_'));
+
+    const report = verifyActiveRuntimeState(state);
+
+    assert.equal(report.api.callerEnabled, false);
+    assert.equal(report.api.callerEnabledBinding, null);
+    assert.equal(report.api.effectiveCallerEnabled, false);
+    assert.equal(report.api.callerId, null);
+    assert.equal(report.api.expectedCallerId, 'crm-api-staging-v1');
+});
+
 test('rejects an active API version with an enabled caller before any bootstrap receipt can be written', () => {
     const state = callerDisabledState();
     state.apiVersionDetail.result.resources.bindings[1].text = 'true';
@@ -105,6 +122,10 @@ test('accepts a missing disabled caller binding but rejects secret or mismatched
   const issuerId = callerDisabledState();
   issuerId.issuerVersionDetail.result.resources.bindings[3].text = 'another-caller';
   assert.throws(() => verifyActiveRuntimeState(issuerId), /issuer_IDENTITY_CRM_DELIVERY_CALLER_ID_MISMATCH/);
+
+  const apiId = callerDisabledState();
+  apiId.apiVersionDetail.result.resources.bindings[2].text = 'another-caller';
+  assert.throws(() => verifyActiveRuntimeState(apiId), /api_CRM_IDENTITY_ISSUER_CALLER_ID_MISMATCH/);
 
   const wrongVersion = callerDisabledState();
     wrongVersion.apiVersionDetail.result.id = issuerVersion;


### PR DESCRIPTION
## Summary\n\n- treat the staging API caller bindings as optional on legacy active versions\n- keep the effective caller disabled when bindings are absent and report null observed values plus the expected caller ID\n- reject enabled, secret, duplicate, or mismatched present bindings\n- update bootstrap preflight and post-custody readback checks\n\n## Validation\n\n- node --test scripts/tests/crm-identity-staging-caller-runtime-readback.test.mjs (6/6)\n- git diff --check\n\nNo production deploy or secret operation was performed.