### PR TITLE
fix(identity): mount staging smoke login through inventory

### DIFF
--- a/scripts/crm-identity-staging-session-smoke.mjs
+++ b/scripts/crm-identity-staging-session-smoke.mjs
@@ -4,9 +4,13 @@ import { pathToFileURL } from 'node:url';
 
 const EXPECTED_ORIGIN = 'https://api-staging.skincos.com.br';
 const ERROR_PATTERN = /^[A-Z0-9_]{3,120}$/;
+const FAILURE_STAGES = new Set(['anonymous', 'query', 'method', 'login', 'session', 'repeated']);
 
-function fail(code) {
-  throw new Error(code);
+function fail(code, { stage, status } = {}) {
+  const error = new Error(code);
+  if (FAILURE_STAGES.has(stage)) error.failureStage = stage;
+  if (Number.isInteger(status) && status >= 100 && status <= 599) error.failureHttpStatus = status;
+  throw error;
 }
 
 function plainObject(value, code) {
@@ -105,6 +109,15 @@ function safeFailureCode(error) {
   return ERROR_PATTERN.test(candidate) ? candidate : 'CRM_SESSION_SMOKE_FAILED';
 }
 
+function safeFailureDiagnostics(error) {
+  const diagnostics = {};
+  if (FAILURE_STAGES.has(error?.failureStage)) diagnostics.failureStage = error.failureStage;
+  if (Number.isInteger(error?.failureHttpStatus) && error.failureHttpStatus >= 100 && error.failureHttpStatus <= 599) {
+    diagnostics.failureHttpStatus = error.failureHttpStatus;
+  }
+  return diagnostics;
+}
+
 function writeReport(reportPath, report) {
   if (typeof reportPath !== 'string' || !reportPath) return;
   fs.mkdirSync(path.dirname(path.resolve(reportPath)), { recursive: true });
@@ -157,13 +170,13 @@ export async function runCrmIdentityStagingSessionSmoke({
     if (method.status !== 405) fail('CRM_SESSION_SMOKE_METHOD_STATUS_INVALID');
     assertGatewayError(await jsonResponse(method, 'CRM_SESSION_SMOKE_METHOD_RESPONSE_INVALID'), 'CRM_SESSION_METHOD_NOT_ALLOWED');
 
-    const login = await fetchImpl(`${origin}/auth/login`, {
+    const login = await fetchImpl(`${origin}/inventory/auth/login`, {
       method: 'POST',
       headers: { accept: 'application/json', 'content-type': 'application/json', 'cache-control': 'no-store' },
       body: JSON.stringify({ email: scenario.email, password: scenario.password }),
       redirect: 'manual',
     });
-    if (login.status !== 200) fail('CRM_SESSION_SMOKE_LOGIN_STATUS_INVALID');
+    if (login.status !== 200) fail('CRM_SESSION_SMOKE_LOGIN_STATUS_INVALID', { stage: 'login', status: login.status });
     const loginPayload = await jsonResponse(login, 'CRM_SESSION_SMOKE_LOGIN_RESPONSE_INVALID');
     if (!loginPayload || typeof loginPayload !== 'object' || loginPayload.success === false) fail('CRM_SESSION_SMOKE_LOGIN_RESPONSE_INVALID');
     const cookie = cookieHeader(login);
@@ -199,7 +212,7 @@ export async function runCrmIdentityStagingSessionSmoke({
     writeReport(reportPath, report);
     return report;
   } catch (error) {
-    const failed = { ...report, result: 'failed', failure: safeFailureCode(error) };
+    const failed = { ...report, result: 'failed', failure: safeFailureCode(error), ...safeFailureDiagnostics(error) };
     writeReport(reportPath, failed);
     throw error;
   }

--- a/scripts/tests/crm-identity-staging-session-smoke.test.mjs
+++ b/scripts/tests/crm-identity-staging-session-smoke.test.mjs
@@ -3,6 +3,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
+import { createGatewayHandler } from '../../api/src/router.js';
 import { runCrmIdentityStagingSessionSmoke } from '../crm-identity-staging-session-smoke.mjs';
 
 function fixtures(directory) {
@@ -27,10 +28,17 @@ test('staging session smoke uses a synthetic cookie only at the gateway and writ
     const fixturePath = fixtures(directory);
     const reportPath = join(directory, 'report.json');
     const calls = [];
+    const inventoryRequests = [];
+    const gateway = createGatewayHandler({
+      inventoryHandler: async (request) => {
+        inventoryRequests.push({ method: request.method, pathname: new URL(request.url).pathname });
+        return response({ success: true }, 200, { 'set-cookie': 'session=synthetic-cookie; HttpOnly; Secure' });
+      },
+    });
     const fetchImpl = async (url, init) => {
       calls.push({ url, method: init.method, hasCookie: Boolean(init.headers?.cookie) });
       const path = new URL(url).pathname;
-      if (path === '/auth/login') return response({ success: true }, 200, { 'set-cookie': 'session=synthetic-cookie; HttpOnly; Secure' });
+      if (path === '/inventory/auth/login') return gateway(new Request(url, init), {}, {});
       if (url.endsWith('/crm/session?unexpected=1')) return response({ ok: false, error: 'CRM_SESSION_QUERY_NOT_ALLOWED' }, 400);
       if (init.method === 'POST' && path === '/crm/session') return response({ ok: false, error: 'CRM_SESSION_METHOD_NOT_ALLOWED' }, 405);
       if (!init.headers?.cookie) return response({ ok: false, error: 'CRM_IDENTITY_REQUIRED' }, 401);
@@ -47,11 +55,16 @@ test('staging session smoke uses a synthetic cookie only at the gateway and writ
     assert.equal(report.result, 'verified');
     assert.equal(report.authenticatedStatus, 200);
     assert.deepEqual(calls.map((call) => [new URL(call.url).pathname, call.method, call.hasCookie]), [
-      ['/crm/session', 'GET', false], ['/crm/session', 'GET', false], ['/crm/session', 'POST', false], ['/auth/login', 'POST', false], ['/crm/session', 'GET', true], ['/crm/session', 'GET', true],
+      ['/crm/session', 'GET', false], ['/crm/session', 'GET', false], ['/crm/session', 'POST', false], ['/inventory/auth/login', 'POST', false], ['/crm/session', 'GET', true], ['/crm/session', 'GET', true],
     ]);
+    assert.deepEqual(inventoryRequests, [{ method: 'POST', pathname: '/auth/login' }]);
     const persisted = readFileSync(reportPath, 'utf8');
     assert.doesNotMatch(persisted, /synthetic@example\.invalid|synthetic-password|synthetic-cookie|idn:/);
     assert.match(persisted, /"credentialMaterialIncluded": false/);
+    assert.deepEqual(Object.keys(JSON.parse(persisted)).sort(), [
+      'anonymousStatus', 'apiOrigin', 'at', 'authenticatedStatus', 'credentialMaterialIncluded', 'environment',
+      'identity', 'methodStatus', 'piiIncluded', 'queryStatus', 'repeatedStatus', 'result', 'schemaVersion',
+    ]);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
@@ -64,7 +77,7 @@ test('staging session smoke refuses a session response that tries to return a co
     const reportPath = join(directory, 'report.json');
     const fetchImpl = async (url, init) => {
       const path = new URL(url).pathname;
-      if (path === '/auth/login') return response({ success: true }, 200, { 'set-cookie': 'session=synthetic-cookie; HttpOnly; Secure' });
+      if (path === '/inventory/auth/login') return response({ success: true }, 200, { 'set-cookie': 'session=synthetic-cookie; HttpOnly; Secure' });
       if (url.endsWith('/crm/session?unexpected=1')) return response({ ok: false, error: 'CRM_SESSION_QUERY_NOT_ALLOWED' }, 400);
       if (init.method === 'POST' && path === '/crm/session') return response({ ok: false, error: 'CRM_SESSION_METHOD_NOT_ALLOWED' }, 405);
       if (!init.headers?.cookie) return response({ ok: false, error: 'CRM_IDENTITY_REQUIRED' }, 401);
@@ -78,6 +91,51 @@ test('staging session smoke refuses a session response that tries to return a co
     assert.equal(persisted.result, 'failed');
     assert.equal(persisted.failure, 'CRM_SESSION_SMOKE_SESSION_SET_COOKIE');
     assert.equal(persisted.credentialMaterialIncluded, false);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('the public API exposes the Identity login only through the Inventory mount', async () => {
+  const forwarded = [];
+  const gateway = createGatewayHandler({
+    inventoryHandler: async (request) => {
+      forwarded.push(new URL(request.url).pathname);
+      return response({ success: true }, 200);
+    },
+  });
+
+  const mounted = await gateway(new Request('https://api-staging.skincos.com.br/inventory/auth/login', { method: 'POST' }), {}, {});
+  assert.equal(mounted.status, 200);
+  assert.deepEqual(forwarded, ['/auth/login']);
+
+  const unmounted = await gateway(new Request('https://api-staging.skincos.com.br/auth/login', { method: 'POST' }), {}, {});
+  assert.equal(unmounted.status, 404);
+  assert.equal((await unmounted.json()).error, 'route_not_found');
+  assert.deepEqual(forwarded, ['/auth/login']);
+});
+
+test('staging session smoke records only an allowlisted login failure stage and HTTP status', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'crm-identity-smoke-'));
+  try {
+    const fixturePath = fixtures(directory);
+    const reportPath = join(directory, 'report.json');
+    const fetchImpl = async (url, init) => {
+      const path = new URL(url).pathname;
+      if (path === '/inventory/auth/login') return response({ error: 'route_not_found', syntheticSecret: 'must-not-persist' }, 404);
+      if (url.endsWith('/crm/session?unexpected=1')) return response({ ok: false, error: 'CRM_SESSION_QUERY_NOT_ALLOWED' }, 400);
+      if (init.method === 'POST' && path === '/crm/session') return response({ ok: false, error: 'CRM_SESSION_METHOD_NOT_ALLOWED' }, 405);
+      return response({ ok: false, error: 'CRM_IDENTITY_REQUIRED' }, 401);
+    };
+    await assert.rejects(
+      runCrmIdentityStagingSessionSmoke({ fetchImpl, fixturesPath: fixturePath, reportPath }),
+      /CRM_SESSION_SMOKE_LOGIN_STATUS_INVALID/,
+    );
+    const persisted = JSON.parse(readFileSync(reportPath, 'utf8'));
+    assert.equal(persisted.failure, 'CRM_SESSION_SMOKE_LOGIN_STATUS_INVALID');
+    assert.equal(persisted.failureStage, 'login');
+    assert.equal(persisted.failureHttpStatus, 404);
+    assert.doesNotMatch(JSON.stringify(persisted), /route_not_found|must-not-persist|synthetic@example\.invalid|synthetic-password/);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- sends the staging-only synthetic login through the public `/inventory/auth/login` mount
- verifies that mount against the real API router and preserves rejection of unmounted `/auth/login`
- records only an allowlisted failed stage and bounded HTTP status; successful proof schema remains unchanged

## Validation
- `node --test scripts/tests/crm-identity-staging-session-smoke.test.mjs api/test/gateway.test.mjs` (54 passing)
- focused Codex Security diff scan: no findings

No Worker, secret, D1, Pages, DNS, production, or deployment configuration change.